### PR TITLE
test: fix ssl_integration_test flake.

### DIFF
--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -280,8 +280,9 @@ TEST_P(SslCertficateIntegrationTest, ServerEcdsaClientRsaOnly) {
   initialize();
   auto codec_client = makeRawHttpConnection(makeSslClientConnection(rsaOnlyClientOptions()));
   EXPECT_FALSE(codec_client->connected());
-  Stats::CounterSharedPtr counter =
-      test_server_->counter(listenerStatPrefix("ssl.connection_error"));
+  const std::string counter_name = listenerStatPrefix("ssl.connection_error");
+  Stats::CounterSharedPtr counter = test_server_->counter(counter_name);
+  test_server_->waitForCounterGe(counter_name, 1);
   EXPECT_EQ(1U, counter->value());
   counter->reset();
 }
@@ -305,8 +306,9 @@ TEST_P(SslCertficateIntegrationTest, ServerRsaClientEcdsaOnly) {
   initialize();
   EXPECT_FALSE(
       makeRawHttpConnection(makeSslClientConnection(ecdsaOnlyClientOptions()))->connected());
-  Stats::CounterSharedPtr counter =
-      test_server_->counter(listenerStatPrefix("ssl.connection_error"));
+  const std::string counter_name = listenerStatPrefix("ssl.connection_error");
+  Stats::CounterSharedPtr counter = test_server_->counter(counter_name);
+  test_server_->waitForCounterGe(counter_name, 1);
   EXPECT_EQ(1U, counter->value());
   counter->reset();
 }


### PR DESCRIPTION
The SSL client disconnects and continues execution in the main test
thread, while the server side code responsible for the stats had not
updated the stat yet.

Fixes #5420.

Risk level: Low
Testing: bazel test test/integration:ssl_integration_test
  test/integration/ssl_integration_test.cc --runs_per_test=1000

Signed-off-by: Harvey Tuch <htuch@google.com>