### PR TITLE
(http conn manager) Add test for large header rejection

### DIFF
--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3595,5 +3595,31 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenOverloaded) {
   EXPECT_EQ(1U, stats_.named_.downstream_cx_overload_disable_keepalive_.value());
 }
 
+TEST_F(HttpConnectionManagerImplTest, LargeRequestRejected) {
+  setup(false, "");
+
+  std::string response_code;
+  std::string response_body;
+  EXPECT_CALL(*codec_, dispatch(_)).Times(1).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+    HeaderMapPtr headers{
+        new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
+    headers->addCopy(LowerCaseString("Foo"), std::string(60 * 1024, 'a'));
+
+    EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
+        .WillOnce(Invoke([&response_code](const HeaderMap& headers, bool) -> void {
+          response_code = headers.Status()->value().c_str();
+        }));
+    decoder->decodeHeaders(std::move(headers), true);
+    conn_manager_->newStream(response_encoder_);
+  }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false); // kick off request
+
+  EXPECT_EQ("431", response_code);
+  EXPECT_EQ("", response_body);
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3595,7 +3595,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenOverloaded) {
   EXPECT_EQ(1U, stats_.named_.downstream_cx_overload_disable_keepalive_.value());
 }
 
-TEST_F(HttpConnectionManagerImplTest, LargeRequestRejected) {
+TEST_F(HttpConnectionManagerImplTest, OverlyLongHeadersRejected) {
   setup(false, "");
 
   std::string response_code;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1873,7 +1873,6 @@ void HttpIntegrationTest::testOverlyLongHeaders() {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  std::string long_value(7500, 'x');
   auto encoder_decoder = codec_client_->startRequest(big_headers);
   auto response = std::move(encoder_decoder.second);
 


### PR DESCRIPTION
Signed-off-by: Auni Ahsan <auni@google.com>

*Description*: Add test for uncovered <reject if request is too big> codepath, in preparation for adding a configurable max_request_size.
*Risk Level*: N/A (test-only)