### PR TITLE
WiP api: Put Event::TimeSystem& into API and plumb that instead of TimeSystem in various places.

### DIFF
--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -22,10 +22,9 @@ public:
 
   /**
    * Allocate a dispatcher.
-   * @param time_source the time source.
    * @return Event::DispatcherPtr which is owned by the caller.
    */
-  virtual Event::DispatcherPtr allocateDispatcher(Event::TimeSystem& time_system) PURE;
+  virtual Event::DispatcherPtr allocateDispatcher() PURE;
 
   /**
    * Create/open a local file that supports async appending.
@@ -51,6 +50,11 @@ public:
    * @return a reference to the ThreadFactory
    */
   virtual Thread::ThreadFactory& threadFactory() PURE;
+
+  /**
+   * @return a reference to the TimeSystem
+   */
+  virtual Event::TimeSystem& timeSystem() PURE;
 };
 
 typedef std::unique_ptr<Api> ApiPtr;

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -145,6 +145,7 @@ envoy_cc_library(
     deps = [
         ":admin_interface",
         "//include/envoy/access_log:access_log_interface",
+        "//include/envoy/api:api_interface",
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:context_interface",
         "//include/envoy/http:filter_interface",

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "envoy/access_log/access_log.h"
+#include "envoy/api/api.h"
 #include "envoy/api/v2/core/base.pb.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/context.h"
@@ -125,6 +126,11 @@ public:
    * listener.
    */
   virtual const envoy::api::v2::core::Metadata& listenerMetadata() const PURE;
+
+  /**
+   * @return Api::Api& a reference to the API.
+   */
+  virtual Api::Api& api() PURE;
 
   /**
    * @return TimeSource& a reference to the time source.

--- a/source/common/api/api_impl.cc
+++ b/source/common/api/api_impl.cc
@@ -11,12 +11,14 @@ namespace Envoy {
 namespace Api {
 
 Impl::Impl(std::chrono::milliseconds file_flush_interval_msec,
-           Thread::ThreadFactory& thread_factory, Stats::Store& stats_store)
+           Thread::ThreadFactory& thread_factory, Stats::Store& stats_store,
+           Event::TimeSystem& time_system)
     : thread_factory_(thread_factory),
-      file_system_(file_flush_interval_msec, thread_factory, stats_store) {}
+      file_system_(file_flush_interval_msec, thread_factory, stats_store),
+      time_system_(time_system) {}
 
-Event::DispatcherPtr Impl::allocateDispatcher(Event::TimeSystem& time_system) {
-  return std::make_unique<Event::DispatcherImpl>(time_system, *this);
+Event::DispatcherPtr Impl::allocateDispatcher() {
+  return std::make_unique<Event::DispatcherImpl>(time_system_, *this);
 }
 
 Filesystem::FileSharedPtr Impl::createFile(const std::string& path, Event::Dispatcher& dispatcher,

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -19,20 +19,22 @@ namespace Api {
 class Impl : public Api::Api {
 public:
   Impl(std::chrono::milliseconds file_flush_interval_msec, Thread::ThreadFactory& thread_factory,
-       Stats::Store& stats_store);
+       Stats::Store& stats_store, Event::TimeSystem& time_system);
 
   // Api::Api
-  Event::DispatcherPtr allocateDispatcher(Event::TimeSystem& time_system) override;
+  Event::DispatcherPtr allocateDispatcher() override;
   Filesystem::FileSharedPtr createFile(const std::string& path, Event::Dispatcher& dispatcher,
                                        Thread::BasicLockable& lock) override;
   bool fileExists(const std::string& path) override;
   std::string fileReadToEnd(const std::string& path) override;
   Thread::ThreadFactory& threadFactory() override;
   Filesystem::Instance& fileSystem() { return file_system_; }
+  Event::TimeSystem& timeSystem() override { return time_system_; }
 
 private:
   Thread::ThreadFactory& thread_factory_;
   Filesystem::Instance file_system_;
+  Event::TimeSystem& time_system_;
 };
 
 } // namespace Api

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -112,7 +112,7 @@ public:
                      context.runtime(), context.random(), std::move(shadow_writer),
                      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, dynamic_stats, true),
                      config.start_child_span(), config.suppress_envoy_headers(),
-                     context.timeSource(), context.httpContext()) {
+                     context.api().timeSystem(), context.httpContext()) {
     for (const auto& upstream_log : config.upstream_log()) {
       upstream_logs_.push_back(AccessLog::AccessLogFactory::fromProto(upstream_log, context));
     }

--- a/source/server/config_validation/api.cc
+++ b/source/server/config_validation/api.cc
@@ -6,11 +6,12 @@ namespace Envoy {
 namespace Api {
 
 ValidationImpl::ValidationImpl(std::chrono::milliseconds file_flush_interval_msec,
-                               Thread::ThreadFactory& thread_factory, Stats::Store& stats_store)
-    : Impl(file_flush_interval_msec, thread_factory, stats_store) {}
+                               Thread::ThreadFactory& thread_factory, Stats::Store& stats_store,
+                               Event::TimeSystem& time_system)
+    : Impl(file_flush_interval_msec, thread_factory, stats_store, time_system) {}
 
-Event::DispatcherPtr ValidationImpl::allocateDispatcher(Event::TimeSystem& time_system) {
-  return Event::DispatcherPtr{new Event::ValidationDispatcher(time_system, *this)};
+Event::DispatcherPtr ValidationImpl::allocateDispatcher() {
+  return Event::DispatcherPtr{new Event::ValidationDispatcher(timeSystem(), *this)};
 }
 
 } // namespace Api

--- a/source/server/config_validation/api.h
+++ b/source/server/config_validation/api.h
@@ -16,9 +16,10 @@ namespace Api {
 class ValidationImpl : public Impl {
 public:
   ValidationImpl(std::chrono::milliseconds file_flush_interval_msec,
-                 Thread::ThreadFactory& thread_factory, Stats::Store& stats_store);
+                 Thread::ThreadFactory& thread_factory, Stats::Store& stats_store,
+                 Event::TimeSystem& time_system);
 
-  Event::DispatcherPtr allocateDispatcher(Event::TimeSystem&) override;
+  Event::DispatcherPtr allocateDispatcher() override;
 };
 
 } // namespace Api

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -40,9 +40,10 @@ ValidationInstance::ValidationInstance(Options& options, Event::TimeSystem& time
                                        Thread::BasicLockable& access_log_lock,
                                        ComponentFactory& component_factory,
                                        Thread::ThreadFactory& thread_factory)
-    : options_(options), time_system_(time_system), stats_store_(store),
-      api_(new Api::ValidationImpl(options.fileFlushIntervalMsec(), thread_factory, store)),
-      dispatcher_(api_->allocateDispatcher(time_system)),
+    : options_(options), stats_store_(store),
+      api_(new Api::ValidationImpl(options.fileFlushIntervalMsec(), thread_factory, store,
+                                   time_system)),
+      dispatcher_(api_->allocateDispatcher()),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory().currentThreadId())),
       access_log_manager_(*api_, *dispatcher_, access_log_lock), mutex_tracer_(nullptr) {
   try {
@@ -82,12 +83,12 @@ void ValidationInstance::initialize(Options& options,
   Configuration::InitialImpl initial_config(bootstrap);
   overload_manager_ = std::make_unique<OverloadManagerImpl>(dispatcher(), stats(), threadLocal(),
                                                             bootstrap.overload_manager());
-  listener_manager_ = std::make_unique<ListenerManagerImpl>(*this, *this, *this, time_system_);
+  listener_manager_ = std::make_unique<ListenerManagerImpl>(*this, *this, *this);
   thread_local_.registerThread(*dispatcher_, true);
   runtime_loader_ = component_factory.createRuntime(*this, initial_config);
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>();
   ssl_context_manager_ =
-      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_system_);
+      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(api_->timeSystem());
   cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(), dispatcher(),
       localInfo(), *secret_manager_, api(), http_context_);

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -92,7 +92,7 @@ public:
   Http::Context& httpContext() override { return http_context_; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
-  Event::TimeSystem& timeSystem() override { return time_system_; }
+  Event::TimeSystem& timeSystem() override { return api_->timeSystem(); }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
 
   std::chrono::milliseconds statsFlushInterval() const override {
@@ -139,7 +139,6 @@ private:
                   ComponentFactory& component_factory);
 
   Options& options_;
-  Event::TimeSystem& time_system_;
   Stats::IsolatedStoreImpl& stats_store_;
   ThreadLocal::InstanceImpl thread_local_;
   Api::ApiPtr api_;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -661,9 +661,8 @@ void ListenerImpl::setSocket(const Network::SocketSharedPtr& socket) {
 
 ListenerManagerImpl::ListenerManagerImpl(Instance& server,
                                          ListenerComponentFactory& listener_factory,
-                                         WorkerFactory& worker_factory, TimeSource& time_source)
-    : server_(server), time_source_(time_source), factory_(listener_factory),
-      stats_(generateStats(server.stats())),
+                                         WorkerFactory& worker_factory)
+    : server_(server), factory_(listener_factory), stats_(generateStats(server.stats())),
       config_tracker_entry_(server.admin().getConfigTracker().add(
           "listeners", [this] { return dumpListenerConfigs(); })) {
   for (uint32_t i = 0; i < server.options().concurrency(); i++) {

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -103,7 +103,7 @@ struct ListenerManagerStats {
 class ListenerManagerImpl : public ListenerManager, Logger::Loggable<Logger::Id::config> {
 public:
   ListenerManagerImpl(Instance& server, ListenerComponentFactory& listener_factory,
-                      WorkerFactory& worker_factory, TimeSource& time_source);
+                      WorkerFactory& worker_factory);
 
   void onListenerWarmed(ListenerImpl& listener);
 
@@ -123,7 +123,6 @@ public:
   Http::Context& httpContext() { return server_.httpContext(); }
 
   Instance& server_;
-  TimeSource& time_source_;
   ListenerComponentFactory& factory_;
 
 private:
@@ -281,7 +280,8 @@ public:
   const envoy::api::v2::core::Metadata& listenerMetadata() const override {
     return config_.metadata();
   };
-  TimeSource& timeSource() override { return parent_.time_source_; }
+  Api::Api& api() override { return parent_.server_.api(); }
+  TimeSource& timeSource() override { return api().timeSystem(); }
   void ensureSocketOptions() {
     if (!listen_socket_options_) {
       listen_socket_options_ =

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -55,13 +55,13 @@ InstanceImpl::InstanceImpl(Options& options, Event::TimeSystem& time_system,
     : shutdown_(false), options_(options), time_system_(time_system), restarter_(restarter),
       start_time_(time(nullptr)), original_start_time_(start_time_), stats_store_(store),
       thread_local_(tls),
-      api_(new Api::Impl(options.fileFlushIntervalMsec(), thread_factory, store)),
+      api_(new Api::Impl(options.fileFlushIntervalMsec(), thread_factory, store, time_system)),
       secret_manager_(std::make_unique<Secret::SecretManagerImpl>()),
-      dispatcher_(api_->allocateDispatcher(time_system)),
+      dispatcher_(api_->allocateDispatcher()),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory().currentThreadId())),
       handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),
       random_generator_(std::move(random_generator)), listener_component_factory_(*this),
-      worker_factory_(thread_local_, *api_, hooks, time_system),
+      worker_factory_(thread_local_, *api_, hooks),
       dns_resolver_(dispatcher_->createDnsResolver({})),
       access_log_manager_(*api_, *dispatcher_, access_log_lock), terminated_(false),
       mutex_tracer_(options.mutexTracingEnabled() ? &Envoy::MutexTracerImpl::getOrCreateTracer()
@@ -288,8 +288,8 @@ void InstanceImpl::initialize(Options& options,
                                                             bootstrap_.overload_manager());
 
   // Workers get created first so they register for thread local updates.
-  listener_manager_ = std::make_unique<ListenerManagerImpl>(*this, listener_component_factory_,
-                                                            worker_factory_, time_system_);
+  listener_manager_ =
+      std::make_unique<ListenerManagerImpl>(*this, listener_component_factory_, worker_factory_);
 
   // The main thread is also registered for thread local updates so that code that does not care
   // whether it runs on the main thread or on workers can still use TLS.

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -16,7 +16,7 @@ namespace Envoy {
 namespace Server {
 
 WorkerPtr ProdWorkerFactory::createWorker(OverloadManager& overload_manager) {
-  Event::DispatcherPtr dispatcher(api_.allocateDispatcher(time_system_));
+  Event::DispatcherPtr dispatcher(api_.allocateDispatcher());
   return WorkerPtr{new WorkerImpl(
       tls_, hooks_, std::move(dispatcher),
       Network::ConnectionHandlerPtr{new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher)},

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -20,9 +20,8 @@ namespace Server {
 
 class ProdWorkerFactory : public WorkerFactory, Logger::Loggable<Logger::Id::main> {
 public:
-  ProdWorkerFactory(ThreadLocal::Instance& tls, Api::Api& api, TestHooks& hooks,
-                    Event::TimeSystem& time_system)
-      : tls_(tls), api_(api), hooks_(hooks), time_system_(time_system) {}
+  ProdWorkerFactory(ThreadLocal::Instance& tls, Api::Api& api, TestHooks& hooks)
+      : tls_(tls), api_(api), hooks_(hooks) {}
 
   // Server::WorkerFactory
   WorkerPtr createWorker(OverloadManager& overload_manager) override;
@@ -31,7 +30,6 @@ private:
   ThreadLocal::Instance& tls_;
   Api::Api& api_;
   TestHooks& hooks_;
-  Event::TimeSystem& time_system_;
 };
 
 /**

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -18,8 +18,8 @@ namespace Envoy {
 namespace AccessLog {
 
 TEST(AccessLogManagerImpl, reopenAllFiles) {
-  Api::MockApi api;
   Event::MockDispatcher dispatcher;
+  Api::MockApi api(dispatcher.timeSystem());
   Thread::MutexBasicLockable lock;
   Stats::IsolatedStoreImpl stats_store;
 

--- a/test/common/api/BUILD
+++ b/test/common/api/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
         "//source/common/api:api_lib",
         "//source/common/stats:isolated_store_lib",
         "//test/test_common:environment_lib",
+        "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/api/api_impl_test.cc
+++ b/test/common/api/api_impl_test.cc
@@ -5,6 +5,7 @@
 #include "common/stats/isolated_store_impl.h"
 
 #include "test/test_common/environment.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -14,8 +15,9 @@ namespace Api {
 
 class ApiImplTest : public testing::Test {
 protected:
-  ApiImplTest() : api_(createApiForTest(store_)) {}
+  ApiImplTest() : api_(createApiForTest(store_, time_system_)) {}
 
+  Event::SimulatedTimeSystem time_system_;
   Stats::IsolatedStoreImpl store_;
   ApiPtr api_;
 };

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -31,8 +31,8 @@ class FilesystemSubscriptionTestHarness : public SubscriptionTestHarness {
 public:
   FilesystemSubscriptionTestHarness()
       : path_(TestEnvironment::temporaryPath("eds.json")),
-        api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_),
-        subscription_(dispatcher_, path_, stats_) {}
+        api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_), subscription_(dispatcher_, path_, stats_) {}
 
   ~FilesystemSubscriptionTestHarness() { EXPECT_EQ(0, ::unlink(path_.c_str())); }
 
@@ -99,8 +99,8 @@ public:
   const std::string path_;
   std::string version_;
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   NiceMock<Config::MockSubscriptionCallbacks<envoy::api::v2::ClusterLoadAssignment>> callbacks_;
   FilesystemEdsSubscriptionImpl subscription_;

--- a/test/common/event/dispatched_thread_impl_test.cc
+++ b/test/common/event/dispatched_thread_impl_test.cc
@@ -24,7 +24,8 @@ namespace Event {
 class DispatchedThreadTest : public testing::Test {
 protected:
   DispatchedThreadTest()
-      : config_(1000, 1000, 1000, 1000), api_(Api::createApiForTest(fakestats_)),
+      : config_(1000, 1000, 1000, 1000),
+        api_(Api::createApiForTest(fakestats_, test_time_.timeSystem())),
         thread_(*api_, test_time_.timeSystem()),
         guard_dog_(fakestats_, config_, test_time_.timeSystem(), *api_) {}
 

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -31,8 +31,8 @@ private:
 TEST(DeferredDeleteTest, DeferredDelete) {
   InSequence s;
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
   DangerousDeprecatedTestTime test_time;
+  Api::ApiPtr api = Api::createApiForTest(stats_store, test_time.timeSystem());
   DispatcherImpl dispatcher(test_time.timeSystem(), *api);
   ReadyWatcher watcher1;
 
@@ -64,7 +64,7 @@ TEST(DeferredDeleteTest, DeferredDelete) {
 class DispatcherImplTest : public ::testing::Test {
 protected:
   DispatcherImplTest()
-      : api_(Api::createApiForTest(stat_store_)),
+      : api_(Api::createApiForTest(stat_store_, test_time_.timeSystem())),
         dispatcher_(std::make_unique<DispatcherImpl>(test_time_.timeSystem(), *api_)),
         work_finished_(false) {
     dispatcher_thread_ = api_->threadFactory().createThread([this]() {

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -18,7 +18,8 @@ namespace Event {
 class FileEventImplTest : public testing::Test {
 public:
   FileEventImplTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_) {}
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_) {}
 
   void SetUp() override {
     int rc = socketpair(AF_UNIX, SOCK_DGRAM, 0, fds_);
@@ -36,8 +37,8 @@ public:
 protected:
   int fds_[2];
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   DispatcherImpl dispatcher_;
 };
 
@@ -58,7 +59,7 @@ TEST_P(FileEventImplActivateTest, Activate) {
 
   DangerousDeprecatedTestTime test_time;
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store, test_time.timeSystem());
   DispatcherImpl dispatcher(test_time.timeSystem(), *api);
   ReadyWatcher read_event;
   EXPECT_CALL(read_event, ready()).Times(1);

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -19,11 +19,12 @@ namespace Filesystem {
 class WatcherImplTest : public testing::Test {
 protected:
   WatcherImplTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_) {}
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_) {}
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
 };
 

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -18,7 +18,8 @@ namespace {
 
 class AsyncClientManagerImplTest : public testing::Test {
 public:
-  AsyncClientManagerImplTest() : api_(Api::createApiForTest(api_stats_store_)) {}
+  AsyncClientManagerImplTest()
+      : api_(Api::createApiForTest(api_stats_store_, test_time_.timeSystem())) {}
 
   Upstream::MockClusterManager cm_;
   NiceMock<ThreadLocal::MockInstance> tls_;

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -47,7 +47,8 @@ public:
 class EnvoyGoogleAsyncClientImplTest : public testing::Test {
 public:
   EnvoyGoogleAsyncClientImplTest()
-      : stats_store_(new Stats::IsolatedStoreImpl), api_(Api::createApiForTest(*stats_store_)),
+      : stats_store_(new Stats::IsolatedStoreImpl),
+        api_(Api::createApiForTest(*stats_store_, test_time_.timeSystem())),
         dispatcher_(test_time_.timeSystem(), *api_), scope_(stats_store_),
         method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")) {
     envoy::api::v2::core::GrpcService config;

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -218,7 +218,8 @@ class GrpcClientIntegrationTest : public GrpcClientIntegrationParamTest {
 public:
   GrpcClientIntegrationTest()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
-        api_(Api::createApiForTest(*stats_store_)), dispatcher_(test_time_.timeSystem(), *api_) {}
+        api_(Api::createApiForTest(*stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_) {}
 
   virtual void initialize() {
     if (fake_upstream_ == nullptr) {

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -261,7 +261,7 @@ TEST_F(CodecClientTest, WatermarkPassthrough) {
 // Test the codec getting input from a real TCP connection.
 class CodecNetworkTest : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  CodecNetworkTest() : api_(Api::createApiForTest(stats_store_)) {
+  CodecNetworkTest() : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())) {
     dispatcher_ = std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem(), *api_);
     upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
@@ -329,8 +329,8 @@ public:
 
 protected:
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
   Network::ListenerPtr upstream_listener_;
   Network::MockListenerCallbacks listener_callbacks_;

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -47,8 +47,8 @@ public:
                       NiceMock<Event::MockTimer>* upstream_ready_timer)
       : ConnPoolImpl(dispatcher, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
                      Upstream::ResourcePriority::Default, nullptr),
-        api_(Api::createApiForTest(stats_store_)), mock_dispatcher_(dispatcher),
-        mock_upstream_ready_timer_(upstream_ready_timer) {}
+        api_(Api::createApiForTest(stats_store_, dispatcher.timeSystem())),
+        mock_dispatcher_(dispatcher), mock_upstream_ready_timer_(upstream_ready_timer) {}
 
   ~ConnPoolImplForTest() {
     EXPECT_EQ(0U, ready_clients_.size());

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -65,7 +65,7 @@ public:
   };
 
   Http2ConnPoolImplTest()
-      : api_(Api::createApiForTest(stats_store_)),
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
         pool_(dispatcher_, host_, Upstream::ResourcePriority::Default, nullptr) {}
 
   ~Http2ConnPoolImplTest() {
@@ -119,8 +119,8 @@ public:
   MOCK_METHOD0(onClientDestroy, void());
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostSharedPtr host_{Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:80")};

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -78,8 +78,8 @@ INSTANTIATE_TEST_CASE_P(IpVersions, ConnectionImplDeathTest,
 
 TEST_P(ConnectionImplDeathTest, BadFd) {
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
   Event::SimulatedTimeSystem time_system;
+  Api::ApiPtr api = Api::createApiForTest(stats_store, time_system);
   Event::DispatcherImpl dispatcher(time_system, *api);
   EXPECT_DEATH_LOG_TO_STDERR(
       ConnectionImpl(dispatcher, std::make_unique<ConnectionSocketImpl>(-1, nullptr, nullptr),
@@ -89,7 +89,7 @@ TEST_P(ConnectionImplDeathTest, BadFd) {
 
 class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {
 public:
-  ConnectionImplTest() : api_(Api::createApiForTest(stats_store_)) {}
+  ConnectionImplTest() : api_(Api::createApiForTest(stats_store_, time_system_)) {}
 
   void setUpBasicConnection() {
     if (dispatcher_.get() == nullptr) {
@@ -1635,11 +1635,11 @@ TEST_P(ReadBufferLimitTest, SomeLimit) {
 class TcpClientConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {
 protected:
   TcpClientConnectionImplTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(time_system_, *api_) {}
+      : api_(Api::createApiForTest(stats_store_, time_system_)), dispatcher_(time_system_, *api_) {}
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   Event::SimulatedTimeSystem time_system_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, TcpClientConnectionImplTest,
@@ -1680,11 +1680,11 @@ TEST_P(TcpClientConnectionImplTest, BadConnectConnRefused) {
 class PipeClientConnectionImplTest : public testing::Test {
 protected:
   PipeClientConnectionImplTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(time_system_, *api_) {}
+      : api_(Api::createApiForTest(stats_store_, time_system_)), dispatcher_(time_system_, *api_) {}
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   Event::SimulatedTimeSystem time_system_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   const std::string path_{TestEnvironment::unixDomainSocketPath("foo")};
 };

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -326,11 +326,12 @@ private:
 class DnsImplConstructor : public testing::Test {
 protected:
   DnsImplConstructor()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_) {}
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_) {}
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
 };
 
@@ -408,7 +409,8 @@ TEST_F(DnsImplConstructor, BadCustomResolvers) {
 class DnsImplTest : public testing::TestWithParam<Address::IpVersion> {
 public:
   DnsImplTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_) {}
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_) {}
 
   void SetUp() override {
     resolver_ = dispatcher_.createDnsResolver({});
@@ -440,8 +442,8 @@ protected:
   Network::TcpListenSocketPtr socket_;
   Stats::IsolatedStoreImpl stats_store_;
   std::unique_ptr<Network::Listener> listener_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   DnsResolverSharedPtr resolver_;
 };

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -23,8 +23,8 @@ static void errorCallbackTest(Address::IpVersion version) {
   // Force the error callback to fire by closing the socket under the listener. We run this entire
   // test in the forked process to avoid confusion when the fork happens.
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
   DangerousDeprecatedTestTime test_time;
+  Api::ApiPtr api = Api::createApiForTest(stats_store, test_time.timeSystem());
   Event::DispatcherImpl dispatcher(test_time.timeSystem(), *api);
 
   Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr,
@@ -79,13 +79,14 @@ protected:
       : version_(GetParam()),
         alt_address_(Network::Test::findOrCheckFreePort(
             Network::Test::getCanonicalLoopbackAddress(version_), Address::SocketType::Stream)),
-        api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_) {}
+        api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_) {}
 
   const Address::IpVersion version_;
   const Address::InstanceConstSharedPtr alt_address_;
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplTest,

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -20,7 +20,8 @@ namespace Envoy {
 
 class ThreadLocalStorePerf {
 public:
-  ThreadLocalStorePerf() : store_(options_, heap_alloc_), api_(Api::createApiForTest(store_)) {
+  ThreadLocalStorePerf()
+      : store_(options_, heap_alloc_), api_(Api::createApiForTest(store_, time_system_)) {
     store_.setTagProducer(std::make_unique<Stats::TagProducerImpl>(stats_config_));
   }
 
@@ -46,8 +47,8 @@ private:
   Stats::StatsOptionsImpl options_;
   Stats::HeapStatDataAllocator heap_alloc_;
   Stats::ThreadLocalStoreImpl store_;
-  Api::ApiPtr api_;
   Event::SimulatedTimeSystem time_system_;
+  Api::ApiPtr api_;
   std::unique_ptr<Event::DispatcherImpl> dispatcher_;
   std::unique_ptr<ThreadLocal::InstanceImpl> tls_;
   envoy::config::metrics::v2::StatsConfig stats_config_;

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -119,7 +119,7 @@ TEST(ThreadLocalInstanceImplDispatcherTest, Dispatcher) {
 
   DangerousDeprecatedTestTime test_time;
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store, test_time.timeSystem());
   Event::DispatcherImpl main_dispatcher(test_time.timeSystem(), *api);
   Event::DispatcherImpl thread_dispatcher(test_time.timeSystem(), *api);
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -169,7 +169,7 @@ envoy::config::bootstrap::v2::Bootstrap parseBootstrapFromV2Yaml(const std::stri
 
 class ClusterManagerImplTest : public testing::Test {
 public:
-  ClusterManagerImplTest() : api_(Api::createApiForTest(stats_store_)) {
+  ClusterManagerImplTest() : api_(Api::createApiForTest(stats_store_, time_system_)) {
     factory_.dispatcher_.setTimeSystem(time_system_);
   }
 
@@ -246,12 +246,12 @@ public:
   }
 
   Stats::IsolatedStoreImpl stats_store_;
+  Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
   NiceMock<TestClusterManagerFactory> factory_;
   std::unique_ptr<ClusterManagerImpl> cluster_manager_;
   AccessLog::MockAccessLogManager log_manager_;
   NiceMock<Server::MockAdmin> admin_;
-  Event::SimulatedTimeSystem time_system_;
   MockLocalClusterUpdate local_cluster_update_;
   Http::ContextImpl http_context_;
 };

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -44,5 +44,6 @@ envoy_cc_test_library(
         "//test/mocks/server:server_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",
+        "//test/test_common:simulated_time_system_lib",
     ] + envoy_all_extensions(),
 )

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -50,7 +50,8 @@ class ProxyProtocolTest : public testing::TestWithParam<Network::Address::IpVers
                           protected Logger::Loggable<Logger::Id::main> {
 public:
   ProxyProtocolTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_),
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_),
         socket_(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true),
         connection_handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), dispatcher_)),
         name_("proxy"), filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
@@ -150,8 +151,8 @@ public:
   }
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   Network::TcpListenSocket socket_;
   Network::ConnectionHandlerPtr connection_handler_;
@@ -871,7 +872,8 @@ class WildcardProxyProtocolTest : public testing::TestWithParam<Network::Address
                                   protected Logger::Loggable<Logger::Id::main> {
 public:
   WildcardProxyProtocolTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_),
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_),
         socket_(Network::Test::getAnyAddress(GetParam()), nullptr, true),
         local_dst_address_(Network::Utility::getAddressWithPort(
             *Network::Test::getCanonicalLoopbackAddress(GetParam()),
@@ -957,8 +959,8 @@ public:
   }
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   Network::TcpListenSocket socket_;
   Network::Address::InstanceConstSharedPtr local_dst_address_;

--- a/test/extensions/resource_monitors/injected_resource/config_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/config_test.cc
@@ -28,8 +28,8 @@ TEST(InjectedResourceMonitorFactoryTest, CreateMonitor) {
   envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig config;
   config.set_filename(TestEnvironment::temporaryPath("injected_resource"));
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
   DangerousDeprecatedTestTime test_time;
+  Api::ApiPtr api = Api::createApiForTest(stats_store, test_time.timeSystem());
   Event::DispatcherImpl dispatcher(test_time.timeSystem(), *api);
   Server::Configuration::ResourceMonitorFactoryContextImpl context(dispatcher);
   Server::ResourceMonitorPtr monitor = factory->createResourceMonitor(config, context);

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -46,7 +46,8 @@ public:
 class InjectedResourceMonitorTest : public testing::Test {
 protected:
   InjectedResourceMonitorTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(test_time_.timeSystem(), *api_),
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        dispatcher_(test_time_.timeSystem(), *api_),
         resource_filename_(TestEnvironment::temporaryPath("injected_resource")),
         file_updater_(resource_filename_), monitor_(createMonitor()) {}
 
@@ -66,8 +67,8 @@ protected:
   }
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   const std::string resource_filename_;
   AtomicFileUpdater file_updater_;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -184,7 +184,7 @@ void testUtil(const TestUtilOptions& options) {
                                                    server_stats_store, std::vector<std::string>{});
 
   DangerousDeprecatedTestTime test_time;
-  Api::ApiPtr api = Api::createApiForTest(server_stats_store);
+  Api::ApiPtr api = Api::createApiForTest(server_stats_store, test_time.timeSystem());
   Event::DispatcherImpl dispatcher(test_time.timeSystem(), *api);
   Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(options.version()),
                                   nullptr, true);
@@ -401,7 +401,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
                                                    server_stats_store, server_names);
 
   DangerousDeprecatedTestTime test_time;
-  Api::ApiPtr api = Api::createApiForTest(server_stats_store);
+  Api::ApiPtr api = Api::createApiForTest(server_stats_store, test_time.timeSystem());
   Event::DispatcherImpl dispatcher(test_time.timeSystem(), *api);
   Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(options.version()),
                                   nullptr, true);
@@ -573,12 +573,12 @@ class SslSocketTest : public SslCertsTest,
                       public testing::WithParamInterface<Network::Address::IpVersion> {
 protected:
   SslSocketTest()
-      : api_(Api::createApiForTest(stats_store_)),
+      : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
         dispatcher_(std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem(), *api_)) {}
 
   Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
   std::unique_ptr<Event::DispatcherImpl> dispatcher_;
 };
 
@@ -2117,7 +2117,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
   DangerousDeprecatedTestTime test_time;
-  Api::ApiPtr api = Api::createApiForTest(server_stats_store);
+  Api::ApiPtr api = Api::createApiForTest(server_stats_store, test_time.timeSystem());
   Event::DispatcherImpl dispatcher(test_time.timeSystem(), *api);
   Network::ListenerPtr listener1 = dispatcher.createListener(socket1, callbacks, true, false);
   Network::ListenerPtr listener2 = dispatcher.createListener(socket2, callbacks, true, false);
@@ -2629,7 +2629,7 @@ void testClientSessionResumption(const std::string& server_ctx_yaml,
                                   true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
-  Api::ApiPtr api = Api::createApiForTest(server_stats_store);
+  Api::ApiPtr api = Api::createApiForTest(server_stats_store, time_system);
   Event::DispatcherImpl dispatcher(time_system, *api);
   Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -372,8 +372,8 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
                            Network::SocketPtr&& listen_socket, FakeHttpConnection::Type type,
                            Event::TestTimeSystem& time_system, bool enable_half_close)
     : http_type_(type), socket_(std::move(listen_socket)),
-      api_(Api::createApiForTest(stats_store_)), time_system_(time_system),
-      dispatcher_(api_->allocateDispatcher(time_system_)),
+      api_(Api::createApiForTest(stats_store_, time_system)), time_system_(time_system),
+      dispatcher_(api_->allocateDispatcher()),
       handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),
       allow_unexpected_disconnects_(false), enable_half_close_(enable_half_close), listener_(*this),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -220,7 +220,7 @@ void IntegrationTcpClient::ConnectionCallbacks::onEvent(Network::ConnectionEvent
 
 BaseIntegrationTest::BaseIntegrationTest(Network::Address::IpVersion version,
                                          TestTimeSystemPtr time_system, const std::string& config)
-    : api_(Api::createApiForTest(stats_store_)),
+    : api_(Api::createApiForTest(stats_store_, *time_system)),
       mock_buffer_factory_(new NiceMock<MockBufferFactory>), time_system_(std::move(time_system)),
       dispatcher_(new Event::DispatcherImpl(
           *time_system_, Buffer::WatermarkFactoryPtr{mock_buffer_factory_}, *api_)),

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -63,8 +63,9 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
                                    const std::string& host, const std::string& content_type) {
 
   NiceMock<Stats::MockIsolatedStatsStore> mock_stats_store;
-  Api::Impl api(std::chrono::milliseconds(9000), Thread::threadFactoryForTest(), mock_stats_store);
-  Event::DispatcherPtr dispatcher(api.allocateDispatcher(evil_singleton_test_time_.timeSystem()));
+  Api::Impl api(std::chrono::milliseconds(9000), Thread::threadFactoryForTest(), mock_stats_store,
+                evil_singleton_test_time_.timeSystem());
+  Event::DispatcherPtr dispatcher(api.allocateDispatcher());
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionConstSharedPtr host_description{
       Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80")};
@@ -111,8 +112,9 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
 RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data,
                                          ReadCallback data_callback,
                                          Network::Address::IpVersion version) {
-  api_ = Api::createApiForTest(stats_store_);
-  dispatcher_ = api_->allocateDispatcher(IntegrationUtil::evil_singleton_test_time_.timeSystem());
+  Event::TimeSystem& time_system = IntegrationUtil::evil_singleton_test_time_.timeSystem();
+  api_ = Api::createApiForTest(stats_store_, time_system);
+  dispatcher_ = api_->allocateDispatcher();
   callbacks_ = std::make_unique<ConnectionCallbacks>();
   client_ = dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(

--- a/test/mocks/api/BUILD
+++ b/test/mocks/api/BUILD
@@ -19,5 +19,6 @@ envoy_cc_mock(
         "//source/common/common:assert_lib",
         "//test/mocks/filesystem:filesystem_mocks",
         "//test/test_common:test_time_system_interface",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -3,16 +3,22 @@
 #include "common/common/assert.h"
 #include "common/common/lock_guard.h"
 
+#include "test/test_common/utility.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using testing::_;
 using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Api {
 
-MockApi::MockApi() { ON_CALL(*this, createFile(_, _, _)).WillByDefault(Return(file_)); }
+MockApi::MockApi(Event::TimeSystem& time_system) : time_system_(time_system) {
+  ON_CALL(*this, createFile(_, _, _)).WillByDefault(Return(file_));
+  ON_CALL(*this, threadFactory()).WillByDefault(ReturnRef(Thread::threadFactoryForTest()));
+}
 
 MockApi::~MockApi() {}
 

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -21,23 +21,25 @@ namespace Api {
 
 class MockApi : public Api {
 public:
-  MockApi();
+  explicit MockApi(Event::TimeSystem& time_system);
   ~MockApi();
 
   // Api::Api
-  Event::DispatcherPtr allocateDispatcher(Event::TimeSystem& time_system) override {
-    return Event::DispatcherPtr{allocateDispatcher_(time_system)};
+  Event::DispatcherPtr allocateDispatcher() override {
+    return Event::DispatcherPtr{allocateDispatcher_()};
   }
 
-  MOCK_METHOD1(allocateDispatcher_, Event::Dispatcher*(Event::TimeSystem&));
+  MOCK_METHOD0(allocateDispatcher_, Event::Dispatcher*());
   MOCK_METHOD3(createFile,
                Filesystem::FileSharedPtr(const std::string& path, Event::Dispatcher& dispatcher,
                                          Thread::BasicLockable& lock));
   MOCK_METHOD1(fileExists, bool(const std::string& path));
   MOCK_METHOD1(fileReadToEnd, std::string(const std::string& path));
   MOCK_METHOD0(threadFactory, Thread::ThreadFactory&());
+  Event::TimeSystem& timeSystem() override { return time_system_; }
 
   std::shared_ptr<Filesystem::MockFile> file_{new Filesystem::MockFile()};
+  Event::TimeSystem& time_system_;
 };
 
 class MockOsSysCalls : public OsSysCallsImpl {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -319,12 +319,13 @@ public:
 class MockInstance : public Instance {
 public:
   MockInstance();
+  explicit MockInstance(DangerousDeprecatedTestTime* test_time);
+  explicit MockInstance(Event::TimeSystem& time_system);
   ~MockInstance();
 
   Secret::SecretManager& secretManager() override { return *(secret_manager_.get()); }
 
   MOCK_METHOD0(admin, Admin&());
-  MOCK_METHOD0(api, Api::Api&());
   MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
   MOCK_METHOD0(sslContextManager, Ssl::ContextManager&());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
@@ -355,16 +356,19 @@ public:
   MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_CONST_METHOD0(statsFlushInterval, std::chrono::milliseconds());
 
-  Event::TestTimeSystem& timeSystem() override { return test_time_.timeSystem(); }
+  // Event::TestTimeSystem& timeSystem() override { return test_time_.timeSystem(); }
+  Event::TimeSystem& timeSystem() override { return time_system_; }
+  Api::Api& api() override { return api_; }
 
+  std::unique_ptr<DangerousDeprecatedTestTime> test_time_;
+  Event::TimeSystem& time_system_;
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   Stats::IsolatedStoreImpl stats_store_;
   std::shared_ptr<testing::NiceMock<Network::MockDnsResolver>> dns_resolver_{
       new testing::NiceMock<Network::MockDnsResolver>()};
-  testing::NiceMock<Api::MockApi> api_;
   testing::NiceMock<MockAdmin> admin_;
-  DangerousDeprecatedTestTime test_time_;
+  testing::NiceMock<Api::MockApi> api_;
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   Thread::MutexBasicLockable access_log_lock_;
   testing::NiceMock<Runtime::MockLoader> runtime_loader_;
@@ -412,6 +416,7 @@ public:
   ~MockFactoryContext();
 
   MOCK_METHOD0(accessLogManager, AccessLog::AccessLogManager&());
+  MOCK_METHOD0(api, Api::Api&());
   MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(drainDecision, const Network::DrainDecision&());
@@ -447,6 +452,7 @@ public:
   testing::NiceMock<MockAdmin> admin_;
   Stats::IsolatedStoreImpl listener_scope_;
   Event::SimulatedTimeSystem time_system_;
+  Api::MockApi api_;
   testing::NiceMock<MockOverloadManager> overload_manager_;
   Tracing::HttpNullTracer null_tracer_;
   Http::ContextImpl http_context_;

--- a/test/server/config_validation/async_client_test.cc
+++ b/test/server/config_validation/async_client_test.cc
@@ -18,7 +18,7 @@ TEST(ValidationAsyncClientTest, MockedMethods) {
 
   DangerousDeprecatedTestTime test_time;
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store, test_time.timeSystem());
   ValidationAsyncClient client(test_time.timeSystem(), *api);
   EXPECT_EQ(nullptr, client.send(std::move(message), callbacks, AsyncClient::RequestOptions()));
   EXPECT_EQ(nullptr, client.start(stream_callbacks, AsyncClient::StreamOptions()));

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -26,9 +26,9 @@ namespace Upstream {
 
 TEST(ValidationClusterManagerTest, MockedMethods) {
   Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api(Api::createApiForTest(stats_store));
-  NiceMock<Runtime::MockLoader> runtime;
   Event::SimulatedTimeSystem time_system;
+  Api::ApiPtr api(Api::createApiForTest(stats_store, time_system));
+  NiceMock<Runtime::MockLoader> runtime;
   NiceMock<ThreadLocal::MockInstance> tls;
   NiceMock<Runtime::MockRandomGenerator> random;
   testing::NiceMock<Secret::MockSecretManager> secret_manager;

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -24,9 +24,10 @@ public:
   ConfigValidation() {
     Event::Libevent::Global::initialize();
 
-    validation_ = std::make_unique<Api::ValidationImpl>(
-        std::chrono::milliseconds(1000), Thread::threadFactoryForTest(), stats_store_);
-    dispatcher_ = validation_->allocateDispatcher(test_time_.timeSystem());
+    validation_ = std::make_unique<Api::ValidationImpl>(std::chrono::milliseconds(1000),
+                                                        Thread::threadFactoryForTest(),
+                                                        stats_store_, test_time_.timeSystem());
+    dispatcher_ = validation_->allocateDispatcher();
   }
 
   DangerousDeprecatedTestTime test_time_;

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -53,14 +53,11 @@ TEST(FilterChainUtility, buildFilterChainFailWithBadFilters) {
 class ConfigurationImplTest : public testing::Test {
 protected:
   ConfigurationImplTest()
-      : api_(Api::createApiForTest(stats_store_)),
-        cluster_manager_factory_(
+      : cluster_manager_factory_(
             server_.runtime(), server_.stats(), server_.threadLocal(), server_.random(),
             server_.dnsResolver(), server_.sslContextManager(), server_.dispatcher(),
-            server_.localInfo(), server_.secretManager(), *api_, server_.httpContext()) {}
+            server_.localInfo(), server_.secretManager(), server_.api(), server_.httpContext()) {}
 
-  Stats::IsolatedStoreImpl stats_store_;
-  Api::ApiPtr api_;
   NiceMock<Server::MockInstance> server_;
   Upstream::ProdClusterManagerFactory cluster_manager_factory_;
 };

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -26,7 +26,7 @@ namespace Server {
 
 class GuardDogTestBase : public testing::Test {
 protected:
-  GuardDogTestBase() : api_(Api::createApiForTest(stats_store_)) {}
+  GuardDogTestBase() : api_(Api::createApiForTest(stats_store_, time_system_)) {}
 
   Event::SimulatedTimeSystem time_system_;
   Stats::IsolatedStoreImpl stats_store_;

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -56,10 +56,9 @@ public:
 
 class ListenerManagerImplTest : public testing::Test {
 public:
-  ListenerManagerImplTest() {
+  ListenerManagerImplTest() : server_(time_system_) {
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
-    manager_ = std::make_unique<ListenerManagerImpl>(server_, listener_factory_, worker_factory_,
-                                                     time_system_);
+    manager_ = std::make_unique<ListenerManagerImpl>(server_, listener_factory_, worker_factory_);
   }
 
   /**

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -24,7 +24,7 @@ namespace Server {
 
 class WorkerImplTest : public testing::Test {
 public:
-  WorkerImplTest() : api_(Api::createApiForTest(stats_store_)) {
+  WorkerImplTest() : api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())) {
     // In the real worker the watchdog has timers that prevent exit. Here we need to prevent event
     // loop exit since we use mock timers.
     no_exit_timer_->enableTimer(std::chrono::hours(1));
@@ -32,12 +32,12 @@ public:
 
   Stats::IsolatedStoreImpl stats_store_;
   NiceMock<ThreadLocal::MockInstance> tls_;
-  DangerousDeprecatedTestTime test_time;
+  DangerousDeprecatedTestTime test_time_;
   Network::MockConnectionHandler* handler_ = new Network::MockConnectionHandler();
   NiceMock<MockGuardDog> guard_dog_;
   NiceMock<MockOverloadManager> overload_manager_;
   Api::ApiPtr api_;
-  Event::DispatcherImpl* dispatcher_ = new Event::DispatcherImpl(test_time.timeSystem(), *api_);
+  Event::DispatcherImpl* dispatcher_ = new Event::DispatcherImpl(test_time_.timeSystem(), *api_);
   DefaultTestHooks hooks_;
   WorkerImpl worker_{tls_,
                      hooks_,

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -396,9 +396,9 @@ ThreadFactory& threadFactoryForTest() {
 
 namespace Api {
 
-ApiPtr createApiForTest(Stats::Store& stat_store) {
+ApiPtr createApiForTest(Stats::Store& stat_store, Event::TimeSystem& time_system) {
   return std::make_unique<Impl>(std::chrono::milliseconds(1000), Thread::threadFactoryForTest(),
-                                stat_store);
+                                stat_store, time_system);
 }
 
 } // namespace Api

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -513,7 +513,7 @@ ThreadFactory& threadFactoryForTest();
 } // namespace Thread
 
 namespace Api {
-ApiPtr createApiForTest(Stats::Store& stat_store);
+ApiPtr createApiForTest(Stats::Store& stat_store, Event::TimeSystem& time_system);
 } // namespace Api
 
 MATCHER_P(HeaderMapEqualIgnoreOrder, rhs, "") {


### PR DESCRIPTION
*Description*: In general it would be better to tunnel more global structures through the API interface rather than passing tons of of global state everywhere. This PR puts an Event::TimeSystem& accessor into Api::Api and plumbs that through where needed. This may make it easier to get (for example) file-systems where they need to go.

Not quite ready for review yet.

*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
