### PR TITLE
README.md: Fix Ubuntu package list

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -33,9 +33,9 @@ On Ubuntu, run the following command:
 sudo apt-get install \
    libtool \
    cmake \
-   realpath \
    clang-format-7 \
    automake \
+   make \
    ninja-build \
    curl \
    unzip


### PR DESCRIPTION
- `clang-format-7` isn't available in 18.04; supposedly, `clang-format-6.0` can be used instead.
- `realpath` is now in `coreutils`.

If we like, we can keep a list for "older Ubuntu versions" also but I think it's more important that the list is up-to-date for latest LTS.
