### PR TITLE
fix a google string vs std::string issue for easier import

### DIFF
--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -154,7 +154,8 @@ TEST_F(OptionsImplTest, SetAll) {
             command_line_options->local_address_ip_version());
   EXPECT_EQ(options->drainTime().count(), command_line_options->drain_time().seconds());
   // The right hand side char* will be converted into fmt::string_view and then compare.
-  EXPECT_EQ(spdlog::level::to_string_view(options->logLevel()), command_line_options->log_level().data());
+  EXPECT_EQ(spdlog::level::to_string_view(options->logLevel()),
+            command_line_options->log_level().data());
   EXPECT_EQ(options->logFormat(), command_line_options->log_format());
   EXPECT_EQ(options->logPath(), command_line_options->log_path());
   EXPECT_EQ(options->parentShutdownTime().count(),

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -153,7 +153,8 @@ TEST_F(OptionsImplTest, SetAll) {
   EXPECT_EQ(envoy::admin::v2alpha::CommandLineOptions::v6,
             command_line_options->local_address_ip_version());
   EXPECT_EQ(options->drainTime().count(), command_line_options->drain_time().seconds());
-  EXPECT_EQ(spdlog::level::to_string_view(options->logLevel()), command_line_options->log_level());
+  // The right hand side char* will be converted into fmt::string_view and then compare.
+  EXPECT_EQ(spdlog::level::to_string_view(options->logLevel()), command_line_options->log_level().data());
   EXPECT_EQ(options->logFormat(), command_line_options->log_format());
   EXPECT_EQ(options->logPath(), command_line_options->log_path());
   EXPECT_EQ(options->parentShutdownTime().count(),


### PR DESCRIPTION
Signed-off-by: Xin Zhuang <stevenzzz@google.com>

Convert the right hand side log-level string into a raw char* before comparing it with a fmt::string_view (which is fmt::basic_string_view). This change enables templated string implementation to be comparable with fmt::basic_string_view.

*Description*: compare fmt::string_view to a raw char* in test/server/options_impl_test.cc
*Risk Level*: LOW
*Testing*: unit test
[Optional Fixes #Issue]
[Optional *Deprecated*:]
