### PR TITLE
jwt_authn: cleanup, separate verifier from the matcher

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -26,12 +26,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   state_ = Calling;
   stopped_ = false;
   // Verify the JWT token, onComplete() will be called when completed.
-  auto matcher = config_->findMatcher(headers);
-  if (!matcher) {
+  const auto* verifier = config_->findVerifier(headers);
+  if (!verifier) {
     onComplete(Status::Ok);
   } else {
     context_ = Verifier::createContext(headers, this);
-    matcher->verifier()->verify(context_);
+    verifier->verify(context_);
   }
 
   if (state_ == Complete) {

--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/http/jwt_authn/matcher.h"
 
+#include "common/common/logger.h"
 #include "common/router/config_impl.h"
 
 #include "absl/strings/match.h"
@@ -20,9 +21,7 @@ namespace {
  */
 class BaseMatcherImpl : public Matcher, public Logger::Loggable<Logger::Id::filter> {
 public:
-  BaseMatcherImpl(const RequirementRule& rule,
-                  const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                  const AuthFactory& factory, const Extractor& extractor)
+  BaseMatcherImpl(const RequirementRule& rule)
       : case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(rule.match(), case_sensitive, true)) {
 
     for (const auto& header_map : rule.match().headers()) {
@@ -32,8 +31,6 @@ public:
     for (const auto& query_parameter : rule.match().query_parameters()) {
       config_query_parameters_.push_back(query_parameter);
     }
-
-    verifier_ = Verifier::create(rule.requires(), providers, factory, extractor);
   }
 
   // Check match for HeaderMatcher and QueryParameterMatcher
@@ -50,15 +47,12 @@ public:
     return matches;
   }
 
-  const VerifierPtr& verifier() const override { return verifier_; }
-
 protected:
   const bool case_sensitive_;
 
 private:
   std::vector<Http::HeaderUtility::HeaderData> config_headers_;
   std::vector<Router::ConfigUtility::QueryParameterMatcher> config_query_parameters_;
-  VerifierPtr verifier_;
 };
 
 /**
@@ -66,10 +60,8 @@ private:
  */
 class PrefixMatcherImpl : public BaseMatcherImpl {
 public:
-  PrefixMatcherImpl(const RequirementRule& rule,
-                    const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                    const AuthFactory& factory, const Extractor& extractor)
-      : BaseMatcherImpl(rule, providers, factory, extractor), prefix_(rule.match().prefix()) {}
+  PrefixMatcherImpl(const RequirementRule& rule)
+      : BaseMatcherImpl(rule), prefix_(rule.match().prefix()) {}
 
   bool matches(const Http::HeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers) &&
@@ -92,10 +84,8 @@ private:
  */
 class PathMatcherImpl : public BaseMatcherImpl {
 public:
-  PathMatcherImpl(const RequirementRule& rule,
-                  const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                  const AuthFactory& factory, const Extractor& extractor)
-      : BaseMatcherImpl(rule, providers, factory, extractor), path_(rule.match().path()) {}
+  PathMatcherImpl(const RequirementRule& rule)
+      : BaseMatcherImpl(rule), path_(rule.match().path()) {}
 
   bool matches(const Http::HeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers)) {
@@ -122,11 +112,9 @@ private:
  */
 class RegexMatcherImpl : public BaseMatcherImpl {
 public:
-  RegexMatcherImpl(const RequirementRule& rule,
-                   const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                   const AuthFactory& factory, const Extractor& extractor)
-      : BaseMatcherImpl(rule, providers, factory, extractor),
-        regex_(RegexUtil::parseRegex(rule.match().regex())), regex_str_(rule.match().regex()) {}
+  RegexMatcherImpl(const RequirementRule& rule)
+      : BaseMatcherImpl(rule), regex_(RegexUtil::parseRegex(rule.match().regex())),
+        regex_str_(rule.match().regex()) {}
 
   bool matches(const Http::HeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers)) {
@@ -149,17 +137,14 @@ private:
 
 } // namespace
 
-MatcherConstSharedPtr
-Matcher::create(const RequirementRule& rule,
-                const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                const AuthFactory& factory, const Extractor& extractor) {
+MatcherConstPtr Matcher::create(const RequirementRule& rule) {
   switch (rule.match().path_specifier_case()) {
   case RouteMatch::PathSpecifierCase::kPrefix:
-    return std::make_shared<PrefixMatcherImpl>(rule, providers, factory, extractor);
+    return std::make_unique<PrefixMatcherImpl>(rule);
   case RouteMatch::PathSpecifierCase::kPath:
-    return std::make_shared<PathMatcherImpl>(rule, providers, factory, extractor);
+    return std::make_unique<PathMatcherImpl>(rule);
   case RouteMatch::PathSpecifierCase::kRegex:
-    return std::make_shared<RegexMatcherImpl>(rule, providers, factory, extractor);
+    return std::make_unique<RegexMatcherImpl>(rule);
   // path specifier is required.
   case RouteMatch::PathSpecifierCase::PATH_SPECIFIER_NOT_SET:
   default:

--- a/source/extensions/filters/http/jwt_authn/matcher.h
+++ b/source/extensions/filters/http/jwt_authn/matcher.h
@@ -1,8 +1,7 @@
 #pragma once
 
+#include "envoy/config/filter/http/jwt_authn/v2alpha/config.pb.h"
 #include "envoy/http/header_map.h"
-
-#include "extensions/filters/http/jwt_authn/verifier.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -10,7 +9,7 @@ namespace HttpFilters {
 namespace JwtAuthn {
 
 class Matcher;
-typedef std::shared_ptr<const Matcher> MatcherConstSharedPtr;
+typedef std::unique_ptr<const Matcher> MatcherConstPtr;
 
 /**
  * Supports matching a HTTP requests with JWT requirements.
@@ -29,26 +28,13 @@ public:
   virtual bool matches(const Http::HeaderMap& headers) const PURE;
 
   /**
-   * Returns the configured verifier for this route.
-   *
-   * @return reference to verifier pointer.
-   */
-  virtual const VerifierPtr& verifier() const PURE;
-
-  /**
    * Factory method to create a shared instance of a matcher based on the rule defined.
    *
    * @param rule  the proto rule match message.
-   * @param providers  the provider name to config map
-   * @param factory  the Authenticator factory
    * @return the matcher instance.
    */
-  static MatcherConstSharedPtr
-  create(const ::envoy::config::filter::http::jwt_authn::v2alpha::RequirementRule& rule,
-         const Protobuf::Map<ProtobufTypes::String,
-                             ::envoy::config::filter::http::jwt_authn::v2alpha::JwtProvider>&
-             providers,
-         const AuthFactory& factory, const Extractor& extractor);
+  static MatcherConstPtr
+  create(const ::envoy::config::filter::http::jwt_authn::v2alpha::RequirementRule& rule);
 };
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -179,10 +179,10 @@ private:
   const Extractor& extractor_;
 };
 
-VerifierPtr innerCreate(const JwtRequirement& requirement,
-                        const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                        const AuthFactory& factory, const Extractor& extractor,
-                        const BaseVerifierImpl* parent);
+VerifierConstPtr innerCreate(const JwtRequirement& requirement,
+                             const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
+                             const AuthFactory& factory, const Extractor& extractor,
+                             const BaseVerifierImpl* parent);
 
 // Base verifier for requires all or any.
 class BaseGroupVerifierImpl : public BaseVerifierImpl {
@@ -201,7 +201,7 @@ public:
 
 protected:
   // The list of requirement verifiers
-  std::vector<VerifierPtr> verifiers_;
+  std::vector<VerifierConstPtr> verifiers_;
 };
 
 // Requires any verifier.
@@ -264,10 +264,10 @@ public:
   }
 };
 
-VerifierPtr innerCreate(const JwtRequirement& requirement,
-                        const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                        const AuthFactory& factory, const Extractor& extractor_for_allow_fail,
-                        const BaseVerifierImpl* parent) {
+VerifierConstPtr innerCreate(const JwtRequirement& requirement,
+                             const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
+                             const AuthFactory& factory, const Extractor& extractor_for_allow_fail,
+                             const BaseVerifierImpl* parent) {
   std::string provider_name;
   std::vector<std::string> audiences;
   switch (requirement.requires_type_case()) {
@@ -311,10 +311,10 @@ ContextSharedPtr Verifier::createContext(Http::HeaderMap& headers, Callbacks* ca
   return std::make_shared<ContextImpl>(headers, callback);
 }
 
-VerifierPtr Verifier::create(const JwtRequirement& requirement,
-                             const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
-                             const AuthFactory& factory,
-                             const Extractor& extractor_for_allow_fail) {
+VerifierConstPtr
+Verifier::create(const JwtRequirement& requirement,
+                 const Protobuf::Map<ProtobufTypes::String, JwtProvider>& providers,
+                 const AuthFactory& factory, const Extractor& extractor_for_allow_fail) {
   return innerCreate(requirement, providers, factory, extractor_for_allow_fail, nullptr);
 }
 

--- a/source/extensions/filters/http/jwt_authn/verifier.h
+++ b/source/extensions/filters/http/jwt_authn/verifier.h
@@ -8,7 +8,7 @@ namespace HttpFilters {
 namespace JwtAuthn {
 
 class Verifier;
-typedef std::unique_ptr<Verifier> VerifierPtr;
+typedef std::unique_ptr<const Verifier> VerifierConstPtr;
 
 /**
  * Supports verification of JWTs with configured requirments.
@@ -71,7 +71,7 @@ public:
   virtual void verify(ContextSharedPtr context) const PURE;
 
   // Factory method for creating verifiers.
-  static VerifierPtr
+  static VerifierConstPtr
   create(const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtRequirement& requirement,
          const Protobuf::Map<ProtobufTypes::String,
                              ::envoy::config::filter::http::jwt_authn::v2alpha::JwtProvider>&

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -29,7 +29,7 @@ public:
 
   JwtAuthentication proto_config_;
   FilterConfigSharedPtr filter_config_;
-  VerifierPtr verifier_;
+  VerifierConstPtr verifier_;
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;
   MockVerifierCallbacks mock_cb_;

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -22,7 +22,6 @@ namespace JwtAuthn {
 class MockMatcher : public Matcher {
 public:
   MOCK_CONST_METHOD1(matches, bool(const Http::HeaderMap& headers));
-  MOCK_CONST_METHOD0(verifier, const VerifierPtr&());
 };
 
 class MockFilterConfig : public FilterConfig {
@@ -31,7 +30,7 @@ public:
       const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
       : FilterConfig(proto_config, stats_prefix, context) {}
-  MOCK_CONST_METHOD1(findMatcher, const MatcherConstSharedPtr(const Http::HeaderMap& headers));
+  MOCK_CONST_METHOD1(findVerifier, const Verifier*(const Http::HeaderMap& headers));
 };
 
 class FilterTest : public ::testing::Test {
@@ -40,22 +39,13 @@ public:
     mock_config_ = ::std::make_shared<MockFilterConfig>(proto_config_, "", mock_context_);
 
     mock_verifier_ = std::make_unique<MockVerifier>();
-    raw_mock_verifier_ = static_cast<MockVerifier*>(mock_verifier_.get());
-
     filter_ = std::make_unique<Filter>(mock_config_);
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
   }
 
   void setupMockConfig() {
-    EXPECT_CALL(*mock_config_.get(), findMatcher(_)).WillOnce(Invoke([&](const Http::HeaderMap&) {
-      auto mock_matcher = std::make_shared<NiceMock<MockMatcher>>();
-      ON_CALL(*mock_matcher.get(), matches(_)).WillByDefault(Invoke([](const Http::HeaderMap&) {
-        return true;
-      }));
-      ON_CALL(*mock_matcher.get(), verifier()).WillByDefault(Invoke([&]() -> const VerifierPtr& {
-        return mock_verifier_;
-      }));
-      return mock_matcher;
+    EXPECT_CALL(*mock_config_.get(), findVerifier(_)).WillOnce(Invoke([&](const Http::HeaderMap&) {
+      return mock_verifier_.get();
     }));
   }
 
@@ -64,8 +54,7 @@ public:
   std::shared_ptr<MockFilterConfig> mock_config_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks_;
   std::unique_ptr<Filter> filter_;
-  VerifierPtr mock_verifier_;
-  MockVerifier* raw_mock_verifier_;
+  std::unique_ptr<MockVerifier> mock_verifier_;
   NiceMock<MockVerifierCallbacks> verifier_callback_;
 };
 
@@ -74,7 +63,7 @@ public:
 TEST_F(FilterTest, InlineOK) {
   setupMockConfig();
   // A successful authentication completed inline: callback is called inside verify().
-  EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
     context->callback()->onComplete(Status::Ok);
   }));
 
@@ -92,7 +81,7 @@ TEST_F(FilterTest, TestSetPayloadCall) {
   setupMockConfig();
   ProtobufWkt::Struct payload;
   // A successful authentication completed inline: callback is called inside verify().
-  EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([&payload](ContextSharedPtr context) {
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([&payload](ContextSharedPtr context) {
     context->callback()->setPayload(payload);
     context->callback()->onComplete(Status::Ok);
   }));
@@ -117,7 +106,7 @@ TEST_F(FilterTest, TestSetPayloadCall) {
 TEST_F(FilterTest, InlineFailure) {
   setupMockConfig();
   // A failed authentication completed inline: callback is called inside verify().
-  EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
     context->callback()->onComplete(Status::JwtBadFormat);
   }));
 
@@ -135,7 +124,7 @@ TEST_F(FilterTest, OutBoundOK) {
   setupMockConfig();
   Verifier::Callbacks* m_cb;
   // callback is saved, not called right
-  EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([&m_cb](ContextSharedPtr context) {
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([&m_cb](ContextSharedPtr context) {
     m_cb = context->callback();
   }));
 
@@ -160,7 +149,7 @@ TEST_F(FilterTest, OutBoundFailure) {
   setupMockConfig();
   Verifier::Callbacks* m_cb;
   // callback is saved, not called right
-  EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([&m_cb](ContextSharedPtr context) {
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([&m_cb](ContextSharedPtr context) {
     m_cb = context->callback();
   }));
 
@@ -185,7 +174,7 @@ TEST_F(FilterTest, OutBoundFailure) {
 
 // Test verifies that if no route matched requirement, then request is allowed.
 TEST_F(FilterTest, TestNoRouteMatched) {
-  EXPECT_CALL(*mock_config_.get(), findMatcher(_)).WillOnce(Invoke([&](const Http::HeaderMap&) {
+  EXPECT_CALL(*mock_config_.get(), findVerifier(_)).WillOnce(Invoke([&](const Http::HeaderMap&) {
     return nullptr;
   }));
 

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -128,7 +128,7 @@ public:
   }
 
   JwtAuthentication proto_config_;
-  VerifierPtr verifier_;
+  VerifierConstPtr verifier_;
   MockVerifierCallbacks mock_cb_;
   std::unordered_map<std::string, std::unique_ptr<MockAuthenticator>> mock_auths_;
   NiceMock<MockAuthFactory> mock_factory_;

--- a/test/extensions/filters/http/jwt_authn/matcher_test.cc
+++ b/test/extensions/filters/http/jwt_authn/matcher_test.cc
@@ -25,8 +25,6 @@ namespace {
 
 class MatcherTest : public ::testing::Test {
 public:
-  NiceMock<MockAuthFactory> mock_factory_;
-  MockExtractor extractor_;
 };
 
 TEST_F(MatcherTest, TestMatchPrefix) {
@@ -34,8 +32,7 @@ TEST_F(MatcherTest, TestMatchPrefix) {
   prefix: "/match")";
   RequirementRule rule;
   MessageUtil::loadFromYaml(config, rule);
-  MatcherConstSharedPtr matcher = Matcher::create(
-      rule, Protobuf::Map<ProtobufTypes::String, JwtProvider>(), mock_factory_, extractor_);
+  MatcherConstPtr matcher = Matcher::create(rule);
   auto headers = TestHeaderMapImpl{{":path", "/match/this"}};
   EXPECT_TRUE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/MATCH"}};
@@ -46,7 +43,6 @@ TEST_F(MatcherTest, TestMatchPrefix) {
   EXPECT_FALSE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/no"}};
   EXPECT_FALSE(matcher->matches(headers));
-  EXPECT_FALSE(matcher->verifier() == nullptr);
 }
 
 TEST_F(MatcherTest, TestMatchRegex) {
@@ -54,8 +50,7 @@ TEST_F(MatcherTest, TestMatchRegex) {
   regex: "/[^c][au]t")";
   RequirementRule rule;
   MessageUtil::loadFromYaml(config, rule);
-  MatcherConstSharedPtr matcher = Matcher::create(
-      rule, Protobuf::Map<ProtobufTypes::String, JwtProvider>(), mock_factory_, extractor_);
+  MatcherConstPtr matcher = Matcher::create(rule);
   auto headers = TestHeaderMapImpl{{":path", "/but"}};
   EXPECT_TRUE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/mat?ok=bye"}};
@@ -66,7 +61,6 @@ TEST_F(MatcherTest, TestMatchRegex) {
   EXPECT_FALSE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/mut/"}};
   EXPECT_FALSE(matcher->matches(headers));
-  EXPECT_FALSE(matcher->verifier() == nullptr);
 }
 
 TEST_F(MatcherTest, TestMatchPath) {
@@ -75,8 +69,7 @@ TEST_F(MatcherTest, TestMatchPath) {
   case_sensitive: false)";
   RequirementRule rule;
   MessageUtil::loadFromYaml(config, rule);
-  MatcherConstSharedPtr matcher = Matcher::create(
-      rule, Protobuf::Map<ProtobufTypes::String, JwtProvider>(), mock_factory_, extractor_);
+  MatcherConstPtr matcher = Matcher::create(rule);
   auto headers = TestHeaderMapImpl{{":path", "/match"}};
   EXPECT_TRUE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/MATCH"}};
@@ -89,7 +82,6 @@ TEST_F(MatcherTest, TestMatchPath) {
   EXPECT_FALSE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/matching"}};
   EXPECT_FALSE(matcher->matches(headers));
-  EXPECT_FALSE(matcher->verifier() == nullptr);
 }
 
 TEST_F(MatcherTest, TestMatchQuery) {
@@ -100,8 +92,7 @@ TEST_F(MatcherTest, TestMatchQuery) {
     value: bar)";
   RequirementRule rule;
   MessageUtil::loadFromYaml(config, rule);
-  MatcherConstSharedPtr matcher = Matcher::create(
-      rule, Protobuf::Map<ProtobufTypes::String, JwtProvider>(), mock_factory_, extractor_);
+  MatcherConstPtr matcher = Matcher::create(rule);
   auto headers = TestHeaderMapImpl{{":path", "/boo?foo=bar"}};
   EXPECT_TRUE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/boo?ok=bye"}};
@@ -112,7 +103,6 @@ TEST_F(MatcherTest, TestMatchQuery) {
   EXPECT_FALSE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/boo?bar=foo"}};
   EXPECT_FALSE(matcher->matches(headers));
-  EXPECT_FALSE(matcher->verifier() == nullptr);
 }
 
 TEST_F(MatcherTest, TestMatchHeader) {
@@ -122,8 +112,7 @@ TEST_F(MatcherTest, TestMatchHeader) {
   - name: a)";
   RequirementRule rule;
   MessageUtil::loadFromYaml(config, rule);
-  MatcherConstSharedPtr matcher = Matcher::create(
-      rule, Protobuf::Map<ProtobufTypes::String, JwtProvider>(), mock_factory_, extractor_);
+  MatcherConstPtr matcher = Matcher::create(rule);
   auto headers = TestHeaderMapImpl{{":path", "/"}, {"a", ""}};
   EXPECT_TRUE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/"}, {"a", "some"}, {"b", ""}};
@@ -134,7 +123,6 @@ TEST_F(MatcherTest, TestMatchHeader) {
   EXPECT_FALSE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/"}, {"", ""}};
   EXPECT_FALSE(matcher->matches(headers));
-  EXPECT_FALSE(matcher->verifier() == nullptr);
 }
 
 TEST_F(MatcherTest, TestMatchPathAndHeader) {
@@ -145,8 +133,7 @@ TEST_F(MatcherTest, TestMatchPathAndHeader) {
     value: bar)";
   RequirementRule rule;
   MessageUtil::loadFromYaml(config, rule);
-  MatcherConstSharedPtr matcher = Matcher::create(
-      rule, Protobuf::Map<ProtobufTypes::String, JwtProvider>(), mock_factory_, extractor_);
+  MatcherConstPtr matcher = Matcher::create(rule);
   auto headers = TestHeaderMapImpl{{":path", "/boo?foo=bar"}};
   EXPECT_TRUE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/boo?ok=bye"}};
@@ -157,7 +144,6 @@ TEST_F(MatcherTest, TestMatchPathAndHeader) {
   EXPECT_FALSE(matcher->matches(headers));
   headers = TestHeaderMapImpl{{":path", "/boo?bar=foo"}};
   EXPECT_FALSE(matcher->matches(headers));
-  EXPECT_FALSE(matcher->verifier() == nullptr);
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -37,7 +37,7 @@ public:
 
   JwtAuthentication proto_config_;
   FilterConfigSharedPtr filter_config_;
-  VerifierPtr verifier_;
+  VerifierConstPtr verifier_;
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;
   MockVerifierCallbacks mock_cb_;


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

This is just code cleanup.  Now Verifier object is stored in Matcher and accessed by calling its verifier() function.  It will be cleaner to store matcher and verifier separately as a pair in the filer_config.

Also changed to use unique_ptr for Matcher too. 

s/MatcherConstSharedPtr/MatcherConstPtr

*Risk Level*:  None

*Testing*:  All unit-tests

