### PR TITLE
CircleCI: Upgrade build-image to Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
        - run: ci/do_circle_ci.sh check_spelling
    build_image:
      docker:
-       - image: circleci/python:2.7
+       - image: circleci/python:3.7
          environment:
            # See comment in do_circle_ci.sh for why we do this.
            NUM_CPUS: 8


### PR DESCRIPTION
Signed-off-by: cclauss <cclauss@me.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Upgrade the CircleCI build-image step to Python 3
*Risk Level*: Medium
*Testing*: CircleCI
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
