### PR TITLE
build: Add example for bazel_remote_cache to ci docs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -70,6 +70,13 @@ For a debug version of the Envoy binary you can run:
 The build artifact can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy-debug` (or wherever
 `$ENVOY_DOCKER_BUILD_DIR` points).
 
+To leverage a [bazel remote cache](https://github.com/envoyproxy/envoy/tree/master/bazel#advanced-caching-setup) add the http_remote_cache endpoint to
+the BAZEL_BUILD_OPTIONS environment variable
+
+```bash
+BAZEL_BUILD_OPTIONS='--remote_http_cache=http://127.0.0.1:28080' ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release'
+```
+
 The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 
 * `bazel.api` &mdash; build and run API tests under `-c fastbuild` with clang.


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: Documents bazel remote_http_cache option with ci builds
*Risk Level*: Low, build docs only
*Docs Changes*: Added
