### PR TITLE
upstream: add phantom types to load/availability

### DIFF
--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -63,6 +63,7 @@ envoy_cc_library(
     deps = [
         ":upstream_interface",
         "//include/envoy/router:router_interface",
+        "//include/envoy/upstream:types_interface",
     ],
 )
 
@@ -97,6 +98,7 @@ envoy_cc_library(
     name = "retry_interface",
     hdrs = ["retry.h"],
     deps = [
+        "//include/envoy/upstream:types_interface",
         "//include/envoy/upstream:upstream_interface",
     ],
 )
@@ -112,6 +114,14 @@ envoy_cc_library(
     deps = [
         ":load_balancer_interface",
         ":upstream_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "types_interface",
+    hdrs = ["types.h"],
+    deps = [
+        "//source/common/common:phantom",
     ],
 )
 

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -5,17 +5,11 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/router/router.h"
+#include "envoy/upstream/types.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Envoy {
 namespace Upstream {
-
-// Mapping from a priority to how much of the total traffic load should be directed to this
-// priority. For example, {50, 30, 20} means that 50% of traffic should go to P0, 30% to P1
-// and 20% to P2.
-//
-// This should either sum to 100 or consist of all zeros.
-typedef std::vector<uint32_t> PriorityLoad;
 
 /**
  * Context information passed to a load balancer to use when choosing a host. Not all load

--- a/include/envoy/upstream/retry.h
+++ b/include/envoy/upstream/retry.h
@@ -1,12 +1,10 @@
 #pragma once
 
+#include "envoy/upstream/types.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Envoy {
 namespace Upstream {
-
-// Redeclare this here in order to get around cyclical dependencies.
-typedef std::vector<uint32_t> PriorityLoad;
 
 /**
  * Used to optionally modify the PriorityLoad when selecting a priority for

--- a/include/envoy/upstream/types.h
+++ b/include/envoy/upstream/types.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "common/common/phantom.h"
+
+namespace Envoy {
+namespace Upstream {
+ 
+// Phantom type indicating that the type is related to load.
+struct Load {};
+
+// Mapping from a priority to how much of the total traffic load should be directed to this
+// priority. For example, {50, 30, 20} means that 50% of traffic should go to P0, 30% to P1
+// and 20% to P2.
+//
+// This should either sum to 100 or consist of all zeros.
+typedef Phantom<std::vector<uint32_t>, Load> PriorityLoad;
+
+// Phantom type indicating that the type is related to host availability.
+struct Availability {};
+
+
+// Mapping from a priority how available the given priority is, eg. the ratio of healthy host to total hosts.
+typedef Phantom<std::vector<uint32_t>, Availability> PriorityAvailability;
+
+}
+}

--- a/include/envoy/upstream/types.h
+++ b/include/envoy/upstream/types.h
@@ -4,7 +4,7 @@
 
 namespace Envoy {
 namespace Upstream {
- 
+
 // Phantom type indicating that the type is related to load.
 struct Load {};
 
@@ -18,9 +18,9 @@ typedef Phantom<std::vector<uint32_t>, Load> PriorityLoad;
 // Phantom type indicating that the type is related to host availability.
 struct Availability {};
 
-
-// Mapping from a priority how available the given priority is, eg. the ratio of healthy host to total hosts.
+// Mapping from a priority how available the given priority is, eg. the ratio of healthy host to
+// total hosts.
 typedef Phantom<std::vector<uint32_t>, Availability> PriorityAvailability;
 
-}
-}
+} // namespace Upstream
+} // namespace Envoy

--- a/include/envoy/upstream/types.h
+++ b/include/envoy/upstream/types.h
@@ -2,6 +2,9 @@
 
 #include "common/common/phantom.h"
 
+#include <vector>
+#include <stdint.h>
+
 namespace Envoy {
 namespace Upstream {
 

--- a/include/envoy/upstream/types.h
+++ b/include/envoy/upstream/types.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "common/common/phantom.h"
+#include <stdint.h>
 
 #include <vector>
-#include <stdint.h>
+
+#include "common/common/phantom.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -165,6 +165,11 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "phantom",
+    hdrs = ["phantom.h"],
+)
+
+envoy_cc_library(
     name = "stl_helpers",
     hdrs = ["stl_helpers.h"],
 )

--- a/source/common/common/phantom.h
+++ b/source/common/common/phantom.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <initializer_list>
+#include <type_traits>
+
+namespace Envoy {
+
+/**
+ * A phantom type provides additional type safety to types that are otherwise
+ * interchangeable. For instance, two uint32_t might have different semantic
+ * meaning, so expressing them with a phantom type provides some compile time
+ * guarantees that they won't be used interchangeably.
+ *
+ * Since a phantom type subclasses the inner type, they can be used wherever
+ * the inner type is required. To ensure that the phantom type is not implictly
+ * created one of the ctors of the inner type, all ctors are marked explicit.
+ */
+template <class I, class M> struct Phantom : I {
+  // This allows invoking any of the ctors of the inner class, based on the inferred type
+  // arguments to the Phantom ctor. This has consequences for how ctors are resolved
+  // compared to the inner type, see the below comment.
+  template <class... S> explicit Phantom(S&&... v) : I(std::forward<S>(v)...) {}
+
+  // This ensures that we're able to use an initializer list to create Phantoms in a ergonomic
+  // way, eg.
+  //
+  // Phantom<std::vector<uint32_t>, struct Foo> p{1u, 2u, 3u};
+  //
+  // *NOTE*: This works similar to how it does for standard types, but because of the variadic
+  // ctor above, when the initializer list needs to be implicitly converted, another ctor might
+  // be chosen instead, eg.
+  //
+  // this calls the iniitalizer list ctor
+  // Phantom<std::vector<uint32_t>, struct Foo> p{1u, 2u}; // call initializer list ctor
+  //
+  // calls the (int&&, int&&) phantom ctor, which  ends up resolving to the
+  // (size_t, const uint32_t&) vector ctor.
+  // Phantom<std::vector<uint32_t>, struct Foo> p{1, 2};
+  //
+  // This differs from constructing a std::vector<unit32_t> directly, where both would invoke the
+  // initializter list ctor.
+  //
+  // The std::enable_if_t is necessary to disable this when the innter class doesn't support
+  // initializer list initialization.
+  template <class S,
+            std::enable_if_t<std::is_constructible<I, std::initializer_list<S>>::value, int> = 0>
+  Phantom(std::initializer_list<S> init) : I(init) {}
+};
+
+} // namespace Envoy

--- a/source/common/common/phantom.h
+++ b/source/common/common/phantom.h
@@ -7,9 +7,16 @@ namespace Envoy {
 
 template <class I, class M> struct Phantom;
 
+// Minor optimization: keeping these as free functions avoids duplicating them for every
+// Phantom type, at the cost of making the globally accessible.
+namespace Internal {
 // Helper structs to determine whether the base inner type is constructible from a
 // std::initializer_list<S>. Exist as structs instead of constexpr funcitons to allow for template
 // specialization.
+//
+// These are needed because whether to include the std::initializer ctor depends on whether the
+// innermost type has a applicable ctor, and for some reason inspecing just the immediate inner type
+// is not sufficient.
 template <class I, class S> struct constructibleFromList {
   static constexpr bool value = std::is_constructible<I, std::initializer_list<S>>::value;
 };
@@ -17,15 +24,19 @@ template <class I, class S> struct constructibleFromList {
 template <class I, class M, class S> struct constructibleFromList<Phantom<I, M>, S> {
   static constexpr bool value = constructibleFromList<I, S>::value;
 };
+} // namespace Internal
 
 /**
  * A phantom type provides additional type safety to types that are otherwise interchangeable.
- * For instance, two uint32_t might have different semantic meaning, so expressing them with a
- * phantom type provides some compile time guarantees that they won't be used interchangeably.
+ * For instance, two std::vector<uint32_t> might have different semantic meaning, so expressing
+ * them with a phantom type provides some compile time guarantees that they won't be used
+ * interchangeably.
  *
  * Since a phantom type subclasses the inner type, they can be used wherever the inner type is
  * required.
- * */
+ *
+ * This template currently only works for non-primitive types due to its reliance on subclassing.
+ */
 template <class I, class M> struct Phantom : I {
   // We force construction through this method because interaction with initializer lists is not
   // intuitive when interacting directly with the constructor.
@@ -33,20 +44,21 @@ template <class I, class M> struct Phantom : I {
     return Phantom<I, M>(std::forward<Args>(args)...);
   }
 
-  // To allow inner types to be constructed from initializer lists, we need this bit to make the
-  // type inference possible. This means that if possible, anything that looks like an initializer
-  // list will be treated as std::initializer_list.
+  // To allow inner types to be constructed from initializer lists, we add a function specifically
+  // for std::initializer_list. This allows invokations such as Phantom<Foo, Bar> f{1,2,3} to prefer
+  // std::initializer_list constructors if one exists.
   //
   // We use std::enable_if to ensure that this function is omitted when the inner type does not
   // have a std::initializer ctor.
-  template <class S, std::enable_if_t<constructibleFromList<I, S>::value, int> = 0>
+  template <class S, std::enable_if_t<Internal::constructibleFromList<I, S>::value, int> = 0>
   static Phantom<I, M> create(std::initializer_list<S> init) {
     return Phantom<I, M>(init);
   }
 
   // The default constructor doesn't have any issues with variadic template type inferrence,
   // so allow it directly if the inner type allows it.
-  template<std::enable_if_t<std::is_default_constructible<I>::value, int> = 0>
+  // TODO(snowp): If we ever want to support inner types without a default ctor, we'll
+  // need to template specialize this entire class as SFINAE can't be used with a no-arg function.
   Phantom() : I() {}
 
 protected:

--- a/source/common/common/phantom.h
+++ b/source/common/common/phantom.h
@@ -4,7 +4,7 @@
 
 namespace Envoy {
 
-// A phantom type allows wrapping a common type with addtional type information in order to allow
+// A phantom type allows wrapping a common type with additional type information in order to allow
 // additional compile time safety when passing it around.
 template <class InnerT, class TagT> struct Phantom {
   Phantom() = default;

--- a/source/common/common/phantom.h
+++ b/source/common/common/phantom.h
@@ -1,87 +1,23 @@
 #pragma once
 
-#include <initializer_list>
-#include <type_traits>
 #include <utility>
 
 namespace Envoy {
 
-template <class I, class M> struct Phantom;
+// A phantom type allows wrapping a common type with addtional type information in order to allow
+// additional compile time safety when passing it around.
+template <class InnerT, class TagT> struct Phantom {
+  Phantom() = default;
+  explicit Phantom(const InnerT& t) : val_(t) {}
+  explicit Phantom(InnerT&& t) : val_(std::move(t)) {}
 
-// Minor optimization: keeping these as free functions avoids duplicating them for every
-// Phantom type, at the cost of making the globally accessible.
-namespace Internal {
-// Helper structs to determine whether the base inner type is constructible from a
-// std::initializer_list<S>. Exist as structs instead of constexpr funcitons to allow for template
-// specialization.
-//
-// These are needed because whether to include the std::initializer ctor depends on whether the
-// innermost type has a applicable ctor, and for some reason inspecing just the immediate inner type
-// is not sufficient.
-template <class I, class S> struct constructibleFromList {
-  static constexpr bool value = std::is_constructible<I, std::initializer_list<S>>::value;
-};
+  InnerT& get() { return val_; }
+  const InnerT& get() const { return val_; };
 
-template <class I, class M, class S> struct constructibleFromList<Phantom<I, M>, S> {
-  static constexpr bool value = constructibleFromList<I, S>::value;
-};
-} // namespace Internal
+  bool operator==(const Phantom<InnerT, TagT>& other) const { return val_ == other.val_; }
 
-/**
- * A phantom type provides additional type safety to types that are otherwise interchangeable.
- * For instance, two std::vector<uint32_t> might have different semantic meaning, so expressing
- * them with a phantom type provides some compile time guarantees that they won't be used
- * interchangeably.
- *
- * Since a phantom type subclasses the inner type, they can be used wherever the inner type is
- * required.
- *
- * This template currently only works for non-primitive types due to its reliance on subclassing.
- */
-template <class I, class M> struct Phantom : I {
-  template <class... Args> static Phantom<I, M> create(Args&&... args) {
-    return Phantom<I, M>(std::forward<Args>(args)...);
-  }
-
-  // To allow inner types to be constructed from initializer lists, we add a function specifically
-  // for std::initializer_list. This allows invokations such as Phantom<Foo, Bar> f{1,2,3} to prefer
-  // std::initializer_list constructors if one exists.
-  //
-  // We use std::enable_if to ensure that this function is omitted when the inner type does not
-  // have a std::initializer ctor.
-  template <class S, std::enable_if_t<Internal::constructibleFromList<I, S>::value, int> = 0>
-  static Phantom<I, M> create(std::initializer_list<S> init) {
-    return Phantom<I, M>(init);
-  }
-
-  // The default constructor doesn't have any issues with variadic template type inferrence,
-  // so allow it directly if the inner type allows it.
-  // TODO(snowp): If we ever want to support inner types without a default ctor, we'll
-  // need to template specialize this entire class as SFINAE can't be used with a no-arg function.
-  Phantom() : I() {}
-
-protected:
-  // This allows invoking any of the ctors of the inner class. Since this has consequences for how
-  // the initializer list works with overload resolution, we restrict access to this ctor to avoid
-  // confusion.
-  //
-  // For posterity's sake: the issue is that the initializer list is not forwarded even with perfect
-  // forwarding. The initializer list is inferred to a set of parameter types before forwarding,
-  // and there seems to be a difference in how the generic varags ctor is inferred vs the regular
-  // ctor. For example:
-  //
-  // This resolves to int&&, int&&, invokes size_t, const uint32_t& ctor:
-  // Phantom<std::vector<uint32_t>> p{1,2};
-  //
-  // This resolves to std::initializer_list<int, int>, invokes initalizer ctor:
-  // std::vector<uint32_t> v{1,2};
-  //
-  // This resolves to std::initializer_list<unsigned int, unsigned int>, invokes initalizer ctor:
-  // Phantom<std::vector<uint32_t>> p{1u,2u};
-  //
-  // To ensure that the phantom type is not implictly created from the ctors of the inner type,
-  // these ctors are marked explicit.
-  template <class... S> explicit Phantom(S&&... v) : I(std::forward<S>(v)...) {}
+private:
+  InnerT val_;
 };
 
 } // namespace Envoy

--- a/source/common/common/phantom.h
+++ b/source/common/common/phantom.h
@@ -5,46 +5,58 @@
 
 namespace Envoy {
 
-/**
- * A phantom type provides additional type safety to types that are otherwise
- * interchangeable. For instance, two uint32_t might have different semantic
- * meaning, so expressing them with a phantom type provides some compile time
- * guarantees that they won't be used interchangeably.
- *
- * Since a phantom type subclasses the inner type, they can be used wherever
- * the inner type is required. To ensure that the phantom type is not implictly
- * created one of the ctors of the inner type, all ctors are marked explicit.
- */
-template <class I, class M> struct Phantom : I {
-  // This allows invoking any of the ctors of the inner class, based on the inferred type
-  // arguments to the Phantom ctor. This has consequences for how ctors are resolved
-  // compared to the inner type, see the below comment.
-  template <class... S> explicit Phantom(S&&... v) : I(std::forward<S>(v)...) {}
+template <class I, class M> struct Phantom;
 
-  // This ensures that we're able to use an initializer list to create Phantoms in a ergonomic
-  // way, eg.
+// Helper structs to determine whether the base inner type is constructible from a
+// std::initializer_list<S>. Exist as structs instead of constexpr funcitons to allow for template
+// specialization.
+template <class I, class S> struct constructibleFromList {
+  static constexpr bool value = std::is_constructible<I, std::initializer_list<S>>::value;
+};
+
+template <class I, class M, class S> struct constructibleFromList<Phantom<I, M>, S> {
+  static constexpr bool value = constructibleFromList<I, S>::value;
+};
+
+/**
+ * A phantom type provides additional type safety to types that are otherwise interchangeable.
+ * For instance, two uint32_t might have different semantic meaning, so expressing them with a
+ * phantom type provides some compile time guarantees that they won't be used interchangeably.
+ *
+ * Since a phantom type subclasses the inner type, they can be used wherever the inner type is
+ * required.
+ * */
+template <class I, class M> struct Phantom : I {
+  // We force construction through this method because interaction with initializer lists is not
+  // intuitive when interacting directly with the constructor.
+  template <class... Args> static Phantom<I, M> create(Args&&... args) {
+    return Phantom<I, M>(std::forward<Args>(args)...);
+  }
+
+  // To allow inner types to be constructed from initializer lists, we need this bit to make the
+  // type inference possible. This means that if possible, anything that looks like an initializer
+  // list will be treated as std::initializer_list.
   //
-  // Phantom<std::vector<uint32_t>, struct Foo> p{1u, 2u, 3u};
+  // We use std::enable_if to ensure that this function is omitted when the inner type does not
+  // have a std::initializer ctor.
+  template <class S, std::enable_if_t<constructibleFromList<I, S>::value, int> = 0>
+  static Phantom<I, M> create(std::initializer_list<S> init) {
+    return Phantom<I, M>(init);
+  }
+
+  // The default constructor doesn't have any issues with variadic template type inferrence,
+  // so allow it directly if the inner type allows it.
+  template<std::enable_if_t<std::is_default_constructible<I>::value, int> = 0>
+  Phantom() : I() {}
+
+protected:
+  // This allows invoking any of the ctors of the inner class, based on the inferred type
+  // arguments to the Phantom ctor. This has consequences for how overload resolution works compared
+  // to the inner type, so we restrict direct access to the constructor to avoid confusion.
   //
-  // *NOTE*: This works similar to how it does for standard types, but because of the variadic
-  // ctor above, when the initializer list needs to be implicitly converted, another ctor might
-  // be chosen instead, eg.
-  //
-  // this calls the iniitalizer list ctor
-  // Phantom<std::vector<uint32_t>, struct Foo> p{1u, 2u}; // call initializer list ctor
-  //
-  // calls the (int&&, int&&) phantom ctor, which  ends up resolving to the
-  // (size_t, const uint32_t&) vector ctor.
-  // Phantom<std::vector<uint32_t>, struct Foo> p{1, 2};
-  //
-  // This differs from constructing a std::vector<unit32_t> directly, where both would invoke the
-  // initializter list ctor.
-  //
-  // The std::enable_if_t is necessary to disable this when the innter class doesn't support
-  // initializer list initialization.
-  template <class S,
-            std::enable_if_t<std::is_constructible<I, std::initializer_list<S>>::value, int> = 0>
-  Phantom(std::initializer_list<S> init) : I(init) {}
+  // To ensure that the phantom type is not implictly created from the ctors of the inner type,
+  // these ctors are marked explicit.
+  template <class... S> explicit Phantom(S&&... v) : I(std::forward<S>(v)...) {}
 };
 
 } // namespace Envoy

--- a/source/common/common/phantom.h
+++ b/source/common/common/phantom.h
@@ -2,6 +2,7 @@
 
 #include <initializer_list>
 #include <type_traits>
+#include <utility>
 
 namespace Envoy {
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -36,15 +36,15 @@ std::pair<int32_t, size_t> distributeLoad(PriorityLoad& per_priority_load,
                                           const PriorityAvailability& per_priority_availability,
                                           size_t total_load, size_t normalized_total_availability) {
   int32_t first_available_priority = -1;
-  for (size_t i = 0; i < per_priority_availability.size(); ++i) {
-    if (first_available_priority < 0 && per_priority_availability[i] > 0) {
+  for (size_t i = 0; i < per_priority_availability.get().size(); ++i) {
+    if (first_available_priority < 0 && per_priority_availability.get()[i] > 0) {
       first_available_priority = i;
     }
     // Now assign as much load as possible to the high priority levels and cease assigning load
     // when total_load runs out.
-    per_priority_load[i] = std::min<uint32_t>(total_load, per_priority_availability[i] * 100 /
-                                                              normalized_total_availability);
-    total_load -= per_priority_load[i];
+    per_priority_load.get()[i] = std::min<uint32_t>(
+        total_load, per_priority_availability.get()[i] * 100 / normalized_total_availability);
+    total_load -= per_priority_load.get()[i];
   }
 
   return {first_available_priority, total_load};
@@ -58,8 +58,8 @@ uint32_t LoadBalancerBase::choosePriority(uint64_t hash, const PriorityLoad& per
   // As with tryChooseLocalLocalityHosts, this can be refactored for efficiency
   // but O(N) is good enough for now given the expected number of priorities is
   // small.
-  for (size_t priority = 0; priority < per_priority_load.size(); ++priority) {
-    aggregate_percentage_load += per_priority_load[priority];
+  for (size_t priority = 0; priority < per_priority_load.get().size(); ++priority) {
+    aggregate_percentage_load += per_priority_load.get()[priority];
     if (hash <= aggregate_percentage_load) {
       return priority;
     }
@@ -109,21 +109,21 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
                                                    const PrioritySet& priority_set,
                                                    PriorityLoad& per_priority_load,
                                                    PriorityAvailability& per_priority_health) {
-  per_priority_load.resize(priority_set.hostSetsPerPriority().size());
-  per_priority_health.resize(priority_set.hostSetsPerPriority().size());
+  per_priority_load.get().resize(priority_set.hostSetsPerPriority().size());
+  per_priority_health.get().resize(priority_set.hostSetsPerPriority().size());
 
   // Determine the health of the newly modified priority level.
   // Health ranges from 0-100, and is the ratio of healthy hosts to total hosts, modified by the
   // overprovisioning factor.
   HostSet& host_set = *priority_set.hostSetsPerPriority()[priority];
-  per_priority_health[priority] = 0;
+  per_priority_health.get()[priority] = 0;
   if (host_set.hosts().size() > 0) {
     // Each priority level's health is ratio of healthy hosts to total number of hosts in a priority
     // multiplied by overprovisioning factor of 1.4 and capped at 100%. It means that if all
     // hosts are healthy that priority's health is 100%*1.4=140% and is capped at 100% which results
     // in 100%. If 80% of hosts are healty, that priority's health is still 100% (80%*1.4=112% and
     // capped at 100%).
-    per_priority_health[priority] =
+    per_priority_health.get()[priority] =
         std::min<uint32_t>(100, (host_set.overprovisioningFactor() *
                                  host_set.healthyHosts().size() / host_set.hosts().size()));
   }
@@ -141,7 +141,7 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
   if (normalized_total_health == 0) {
     // Everything is terrible. Send all load to P=0.
     // In this one case sumEntries(per_priority_load) != 100 since we sinkhole all traffic in P=0.
-    per_priority_load[0] = 100;
+    per_priority_load.get()[0] = 100;
     return;
   }
 
@@ -152,8 +152,8 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
   if (remaining_load != 0) {
     ASSERT(first_available_and_remaining.first != -1);
     // Account for rounding errors by assigning it to the first available priority.
-    ASSERT(remaining_load < per_priority_load.size());
-    per_priority_load[first_available_and_remaining.first] += remaining_load;
+    ASSERT(remaining_load < per_priority_load.get().size());
+    per_priority_load.get()[first_available_and_remaining.first] += remaining_load;
   }
 }
 
@@ -165,12 +165,12 @@ void LoadBalancerBase::recalculatePerPriorityPanic() {
 
   if (normalized_total_health == 0) {
     // Everything is terrible. All load should be to P=0. Turn on panic mode.
-    ASSERT(per_priority_load_[0] == 100);
+    ASSERT(per_priority_load_.get()[0] == 100);
     per_priority_panic_[0] = true;
     return;
   }
 
-  for (size_t i = 0; i < per_priority_health_.size(); ++i) {
+  for (size_t i = 0; i < per_priority_health_.get().size(); ++i) {
     // For each level check if it should run in panic mode. Never set panic mode if
     // normalized total health is 100%, even when individual priority level has very low # of
     // healthy hosts.

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -33,7 +33,7 @@ static const std::string RuntimePanicThreshold = "upstream.healthy_panic_thresho
 // scale the load when the total availability is less than 100%.
 // @return the first available priority and the remaining load
 std::pair<int32_t, size_t> distributeLoad(PriorityLoad& per_priority_load,
-                                          const std::vector<uint32_t>& per_priority_availability,
+                                          const PriorityAvailability& per_priority_availability,
                                           size_t total_load, size_t normalized_total_availability) {
   int32_t first_available_priority = -1;
   for (size_t i = 0; i < per_priority_availability.size(); ++i) {
@@ -52,8 +52,7 @@ std::pair<int32_t, size_t> distributeLoad(PriorityLoad& per_priority_load,
 
 } // namespace
 
-uint32_t LoadBalancerBase::choosePriority(uint64_t hash,
-                                          const std::vector<uint32_t>& per_priority_load) {
+uint32_t LoadBalancerBase::choosePriority(uint64_t hash, const PriorityLoad& per_priority_load) {
   hash = hash % 100 + 1; // 1-100
   uint32_t aggregate_percentage_load = 0;
   // As with tryChooseLocalLocalityHosts, this can be refactored for efficiency
@@ -109,7 +108,7 @@ LoadBalancerBase::LoadBalancerBase(const PrioritySet& priority_set, ClusterStats
 void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
                                                    const PrioritySet& priority_set,
                                                    PriorityLoad& per_priority_load,
-                                                   std::vector<uint32_t>& per_priority_health) {
+                                                   PriorityAvailability& per_priority_health) {
   per_priority_load.resize(priority_set.hostSetsPerPriority().size());
   per_priority_health.resize(priority_set.hostSetsPerPriority().size());
 

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -28,7 +28,7 @@ public:
   // a priority vector in the style of per_priority_load_
   //
   // Returns the priority, a number between 0 and per_priority_load.size()-1
-  static uint32_t choosePriority(uint64_t hash, const std::vector<uint32_t>& per_priority_load);
+  static uint32_t choosePriority(uint64_t hash, const PriorityLoad& per_priority_load);
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
@@ -78,7 +78,7 @@ public:
   // priority levels.
   void static recalculatePerPriorityState(uint32_t priority, const PrioritySet& priority_set,
                                           PriorityLoad& priority_load,
-                                          std::vector<uint32_t>& per_priority_health);
+                                          PriorityAvailability& per_priority_health);
   void recalculatePerPriorityPanic();
 
 protected:
@@ -88,14 +88,14 @@ protected:
   // Calculating normalized total health starts with summarizing all priorities' health values.
   // It can exceed 100%. For example if there are three priorities and each is 100% healthy, the
   // total of all priorities is 300%. Normalized total health is then capped at 100%.
-  static uint32_t calcNormalizedTotalHealth(std::vector<uint32_t>& per_priority_health) {
+  static uint32_t calcNormalizedTotalHealth(PriorityAvailability& per_priority_health) {
     return std::min<uint32_t>(
         std::accumulate(per_priority_health.begin(), per_priority_health.end(), 0), 100);
   }
   // The percentage load (0-100) for each priority level
-  std::vector<uint32_t> per_priority_load_;
+  PriorityLoad per_priority_load_;
   // The health (0-100) for each priority level.
-  std::vector<uint32_t> per_priority_health_;
+  PriorityAvailability per_priority_health_;
   // Levels which are in panic
   std::vector<bool> per_priority_panic_;
 };

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -62,7 +62,7 @@ protected:
   // Choose host set randomly, based on the per_priority_load_;
   HostSet& chooseHostSet(LoadBalancerContext* context);
 
-  uint32_t percentageLoad(uint32_t priority) const { return per_priority_load_[priority]; }
+  uint32_t percentageLoad(uint32_t priority) const { return per_priority_load_.get()[priority]; }
   bool isInPanic(uint32_t priority) const { return per_priority_panic_[priority]; }
 
   ClusterStats& stats_;
@@ -90,7 +90,8 @@ protected:
   // total of all priorities is 300%. Normalized total health is then capped at 100%.
   static uint32_t calcNormalizedTotalHealth(PriorityAvailability& per_priority_health) {
     return std::min<uint32_t>(
-        std::accumulate(per_priority_health.begin(), per_priority_health.end(), 0), 100);
+        std::accumulate(per_priority_health.get().begin(), per_priority_health.get().end(), 0),
+        100);
   }
   // The percentage load (0-100) for each priority level
   PriorityLoad per_priority_load_;

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -21,7 +21,7 @@ void ThreadAwareLoadBalancerBase::initialize() {
 void ThreadAwareLoadBalancerBase::refresh() {
   auto per_priority_state_vector = std::make_shared<std::vector<PerPriorityStatePtr>>(
       priority_set_.hostSetsPerPriority().size());
-  auto per_priority_load = std::make_shared<PriorityLoad>(PriorityLoad::create(per_priority_load_));
+  auto per_priority_load = std::make_shared<PriorityLoad>(PriorityLoad(per_priority_load_));
 
   for (const auto& host_set : priority_set_.hostSetsPerPriority()) {
     const uint32_t priority = host_set->priority();

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -21,7 +21,7 @@ void ThreadAwareLoadBalancerBase::initialize() {
 void ThreadAwareLoadBalancerBase::refresh() {
   auto per_priority_state_vector = std::make_shared<std::vector<PerPriorityStatePtr>>(
       priority_set_.hostSetsPerPriority().size());
-  auto per_priority_load = std::make_shared<PriorityLoad>(per_priority_load_);
+  auto per_priority_load = std::make_shared<PriorityLoad>(PriorityLoad::create(per_priority_load_));
 
   for (const auto& host_set : priority_set_.hostSetsPerPriority()) {
     const uint32_t priority = host_set->priority();

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -21,7 +21,7 @@ void ThreadAwareLoadBalancerBase::initialize() {
 void ThreadAwareLoadBalancerBase::refresh() {
   auto per_priority_state_vector = std::make_shared<std::vector<PerPriorityStatePtr>>(
       priority_set_.hostSetsPerPriority().size());
-  auto per_priority_load = std::make_shared<std::vector<uint32_t>>(per_priority_load_);
+  auto per_priority_load = std::make_shared<PriorityLoad>(per_priority_load_);
 
   for (const auto& host_set : priority_set_.hostSetsPerPriority()) {
     const uint32_t priority = host_set->priority();

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -57,7 +57,7 @@ private:
     ClusterStats& stats_;
     Runtime::RandomGenerator& random_;
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_;
-    std::shared_ptr<std::vector<uint32_t>> per_priority_load_;
+    std::shared_ptr<PriorityLoad> per_priority_load_;
   };
 
   struct LoadBalancerFactoryImpl : public LoadBalancerFactory {
@@ -72,7 +72,7 @@ private:
     absl::Mutex mutex_;
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_ GUARDED_BY(mutex_);
     // This is split out of PerPriorityState so LoadBalancerBase::ChoosePriorirty can be reused.
-    std::shared_ptr<std::vector<uint32_t>> per_priority_load_ GUARDED_BY(mutex_);
+    std::shared_ptr<PriorityLoad> per_priority_load_ GUARDED_BY(mutex_);
   };
 
   virtual HashingLoadBalancerSharedPtr createLoadBalancer(const HostSet& host_set,

--- a/source/extensions/retry/priority/previous_priorities/previous_priorities.cc
+++ b/source/extensions/retry/priority/previous_priorities/previous_priorities.cc
@@ -59,7 +59,7 @@ bool PreviousPrioritiesRetryPriority::adjustForAttemptedPriorities(
     return false;
   }
 
-  std::fill(per_priority_load_.begin(), per_priority_load_.end(), 0);
+  std::fill(per_priority_load_.get().begin(), per_priority_load_.get().end(), 0);
   // We then adjust the load by rebalancing priorities with the adjusted health values.
   size_t total_load = 100;
   // The outer loop is used to eliminate rounding errors: any remaining load will be assigned to the
@@ -70,7 +70,7 @@ bool PreviousPrioritiesRetryPriority::adjustForAttemptedPriorities(
       // when total_load runs out.
       auto delta =
           std::min<uint32_t>(total_load, adjusted_per_priority_health[i] * 100 / total_health);
-      per_priority_load_[i] += delta;
+      per_priority_load_.get()[i] += delta;
       total_load -= delta;
     }
   }
@@ -82,12 +82,12 @@ std::pair<std::vector<uint32_t>, uint32_t> PreviousPrioritiesRetryPriority::adju
   // Create an adjusted health view of the priorities, where attempted priorities are
   // given a zero weight.
   uint32_t total_health = 0;
-  std::vector<uint32_t> adjusted_per_priority_health(per_priority_health_.size(), 0);
+  std::vector<uint32_t> adjusted_per_priority_health(per_priority_health_.get().size(), 0);
 
-  for (size_t i = 0; i < per_priority_health_.size(); ++i) {
+  for (size_t i = 0; i < per_priority_health_.get().size(); ++i) {
     if (!excluded_priorities_[i]) {
-      adjusted_per_priority_health[i] = per_priority_health_[i];
-      total_health += per_priority_health_[i];
+      adjusted_per_priority_health[i] = per_priority_health_.get()[i];
+      total_health += per_priority_health_.get()[i];
     }
   }
 

--- a/source/extensions/retry/priority/previous_priorities/previous_priorities.h
+++ b/source/extensions/retry/priority/previous_priorities/previous_priorities.h
@@ -43,7 +43,7 @@ private:
   std::vector<uint32_t> attempted_priorities_;
   std::vector<bool> excluded_priorities_;
   Upstream::PriorityLoad per_priority_load_;
-  std::vector<uint32_t> per_priority_health_;
+  Upstream::PriorityAvailability per_priority_health_;
 };
 
 } // namespace Priority

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -62,6 +62,12 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "phantom_test",
+    srcs = ["phantom_test.cc"],
+    deps = ["//source/common/common:phantom"],
+)
+
+envoy_cc_test(
     name = "fmt_test",
     srcs = ["fmt_test.cc"],
     deps = [

--- a/test/common/common/phantom_test.cc
+++ b/test/common/common/phantom_test.cc
@@ -38,8 +38,10 @@ void baseRef(
 // type's constructors
 TEST(PhantomTest, TypeBehavior) {
   {
-    Phantom<PhantomA, struct PhantomTest> x{4};
-    Phantom<PhantomA, struct PhantomTest> y{4};
+    const auto x = Phantom<PhantomA, struct PhantomTest>::create(4);
+    const auto y = Phantom<PhantomA, struct PhantomTest>::create(4);
+    /* Phantom<PhantomA, struct PhantomTest> x{4}; */
+    /* Phantom<PhantomA, struct PhantomTest> y{4}; */
 
     // Equality is provided by the super class.
     EXPECT_EQ(x, y);
@@ -48,8 +50,8 @@ TEST(PhantomTest, TypeBehavior) {
   }
 
   {
-    Phantom<PhantomB, struct PhantomTest> x{4};
-    Phantom<PhantomB, struct PhantomTest> y{4};
+    const auto x = Phantom<PhantomB, struct PhantomTest>::create(4);
+    const auto y = Phantom<PhantomB, struct PhantomTest>::create(4);
 
     // Equality is provided by the super class.
     EXPECT_EQ(x, y);
@@ -58,36 +60,44 @@ TEST(PhantomTest, TypeBehavior) {
   }
 
   {
-    Phantom<PhantomB, struct PhantomTest> x{4};
-    Phantom<PhantomB, struct PhantomTest2> y{4};
+    auto x = Phantom<PhantomA, struct PhantomTest>::create(4);
+    const auto y = Phantom<PhantomA, struct PhantomTest2>::create(4);
 
     // Should not be possible to convert x to y directly.
     static_assert(!std::is_convertible<decltype(x), decltype(y)>::value, "not convertible");
+    static_assert(!std::is_assignable<decltype(x), decltype(y)>::value, "not assignable");
 
     // Explicit conversion should be possible.
-    x = Phantom<PhantomB, struct PhantomTest>(y);
+    x = Phantom<PhantomA, struct PhantomTest>::create(y);
   }
 
   {
     // Verify initializer list initialization of a vector.
-    Phantom<std::vector<uint32_t>, struct PhantomTest2> v({1u, 2u, 3u, 4u});
-    Phantom<std::vector<uint32_t>, struct PhantomTest2> v2{1u, 2u, 3u, 4u};
+    /* Phantom<std::vector<uint32_t>, struct PhantomTest2> v({1u, 2u, 3u, 4u}); */
+    /* Phantom<std::vector<uint32_t>, struct PhantomTest2> v2{1u, 2u, 3u, 4u}; */
+    const auto v = Phantom<std::vector<uint32_t>, struct PhantomTest>::create({1u, 2u, 3u, 4u});
+    const auto v2 = Phantom<std::vector<uint32_t>, struct PhantomTest>::create({1u, 2u, 3u, 4u});
 
     EXPECT_EQ(v, v2);
   }
 
   {
     // Verify that initializer syntax is preferred over size_t, const T& ctor
-    Phantom<std::vector<uint32_t>, struct PhantomTest2> v{1u, 2u};
-    Phantom<std::vector<uint32_t>, struct PhantomTest2> v2({1u, 2u});
+    /* Phantom<std::vector<uint32_t>, struct PhantomTest2> v{1u, 2u}; */
+    /* Phantom<std::vector<uint32_t>, struct PhantomTest2> v2({1u, 2u}); */
+    const auto v = Phantom<std::vector<uint32_t>, struct PhantomTest>::create({1u, 2u});
+    const auto v2 = Phantom<std::vector<uint32_t>, struct PhantomTest>::create({1u, 2u});
 
     EXPECT_EQ(v, v2);
   }
 
   {
-    Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2> nested{1u, 2u};
-    Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2> nested2{1u,
-                                                                                             2u};
+    const auto nested =
+        Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2>::create(
+            {1u, 2u});
+    const auto nested2 =
+        Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2>::create(
+            {1u, 2u});
 
     EXPECT_EQ(nested, nested2);
 
@@ -99,7 +109,7 @@ TEST(PhantomTest, TypeBehavior) {
     base(nested);
     baseRef(nested);
 
-    Phantom<std::vector<uint32_t>, struct PhantomTest> inner;
+    const auto inner = Phantom<std::vector<uint32_t>, struct PhantomTest>::create();
 
     static_assert(!std::__invokable<decltype(base), decltype(inner)>::value,
                   "cannot pass inner to parent func");

--- a/test/common/common/phantom_test.cc
+++ b/test/common/common/phantom_test.cc
@@ -1,0 +1,111 @@
+#include "common/common/phantom.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+// Verify that we're able to initialize a class with explict ctor.
+struct PhantomA {
+  explicit PhantomA(uint32_t x) : x_(x) {}
+
+  bool operator==(const PhantomA& other) { return x_ == other.x_; }
+
+  bool operator==(const PhantomA& other) const { return x_ == other.x_; }
+
+  uint32_t x_;
+};
+
+// Verify that we're able to initialize a class with implicit ctor.
+struct PhantomB {
+  PhantomB(uint32_t x) : x_(x) {}
+
+  bool operator==(const PhantomB& other) { return x_ == other.x_; }
+
+  bool operator==(const PhantomB& other) const { return x_ == other.x_; }
+
+  uint32_t x_;
+};
+
+// Helper functions for testing type interaction with nested phantoms.
+void parent(Phantom<std::vector<uint32_t>, struct PhantomTest>) {}
+void parentRef(const Phantom<std::vector<uint32_t>, struct PhantomTest>&) {}
+
+void base(Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2>) {}
+void baseRef(
+    const Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2>&) {}
+
+// Verify that a phantom type can be constructed using the inner
+// type's constructors
+TEST(PhantomTest, TypeBehavior) {
+  {
+    Phantom<PhantomA, struct PhantomTest> x{4};
+    Phantom<PhantomA, struct PhantomTest> y{4};
+
+    // Equality is provided by the super class.
+    EXPECT_EQ(x, y);
+    // Phantom should be convertible to the inner type.
+    EXPECT_EQ(PhantomA(x), PhantomA(4));
+  }
+
+  {
+    Phantom<PhantomB, struct PhantomTest> x{4};
+    Phantom<PhantomB, struct PhantomTest> y{4};
+
+    // Equality is provided by the super class.
+    EXPECT_EQ(x, y);
+    // Phantom should be convertible to the inner type.
+    EXPECT_EQ(PhantomB(x), 4u);
+  }
+
+  {
+    Phantom<PhantomB, struct PhantomTest> x{4};
+    Phantom<PhantomB, struct PhantomTest2> y{4};
+
+    // Should not be possible to convert x to y directly.
+    static_assert(!std::is_convertible<decltype(x), decltype(y)>::value, "not convertible");
+
+    // Explicit conversion should be possible.
+    x = Phantom<PhantomB, struct PhantomTest>(y);
+  }
+
+  {
+    // Verify initializer list initialization of a vector.
+    Phantom<std::vector<uint32_t>, struct PhantomTest2> v({1u, 2u, 3u, 4u});
+    Phantom<std::vector<uint32_t>, struct PhantomTest2> v2{1u, 2u, 3u, 4u};
+
+    EXPECT_EQ(v, v2);
+  }
+
+  {
+    // Verify that initializer syntax is preferred over size_t, const T& ctor
+    Phantom<std::vector<uint32_t>, struct PhantomTest2> v{1u, 2u};
+    Phantom<std::vector<uint32_t>, struct PhantomTest2> v2({1u, 2u});
+
+    EXPECT_EQ(v, v2);
+  }
+
+  {
+    Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2> nested{1u, 2u};
+    Phantom<Phantom<std::vector<uint32_t>, struct PhantomTest>, struct PhantomTest2> nested2{1u,
+                                                                                             2u};
+
+    EXPECT_EQ(nested, nested2);
+
+    // Passing the nested type to a function that takes the inner phantom works due to inheritence.
+    // We know we're not doing a copy here because all the ctors are explicit.
+    parent(nested);
+    parentRef(nested);
+
+    base(nested);
+    baseRef(nested);
+
+    Phantom<std::vector<uint32_t>, struct PhantomTest> inner;
+
+    static_assert(!std::__invokable<decltype(base), decltype(inner)>::value,
+                  "cannot pass inner to parent func");
+    static_assert(!std::__invokable<decltype(baseRef), decltype(inner)>::value,
+                  "cannot pass inner to parent func");
+  }
+}
+
+} // namespace Envoy

--- a/test/common/common/phantom_test.cc
+++ b/test/common/common/phantom_test.cc
@@ -4,122 +4,16 @@
 
 namespace Envoy {
 
-// Verify that we're able to initialize a class with explict ctor.
-struct PhantomA {
-  explicit PhantomA(uint32_t x) : x_(x) {}
-
-  bool operator==(const PhantomA& other) { return x_ == other.x_; }
-
-  bool operator==(const PhantomA& other) const { return x_ == other.x_; }
-
-  uint32_t x_;
-};
-
-// Verify that we're able to initialize a class with implicit ctor.
-struct PhantomB {
-  PhantomB(uint32_t x) : x_(x) {}
-
-  bool operator==(const PhantomB& other) { return x_ == other.x_; }
-
-  bool operator==(const PhantomB& other) const { return x_ == other.x_; }
-
-  uint32_t x_;
-};
-
-// Empty types to use as phantom type.
 struct PhantomTest {};
 struct PhantomTest2 {};
 
-typedef Phantom<PhantomA, PhantomTest> PhantomATest;
-typedef Phantom<PhantomA, PhantomTest2> PhantomATest2;
-typedef Phantom<PhantomB, PhantomTest> PhantomBTest;
-typedef Phantom<PhantomB, PhantomTest2> PhantomBTest2;
+typedef Phantom<uint32_t, PhantomTest> PhantomIntTest;
+typedef Phantom<uint32_t, PhantomTest2> PhantomIntTest2;
 
-typedef Phantom<std::vector<uint32_t>, PhantomTest> PhantomVector;
-typedef Phantom<PhantomVector, PhantomTest> NestedPhantomVector;
-
-// Helper functions for testing type interaction with nested phantoms.
-void parent(PhantomVector) {}
-void parentRef(const PhantomVector&) {}
-
-void base(NestedPhantomVector) {}
-void baseRef(const NestedPhantomVector&) {}
-
-// Verify that a phantom type can be constructed using the inner
-// type's constructors
 TEST(PhantomTest, TypeBehavior) {
-  {
-    const auto x = PhantomATest::create(4);
-    const auto y = PhantomATest::create(4);
-    /* Phantom<PhantomA, struct PhantomTest> x{4}; */
-    /* Phantom<PhantomA, struct PhantomTest> y{4}; */
-
-    // Equality is provided by the super class.
-    EXPECT_EQ(x, y);
-    // Phantom should be convertible to the inner type.
-    EXPECT_EQ(PhantomA(x), PhantomA(4));
-  }
-
-  {
-    const auto x = PhantomBTest::create(4);
-    const auto y = PhantomBTest::create(4);
-
-    // Equality is provided by the super class.
-    EXPECT_EQ(x, y);
-    // Phantom should be convertible to the inner type.
-    EXPECT_EQ(PhantomB(x), 4u);
-  }
-
-  {
-    auto x = PhantomATest::create(4);
-    const auto y = PhantomATest2::create(4);
-
-    // Should not be possible to convert x to y directly.
-    static_assert(!std::is_convertible<decltype(x), decltype(y)>::value, "not convertible");
-    static_assert(!std::is_assignable<decltype(x), decltype(y)>::value, "not assignable");
-
-    // Explicit conversion should be possible.
-    x = Phantom<PhantomA, struct PhantomTest>::create(y);
-  }
-
-  {
-    // Verify initializer list initialization of a vector.
-    const auto v = PhantomVector::create({1u, 2u, 3u, 4u});
-  }
-
-  {
-    // Verify that initializer syntax is preferred over size_t, const T& ctor.
-    const auto v = PhantomVector::create({1u, 2u});
-    const auto v2 = PhantomVector::create(std::vector<uint32_t>({1u, 2u}));
-
-    EXPECT_EQ(v, v2);
-  }
-
-  {
-    const auto nested = NestedPhantomVector::create({1u, 2u});
-    const auto nested2 = NestedPhantomVector::create({1u, 2u});
-
-    EXPECT_EQ(nested, nested2);
-
-    // Passing the nested type to a function that takes the inner phantom works due to inheritence.
-    // We know we're not doing a copy here because all the ctors are explicit.
-    parent(nested);
-    parentRef(nested);
-
-    base(nested);
-    baseRef(nested);
-
-    const auto inner = PhantomVector::create();
-
-    // TODO(snowp): Need C++17 for these, but would be nice to have.
-    // static_assert(!std::is_invokable<decltype(base), decltype(inner)>::value,
-    //   "cannot pass inner to parent func");
-    // static_assert(!std::is_invokable<decltype(baseRef), decltype(inner)>::value,
-    //  "cannot pass inner to parent func");
-  }
-
-  // Verify that default initialization works.
-  NestedPhantomVector v;
+  // Should not be possible to implicitly convert from two phantoms with different markers.
+  static_assert(!std::is_convertible<PhantomIntTest, PhantomTest2>::value,
+                "should not be convertible");
 }
 
 } // namespace Envoy

--- a/test/common/common/phantom_test.cc
+++ b/test/common/common/phantom_test.cc
@@ -114,7 +114,7 @@ TEST(PhantomTest, TypeBehavior) {
     // TODO(snowp): Need C++17 for these, but would be nice to have.
     // static_assert(!std::is_invokable<decltype(base), decltype(inner)>::value,
     //   "cannot pass inner to parent func");
-    //static_assert(!std::is_invokable<decltype(baseRef), decltype(inner)>::value,
+    // static_assert(!std::is_invokable<decltype(baseRef), decltype(inner)>::value,
     //  "cannot pass inner to parent func");
   }
 

--- a/test/common/common/phantom_test.cc
+++ b/test/common/common/phantom_test.cc
@@ -111,10 +111,11 @@ TEST(PhantomTest, TypeBehavior) {
 
     const auto inner = PhantomVector::create();
 
-    static_assert(!std::__invokable<decltype(base), decltype(inner)>::value,
-                  "cannot pass inner to parent func");
-    static_assert(!std::__invokable<decltype(baseRef), decltype(inner)>::value,
-                  "cannot pass inner to parent func");
+    // TODO(snowp): Need C++17 for these, but would be nice to have.
+    // static_assert(!std::is_invokable<decltype(base), decltype(inner)>::value,
+    //   "cannot pass inner to parent func");
+    //static_assert(!std::is_invokable<decltype(baseRef), decltype(inner)>::value,
+    //  "cannot pass inner to parent func");
   }
 
   // Verify that default initialization works.

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -107,7 +107,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   updateHostSet(failover_host_set_, 1, 0);
 
-  auto priority_load = PriorityLoad({100u, 0u});
+  PriorityLoad priority_load({100u, 0u});
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -107,7 +107,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   updateHostSet(failover_host_set_, 1, 0);
 
-  auto priority_load = PriorityLoad::create({100u, 0u});
+  auto priority_load = PriorityLoad({100u, 0u});
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.
@@ -122,7 +122,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   EXPECT_EQ(0, lb_.percentageLoad(0));
   EXPECT_EQ(0, lb_.percentageLoad(1));
   EXPECT_EQ(100, lb_.percentageLoad(2));
-  priority_load = PriorityLoad::create({0u, 0u, 100u});
+  priority_load = PriorityLoad({0u, 0u, 100u});
   EXPECT_EQ(&tertiary_host_set_, &lb_.chooseHostSet(&context));
 
   // Now add a healthy host in P=0 and make sure it is immediately selected.
@@ -131,14 +131,14 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   host_set_.runCallbacks({}, {});
   EXPECT_EQ(100, lb_.percentageLoad(0));
   EXPECT_EQ(0, lb_.percentageLoad(2));
-  priority_load = PriorityLoad::create({100u, 0u, 0u});
+  priority_load = PriorityLoad({100u, 0u, 0u});
   EXPECT_EQ(&host_set_, &lb_.chooseHostSet(&context));
 
   // Remove the healthy host and ensure we fail back over to tertiary_host_set_
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   EXPECT_EQ(0, lb_.percentageLoad(0));
   EXPECT_EQ(100, lb_.percentageLoad(2));
-  priority_load = PriorityLoad::create({0u, 0u, 100u});
+  priority_load = PriorityLoad({0u, 0u, 100u});
   EXPECT_EQ(&tertiary_host_set_, &lb_.chooseHostSet(&context));
 }
 
@@ -146,7 +146,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
 TEST_P(LoadBalancerBaseTest, PrioritySelectionWithFilter) {
   NiceMock<Upstream::MockLoadBalancerContext> context;
 
-  PriorityLoad priority_load = PriorityLoad::create({0u, 100u});
+  PriorityLoad priority_load = PriorityLoad({0u, 100u});
   // return a filter that excludes priority 0
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillOnce(ReturnRef(priority_load));
 
@@ -614,9 +614,9 @@ TEST_P(RoundRobinLoadBalancerTest, HostSelectionWithFilter) {
   PriorityLoad priority_load;
 
   if (GetParam()) {
-    priority_load = PriorityLoad::create({100u, 0u});
+    priority_load = PriorityLoad({100u, 0u});
   } else {
-    priority_load = PriorityLoad::create({0u, 100u});
+    priority_load = PriorityLoad({0u, 100u});
   }
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   EXPECT_CALL(context, hostSelectionRetryCount()).WillRepeatedly(Return(2));

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -107,7 +107,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   updateHostSet(failover_host_set_, 1, 0);
 
-  auto priority_load = PriorityLoad{100u, 0u};
+  auto priority_load = PriorityLoad::create({100u, 0u});
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.
@@ -122,7 +122,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   EXPECT_EQ(0, lb_.percentageLoad(0));
   EXPECT_EQ(0, lb_.percentageLoad(1));
   EXPECT_EQ(100, lb_.percentageLoad(2));
-  priority_load = PriorityLoad{0u, 0u, 100u};
+  priority_load = PriorityLoad::create({0u, 0u, 100u});
   EXPECT_EQ(&tertiary_host_set_, &lb_.chooseHostSet(&context));
 
   // Now add a healthy host in P=0 and make sure it is immediately selected.
@@ -131,14 +131,14 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   host_set_.runCallbacks({}, {});
   EXPECT_EQ(100, lb_.percentageLoad(0));
   EXPECT_EQ(0, lb_.percentageLoad(2));
-  priority_load = PriorityLoad{100u, 0u, 0u};
+  priority_load = PriorityLoad::create({100u, 0u, 0u});
   EXPECT_EQ(&host_set_, &lb_.chooseHostSet(&context));
 
   // Remove the healthy host and ensure we fail back over to tertiary_host_set_
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   EXPECT_EQ(0, lb_.percentageLoad(0));
   EXPECT_EQ(100, lb_.percentageLoad(2));
-  priority_load = PriorityLoad{0u, 0u, 100u};
+  priority_load = PriorityLoad::create({0u, 0u, 100u});
   EXPECT_EQ(&tertiary_host_set_, &lb_.chooseHostSet(&context));
 }
 
@@ -146,7 +146,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
 TEST_P(LoadBalancerBaseTest, PrioritySelectionWithFilter) {
   NiceMock<Upstream::MockLoadBalancerContext> context;
 
-  PriorityLoad priority_load = PriorityLoad{0u, 100u};
+  PriorityLoad priority_load = PriorityLoad::create({0u, 100u});
   // return a filter that excludes priority 0
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillOnce(ReturnRef(priority_load));
 
@@ -614,9 +614,9 @@ TEST_P(RoundRobinLoadBalancerTest, HostSelectionWithFilter) {
   PriorityLoad priority_load;
 
   if (GetParam()) {
-    priority_load = PriorityLoad{100u, 0u};
+    priority_load = PriorityLoad::create({100u, 0u});
   } else {
-    priority_load = PriorityLoad{0u, 100u};
+    priority_load = PriorityLoad::create({0u, 100u});
   }
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   EXPECT_CALL(context, hostSelectionRetryCount()).WillRepeatedly(Return(2));

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -107,7 +107,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   updateHostSet(failover_host_set_, 1, 0);
 
-  PriorityLoad priority_load = {100, 0};
+  auto priority_load = PriorityLoad{100u, 0u};
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   // With both the primary and failover hosts unhealthy, we should select an
   // unhealthy primary host.
@@ -122,7 +122,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   EXPECT_EQ(0, lb_.percentageLoad(0));
   EXPECT_EQ(0, lb_.percentageLoad(1));
   EXPECT_EQ(100, lb_.percentageLoad(2));
-  priority_load = {0, 0, 100};
+  priority_load = PriorityLoad{0u, 0u, 100u};
   EXPECT_EQ(&tertiary_host_set_, &lb_.chooseHostSet(&context));
 
   // Now add a healthy host in P=0 and make sure it is immediately selected.
@@ -131,14 +131,14 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
   host_set_.runCallbacks({}, {});
   EXPECT_EQ(100, lb_.percentageLoad(0));
   EXPECT_EQ(0, lb_.percentageLoad(2));
-  priority_load = {100, 0, 0};
+  priority_load = PriorityLoad{100u, 0u, 0u};
   EXPECT_EQ(&host_set_, &lb_.chooseHostSet(&context));
 
   // Remove the healthy host and ensure we fail back over to tertiary_host_set_
   updateHostSet(host_set_, 1 /* num_hosts */, 0 /* num_healthy_hosts */);
   EXPECT_EQ(0, lb_.percentageLoad(0));
   EXPECT_EQ(100, lb_.percentageLoad(2));
-  priority_load = {0, 0, 100};
+  priority_load = PriorityLoad{0u, 0u, 100u};
   EXPECT_EQ(&tertiary_host_set_, &lb_.chooseHostSet(&context));
 }
 
@@ -146,7 +146,7 @@ TEST_P(LoadBalancerBaseTest, PrioritySelection) {
 TEST_P(LoadBalancerBaseTest, PrioritySelectionWithFilter) {
   NiceMock<Upstream::MockLoadBalancerContext> context;
 
-  PriorityLoad priority_load = {0, 100};
+  PriorityLoad priority_load = PriorityLoad{0u, 100u};
   // return a filter that excludes priority 0
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillOnce(ReturnRef(priority_load));
 
@@ -614,9 +614,9 @@ TEST_P(RoundRobinLoadBalancerTest, HostSelectionWithFilter) {
   PriorityLoad priority_load;
 
   if (GetParam()) {
-    priority_load = {100, 0};
+    priority_load = PriorityLoad{100u, 0u};
   } else {
-    priority_load = {0, 100};
+    priority_load = PriorityLoad{0u, 100u};
   }
   EXPECT_CALL(context, determinePriorityLoad(_, _)).WillRepeatedly(ReturnRef(priority_load));
   EXPECT_CALL(context, hostSelectionRetryCount()).WillRepeatedly(Return(2));

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -49,7 +49,7 @@ public:
 TEST_F(RetryPriorityTest, DefaultFrequency) {
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad::create({100u, 0u});
+  const auto original_priority_load = Upstream::PriorityLoad({100u, 0u});
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -63,7 +63,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
   ASSERT_EQ(original_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
-  const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 100u});
+  const auto expected_priority_load = Upstream::PriorityLoad({0u, 100u});
   // After attempting a host in P0, P1 should receive all the load.
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
@@ -80,7 +80,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
 TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad::create({0u, 0u, 0u});
+  const auto original_priority_load = Upstream::PriorityLoad({0u, 0u, 0u});
   addHosts(0, 10, 0);
   addHosts(1, 10, 0);
   addHosts(2, 10, 0);
@@ -100,7 +100,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 
   {
     // After attempting a host in P0, load should remain unchanged.
-    const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 0u, 0u});
+    const auto expected_priority_load = Upstream::PriorityLoad({0u, 0u, 0u});
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -111,7 +111,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad::create({42u, 28u, 30u});
+  const auto original_priority_load = Upstream::PriorityLoad({42u, 28u, 30u});
   addHosts(0, 10, 3);
   addHosts(1, 10, 2);
   addHosts(2, 10, 10);
@@ -131,14 +131,14 @@ TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
 
   {
     // After attempting a host in P0, load should be split between P1 and P2 since P1 is degraded.
-    const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 28u, 72u});
+    const auto expected_priority_load = Upstream::PriorityLoad({0u, 28u, 72u});
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
   }
 
   // After we've tried host2, everything should go to P2.
-  const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 0u, 100u});
+  const auto expected_priority_load = Upstream::PriorityLoad({0u, 0u, 100u});
   retry_priority_->onHostAttempted(host2);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -155,7 +155,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
   update_frequency_ = 2;
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad::create({100u, 0u});
+  const auto original_priority_load = Upstream::PriorityLoad({100u, 0u});
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -175,7 +175,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
   // After a second attempt, the prioity load should change.
-  const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 100u});
+  const auto expected_priority_load = Upstream::PriorityLoad({0u, 100u});
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -49,7 +49,7 @@ public:
 TEST_F(RetryPriorityTest, DefaultFrequency) {
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad({100u, 0u});
+  const Upstream::PriorityLoad original_priority_load({100u, 0u});
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -63,7 +63,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
   ASSERT_EQ(original_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
-  const auto expected_priority_load = Upstream::PriorityLoad({0u, 100u});
+  const Upstream::PriorityLoad expected_priority_load({0u, 100u});
   // After attempting a host in P0, P1 should receive all the load.
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
@@ -80,7 +80,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
 TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad({0u, 0u, 0u});
+  const Upstream::PriorityLoad original_priority_load({0u, 0u, 0u});
   addHosts(0, 10, 0);
   addHosts(1, 10, 0);
   addHosts(2, 10, 0);
@@ -100,7 +100,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 
   {
     // After attempting a host in P0, load should remain unchanged.
-    const auto expected_priority_load = Upstream::PriorityLoad({0u, 0u, 0u});
+    const Upstream::PriorityLoad expected_priority_load({0u, 0u, 0u});
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -111,7 +111,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad({42u, 28u, 30u});
+  const Upstream::PriorityLoad original_priority_load({42u, 28u, 30u});
   addHosts(0, 10, 3);
   addHosts(1, 10, 2);
   addHosts(2, 10, 10);
@@ -131,14 +131,14 @@ TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
 
   {
     // After attempting a host in P0, load should be split between P1 and P2 since P1 is degraded.
-    const auto expected_priority_load = Upstream::PriorityLoad({0u, 28u, 72u});
+    const Upstream::PriorityLoad expected_priority_load({0u, 28u, 72u});
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
   }
 
   // After we've tried host2, everything should go to P2.
-  const auto expected_priority_load = Upstream::PriorityLoad({0u, 0u, 100u});
+  const Upstream::PriorityLoad expected_priority_load({0u, 0u, 100u});
   retry_priority_->onHostAttempted(host2);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -155,7 +155,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
   update_frequency_ = 2;
   initialize();
 
-  const auto original_priority_load = Upstream::PriorityLoad({100u, 0u});
+  const Upstream::PriorityLoad original_priority_load({100u, 0u});
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -175,7 +175,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
   // After a second attempt, the prioity load should change.
-  const auto expected_priority_load = Upstream::PriorityLoad({0u, 100u});
+  const Upstream::PriorityLoad expected_priority_load({0u, 100u});
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -49,7 +49,7 @@ public:
 TEST_F(RetryPriorityTest, DefaultFrequency) {
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{100u, 0u};
+  const auto original_priority_load = Upstream::PriorityLoad::create({100u, 0u});
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -63,7 +63,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
   ASSERT_EQ(original_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
-  const Upstream::PriorityLoad expected_priority_load{0u, 100u};
+  const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 100u});
   // After attempting a host in P0, P1 should receive all the load.
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
@@ -80,7 +80,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
 TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{0u, 0u, 0u};
+  const auto original_priority_load = Upstream::PriorityLoad::create({0u, 0u, 0u});
   addHosts(0, 10, 0);
   addHosts(1, 10, 0);
   addHosts(2, 10, 0);
@@ -100,7 +100,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 
   {
     // After attempting a host in P0, load should remain unchanged.
-    const Upstream::PriorityLoad expected_priority_load{0u, 0u, 0u};
+    const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 0u, 0u});
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -111,7 +111,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{42u, 28u, 30u};
+  const auto original_priority_load = Upstream::PriorityLoad::create({42u, 28u, 30u});
   addHosts(0, 10, 3);
   addHosts(1, 10, 2);
   addHosts(2, 10, 10);
@@ -131,14 +131,14 @@ TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
 
   {
     // After attempting a host in P0, load should be split between P1 and P2 since P1 is degraded.
-    const Upstream::PriorityLoad expected_priority_load{0u, 28u, 72u};
+    const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 28u, 72u});
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
   }
 
   // After we've tried host2, everything should go to P2.
-  const Upstream::PriorityLoad expected_priority_load{0u, 0u, 100u};
+  const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 0u, 100u});
   retry_priority_->onHostAttempted(host2);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -155,7 +155,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
   update_frequency_ = 2;
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{100u, 0u};
+  const auto original_priority_load = Upstream::PriorityLoad::create({100u, 0u});
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -175,7 +175,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
   // After a second attempt, the prioity load should change.
-  const Upstream::PriorityLoad expected_priority_load{0u, 100u};
+  const auto expected_priority_load = Upstream::PriorityLoad::create({0u, 100u});
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -49,7 +49,7 @@ public:
 TEST_F(RetryPriorityTest, DefaultFrequency) {
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{100, 0};
+  const Upstream::PriorityLoad original_priority_load{100u, 0u};
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -63,7 +63,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
   ASSERT_EQ(original_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
-  const Upstream::PriorityLoad expected_priority_load{0, 100};
+  const Upstream::PriorityLoad expected_priority_load{0u, 100u};
   // After attempting a host in P0, P1 should receive all the load.
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
@@ -80,7 +80,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
 TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{0, 0, 0};
+  const Upstream::PriorityLoad original_priority_load{0u, 0u, 0u};
   addHosts(0, 10, 0);
   addHosts(1, 10, 0);
   addHosts(2, 10, 0);
@@ -100,7 +100,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 
   {
     // After attempting a host in P0, load should remain unchanged.
-    const Upstream::PriorityLoad expected_priority_load{0, 0, 0};
+    const Upstream::PriorityLoad expected_priority_load{0u, 0u, 0u};
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -111,7 +111,7 @@ TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
 TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{42, 28, 30};
+  const Upstream::PriorityLoad original_priority_load{42u, 28u, 30u};
   addHosts(0, 10, 3);
   addHosts(1, 10, 2);
   addHosts(2, 10, 10);
@@ -131,14 +131,14 @@ TEST_F(RetryPriorityTest, DefaultFrequencyDegradedPriorities) {
 
   {
     // After attempting a host in P0, load should be split between P1 and P2 since P1 is degraded.
-    const Upstream::PriorityLoad expected_priority_load{0, 28, 72};
+    const Upstream::PriorityLoad expected_priority_load{0u, 28u, 72u};
     retry_priority_->onHostAttempted(host1);
     ASSERT_EQ(expected_priority_load,
               retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
   }
 
   // After we've tried host2, everything should go to P2.
-  const Upstream::PriorityLoad expected_priority_load{0, 0, 100};
+  const Upstream::PriorityLoad expected_priority_load{0u, 0u, 100u};
   retry_priority_->onHostAttempted(host2);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
@@ -155,7 +155,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
   update_frequency_ = 2;
   initialize();
 
-  const Upstream::PriorityLoad original_priority_load{100, 0};
+  const Upstream::PriorityLoad original_priority_load{100u, 0u};
   addHosts(0, 2, 2);
   addHosts(1, 2, 2);
 
@@ -175,7 +175,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));
 
   // After a second attempt, the prioity load should change.
-  const Upstream::PriorityLoad expected_priority_load{0, 100};
+  const Upstream::PriorityLoad expected_priority_load{0u, 100u};
   retry_priority_->onHostAttempted(host1);
   ASSERT_EQ(expected_priority_load,
             retry_priority_->determinePriorityLoad(priority_set_, original_priority_load));

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -829,7 +829,7 @@ void HttpIntegrationTest::testGrpcRetry() {
 // The retry priority will always target P1, which would otherwise never be hit due to P0 being
 // healthy.
 void HttpIntegrationTest::testRetryPriority() {
-  const auto priority_load = Upstream::PriorityLoad::create({0u, 100u});
+  const auto priority_load = Upstream::PriorityLoad({0u, 100u});
   NiceMock<Upstream::MockRetryPriority> retry_priority(priority_load);
   Upstream::MockRetryPriorityFactory factory(retry_priority);
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -829,7 +829,7 @@ void HttpIntegrationTest::testGrpcRetry() {
 // The retry priority will always target P1, which would otherwise never be hit due to P0 being
 // healthy.
 void HttpIntegrationTest::testRetryPriority() {
-  const Upstream::PriorityLoad priority_load{0, 100};
+  const Upstream::PriorityLoad priority_load{0u, 100u};
   NiceMock<Upstream::MockRetryPriority> retry_priority(priority_load);
   Upstream::MockRetryPriorityFactory factory(retry_priority);
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -829,7 +829,7 @@ void HttpIntegrationTest::testGrpcRetry() {
 // The retry priority will always target P1, which would otherwise never be hit due to P0 being
 // healthy.
 void HttpIntegrationTest::testRetryPriority() {
-  const Upstream::PriorityLoad priority_load{0u, 100u};
+  const auto priority_load = Upstream::PriorityLoad::create({0u, 100u});
   NiceMock<Upstream::MockRetryPriority> retry_priority(priority_load);
   Upstream::MockRetryPriorityFactory factory(retry_priority);
 


### PR DESCRIPTION
This adds a `Phantom` template that can be used to add additional type information to
other types, which allows for stronger typing between types represented by the same
type. Applies this to `PriorityLoad` and `PriorityAvailability`, both of which are represented
by a `std::vector<uint32_t>`.

*Risk Level*: Low
*Testing*: UTs for `Phantom`, everything else is compile time
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #5570 