### PR TITLE
Add quic_prefetch_impl.h to QUICHE platform implementation

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -119,6 +119,7 @@ cc_library(
         "quiche/quic/platform/api/quic_fallthrough.h",
         "quiche/quic/platform/api/quic_flag_utils.h",
         "quiche/quic/platform/api/quic_iovec.h",
+        "quiche/quic/platform/api/quic_prefetch.h",
         "quiche/quic/platform/api/quic_string.h",
         "quiche/quic/platform/api/quic_string_piece.h",
         # TODO: uncomment the following files as implementations are added.
@@ -144,7 +145,6 @@ cc_library(
         # "quiche/quic/platform/api/quic_mock_log.h",
         # "quiche/quic/platform/api/quic_mutex.h",
         # "quiche/quic/platform/api/quic_pcc_sender.h",
-        # "quiche/quic/platform/api/quic_prefetch.h",
         # "quiche/quic/platform/api/quic_ptr_util.h",
         # "quiche/quic/platform/api/quic_reference_counted.h",
         # "quiche/quic/platform/api/quic_server_stats.h",

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
         "quic_fallthrough_impl.h",
         "quic_flag_utils_impl.h",
         "quic_iovec_impl.h",
+        "quic_prefetch_impl.h",
         "quic_string_impl.h",
         "quic_string_piece_impl.h",
     ],

--- a/source/extensions/quic_listeners/quiche/platform/quic_prefetch_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_prefetch_impl.h
@@ -8,8 +8,12 @@
 
 namespace quic {
 
-inline void QuicPrefetchT0Impl(const void* addr) {
-  // TODO(wub): Implement.
-}
+#if defined(__GNUC__)
+// See __builtin_prefetch in:
+// https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html.
+inline void QuicPrefetchT0Impl(const void* addr) { __builtin_prefetch(addr, 0, 3); }
+#else
+inline void QuicPrefetchT0Impl(const void*) {}
+#endif
 
 } // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_prefetch_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_prefetch_impl.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+namespace quic {
+
+inline void QuicPrefetchT0Impl(const void* addr) {
+  // TODO(wub): Implement.
+}
+
+} // namespace quic


### PR DESCRIPTION
*Description*:

Add quic_prefetch_impl.h to QUICHE platform implementation

*Risk Level*: minimal: code not used yet
*Testing*: bazel build @com_googlesource_quiche//:quic_platform
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
