### PR TITLE
main: remove log messages when exceptions are thrown

### DIFF
--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -27,8 +27,10 @@ int main(int argc, char** argv) {
   } catch (const Envoy::NoServingException& e) {
     return EXIT_SUCCESS;
   } catch (const Envoy::MalformedArgvException& e) {
+    std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
   } catch (const Envoy::EnvoyException& e) {
+    std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -142,7 +142,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   auto check_numeric_arg = [](bool is_error, uint64_t value, absl::string_view pattern) {
     if (is_error) {
       const std::string message = fmt::format(std::string(pattern), value);
-      std::cerr << message << std::endl;
       throw MalformedArgvException(message);
     }
   };
@@ -177,7 +176,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     mode_ = Server::Mode::InitOnly;
   } else {
     const std::string message = fmt::format("error: unknown mode '{}'", mode.getValue());
-    std::cerr << message << std::endl;
     throw MalformedArgvException(message);
   }
 
@@ -188,7 +186,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   } else {
     const std::string message =
         fmt::format("error: unknown IP address version '{}'", local_address_ip_version.getValue());
-    std::cerr << message << std::endl;
     throw MalformedArgvException(message);
   }
 
@@ -254,10 +251,7 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
 
 uint32_t OptionsImpl::count() const { return count_; }
 
-void OptionsImpl::logError(const std::string& error) const {
-  std::cerr << error << std::endl;
-  throw MalformedArgvException(error);
-}
+void OptionsImpl::logError(const std::string& error) const { throw MalformedArgvException(error); }
 
 Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   Server::CommandLineOptionsPtr command_line_options =

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -179,7 +179,6 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
   if (config_path.empty() && config_yaml.empty()) {
     const std::string message =
         "At least one of --config-path and --config-yaml should be non-empty";
-    std::cerr << message << std::endl;
     throw EnvoyException(message);
   }
 

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -22,3 +22,31 @@ expect_fail_with_error "PARSE ERROR: Argument: --bogus-flag" --bogus-flag
 start_test Launching envoy without --config-path or --config-yaml fails.
 expect_fail_with_error \
   "At least one of --config-path and --config-yaml should be non-empty"
+
+start_test Launching envoy with a bogus command line flag.
+expect_fail_with_error "PARSE ERROR: Argument: --bogus-flag" --bogus-flag
+
+start_test Launching envoy without --config-path or --config-yaml fails.
+expect_fail_with_error \
+  "At least one of --config-path and --config-yaml should be non-empty"
+
+start_test Launching envoy with unknown IP address.
+expect_fail_with_error "error: unknown IP address version" --local-address-ip-version foo
+
+start_test Launching envoy with unknown mode.
+expect_fail_with_error "error: unknown mode" --mode foo
+
+start_test Launching envoy with bogus component log level.
+expect_fail_with_error "error: component log level not correctly specified" --component-log-level upstream:foo:bar
+
+start_test Launching envoy with invalid log level.
+expect_fail_with_error "error: invalid log level specified" --component-log-level upstream:foo
+
+start_test Launching envoy with invalid component.
+expect_fail_with_error "error: invalid component specified" --component-log-level foo:debug
+
+start_test Launching envoy with max-obj-name-len value less than minimum value of 60.
+expect_fail_with_error "error: the 'max-obj-name-len' value specified .* is less than the minimum" --max-obj-name-len 1
+
+start_test Launching envoy with max-stats value more than maximum value of 100M.
+expect_fail_with_error "error: the 'max-stats' value specified .* is more than the maximum value" --max-stats 1000000000

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -23,13 +23,6 @@ start_test Launching envoy without --config-path or --config-yaml fails.
 expect_fail_with_error \
   "At least one of --config-path and --config-yaml should be non-empty"
 
-start_test Launching envoy with a bogus command line flag.
-expect_fail_with_error "PARSE ERROR: Argument: --bogus-flag" --bogus-flag
-
-start_test Launching envoy without --config-path or --config-yaml fails.
-expect_fail_with_error \
-  "At least one of --config-path and --config-yaml should be non-empty"
-
 start_test Launching envoy with unknown IP address.
 expect_fail_with_error "error: unknown IP address version" --local-address-ip-version foo
 


### PR DESCRIPTION
Signed-off-by: rishabhkumar296 <kris.kr296@gmail.com>
Fixes #5453 
*Description*: removes std::cerr log messages when exceptions are thrown
*Risk Level*: Low
*Testing*: Unit test
*Docs Changes*: N/A
*Release Notes*: N/A