### PR TITLE
mongo_proxy: add BSON symbol support

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/bson.h
+++ b/source/extensions/filters/network/mongo_proxy/bson.h
@@ -40,6 +40,7 @@ public:
     DATETIME = 0x09,
     NULL_VALUE = 0x0A,
     REGEX = 0x0B,
+    SYMBOL = 0x0E,
     INT32 = 0x10,
     TIMESTAMP = 0x11,
     INT64 = 0x12
@@ -66,6 +67,7 @@ public:
 
   virtual double asDouble() const PURE;
   virtual const std::string& asString() const PURE;
+  virtual const std::string& asSymbol() const PURE;
   virtual const Document& asDocument() const PURE;
   virtual const Document& asArray() const PURE;
   virtual const std::string& asBinary() const PURE;
@@ -96,6 +98,7 @@ public:
 
   virtual DocumentSharedPtr addDouble(const std::string& key, double value) PURE;
   virtual DocumentSharedPtr addString(const std::string& key, std::string&& value) PURE;
+  virtual DocumentSharedPtr addSymbol(const std::string& key, std::string&& value) PURE;
   virtual DocumentSharedPtr addDocument(const std::string& key, DocumentSharedPtr value) PURE;
   virtual DocumentSharedPtr addArray(const std::string& key, DocumentSharedPtr value) PURE;
   virtual DocumentSharedPtr addBinary(const std::string& key, std::string&& value) PURE;

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -165,7 +165,8 @@ int32_t FieldImpl::byteSize() const {
     return total + 8;
   }
 
-  case Type::STRING: {
+  case Type::STRING:
+  case Type::SYMBOL: {
     return total + 4 + value_.string_value_.size() + 1;
   }
 
@@ -211,7 +212,8 @@ void FieldImpl::encode(Buffer::Instance& output) const {
     return BufferHelper::writeDouble(output, value_.double_value_);
   }
 
-  case Type::STRING: {
+  case Type::STRING:
+  case Type::SYMBOL: {
     return BufferHelper::writeString(output, value_.string_value_);
   }
 
@@ -269,6 +271,10 @@ bool FieldImpl::operator==(const Field& rhs) const {
     return asString() == rhs.asString();
   }
 
+  case Type::SYMBOL: {
+    return asSymbol() == rhs.asSymbol();
+  }
+
   case Type::DOCUMENT: {
     return asDocument() == rhs.asDocument();
   }
@@ -324,6 +330,7 @@ std::string FieldImpl::toString() const {
   }
 
   case Type::STRING:
+  case Type::SYMBOL:
   case Type::BINARY: {
     return fmt::format("\"{}\"", StringUtil::escape(value_.string_value_));
   }
@@ -402,6 +409,13 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
       std::string value = BufferHelper::removeString(data);
       ENVOY_LOG(trace, "BSON string: {}", value);
       addString(key, std::move(value));
+      break;
+    }
+
+    case Field::Type::SYMBOL: {
+      std::string value = BufferHelper::removeString(data);
+      ENVOY_LOG(trace, "BSON symbol: {}", value);
+      addSymbol(key, std::move(value));
       break;
     }
 

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.h
@@ -88,6 +88,11 @@ public:
     return value_.string_value_;
   }
 
+  const std::string& asSymbol() const override {
+    checkType(Type::SYMBOL);
+    return value_.string_value_;
+  }
+
   const Document& asDocument() const override {
     checkType(Type::DOCUMENT);
     return *value_.document_value_;
@@ -191,6 +196,11 @@ public:
 
   DocumentSharedPtr addString(const std::string& key, std::string&& value) override {
     fields_.emplace_back(new FieldImpl(Field::Type::STRING, key, std::move(value)));
+    return shared_from_this();
+  }
+
+  DocumentSharedPtr addSymbol(const std::string& key, std::string&& value) override {
+    fields_.emplace_back(new FieldImpl(Field::Type::SYMBOL, key, std::move(value)));
     return shared_from_this();
   }
 

--- a/test/extensions/filters/network/mongo_proxy/codec_impl_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/codec_impl_test.cc
@@ -90,6 +90,7 @@ TEST_F(MongoCodecImplTest, Query) {
   query.query(
       Bson::DocumentImpl::create()
           ->addString("string", "string")
+          ->addSymbol("symbol", "symbol")
           ->addDouble("double", 2.1)
           ->addDocument("document", Bson::DocumentImpl::create()->addString("hello", "world"))
           ->addArray("array", Bson::DocumentImpl::create()->addString("0", "foo"))


### PR DESCRIPTION
*Description*: Add support for the BSON symbol type
*Risk Level*: Low; the encoding of symbols is identical to the existing string type
*Testing*: A test has been added and existing tests still pass
*Docs Changes*: n/a
*Release Notes*: Adds support for the BSON symbol to mongo_proxy
[Optional Fixes #Issue]
[Optional *Deprecated*:]
