### PR TITLE
mysql_proxy: access EnvoyException by reference.

### DIFF
--- a/source/extensions/filters/network/mysql_proxy/mysql_utils.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_utils.cc
@@ -43,7 +43,7 @@ int BufferHelper::peekUint8(Buffer::Instance& buffer, uint64_t& offset, uint8_t&
     val = buffer.peekLEInt<uint8_t>(offset);
     offset += sizeof(uint8_t);
     return MYSQL_SUCCESS;
-  } catch (EnvoyException e) {
+  } catch (EnvoyException& e) {
     // buffer underflow
     return MYSQL_FAILURE;
   }
@@ -54,7 +54,7 @@ int BufferHelper::peekUint16(Buffer::Instance& buffer, uint64_t& offset, uint16_
     val = buffer.peekLEInt<uint16_t>(offset);
     offset += sizeof(uint16_t);
     return MYSQL_SUCCESS;
-  } catch (EnvoyException e) {
+  } catch (EnvoyException& e) {
     // buffer underflow
     return MYSQL_FAILURE;
   }
@@ -65,7 +65,7 @@ int BufferHelper::peekUint32(Buffer::Instance& buffer, uint64_t& offset, uint32_
     val = buffer.peekLEInt<uint32_t>(offset);
     offset += sizeof(uint32_t);
     return MYSQL_SUCCESS;
-  } catch (EnvoyException e) {
+  } catch (EnvoyException& e) {
     // buffer underflow
     return MYSQL_FAILURE;
   }
@@ -97,7 +97,7 @@ int BufferHelper::peekLengthEncodedInteger(Buffer::Instance& buffer, uint64_t& o
     } else {
       return MYSQL_FAILURE;
     }
-  } catch (EnvoyException e) {
+  } catch (EnvoyException& e) {
     // buffer underflow
     return MYSQL_FAILURE;
   }


### PR DESCRIPTION
*Description*:
Compilation failed because Envoy::EnvoyException values were caught by value. Change the catching to references to fix the issue.

The error message was this:

    source/extensions/filters/network/mysql_proxy/mysql_utils.cc:100:27: error: catching polymorphic type 'class Envoy::EnvoyException' by value [-Werror=catch-value=]

*Risk Level*: Low
*Testing*:
Ran unit tests. One test (`MySQLCommandTest.MySQLTest39`) failed. But since that test was expecting a success case (`MYSQL_SUCCESS`), the test failure probably isn't related. Without the patch, I couldn't run the test due to the compilation issue.
*Docs Changes*: N/A
*Release Notes*: N/A
