### PR TITLE
Set do_ci.sh build_setup_args=-nofetch for bazel.clang_tidy subcommand.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -5,7 +5,7 @@
 set -e
 
 build_setup_args=""
-if [[ "$1" == "fix_format" || "$1" == "check_format" || "$1" == "check_repositories" || "$1" == "check_spelling" || "$1" == "fix_spelling" ]]; then
+if [[ "$1" == "fix_format" || "$1" == "check_format" || "$1" == "check_repositories" || "$1" == "check_spelling" || "$1" == "fix_spelling" || "$1" == "bazel.clang_tidy" ]]; then
   build_setup_args="-nofetch"
 fi
 


### PR DESCRIPTION
*Description*:
Add bazel.clang_tidy to the set of do_ci.sh subcommands for which build_setup_args=-nofetch.

This appears to be necessary in order to run './ci/do_ci.sh bazel.clang_tidy'
locally. Without this change, there is the following failure:

  ```
$ ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.clang_tidy'
  No remote cache bucket is set, skipping setup remote cache.
  ENVOY_SRCDIR=/source
  fatal: Not a git repository (or any parent up to mount point /build)
  Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

With this change, the above succeeds.

Signed-off-by: Michael Warres <mpw@google.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Risk Level*: low
*Testing*: manual runs in local workspace
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
