### PR TITLE
add a performance benchmark test for Http::HeaderMapImpl

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -223,6 +223,17 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test_binary(
+    name = "header_map_impl_speed_test",
+    srcs = ["header_map_impl_speed_test.cc"],
+    external_deps = [
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/http:header_map_lib",
+    ],
+)
+
 envoy_proto_library(
     name = "header_map_impl_fuzz_proto",
     srcs = ["header_map_impl_fuzz.proto"],

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -1,0 +1,112 @@
+#include "common/http/header_map_impl.h"
+
+#include "testing/base/public/benchmark.h"
+
+namespace Envoy {
+namespace Http {
+
+/**
+ * Add several dummy headers to a HeaderMap.
+ * @param num_headers the number of dummy headers to add.
+ */
+static void addDummyHeaders(HeaderMap& headers, size_t num_headers) {
+  const std::string prefix("dummy-key-");
+  for (size_t i = 0; i < num_headers; i++) {
+    headers.addCopy(LowerCaseString(prefix + std::to_string(i)), "abcd");
+  }
+}
+
+/** Measure the construction/destruction speed of HeaderMapImpl.*/
+static void HeaderMapImplCreate(benchmark::State& state) {
+  for (auto _ : state) {
+    HeaderMapImpl headers;
+    benchmark::DoNotOptimize(headers.size());
+  }
+}
+BENCHMARK(HeaderMapImplCreate);
+
+/**
+ * Measure the speed of setting/overwriting a header value. The numeric Arg passed
+ * by the BENCHMARK(...) macro call below indicates how many dummy headers this test
+ * will add to the HeaderMapImpl before testing the setReference() method. That helps
+ * identify whether the speed of setReference() is dependent on the number of other
+ * headers in the HeaderMapImpl.
+ */
+static void HeaderMapImplSetReference(benchmark::State& state) {
+  const LowerCaseString key("example-key");
+  const std::string value("01234567890123456789");
+  HeaderMapImpl headers;
+  addDummyHeaders(headers, state.range(0));
+  for (auto _ : state) {
+    headers.setReference(key, value);
+  }
+  benchmark::DoNotOptimize(headers.size());
+}
+BENCHMARK(HeaderMapImplSetReference)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
+
+/**
+ * Measure the speed of retrieving a header value. The numeric Arg passed by the
+ * BENCHMARK(...) macro call below indicates how many dummy headers this test
+ * will add to the HeaderMapImpl during test setup. The relative performance of
+ * this test for different Arg values will help reveal how the speed of the get()
+ * method depends (or doesn't depend) on the number of other headers in the
+ * HeaderMapImpl.
+ */
+static void HeaderMapImplGet(benchmark::State& state) {
+  const LowerCaseString key("example-key");
+  const std::string value("01234567890123456789");
+  HeaderMapImpl headers;
+  addDummyHeaders(headers, state.range(0));
+  headers.setReference(key, value);
+  size_t successes = 0;
+  for (auto _ : state) {
+    successes += (headers.get(key) != nullptr);
+  }
+  benchmark::DoNotOptimize(successes);
+}
+BENCHMARK(HeaderMapImplGet)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
+
+/**
+ * Measure the retrieval speed of a header for which HeaderMapImpl is expected to
+ * provide special optimizations.
+ */
+static void HeaderMapImplGetInline(benchmark::State& state) {
+  const std::string value("01234567890123456789");
+  HeaderMapImpl headers;
+  addDummyHeaders(headers, state.range(0));
+  headers.insertConnection().value().setReference(value);
+  size_t size = 0;
+  for (auto _ : state) {
+    size += headers.Connection()->value().size();
+  }
+  benchmark::DoNotOptimize(size);
+}
+BENCHMARK(HeaderMapImplGetInline)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
+
+/**
+ * Measure the speed of writing to a header for which HeaderMapImpl is expected to
+ * provide special optimizations.
+ */
+static void HeaderMapImplSetInline(benchmark::State& state) {
+  const std::string value("01234567890123456789");
+  HeaderMapImpl headers;
+  addDummyHeaders(headers, state.range(0));
+  for (auto _ : state) {
+    headers.insertConnection().value().setReference(value);
+  }
+  benchmark::DoNotOptimize(headers.size());
+}
+BENCHMARK(HeaderMapImplSetInline)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
+
+} // namespace Http
+} // namespace Envoy
+
+// Boilerplate main(), which discovers benchmarks in the same file and runs them.
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
*Description*:
This change adds a performance benchmark test for the HTTP header map implementation.

*Risk Level*: low

*Testing*:
```
$ bazel build -c opt //test/common/http/...
[build output omitted for clarity]
$ bazel-bin/test/common/http/header_map_impl_speed_test
$ bazel-bin/test/common/http/header_map_impl_speed_test
2019-01-20 17:49:24
Running bazel-bin/test/common/http/header_map_impl_speed_test
Run on (12 X 3500 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 262K (x6)
  L3 Unified 12582K (x1)
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
HeaderMapImplCreate                  15 ns         15 ns   47149160
HeaderMapImplSetReference/0         139 ns        139 ns    5166128
HeaderMapImplSetReference/1         141 ns        141 ns    4321841
HeaderMapImplSetReference/10        208 ns        208 ns    3363412
HeaderMapImplSetReference/50        441 ns        441 ns    1625635
HeaderMapImplGet/0                   15 ns         15 ns   47585382
HeaderMapImplGet/1                   21 ns         21 ns   33841602
HeaderMapImplGet/10                  75 ns         75 ns    9267963
HeaderMapImplGet/50                 320 ns        320 ns    2185833
HeaderMapImplGetInline/0              2 ns          2 ns  366732155
HeaderMapImplGetInline/1              2 ns          2 ns  369582319
HeaderMapImplGetInline/10             2 ns          2 ns  367703064
HeaderMapImplGetInline/50             2 ns          2 ns  339792629
HeaderMapImplSetInline/0              8 ns          8 ns   83102822
HeaderMapImplSetInline/1              8 ns          8 ns   82857887
HeaderMapImplSetInline/10             8 ns          8 ns   82959030
HeaderMapImplSetInline/50             8 ns          8 ns   82152875
```

*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Brian Pane <brianp+github@brianp.net>