### PR TITLE
Googletest namechange

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -146,9 +146,11 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://files.pythonhosted.org/packages/f9/e7/4f80d582578f8489226370762d2cf6bc9381175d1929eba1754e03f70708/twitter.common.finagle-thrift-0.3.9.tar.gz"],
     ),
     com_google_googletest = dict(
-        sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
-        strip_prefix = "googletest-release-1.8.1",
-        urls = ["https://github.com/google/googletest/archive/release-1.8.1.tar.gz"],
+        sha256 = "a4cb4b0c3ebb191b798594aca674ad47eee255dcb4c26885cf7f49777703484f",
+        strip_prefix = "googletest-eb9225ce361affe561592e0912320b9db84985d0",
+        # TODO(akonradi): Switch this back to a released version later than 1.8.1 once there is
+        # one available.
+        urls = ["https://github.com/google/googletest/archive/eb9225ce361affe561592e0912320b9db84985d0.tar.gz"],
     ),
     com_google_protobuf = dict(
         sha256 = "46f1da3a6a6db66dd240cf95a5553198f7c6e98e6ac942fceb8a1cf03291d96e",

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -302,7 +302,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_);
 }
 
-INSTANTIATE_TEST_CASE_P(SubscriptionFactoryTestApiConfigSource,
+INSTANTIATE_TEST_SUITE_P(SubscriptionFactoryTestApiConfigSource,
                         SubscriptionFactoryTestApiConfigSource,
                         ::testing::Values(envoy::api::v2::core::ApiConfigSource::REST,
                                           envoy::api::v2::core::ApiConfigSource::GRPC));

--- a/test/common/config/subscription_impl_test.cc
+++ b/test/common/config/subscription_impl_test.cc
@@ -57,7 +57,7 @@ public:
   std::unique_ptr<SubscriptionTestHarness> test_harness_;
 };
 
-INSTANTIATE_TEST_CASE_P(SubscriptionImplTest, SubscriptionImplTest,
+INSTANTIATE_TEST_SUITE_P(SubscriptionImplTest, SubscriptionImplTest,
                         testing::ValuesIn({SubscriptionType::Grpc, SubscriptionType::Http,
                                            SubscriptionType::Filesystem}));
 

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -43,7 +43,7 @@ protected:
 
 class FileEventImplActivateTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 
-INSTANTIATE_TEST_CASE_P(IpVersions, FileEventImplActivateTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, FileEventImplActivateTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -12,7 +12,7 @@ namespace Grpc {
 namespace {
 
 // Parameterize the loopback test server socket address and gRPC client type.
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, GrpcClientIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, GrpcClientIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS,
                         GrpcClientIntegrationParamTest::protocolTestParamsToString);
 
@@ -348,7 +348,7 @@ TEST_P(GrpcClientIntegrationTest, CancelRequest) {
 }
 
 // Parameterize the loopback test server socket address and gRPC client type.
-INSTANTIATE_TEST_CASE_P(SslIpVersionsClientType, GrpcSslClientIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(SslIpVersionsClientType, GrpcSslClientIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS,
                         GrpcClientIntegrationParamTest::protocolTestParamsToString);
 
@@ -411,7 +411,7 @@ public:
 };
 
 // Parameterize the loopback test server socket address and gRPC client type.
-INSTANTIATE_TEST_CASE_P(SslIpVersionsClientType, GrpcAccessTokenClientIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(SslIpVersionsClientType, GrpcAccessTokenClientIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS,
                         GrpcClientIntegrationParamTest::protocolTestParamsToString);
 

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -424,7 +424,7 @@ TEST_P(CodecNetworkTest, SendHeadersAndCloseUnderReadDisable) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, CodecNetworkTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, CodecNetworkTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -803,12 +803,12 @@ TEST_P(Http2CodecImplStreamLimitTest, MaxClientStreams) {
                      ::testing::Values(Http2Settings::MIN_INITIAL_CONNECTION_WINDOW_SIZE))
 
 // Deferred reset tests use only small windows so that we can test certain conditions.
-INSTANTIATE_TEST_CASE_P(Http2CodecImplDeferredResetTest, Http2CodecImplDeferredResetTest,
+INSTANTIATE_TEST_SUITE_P(Http2CodecImplDeferredResetTest, Http2CodecImplDeferredResetTest,
                         ::testing::Combine(HTTP2SETTINGS_SMALL_WINDOW_COMBINE,
                                            HTTP2SETTINGS_SMALL_WINDOW_COMBINE));
 
 // Flow control tests only use only small windows so that we can test certain conditions.
-INSTANTIATE_TEST_CASE_P(Http2CodecImplFlowControlTest, Http2CodecImplFlowControlTest,
+INSTANTIATE_TEST_SUITE_P(Http2CodecImplFlowControlTest, Http2CodecImplFlowControlTest,
                         ::testing::Combine(HTTP2SETTINGS_SMALL_WINDOW_COMBINE,
                                            HTTP2SETTINGS_SMALL_WINDOW_COMBINE));
 
@@ -821,11 +821,11 @@ INSTANTIATE_TEST_CASE_P(Http2CodecImplFlowControlTest, Http2CodecImplFlowControl
 
 // Stream limit test only uses the default values because not all combinations of
 // edge settings allow for the number of streams needed by the test.
-INSTANTIATE_TEST_CASE_P(Http2CodecImplStreamLimitTest, Http2CodecImplStreamLimitTest,
+INSTANTIATE_TEST_SUITE_P(Http2CodecImplStreamLimitTest, Http2CodecImplStreamLimitTest,
                         ::testing::Combine(HTTP2SETTINGS_DEFAULT_COMBINE,
                                            HTTP2SETTINGS_DEFAULT_COMBINE));
 
-INSTANTIATE_TEST_CASE_P(Http2CodecImplTestDefaultSettings, Http2CodecImplTest,
+INSTANTIATE_TEST_SUITE_P(Http2CodecImplTestDefaultSettings, Http2CodecImplTest,
                         ::testing::Combine(HTTP2SETTINGS_DEFAULT_COMBINE,
                                            HTTP2SETTINGS_DEFAULT_COMBINE));
 
@@ -839,7 +839,7 @@ INSTANTIATE_TEST_CASE_P(Http2CodecImplTestDefaultSettings, Http2CodecImplTest,
       ::testing::Values(Http2Settings::MIN_INITIAL_CONNECTION_WINDOW_SIZE,                         \
                         Http2Settings::MAX_INITIAL_CONNECTION_WINDOW_SIZE))
 
-INSTANTIATE_TEST_CASE_P(Http2CodecImplTestEdgeSettings, Http2CodecImplTest,
+INSTANTIATE_TEST_SUITE_P(Http2CodecImplTestEdgeSettings, Http2CodecImplTest,
                         ::testing::Combine(HTTP2SETTINGS_EDGE_COMBINE, HTTP2SETTINGS_EDGE_COMBINE));
 
 TEST(Http2CodecUtility, reconstituteCrumbledCookies) {

--- a/test/common/json/config_schemas_test.cc
+++ b/test/common/json/config_schemas_test.cc
@@ -62,6 +62,6 @@ TEST_P(ConfigSchemasTest, CheckValidationExpectation) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(Default, ConfigSchemasTest, testing::ValuesIn(generateTestInputs()));
+INSTANTIATE_TEST_SUITE_P(Default, ConfigSchemasTest, testing::ValuesIn(generateTestInputs()));
 } // namespace Json
 } // namespace Envoy

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -104,7 +104,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
 } // namespace
 
 class AddressImplSocketTest : public testing::TestWithParam<IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, AddressImplSocketTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AddressImplSocketTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -451,7 +451,7 @@ struct TestCase test_cases[] = {
     {TestCase::Ipv6, "01:023::00ef", 2},    {TestCase::Ipv6, "01:023::00ed", 1},
     {TestCase::Pipe, "/path/to/pipe/1", 0}, {TestCase::Pipe, "/path/to/pipe/2", 0}};
 
-INSTANTIATE_TEST_CASE_P(AddressCrossProduct, MixedAddressTest,
+INSTANTIATE_TEST_SUITE_P(AddressCrossProduct, MixedAddressTest,
                         ::testing::Combine(::testing::ValuesIn(test_cases),
                                            ::testing::ValuesIn(test_cases)));
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -72,7 +72,7 @@ TEST(ConnectionImplUtility, updateBufferStats) {
 }
 
 class ConnectionImplDeathTest : public testing::TestWithParam<Address::IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, ConnectionImplDeathTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectionImplDeathTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -221,7 +221,7 @@ protected:
   Socket::OptionsSharedPtr socket_options_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ConnectionImplTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectionImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -1618,7 +1618,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ReadBufferLimitTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ReadBufferLimitTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -1642,7 +1642,7 @@ protected:
   Event::SimulatedTimeSystem time_system_;
   Event::DispatcherImpl dispatcher_;
 };
-INSTANTIATE_TEST_CASE_P(IpVersions, TcpClientConnectionImplTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, TcpClientConnectionImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -457,7 +457,7 @@ static bool hasAddress(const std::list<Address::InstanceConstSharedPtr>& results
 }
 
 // Parameterize the DNS test server socket address.
-INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, DnsImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -761,7 +761,7 @@ protected:
 };
 
 // Parameterize the DNS test server socket address.
-INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplZeroTimeoutTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, DnsImplZeroTimeoutTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -112,11 +112,11 @@ protected:
 using ListenSocketImplTestTcp = ListenSocketImplTest<Network::Address::SocketType::Stream>;
 using ListenSocketImplTestUdp = ListenSocketImplTest<Network::Address::SocketType::Datagram>;
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ListenSocketImplTestTcp,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ListenSocketImplTestTcp,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ListenSocketImplTestUdp,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ListenSocketImplTestUdp,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -56,7 +56,7 @@ static void errorCallbackTest(Address::IpVersion version) {
 }
 
 class ListenerImplDeathTest : public testing::TestWithParam<Address::IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplDeathTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ListenerImplDeathTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 TEST_P(ListenerImplDeathTest, ErrorCallback) {
@@ -88,7 +88,7 @@ protected:
   DangerousDeprecatedTestTime test_time_;
   Event::DispatcherImpl dispatcher_;
 };
-INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ListenerImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -156,7 +156,7 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
 
 class NetworkUtilityGetLocalAddress : public testing::TestWithParam<Address::IpVersion> {};
 
-INSTANTIATE_TEST_CASE_P(IpVersions, NetworkUtilityGetLocalAddress,
+INSTANTIATE_TEST_SUITE_P(IpVersions, NetworkUtilityGetLocalAddress,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -347,7 +347,7 @@ TEST_P(TimestampUtilTest, SystemClockToTimestampTest) {
   EXPECT_EQ(time_original, time_reflected);
 }
 
-INSTANTIATE_TEST_CASE_P(TimestampUtilTestAcrossRange, TimestampUtilTest,
+INSTANTIATE_TEST_SUITE_P(TimestampUtilTestAcrossRange, TimestampUtilTest,
                         ::testing::Values(-1000 * 60 * 60 * 24 * 7, // week
                                           -1000 * 60 * 60 * 24,     // day
                                           -1000 * 60 * 60,          // hour

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -65,7 +65,7 @@ TEST(UUID, sanityCheckOfUniqueness) {
 
 class DiskBackedLoaderImplTest : public testing::Test {
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     TestEnvironment::exec(
         {TestEnvironment::runfilesPath("test/common/runtime/filesystem_setup.sh")});
   }

--- a/test/common/ssl/ssl_certs_test.h
+++ b/test/common/ssl/ssl_certs_test.h
@@ -8,7 +8,7 @@
 namespace Envoy {
 class SslCertsTest : public testing::Test {
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     TestEnvironment::exec({TestEnvironment::runfilesPath("test/common/ssl/gen_unittest_certs.sh")});
   }
 

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -582,7 +582,7 @@ protected:
   std::unique_ptr<Event::DispatcherImpl> dispatcher_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SslSocketTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SslSocketTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -3736,7 +3736,7 @@ public:
   Network::Address::InstanceConstSharedPtr source_address_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SslReadBufferLimitTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SslReadBufferLimitTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -3382,7 +3382,7 @@ class BadResponseGrpcHealthCheckerImplTest
     : public GrpcHealthCheckerImplTestBase,
       public testing::TestWithParam<GrpcHealthCheckerImplTest::ResponseSpec> {};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     BadResponse, BadResponseGrpcHealthCheckerImplTest,
     testing::ValuesIn(std::vector<GrpcHealthCheckerImplTest::ResponseSpec>{
         // Non-200 response.

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -99,7 +99,7 @@ public:
   TestLb lb_{priority_set_, stats_, runtime_, random_, common_config_};
 };
 
-INSTANTIATE_TEST_CASE_P(PrimaryOrFailover, LoadBalancerBaseTest, ::testing::Values(true));
+INSTANTIATE_TEST_SUITE_P(PrimaryOrFailover, LoadBalancerBaseTest, ::testing::Values(true));
 
 // Basic test of host set selection.
 TEST_P(LoadBalancerBaseTest, PrioritySelection) {
@@ -418,7 +418,7 @@ TEST_P(FailoverTest, ExtendPrioritiesWithLocalPrioritySet) {
   EXPECT_EQ(tertiary_host_set_.hosts_[0], lb_->chooseHost(nullptr));
 }
 
-INSTANTIATE_TEST_CASE_P(PrimaryOrFailover, FailoverTest, ::testing::Values(true));
+INSTANTIATE_TEST_SUITE_P(PrimaryOrFailover, FailoverTest, ::testing::Values(true));
 
 TEST_P(RoundRobinLoadBalancerTest, NoHosts) {
   init(false);
@@ -974,7 +974,7 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNoLocalLocality) {
   EXPECT_EQ(1U, stats_.lb_local_cluster_not_ok_.value());
 }
 
-INSTANTIATE_TEST_CASE_P(PrimaryOrFailover, RoundRobinLoadBalancerTest,
+INSTANTIATE_TEST_SUITE_P(PrimaryOrFailover, RoundRobinLoadBalancerTest,
                         ::testing::Values(true, false));
 
 class LeastRequestLoadBalancerTest : public LoadBalancerTestBase {
@@ -1153,7 +1153,7 @@ TEST_P(LeastRequestLoadBalancerTest, WeightImbalanceCallbacks) {
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_.chooseHost(nullptr));
 }
 
-INSTANTIATE_TEST_CASE_P(PrimaryOrFailover, LeastRequestLoadBalancerTest,
+INSTANTIATE_TEST_SUITE_P(PrimaryOrFailover, LeastRequestLoadBalancerTest,
                         ::testing::Values(true, false));
 
 class RandomLoadBalancerTest : public LoadBalancerTestBase {
@@ -1174,7 +1174,7 @@ TEST_P(RandomLoadBalancerTest, Normal) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_.chooseHost(nullptr));
 }
 
-INSTANTIATE_TEST_CASE_P(PrimaryOrFailover, RandomLoadBalancerTest, ::testing::Values(true, false));
+INSTANTIATE_TEST_SUITE_P(PrimaryOrFailover, RandomLoadBalancerTest, ::testing::Values(true, false));
 
 TEST(LoadBalancerSubsetInfoImplTest, DefaultConfigIsDiabled) {
   auto subset_info =

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -242,7 +242,7 @@ std::vector<LogicalDnsConfigTuple> generateLogicalDnsParams() {
 class LogicalDnsParamTest : public LogicalDnsClusterTest,
                             public testing::WithParamInterface<LogicalDnsConfigTuple> {};
 
-INSTANTIATE_TEST_CASE_P(DnsParam, LogicalDnsParamTest,
+INSTANTIATE_TEST_SUITE_P(DnsParam, LogicalDnsParamTest,
                         testing::ValuesIn(generateLogicalDnsParams()));
 
 // Validate that if the DNS resolves immediately, during the LogicalDnsCluster

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -63,9 +63,9 @@ public:
 // For tests which don't need to be run in both primary and failover modes.
 typedef RingHashLoadBalancerTest RingHashFailoverTest;
 
-INSTANTIATE_TEST_CASE_P(RingHashPrimaryOrFailover, RingHashLoadBalancerTest,
+INSTANTIATE_TEST_SUITE_P(RingHashPrimaryOrFailover, RingHashLoadBalancerTest,
                         ::testing::Values(true, false));
-INSTANTIATE_TEST_CASE_P(RingHashPrimaryOrFailover, RingHashFailoverTest, ::testing::Values(true));
+INSTANTIATE_TEST_SUITE_P(RingHashPrimaryOrFailover, RingHashFailoverTest, ::testing::Values(true));
 
 TEST_P(RingHashLoadBalancerTest, NoHost) {
   init();

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -1541,7 +1541,7 @@ TEST_P(SubsetLoadBalancerTest, GaugesUpdatedOnDestroy) {
   EXPECT_EQ(1U, stats_.lb_subsets_removed_.value());
 }
 
-INSTANTIATE_TEST_CASE_P(UpdateOrderings, SubsetLoadBalancerTest,
+INSTANTIATE_TEST_SUITE_P(UpdateOrderings, SubsetLoadBalancerTest,
                         testing::ValuesIn({REMOVES_FIRST, SIMULTANEOUS}));
 
 } // namespace SubsetLoadBalancerTest

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -117,7 +117,7 @@ std::vector<StrictDnsConfigTuple> generateStrictDnsParams() {
 
 class StrictDnsParamTest : public testing::TestWithParam<StrictDnsConfigTuple> {};
 
-INSTANTIATE_TEST_CASE_P(DnsParam, StrictDnsParamTest, testing::ValuesIn(generateStrictDnsParams()));
+INSTANTIATE_TEST_SUITE_P(DnsParam, StrictDnsParamTest, testing::ValuesIn(generateStrictDnsParams()));
 
 TEST_P(StrictDnsParamTest, ImmediateResolve) {
   Stats::IsolatedStoreImpl stats;

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -154,7 +154,7 @@ TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
 #endif
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, MainCommonTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, MainCommonTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -378,7 +378,7 @@ TEST_P(MainCommonTest, ConstructDestructLogger) {
   Logger::Registry::getSink()->log(log_msg);
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AdminRequestTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AdminRequestTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
@@ -103,7 +103,7 @@ public:
   FakeStreamPtr access_log_request_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsCientType, AccessLogIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsCientType, AccessLogIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Test a basic full access logging flow.

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -5,7 +5,7 @@ namespace {
 
 typedef HttpProtocolIntegrationTest BufferIntegrationTest;
 
-INSTANTIATE_TEST_CASE_P(Protocols, BufferIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, BufferIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/extensions/filters/http/cors/cors_filter_integration_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_integration_test.cc
@@ -108,7 +108,7 @@ protected:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, CorsFilterIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, CorsFilterIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -114,7 +114,7 @@ envoy::config::filter::http::ext_authz::v2alpha::ExtAuthz GetFilterConfig() {
   return proto_config;
 }
 
-INSTANTIATE_TEST_CASE_P(ParameterizedFilterConfig, HttpFilterTestParam,
+INSTANTIATE_TEST_SUITE_P(ParameterizedFilterConfig, HttpFilterTestParam,
                         Values(&GetFilterConfig<true, true>, &GetFilterConfig<false, false>,
                                &GetFilterConfig<true, false>, &GetFilterConfig<false, true>));
 

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -45,7 +45,7 @@ config:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ReverseBridgeIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ReverseBridgeIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -154,7 +154,7 @@ protected:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, GrpcJsonTranscoderIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, GrpcJsonTranscoderIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -718,7 +718,7 @@ TEST_P(GrpcJsonTranscoderFilterPrintTest, PrintOptions) {
   EXPECT_EQ(GetParam().expected_response_, response_json);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GrpcJsonTranscoderFilterPrintOptions, GrpcJsonTranscoderFilterPrintTest,
     ::testing::Values(
         GrpcJsonTranscoderFilterPrintTestParam{

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -344,7 +344,7 @@ TEST_P(GrpcWebFilterTest, Unary) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(Unary, GrpcWebFilterTest,
+INSTANTIATE_TEST_SUITE_P(Unary, GrpcWebFilterTest,
                         Combine(Values(Http::Headers::get().ContentTypeValues.GrpcWeb,
                                        Http::Headers::get().ContentTypeValues.GrpcWebProto,
                                        Http::Headers::get().ContentTypeValues.GrpcWebText,

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -86,7 +86,7 @@ public:
   Decompressor::ZlibDecompressorImpl decompressor_{};
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, GzipIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, GzipIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -33,7 +33,7 @@ std::string getFilterConfig(bool use_local_jwks) {
 
 typedef HttpProtocolIntegrationTest LocalJwksIntegrationTest;
 
-INSTANTIATE_TEST_CASE_P(Protocols, LocalJwksIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, LocalJwksIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
@@ -185,7 +185,7 @@ public:
   FakeStreamPtr jwks_request_{};
 };
 
-INSTANTIATE_TEST_CASE_P(Protocols, RemoteJwksIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, RemoteJwksIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -92,7 +92,7 @@ public:
   FakeStreamPtr lua_request_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, LuaIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, LuaIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -19,7 +19,7 @@ config:
 
 typedef HttpProtocolIntegrationTest RBACIntegrationTest;
 
-INSTANTIATE_TEST_CASE_P(Protocols, RBACIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, RBACIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/extensions/filters/http/squash/squash_filter_integration_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_integration_test.cc
@@ -119,7 +119,7 @@ const std::string SquashFilterIntegrationTest::SQUASH_CREATE_DEFAULT =
     "\"image\":\"debug\",\"node\":\"debug-node\"},"
     "\"status\":{\"state\":\"none\"}}";
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SquashFilterIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SquashFilterIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -166,7 +166,7 @@ public:
 };
 
 // Parameterize the listener socket address version.
-INSTANTIATE_TEST_CASE_P(IpVersions, ProxyProtocolTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyProtocolTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -974,7 +974,7 @@ public:
 };
 
 // Parameterize the listener socket address version.
-INSTANTIATE_TEST_CASE_P(IpVersions, WildcardProxyProtocolTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, WildcardProxyProtocolTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/network/client_ssl_auth/config_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/config_test.cc
@@ -19,7 +19,7 @@ namespace ClientSslAuth {
 
 class IpWhiteListConfigTest : public ::testing::TestWithParam<std::string> {};
 
-INSTANTIATE_TEST_CASE_P(IpList, IpWhiteListConfigTest,
+INSTANTIATE_TEST_SUITE_P(IpList, IpWhiteListConfigTest,
                         ::testing::Values(R"EOF(["192.168.3.0/24"])EOF",
                                           R"EOF(["2001:abcd::/64"])EOF"));
 

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -21,7 +21,7 @@ public:
   RoleBasedAccessControlNetworkFilterIntegrationTest()
       : BaseIntegrationTest(GetParam(), realTime(), rbac_config) {}
 
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     rbac_config = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -59,7 +59,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, RoleBasedAccessControlNetworkFilterIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, RoleBasedAccessControlNetworkFilterIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -209,10 +209,10 @@ TEST_P(RedisSingleServerRequestTest, NoUpstream) {
   EXPECT_EQ(nullptr, handle_);
 };
 
-INSTANTIATE_TEST_CASE_P(RedisSingleServerRequestTest, RedisSingleServerRequestTest,
+INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestTest, RedisSingleServerRequestTest,
                         testing::ValuesIn(SupportedCommands::simpleCommands()));
 
-INSTANTIATE_TEST_CASE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
+INSTANTIATE_TEST_SUITE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
                         RedisSingleServerRequestTest, testing::Values("INCR", "inCrBY"));
 
 TEST_F(RedisSingleServerRequestTest, PingSuccess) {
@@ -715,7 +715,7 @@ TEST_P(RedisSplitKeysSumResultHandlerTest, NoUpstreamHostForAll) {
   EXPECT_EQ(1UL, store_.counter("redis.foo.command." + GetParam() + ".error").value());
 };
 
-INSTANTIATE_TEST_CASE_P(RedisSplitKeysSumResultHandlerTest, RedisSplitKeysSumResultHandlerTest,
+INSTANTIATE_TEST_SUITE_P(RedisSplitKeysSumResultHandlerTest, RedisSplitKeysSumResultHandlerTest,
                         testing::ValuesIn(SupportedCommands::hashMultipleSumResultCommands()));
 
 } // namespace CommandSplitter

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -14,7 +14,7 @@ namespace TcpProxy {
 
 class RouteIpListConfigTest : public ::testing::TestWithParam<std::string> {};
 
-INSTANTIATE_TEST_CASE_P(IpList, RouteIpListConfigTest,
+INSTANTIATE_TEST_SUITE_P(IpList, RouteIpListConfigTest,
                         ::testing::Values(R"EOF("destination_ip_list": [
                                                   "192.168.1.1/32",
                                                   "192.168.1.0/24"

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -1032,7 +1032,7 @@ TEST_P(CompactProtocolFieldTypeTest, ConvertsToFieldType) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(CompactFieldTypes, CompactProtocolFieldTypeTest,
+INSTANTIATE_TEST_SUITE_P(CompactFieldTypes, CompactProtocolFieldTypeTest,
                         Values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
 
 TEST_F(CompactProtocolTest, WriteMessageBegin) {

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -74,7 +74,7 @@ class ThriftFilterTransportConfigTest
       public testing::TestWithParam<
           envoy::config::filter::network::thrift_proxy::v2alpha1::TransportType> {};
 
-INSTANTIATE_TEST_CASE_P(TransportTypes, ThriftFilterTransportConfigTest,
+INSTANTIATE_TEST_SUITE_P(TransportTypes, ThriftFilterTransportConfigTest,
                         testing::ValuesIn(getTransportTypes()));
 
 class ThriftFilterProtocolConfigTest
@@ -82,7 +82,7 @@ class ThriftFilterProtocolConfigTest
       public testing::TestWithParam<
           envoy::config::filter::network::thrift_proxy::v2alpha1::ProtocolType> {};
 
-INSTANTIATE_TEST_CASE_P(ProtocolTypes, ThriftFilterProtocolConfigTest,
+INSTANTIATE_TEST_SUITE_P(ProtocolTypes, ThriftFilterProtocolConfigTest,
                         testing::ValuesIn(getProtocolTypes()));
 
 TEST_F(ThriftFilterConfigTest, ValidateFail) {

--- a/test/extensions/filters/network/thrift_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/decoder_test.cc
@@ -196,7 +196,7 @@ static std::string protoStateParamToString(const TestParamInfo<ProtocolState>& p
   return ProtocolStateNameValues::name(params.param);
 }
 
-INSTANTIATE_TEST_CASE_P(NonValueProtocolStates, DecoderStateMachineNonValueTest,
+INSTANTIATE_TEST_SUITE_P(NonValueProtocolStates, DecoderStateMachineNonValueTest,
                         Values(ProtocolState::MessageBegin, ProtocolState::MessageEnd,
                                ProtocolState::StructBegin, ProtocolState::StructEnd,
                                ProtocolState::FieldBegin, ProtocolState::FieldEnd,
@@ -210,7 +210,7 @@ class DecoderStateMachineTest : public DecoderStateMachineTestBase, public testi
 class DecoderStateMachineValueTest : public DecoderStateMachineTestBase,
                                      public TestWithParam<FieldType> {};
 
-INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, DecoderStateMachineValueTest,
+INSTANTIATE_TEST_SUITE_P(PrimitiveFieldTypes, DecoderStateMachineValueTest,
                         Values(FieldType::Bool, FieldType::Byte, FieldType::Double, FieldType::I16,
                                FieldType::I32, FieldType::I64, FieldType::String),
                         fieldTypeParamToString);
@@ -227,7 +227,7 @@ static std::string nestedFieldTypesParamToString(
                      fieldTypeToString(inner_type), fieldTypeToString(value_type));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     NestedTypes, DecoderStateMachineNestingTest,
     Combine(Values(FieldType::Struct, FieldType::List, FieldType::Map, FieldType::Set),
             Values(FieldType::Struct, FieldType::List, FieldType::Map, FieldType::Set),

--- a/test/extensions/filters/network/thrift_proxy/integration.h
+++ b/test/extensions/filters/network/thrift_proxy/integration.h
@@ -60,7 +60,7 @@ public:
                        Buffer::Instance& response_buffer);
 
 protected:
-  // Tests should use a static SetUpTestCase method to initialize this field with a suitable
+  // Tests should use a static SetUpTestSuite method to initialize this field with a suitable
   // configuration.
   static std::string thrift_config_;
 

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -165,7 +165,7 @@ paramToString(const TestParamInfo<std::tuple<TransportType, ProtocolType, bool>>
   return fmt::format("{}{}", transport_name, protocol_name);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TransportAndProtocol, ThriftConnManagerIntegrationTest,
     Combine(Values(TransportType::Framed, TransportType::Unframed, TransportType::Header),
             Values(ProtocolType::Binary, ProtocolType::Compact), Values(false, true)),
@@ -364,7 +364,7 @@ TEST_P(ThriftConnManagerIntegrationTest, OnewayEarlyClosePartialRequest) {
 
 class ThriftTwitterConnManagerIntegrationTest : public ThriftConnManagerIntegrationTest {};
 
-INSTANTIATE_TEST_CASE_P(FramedTwitter, ThriftTwitterConnManagerIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(FramedTwitter, ThriftTwitterConnManagerIntegrationTest,
                         Combine(Values(TransportType::Framed), Values(ProtocolType::Twitter),
                                 Values(false, true)),
                         paramToString);

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -20,7 +20,7 @@ class ThriftConnManagerIntegrationTest
     : public BaseThriftIntegrationTest,
       public TestWithParam<std::tuple<TransportType, ProtocolType, bool>> {
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     thrift_config_ = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -337,7 +337,7 @@ class ThriftRouterFieldTypeTest : public ThriftRouterTestBase, public TestWithPa
 public:
 };
 
-INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftRouterFieldTypeTest,
+INSTANTIATE_TEST_SUITE_P(PrimitiveFieldTypes, ThriftRouterFieldTypeTest,
                         Values(FieldType::Bool, FieldType::Byte, FieldType::I16, FieldType::I32,
                                FieldType::I64, FieldType::Double, FieldType::String),
                         fieldTypeParamToString);
@@ -346,7 +346,7 @@ class ThriftRouterContainerTest : public ThriftRouterTestBase, public TestWithPa
 public:
 };
 
-INSTANTIATE_TEST_CASE_P(ContainerFieldTypes, ThriftRouterContainerTest,
+INSTANTIATE_TEST_SUITE_P(ContainerFieldTypes, ThriftRouterContainerTest,
                         Values(FieldType::Map, FieldType::List, FieldType::Set),
                         fieldTypeParamToString);
 

--- a/test/extensions/filters/network/thrift_proxy/thrift_object_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/thrift_object_impl_test.cc
@@ -165,7 +165,7 @@ TEST_F(ThriftObjectImplTest, ParseEmptyStruct) {
 class ThriftObjectImplValueTest : public ThriftObjectImplTestBase,
                                   public TestWithParam<FieldType> {};
 
-INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftObjectImplValueTest,
+INSTANTIATE_TEST_SUITE_P(PrimitiveFieldTypes, ThriftObjectImplValueTest,
                         Values(FieldType::Bool, FieldType::Byte, FieldType::Double, FieldType::I16,
                                FieldType::I32, FieldType::I64, FieldType::String),
                         fieldTypeParamToString);

--- a/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
@@ -22,7 +22,7 @@ class ThriftTranslationIntegrationTest
     : public BaseThriftIntegrationTest,
       public TestWithParam<std::tuple<TransportType, ProtocolType, TransportType, ProtocolType>> {
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     thrift_config_ = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:

--- a/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
@@ -108,7 +108,7 @@ static std::string paramToString(
                      protocolNameForTest(upstream_protocol));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TransportsAndProtocols, ThriftTranslationIntegrationTest,
     Combine(Values(TransportType::Framed, TransportType::Unframed, TransportType::Header),
             Values(ProtocolType::Binary, ProtocolType::Compact),

--- a/test/extensions/grpc_credentials/file_based_metadata/file_based_metadata_grpc_credentials_test.cc
+++ b/test/extensions/grpc_credentials/file_based_metadata/file_based_metadata_grpc_credentials_test.cc
@@ -77,7 +77,7 @@ secret_data:
 };
 
 // Parameterize the loopback test server socket address and gRPC client type.
-INSTANTIATE_TEST_CASE_P(SslIpVersionsClientType, GrpcFileBasedMetadataClientIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(SslIpVersionsClientType, GrpcFileBasedMetadataClientIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Validate that a simple request-reply unary RPC works with FileBasedMetadata auth.

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -29,7 +29,7 @@ public:
 };
 
 class UdpStatsdSinkTest : public testing::TestWithParam<Network::Address::IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, UdpStatsdSinkTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -73,7 +73,7 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
 }
 
 class UdpStatsdSinkWithTagsTest : public testing::TestWithParam<Network::Address::IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkWithTagsTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, UdpStatsdSinkWithTagsTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/stats_sinks/dog_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/dog_statsd/config_test.cc
@@ -27,7 +27,7 @@ namespace StatSinks {
 namespace DogStatsd {
 
 class DogStatsdConfigLoopbackTest : public testing::TestWithParam<Network::Address::IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, DogStatsdConfigLoopbackTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, DogStatsdConfigLoopbackTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -129,7 +129,7 @@ public:
   FakeStreamPtr metrics_service_request_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, MetricsServiceIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, MetricsServiceIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Test a basic metric service flow.

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -48,7 +48,7 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
 
 class StatsConfigParameterizedTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 
-INSTANTIATE_TEST_CASE_P(IpVersions, StatsConfigParameterizedTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, StatsConfigParameterizedTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -164,7 +164,7 @@ TEST(StatsConfigTest, TcpSinkCustomPrefix) {
 }
 
 class StatsConfigLoopbackTest : public testing::TestWithParam<Network::Address::IpVersion> {};
-INSTANTIATE_TEST_CASE_P(IpVersions, StatsConfigLoopbackTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, StatsConfigLoopbackTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -140,7 +140,7 @@ public:
                                 /* client_connect_handshaker */ true) {}
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AltsIntegrationTestValidPeer,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AltsIntegrationTestValidPeer,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -161,7 +161,7 @@ public:
                                 /* client_connect_handshaker */ true) {}
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AltsIntegrationTestEmptyPeer,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AltsIntegrationTestEmptyPeer,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -182,7 +182,7 @@ public:
                                 /* client_connect_handshaker */ true) {}
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AltsIntegrationTestClientInvalidPeer,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AltsIntegrationTestClientInvalidPeer,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -202,7 +202,7 @@ public:
                                 /* client_connect_handshaker */ true) {}
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AltsIntegrationTestServerInvalidPeer,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AltsIntegrationTestServerInvalidPeer,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -230,7 +230,7 @@ public:
                                 /* client_connect_handshaker */ false) {}
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AltsIntegrationTestClientWrongHandshaker,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AltsIntegrationTestClientWrongHandshaker,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -37,7 +37,7 @@ TEST_P(FuzzerCorpusTest, RunOneCorpusFile) {
   LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t*>(buf.c_str()), buf.size());
 }
 
-INSTANTIATE_TEST_CASE_P(CorpusExamples, FuzzerCorpusTest, testing::ValuesIn(test_corpus_));
+INSTANTIATE_TEST_SUITE_P(CorpusExamples, FuzzerCorpusTest, testing::ValuesIn(test_corpus_));
 
 } // namespace
 } // namespace Envoy

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -328,7 +328,7 @@ public:
   Ssl::ContextManagerImpl context_manager_{timeSystem()};
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, AdsIntegrationTest, GRPC_CLIENT_INTEGRATION_PARAMS);
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, AdsIntegrationTest, GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Validate basic config delivery and upgrade.
 TEST_P(AdsIntegrationTest, Basic) {
@@ -598,7 +598,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, AdsFailIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, AdsFailIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Validate that we don't crash on failed ADS stream.
@@ -650,7 +650,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, AdsConfigIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, AdsConfigIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // This is s regression validating that we don't crash on EDS static Cluster that uses ADS.

--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -168,7 +168,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, CdsIntegrationTest, GRPC_CLIENT_INTEGRATION_PARAMS);
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, CdsIntegrationTest, GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // 1) Envoy starts up with no static clusters (other than the CDS-over-gRPC server).
 // 2) Envoy is told of a cluster via CDS.

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -42,7 +42,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, EchoIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, EchoIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -13,7 +13,7 @@ public:
   EchoIntegrationTest() : BaseIntegrationTest(GetParam(), realTime(), echo_config) {}
 
   // Called once by the gtest framework before any EchoIntegrationTests are run.
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     echo_config = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -58,7 +58,7 @@ public:
   EdsHelper eds_helper_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, EdsIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, EdsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 // Validate that health status updates are consumed from EDS.

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -229,7 +229,7 @@ public:
   envoy::service::discovery::v2::HealthCheckSpecifier server_health_check_specifier_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, HdsIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, HdsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -419,7 +419,7 @@ protected:
   FakeStreamPtr eds_stream_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsSuppressEnvoyHeaders, HeaderIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsSuppressEnvoyHeaders, HeaderIntegrationTest,
                         testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                                          testing::Bool()),
                         ipSuppressEnvoyHeadersTestParamsToString);

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -18,7 +18,7 @@ using ::testing::MatchesRegex;
 
 namespace Envoy {
 
-INSTANTIATE_TEST_CASE_P(IpVersions, Http2IntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, Http2IntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -501,11 +501,11 @@ void Http2RingHashIntegrationTest::createUpstreams() {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, Http2RingHashIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, Http2RingHashIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
-INSTANTIATE_TEST_CASE_P(IpVersions, Http2MetadataIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, Http2MetadataIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -12,7 +12,7 @@
 
 namespace Envoy {
 
-INSTANTIATE_TEST_CASE_P(IpVersions, Http2UpstreamIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, Http2UpstreamIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -18,7 +18,7 @@ struct HttpProtocolTestParams {
 //
 // typedef HttpProtocolIntegrationTest MyTest
 //
-// INSTANTIATE_TEST_CASE_P(Protocols, BufferIntegrationTest,
+// INSTANTIATE_TEST_SUITE_P(Protocols, BufferIntegrationTest,
 //                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
 //                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 //

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -78,7 +78,7 @@ public:
   DangerousDeprecatedTestTime test_time_;
 };
 
-INSTANTIATE_TEST_CASE_P(Protocols, IdleTimeoutIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, IdleTimeoutIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -16,7 +16,7 @@
 
 namespace Envoy {
 
-INSTANTIATE_TEST_CASE_P(Protocols, IntegrationAdminTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, IntegrationAdminTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
                             {Http::CodecClient::Type::HTTP1, Http::CodecClient::Type::HTTP2},
                             {FakeHttpConnection::Type::HTTP1})),
@@ -474,7 +474,7 @@ public:
   BufferingStreamDecoderPtr response_;
   envoy::config::metrics::v2::StatsMatcher stats_matcher_;
 };
-INSTANTIATE_TEST_CASE_P(IpVersions, StatsMatcherIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, StatsMatcherIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -27,7 +27,7 @@ using testing::Not;
 
 namespace Envoy {
 
-INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, IntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -336,7 +336,7 @@ public:
   const uint32_t load_report_interval_ms_ = 500;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, LoadStatsIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, LoadStatsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -52,7 +52,7 @@ protected:
   AtomicFileUpdater file_updater_;
 };
 
-INSTANTIATE_TEST_CASE_P(Protocols, OverloadIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, OverloadIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -11,7 +11,7 @@
 
 namespace Envoy {
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ProxyProtoIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyProtoIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -216,13 +216,13 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, RatelimitIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, RatelimitIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, RatelimitFailureModeIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, RatelimitFailureModeIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, RatelimitBootStrapOnlyIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, RatelimitBootStrapOnlyIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, RatelimitBootStrapIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, RatelimitBootStrapIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 TEST_P(RatelimitBootStrapOnlyIntegrationTest, Ok) { basicFlow(); }

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -100,7 +100,7 @@ TEST_P(RedirectIntegrationTest, InvalidRedirect) {
       test_server_->counter("cluster.cluster_0.upstream_internal_redirect_failed_total")->value());
 }
 
-INSTANTIATE_TEST_CASE_P(Protocols, RedirectIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, RedirectIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -212,7 +212,7 @@ protected:
   Network::TransportSocketFactoryPtr client_ssl_ctx_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, SdsDynamicDownstreamIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, SdsDynamicDownstreamIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // A test that SDS server send a good server secret for a static listener.
@@ -309,7 +309,7 @@ private:
   bool use_combined_validation_context_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, SdsDynamicDownstreamCertValidationContextTest,
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, SdsDynamicDownstreamCertValidationContextTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // A test that SDS server send a good certificate validation context for a static listener.
@@ -390,7 +390,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SdsDynamicUpstreamIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SdsDynamicUpstreamIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // To test a static cluster with sds. SDS send a good client secret first.

--- a/test/integration/sds_static_integration_test.cc
+++ b/test/integration/sds_static_integration_test.cc
@@ -94,7 +94,7 @@ private:
   Network::TransportSocketFactoryPtr client_ssl_ctx_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SdsStaticDownstreamIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SdsStaticDownstreamIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -153,7 +153,7 @@ private:
   Ssl::ContextManagerImpl context_manager_{timeSystem()};
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SdsStaticUpstreamIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SdsStaticUpstreamIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -75,7 +75,7 @@ void SslIntegrationTestBase::checkStats() {
   counter->reset();
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SslIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SslIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -220,7 +220,7 @@ public:
   const envoy::api::v2::auth::TlsParameters_TlsProtocol tls_version_{std::get<1>(GetParam())};
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     IpVersionsClientVersions, SslCertficateIntegrationTest,
     testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                      testing::Values(envoy::api::v2::auth::TlsParameters::TLSv1_2,
@@ -367,7 +367,7 @@ public:
   bool text_format_{};
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, SslCaptureIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, SslCaptureIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -25,7 +25,7 @@ public:
   void initialize() override { BaseIntegrationTest::initialize(); }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, StatsIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, StatsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -142,7 +142,7 @@ private:
   Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> filter_resolver_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, TcpConnPoolIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, TcpConnPoolIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -119,7 +119,7 @@ public:
         filter_resolver_(config_factory_) {}
 
   // Called once by the gtest framework before any tests are run.
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     tcp_conn_pool_config = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       - filters:

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -22,7 +22,7 @@ using testing::NiceMock;
 namespace Envoy {
 namespace {
 
-INSTANTIATE_TEST_CASE_P(IpVersions, TcpProxyIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, TcpProxyIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -357,7 +357,7 @@ TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithLargeOutstandingData) {
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect(true));
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, TcpProxySslIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, TcpProxySslIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -9,7 +9,7 @@
 
 namespace Envoy {
 
-INSTANTIATE_TEST_CASE_P(TestParameters, UdsUpstreamIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(TestParameters, UdsUpstreamIntegrationTest,
                         testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
 #if defined(__linux__)
                                          testing::Values(false, true)
@@ -38,7 +38,7 @@ TEST_P(UdsUpstreamIntegrationTest, RouterDownstreamDisconnectBeforeResponseCompl
   testRouterDownstreamDisconnectBeforeResponseComplete();
 }
 
-INSTANTIATE_TEST_CASE_P(TestParameters, UdsListenerIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(TestParameters, UdsListenerIntegrationTest,
                         testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
 #if defined(__linux__)
                                          testing::Values(false, true)

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -107,7 +107,7 @@ void WebsocketIntegrationTest::commonValidate(Http::HeaderMap& proxied_headers,
   }
 }
 
-INSTANTIATE_TEST_CASE_P(Protocols, WebsocketIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(Protocols, WebsocketIntegrationTest,
                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -28,7 +28,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, XdsIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, XdsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -164,7 +164,7 @@ void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previ
   EXPECT_TRUE(response->complete());
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, XfccIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, XfccIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -61,7 +61,7 @@ TEST_F(ConfigValidation, SharedDnsResolver) {
   EXPECT_EQ(use_count + 1, dns2.use_count()); // Each call causes ++ in use_count.
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ConfigValidation,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ConfigValidation,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -19,7 +19,7 @@ public:
     directory_ = TestEnvironment::temporaryDirectory() + "/test/config_test/";
   }
 
-  static void SetUpTestCase() { SetupTestDirectory(); }
+  static void SetUpTestSuite() { SetupTestDirectory(); }
 
 protected:
   ValidationServerTest() : options_(directory_ + GetParam()) {}

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -57,7 +57,7 @@ TEST_P(ValidationServerTest, Validate) {
 // all the example configs) but can't until light validation is implemented, mocking out access to
 // the filesystem for TLS certs, etc. In the meantime, these are the example configs that work
 // as-is.
-INSTANTIATE_TEST_CASE_P(ValidConfigs, ValidationServerTest,
+INSTANTIATE_TEST_SUITE_P(ValidConfigs, ValidationServerTest,
                         ::testing::Values("front-proxy_front-envoy.yaml",
                                           "google_com_proxy.v2.yaml",
                                           "grpc-bridge_config_s2s-grpc-envoy.yaml",
@@ -71,7 +71,7 @@ TEST_P(ValidationServerTest_1, RunWithoutCrash) {
   SUCCEED();
 }
 
-INSTANTIATE_TEST_CASE_P(AllConfigs, ValidationServerTest_1,
+INSTANTIATE_TEST_SUITE_P(AllConfigs, ValidationServerTest_1,
                         ::testing::ValuesIn(ValidationServerTest_1::GetAllConfigFiles()));
 } // namespace Server
 } // namespace Envoy

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -244,7 +244,7 @@ TEST_P(HotRestartImplAlignmentTest, objectOverlap) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(HotRestartImplAlignmentTest, HotRestartImplAlignmentTest,
+INSTANTIATE_TEST_SUITE_P(HotRestartImplAlignmentTest, HotRestartImplAlignmentTest,
                         testing::Range(0UL, alignof(Stats::RawStatData) + 1));
 
 } // namespace Server

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -86,7 +86,7 @@ public:
   Http::TestHeaderMapImpl request_headers_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AdminStatsTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AdminStatsTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -552,7 +552,7 @@ TEST_P(AdminStatsTest, UsedOnlyStatsAsJsonFilterString) {
   store_->shutdownThreading();
 }
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AdminFilterTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AdminFilterTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
@@ -630,7 +630,7 @@ public:
   Server::AdminFilter admin_filter_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, AdminInstanceTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -167,7 +167,7 @@ protected:
   std::unique_ptr<InstanceImpl> server_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, ServerInstanceImplTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ServerInstanceImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 

--- a/test/test_common/network_utility_test.cc
+++ b/test/test_common/network_utility_test.cc
@@ -15,7 +15,7 @@ protected:
   const Address::IpVersion version_;
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, NetworkUtilityTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, NetworkUtilityTest,
                         testing::ValuesIn(TestEnvironment::getIpTestParameters()));
 
 // This validates Network::Test::bindFreeLoopbackPort behaves as desired, i.e. that we don't have


### PR DESCRIPTION
Pin googletest to the current master to get access to the new macro and method names. Besides the version pinning, this is purely a name change and is a functional no-op.

*Risk Level*: Low
*Testing*: compiled and ran all tests
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #5607
