### PR TITLE
Revert "ci: enable check for static non-POD"

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,fuchsia-statically-constructed-objects'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
-WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move,fuchsia-statically-constructed-objects'
+WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/include/envoy/singleton/manager.h
+++ b/include/envoy/singleton/manager.h
@@ -45,11 +45,9 @@ public:
  */
 #define SINGLETON_MANAGER_REGISTRATION(NAME)                                                       \
   static constexpr char NAME##_singleton_name[] = #NAME "_singleton";                              \
-  static Envoy::Registry::                                                                         \
-      RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */                         \
-                      Envoy::Singleton::RegistrationImpl<NAME##_singleton_name>,                   \
-                      Envoy::Singleton::Registration>                                              \
-          NAME##_singleton_registered_;
+  static Envoy::Registry::RegisterFactory<                                                         \
+      Envoy::Singleton::RegistrationImpl<NAME##_singleton_name>, Envoy::Singleton::Registration>   \
+      NAME##_singleton_registered_;
 
 #define SINGLETON_MANAGER_REGISTERED_NAME(NAME) NAME##_singleton_name
 


### PR DESCRIPTION
Reverts envoyproxy/envoy#5602

Turns out it fails when adding tests.