### PR TITLE
tools: tagging deprecation issues as no stalebot

### DIFF
--- a/tools/deprecate_version/deprecate_version.py
+++ b/tools/deprecate_version/deprecate_version.py
@@ -39,7 +39,7 @@ except NameError:
   pass  # Python 3
 
 # Tag issues created with these labels.
-LABELS = ['deprecation', 'tech debt']
+LABELS = ['deprecation', 'tech debt', 'no stalebot']
 
 
 # Errors that happen during issue creation.


### PR DESCRIPTION
*Risk Level*: low
*Testing*: will be tested next release
*Docs Changes*: n/a
*Release Notes*: n/a
