### PR TITLE
tracing: inject tracing context in router

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -755,9 +755,6 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
       request_headers_->removeEnvoyDecoratorOperation();
     }
   }
-
-  // Inject the active span's tracing context into the request headers.
-  active_span_->injectContext(*request_headers_);
 }
 
 void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilter* filter,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -363,6 +363,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     headers.insertEnvoyAttemptCount().value(attempt_count_);
   }
 
+  // Inject the active span's tracing context into the request headers.
+  callbacks_->activeSpan().injectContext(headers);
+
   route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
                                        !config_.suppress_envoy_headers_);
   FilterUtility::setUpstreamScheme(headers, *cluster_);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -176,6 +176,7 @@ public:
 
     Http::TestHeaderMapImpl headers;
     HttpTestUtility::addDefaultHeaders(headers);
+    EXPECT_CALL(callbacks_, activeSpan()).Times(1);
     router_.decodeHeaders(headers, true);
 
     // When the router filter gets reset we should cancel the pool request.
@@ -196,6 +197,7 @@ public:
               return nullptr;
             }));
     HttpTestUtility::addDefaultHeaders(default_request_headers_);
+    EXPECT_CALL(callbacks_, activeSpan()).Times(1);
     router_.decodeHeaders(default_request_headers_, end_stream);
   }
 
@@ -289,6 +291,7 @@ TEST_F(RouterTest, PoolFailureWithPriority) {
       .WillOnce(Invoke([&](const Upstream::HostDescriptionConstSharedPtr host) -> void {
         EXPECT_EQ(host_address_, host->address());
       }));
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -306,6 +309,7 @@ TEST_F(RouterTest, Http1Upstream) {
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.route_->route_entry_, finalizeRequestHeaders(_, _, true));
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
   EXPECT_EQ("10", headers.get_("x-envoy-expected-rq-timeout-ms"));
 
@@ -328,6 +332,7 @@ TEST_F(RouterTestSuppressEnvoyHeaders, Http1Upstream) {
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.route_->route_entry_, finalizeRequestHeaders(_, _, false));
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
   EXPECT_FALSE(headers.has("x-envoy-expected-rq-timeout-ms"));
 
@@ -347,6 +352,7 @@ TEST_F(RouterTest, Http2Upstream) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -367,6 +373,7 @@ TEST_F(RouterTest, UseDownstreamProtocol1) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -387,6 +394,7 @@ TEST_F(RouterTest, UseDownstreamProtocol2) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -412,6 +420,7 @@ TEST_F(RouterTest, HashPolicy) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -437,6 +446,7 @@ TEST_F(RouterTest, HashPolicyNoHash) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -489,6 +499,7 @@ TEST_F(RouterTest, AddCookie) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -535,6 +546,7 @@ TEST_F(RouterTest, AddCookieNoDuplicate) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(
@@ -595,6 +607,7 @@ TEST_F(RouterTest, AddMultipleCookies) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -620,6 +633,7 @@ TEST_F(RouterTest, MetadataMatchCriteria) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -649,6 +663,7 @@ TEST_F(RouterTest, NoMetadataMatchCriteria) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -662,6 +677,7 @@ TEST_F(RouterTest, CancelBeforeBoundToPool) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -744,6 +760,7 @@ TEST_F(RouterTest, EnvoyUpstreamServiceTime) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -804,6 +821,7 @@ TEST_F(RouterTest, NoRetriesOverflow) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // 5xx response.
@@ -857,6 +875,7 @@ TEST_F(RouterTest, ResetDuringEncodeHeaders) {
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(503));
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
 }
@@ -880,6 +899,7 @@ TEST_F(RouterTest, UpstreamTimeout) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
   Buffer::OwnedImpl data;
   router_.decodeData(data, true);
@@ -917,6 +937,7 @@ TEST_F(RouterTest, GrpcOkTrailersOnly) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(
@@ -941,6 +962,7 @@ TEST_F(RouterTest, GrpcAlreadyExistsTrailersOnly) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(
@@ -965,6 +987,7 @@ TEST_F(RouterTest, GrpcInternalTrailersOnly) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(
@@ -990,6 +1013,7 @@ TEST_F(RouterTest, GrpcDataEndStream) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -1017,6 +1041,7 @@ TEST_F(RouterTest, GrpcReset) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -1043,6 +1068,7 @@ TEST_F(RouterTest, GrpcOk) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -1069,6 +1095,7 @@ TEST_F(RouterTest, GrpcInternal) {
 
   Http::TestHeaderMapImpl headers{{"content-type", "application/grpc"}, {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -1100,6 +1127,7 @@ TEST_F(RouterTest, UpstreamTimeoutWithAltResponse) {
   Http::TestHeaderMapImpl headers{{"x-envoy-upstream-rq-timeout-alt-response", "204"},
                                   {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
   Buffer::OwnedImpl data;
   router_.decodeData(data, true);
@@ -1141,6 +1169,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeout) {
   Http::TestHeaderMapImpl headers{{"x-envoy-internal", "true"},
                                   {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
   Buffer::OwnedImpl data;
   router_.decodeData(data, true);
@@ -1169,6 +1198,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
   Http::StreamDecoder* response_decoder = nullptr;
   Http::ConnectionPool::Callbacks* pool_callbacks;
 
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
                            -> Http::ConnectionPool::Cancellable* {
@@ -1235,6 +1265,7 @@ TEST_F(RouterTest, RetryRequestNotComplete) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
 
   router_.retry_state_->expectRetry();
@@ -1262,6 +1293,7 @@ TEST_F(RouterTest, RetryNoneHealthy) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   router_.retry_state_->expectRetry();
@@ -1293,6 +1325,7 @@ TEST_F(RouterTest, RetryUpstreamReset) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   router_.retry_state_->expectRetry();
@@ -1339,6 +1372,7 @@ TEST_F(RouterTest, RetryUpstreamPerTryTimeout) {
                                   {"x-envoy-internal", "true"},
                                   {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   EXPECT_CALL(*router_.retry_state_, onHostAttempted(_));
@@ -1382,6 +1416,7 @@ TEST_F(RouterTest, RetryUpstreamConnectionFailure) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   EXPECT_CALL(*router_.retry_state_, onHostAttempted(_)).Times(0);
@@ -1429,6 +1464,7 @@ TEST_F(RouterTest, DontResetStartedResponseOnUpstreamPerTryTimeout) {
   Http::TestHeaderMapImpl headers{{"x-envoy-internal", "true"},
                                   {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // Since the response is already started we don't retry.
@@ -1461,6 +1497,7 @@ TEST_F(RouterTest, RetryUpstreamResetResponseStarted) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // Since the response is already started we don't retry.
@@ -1490,6 +1527,7 @@ TEST_F(RouterTest, RetryUpstreamReset100ContinueResponseStarted) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // The 100-continue will result in resetting retry_state_, so when the stream
@@ -1516,6 +1554,7 @@ TEST_F(RouterTest, RetryUpstream5xx) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // 5xx response.
@@ -1560,6 +1599,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelay) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // 5xx response.
@@ -1596,6 +1636,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHost) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // 5xx response.
@@ -1645,6 +1686,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHostAltRespo
                                   {"x-envoy-internal", "true"},
                                   {"x-envoy-upstream-rq-timeout-alt-response", "204"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // 5xx response.
@@ -1689,6 +1731,7 @@ TEST_F(RouterTest, RetryUpstream5xxNotComplete) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
 
   Buffer::InstancePtr body_data(new Buffer::OwnedImpl("hello"));
@@ -1762,6 +1805,7 @@ TEST_F(RouterTest, RetryUpstreamGrpcCancelled) {
                                   {"content-type", "application/grpc"},
                                   {"grpc-timeout", "20S"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   // gRPC with status "cancelled" (1)
@@ -1811,6 +1855,7 @@ TEST_F(RouterTest, RetryRespsectsMaxHostSelectionCount) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
 
   ON_CALL(*router_.retry_state_, hostSelectionMaxAttempts()).WillByDefault(Return(3));
@@ -1877,6 +1922,7 @@ TEST_F(RouterTest, RetryRespectsRetryHostPredicate) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
 
   NiceMock<Upstream::MockHost> host;
@@ -2076,6 +2122,7 @@ TEST_F(RouterTest, Shadow) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
 
   Buffer::InstancePtr body_data(new Buffer::OwnedImpl("hello"));
@@ -2117,6 +2164,7 @@ TEST_F(RouterTest, AltStatName) {
   Http::TestHeaderMapImpl headers{{"x-envoy-upstream-alt-stat-name", "alt_stat"},
                                   {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
@@ -2543,6 +2591,7 @@ TEST_F(RouterTest, CanaryStatusTrue) {
   Http::TestHeaderMapImpl headers{{"x-envoy-upstream-alt-stat-name", "alt_stat"},
                                   {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(
@@ -2576,6 +2625,7 @@ TEST_F(RouterTest, CanaryStatusFalse) {
   Http::TestHeaderMapImpl headers{{"x-envoy-upstream-alt-stat-name", "alt_stat"},
                                   {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(
@@ -2596,6 +2646,7 @@ TEST_F(RouterTest, AutoHostRewriteEnabled) {
 
   Http::TestHeaderMapImpl incoming_headers;
   HttpTestUtility::addDefaultHeaders(incoming_headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   incoming_headers.Host()->value(req_host);
 
   cm_.conn_pool_.host_->hostname_ = "scooby.doo";
@@ -2634,6 +2685,7 @@ TEST_F(RouterTest, AutoHostRewriteDisabled) {
 
   Http::TestHeaderMapImpl incoming_headers;
   HttpTestUtility::addDefaultHeaders(incoming_headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   incoming_headers.Host()->value(req_host);
 
   cm_.conn_pool_.host_->hostname_ = "scooby.doo";
@@ -2686,6 +2738,7 @@ public:
               return nullptr;
             }));
     HttpTestUtility::addDefaultHeaders(headers_);
+    EXPECT_CALL(callbacks_, activeSpan()).Times(1);
     router_.decodeHeaders(headers_, header_only_request);
   }
   void sendResponse() {
@@ -2799,6 +2852,7 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
 
   Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_, activeSpan()).Times(1);
   router_.decodeHeaders(headers, false);
   Buffer::OwnedImpl data("1234567890123");
   EXPECT_CALL(*router_.retry_state_, enabled()).Times(1).WillOnce(Return(true));


### PR DESCRIPTION
*Description*:

This moves the moment that headers related to tracing are injected
in proxied requests.
More details in issue #5504  and the earlier PR #5529 that didn't fix this correctly

Signed-off-by: Caleb Gilmour <caleb.gilmour@datadoghq.com>

*Risk Level*: Low
*Testing*: unit tests and E2E with
- tracing disabled
- datadog tracer with healthchecks from "front-end" to "service1"
- zipkin tracer

*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #5504