### PR TITLE
upstream: account for degraded hosts in panic mode calculations

### DIFF
--- a/docs/root/intro/arch_overview/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/connection_pooling.rst
@@ -32,6 +32,6 @@ Health checking interactions
 
 If Envoy is configured for either active or passive :ref:`health checking
 <arch_overview_health_checking>`, all connection pool connections will be closed on behalf of a host
-that transitions from a healthy state to an unhealthy state. If the host reenters the load
+that transitions from a available state to an unavailable state. If the host reenters the load
 balancing rotation it will create fresh connections which will maximize the chance of working
 around a bad flow (due to ECMP route or something else).

--- a/docs/root/intro/arch_overview/load_balancing/degraded.rst
+++ b/docs/root/intro/arch_overview/load_balancing/degraded.rst
@@ -30,7 +30,3 @@ traffic is gradually shifted to degraded hosts as it becomes necessary.
 
 Endpoints can be marked as degraded by using active health checking and having the upstream host
 return a :ref:`special header <arch_overview_health_checking_degraded>`.
-
-Note: Degraded endpoints are considered unhealthy when computing panic thresholds. This means that
-the number of unhealthy hosts plus the number of degraded hosts is above the panic threshold, the
-containing priority will enter panic mode.

--- a/docs/root/intro/arch_overview/load_balancing/load_balancers.rst
+++ b/docs/root/intro/arch_overview/load_balancing/load_balancers.rst
@@ -8,14 +8,15 @@ uses a load balancing policy to determine which host is selected. The load balan
 pluggable and are specified on a per upstream cluster basis in the :ref:`configuration
 <envoy_api_msg_Cluster>`. Note that if no active health checking policy is :ref:`configured
 <config_cluster_manager_cluster_hc>` for a cluster, all upstream cluster members are considered
-healthy.
+healthy, unless otherwise specified through
+:ref:`health_status <envoy_api_field_endpoint.LbEndpoint.health_status>`.
 
 .. _arch_overview_load_balancing_types_round_robin:
 
 Weighted round robin
 ^^^^^^^^^^^^^^^^^^^^
 
-This is a simple policy in which each healthy upstream host is selected in round
+This is a simple policy in which each available upstream host is selected in round
 robin order. If :ref:`weights
 <envoy_api_field_endpoint.LbEndpoint.load_balancing_weight>` are assigned to
 endpoints in a locality, then a weighted round robin schedule is used, where
@@ -30,7 +31,7 @@ Weighted least request
 The least request load balancer uses different algorithms depending on whether any of the hosts have
 weight greater than 1.
 
-* *all weights 1*: An O(1) algorithm which selects N random healthy hosts as specified in the
+* *all weights 1*: An O(1) algorithm which selects N random available hosts as specified in the
   :ref:`configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` (2 by default) and picks the
   host which has the fewest active requests (`Research
   <http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf>`_ has shown that this
@@ -99,7 +100,7 @@ versus Maglev with different parameters.
 Random
 ^^^^^^
 
-The random load balancer selects a random healthy host. The random load balancer generally performs
+The random load balancer selects a random available host. The random load balancer generally performs
 better than round robin if no health checking policy is configured. Random selection avoids bias
 towards the host in the set that comes after a failed host.
 

--- a/docs/root/intro/arch_overview/load_balancing/locality_weight.rst
+++ b/docs/root/intro/arch_overview/load_balancing/locality_weight.rst
@@ -12,17 +12,17 @@ in the case of locality aware LB, we rely on the management server to provide th
 locality weighting, rather than the Envoy-side heuristics used in zone aware
 routing.
 
-When all endpoints are healthy, the locality is picked using a weighted
+When all endpoints are available, the locality is picked using a weighted
 round-robin schedule, where the locality weight is used for weighting. When some
-endpoints in a locality are unhealthy, we adjust the locality weight to reflect
+endpoints in a locality are unavailable, we adjust the locality weight to reflect
 this. As with :ref:`priority levels
 <arch_overview_load_balancing_priority_levels>`, we assume an
 :ref:`over-provision factor <arch_overview_load_balancing_overprovisioning_factor>`
 (default value 1.4), which means we do not perform any weight
-adjustment when only a small number of endpoints in a locality are unhealthy.
+adjustment when only a small number of endpoints in a locality are unavilable.
 
 Assume a simple set-up with 2 localities X and Y, where X has a locality weight
-of 1 and Y has a locality weight of 2, L=Y 100% healthy,
+of 1 and Y has a locality weight of 2, L=Y 100% available,
 with default overprovisioning factor 1.4.
 
 +----------------------------+---------------------------+----------------------------+
@@ -46,8 +46,8 @@ To sum this up in pseudo algorithms:
 
 ::
 
-  health(L_X) = 140 * healthy_X_backends / total_X_backends
-  effective_weight(L_X) = locality_weight_X * min(100, health(L_X))
+  availability(L_X) = 140 * available_X_upstreams / total_X_upstreams
+  effective_weight(L_X) = locality_weight_X * min(100, availability(L_X))
   load to L_X = effective_weight(L_X) / Σ_c(effective_weight(L_c))
 
 Note that the locality weighted pick takes place after the priority level is

--- a/docs/root/intro/arch_overview/load_balancing/overprovisioning.rst
+++ b/docs/root/intro/arch_overview/load_balancing/overprovisioning.rst
@@ -4,7 +4,7 @@ Overprovisioning Factor
 -----------------------
 Priority levels and localities are considered overprovisioned with
 :ref:`this percentage <envoy_api_field_ClusterLoadAssignment.Policy.overprovisioning_factor>`.
-Envoy doesn't consider a priority level or locality unhealthy until the
-percentage of healthy hosts multiplied by the overprovisioning factor drops
+Envoy doesn't consider a priority level or locality unavailable until the
+percentage of available hosts multiplied by the overprovisioning factor drops
 below 100. The default value is 1.4, so a priority level or locality will not be
-considered unhealthy until the percentage of healthy endpoints goes below 72%.
+considered unavailable until the percentage of available endpoints goes below 72%.

--- a/docs/root/intro/arch_overview/load_balancing/panic_threshold.rst
+++ b/docs/root/intro/arch_overview/load_balancing/panic_threshold.rst
@@ -23,7 +23,7 @@ available hosts across all priority levels. It continues to distribute traffic l
 but if a given priority level's availability is below the panic threshold, traffic will go to all hosts
 in that priority level regardless of their availability.
 
-The following examples explain the relationship between normalized total availablity and panic threshold.
+The following examples explain the relationship between normalized total availability and panic threshold.
 It is assumed that the default value of 50% is used for the panic threshold.
 
 Assume a simple set-up with 2 priority levels, P=1 100% healthy. In this scenario normalized total

--- a/docs/root/intro/arch_overview/load_balancing/panic_threshold.rst
+++ b/docs/root/intro/arch_overview/load_balancing/panic_threshold.rst
@@ -3,27 +3,27 @@
 Panic threshold
 ---------------
 
-During load balancing, Envoy will generally only consider healthy hosts in an upstream cluster.
-However, if the percentage of healthy hosts in the cluster becomes too low, Envoy will disregard
-health status and balance amongst all hosts. This is known as the *panic threshold*. The default
-panic threshold is 50%. This is :ref:`configurable <config_cluster_manager_cluster_runtime>` via
-runtime as well as in the :ref:`cluster configuration
-<envoy_api_field_Cluster.CommonLbConfig.healthy_panic_threshold>`. The panic threshold
-is used to avoid a situation in which host failures cascade throughout the cluster as load
-increases.
+During load balancing, Envoy will generally only consider available (healthy or degraded) hosts in
+an upstream cluster. However, if the percentage of available hosts in the cluster becomes too low,
+Envoy will disregard health status and balance amongst all hosts. This is known as the *panic
+threshold*. The default panic threshold is 50%. This is
+:ref:`configurable <config_cluster_manager_cluster_runtime>` via runtime as well as in the
+:ref:`cluster configuration <envoy_api_field_Cluster.CommonLbConfig.healthy_panic_threshold>`.
+The panic threshold is used to avoid a situation in which host failures cascade throughout the
+cluster as load increases.
 
-Panic thresholds work in conjunction with priorities. If the number of healthy hosts in a given
+Panic thresholds work in conjunction with priorities. If the number of available hosts in a given
 priority goes down, Envoy will try to shift some traffic to lower priorities. If it succeeds in
-finding enough healthy hosts in lower priorities, Envoy will disregard panic thresholds. In
-mathematical terms, if normalized total health across all priority levels is 100%, Envoy disregards
-panic thresholds and continues to distribute traffic load across priorities according to the
-algorithm described :ref:`here <arch_overview_load_balancing_priority_levels>`.
-However, when normalized total health drops below 100%, Envoy assumes that there are not enough
-healthy hosts across all priority levels. It continues to distribute traffic load across priorities,
-but if a given priority level's health is below the panic threshold, traffic will go to all hosts
-in that priority level regardless of their health.
+finding enough available hosts in lower priorities, Envoy will disregard panic thresholds. In
+mathematical terms, if normalized total availability across all priority levels is 100%, Envoy
+disregards panic thresholds and continues to distribute traffic load across priorities according to
+the algorithm described :ref:`here <arch_overview_load_balancing_priority_levels>`.
+However, when normalized total availablility drops below 100%, Envoy assumes that there are not enough
+available hosts across all priority levels. It continues to distribute traffic load across priorities,
+but if a given priority level's availability is below the panic threshold, traffic will go to all hosts
+in that priority level regardless of their availability.
 
-The following examples explain the relationship between normalized total health and panic threshold.
+The following examples explain the relationship between normalized total availablity and panic threshold.
 It is assumed that the default value of 50% is used for the panic threshold.
 
 Assume a simple set-up with 2 priority levels, P=1 100% healthy. In this scenario normalized total

--- a/docs/root/intro/arch_overview/load_balancing/priority.rst
+++ b/docs/root/intro/arch_overview/load_balancing/priority.rst
@@ -102,3 +102,6 @@ To sum this up in pseudo algorithms:
   priority_load(P_X) = min(100 - Σ(priority_load(P_0)..priority_load(P_X-1)),
                            health(P_X) / normalized_total_health)
 
+Note: This sectioned talked about healthy priorities, but this also extends to
+:ref:`degraded priorities <arch_overview_load_balancing_degraded>`.
+

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -217,10 +217,6 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
 void LoadBalancerBase::recalculatePerPriorityPanic() {
   per_priority_panic_.resize(priority_set_.hostSetsPerPriority().size());
 
-  // TODO(snowp): Right now panic thresholds doesn't work well with degraded.
-  // The normalized_total_health takes degraded hosts into account, while
-  // the subsequent panic calculation only looks at healthy hosts. Ideally
-  // they should both take degraded into account.
   const uint32_t normalized_total_availability =
       calculateNormalizedTotalAvailability(per_priority_health_, per_priority_degraded_);
 
@@ -445,15 +441,17 @@ HostConstSharedPtr LoadBalancerBase::chooseHost(LoadBalancerContext* context) {
 }
 
 bool LoadBalancerBase::isGlobalPanic(const HostSet& host_set) {
-  // TODO(snowp): This should also account for degraded hosts.
   uint64_t global_panic_threshold = std::min<uint64_t>(
       100, runtime_.snapshot().getInteger(RuntimePanicThreshold, default_healthy_panic_percent_));
   double healthy_percent = host_set.hosts().size() == 0
                                ? 0
                                : 100.0 * host_set.healthyHosts().size() / host_set.hosts().size();
 
+  double degraded_percent = host_set.hosts().size() == 0
+                                ? 0
+                                : 100.0 * host_set.degradedHosts().size() / host_set.hosts().size();
   // If the % of healthy hosts in the cluster is less than our panic threshold, we use all hosts.
-  if (healthy_percent < global_panic_threshold) {
+  if ((healthy_percent + degraded_percent) < global_panic_threshold) {
     return true;
   }
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -350,6 +350,18 @@ TEST_P(LoadBalancerBaseTest, GentleFailoverWithExtraLevels) {
   ASSERT_THAT(getDegradedLoadPercentage(), ElementsAre(0, 0, 0));
   ASSERT_THAT(getPanic(), ElementsAre(true, true, true));
 
+  // Level P=0 is totally degraded. P=1 is 40*1.4=56% healthy and 40*1.4=56% degraded. P=2 is
+  // 40*1.4=56%% healthy. 100% of the traffic should go to P=2. No priorities should be in panic
+  // mode.
+  updateHostSet(host_set_, 5 /* num_hosts */, 0 /* num_healthy_hosts */,
+                5 /* num_degraded_hosts */);
+  updateHostSet(failover_host_set_, 5 /* num_hosts */, 2 /* num_healthy_hosts */,
+                2 /* num_degraded_hosts */);
+  updateHostSet(tertiary_host_set_, 5 /* num_hosts */, 2 /* num_healthy_hosts */);
+  ASSERT_THAT(getLoadPercentage(), ElementsAre(0, 56, 44));
+  ASSERT_THAT(getDegradedLoadPercentage(), ElementsAre(0, 0, 0));
+  ASSERT_THAT(getPanic(), ElementsAre(false, false, false));
+
   // All levels are completely down. 100% of traffic should go to P=0
   // and P=0 should be in panic mode
   updateHostSet(host_set_, 5 /* num_hosts */, 0 /* num_healthy_hosts */);


### PR DESCRIPTION
Updates the way panic mode is calculated to treat degraded hosts as
available. This ensures that panic mode is entered when there are
insufficient available hosts.

Also updates the panic mode documentation to use more generic language.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium
*Testing*: UTs for mixed healthy/degraded hosts
*Docs Changes*: Updated panic mode docs
*Release Notes*: n/a
#5063 