### PR TITLE
Move quiche.BUILD sed hackery into a genrule_cmd

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -15,11 +15,8 @@ licenses(["notice"])  # Apache 2
 # source files in group 3 (the Platform impl). Unfortunately, QUICHE does not
 # yet provide a built-in way to customize this dependency, e.g. to override the
 # directory or namespace in which Platform impl types are defined. Hence the
-# gross hacks in this file and quiche.genrule_cmd.
-#
-# Transformations to QUICHE tarball performed here, via quiche.genrule_cmd:
-# - Move subtree under quiche/ base dir, for clarity in #include statements.
-# - Rewrite include directives for platform/impl files.
+# gross hacks in quiche.genrule_cmd, invoked from here to tweak QUICHE source
+# files into a form usable by Envoy.
 #
 # The mechanics of this will change as QUICHE evolves, supplies its own Bazel
 # buildfiles, and provides a built-in way to override platform impl directory

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# Transformations to QUICHE tarball performed here:
+# - Move subtree under quiche/ base dir, for clarity in #include statements.
+# - Rewrite include directives for platform/impl files to point to the directory
+#   containing Envoy's QUICHE platform implementation.
+# - Fix include directives for non-platform/impl files to remove
+#   "net/third_party" from the path. (This is an artifact of Chromium source
+#   tree structure.)
+
+# Determine base directory of unmodified QUICHE source files. In practice, this
+# ends up being "external/com_googlesource_quiche".
+src_base_dir=$$(dirname $$(dirname $$(dirname $(rootpath quic/core/quic_constants.h))))
+
+# sed commands to apply to each source file.
+cat <<EOF >sed_commands
+# Rewrite include directives for platform impl files.
+/^#include/ s!net/(http2|spdy|quic)/platform/impl/!extensions/quic_listeners/quiche/platform/!
+
+# Strip "net/third_party" from include directives to other QUICHE files.
+/^#include/ s!net/third_party/quiche/src/!quiche/!
+EOF
+
+for src_file in $(SRCS); do
+  # Extract relative path (e.g. "quic/core/quic_utils.cc") from full path in
+  # src_path (e.g. "external/com_googlesource_quiche/quic/core/quic_utils.cc").
+  src_path=$${src_file#$$src_base_dir/}
+
+  # Map to output file with quiche/ base directory inserted in path.
+  out_file=$(@D)/quiche/$$src_path
+  mkdir -p $$(dirname $$out_file)
+
+  # Apply text substitutions. -E ensures consistent behavior on Linux vs. OS X.
+  sed -E -f sed_commands $$src_file > $$out_file
+done

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -21,6 +21,9 @@ cat <<EOF >sed_commands
 
 # Strip "net/third_party" from include directives to other QUICHE files.
 /^#include/ s!net/third_party/quiche/src/!quiche/!
+
+# Rewrite gtest includes.
+/^#include/ s!testing/gtest/include/gtest/!gtest/!
 EOF
 
 for src_file in $(SRCS); do

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -31,12 +31,12 @@ EOF
 for src_file in $(SRCS); do
   # Extract relative path (e.g. "quic/core/quic_utils.cc") from full path in
   # src_path (e.g. "external/com_googlesource_quiche/quic/core/quic_utils.cc").
-  src_path=$${src_file#$$src_base_dir/}
+  src_path="$${src_file#$$src_base_dir/}"
 
   # Map to output file with quiche/ base directory inserted in path.
-  out_file=$(@D)/quiche/$$src_path
-  mkdir -p $$(dirname $$out_file)
+  out_file="$(@D)/quiche/$$src_path"
+  mkdir -p "$$(dirname "$$out_file")"
 
   # Apply text substitutions. -E ensures consistent behavior on Linux vs. OS X.
-  sed -E -f sed_commands $$src_file > $$out_file
+  sed -E -f sed_commands "$$src_file" > "$$out_file"
 done

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -2,7 +2,9 @@
 
 set -e
 
-# Transformations to QUICHE tarball performed here:
+# This script is invoked from quiche.BUILD to tweak QUICHE source files into a
+# form usable by Envoy. Transformations performed here:
+#
 # - Move subtree under quiche/ base dir, for clarity in #include statements.
 # - Rewrite include directives for platform/impl files to point to the directory
 #   containing Envoy's QUICHE platform implementation.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -572,8 +572,12 @@ def _com_google_protobuf():
     )
 
 def _com_googlesource_quiche():
-    _repository_impl(
+    location = REPOSITORY_LOCATIONS["com_googlesource_quiche"]
+    genrule_repository(
         name = "com_googlesource_quiche",
+        urls = location["urls"],
+        sha256 = location["sha256"],
+        genrule_cmd_file = "@envoy//bazel/external:quiche.genrule_cmd",
         build_file = "@envoy//bazel/external:quiche.BUILD",
     )
 


### PR DESCRIPTION
*Description*:
Move quiche.BUILD sed hackery into a genrule_cmd, to allow for easier addition of further transforms, as well as comments.
*Risk Level*: Low, only affects QUICHE platform impl files/tests, which are not yet used in Envoy.
*Testing*: Existing unit tests.
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
