### PR TITLE
config: removing deprecated --v2-config-only from the command line

### DIFF
--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -9,4 +9,4 @@ EXPOSE 10000
 
 COPY ci/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]
+CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -9,4 +9,4 @@ EXPOSE 10000
 
 COPY ci/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]
+CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -17,4 +17,4 @@ EXPOSE 10000
 
 COPY ci/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]
+CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.10.0 (pending)
 ================
 * config: added support of using google.protobuf.Any in opaque configs for extensions.
+* config: removed deprecated --v2-config-only from command line config.
 * access log: added a new flag for upstream retry count exceeded.
 * admin: the admin server can now be accessed via HTTP/2 (prior knowledge).
 * buffer: fix vulnerabilities when allocation fails
@@ -492,7 +493,7 @@ Version history
   endpoint. Histograms are not currently output.
 * admin: added ``version_info`` to the :ref:`/clusters admin endpoint<operations_admin_interface_clusters>`.
 * config: the :ref:`v2 API <config_overview_v2>` is now considered production ready.
-* config: added :option:`--v2-config-only` CLI flag.
+* config: added --v2-config-only CLI flag.
 * cors: added :ref:`CORS filter <config_http_filters_cors>`.
 * health check: added :ref:`x-envoy-immediate-health-check-fail
   <config_http_filters_router_x-envoy-immediate-health-check-fail>` header support.

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -31,11 +31,6 @@ following are the command line options that Envoy supports.
 
       ./envoy -c bootstrap.yaml --config-yaml "node: {id: 'node1'}"
 
-.. option:: --v2-config-only
-
-  *(deprecated)* This flag used to allow opting into only using a
-  :ref:`v2 bootstrap configuration file <config_overview_v2_bootstrap>`. This is now set by default.
-
 .. option:: --mode <string>
 
   *(optional)* One of the operating modes for Envoy:

--- a/examples/lua/Dockerfile-proxy
+++ b/examples/lua/Dockerfile-proxy
@@ -1,2 +1,2 @@
 FROM envoyproxy/envoy:latest
-CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy --v2-config-only
+CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy

--- a/examples/redis/Dockerfile-proxy
+++ b/examples/redis/Dockerfile-proxy
@@ -1,2 +1,2 @@
 FROM envoyproxy/envoy:latest
-CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy --v2-config-only
+CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -63,9 +63,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
       "", "config-yaml", "Inline YAML configuration, merges with the contents of --config-path",
       false, "", "string", cmd);
 
-  // Deprecated and unused.
-  TCLAP::SwitchArg v2_config_only("", "v2-config-only", "deprecated", cmd, true);
-
   TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
                                         "allow unknown fields in the configuration", cmd, false);
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -66,7 +66,7 @@ TEST_F(OptionsImplTest, All) {
       "--service-cluster cluster --service-node node --service-zone zone "
       "--file-flush-interval-msec 9000 "
       "--drain-time-s 60 --log-format [%v] --parent-shutdown-time-s 90 --log-path /foo/bar "
-      "--v2-config-only --disable-hot-restart");
+      "--disable-hot-restart");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());
@@ -198,12 +198,11 @@ TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
   Server::CommandLineOptionsPtr command_line_options = options->toCommandLineOptions();
   // Failure of this condition indicates that the server_info proto is not in sync with the options.
   // If an option is added/removed, please update server_info proto as well to keep it in sync.
-  // Currently the following 4 options are not defined in proto, hence the count differs by 4.
-  // 1. v2-config-only - being deprecated.
+  // Currently the following 3 options are not defined in proto, hence the count differs by 3.
   // 2. version        - default TCLAP argument.
   // 3. help           - default TCLAP argument.
   // 4. ignore_rest    - default TCLAP argument.
-  EXPECT_EQ(options->count() - 4, command_line_options->GetDescriptor()->field_count());
+  EXPECT_EQ(options->count() - 3, command_line_options->GetDescriptor()->field_count());
 }
 
 TEST_F(OptionsImplTest, BadCliOption) {


### PR DESCRIPTION
*Risk Level*: Low (though may force folks to update their config :-(  (
*Testing*: n/a
*Docs Changes*: cleaned up deprecated docs
*Release Notes*: inline