### PR TITLE
CircleCI: Add a build_image_python3 build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,21 @@ jobs:
        - checkout
        - setup_remote_docker
        - run: ci/build_container/docker_push.sh
+   build_image_python3:
+     docker:
+       - image: circleci/python:3.7
+         environment:
+           # See comment in do_circle_ci.sh for why we do this.
+           NUM_CPUS: 8
+     resource_class: xlarge
+     steps:
+       - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
+       - checkout
+       - run: pip install --user flake8  # Flag all Python syntax errors or undefined names
+       - run: python -m flake8 . --select=E901,E999,F821,F822,F823 --show-source --statistics
+       - setup_remote_docker
+       # Comment out the next line for now so "ci/circleci: release" does not fail
+       # - run: ci/build_container/docker_push.sh
    docs:
      executor: ubuntu-build
      steps:
@@ -173,6 +188,7 @@ workflows:
       - format
       - clang_tidy
       - build_image
+      - build_image_python3
       - docs:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,8 +145,8 @@ jobs:
        - checkout
        - run: pip install --user flake8  # Flag all Python syntax errors or undefined names
        - run: python -m flake8 . --select=E901,E999,F821,F822,F823 --show-source --statistics
-       - setup_remote_docker
-       # Comment out the next line for now so "ci/circleci: release" does not fail
+       # Comment out the next two lines for now so "ci/circleci: release" does not fail
+       # - setup_remote_docker
        # - run: ci/build_container/docker_push.sh
    docs:
      executor: ubuntu-build

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# flake8: noqa
+
 import contextlib
 import os
 import shlex


### PR DESCRIPTION
Related to #4552 
~Should not be merged until _after_ #5599 fixes __ci/circleci: build_image_python3__ failures.~

Add a ___build_image_python3___ build step which is based on __circleci/python:3.7__ and adds a [flake8](http://flake8.pycqa.org) test to ensure that there are no Python 3 syntax errors or undefined names.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: CircleCI: Add a build_image_python3 build step
*Risk Level*: Minmal
*Testing*: Adds a CircleCI build step with flake8 tests
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
