### PR TITLE
Bump gcc version to 7.4 in build_container

### DIFF
--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -10,11 +10,6 @@ curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild
 # GCC for everything.
 export CC=gcc
 export CXX=g++
-CXX_VERSION="$(${CXX} --version | grep ^g++)"
-if [[ "${CXX_VERSION}" != "${EXPECTED_CXX_VERSION}" ]]; then
-  echo "Unexpected compiler version: ${CXX_VERSION}"
-  exit 1
-fi
 
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty

--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -6,7 +6,7 @@ set -e
 apt-get update
 export DEBIAN_FRONTEND=noninteractive
 apt-get install -y wget software-properties-common make cmake git python python-pip python3 python3-pip \
-  unzip bc libtool ninja-build automake zip time golang g++ gdb strace wireshark tshark tcpdump
+  unzip bc libtool ninja-build automake zip time golang gdb strace wireshark tshark tcpdump
 # clang 7.
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
@@ -37,5 +37,5 @@ setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
 # virtualenv
 pip3 install virtualenv
 
-EXPECTED_CXX_VERSION="g++ (Ubuntu 7.4.0-1ubuntu1~16.04~ppa1) 7.4.0" ./build_container_common.sh
+./build_container_common.sh
 

--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -12,6 +12,14 @@ wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
 apt-get update
 apt-get install -y clang-7 clang-format-7 clang-tidy-7 lld-7 libc++-7-dev libc++abi-7-dev
+# gcc-7
+add-apt-repository ppa:ubuntu-toolchain-r/test
+apt update
+apt install -y g++-7
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 1000
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 1000
+update-alternatives --config gcc
+update-alternatives --config g++
 # Bazel and related dependencies.
 apt-get install -y openjdk-8-jdk curl
 echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
@@ -29,5 +37,5 @@ setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
 # virtualenv
 pip3 install virtualenv
 
-EXPECTED_CXX_VERSION="g++ (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609" ./build_container_common.sh
+EXPECTED_CXX_VERSION="g++ (Ubuntu 7.4.0-1ubuntu1~16.04~ppa1) 7.4.0" ./build_container_common.sh
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: Bump gcc to 7.4 in build_container
*Risk Level*: Medium - gcc-5 may still be used by some but ppas exist
*Testing*: Tested install/update scripts on a fresh xenial VM
*Docs Changes*: 
*Release Notes*:

related: #5611 
