### PR TITLE
Upgrade gabime/spdlog dependency to 1.3.0

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -53,9 +53,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/fmtlib/fmt/releases/download/5.3.0/fmt-5.3.0.zip"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "867a4b7cedf9805e6f76d3ca41889679054f7e5a3b67722fe6d0eae41852a767",
-        strip_prefix = "spdlog-1.2.1",
-        urls = ["https://github.com/gabime/spdlog/archive/v1.2.1.tar.gz"],
+        sha256 = "78786c641ca278388107e30f1f0fa0307e7e98e1c5279c3d29f71a143f9176b6",
+        strip_prefix = "spdlog-1.3.0",
+        urls = ["https://github.com/gabime/spdlog/archive/v1.3.0.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         sha256 = "8a60ba6242d67a58320e9e16630d80448ef6d5284fda5fb3eff927b63c8b04a2",

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -57,7 +57,7 @@ void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
   absl::ReleasableMutexLock lock(&format_mutex_);
   if (!formatter_) {
     lock.Release();
-    sink_->log(absl::string_view(msg.raw.data(), msg.raw.size()));
+    sink_->log(absl::string_view(msg.payload.data(), msg.payload.size()));
     return;
   }
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -77,7 +77,9 @@ public:
     off = spdlog::level::off
   } levels;
 
-  std::string levelString() const { return spdlog::level::level_names[logger_->level()]; }
+  spdlog::string_view_t levelString() const {
+    return spdlog::level::level_string_views[logger_->level()];
+  }
   std::string name() const { return logger_->name(); }
   void setLevel(spdlog::level::level_enum level) { logger_->set_level(level); }
   spdlog::level::level_enum level() const { return logger_->level(); }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -243,8 +243,8 @@ bool AdminImpl::changeLogLevel(const Http::Utility::QueryParams& params) {
 
   // First see if the level is valid.
   size_t level_to_use = std::numeric_limits<size_t>::max();
-  for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
-    if (level == spdlog::level::level_names[i]) {
+  for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
+    if (level == spdlog::level::level_string_views[i]) {
       level_to_use = i;
       break;
     }
@@ -538,8 +538,8 @@ Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
     response.add("usage: /logging?<name>=<level> (change single level)\n");
     response.add("usage: /logging?level=<level> (change all levels)\n");
     response.add("levels: ");
-    for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
-      response.add(fmt::format("{} ", spdlog::level::level_names[i]));
+    for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
+      response.add(fmt::format("{} ", spdlog::level::level_string_views[i]));
     }
 
     response.add("\n");

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -37,11 +37,11 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                          spdlog::level::level_enum default_log_level)
     : signal_handling_enabled_(true) {
   std::string log_levels_string = "Log levels: ";
-  for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
-    log_levels_string += fmt::format("[{}]", spdlog::level::level_names[i]);
+  for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
+    log_levels_string += fmt::format("[{}]", spdlog::level::level_string_views[i]);
   }
   log_levels_string +=
-      fmt::format("\nDefault is [{}]", spdlog::level::level_names[default_log_level]);
+      fmt::format("\nDefault is [{}]", spdlog::level::level_string_views[default_log_level]);
 
   const std::string component_log_level_string =
       "Comma separated list of component log levels. For example upstream:debug,config:trace";
@@ -75,9 +75,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                                                         "The local "
                                                         "IP address version (v4 or v6).",
                                                         false, "v4", "string", cmd);
-  TCLAP::ValueArg<std::string> log_level("l", "log-level", log_levels_string, false,
-                                         spdlog::level::level_names[default_log_level], "string",
-                                         cmd);
+  TCLAP::ValueArg<std::string> log_level(
+      "l", "log-level", log_levels_string, false,
+      spdlog::level::level_string_views[default_log_level].data(), "string", cmd);
   TCLAP::ValueArg<std::string> component_log_level(
       "", "component-log-level", component_log_level_string, false, "", "string", cmd);
   TCLAP::ValueArg<std::string> log_format("", "log-format", log_format_string, false,
@@ -158,8 +158,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   mutex_tracing_enabled_ = enable_mutex_tracing.getValue();
 
   log_level_ = default_log_level;
-  for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
-    if (log_level.getValue() == spdlog::level::level_names[i]) {
+  for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
+    if (log_level.getValue() == spdlog::level::level_string_views[i]) {
       log_level_ = static_cast<spdlog::level::level_enum>(i);
     }
   }
@@ -231,8 +231,8 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
     std::string log_name = log_name_level[0];
     std::string log_level = log_name_level[1];
     size_t level_to_use = std::numeric_limits<size_t>::max();
-    for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
-      if (log_level == spdlog::level::level_names[i]) {
+    for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
+      if (log_level == spdlog::level::level_string_views[i]) {
         level_to_use = i;
         break;
       }
@@ -263,7 +263,8 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_allow_unknown_fields(allow_unknown_fields_);
   command_line_options->set_admin_address_path(adminAddressPath());
   command_line_options->set_component_log_level(component_log_level_str_);
-  command_line_options->set_log_level(spdlog::level::to_c_str(logLevel()));
+  command_line_options->set_log_level(spdlog::level::to_string_view(logLevel()).data(),
+                                      spdlog::level::to_string_view(logLevel()).size());
   command_line_options->set_log_format(logFormat());
   command_line_options->set_log_path(logPath());
   command_line_options->set_service_cluster(serviceClusterName());

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -374,7 +374,7 @@ TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
 
   const std::string logger_name = "logger";
-  spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err);
+  spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err, "error");
   Logger::Registry::getSink()->log(log_msg);
 }
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -96,7 +96,7 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_EQ(spdlog::level::trace, Logger::Registry::getLog(Logger::Id::assert).level());
 
-  const char* level_name = spdlog::level::level_names[default_log_level_];
+  spdlog::string_view_t level_name = spdlog::level::level_string_views[default_log_level_];
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST",
                                                 fmt::format("/logging?level={}", level_name), "",
                                                 downstreamProtocol(), version_);

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -153,7 +153,7 @@ TEST_F(OptionsImplTest, SetAll) {
   EXPECT_EQ(envoy::admin::v2alpha::CommandLineOptions::v6,
             command_line_options->local_address_ip_version());
   EXPECT_EQ(options->drainTime().count(), command_line_options->drain_time().seconds());
-  EXPECT_EQ(spdlog::level::to_c_str(options->logLevel()), command_line_options->log_level());
+  EXPECT_EQ(spdlog::level::to_string_view(options->logLevel()), command_line_options->log_level());
   EXPECT_EQ(options->logFormat(), command_line_options->log_format());
   EXPECT_EQ(options->logPath(), command_line_options->log_path());
   EXPECT_EQ(options->parentShutdownTime().count(),


### PR DESCRIPTION
Signed-off-by: rishabhkumar296 <kris.kr296@gmail.com>

Fixes: #5585 

*Description*: Upgrade spdlog dependency from 1.2.1 to 1.3.0
*Risk Level*: Low
*Testing*: Unit tests
*Docs Changes*: N/A
*Release Notes*: N/A