### PR TITLE
Update Datadog tracer version to v0.4.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -100,9 +100,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/googleapis/googleapis/archive/d6f78d948c53f3b400bb46996eb3084359914f9b.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "32967149fbc672f321ba6ce6c3e5cc299b15ab914f6f5b2993c7c9ddc1894439",
-        strip_prefix = "dd-opentracing-cpp-0.3.6",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.3.6.tar.gz"],
+        sha256 = "1798ce816e389ad89c379cb734487ed8b7db3d909be0c8548bd96538f78639b7",
+        strip_prefix = "dd-opentracing-cpp-0.4.1",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.4.1.tar.gz"],
     ),
     com_github_msgpack_msgpack_c = dict(
         sha256 = "bda49f996a73d2c6080ff0523e7b535917cd28c8a79c3a5da54fc29332d61d1e",


### PR DESCRIPTION
Signed-off-by: Will Gittoes <will.gittoes@datadoghq.com>

*Description*:
Updates the version of the Datadog tracing dependency to v0.4.1. Adds optional environment variable control of the propagation headers used.

*Risk Level*: Low

*Testing*:
No code added, no tests added. All tests still pass.

*Docs Changes*: N/A
*Release Notes*: N/A
