### PR TITLE
health filter: cache degraded health checks

### DIFF
--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -82,7 +82,7 @@ Http::FilterHeadersStatus HealthCheckFilter::encodeHeaders(Http::HeaderMap& head
     if (cache_manager_) {
       cache_manager_->setCachedResponseCode(
           static_cast<Http::Code>(Http::Utility::getResponseStatus(headers)),
-            headers.EnvoyDegraded() != nullptr);
+          headers.EnvoyDegraded() != nullptr);
     }
 
     headers.insertEnvoyUpstreamHealthCheckedCluster().value(context_.localInfo().clusterName());
@@ -147,11 +147,13 @@ void HealthCheckFilter::onComplete() {
     }
   }
 
-  callbacks_->sendLocalReply(final_status, "", [degraded](auto& headers) {
-      if (degraded) {
-      headers.insertEnvoyDegraded();
-      }
-      }, absl::nullopt);
+  callbacks_->sendLocalReply(final_status, "",
+                             [degraded](auto& headers) {
+                               if (degraded) {
+                                 headers.insertEnvoyDegraded();
+                               }
+                             },
+                             absl::nullopt);
 }
 
 } // namespace HealthCheck

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -28,7 +28,7 @@ HealthCheckCacheManager::HealthCheckCacheManager(Event::Dispatcher& dispatcher,
 }
 
 void HealthCheckCacheManager::onTimer() {
-  use_cached_response_code_ = false;
+  use_cached_response_ = false;
   clear_cache_timer_->enableTimer(timeout_);
 }
 
@@ -47,7 +47,7 @@ Http::FilterHeadersStatus HealthCheckFilter::decodeHeaders(Http::HeaderMap& head
     // If we are not in pass through mode, we always handle. Otherwise, we handle if the server is
     // in the failed state or if we are using caching and we should use the cached response.
     if (!pass_through_mode_ || context_.healthCheckFailed() ||
-        (cache_manager_ && cache_manager_->useCachedResponseCode())) {
+        (cache_manager_ && cache_manager_->useCachedResponse())) {
       handling_ = true;
     }
   }
@@ -80,7 +80,7 @@ Http::FilterTrailersStatus HealthCheckFilter::decodeTrailers(Http::HeaderMap&) {
 Http::FilterHeadersStatus HealthCheckFilter::encodeHeaders(Http::HeaderMap& headers, bool) {
   if (health_check_request_) {
     if (cache_manager_) {
-      cache_manager_->setCachedResponseCode(
+      cache_manager_->setCachedResponse(
           static_cast<Http::Code>(Http::Utility::getResponseStatus(headers)),
           headers.EnvoyDegraded() != nullptr);
     }
@@ -103,7 +103,7 @@ void HealthCheckFilter::onComplete() {
     final_status = Http::Code::ServiceUnavailable;
   } else {
     if (cache_manager_) {
-      const auto status_and_degraded = cache_manager_->getCachedResponseCode();
+      const auto status_and_degraded = cache_manager_->getCachedResponse();
       final_status = status_and_degraded.first;
       degraded = status_and_degraded.second;
     } else if (cluster_min_healthy_percentages_ != nullptr &&

--- a/source/extensions/filters/http/health_check/health_check.h
+++ b/source/extensions/filters/http/health_check/health_check.h
@@ -27,7 +27,9 @@ class HealthCheckCacheManager {
 public:
   HealthCheckCacheManager(Event::Dispatcher& dispatcher, std::chrono::milliseconds timeout);
 
-  std::pair<Http::Code, bool> getCachedResponseCode() { return {last_response_code_, last_response_degraded_}; }
+  std::pair<Http::Code, bool> getCachedResponseCode() {
+    return {last_response_code_, last_response_degraded_};
+  }
   void setCachedResponseCode(Http::Code code, bool degraded) {
     last_response_code_ = code;
     last_response_degraded_ = degraded;

--- a/source/extensions/filters/http/health_check/health_check.h
+++ b/source/extensions/filters/http/health_check/health_check.h
@@ -27,22 +27,22 @@ class HealthCheckCacheManager {
 public:
   HealthCheckCacheManager(Event::Dispatcher& dispatcher, std::chrono::milliseconds timeout);
 
-  std::pair<Http::Code, bool> getCachedResponseCode() {
+  std::pair<Http::Code, bool> getCachedResponse() {
     return {last_response_code_, last_response_degraded_};
   }
-  void setCachedResponseCode(Http::Code code, bool degraded) {
+  void setCachedResponse(Http::Code code, bool degraded) {
     last_response_code_ = code;
     last_response_degraded_ = degraded;
-    use_cached_response_code_ = true;
+    use_cached_response_ = true;
   }
-  bool useCachedResponseCode() { return use_cached_response_code_; }
+  bool useCachedResponse() { return use_cached_response_; }
 
 private:
   void onTimer();
 
   Event::TimerPtr clear_cache_timer_;
   const std::chrono::milliseconds timeout_;
-  std::atomic<bool> use_cached_response_code_{};
+  std::atomic<bool> use_cached_response_{};
   std::atomic<Http::Code> last_response_code_{};
   std::atomic<bool> last_response_degraded_{};
 };

--- a/source/extensions/filters/http/health_check/health_check.h
+++ b/source/extensions/filters/http/health_check/health_check.h
@@ -27,9 +27,10 @@ class HealthCheckCacheManager {
 public:
   HealthCheckCacheManager(Event::Dispatcher& dispatcher, std::chrono::milliseconds timeout);
 
-  Http::Code getCachedResponseCode() { return last_response_code_; }
-  void setCachedResponseCode(Http::Code code) {
+  std::pair<Http::Code, bool> getCachedResponseCode() { return {last_response_code_, last_response_degraded_}; }
+  void setCachedResponseCode(Http::Code code, bool degraded) {
     last_response_code_ = code;
+    last_response_degraded_ = degraded;
     use_cached_response_code_ = true;
   }
   bool useCachedResponseCode() { return use_cached_response_code_; }
@@ -41,6 +42,7 @@ private:
   const std::chrono::milliseconds timeout_;
   std::atomic<bool> use_cached_response_code_{};
   std::atomic<Http::Code> last_response_code_{};
+  std::atomic<bool> last_response_degraded_{};
 };
 
 typedef std::shared_ptr<HealthCheckCacheManager> HealthCheckCacheManagerSharedPtr;

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -266,7 +266,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedServiceUnavailableCallbackCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillRepeatedly(Return(false));
   EXPECT_CALL(callbacks_.stream_info_, healthCheck(true));
   EXPECT_CALL(callbacks_.active_span_, setSampled(false));
-  cache_manager_->setCachedResponseCode(Http::Code::ServiceUnavailable);
+  cache_manager_->setCachedResponseCode(Http::Code::ServiceUnavailable, false);
 
   Http::TestHeaderMapImpl health_check_response{{":status", "503"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
@@ -287,7 +287,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedOkCallbackNotCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillRepeatedly(Return(false));
   EXPECT_CALL(callbacks_.stream_info_, healthCheck(true));
   EXPECT_CALL(callbacks_.active_span_, setSampled(false));
-  cache_manager_->setCachedResponseCode(Http::Code::OK);
+  cache_manager_->setCachedResponseCode(Http::Code::OK, false);
 
   Http::TestHeaderMapImpl health_check_response{{":status", "200"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
@@ -313,7 +313,39 @@ TEST_F(HealthCheckFilterCachingTest, All) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->encodeHeaders(service_response_headers, true));
 
-  // Verify that the next request uses the cached value.
+  // Verify that the next request uses the cached value without setting the degraded header.
+  prepareFilter(true);
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck));
+  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
+      .Times(1)
+      .WillRepeatedly(Invoke([&](Http::HeaderMap& headers, bool end_stream) {
+        filter_->encodeHeaders(headers, end_stream);
+        EXPECT_STREQ("cluster_name", headers.EnvoyUpstreamHealthCheckedCluster()->value().c_str());
+      }));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, true));
+
+  // Fire the timer, this should result in the next request going through.
+  EXPECT_CALL(*cache_timer_, enableTimer(_));
+  cache_timer_->callback_();
+  prepareFilter(true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
+}
+
+TEST_F(HealthCheckFilterCachingTest, DegradedHeader) {
+  EXPECT_CALL(callbacks_.stream_info_, healthCheck(true)).Times(3);
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false)).Times(3);
+
+  // Verify that the first request goes through.
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
+  Http::TestHeaderMapImpl service_response_headers{{":status", "503"}, {"x-envoy-degraded", "true"}};
+  Http::TestHeaderMapImpl health_check_response{{":status", "503"}, {"x-envoy-degraded", ""}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->encodeHeaders(service_response_headers, true));
+
+  // Verify that the next request uses the cached value and that the x-envoy-degraded header is set.
   prepareFilter(true);
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck));

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -339,7 +339,8 @@ TEST_F(HealthCheckFilterCachingTest, DegradedHeader) {
 
   // Verify that the first request goes through.
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
-  Http::TestHeaderMapImpl service_response_headers{{":status", "503"}, {"x-envoy-degraded", "true"}};
+  Http::TestHeaderMapImpl service_response_headers{{":status", "503"},
+                                                   {"x-envoy-degraded", "true"}};
   Http::TestHeaderMapImpl health_check_response{{":status", "503"}, {"x-envoy-degraded", ""}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -266,7 +266,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedServiceUnavailableCallbackCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillRepeatedly(Return(false));
   EXPECT_CALL(callbacks_.stream_info_, healthCheck(true));
   EXPECT_CALL(callbacks_.active_span_, setSampled(false));
-  cache_manager_->setCachedResponseCode(Http::Code::ServiceUnavailable, false);
+  cache_manager_->setCachedResponse(Http::Code::ServiceUnavailable, false);
 
   Http::TestHeaderMapImpl health_check_response{{":status", "503"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
@@ -287,7 +287,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedOkCallbackNotCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillRepeatedly(Return(false));
   EXPECT_CALL(callbacks_.stream_info_, healthCheck(true));
   EXPECT_CALL(callbacks_.active_span_, setSampled(false));
-  cache_manager_->setCachedResponseCode(Http::Code::OK, false);
+  cache_manager_->setCachedResponse(Http::Code::OK, false);
 
   Http::TestHeaderMapImpl health_check_response{{":status", "200"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))


### PR DESCRIPTION
Updates the health check filter to cache whether the health check
returned the degraded label and to insert the degraded header when serving a cached
degraded response. 

Without this, each cached response will essentially clear the degraded health check
value, causing the health value of hosts to flap between healthy and degraded.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Description*:
*Risk Level*: Medium
*Testing*: Added UT to verify 
*Docs Changes*: n/a
*Release Notes*: n/a
#5063 