### PR TITLE
redis: add hashtagging

### DIFF
--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -31,6 +31,18 @@ message RedisProxy {
     // is ready.
     google.protobuf.Duration op_timeout = 1
         [(validate.rules).duration.required = true, (gogoproto.stdduration) = true];
+
+    // Use hash tagging on every redis key to guarantee that keys with the same hash tag will be
+    // forwarded to the same upstream. The hash key used for determining the upstream in a
+    // consistent hash ring configuration will be computed from the hash tagged key instead of the
+    // whole key. The algorithm used to compute the hash tag is identical to the `redis-cluster
+    // implementation <https://redis.io/topics/cluster-spec#keys-hash-tags>`_.
+    //
+    // Examples:
+    //
+    // * '{user1000}.following' and '{user1000}.followers' **will** be sent to the same upstream
+    // * '{user1000}.following' and '{user1001}.following' **might** be sent to the same upstream
+    bool enable_hashtagging = 2;
   }
 
   // Network settings for the connection pool to the upstream cluster.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -25,8 +25,9 @@ Version history
 * outlier_detection: added support for :ref:`outlier detection event protobuf-based logging <arch_overview_outlier_detection_logging>`.
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to ::ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
 * http: added :ref:`max request headers size <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_kb>`. The default behaviour is unchanged.
-* redis: added :ref:`success and error stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
+* redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
+* redis: added :ref:`success and error stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
 * redis: migrate hash function for host selection to `MurmurHash2 <https://sites.google.com/site/murmurhash>`_ from std::hash. MurmurHash2 is compatible with std::hash in GNU libstdc++ 3.4.20 or above. This is typically the case when compiled on Linux and not macOS.
 * router: added ability to configure a :ref:`retry policy <envoy_api_msg_route.RetryPolicy>` at the
   virtual host level.

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -94,6 +94,12 @@ public:
    * passive healthcheck operations.
    */
   virtual bool disableOutlierEvents() const PURE;
+
+  /**
+   * @return when enabled, a hash tagging function will be used to guarantee that keys with the
+   * same hash tag will be forwarded to the same upstream.
+   */
+  virtual bool enableHashtagging() const PURE;
 };
 
 /**

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -37,9 +37,11 @@ public:
 
   bool disableOutlierEvents() const override { return false; }
   std::chrono::milliseconds opTimeout() const override { return op_timeout_; }
+  bool enableHashtagging() const override { return enable_hashtagging_; }
 
 private:
   const std::chrono::milliseconds op_timeout_;
+  const bool enable_hashtagging_;
 };
 
 class ClientImpl : public Client, public DecoderCallbacks, public Network::ConnectionCallbacks {
@@ -127,7 +129,7 @@ public:
       const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config);
 
   // RedisProxy::ConnPool::Instance
-  PoolRequest* makeRequest(const std::string& hash_key, const RespValue& request,
+  PoolRequest* makeRequest(const std::string& key, const RespValue& request,
                            PoolCallbacks& callbacks) override;
 
 private:
@@ -152,7 +154,7 @@ private:
                            public Upstream::ClusterUpdateCallbacks {
     ThreadLocalPool(InstanceImpl& parent, Event::Dispatcher& dispatcher, std::string cluster_name);
     ~ThreadLocalPool();
-    PoolRequest* makeRequest(const std::string& hash_key, const RespValue& request,
+    PoolRequest* makeRequest(const std::string& key, const RespValue& request,
                              PoolCallbacks& callbacks);
     void onClusterAddOrUpdateNonVirtual(Upstream::ThreadLocalCluster& cluster);
     void onHostsRemoved(const std::vector<Upstream::HostSharedPtr>& hosts_removed);
@@ -173,9 +175,12 @@ private:
   };
 
   struct LbContextImpl : public Upstream::LoadBalancerContextBase {
-    LbContextImpl(const std::string& hash_key) : hash_key_(MurmurHash::murmurHash2_64(hash_key)) {}
+    LbContextImpl(const std::string& key, bool enabled_hashtagging)
+        : hash_key_(MurmurHash::murmurHash2_64(hashtag(key, enabled_hashtagging))) {}
 
     absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
+
+    absl::string_view hashtag(absl::string_view v, bool enabled);
 
     const absl::optional<uint64_t> hash_key_;
   };

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -57,6 +57,7 @@ private:
       // Allow the main Health Check infra to control timeout.
       return parent_.timeout_ * 2;
     }
+    bool enableHashtagging() const override { return false; }
 
     // Extensions::NetworkFilters::RedisProxy::ConnPool::PoolCallbacks
     void onResponse(Extensions::NetworkFilters::RedisProxy::RespValuePtr&& value) override;


### PR DESCRIPTION
*Description*:

Add hashtagging support to the redis-proxy filter via an opt-in setting in the connection pool options to preserve backward compatibility. The hashtagging algorithm is inspired from the [redis-cluster actual implementation](https://redis.io/topics/cluster-spec#keys-hash-tags), however instead of using a `crc16(key) % 16384`, I reused the original hashing algorithm that was being used to compute the hash key. This is mostly to ensure keys with a specific hashtag will get routed to the same upstream.

Based on the already existing code, I have a small question regarding this [comment] (https://github.com/maximebedard/envoy/blob/master/source/extensions/filters/network/redis_proxy/conn_pool_impl.h#L176). I assume this PR would involve a similar strategy? Is adding a configuration option to the public API a correct way of achieving this? I'm also not too sure if I added everything in the right places, but I'm happy to move things around to the proper classes where necessary.

Still very new to the project and to c++ in general, not entirely sure if this is the correct approach, but any guidance and feedback is truly appreciated!

*Risk Level*: Low
*Testing*: Added a unit test that verifies if the connection pool forwards the key using the expected hash key.
*Docs Changes*: Add a `hashtags` setting by connection pool to preserve backward compatibly.
*Release Notes*: N/A yet
