### PR TITLE
perf fix for Ipv4Instance creation

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -173,6 +173,8 @@ int InstanceBase::socketFromSocketType(SocketType socketType) const {
 Ipv4Instance::Ipv4Instance(const sockaddr_in* address) : InstanceBase(Type::Ip) {
   ip_.ipv4_.address_ = *address;
   ip_.friendly_address_ = sockaddrToString(*address);
+
+  // Based on benchmark testing, this reserve+append implementation runs faster than absl::StrCat.
   fmt::format_int port(ntohs(address->sin_port));
   friendly_name_.reserve(ip_.friendly_address_.size() + 1 + port.size());
   friendly_name_.append(ip_.friendly_address_);

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -172,10 +172,10 @@ int InstanceBase::socketFromSocketType(SocketType socketType) const {
 
 Ipv4Instance::Ipv4Instance(const sockaddr_in* address) : InstanceBase(Type::Ip) {
   ip_.ipv4_.address_ = *address;
-  std::string friendly_address = sockaddrToString(*address);
-  ip_.friendly_address_ = friendly_address;
+  ip_.friendly_address_ = sockaddrToString(*address);
   fmt::format_int port(ntohs(address->sin_port));
-  friendly_name_ = friendly_address;
+  friendly_name_.reserve(ip_.friendly_address_.size() + 1 + port.size());
+  friendly_name_.append(ip_.friendly_address_);
   friendly_name_.push_back(':');
   friendly_name_.append(port.data(), port.size());
   validateIpv4Supported(friendly_name_);

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -102,6 +102,14 @@ public:
   const Ip* ip() const override { return &ip_; }
   int socket(SocketType type) const override;
 
+  /**
+   * Convenience function to convert an IPv4 address to canonical string format.
+   * @note This works similarly to inet_ntop() but is faster.
+   * @param addr address to format.
+   * @return the address in dotted-decimal string format.
+   */
+  static std::string sockaddrToString(const sockaddr_in& addr);
+
 private:
   struct Ipv4Helper : public Ipv4 {
     uint32_t address() const override { return address_.sin_addr.s_addr; }

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -19,6 +20,17 @@ envoy_cc_test(
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test_binary(
+    name = "address_impl_speed_test",
+    srcs = ["address_impl_speed_test.cc"],
+    external_deps = [
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/network:address_lib",
     ],
 )
 

--- a/test/common/network/address_impl_speed_test.cc
+++ b/test/common/network/address_impl_speed_test.cc
@@ -1,0 +1,52 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include "common/common/fmt.h"
+#include "common/network/address_impl.h"
+
+#include "testing/base/public/benchmark.h"
+
+namespace Envoy {
+namespace Network {
+namespace Address {
+
+static void Ipv4InstanceCreate(benchmark::State& state) {
+  sockaddr_in addr;
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(443);
+  static constexpr uint32_t Addr = 0xc00002ff; // From the RFC 5737 example range.
+  addr.sin_addr.s_addr = htonl(Addr);
+  for (auto _ : state) {
+    Ipv4Instance address(&addr);
+    benchmark::DoNotOptimize(address.ip());
+  }
+}
+BENCHMARK(Ipv4InstanceCreate);
+
+static void Ipv6InstanceCreate(benchmark::State& state) {
+  sockaddr_in6 addr;
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(443);
+  static const char* Addr = "2001:DB8::1234"; // From the RFC 3849 example range.
+  inet_pton(AF_INET6, Addr, &addr.sin6_addr);
+  for (auto _ : state) {
+    Ipv6Instance address(addr);
+    benchmark::DoNotOptimize(address.ip());
+  }
+}
+BENCHMARK(Ipv6InstanceCreate);
+
+} // namespace Address
+} // namespace Network
+} // namespace Envoy
+
+// Boilerplate main(), which discovers benchmarks in the same file and runs them.
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -5,6 +5,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -116,6 +117,22 @@ TEST_P(AddressImplSocketTest, SocketBindAndConnect) {
 TEST(Ipv4CompatAddressImplSocktTest, SocketBindAndConnect) {
   if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v6)) {
     testSocketBindAndConnect(Network::Address::IpVersion::v6, false);
+  }
+}
+
+TEST(Ipv4InstanceTest, SockaddrToString) {
+  // Test addresses from various RF 5735 reserved ranges
+  static const char* addresses[] = {"0.0.0.0",        "0.0.0.255",       "0.0.255.255",
+                                    "0.255.255.255",  "192.0.2.0",       "198.151.100.1",
+                                    "198.151.100.10", "198.151.100.100", "10.0.0.1",
+                                    "10.0.20.1",      "10.3.201.1"};
+
+  for (const auto address : addresses) {
+    sockaddr_in addr4;
+    addr4.sin_family = AF_INET;
+    EXPECT_EQ(1, inet_pton(AF_INET, address, &addr4.sin_addr));
+    addr4.sin_port = 0;
+    EXPECT_EQ(address, Ipv4Instance::sockaddrToString(addr4));
   }
 }
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -121,11 +121,11 @@ TEST(Ipv4CompatAddressImplSocktTest, SocketBindAndConnect) {
 }
 
 TEST(Ipv4InstanceTest, SockaddrToString) {
-  // Test addresses from various RF 5735 reserved ranges
+  // Test addresses from various RFC 5735 reserved ranges
   static const char* addresses[] = {"0.0.0.0",        "0.0.0.255",       "0.0.255.255",
                                     "0.255.255.255",  "192.0.2.0",       "198.151.100.1",
                                     "198.151.100.10", "198.151.100.100", "10.0.0.1",
-                                    "10.0.20.1",      "10.3.201.1"};
+                                    "10.0.20.1",      "10.3.201.1",      "255.255.255.255"};
 
   for (const auto address : addresses) {
     sockaddr_in addr4;

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -132,7 +132,7 @@ TEST(Ipv4InstanceTest, SockaddrToString) {
     addr4.sin_family = AF_INET;
     EXPECT_EQ(1, inet_pton(AF_INET, address, &addr4.sin_addr));
     addr4.sin_port = 0;
-    EXPECT_EQ(address, Ipv4Instance::sockaddrToString(addr4));
+    EXPECT_STREQ(address, Ipv4Instance::sockaddrToString(addr4).c_str());
   }
 }
 


### PR DESCRIPTION
*Description*:
Speed up the creation of an `Ipv4Instance` from a `sockaddr_in`.
I noticed in a CPU profile that this constructor was taking a surprisingly large amount of time.
This change includes a new performance benchmark test.

Before:
```
Benchmark                   Time           CPU Iterations
----------------------------------------------------------
Ipv4InstanceCreate        474 ns        474 ns    1470706
```
After:
```
----------------------------------------------------------
Benchmark                   Time           CPU Iterations
----------------------------------------------------------
Ipv4InstanceCreate         58 ns         58 ns   12214700
```

*Risk Level*: medium

*Testing*: unit tests plus new performance benchmark test

*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Brian Pane <brianp+github@brianp.net>