### PR TITLE
config: invoke initialization callbacks on remote close

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -268,7 +268,7 @@ void GrpcMuxImpl::onRemoteClose(Grpc::Status::GrpcStatus status, const std::stri
   ENVOY_LOG(warn, "gRPC config stream closed: {}, {}", status, message);
   stream_ = nullptr;
   control_plane_stats_.connected_state_.set(0);
-  setRetryTimer();
+  handleFailure();
 }
 
 } // namespace Config

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -138,6 +138,7 @@ TEST_F(GrpcMuxImplTest, ResetStream) {
   expectSendMessage("baz", {"z"}, "");
   grpc_mux_->start();
 
+  EXPECT_CALL(callbacks_, onConfigUpdateFailed(_)).Times(3);
   EXPECT_CALL(random_, random());
   ASSERT_TRUE(timer != nullptr); // initialized from dispatcher mock.
   EXPECT_CALL(*timer, enableTimer(_));

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -42,14 +42,14 @@ TEST_F(GrpcSubscriptionImplTest, RemoteStreamClose) {
   EXPECT_CALL(*timer_, enableTimer(_));
   EXPECT_CALL(random_, random());
   subscription_->grpcMux().onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(2, 0, 0, 1, 0);
   verifyControlPlaneStats(0);
 
   // Retry and succeed.
   EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({"cluster0", "cluster1"}, "");
   timer_cb_();
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(2, 0, 0, 1, 0);
 }
 
 // Validate that When the management server gets multiple requests for the same version, it can


### PR DESCRIPTION
*Description*: Invokes initialization callbacks on remote close
*Risk Level*: Low
*Testing*: Changed existing automated tests
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #5622 
