### PR TITLE
http: Reduce header-file explosion slightly by un-inlining a private class.

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -271,6 +271,10 @@ void HeaderMapImpl::HeaderEntryImpl::value(const HeaderEntry& header) {
     return {&h.inline_headers_.name##_, &Headers::get().name};                                     \
   });
 
+/**
+ * This is the static lookup table that is used to determine whether a header is one of the O(1)
+ * headers. This uses a trie for lookup time at most equal to the size of the incoming string.
+ */
 struct HeaderMapImpl::StaticLookupTable : public TrieLookupTable<EntryCb> {
   StaticLookupTable() {
     ALL_INLINE_HEADERS(INLINE_HEADER_STATIC_MAP_ENTRY)

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -271,14 +271,16 @@ void HeaderMapImpl::HeaderEntryImpl::value(const HeaderEntry& header) {
     return {&h.inline_headers_.name##_, &Headers::get().name};                                     \
   });
 
-HeaderMapImpl::StaticLookupTable::StaticLookupTable() {
-  ALL_INLINE_HEADERS(INLINE_HEADER_STATIC_MAP_ENTRY)
+struct HeaderMapImpl::StaticLookupTable : public TrieLookupTable<EntryCb> {
+  StaticLookupTable() {
+    ALL_INLINE_HEADERS(INLINE_HEADER_STATIC_MAP_ENTRY)
 
-  // Special case where we map a legacy host header to :authority.
-  add(Headers::get().HostLegacy.get().c_str(), [](HeaderMapImpl& h) -> StaticLookupResponse {
-    return {&h.inline_headers_.Host_, &Headers::get().Host};
-  });
-}
+    // Special case where we map a legacy host header to :authority.
+    add(Headers::get().HostLegacy.get().c_str(), [](HeaderMapImpl& h) -> StaticLookupResponse {
+      return {&h.inline_headers_.Host_, &Headers::get().Host};
+    });
+  }
+};
 
 void HeaderMapImpl::appendToHeader(HeaderString& header, absl::string_view data) {
   if (data.empty()) {

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -115,7 +115,7 @@ protected:
    * This is the static lookup table that is used to determine whether a header is one of the O(1)
    * headers. This uses a trie for lookup time at most equal to the size of the incoming string.
    */
-  struct StaticLookupTable;
+  struct StaticLookupTable; // Defined in header_map_impl.cc.
 
   struct AllInlineHeaders {
     ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER_STRUCT)

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -9,7 +9,6 @@
 #include "envoy/http/header_map.h"
 
 #include "common/common/non_copyable.h"
-#include "common/common/utility.h"
 #include "common/http/headers.h"
 
 namespace Envoy {
@@ -116,9 +115,7 @@ protected:
    * This is the static lookup table that is used to determine whether a header is one of the O(1)
    * headers. This uses a trie for lookup time at most equal to the size of the incoming string.
    */
-  struct StaticLookupTable : public TrieLookupTable<EntryCb> {
-    StaticLookupTable();
-  };
+  struct StaticLookupTable;
 
   struct AllInlineHeaders {
     ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER_STRUCT)


### PR DESCRIPTION
*Description*: This has the benefit of allowing header_map_impl.h to no longer
include common/common/utility.h, which is large and (of note for some
of us) requires compiling with exception-handling enabled.
*Risk Level*: low
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

