### PR TITLE
CI: Run remaining format tests on Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,8 @@ jobs:
      steps:
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
        - checkout
-       - run: pip install -r tools/requirements.txt
+       - run: pip3 install --upgrade pip
+       - run: pip3 install -r tools/requirements.txt
        - run: ci/do_circle_ci.sh check_format
        - run: ci/do_circle_ci.sh check_repositories
        - run: ci/do_circle_ci.sh check_spelling

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -599,7 +599,7 @@ if __name__ == "__main__":
     results = []
     # For each file in target_path, start a new task in the pool and collect the
     # results (results is passed by reference, and is used as an output).
-    os.path.walk(target_path, checkFormatVisitor, (pool, results))
+    os.walk(target_path, checkFormatVisitor, (pool, results))
 
     # Close the pool to new tasks, wait for all of the running tasks to finish,
     # then collect the error messages.

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -472,7 +472,7 @@ def executeCommand(command,
     # In case we can't find any line numbers, record an error message first.
     error_messages = ["%s for file: %s" % (error_message, file_path)]
     for line in e.output.splitlines():
-      for num in regex.findall(line):
+      for num in regex.findall(str(line)):
         error_messages.append("  %s:%s" % (file_path, num))
     return error_messages
 

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Tests check_format.py. This must be run in a context where the clang
 # version and settings are compatible with the one in the Envoy
@@ -31,7 +31,7 @@ def runCommand(command):
   try:
     out = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip()
     if out:
-      stdout = out.split("\n")
+      stdout = str(out).splitlines()
   except subprocess.CalledProcessError as e:
     status = e.returncode
     for line in e.output.splitlines():
@@ -101,7 +101,7 @@ def fixFileExpectingNoChange(file):
 
 
 def emitStdoutAsError(stdout):
-  logging.error("\n".join(stdout))
+  logging.error("\n".join(str(line) for line in stdout))
 
 
 def expectError(status, stdout, expected_substring):
@@ -109,7 +109,7 @@ def expectError(status, stdout, expected_substring):
     logging.error("Expected failure `%s`, but succeeded" % expected_substring)
     return 1
   for line in stdout:
-    if expected_substring in line:
+    if expected_substring in str(line):
       return 0
   logging.error("Could not find '%s' in:\n" % expected_substring)
   emitStdoutAsError(stdout)

--- a/tools/format_python_tools.py
+++ b/tools/format_python_tools.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import fnmatch
 import os

--- a/tools/format_python_tools.sh
+++ b/tools/format_python_tools.sh
@@ -11,12 +11,11 @@ cd "$SCRIPTPATH"
 if [ "${CIRCLECI}" != "true" ]; then
   source_venv "$VENV_DIR"
   echo "Installing requirements..."
-  pip install -r requirements.txt
+  pip3 install -r requirements.txt
 fi
 
 echo "Running Python format check..."
-python format_python_tools.py $1
+./format_python_tools.py $1
 
 echo "Running Python3 flake8 check..."
-pip3 install flake8
 flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics


### PR DESCRIPTION
Finish the work done in #5636 by dropping all legacy Python from the CircleCI "_format_" job.

Signed-off-by: cclauss <cclauss@me.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
