### PR TITLE
api: revert option java_multiple_files = true

### DIFF
--- a/api/envoy/admin/v2alpha/certs.proto
+++ b/api/envoy/admin/v2alpha/certs.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 import "google/protobuf/timestamp.proto";
 

--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 import "envoy/admin/v2alpha/metrics.proto";
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/admin/v2alpha/config_dump.proto
+++ b/api/envoy/admin/v2alpha/config_dump.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 import "envoy/api/v2/cds.proto";
 import "envoy/api/v2/lds.proto";

--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 // [#protodoc-title: Memory]
 

--- a/api/envoy/admin/v2alpha/metrics.proto
+++ b/api/envoy/admin/v2alpha/metrics.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 // [#protodoc-title: Metrics]
 

--- a/api/envoy/admin/v2alpha/mutex_stats.proto
+++ b/api/envoy/admin/v2alpha/mutex_stats.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 // [#protodoc-title: MutexStats]
 

--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.admin.v2alpha;
 option java_package = "io.envoyproxy.envoy.admin.v2alpha";
-option java_multiple_files = true;
 
 import "google/protobuf/duration.proto";
 

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.auth;
 option java_package = "io.envoyproxy.envoy.api.v2.auth";
-option java_multiple_files = true;
 option go_package = "auth";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2;
 option java_package = "io.envoyproxy.envoy.api.v2";
-option java_multiple_files = true;
 
 option java_generic_services = true;
 

--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.cluster;
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
-option java_multiple_files = true;
 option go_package = "cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
 

--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.cluster;
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
-option java_multiple_files = true;
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/duration.proto";

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/base.proto";
 

--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 option go_package = "core";
 
 import "google/protobuf/any.proto";

--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/grpc_service.proto";
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/base.proto";
 

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/base.proto";
 

--- a/api/envoy/api/v2/core/http_uri.proto
+++ b/api/envoy/api/v2/core/http_uri.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 
 import "google/protobuf/duration.proto";
 import "gogoproto/gogo.proto";

--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
-option java_multiple_files = true;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";

--- a/api/envoy/api/v2/discovery.proto
+++ b/api/envoy/api/v2/discovery.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2;
 option java_package = "io.envoyproxy.envoy.api.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2;
 option java_package = "io.envoyproxy.envoy.api.v2";
-option java_multiple_files = true;
 
 option java_generic_services = true;
 

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.endpoint;
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";
-option java_multiple_files = true;
 option go_package = "endpoint";
 
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/api/v2/endpoint/load_report.proto
+++ b/api/envoy/api/v2/endpoint/load_report.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.endpoint;
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2;
 option java_package = "io.envoyproxy.envoy.api.v2";
-option java_multiple_files = true;
 
 option java_generic_services = true;
 

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.listener;
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
-option java_multiple_files = true;
 option go_package = "listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
 

--- a/api/envoy/api/v2/ratelimit/ratelimit.proto
+++ b/api/envoy/api/v2/ratelimit/ratelimit.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.ratelimit;
 option java_package = "io.envoyproxy.envoy.api.v2.ratelimit";
-option java_multiple_files = true;
 option go_package = "ratelimit";
 
 import "validate/validate.proto";

--- a/api/envoy/api/v2/rds.proto
+++ b/api/envoy/api/v2/rds.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2;
 option java_package = "io.envoyproxy.envoy.api.v2";
-option java_multiple_files = true;
 
 option java_generic_services = true;
 

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.route;
 option java_package = "io.envoyproxy.envoy.api.v2.route";
-option java_multiple_files = true;
 option go_package = "route";
 option java_generic_services = true;
 

--- a/api/envoy/config/accesslog/v2/als.proto
+++ b/api/envoy/config/accesslog/v2/als.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.accesslog.v2;
 option java_package = "io.envoyproxy.envoy.config.accesslog.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/grpc_service.proto";

--- a/api/envoy/config/accesslog/v2/file.proto
+++ b/api/envoy/config/accesslog/v2/file.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.accesslog.v2;
 option java_package = "io.envoyproxy.envoy.config.accesslog.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "validate/validate.proto";

--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -7,7 +7,6 @@ syntax = "proto3";
 
 package envoy.config.bootstrap.v2;
 option java_package = "io.envoyproxy.envoy.config.bootstrap.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.accesslog.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.accesslog.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/config/filter/fault/v2/fault.proto
+++ b/api/envoy/config/filter/fault/v2/fault.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.fault.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.fault.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/type/percent.proto";

--- a/api/envoy/config/filter/http/buffer/v2/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v2/buffer.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.buffer.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.buffer.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "google/protobuf/duration.proto";

--- a/api/envoy/config/filter/http/ext_authz/v2alpha/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2alpha/ext_authz.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.ext_authz.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.filter.http.ext_authz.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.fault.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.fault.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/route/route.proto";

--- a/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto
+++ b/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.filter.http.grpc_http1_reverse_bridge.v2alpha1;
 option java_package = "io.envoyproxy.envoy.extensions.filter.http.grpc_http1_reverse_bridge.v2alpha1";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "validate/validate.proto";

--- a/api/envoy/config/filter/http/gzip/v2/gzip.proto
+++ b/api/envoy/config/filter/http/gzip/v2/gzip.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.gzip.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.gzip.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "google/protobuf/wrappers.proto";

--- a/api/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.proto
+++ b/api/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.header_to_metadata.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.header_to_metadata.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "validate/validate.proto";

--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.health_check.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.health_check.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "google/protobuf/duration.proto";

--- a/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto
+++ b/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.ip_tagging.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.ip_tagging.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.jwt_authn.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.filter.http.jwt_authn.v2alpha";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/http_uri.proto";

--- a/api/envoy/config/filter/http/lua/v2/lua.proto
+++ b/api/envoy/config/filter/http/lua/v2/lua.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.lua.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.lua.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "validate/validate.proto";

--- a/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.rate_limit.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.rate_limit.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/ratelimit/v2/rls.proto";

--- a/api/envoy/config/filter/http/rbac/v2/rbac.proto
+++ b/api/envoy/config/filter/http/rbac/v2/rbac.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.rbac.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.rbac.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/rbac/v2alpha/rbac.proto";

--- a/api/envoy/config/filter/http/router/v2/router.proto
+++ b/api/envoy/config/filter/http/router/v2/router.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.router.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.router.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/filter/accesslog/v2/accesslog.proto";

--- a/api/envoy/config/filter/http/squash/v2/squash.proto
+++ b/api/envoy/config/filter/http/squash/v2/squash.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.squash.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.squash.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "google/protobuf/duration.proto";

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.http.transcoder.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.http.transcoder.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "validate/validate.proto";

--- a/api/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto
+++ b/api/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.listener.original_src.v2alpha1;
 option java_package = "io.envoyproxy.envoy.config.filter.listener.original_src.v2alpha1";
-option java_multiple_files = true;
 
 option go_package = "v2alpha1";
 

--- a/api/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.proto
+++ b/api/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.client_ssl_auth.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.client_ssl_auth.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.proto
+++ b/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.filters.network.dubbo_proxy.v2alpha1;
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.dubbo_proxy.v2alpha1";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "validate/validate.proto";

--- a/api/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.ext_authz.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.ext_authz.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/grpc_service.proto";

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.http_connection_manager.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/config_source.proto";

--- a/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto
+++ b/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.mongo_proxy.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.mongo_proxy.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/filter/fault/v2/fault.proto";

--- a/api/envoy/config/filter/network/mysql_proxy/v1alpha1/mysql_proxy.proto
+++ b/api/envoy/config/filter/network/mysql_proxy/v1alpha1/mysql_proxy.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.mysql_proxy.v1alpha1;
 option java_package = "io.envoyproxy.envoy.config.filter.network.mysql_proxy.v1alpha1";
-option java_multiple_files = true;
 option go_package = "v1alpha1";
 
 import "validate/validate.proto";

--- a/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.rate_limit.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.rate_limit.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/ratelimit/ratelimit.proto";

--- a/api/envoy/config/filter/network/rbac/v2/rbac.proto
+++ b/api/envoy/config/filter/network/rbac/v2/rbac.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.rbac.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.rbac.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/rbac/v2alpha/rbac.proto";

--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.redis_proxy.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.redis_proxy.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "google/protobuf/duration.proto";

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.tcp_proxy.v2;
 option java_package = "io.envoyproxy.envoy.config.filter.network.tcp_proxy.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/filter/accesslog/v2/accesslog.proto";

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.thrift_proxy.v2alpha1;
 option java_package = "io.envoyproxy.envoy.config.filter.network.thrift_proxy.v2alpha1";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.network.thrift_proxy.v2alpha1;
 option java_package = "io.envoyproxy.envoy.config.filter.network.thrift_proxy.v2alpha1";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto";

--- a/api/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.proto
+++ b/api/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.thrift.rate_limit.v2alpha1;
 option java_package = "io.envoyproxy.envoy.config.filter.thrift.rate_limit.v2alpha1";
-option java_multiple_files = true;
 option go_package = "v2alpha1";
 
 import "envoy/config/ratelimit/v2/rls.proto";

--- a/api/envoy/config/filter/thrift/router/v2alpha1/router.proto
+++ b/api/envoy/config/filter/thrift/router/v2alpha1/router.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.filter.thrift.router.v2alpha1;
 option java_package = "io.envoyproxy.envoy.config.filter.thrift.router.v2alpha1";
-option java_multiple_files = true;
 option go_package = "v2alpha1";
 
 // [#protodoc-title: Router]

--- a/api/envoy/config/grpc_credential/v2alpha/file_based_metadata.proto
+++ b/api/envoy/config/grpc_credential/v2alpha/file_based_metadata.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 
 package envoy.config.grpc_credential.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.grpc_credential.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/config/health_checker/redis/v2/redis.proto
+++ b/api/envoy/config/health_checker/redis/v2/redis.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.health_checker.redis.v2;
 option java_package = "io.envoyproxy.envoy.config.health_checker.redis.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 // [#protodoc-title: Redis]

--- a/api/envoy/config/metrics/v2/metrics_service.proto
+++ b/api/envoy/config/metrics/v2/metrics_service.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 
 package envoy.config.metrics.v2;
 option java_package = "io.envoyproxy.envoy.config.metrics.v2";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/grpc_service.proto";
 

--- a/api/envoy/config/metrics/v2/stats.proto
+++ b/api/envoy/config/metrics/v2/stats.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 
 package envoy.config.metrics.v2;
 option java_package = "io.envoyproxy.envoy.config.metrics.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.overload.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.overload.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 
 import "google/protobuf/any.proto";

--- a/api/envoy/config/ratelimit/v2/rls.proto
+++ b/api/envoy/config/ratelimit/v2/rls.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.ratelimit.v2;
 option java_package = "io.envoyproxy.envoy.config.ratelimit.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/grpc_service.proto";

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -8,7 +8,6 @@ import "envoy/type/matcher/string.proto";
 
 package envoy.config.rbac.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.rbac.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 
 // [#protodoc-title: Role Based Access Control (RBAC)]

--- a/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto
+++ b/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.resource_monitor.fixed_heap.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.resource_monitor.fixed_heap.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 
 // [#protodoc-title: Fixed heap]

--- a/api/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.proto
+++ b/api/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.resource_monitor.injected_resource.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.resource_monitor.injected_resource.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 
 import "validate/validate.proto";

--- a/api/envoy/config/retry/previous_priorities/previous_priorities_config.proto
+++ b/api/envoy/config/retry/previous_priorities/previous_priorities_config.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.retry.previous_priorities;
 option java_package = "io.envoyproxy.envoy.config.retry.previous_priorities";
-option java_multiple_files = true;
 
 // A retry host selector that attempts to spread retries between priorities, even if certain
 // priorities would not normally be attempted due to higher priorities being available.

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 
 package envoy.config.trace.v2;
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/grpc_service.proto";

--- a/api/envoy/config/transport_socket/alts/v2alpha/alts.proto
+++ b/api/envoy/config/transport_socket/alts/v2alpha/alts.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.transport_socket.alts.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.transport_socket.alts.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2";
 
 // [#protodoc-title: ALTS]

--- a/api/envoy/config/transport_socket/capture/v2alpha/capture.proto
+++ b/api/envoy/config/transport_socket/capture/v2alpha/capture.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.transport_socket.capture.v2alpha;
 option java_package = "io.envoyproxy.envoy.config.transport_socket.capture.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2";
 
 // [#protodoc-title: Capture]

--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.data.accesslog.v2;
 option java_package = "io.envoyproxy.envoy.data.accesslog.v2";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.data.core.v2alpha;
 option java_package = "io.envoyproxy.envoy.data.core.v2alpha";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/address.proto";
 

--- a/api/envoy/data/tap/v2alpha/capture.proto
+++ b/api/envoy/data/tap/v2alpha/capture.proto
@@ -6,7 +6,6 @@ syntax = "proto3";
 
 package envoy.data.tap.v2alpha;
 option java_package = "io.envoyproxy.envoy.data.tap.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/address.proto";

--- a/api/envoy/service/accesslog/v2/als.proto
+++ b/api/envoy/service/accesslog/v2/als.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.accesslog.v2;
 option java_package = "io.envoyproxy.envoy.service.accesslog.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 option java_generic_services = true;
 

--- a/api/envoy/service/auth/v2alpha/attribute_context.proto
+++ b/api/envoy/service/auth/v2alpha/attribute_context.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.auth.v2alpha;
 option java_package = "io.envoyproxy.envoy.service.auth.v2alpha";
-option java_multiple_files = true;
 
 import "envoy/api/v2/core/address.proto";
 

--- a/api/envoy/service/auth/v2alpha/external_auth.proto
+++ b/api/envoy/service/auth/v2alpha/external_auth.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.auth.v2alpha;
 option java_package = "io.envoyproxy.envoy.service.auth.v2alpha";
-option java_multiple_files = true;
 option go_package = "v2alpha";
 option java_generic_services = true;
 

--- a/api/envoy/service/discovery/v2/ads.proto
+++ b/api/envoy/service/discovery/v2/ads.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.discovery.v2;
 option java_package = "io.envoyproxy.envoy.service.discovery.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 option java_generic_services = true;
 

--- a/api/envoy/service/discovery/v2/hds.proto
+++ b/api/envoy/service/discovery/v2/hds.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.discovery.v2;
 option java_package = "io.envoyproxy.envoy.service.discovery.v2";
-option java_multiple_files = true;
 
 option java_generic_services = true;
 

--- a/api/envoy/service/discovery/v2/sds.proto
+++ b/api/envoy/service/discovery/v2/sds.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.discovery.v2;
 option java_package = "io.envoyproxy.envoy.service.discovery.v2";
-option java_multiple_files = true;
 
 import "envoy/api/v2/discovery.proto";
 

--- a/api/envoy/service/load_stats/v2/lrs.proto
+++ b/api/envoy/service/load_stats/v2/lrs.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.load_stats.v2;
 option java_package = "io.envoyproxy.envoy.service.load_stats.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 option java_generic_services = true;
 

--- a/api/envoy/service/metrics/v2/metrics_service.proto
+++ b/api/envoy/service/metrics/v2/metrics_service.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.metrics.v2;
 option java_package = "io.envoyproxy.envoy.service.metrics.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 option java_generic_services = true;
 

--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.service.ratelimit.v2;
 option java_package = "io.envoyproxy.envoy.service.ratelimit.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 
 import "envoy/api/v2/core/base.proto";

--- a/api/envoy/service/trace/v2/trace_service.proto
+++ b/api/envoy/service/trace/v2/trace_service.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 
 package envoy.service.trace.v2;
 option java_package = "io.envoyproxy.envoy.service.trace.v2";
-option java_multiple_files = true;
 option go_package = "v2";
 option java_generic_services = true;
 

--- a/api/envoy/type/http_status.proto
+++ b/api/envoy/type/http_status.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type;
 option java_package = "io.envoyproxy.envoy.type";
-option java_multiple_files = true;
 
 import "validate/validate.proto";
 

--- a/api/envoy/type/matcher/metadata.proto
+++ b/api/envoy/type/matcher/metadata.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type.matcher;
 option java_package = "io.envoyproxy.envoy.type.matcher";
-option java_multiple_files = true;
 option go_package = "matcher";
 
 import "envoy/type/matcher/value.proto";

--- a/api/envoy/type/matcher/number.proto
+++ b/api/envoy/type/matcher/number.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type.matcher;
 option java_package = "io.envoyproxy.envoy.type.matcher";
-option java_multiple_files = true;
 option go_package = "matcher";
 
 import "envoy/type/range.proto";

--- a/api/envoy/type/matcher/string.proto
+++ b/api/envoy/type/matcher/string.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type.matcher;
 option java_package = "io.envoyproxy.envoy.type.matcher";
-option java_multiple_files = true;
 option go_package = "matcher";
 
 import "validate/validate.proto";

--- a/api/envoy/type/matcher/value.proto
+++ b/api/envoy/type/matcher/value.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type.matcher;
 option java_package = "io.envoyproxy.envoy.type.matcher";
-option java_multiple_files = true;
 option go_package = "matcher";
 
 import "envoy/type/matcher/number.proto";

--- a/api/envoy/type/percent.proto
+++ b/api/envoy/type/percent.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type;
 option java_package = "io.envoyproxy.envoy.type";
-option java_multiple_files = true;
 
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";

--- a/api/envoy/type/range.proto
+++ b/api/envoy/type/range.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.type;
 option java_package = "io.envoyproxy.envoy.type";
-option java_multiple_files = true;
 option go_package = "envoy_type";
 
 import "gogoproto/gogo.proto";

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -148,8 +148,6 @@ def checkNamespace(file_path):
 
 
 def fixJavaProtoOptions(file_path):
-  java_multiple_files = False
-  java_package_correct = False
   package_name = None
   for line in fileinput.FileInput(file_path):
     if line.startswith("package "):
@@ -158,21 +156,13 @@ def fixJavaProtoOptions(file_path):
         continue
 
       package_name = result.group(1)
-    if "option java_multiple_files = true;" in line:
-      java_multiple_files = True
     if "option java_package = \"io.envoyproxy.envoy" in line:
-      java_package_correct = True
-    if java_multiple_files and java_package_correct:
       return []
 
   if package_name is None:
     return ["Unable to find package name for proto file: %s" % file_path]
 
-  to_add = ""
-  if not java_package_correct:
-    to_add = to_add + "option java_package = \"io.envoyproxy.{}\";\n".format(package_name)
-  if not java_multiple_files:
-    to_add = to_add + "option java_multiple_files = true;\n"
+  to_add = "option java_package = \"io.envoyproxy.{}\";\n".format(package_name)
 
   for line in fileinput.FileInput(file_path, inplace=True):
     if line.startswith("package "):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -173,24 +173,11 @@ def fixJavaProtoOptions(file_path):
 
 
 def checkJavaProtoOptions(file_path):
-  java_multiple_files = False
-  java_package_correct = False
   for line in fileinput.FileInput(file_path):
-    if "option java_multiple_files = true;" in line:
-      java_multiple_files = True
     if "option java_package = \"io.envoyproxy.envoy" in line:
-      java_package_correct = True
-    if java_multiple_files and java_package_correct:
       return []
 
-  error_messages = []
-  if not java_multiple_files:
-    error_messages.append(
-        "Java proto option 'java_multiple_files' not set correctly for file: %s" % file_path)
-  if not java_package_correct:
-    error_messages.append(
-        "Java proto option 'java_package' not set correctly for file: %s" % file_path)
-  return error_messages
+  return ["Java proto option 'java_package' not set correctly for file: %s" % file_path]
 
 
 # To avoid breaking the Lyft import, we just check for path inclusion here.

--- a/tools/testdata/check_format/api/java_options.proto.gold
+++ b/tools/testdata/check_format/api/java_options.proto.gold
@@ -1,3 +1,2 @@
 package envoy.foo;
 option java_package = "io.envoyproxy.envoy.foo";
-option java_multiple_files = true;


### PR DESCRIPTION
*Description*:
- Partially revert envoyproxy/envoy@02659d4 to remove `option java_multiple_files = true;`, because this is causing envoyproxy/java-control-plane#87 on MacOS.

- The proto files change is generated by the script:
```
cd api
for f in $(find . -name "*.proto")
do
  sed -i -e '/^option\sjava_multiple_files\s=/d' $f
done
```

- `tools/check_format.py` is also changed accordingly.

*Risk Level*:
Medium
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
