### PR TITLE
envoy: basic spellcheck

### DIFF
--- a/source/common/common/perf_annotation.cc
+++ b/source/common/common/perf_annotation.cc
@@ -29,7 +29,7 @@ void PerfOperation::record(absl::string_view category, absl::string_view descrip
 
 // The ctor is explicitly declared private to encourage clients to use getOrCreate(), at
 // least for now. Given that it's declared it must be instantiated. It's not inlined
-// because the contructor is non-trivial due to the contained unordered_map.
+// because the constructor is non-trivial due to the contained unordered_map.
 PerfAnnotationContext::PerfAnnotationContext() {}
 
 void PerfAnnotationContext::record(std::chrono::nanoseconds duration, absl::string_view category,

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -841,7 +841,7 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
   for (; entry != decoder_filters_.end(); entry++) {
     // If end_stream_ is marked for a filter, the data is not for this filter and filters after.
     //
-    // In following case, ActiveStreamFilterBase::commonContine() could be called recursively and
+    // In following case, ActiveStreamFilterBase::commonContinue() could be called recursively and
     // its doData() is called with wrong data.
     //
     //  There are 3 decode filters and "wrapper" refers to ActiveStreamFilter object.
@@ -1786,7 +1786,7 @@ bool ConnectionManagerImpl::ActiveStreamDecoderFilter::recreateStream() {
   HeaderMapPtr request_headers(std::move(parent_.request_headers_));
   StreamEncoder* response_encoder = parent_.response_encoder_;
   parent_.response_encoder_ = nullptr;
-  // This functionally deletes the stream (via defered delete) so do not
+  // This functionally deletes the stream (via deferred delete) so do not
   // reference anything beyond this point.
   parent_.connection_manager_.doEndStream(this->parent_);
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -109,7 +109,7 @@ void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream)
                    Headers::get().TransferEncoding.get().size(),
                    Headers::get().TransferEncodingValues.Chunked.c_str(),
                    Headers::get().TransferEncodingValues.Chunked.size());
-      // We do not aply chunk encoding for HTTP upgrades.
+      // We do not apply chunk encoding for HTTP upgrades.
       // If there is a body in a WebSocket Upgrade response, the chunks will be
       // passed through via maybeDirectDispatch so we need to avoid appending
       // extra chunk boundaries.
@@ -133,7 +133,7 @@ void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream)
 
 void StreamEncoderImpl::encodeData(Buffer::Instance& data, bool end_stream) {
   // end_stream may be indicated with a zero length data buffer. If that is the case, so not
-  // atually write the zero length buffer out.
+  // actually write the zero length buffer out.
   if (data.length() > 0) {
     if (chunk_encoding_) {
       connection_.buffer().add(fmt::format("{:x}\r\n", data.length()));

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -182,7 +182,7 @@ private:
  * Custom stream to allow access to the line number for each object.
  */
 class LineCountingStringStream : public rapidjson::StringStream {
-  // Ch is typdef in parent class to handle character encoding.
+  // Ch is typedef in parent class to handle character encoding.
 public:
   LineCountingStringStream(const Ch* src) : rapidjson::StringStream(src), line_number_(1) {}
   Ch Take() {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -290,7 +290,7 @@ Api::SysCallIntResult Ipv6Instance::connect(int fd) const {
 
 int Ipv6Instance::socket(SocketType type) const {
   const int fd = socketFromSocketType(type);
-  // Setting IPV6_V6ONLY resticts the IPv6 socket to IPv6 connections only.
+  // Setting IPV6_V6ONLY restricts the IPv6 socket to IPv6 connections only.
   const int v6only = ip_.v6only_;
   RELEASE_ASSERT(::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != -1, "");
   return fd;

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -193,7 +193,7 @@ void DnsResolverImpl::onAresSocketStateChange(int fd, int read, int write) {
 ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
                                          DnsLookupFamily dns_lookup_family, ResolveCb callback) {
   // TODO(hennna): Add DNS caching which will allow testing the edge case of a
-  // failed initial call to getHostbyName followed by a synchronous IPv4
+  // failed initial call to getHostByName followed by a synchronous IPv4
   // resolution.
   std::unique_ptr<PendingResolution> pending_resolution(
       new PendingResolution(callback, dispatcher_, channel_, dns_name));

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -194,7 +194,7 @@ void Utility::throwWithMalformedIp(const std::string& ip_address) {
 }
 
 // TODO(hennna): Currently getLocalAddress does not support choosing between
-// multiple interfaces and addresses not returned by getifaddrs. In additon,
+// multiple interfaces and addresses not returned by getifaddrs. In addition,
 // the default is to return a loopback address of type version. This function may
 // need to be updated in the future. Discussion can be found at Github issue #939.
 Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersion version) {
@@ -227,7 +227,7 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
     freeifaddrs(ifaddr);
   }
 
-  // If the local address is not found above, then return the loopback addresss by default.
+  // If the local address is not found above, then return the loopback address by default.
   if (ret == nullptr) {
     if (version == Address::IpVersion::v4) {
       ret.reset(new Address::Ipv4Instance("127.0.0.1"));

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -254,7 +254,7 @@ bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason& reset_re
 bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
                                 const absl::optional<Http::StreamResetReason>& reset_reason) {
   // First check "never retry" conditions so we can short circuit, then delegate to
-  // helper methods for checks dependant on retry policy.
+  // helper methods for checks dependent on retry policy.
 
   // we never retry if the reset reason is overflow.
   if (reset_reason && reset_reason.value() == Http::StreamResetReason::Overflow) {

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -215,7 +215,7 @@ Symbol SymbolTable::toSymbol(absl::string_view sv) {
     // We create the actual string, place it in the decode_map_, and then insert
     // a string_view pointing to it in the encode_map_. This allows us to only
     // store the string once. We use unique_ptr so copies are not made as
-    // flat_hash_map moves values arond.
+    // flat_hash_map moves values around.
     auto str = std::make_unique<std::string>(std::string(sv));
     auto encode_insert = encode_map_.insert({*str, SharedSymbol(next_symbol_)});
     ASSERT(encode_insert.second);

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -338,7 +338,7 @@ Gauge& ThreadLocalStoreImpl::ScopeImpl::gauge(const std::string& name) {
   // Note that we can do map.find(final_name.c_str()), but we cannot do
   // map[final_name.c_str()] as the char*-keyed maps would then save the pointer to
   // a temporary, and address sanitization errors would follow. Instead we must
-  // do a find() first, using tha if it succeeds. If it fails, then after we
+  // do a find() first, using that if it succeeds. If it fails, then after we
   // construct the stat we can insert it into the required maps.
   std::string final_name = prefix_ + name;
   if (parent_.rejects(final_name)) {
@@ -366,7 +366,7 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogram(const std::string& name) {
   // Note that we can do map.find(final_name.c_str()), but we cannot do
   // map[final_name.c_str()] as the char*-keyed maps would then save the pointer to
   // a temporary, and address sanitization errors would follow. Instead we must
-  // do a find() first, using tha if it succeeds. If it fails, then after we
+  // do a find() first, using that if it succeeds. If it fails, then after we
   // construct the stat we can insert it into the required maps.
   std::string final_name = prefix_ + name;
   if (parent_.rejects(final_name)) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -28,7 +28,7 @@ static const std::string RuntimePanicThreshold = "upstream.healthy_panic_thresho
 // @param per_priority_availability the percentage availability of each priority, used to determine
 // how much load each priority can handle.
 // @param total_load the amount of load that may be distributed. Will be updated with the amount of
-// load reminaining after distribution.
+// load remaining after distribution.
 // @param normalized_total_availability the total availability, up to a max of 100. Used to
 // scale the load when the total availability is less than 100%.
 // @return the first available priority and the remaining load
@@ -93,7 +93,7 @@ LoadBalancerBase::LoadBalancerBase(const PrioritySet& priority_set, ClusterStats
     recalculatePerPriorityState(host_set->priority(), priority_set_, per_priority_load_,
                                 per_priority_health_, per_priority_degraded_);
   }
-  // Reclaculate panic mode for all levels.
+  // Recalculate panic mode for all levels.
   recalculatePerPriorityPanic();
 
   priority_set_.addPriorityUpdateCb(
@@ -116,7 +116,7 @@ LoadBalancerBase::LoadBalancerBase(const PrioritySet& priority_set, ClusterStats
 //   Do not enter panic mode, even if a specific priority has low number of healthy hosts.
 // - normalized total health is < 100%. There are not enough healthy hosts to handle the load.
 // Continue
-//   distibuting the load among priority sets, but turn on panic mode for a given priority
+//   distributing the load among priority sets, but turn on panic mode for a given priority
 //   if # of healthy hosts in priority set is low.
 // - normalized total health is 0%. All hosts are down. Redirect 100% of traffic to P=0 and enable
 // panic mode.
@@ -140,7 +140,7 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
     // Each priority level's health is ratio of healthy hosts to total number of hosts in a priority
     // multiplied by overprovisioning factor of 1.4 and capped at 100%. It means that if all
     // hosts are healthy that priority's health is 100%*1.4=140% and is capped at 100% which results
-    // in 100%. If 80% of hosts are healty, that priority's health is still 100% (80%*1.4=112% and
+    // in 100%. If 80% of hosts are healthy, that priority's health is still 100% (80%*1.4=112% and
     // capped at 100%).
     per_priority_health.get()[priority] =
         std::min<uint32_t>(100, (host_set.overprovisioningFactor() *
@@ -330,7 +330,7 @@ void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
   // half the hosts in all host sets go unhealthy, this priority set will
   // still send half of the incoming load to the local locality and 80% to residual.
   //
-  // Basically, fariness across localities within a priority is guaranteed. Fairness across
+  // Basically, fairness across localities within a priority is guaranteed. Fairness across
   // localities across priorities is not.
   STACK_ARRAY(local_percentage, uint64_t, num_localities);
   calculateLocalityPercentage(localHostSet().healthyHostsPerLocality(), local_percentage.begin());
@@ -439,7 +439,7 @@ HostConstSharedPtr LoadBalancerBase::chooseHost(LoadBalancerContext* context) {
     }
   }
 
-  // If we didnt find anything, return the last host.
+  // If we didn't find anything, return the last host.
   return host;
 }
 

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -369,7 +369,7 @@ private:
 };
 
 /**
- * A round roubin load balancer. When in weighted mode, EDF scheduling is used. When in not
+ * A round robin load balancer. When in weighted mode, EDF scheduling is used. When in not
  * weighted mode, simple RR index selection is used.
  */
 class RoundRobinLoadBalancer : public EdfLoadBalancerBase {

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -120,7 +120,7 @@ RingHashLoadBalancer::Ring::Ring(
       absl::string_view hash_key(hash_key_buffer, total_hash_key_len);
 
       // Sadly std::hash provides no mechanism for hashing arbitrary bytes so we must copy here.
-      // xxHash is done wihout copies.
+      // xxHash is done without copies.
       const uint64_t hash =
           use_std_hash
               ? std::hash<std::string>()(std::string(hash_key))

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -125,7 +125,7 @@ HostConstSharedPtr SubsetLoadBalancer::tryChooseHostFromContext(LoadBalancerCont
 }
 
 // Iterates over the given metadata match criteria (which must be lexically sorted by key) and find
-// a matching LbSubsetEnryPtr, if any.
+// a matching LbSubsetEntryPtr, if any.
 SubsetLoadBalancer::LbSubsetEntryPtr SubsetLoadBalancer::findSubset(
     const std::vector<Router::MetadataMatchCriterionConstSharedPtr>& match_criteria) {
   const LbSubsetMap* subsets = &subsets_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -451,7 +451,7 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
   case envoy::api::v2::Cluster::ORIGINAL_DST_LB:
     if (config.type() != envoy::api::v2::Cluster::ORIGINAL_DST) {
       throw EnvoyException(fmt::format(
-          "cluster: LB type 'original_dst_lb' may only be used with cluser type 'original_dst'"));
+          "cluster: LB type 'original_dst_lb' may only be used with cluster type 'original_dst'"));
     }
     lb_type_ = LoadBalancerType::OriginalDst;
     break;

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -35,6 +35,6 @@ int main(int argc, char** argv) {
   }
 
   // Run the server listener loop outside try/catch blocks, so that unexpected exceptions
-  // show up as a core-dumps for easier diagnostis.
+  // show up as a core-dumps for easier diagnostics.
   return main_common->run() ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -21,7 +21,7 @@ namespace JwtAuthn {
 namespace {
 
 /**
- * Contant values
+ * Constant values
  */
 struct JwtConstValueStruct {
   // The header value prefix for Authorization.

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -224,7 +224,7 @@ void SquashFilter::onCreateAttachmentFailure(Http::AsyncClient::FailureReason) {
   bool request_created = in_flight_request_ != nullptr;
   in_flight_request_ = nullptr;
 
-  // No retries here, as we couldnt create the attachment object.
+  // No retries here, as we couldn't create the attachment object.
   if (request_created) {
     // Cleanup not needed if onFailure called inline in async client send, as this means that
     // decodeHeaders is down the stack and will return Continue.

--- a/source/extensions/filters/network/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/network/ext_authz/ext_authz.cc
@@ -34,7 +34,7 @@ void Filter::callCheck() {
 Network::FilterStatus Filter::onData(Buffer::Instance&, bool /* end_stream */) {
   if (status_ == Status::NotStarted) {
     // By waiting to invoke the check at onData() the call to authorization service will have
-    // sufficient information to fillout the checkRequest_.
+    // sufficient information to fill out the checkRequest_.
     callCheck();
   }
   return filter_return_ == FilterReturn::Stop ? Network::FilterStatus::StopIteration

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -197,7 +197,7 @@ FilterStatus Router::transportEnd() {
 
 FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
   // TODO(zuercher): route stats (e.g., no_route, no_cluster, upstream_rq_maintenance_mode, no
-  // healtthy upstream)
+  // healthy upstream)
 
   route_ = callbacks_->route();
   if (!route_) {

--- a/source/extensions/filters/network/thrift_proxy/thrift_object_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/thrift_object_impl.cc
@@ -252,7 +252,7 @@ void ThriftMapValueImpl::delegateComplete() {
     return;
   }
 
-  // Prepare for any elements's value.
+  // Prepare for any element's value.
   auto& elem = elements_.back();
   if (elem.second == nullptr) {
     auto value = makeValue(this, elem_type_);

--- a/source/extensions/retry/priority/previous_priorities/previous_priorities.cc
+++ b/source/extensions/retry/priority/previous_priorities/previous_priorities.cc
@@ -56,7 +56,7 @@ bool PreviousPrioritiesRetryPriority::adjustForAttemptedPriorities(
   }
 
   // If total availability is still zero at this point, it must mean that all clusters are
-  // completely unavailable. If so, fall back to using the original priority loads. This mantains
+  // completely unavailable. If so, fall back to using the original priority loads. This maintains
   // whatever handling the default LB uses when all priorities are unavailable.
   if (total_availability == 0) {
     return false;

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -105,7 +105,7 @@ void MetricsServiceSink::flush(Stats::Source& source) {
   }
 
   grpc_metrics_streamer_->send(message_);
-  // for perf reasons, clear the identifer after the first flush.
+  // for perf reasons, clear the identifier after the first flush.
   if (message_.has_identifier()) {
     message_.clear_identifier();
   }

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -46,10 +46,10 @@ public:
 
   bool isReady() const override {
     const bool tls_is_ready =
-        (tls_certficate_providers_.empty() || !tls_certificate_configs_.empty());
+        (tls_certificate_providers_.empty() || !tls_certificate_configs_.empty());
     const bool combined_cvc_is_ready =
         (default_cvc_ == nullptr || validation_context_config_ != nullptr);
-    const bool cvc_is_ready = (certficate_validation_context_provider_ == nullptr ||
+    const bool cvc_is_ready = (certificate_validation_context_provider_ == nullptr ||
                                default_cvc_ != nullptr || validation_context_config_ != nullptr);
     return tls_is_ready && combined_cvc_is_ready && cvc_is_ready;
   }
@@ -81,11 +81,11 @@ private:
   // holds a copy of CombinedCertificateValidationContext::default_validation_context.
   // Otherwise, default_cvc_ is nullptr.
   std::unique_ptr<envoy::api::v2::auth::CertificateValidationContext> default_cvc_;
-  std::vector<Secret::TlsCertificateConfigProviderSharedPtr> tls_certficate_providers_;
+  std::vector<Secret::TlsCertificateConfigProviderSharedPtr> tls_certificate_providers_;
   // Handle for TLS certificate dyanmic secret callback.
   Common::CallbackHandle* tc_update_callback_handle_{};
   Secret::CertificateValidationContextConfigProviderSharedPtr
-      certficate_validation_context_provider_;
+      certificate_validation_context_provider_;
   // Handle for certificate validation context dyanmic secret callback.
   Common::CallbackHandle* cvc_update_callback_handle_{};
   Common::CallbackHandle* cvc_validation_callback_handle_{};

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -953,7 +953,7 @@ bool ServerContextImpl::isClientEcdsaCapable(const SSL_CLIENT_HELLO* ssl_client_
   CBS_init(&client_hello, ssl_client_hello->client_hello, ssl_client_hello->client_hello_len);
 
   // This is the TLSv1.3 case (TLSv1.2 on the wire and the supported_versions extensions present).
-  // We just need to loook at signature algorithms.
+  // We just need to look at signature algorithms.
   const uint16_t client_version = ssl_client_hello->version;
   if (client_version == TLS1_2_VERSION && tls_max_version_ == TLS1_3_VERSION) {
     // If the supported_versions extension is found then we assume that the client is competent

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -65,7 +65,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
     PostIoAction action = doHandshake();
     if (action == PostIoAction::Close || !handshake_complete_) {
       // end_stream is false because either a hard error occurred (action == Close) or
-      // the handhshake isn't complete, so a half-close cannot occur yet.
+      // the handshake isn't complete, so a half-close cannot occur yet.
       return {action, 0, false};
     }
   }

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -186,7 +186,7 @@ void ConnectionHandlerImpl::ActiveSocket::continueFilterChain(bool success) {
     }
     if (new_listener != nullptr) {
       // Hands off connections redirected by iptables to the listener associated with the
-      // original destination address. Pass 'hand_off_restored_destionations' as false to
+      // original destination address. Pass 'hand_off_restored_destination_connections' as false to
       // prevent further redirection.
       new_listener->onAccept(std::move(socket_), false);
     } else {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -435,7 +435,7 @@ RunHelper::RunHelper(Instance& instance, Options& options, Event::Dispatcher& di
 
     ENVOY_LOG(info, "all clusters initialized. initializing init manager");
 
-    // Note: the lamda below should not capture "this" since the RunHelper object may
+    // Note: the lambda below should not capture "this" since the RunHelper object may
     // have been destructed by the time it gets executed.
     init_manager.initialize([&instance, workers_start_cb]() {
       if (instance.isShutdown()) {

--- a/test/common/filesystem/directory_test.cc
+++ b/test/common/filesystem/directory_test.cc
@@ -126,7 +126,7 @@ TEST_F(DirectoryTest, DirectoryWithFileInSubDirectory) {
   EXPECT_EQ(expected, getDirectoryContents(dir_path_, false));
 }
 
-// Test that when recursively creating DirectoryIterators, they do not interfere with eachother
+// Test that when recursively creating DirectoryIterators, they do not interfere with each other
 TEST_F(DirectoryTest, RecursionIntoSubDirectory) {
   addSubDirs({"sub_dir"});
   addFiles({"file", "sub_dir/sub_file"});

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -60,7 +60,7 @@ public:
   }
 
   DangerousDeprecatedTestTime test_time_;
-  Stats::IsolatedStoreImpl* stats_store_; // Ownership transerred to scope_.
+  Stats::IsolatedStoreImpl* stats_store_; // Ownership transferred to scope_.
   Api::ApiPtr api_;
   Event::DispatcherImpl dispatcher_;
   Stats::ScopeSharedPtr scope_;

--- a/test/common/http/codes_test.cc
+++ b/test/common/http/codes_test.cc
@@ -256,7 +256,7 @@ TEST_F(CodeStatsTest, StripTrailingDot) {
 TEST_F(CodeStatsTest, Join) {
   EXPECT_EQ("hello.world", join({"hello", "world"}));
   EXPECT_EQ("hello.world", join({"", "hello", "world"})); // leading empty token ignored.
-  EXPECT_EQ("hello.", join({"hello", ""}));               // trailign empty token not ignored.
+  EXPECT_EQ("hello.", join({"hello", ""}));               // trailing empty token not ignored.
   EXPECT_EQ("hello", join({"hello"}));
   EXPECT_EQ("", join({""}));
 }

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -737,7 +737,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsForwardOnlyClientCert) {
             headers.get_("x-forwarded-client-cert"));
 }
 
-// The server (local) dentity is foo.com/be. The client does not set XFCC.
+// The server (local) identity is foo.com/be. The client does not set XFCC.
 TEST_F(ConnectionManagerUtilityTest, MtlsSetForwardClientCert) {
   NiceMock<Ssl::MockConnection> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
@@ -771,7 +771,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSetForwardClientCert) {
 }
 
 // This test assumes the following scenario:
-// The client identity is foo.com/fe, and the server (local) dentity is foo.com/be. The client
+// The client identity is foo.com/fe, and the server (local) identity is foo.com/be. The client
 // also sends the XFCC header with the authentication result of the previous hop, (bar.com/be
 // calling foo.com/fe).
 TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCert) {
@@ -807,7 +807,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCert) {
 }
 
 // This test assumes the following scenario:
-// The client identity is foo.com/fe, and the server (local) dentity is foo.com/be. The client
+// The client identity is foo.com/fe, and the server (local) identity is foo.com/be. The client
 // also sends the XFCC header with the authentication result of the previous hop, (bar.com/be
 // calling foo.com/fe).
 TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCertLocalSanEmpty) {
@@ -835,7 +835,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCertLocalSanEmpty) {
 }
 
 // This test assumes the following scenario:
-// The client identity is foo.com/fe, and the server (local) dentity is foo.com/be. The client
+// The client identity is foo.com/fe, and the server (local) identity is foo.com/be. The client
 // also sends the XFCC header with the authentication result of the previous hop, (bar.com/be
 // calling foo.com/fe).
 TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCert) {
@@ -870,7 +870,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCert) {
 }
 
 // This test assumes the following scenario:
-// The client identity is foo.com/fe, and the server (local) dentity is foo.com/be. The client
+// The client identity is foo.com/fe, and the server (local) identity is foo.com/be. The client
 // also sends the XFCC header with the authentication result of the previous hop, (bar.com/be
 // calling foo.com/fe).
 TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCertPeerSanEmpty) {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -41,7 +41,7 @@ TEST(HeaderStringTest, All) {
     EXPECT_EQ(5U, string.size());
   }
 
-  // Static move contructor
+  // Static move constructor
   {
     std::string static_string("HELLO");
     HeaderString string1(static_string);

--- a/test/common/http/http2/codec_impl_fuzz_test.cc
+++ b/test/common/http/http2/codec_impl_fuzz_test.cc
@@ -112,7 +112,7 @@ public:
 
   void resetStream() { request_.stream_state_ = response_.stream_state_ = StreamState::Closed; }
 
-  // Some stream action applied in either the request or resposne direction.
+  // Some stream action applied in either the request or response direction.
   void directionalAction(DirectionalState& state,
                          const test::common::http::http2::DirectionalAction& directional_action) {
     const bool end_stream = directional_action.end_stream();

--- a/test/common/http/http2/metadata_encoder_decoder_test.cc
+++ b/test/common/http/http2/metadata_encoder_decoder_test.cc
@@ -227,7 +227,7 @@ TEST_F(MetadataEncoderDecoderTest, VerifyEncoderDecoderMultipleMetadataReachSize
       break;
     }
   }
-  // Verifies max matadata limit reached.
+  // Verifies max metadata limit reached.
   EXPECT_LT(result, 0);
   EXPECT_LE(decoder_->max_payload_size_bound_, decoder_->total_payload_size_);
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -5117,7 +5117,7 @@ virtual_hosts:
 
 TEST(RouteConfigurationV2, RegexPrefixWithNoRewriteWorksWhenPathChanged) {
 
-  // setup regex route entry. the regex is trivial, thats ok as we only want to test that
+  // Setup regex route entry. the regex is trivial, that's ok as we only want to test that
   // path change works.
   std::string RegexRewrite = R"EOF(
 name: RegexNoMatch

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -110,7 +110,7 @@ public:
    * @return std::string the metric_name with tags removed.
    */
   std::string produceTagsReverse(const std::string& metric_name, std::vector<Tag>& tags) const {
-    // Note: one discrepency between this and TagProducerImpl::produceTags is that this
+    // Note: one discrepancy between this and TagProducerImpl::produceTags is that this
     // version does not add in tag_extractors_.default_tags_ into tags. That doesn't matter
     // for this test, however.
     std::list<const TagExtractor*> extractors; // Note push-front is used to reverse order.

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -671,7 +671,7 @@ TEST_F(HeapStatsThreadLocalStoreTest, NonHotRestartNoTruncation) {
   store_->counter(name_1);
 
   // This works fine, and we can find it by its long name because heap-stats do not
-  // get truncsated.
+  // get truncated.
   EXPECT_NE(nullptr, TestUtility::findCounter(*store_, name_1).get());
 }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -499,7 +499,7 @@ TEST_F(ClusterManagerImplTest, OriginalDstLbRestriction2) {
 
   EXPECT_THROW_WITH_MESSAGE(
       create(parseBootstrapFromJson(json)), EnvoyException,
-      "cluster: LB type 'original_dst_lb' may only be used with cluser type 'original_dst'");
+      "cluster: LB type 'original_dst_lb' may only be used with cluster type 'original_dst'");
 }
 
 TEST_F(ClusterManagerImplTest, SubsetLoadBalancerInitialization) {
@@ -2044,7 +2044,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
       }))
       .WillOnce(Invoke([](uint32_t priority, const HostVector& hosts_added,
                           const HostVector& hosts_removed) -> void {
-        // Triggerd by the 2 HC updates, it's a merged update so no added/removed
+        // Triggered by the 2 HC updates, it's a merged update so no added/removed
         // hosts.
         EXPECT_EQ(0, priority);
         EXPECT_EQ(0, hosts_added.size());

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -881,7 +881,7 @@ TEST_F(EdsTest, RemoveUnreferencedLocalities) {
     EXPECT_EQ(2, hosts_per_locality.size());
   }
 
-  // Reset the ClusterLoadAssingment to only contain one of the locality per priority.
+  // Reset the ClusterLoadAssignment to only contain one of the locality per priority.
   // This should leave us with only one locality.
   cluster_load_assignment->clear_endpoints();
   add_hosts_to_locality("oceania", "koala", "ingsoc", 4, 0);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -2733,7 +2733,7 @@ public:
         .WillOnce(Return(45000));
     expectHealthcheckStop(0, 45000);
 
-    // Host state should not be changed (remains healty).
+    // Host state should not be changed (remains healhty).
     EXPECT_CALL(*this, onHostStatus(cluster_->prioritySet().getMockHostSet(0)->hosts_[0],
                                     HealthTransition::Unchanged));
     respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
@@ -2864,7 +2864,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessNoTraffic) {
 
   // Default healthcheck interval for hosts without traffic is 60 seconds.
   expectHealthcheckStop(0, 60000);
-  // Host state should not be changed (remains healty).
+  // Host state should not be changed (remains healthy).
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
   expectHostHealthy(true);
@@ -2892,7 +2892,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   expectHostHealthy(true);
 }
 
-// Test host recovery after first failed check requires several successul checks.
+// Test host recovery after first failed check requires several successful checks.
 TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -2934,7 +2934,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   expectHostHealthy(true);
 }
 
-// Test host recovery after explicit check failure requires several successul checks.
+// Test host recovery after explicit check failure requires several successful checks.
 TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -3351,7 +3351,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgress) {
             cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
-// Test receing GOAWAY between checks affects nothing.
+// Test receiving GOAWAY between checks affects nothing.
 TEST_F(GrpcHealthCheckerImplTest, GoAwayBetweenChecks) {
   setupHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -587,7 +587,7 @@ TEST_P(SubsetLoadBalancerTest, UpdateFailover) {
   EXPECT_CALL(subset_info_, subsetKeys()).WillRepeatedly(ReturnRef(subset_keys));
   TestLoadBalancerContext context_10({{"version", "1.0"}});
 
-  // Start with an empty lb. Chosing a host should result in failure.
+  // Start with an empty lb. Choosing a host should result in failure.
   init({});
   EXPECT_TRUE(nullptr == lb_->chooseHost(&context_10).get());
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -243,7 +243,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
      },
     "hosts": [{"url": "tcp://localhost1:11001"},
               {"url": "tcp://localhost2:11002"}]
-              
+
   }
   )EOF";
 
@@ -533,7 +533,7 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   EXPECT_EQ("localhost1", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->hostname());
   EXPECT_EQ(100, cluster.prioritySet().hostSetsPerPriority()[0]->overprovisioningFactor());
 
-  // This is the first time we receveived an update for localhost1, we expect to rebuild.
+  // This is the first time we received an update for localhost1, we expect to rebuild.
   EXPECT_EQ(0UL, stats.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.expectResolve(*dns_resolver);

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -145,7 +145,7 @@ TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
         // so dynamically find a size that is too large.
         const uint64_t initial = 1 << 30;
         for (uint64_t size = initial;
-             size >= initial; // Disallow wraparound to avoid inifinite loops on failure.
+             size >= initial; // Disallow wraparound to avoid infinite loops on failure.
              size *= 1000) {
           new int[size];
         }

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -48,11 +48,11 @@ public:
           server_uri:
             uri: "ext_authz:9000"
             cluster: "ext_authz"
-            timeout: 0.25s  
+            timeout: 0.25s
 
-          authorization_request: 
-            allowed_headers: 
-              patterns: 
+          authorization_request:
+            allowed_headers:
+              patterns:
               - exact: Baz
               - prefix: "x-"
             headers_to_add:
@@ -61,13 +61,13 @@ public:
             - key: "x-authz-header2"
               value: "value"
 
-          authorization_response: 
-            allowed_upstream_headers: 
-              patterns: 
+          authorization_response:
+            allowed_upstream_headers:
+              patterns:
               - exact: Bar
               - prefix: "x-"
-            allowed_client_headers: 
-              patterns: 
+            allowed_client_headers:
+              patterns:
               - exact: Foo
               - prefix: "x-"
         )EOF";
@@ -309,7 +309,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedWithAllAttributes) {
   client_.onSuccess(TestCommon::makeMessageResponse(expected_headers, expected_body));
 }
 
-// Verify client response headers whe the authorization server denies the request and
+// Verify client response headers when the authorization server denies the request and
 // allowed_client_headers is configured.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
   const auto expected_body = std::string{"test"};

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -123,7 +123,7 @@ TEST_F(HttpFilterTest, MergeConfig) {
   envoy::config::filter::http::ext_authz::v2alpha::ExtAuthzPerRoute settings;
   auto&& extensions = settings.mutable_check_settings()->mutable_context_extensions();
 
-  // First config base config with one base value, and one value to be overriden.
+  // First config base config with one base value, and one value to be overridden.
   (*extensions)["base_key"] = "base_value";
   (*extensions)["merged_key"] = "base_value";
   FilterConfigPerRoute base_config(settings);
@@ -272,7 +272,7 @@ TEST_F(HttpFilterTestParam, ContextExtensions) {
   envoy::config::filter::http::ext_authz::v2alpha::ExtAuthzPerRoute settingsvhost;
   (*settingsvhost.mutable_check_settings()->mutable_context_extensions())["key_vhost"] =
       "value_vhost";
-  // add a default route value to see it overriden
+  // add a default route value to see it overridden
   (*settingsvhost.mutable_check_settings()->mutable_context_extensions())["key_route"] =
       "default_route_value";
   // Initialize the virtual host's per filter config.

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -653,7 +653,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryWithHttpBodyAsOutputAndSpli
 
   auto response_data = Grpc::Common::serializeBody(response);
 
-  // Firstly, the response data buffer is splitted into two parts.
+  // Firstly, the response data buffer is split into two parts.
   Buffer::OwnedImpl response_data_first_part;
   response_data_first_part.move(*response_data, response_data->length() / 2);
 

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -259,7 +259,7 @@ TEST_F(AuthenticatorTest, TestPubkeyFetchFail) {
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "401"}}}));
 }
 
-// This test verifies when a Jwks fetching is not completed yet, but onDestory() is called,
+// This test verifies when a Jwks fetching is not completed yet, but onDestroy() is called,
 // onComplete() callback should not be called, but internal request->cancel() should be called.
 // Most importantly, no crash.
 TEST_F(AuthenticatorTest, TestOnDestroy) {
@@ -278,7 +278,7 @@ TEST_F(AuthenticatorTest, TestOnDestroy) {
   auth_->onDestroy();
 }
 
-// This test verifies if "forward_playload_header" is empty, payload is not forwarded.
+// This test verifies if "forward_payload_header" is empty, payload is not forwarded.
 TEST_F(AuthenticatorTest, TestNoForwardPayloadHeader) {
   // In this config, there is no forward_payload_header
   auto& provider0 = (*proto_config_.mutable_providers())[std::string(ProviderName)];

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -145,7 +145,7 @@ TEST_F(ExtractorTest, TestCustomHeaderToken) {
 }
 
 // Test extracting token from the custom header: "prefix-header"
-// value prefix doesn't match. It has to be eitehr "AAA" or "AAABBB".
+// value prefix doesn't match. It has to be either "AAA" or "AAABBB".
 TEST_F(ExtractorTest, TestPrefixHeaderNotMatch) {
   auto headers = TestHeaderMapImpl{{"prefix-header", "jwt_token"}};
   auto tokens = extractor_->extract(headers);

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -113,7 +113,7 @@ TEST_F(FilterTest, TestSetPayloadCall) {
 }
 
 // This test verifies Verifier::Callback is called inline with a failure status.
-// All functions should return Continue except decodeHeaders(), it returns StopIteraton.
+// All functions should return Continue except decodeHeaders(), it returns StopIteration.
 TEST_F(FilterTest, InlineFailure) {
   setupMockConfig();
   // A failed authentication completed inline: callback is called inside verify().

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -286,7 +286,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllMissing) {
   EXPECT_FALSE(headers.has("other-auth-userinfo"));
 }
 
-// Test requrires all and mock auths simulate cache misses and async return of failure statuses.
+// Test requires all and mock auths simulate cache misses and async return of failure statuses.
 TEST_F(GroupVerifierTest, TestRequiresAllBothFailed) {
   MessageUtil::loadFromYaml(RequiresAllConfig, proto_config_);
   auto callbacks = createAsyncMockAuthsAndVerifier(
@@ -370,7 +370,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyAllAuthFailed) {
 }
 
 // Test contains a 2 provider_name in a require any along with another provider_name in require all.
-// Test simulates first require any is OK and proivder_name is OK.
+// Test simulates first require any is OK and provider_name is OK.
 TEST_F(GroupVerifierTest, TestAnyInAllFirstAnyIsOk) {
   MessageUtil::loadFromYaml(AllWithAny, proto_config_);
   createSyncMockAuthsAndVerifier(StatusMap{{"provider_1", Status::Ok}, {"provider_3", Status::Ok}});
@@ -386,7 +386,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllFirstAnyIsOk) {
 }
 
 // Test contains a 2 provider_name in a require any along with another provider_name in require all.
-// Test simulates first require any is OK and proivder_name is OK.
+// Test simulates first require any is OK and provider_name is OK.
 TEST_F(GroupVerifierTest, TestAnyInAllLastAnyIsOk) {
   MessageUtil::loadFromYaml(AllWithAny, proto_config_);
   createSyncMockAuthsAndVerifier(StatusMap{{"provider_1", Status::JwtUnknownIssuer},
@@ -404,7 +404,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllLastAnyIsOk) {
 }
 
 // Test contains a 2 provider_name in a require any along with another provider_name in require all.
-// Test simulates all require any OK and proivder_name is OK.
+// Test simulates all require any OK and provider_name is OK.
 TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyIsOk) {
   MessageUtil::loadFromYaml(AllWithAny, proto_config_);
   auto callbacks = createAsyncMockAuthsAndVerifier(
@@ -422,7 +422,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyIsOk) {
 }
 
 // Test contains a 2 provider_name in a require any along with another provider_name in require all.
-// Test simulates all require any failed and proivder_name is OK.
+// Test simulates all require any failed and provider_name is OK.
 TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyFailed) {
   MessageUtil::loadFromYaml(AllWithAny, proto_config_);
   auto callbacks = createAsyncMockAuthsAndVerifier(

--- a/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
@@ -118,12 +118,12 @@ TEST_F(JwksCacheTest, TestAudiences) {
   // incoming has http://, config doesn't
   EXPECT_TRUE(jwks->areAudiencesAllowed({"http://example_service/"}));
 
-  // incomding has https://, config is http://
+  // incoming has https://, config is http://
   // incoming has tailing slash, config has not tailing slash
   EXPECT_TRUE(jwks->areAudiencesAllowed({"https://example_service1/"}));
 
   // incoming without tailing slash, config has tailing slash
-  // incomding has http://, config is https://
+  // incoming has http://, config is https://
   EXPECT_TRUE(jwks->areAudiencesAllowed({"http://example_service2"}));
 
   // Multiple audiences: a good one and a wrong one

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -537,7 +537,7 @@ TEST_P(ProxyProtocolTest, v2ParseExtensionsIoctlError) {
 }
 
 TEST_P(ProxyProtocolTest, v2ParseExtensionsFrag) {
-  // A well-formed ipv4/tcp header with 2 TLV/extenions, these are fragmented on delivery
+  // A well-formed ipv4/tcp header with 2 TLV/extensions, these are fragmented on delivery
   constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
                                 0x54, 0x0a, 0x21, 0x11, 0x00, 0x14, 0x01, 0x02, 0x03, 0x04,
                                 0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x00, 0x02};

--- a/test/extensions/filters/network/dubbo_proxy/filter_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/filter_test.cc
@@ -92,7 +92,7 @@ public:
         0x00,   0x00,   0x00,   0x00, 0x00, 0x00, 0x00, 0x01, // Request Id
         0x00,   0x00,   0x00,   0x16,                         // Body Length
         0x05,   '2',    '.',    '0',  '.',  '2',              // Dubbo version
-        0x04,   't',    'e',    's',  't',                    // Service naem
+        0x04,   't',    'e',    's',  't',                    // Service name
         0x05,   '0',    '.',    '0',  '.',  '0',              // Service version
         0x04,   't',    'e',    's',  't',                    // method name
     });
@@ -154,7 +154,7 @@ public:
                              0x05, '2', '.', '0', '.', '2'}); // Dubbo version
     } else {
       buffer.add(std::string{
-          0x04, 't', 'e', 's', 't',      // Service naem
+          0x04, 't', 'e', 's', 't',      // Service name
           0x05, '0', '.', '0', '.', '0', // Service version
           0x04, 't', 'e', 's', 't',      // method name
       });
@@ -178,7 +178,7 @@ public:
     addInt64(buffer, request_id);                            // Request Id
     buffer.add(std::string{0x00, 0x00, 0x00, 0x16,           // Body Length
                            0x05, '2',  '.',  '0',  '.', '2', // Dubbo version
-                           0x04, 't',  'e',  's',  't',      // Service naem
+                           0x04, 't',  'e',  's',  't',      // Service name
                            0x05, '0',  '.',  '0',  '.', '0', // Service version
                            0x04, 't',  'e',  's',  't'});    // method name
   }

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -323,7 +323,7 @@ TEST_F(ExtAuthzFilterTest, ImmediateOK) {
 }
 
 // Test to verify that on stack denied response from the authorization service does
-// result in stopage of the filter chain.
+// result in stoppage of the filter chain.
 TEST_F(ExtAuthzFilterTest, ImmediateNOK) {
   InSequence s;
 

--- a/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
@@ -563,7 +563,7 @@ TEST_F(MySQLFilterTest, MySqlHandshake41OkOOOFullLoginTest) {
  * Negative sequence
  * Test MySQL Handshake with protocol version 41
  * - send greeting messages followed by login ok
- * -> expect filte to ignore serverOK, because it has not
+ * -> expect filter to ignore serverOK, because it has not
  *    processed Challenge message
  */
 TEST_F(MySQLFilterTest, MySqlHandshake41OkGreetingLoginOKTest) {

--- a/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
@@ -699,7 +699,7 @@ routes:
   v3.set_string_value("v3");
   HashedValue hv1(v1), hv2(v2), hv3(v3);
 
-  // match with multiple weighted cluster metadata criterions defined
+  // match with multiple sets of weighted cluster metadata criteria defined
   {
     RouteConstSharedPtr route = matcher.route(metadata, 0);
     EXPECT_NE(nullptr, route);

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -92,7 +92,7 @@ TEST_F(RetryPriorityTest, DefaultFrequency) {
   verifyPriorityLoads(original_priority_load, original_degraded_priority_load);
 }
 
-// Tests that we handle all hosts being unhealthy in the orignal priority set.
+// Tests that we handle all hosts being unhealthy in the original priority set.
 TEST_F(RetryPriorityTest, NoHealthyUpstreams) {
   const Upstream::HealthyLoad original_priority_load({0, 0, 0});
   const Upstream::DegradedLoad original_degraded_priority_load({0, 0});
@@ -160,7 +160,7 @@ TEST_F(RetryPriorityTest, DefaultFrequencyUnhealthyPriorities) {
   retry_priority_->onHostAttempted(host2);
   verifyPriorityLoads(expected_priority_load, expected_degraded_priority_load);
 
-  // Once we've exhausted all priorities, we should return to the originial load.
+  // Once we've exhausted all priorities, we should return to the original load.
   retry_priority_->onHostAttempted(host3);
   verifyPriorityLoads(original_priority_load, original_degraded_priority_load);
 }
@@ -202,7 +202,7 @@ TEST_F(RetryPriorityTest, DefaultFrequencyUnhealthyPrioritiesDegradedLoad) {
   retry_priority_->onHostAttempted(host2);
   verifyPriorityLoads(expected_priority_load, expected_degraded_priority_load);
 
-  // Once we've exhausted all priorities, we should return to the originial load.
+  // Once we've exhausted all priorities, we should return to the original load.
   retry_priority_->onHostAttempted(host3);
   verifyPriorityLoads(original_priority_load, original_degraded_priority_load);
 }
@@ -244,7 +244,7 @@ TEST_F(RetryPriorityTest, DefaultFrequencyUnhealthyPrioritiesDegradedLoadSpillov
   retry_priority_->onHostAttempted(host3);
   verifyPriorityLoads(expected_priority_load, expected_degraded_priority_load);
 
-  // Once we've exhausted all priorities, we should return to the originial load.
+  // Once we've exhausted all priorities, we should return to the original load.
   retry_priority_->onHostAttempted(host1);
   verifyPriorityLoads(original_priority_load, original_degraded_priority_load);
 }
@@ -274,7 +274,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
   retry_priority_->onHostAttempted(host1);
   verifyPriorityLoads(original_priority_load, original_degraded_priority_load);
 
-  // After a second attempt, the prioity load should change.
+  // After a second attempt, the priority load should change.
   const Upstream::HealthyLoad expected_priority_load({0, 100});
   const Upstream::DegradedLoad expected_degraded_priority_load({0, 0});
   retry_priority_->onHostAttempted(host1);

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -68,7 +68,7 @@ public:
   }
 
   // TODO(#4160): Currently time_system_ is initialized from DangerousDeprecatedTestTime, which uses
-  // real time, not mock-time. When that is switched to use mock-time intead, I think
+  // real time, not mock-time. When that is switched to use mock-time instead, I think
   // generateRandom64() may not be as random as we want, and we'll need to inject entropy
   // appropriate for the test.
   uint64_t generateRandom64() { return Util::generateRandom64(time_source_); }

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -234,7 +234,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, AltsIntegrationTestClientWrongHandshaker,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
-// Verifies that when client connects to a wrong handshakerserver, handshake fails
+// Verifies that when client connects to the wrong handshaker server, handshake fails
 // and connection closes.
 TEST_P(AltsIntegrationTestClientWrongHandshaker, ConnectToWrongHandshakerAddress) {
   initialize();

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -583,7 +583,7 @@ TEST(ClientContextConfigImplTest, InvalidCertificateSpki) {
                           EnvoyException, "Invalid base64-encoded SHA-256 .*");
 }
 
-// Validate that 2048-bit RSA ceritificates load successfully.
+// Validate that 2048-bit RSA certificates load successfully.
 TEST(ClientContextConfigImplTest, RSA2048Cert) {
   envoy::api::v2::auth::UpstreamTlsContext tls_context;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
@@ -628,7 +628,7 @@ TEST(ClientContextConfigImplTest, RSA1024Cert) {
 #endif
 }
 
-// Validate that 3072-bit RSA ceritificates load successfully.
+// Validate that 3072-bit RSA certificates load successfully.
 TEST(ClientContextConfigImplTest, RSA3072Cert) {
   envoy::api::v2::auth::UpstreamTlsContext tls_context;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
@@ -647,7 +647,7 @@ TEST(ClientContextConfigImplTest, RSA3072Cert) {
   manager.createSslClientContext(store, client_context_config);
 }
 
-// Validate that 4096-bit RSA ceritificates load successfully in non-FIPS builds, but are rejected
+// Validate that 4096-bit RSA certificates load successfully in non-FIPS builds, but are rejected
 // in FIPS builds.
 TEST(ClientContextConfigImplTest, RSA4096Cert) {
   envoy::api::v2::auth::UpstreamTlsContext tls_context;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -1075,7 +1075,7 @@ TEST_P(SslSocketTest, FailedClientCertAllowExpiredBadHashVerification) {
                  .setExpectedClientCertUri("spiffe://lyft.com/test-team"));
 }
 
-// Allow expired certificatess, but use the wrong CA so it should fail still.
+// Allow expired certificates, but use the wrong CA so it should fail still.
 TEST_P(SslSocketTest, FailedClientCertAllowServerExpiredWrongCAVerification) {
   envoy::api::v2::Listener listener;
   envoy::api::v2::auth::UpstreamTlsContext client;

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -1,5 +1,5 @@
 // This is an Envoy test driver for fuzz tests. Unlike regular Envoy tests, we
-// operate in a more restricted environment, comparable to what oss-fuz uses. We
+// operate in a more restricted environment, comparable to what oss-fuzz uses. We
 // use the same Envoy::Fuzz::Runner library that oss-fuzz
 // (https://github.com/google/oss-fuzz) links against, providing the ability to
 // develop tests purely inside the Envoy repository and also to regression test
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     }
     ++input_args;
     // Outputs from envoy_directory_genrule might be directories or we might
-    // have artisinal files.
+    // have artisanal files.
     if (Envoy::Filesystem::directoryExists(arg)) {
       const auto paths = Envoy::TestUtility::listFiles(arg, true);
       Envoy::test_corpus_.insert(Envoy::test_corpus_.begin(), paths.begin(), paths.end());

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -294,7 +294,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointTimeoutHttp) {
   // Envoy sends a health check message to an endpoint
   healthcheckEndpoints();
 
-  // Endpoint doesn't repond to the health check
+  // Endpoint doesn't respond to the health check
 
   // Receive updates until the one we expect arrives
   waitForEndpointHealthResponse(envoy::api::v2::core::HealthStatus::TIMEOUT);
@@ -469,7 +469,7 @@ TEST_P(HdsIntegrationTest, TwoEndpointsSameLocality) {
 
   healthcheckEndpoints("anna");
 
-  // Endpoints repond to the health check
+  // Endpoints respond to the health check
   host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
   host_stream_->encodeData(1024, true);
   host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -152,7 +152,7 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
   upstream_request_->encodeData(1024, false);
   response->waitForBodyData(1024);
 
-  // Finish sending therequest.
+  // Finish sending the request.
   codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{{"trailer", "foo"}});
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -886,7 +886,7 @@ void HttpIntegrationTest::testRetryPriority() {
                                                                  {"x-envoy-retry-on", "5xx"}},
                                          1024);
 
-  // Note how we're exepcting each upstream request to hit the same upstream.
+  // Note how we're expecting each upstream request to hit the same upstream.
   waitForNextUpstreamRequest(0);
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
 
@@ -944,7 +944,7 @@ void HttpIntegrationTest::testRetryHostPredicateFilter() {
                                                                  {"x-envoy-retry-on", "5xx"}},
                                          1024);
 
-  // Note how we're exepcting each upstream request to hit the same upstream.
+  // Note how we're expecting each upstream request to hit the same upstream.
   auto upstream_idx = waitForNextUpstreamRequest({0, 1});
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
 
@@ -1761,7 +1761,7 @@ void HttpIntegrationTest::testEquivalent(const std::string& request) {
     cloned_listener->CopyFrom(*old_listener);
     old_listener->set_name("http_forward");
   });
-  // Set the first listener to allow absoute URLs.
+  // Set the first listener to allow absolute URLs.
   config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
   initialize();
 

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -238,7 +238,7 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutUnconfiguredDoesNotTriggerOnBod
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestWithHeaders) {
-  // Omitting \r\n\n\n does not indicate incopmlete request in HTTP2
+  // Omitting \r\n\n\n does not indicate incomplete request in HTTP2
   if (downstreamProtocol() == Envoy::Http::CodecClient::Type::HTTP2) {
     return;
   }

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -163,14 +163,14 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
-  // Testing a fitler with no matches
+  // Testing a filter with no matches
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats?filter=foo", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
-  // Testing a fitler with matches
+  // Testing a filter with matches
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats?filter=server",
                                                 "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -21,7 +21,7 @@ public:
   LoadStatsIntegrationTest()
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), realTime()) {
     // We rely on some fairly specific load balancing picks in this test, so
-    // determinizie the schedule.
+    // determinize the schedule.
     setDeterministic();
   }
 

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -89,7 +89,7 @@ TEST_P(RedirectIntegrationTest, InvalidRedirect) {
 
   redirect_response_.insertLocation().value("invalid_url", 11);
 
-  // Send the same rquest as above, only send an invalid URL as the response.
+  // Send the same request as above, only send an invalid URL as the response.
   // The request should not be redirected.
   codec_client_ = makeHttpConnection(lookupPort("http"));
   default_request_headers_.insertHost().value("handle.internal.redirect", 24);

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -406,10 +406,10 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, BasicSuccess) {
   fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // There is a race condition here; there are two static clusters:
-  // backend cluster_0 with sds and sds_cluser. cluster_0 is created first, its init_manager
+  // backend cluster_0 with sds and sds_cluster. cluster_0 is created first, its init_manager
   // is called so it issues a sds call, but fail since sds_cluster is not added yet.
   // so cluster_0 is initialized with an empty secret. initialize() will not wait and will return.
-  // the testing request will be called, even though in the pre_workder_function, a good sds is
+  // the testing request will be called, even though in the pre_worker_function, a good sds is
   // send, the cluster will be updated with good secret, the testing request may fail if it is
   // before context is updated. Hence, need to wait for context_update counter.
   test_server_->waitForCounterGe(

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -388,7 +388,7 @@ void TcpProxySslIntegrationTest::setupConnections() {
             .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
         return client_write_buffer_;
       }));
-  // Set up the SSl client.
+  // Set up the SSL client.
   Network::Address::InstanceConstSharedPtr address =
       Ssl::getSslAddress(version_, lookupPort("tcp_proxy"));
   context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_);

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -101,7 +101,7 @@ void WebsocketIntegrationTest::commonValidate(Http::HeaderMap& proxied_headers,
       proxied_headers.Connection()->value() == "upgrade" &&
       original_headers.Connection() != nullptr &&
       original_headers.Connection()->value() == "keep-alive, upgrade") {
-    // The keep-alive is implicit for HTTP/1.1, so Enovy only sets the upgrade
+    // The keep-alive is implicit for HTTP/1.1, so Envoy only sets the upgrade
     // header when converting from HTTP/1.1 to H2
     proxied_headers.Connection()->value().setCopy("keep-alive, upgrade", 19);
   }
@@ -282,7 +282,7 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionIdleTimeout) {
   ASSERT_TRUE(waitForUpstreamDisconnectOrReset());
 }
 
-// Technically not a websocket tests, but verfies normal upgrades have parity
+// Technically not a websocket tests, but verifies normal upgrades have parity
 // with websocket upgrades
 TEST_P(WebsocketIntegrationTest, NonWebsocketUpgrade) {
   config_helper_.addConfigModifier(

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -659,7 +659,7 @@ TEST_P(AdminInstanceTest, MutatesErrorWithGet) {
   Http::HeaderMapImpl header_map;
   const std::string path("/healthcheck/fail");
   // TODO(jmarantz): the call to getCallback should be made to fail, but as an interim we will
-  // just issue a warning, so that scripts using curl GET comamnds to mutate state can be fixed.
+  // just issue a warning, so that scripts using curl GET commands to mutate state can be fixed.
   EXPECT_LOG_CONTAINS("error",
                       "admin path \"" + path + "\" mutates state, method=GET rather than POST",
                       EXPECT_EQ(Http::Code::BadRequest, getCallback(path, header_map, data)));

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -279,7 +279,7 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithoutAccessLog) {
                             "An admin access log path is required for a listening server.");
 }
 
-// Empty bootstrap succeeeds.
+// Empty bootstrap succeeds.
 TEST_P(ServerInstanceImplTest, EmptyBootstrap) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
@@ -394,7 +394,7 @@ TEST_P(ServerInstanceImplTest, ZipkinHttpTracingEnabled) {
   EXPECT_NO_THROW(initialize("test/server/zipkin_tracing.yaml"));
   EXPECT_EQ(nullptr, dynamic_cast<Tracing::HttpNullTracer*>(tracer()));
 
-  // Note: there is no ZipkingTracerImpl object;
+  // Note: there is no ZipkinTracerImpl object;
   // source/extensions/tracers/zipkin/config.cc instantiates the tracer with
   //     std::make_unique<Tracing::HttpTracerImpl>(std::move(zipkin_driver), server.localInfo());
   // so we look for a successful dynamic cast to HttpTracerImpl, rather

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -120,7 +120,7 @@ public:
              Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   /**
-   * Substitute ports, paths, and IP loopback addressses in a JSON file in the
+   * Substitute ports, paths, and IP loopback addresses in a JSON file in the
    * private writable test temporary directory.
    * @param path path prefix for the input file with port and path templates.
    * @param port_map map from port name to port number.
@@ -130,7 +130,7 @@ public:
   static std::string temporaryFileSubstitute(const std::string& path, const PortMap& port_map,
                                              Network::Address::IpVersion version);
   /**
-   * Substitute ports, paths, and IP loopback addressses in a JSON file in the
+   * Substitute ports, paths, and IP loopback addresses in a JSON file in the
    * private writable test temporary directory.
    * @param path path prefix for the input file with port and path templates.
    * @param param_map map from parameter name to values.


### PR DESCRIPTION
This risks generating a boat load of merge conflicts, but I finally saw one too many typos. I only directly searched for typos in comments, but in doing so came across the spot where certificate was spelled incorrectly in some SSL code and comments, so I fixed that. One error message containing "cluser" also got fixed.

*Risk Level*: low
*Testing*: existing tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher \<zuercher@gmail.com\>
