### PR TITLE
build: fix cc_wrapper.py treatment of -lc++.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -94,6 +94,9 @@ Note: this assumes that both: clang compiler and libc++ library are installed in
 and that `clang` and `clang++` are available in `$PATH`. On some systems, exports might need
 to be changed to versioned binaries, e.g. `CC=clang-7` and `CXX=clang++-7`.
 
+You might also need to ensure libc++ is installed correctly on your system, e.g. on Ubuntu this
+might look like `sudo apt-get install libc++abi-7-dev libc++-7-dev`.
+
 ## Using a compiler toolchain in a non-standard location
 
 By setting the `CC` and `LD_LIBRARY_PATH` in the environment that Bazel executes from as

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -56,7 +56,7 @@ def main():
     for arg in sys.argv[1:]:
       if arg == "-lstdc++":
         if "-stdlib=libc++" in envoy_cxxflags:
-          arg.append("-lc++")
+          argv.append("-lc++")
       elif arg.startswith("-Wl,@"):
         # tempfile.mkstemp will write to the out-of-sandbox tempdir
         # unless the user has explicitly set environment variables


### PR DESCRIPTION
I think this was the intended code, I noticed a failure in
compile_time_options for
https://github.com/envoyproxy/envoy/pull/5218.

Risk Level: Low
Testing: bazel build --config=libc++ //source/exe:envoy-static

Signed-off-by: Harvey Tuch <htuch@google.com>