### PR TITLE
Start overload manager before worker threads

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -418,6 +418,9 @@ RunHelper::RunHelper(Instance& instance, Options& options, Event::Dispatcher& di
     });
   }
 
+  // Start overload manager before workers.
+  overload_manager.start();
+
   // Register for cluster manager init notification. We don't start serving worker traffic until
   // upstream clusters are initialized which may involve running the event loop. Note however that
   // this can fire immediately if all clusters have already initialized. Also note that we need
@@ -449,8 +452,6 @@ RunHelper::RunHelper(Instance& instance, Options& options, Event::Dispatcher& di
     // as we've subscribed to all the statically defined RDS resources.
     cm.adsMux().resume(Config::TypeUrl::get().RouteConfiguration);
   });
-
-  overload_manager.start();
 }
 
 void InstanceImpl::run() {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -63,8 +63,8 @@ public:
     sigint_ = new Event::MockSignalEvent(&dispatcher_);
     sigusr1_ = new Event::MockSignalEvent(&dispatcher_);
     sighup_ = new Event::MockSignalEvent(&dispatcher_);
-    EXPECT_CALL(cm_, setInitializedCb(_)).WillOnce(SaveArg<0>(&cm_init_callback_));
     EXPECT_CALL(overload_manager_, start());
+    EXPECT_CALL(cm_, setInitializedCb(_)).WillOnce(SaveArg<0>(&cm_init_callback_));
     ON_CALL(server_, shutdown()).WillByDefault(Assign(&shutdown_, true));
 
     helper_ = std::make_unique<RunHelper>(server_, options_, dispatcher_, cm_, access_log_manager_,


### PR DESCRIPTION
Start the overload manager a little earlier in the startup sequence to ensure it happens before worker thread starts and client requests can be handled. I discovered this problem when writing an integration test and a race condition would sometimes cause envoy to crash if it got a client request before the overload manager had been started.

*Risk Level*: low
*Testing*: unit & integration tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>

