### PR TITLE
Fix next(), print(), and raw_input() to work in Python 2 and 3

### DIFF
--- a/api/tools/capture2pcap.py
+++ b/api/tools/capture2pcap.py
@@ -17,6 +17,7 @@ issue.
 TODO(htuch):
 - Figure out IPv6 PCAP issue above, or file a bug once the root cause is clear.
 """
+from __future__ import print_function
 
 import datetime
 import socket
@@ -81,6 +82,6 @@ def Capture2Pcap(capture_path, pcap_path):
 
 if __name__ == '__main__':
   if len(sys.argv) != 3:
-    print 'Usage: %s <capture .pb/.pb_text> <pcap path>' % sys.argv[0]
+    print('Usage: %s <capture .pb/.pb_text> <pcap path>' % sys.argv[0])
     sys.exit(1)
   Capture2Pcap(sys.argv[1], sys.argv[2])

--- a/api/tools/capture2pcap_test.py
+++ b/api/tools/capture2pcap_test.py
@@ -1,4 +1,5 @@
 """Tests for capture2pcap."""
+from __future__ import print_function
 
 import os
 import subprocess as sp
@@ -20,7 +21,7 @@ if __name__ == '__main__':
   with open(expected_path, 'r') as f:
     expected_output = f.read()
   if actual_output != expected_output:
-    print 'Mismatch'
-    print 'Expected: %s' % expected_output
-    print 'Actual: %s' % actual_output
+    print('Mismatch')
+    print('Expected: %s' % expected_output)
+    print('Actual: %s' % actual_output)
     sys.exit(1)

--- a/api/tools/generate_listeners.py
+++ b/api/tools/generate_listeners.py
@@ -47,7 +47,7 @@ def GenerateListeners(listeners_pb_path, output_pb_path, output_json_path, fragm
 
   for filter_chain in listener.filter_chains:
     for f in filter_chain.filters:
-      f.config.CopyFrom(ProtoToStruct(ParseProto(fragments.next(), f.name)))
+      f.config.CopyFrom(ProtoToStruct(ParseProto(next(fragments), f.name)))
 
   with open(output_pb_path, 'w') as f:
     f.write(str(listener))

--- a/bazel/git_repository_info.py
+++ b/bazel/git_repository_info.py
@@ -2,6 +2,8 @@
 
 # Quick-and-dirty Python to fetch git repository info in bazel/repository_locations.bzl.
 
+from __future__ import print_function
+
 import imp
 import sys
 import subprocess as sp
@@ -10,11 +12,11 @@ repolocs = imp.load_source('replocs', 'bazel/repository_locations.bzl')
 
 if __name__ == '__main__':
   if len(sys.argv) != 2:
-    print 'Usage: %s <repository name>' % sys.argv[0]
+    print('Usage: %s <repository name>' % sys.argv[0])
     sys.exit(1)
   repo = sys.argv[1]
   if repo not in repolocs.REPOSITORY_LOCATIONS:
-    print 'Unknown repository: %s' % repo
+    print('Unknown repository: %s' % repo)
     sys.exit(1)
   repoloc = repolocs.REPOSITORY_LOCATIONS[repo]
-  print '%s %s' % (repoloc['remote'], repoloc['commit'])
+  print('%s %s' % (repoloc['remote'], repoloc['commit']))

--- a/test/integration/capture_fuzz_gen.py
+++ b/test/integration/capture_fuzz_gen.py
@@ -5,6 +5,7 @@ test.integration.CaptureFuzzTestCase.
 
 Usage: capture_fuzz_gen.py <listener capture> [<cluster capture>]
 """
+from __future__ import print_function
 
 import functools
 import sys
@@ -82,11 +83,11 @@ def CaptureFuzzGen(listener_path, cluster_path=None):
       text_format.Merge(f.read(), cluster_trace)
     cluster_events = Coalesce(cluster_trace)
 
-  print TestCaseGen(listener_events, cluster_events)
+  print(TestCaseGen(listener_events, cluster_events))
 
 
 if __name__ == '__main__':
   if len(sys.argv) < 2 or len(sys.argv) > 3:
-    print 'Usage: %s <listener capture> [<cluster capture>]' % sys.argv[0]
+    print('Usage: %s <listener capture> [<cluster capture>]' % sys.argv[0])
     sys.exit(1)
   CaptureFuzzGen(*sys.argv[1:])

--- a/tools/build_profile.py
+++ b/tools/build_profile.py
@@ -3,6 +3,8 @@
 # This tool take the foo.dep.log output from a build recipe run under recipe_wrapper.sh on stdin and
 # produces a profile of command execution time on the stdout.
 
+from __future__ import print_function
+
 import re
 import sys
 
@@ -15,7 +17,7 @@ def PrintProfile(f):
     if sr:
       timestamp, cmd = sr.groups()
       if prev_cmd:
-        print '%.2f %s' % (float(timestamp) - float(prev_timestamp), prev_cmd)
+        print('%.2f %s' % (float(timestamp) - float(prev_timestamp), prev_cmd))
       prev_timestamp, prev_cmd = timestamp, cmd
 
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import common
 import fileinput
@@ -531,7 +533,7 @@ def checkFormatVisitor(arg, dir_name, names):
 def checkErrorMessages(error_messages):
   if error_messages:
     for e in error_messages:
-      print "ERROR: %s" % e
+      print("ERROR: %s" % e)
     return True
   return False
 
@@ -591,8 +593,8 @@ if __name__ == "__main__":
     error_messages = sum((r.get() for r in results), [])
 
   if checkErrorMessages(error_messages):
-    print "ERROR: check format failed. run 'tools/check_format.py fix'"
+    print("ERROR: check format failed. run 'tools/check_format.py fix'")
     sys.exit(1)
 
   if operation_type == "check":
-    print "PASS"
+    print("PASS")

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -5,6 +5,8 @@
 # docker. Normally this is run via check_format_test.sh, which
 # executes it in under docker.
 
+from __future__ import print_function
+
 import argparse
 import os
 import shutil
@@ -69,12 +71,12 @@ def fixFileHelper(filename):
 def fixFileExpectingSuccess(file):
   command, infile, outfile, status, stdout = fixFileHelper(file)
   if status != 0:
-    print "FAILED:"
+    print("FAILED:")
     emitStdoutAsError(stdout)
     return 1
   status, stdout = runCommand('diff ' + outfile + ' ' + infile + '.gold')
   if status != 0:
-    print "FAILED:"
+    print("FAILED:")
     emitStdoutAsError(stdout)
     return 1
   return 0

--- a/tools/deprecate_version/deprecate_version.py
+++ b/tools/deprecate_version/deprecate_version.py
@@ -23,6 +23,8 @@
 # - Later PRs can clobber earlier changed to DEPRECATED.md, meaning we miss
 #   issues.
 
+from __future__ import print_function
+
 from collections import defaultdict
 import os
 import re
@@ -30,6 +32,11 @@ import sys
 
 import github
 from git import Repo
+
+try:
+  input = raw_input  # Python 2
+except NameError:
+  pass  # Python 3
 
 # Tag issues created with these labels.
 LABELS = ['deprecation', 'tech debt']
@@ -62,10 +69,7 @@ def GetHistory():
 
 def GetConfirmation():
   """Obtain stdin confirmation to create issues in GH."""
-  inp = raw_input('Creates issues? [yN] ')
-  if inp == 'y':
-    return True
-  return False
+  return input('Creates issues? [yN] ').strip().lower() in ('y', 'yes')
 
 
 def CreateIssues(deprecate_for_version, deprecate_by_version, access_token, commits):
@@ -104,41 +108,41 @@ def CreateIssues(deprecate_for_version, deprecate_by_version, access_token, comm
                                                                             pr)
     body = ('#%d (%s) introduced a deprecation notice for v%s. This issue '
             'tracks source code cleanup.') % (pr, pr_info.title, deprecate_for_version)
-    print title
-    print body
-    print '  >> Assigning to %s' % pr_info.user.login
+    print(title)
+    print(body)
+    print('  >> Assigning to %s' % pr_info.user.login)
     # TODO(htuch): Figure out how to do this without legacy and faster.
     exists = repo.legacy_search_issues('open', '"%s"' % title) or repo.legacy_search_issues(
         'closed', '"%s"' % title)
     if exists:
-      print '  >> Issue already exists, not posting!'
+      print('  >> Issue already exists, not posting!')
     else:
       issues.append((title, body, pr_info.user))
   if GetConfirmation():
-    print 'Creating issues...'
+    print('Creating issues...')
     for title, body, user in issues:
       try:
         repo.create_issue(
             title, body=body, assignees=[user.login], milestone=milestone, labels=labels)
       except github.GithubException as e:
-        print('GithubException while creating issue. This is typically because'
-              ' a user is not a member of envoyproxy org. Check that %s is in '
-              'the org.') % user.login
+        print(('GithubException while creating issue. This is typically because'
+               ' a user is not a member of envoyproxy org. Check that %s is in '
+               'the org.') % user.login)
         raise
 
 
 if __name__ == '__main__':
   if len(sys.argv) != 3:
-    print 'Usage: %s <deprecate for version> <deprecate by version>' % sys.argv[0]
+    print('Usage: %s <deprecate for version> <deprecate by version>' % sys.argv[0])
     sys.exit(1)
   access_token = os.getenv('GH_ACCESS_TOKEN')
   if not access_token:
-    print 'Missing GH_ACCESS_TOKEN'
+    print('Missing GH_ACCESS_TOKEN')
     sys.exit(1)
   deprecate_for_version = sys.argv[1]
   deprecate_by_version = sys.argv[2]
   history = GetHistory()
   if deprecate_for_version not in history:
-    print 'Unknown version: %s (valid versions: %s)' % (deprecate_for_version, history.keys())
+    print('Unknown version: %s (valid versions: %s)' % (deprecate_for_version, history.keys()))
   CreateIssues(deprecate_for_version, deprecate_by_version, access_token,
                history[deprecate_for_version])

--- a/tools/envoy_build_fixer.py
+++ b/tools/envoy_build_fixer.py
@@ -2,6 +2,8 @@
 
 # Enforce license headers on Envoy BUILD files (maybe more later?)
 
+from __future__ import print_function
+
 import sys
 
 LICENSE_STRING = 'licenses(["notice"])  # Apache 2\n'
@@ -63,5 +65,5 @@ if __name__ == '__main__':
     with open(sys.argv[2], 'w') as f:
       f.write(reorderd_source)
     sys.exit(0)
-  print 'Usage: %s <source file path> [<destination file path>]' % sys.argv[0]
+  print('Usage: %s <source file path> [<destination file path>]' % sys.argv[0])
   sys.exit(1)

--- a/tools/gen_gdb_wrapper_script.py
+++ b/tools/gen_gdb_wrapper_script.py
@@ -5,6 +5,8 @@
 # in the bazel test environment. This is a workaround for the fact that --run_under does not attach
 # stdin.
 
+from __future__ import print_function
+
 import os
 import pipes
 import string
@@ -33,5 +35,5 @@ if __name__ == '__main__':
             gdb=gdb,
             test_args=' '.join(pipes.quote(arg) for arg in test_args)))
   # To make bazel consider the test a failure we exit non-zero.
-  print 'Test was not run, instead a gdb wrapper script was produced in %s' % generated_path
+  print('Test was not run, instead a gdb wrapper script was produced in %s' % generated_path)
   sys.exit(1)

--- a/tools/header_order.py
+++ b/tools/header_order.py
@@ -12,6 +12,8 @@
 # enough to handle block splitting and correctly detecting the main header subject to the Envoy
 # canonical paths.
 
+from __future__ import print_function
+
 import common
 import re
 import sys
@@ -29,7 +31,7 @@ def ReorderHeaders(path):
   # Collect all the lines prior to the first #include in before_includes_lines.
   try:
     while True:
-      line = all_lines.next()
+      line = next(all_lines)
       if line.startswith('#include'):
         includes_lines.append(line)
         break
@@ -40,7 +42,7 @@ def ReorderHeaders(path):
   # Collect all the #include and whitespace lines in includes_lines.
   try:
     while True:
-      line = all_lines.next()
+      line = next(all_lines)
       if not line:
         continue
       if not line.startswith('#include'):
@@ -111,5 +113,5 @@ if __name__ == '__main__':
     with open(path, 'w') as f:
       f.write(reorderd_source)
     sys.exit(0)
-  print 'Usage: %s [--rewrite] <source file path>' % sys.argv[0]
+  print('Usage: %s [--rewrite] <source file path>' % sys.argv[0])
   sys.exit(1)


### PR DESCRIPTION
Related to #4552

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Resolves syntax errors and name errors that have the potential to halt the runtime.
*Risk Level*: Minimal
*Testing*: http://flake8.pycqa.org
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
