### PR TITLE
crypto: add include for vector header

### DIFF
--- a/source/common/crypto/utility.h
+++ b/source/common/crypto/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "envoy/buffer/buffer.h"
 
 namespace Envoy {


### PR DESCRIPTION
*Description*:

Running tests cause this compilation error:

    utility_lib/common/crypto/utility.h:16:15: error: 'vector' in namespace 'std' does not name a template type
       static std::vector<uint8_t> getSha256Digest(const Buffer::Instance& buffer);
                   ^~~~~~

Add header "vector" to fix the issue.

*Risk Level*: Low
*Testing*: Re-ran the tests.
*Docs Changes*: N/A
*Release Notes*: N/A
