### PR TITLE
CircleCI: Split Docker build/push steps out of release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
            path: /build/envoy/generated
            destination: /
    docker:
-     executor: ubuntu-build
+     docker:
+       - image: docker
      steps:
        - attach_workspace:
            at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,22 @@ jobs:
            command:
              ci/do_circle_ci.sh bazel.release
            no_output_timeout: 60m
-       - setup_remote_docker
-       - run: ci/docker_push.sh
-       - run: ci/docker_tag.sh
+       - persist_to_workspace:
+           root: .
+           paths:
+             - build_release
+             - build_release_stripped
        - store_artifacts:
            path: /build/envoy/generated
            destination: /
+   docker:
+     executor: ubuntu-build
+     steps:
+       - attach_workspace:
+           at: .
+       - setup_remote_docker
+       - run: ci/docker_push.sh
+       - run: ci/docker_tag.sh
    asan:
      executor: ubuntu-build
      steps:
@@ -181,6 +191,8 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - docker:
+          requires: [release]
       - asan
       - tsan
       - compile_time_options

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
        - attach_workspace:
            at: .
        - setup_remote_docker
+       - run: ci/docker_build.sh
        - run: ci/docker_push.sh
        - run: ci/docker_tag.sh
    asan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
      docker:
        - image: docker
      steps:
+       - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
+       - checkout
        - attach_workspace:
            at: .
        - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,9 @@ workflows:
               only: /^v.*/
       - docker:
           requires: [release]
+          filters:
+            tags:
+              only: /^v.*/
       - asan
       - tsan
       - compile_time_options

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -69,14 +69,6 @@ function bazel_debug_binary_build() {
 }
 
 if [[ "$1" == "bazel.release" ]]; then
-  # The release build step still runs during tag events. Avoid rebuilding for no reason.
-  # TODO(mattklein123): Consider moving this into its own "build".
-  if [[ -n "$CIRCLE_TAG" ]]
-  then
-    echo 'Ignoring build for git tag event'
-    exit 0
-  fi
-
   setup_gcc_toolchain
   echo "bazel release build with tests..."
   bazel_release_binary_build

--- a/ci/docker_build.sh
+++ b/ci/docker_build.sh
@@ -1,16 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
-
-# TODO(mattklein123): Currently we are doing this push in the context of the release job which
-# happens inside of our build image. We should switch to using Circle caching so each of these
-# are discrete jobs that work with the binary. All of these commands run on a remote docker
-# server also so we have to temporarily install docker here.
-# https://circleci.com/docs/2.0/building-docker-images/
-VER="17.03.0-ce"
-curl -L -o /tmp/docker-"$VER".tgz https://get.docker.com/builds/Linux/x86_64/docker-"$VER".tgz
-tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
-mv /tmp/docker/* /usr/bin
 
 docker build -f ci/Dockerfile-envoy-image -t envoyproxy/envoy:latest .
 docker build -f ci/Dockerfile-envoy-alpine -t envoyproxy/envoy-alpine:latest .

--- a/ci/docker_build.sh
+++ b/ci/docker_build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+# TODO(mattklein123): Currently we are doing this push in the context of the release job which
+# happens inside of our build image. We should switch to using Circle caching so each of these
+# are discrete jobs that work with the binary. All of these commands run on a remote docker
+# server also so we have to temporarily install docker here.
+# https://circleci.com/docs/2.0/building-docker-images/
+VER="17.03.0-ce"
+curl -L -o /tmp/docker-"$VER".tgz https://get.docker.com/builds/Linux/x86_64/docker-"$VER".tgz
+tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
+mv /tmp/docker/* /usr/bin
+
+docker build -f ci/Dockerfile-envoy-image -t envoyproxy/envoy:latest .
+docker build -f ci/Dockerfile-envoy-alpine -t envoyproxy/envoy-alpine:latest .
+docker build -f ci/Dockerfile-envoy-alpine-debug -t envoyproxy/envoy-alpine-debug:latest .

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -25,18 +25,16 @@ then
    tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
    mv /tmp/docker/* /usr/bin
 
-   docker build -f ci/Dockerfile-envoy-image -t envoyproxy/envoy:latest .
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+
    docker push envoyproxy/envoy:latest
    docker tag envoyproxy/envoy:latest envoyproxy/envoy:"$CIRCLE_SHA1"
    docker push envoyproxy/envoy:"$CIRCLE_SHA1"
 
-   docker build -f ci/Dockerfile-envoy-alpine -t envoyproxy/envoy-alpine:latest .
    docker tag envoyproxy/envoy-alpine:latest envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
    docker push envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
    docker push envoyproxy/envoy-alpine:latest
 
-   docker build -f ci/Dockerfile-envoy-alpine-debug -t envoyproxy/envoy-alpine-debug:latest .
    docker tag envoyproxy/envoy-alpine-debug:latest envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
    docker push envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
    docker push envoyproxy/envoy-alpine-debug:latest

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Do not ever set -x here, it is a security hazard as it will place the credentials below in the
 # CircleCI logs.
@@ -15,16 +15,6 @@ do
 done
 if [ -z "$CIRCLE_PULL_REQUEST" ] && [ -z "$CIRCLE_TAG" ] && [ "$want_push" == "true" ]
 then
-   # TODO(mattklein123): Currently we are doing this push in the context of the release job which
-   # happens inside of our build image. We should switch to using Circle caching so each of these
-   # are discrete jobs that work with the binary. All of these commands run on a remote docker
-   # server also so we have to temporarily install docker here.
-   # https://circleci.com/docs/2.0/building-docker-images/
-   VER="17.03.0-ce"
-   curl -L -o /tmp/docker-"$VER".tgz https://get.docker.com/builds/Linux/x86_64/docker-"$VER".tgz
-   tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
-   mv /tmp/docker/* /usr/bin
-
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
    docker push envoyproxy/envoy:latest

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -4,16 +4,14 @@
 # CircleCI logs.
 set -e
 
-# push the envoy image on merge to master
-want_push='false'
-for branch in "master"
-do
-   if [ "$CIRCLE_BRANCH" == "$branch" ]
-   then
-       want_push='true'
-   fi
-done
-if [ -z "$CIRCLE_PULL_REQUEST" ] && [ -z "$CIRCLE_TAG" ] && [ "$want_push" == "true" ]
+if [ -n "$CIRCLE_PULL_REQUEST" ]
+then
+   echo 'Ignoring PR branch for docker push.'
+   exit 0
+fi
+
+# push the envoy image on tags or merge to master
+if [ -n "$CIRCLE_TAG" ] || [ "$CIRCLE_BRANCH" == 'master' ]
 then
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
@@ -34,5 +32,5 @@ then
    # have a better CI setup.
    #./ci/verify_examples.sh
 else
-   echo 'Ignoring PR branch for docker push.'
+   echo 'Ignoring non-master branch for docker push.'
 fi

--- a/ci/docker_tag.sh
+++ b/ci/docker_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Do not ever set -x here, it is a security hazard as it will place the credentials below in the
 # CircleCI logs.
@@ -6,16 +6,6 @@ set -e
 
 if [ -n "$CIRCLE_TAG" ]
 then
-   # TODO(mattklein123): Currently we are doing this push in the context of the release job which
-   # happens inside of our build image. We should switch to using Circle caching so each of these
-   # are discrete jobs that work with the binary. All of these commands run on a remote docker
-   # server also so we have to temporarily install docker here.
-   # https://circleci.com/docs/2.0/building-docker-images/
-   VER="17.03.0-ce"
-   curl -L -o /tmp/docker-"$VER".tgz https://get.docker.com/builds/Linux/x86_64/docker-"$VER".tgz
-   tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
-   mv /tmp/docker/* /usr/bin
-
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
    docker pull envoyproxy/envoy:"$CIRCLE_SHA1"


### PR DESCRIPTION
*Description*:
In the CircleCI configuration, split the parts of the release job that build the runtime Docker images into a separate job that depends on the release job.

This ensures that the runtime Docker images are built as part of every CI build (but only pushed if master/tag).

This is work towards adding basic tests for the runtime Docker images, some discussion was [here](https://github.com/envoyproxy/envoy/pull/5326#discussion_r242537348).

This is work towards 
*Risk Level*:
Low.

Since the Docker push/tag flow is only run on the master branch, I won't know if I've broken something there until this is merged to master.

*Testing*:
I'm not able to test this beyond making sure CircleCI accepts the config file without creating a PR, since the CircleCI runs require a paid account in order to have the resources to build Envoy.

*Docs Changes*:
I don't _think_ there are any docs around this.

*Release Notes*:
N/A- this is a CI change.

*Related Issues*:
This work relates to #5325.