### PR TITLE
upstream: allow handling membership updates outside of HostSet

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -774,6 +774,11 @@ public:
    * @return the const PrioritySet for the cluster.
    */
   virtual const PrioritySet& prioritySet() const PURE;
+
+  /**
+   * @return bool whether this cluster will trigger membership updates on host set changes.
+   */
+  virtual bool manageMembershipUpdates() const PURE;
 };
 
 typedef std::shared_ptr<Cluster> ClusterSharedPtr;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -219,6 +219,9 @@ public:
   ClusterManagerFactory& clusterManagerFactory() override { return factory_; }
 
 protected:
+  virtual void postThreadLocalMembershipUpdate(const Cluster& cluster,
+                                               const HostVector& hosts_added,
+                                               const HostVector& hosts_removed);
   virtual void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
                                             const HostVector& hosts_added,
                                             const HostVector& hosts_removed);
@@ -273,7 +276,7 @@ private:
 
     struct ClusterEntry : public ThreadLocalCluster {
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
-                   const LoadBalancerFactorySharedPtr& lb_factory);
+                   const LoadBalancerFactorySharedPtr& lb_factory, bool manage_membership_updates);
       ~ClusterEntry();
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority, Http::Protocol protocol,
@@ -314,6 +317,8 @@ private:
                                         LocalityWeightsConstSharedPtr locality_weights,
                                         const HostVector& hosts_added,
                                         const HostVector& hosts_removed, ThreadLocal::Slot& tls);
+    static void triggerMembershipCallbacks(const std::string& name, const HostVector& hosts_added,
+                                           const HostVector& hosts_removed, ThreadLocal::Slot& tls);
     static void onHostHealthFailure(const HostSharedPtr& host, ThreadLocal::Slot& tls);
 
     ClusterManagerImpl& parent_;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -23,7 +23,7 @@ EdsClusterImpl::EdsClusterImpl(
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api)
     : BaseDynamicClusterImpl(cluster, runtime, factory_context, std::move(stats_scope),
-                             added_via_api),
+                             added_via_api, true),
       cm_(factory_context.clusterManager()), local_info_(factory_context.localInfo()),
       cluster_name_(cluster.eds_cluster_config().service_name().empty()
                         ? cluster.name()

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -195,7 +195,7 @@ HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
       ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
       initial_hosts_(new HostVector()) {
   ENVOY_LOG(debug, "Creating an HdsCluster");
-  priority_set_.getOrCreateHostSet(0);
+  priority_set_.getOrCreateHostSet(0, true);
 
   info_ = info_factory.createClusterInfo({admin, runtime_, cluster_, bind_config_, stats_,
                                           ssl_context_manager_, added_via_api_, cm, local_info,
@@ -248,7 +248,7 @@ void HdsCluster::initialize(std::function<void()> callback) {
     host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   }
 
-  auto& first_host_set = priority_set_.getOrCreateHostSet(0);
+  auto& first_host_set = priority_set_.getOrCreateHostSet(0, true);
 
   first_host_set.updateHosts(
       HostSetImpl::partitionHosts(initial_hosts_, HostsPerLocalityImpl::empty()), {},

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -54,6 +54,7 @@ public:
   Outlier::Detector* outlierDetector() override { return outlier_detector_.get(); }
   const Outlier::Detector* outlierDetector() const override { return outlier_detector_.get(); }
   void initialize(std::function<void()> callback) override;
+  bool manageMembershipUpdates() const override { return true; }
 
   // Creates and starts healthcheckers to its endpoints
   void startHealthchecks(AccessLog::AccessLogManager& access_log_manager, Runtime::Loader& runtime,
@@ -62,7 +63,7 @@ public:
   std::vector<Upstream::HealthCheckerSharedPtr> healthCheckers() { return health_checkers_; };
 
 protected:
-  PrioritySetImpl priority_set_;
+  PrioritySetImpl priority_set_{true};
   HealthCheckerSharedPtr health_checker_;
   Outlier::DetectorSharedPtr outlier_detector_;
 

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -22,7 +22,8 @@ LogicalDnsCluster::LogicalDnsCluster(
     Network::DnsResolverSharedPtr dns_resolver, ThreadLocal::SlotAllocator& tls,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api)
-    : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api),
+    : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api,
+                      true),
       dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(cluster, dns_refresh_rate, 5000))),

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -422,7 +422,7 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
                                                            HostPredicate predicate,
                                                            bool locality_weight_aware,
                                                            bool scale_locality_weight)
-    : PrioritySetImpl(), original_priority_set_(subset_lb.original_priority_set_),
+    : PrioritySetImpl(true), original_priority_set_(subset_lb.original_priority_set_),
       predicate_(predicate), locality_weight_aware_(locality_weight_aware),
       scale_locality_weight_(scale_locality_weight) {
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -388,7 +388,9 @@ HostSet& PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
       HostSetImplPtr host_set = createHostSet(i, overprovisioning_factor);
       host_set->addPriorityUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
                                            const HostVector& hosts_removed) {
-        runUpdateCallbacks(hosts_added, hosts_removed);
+        if (manage_membership_updates_) {
+          runUpdateCallbacks(hosts_added, hosts_removed);
+        }
         runReferenceUpdateCallbacks(priority, hosts_added, hosts_removed);
       });
       host_sets_.push_back(std::move(host_set));
@@ -614,8 +616,8 @@ ClusterSharedPtr ClusterImplBase::create(
 ClusterImplBase::ClusterImplBase(
     const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
-    Stats::ScopePtr&& stats_scope, bool added_via_api)
-    : runtime_(runtime) {
+    Stats::ScopePtr&& stats_scope, bool added_via_api, bool manage_membership_updates)
+    : runtime_(runtime), priority_set_(manage_membership_updates) {
   factory_context.setInitManager(init_manager_);
   auto socket_factory = createTransportSocketFactory(cluster, factory_context);
   info_ = std::make_unique<ClusterInfoImpl>(cluster, factory_context.clusterManager().bindConfig(),
@@ -967,7 +969,8 @@ StaticClusterImpl::StaticClusterImpl(
     const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api)
-    : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api),
+    : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api,
+                      true),
       priority_state_manager_(new PriorityStateManager(*this, factory_context.localInfo())) {
   // TODO(dio): Use by-reference when cluster.hosts() is removed.
   const envoy::api::v2::ClusterLoadAssignment cluster_load_assignment(
@@ -1203,7 +1206,7 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api)
     : BaseDynamicClusterImpl(cluster, runtime, factory_context, std::move(stats_scope),
-                             added_via_api),
+                             added_via_api, true),
       local_info_(factory_context.localInfo()), dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(cluster, dns_refresh_rate, 5000))) {

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -37,7 +37,7 @@ public:
         {}, absl::nullopt);
   }
 
-  PrioritySetImpl priority_set_;
+  PrioritySetImpl priority_set_{true};
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
 };
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -427,7 +427,7 @@ class RoundRobinLoadBalancerTest : public LoadBalancerTestBase {
 public:
   void init(bool need_local_cluster) {
     if (need_local_cluster) {
-      local_priority_set_.reset(new PrioritySetImpl());
+      local_priority_set_.reset(new PrioritySetImpl(true));
       local_host_set_ = reinterpret_cast<HostSetImpl*>(&local_priority_set_->getOrCreateHostSet(0));
     }
     lb_.reset(new RoundRobinLoadBalancer(priority_set_, local_priority_set_.get(), stats_, runtime_,

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -39,7 +39,7 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   const uint64_t weight = 2;          // weighted_subset_percent of hosts will have this weight.
   const uint64_t active_requests = 3; // weighted_subset_percent will have this active requests.
 
-  PrioritySetImpl priority_set;
+  PrioritySetImpl priority_set(true);
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   HostSet& host_set = priority_set.getOrCreateHostSet(0);
   HostVector hosts;
@@ -111,7 +111,7 @@ public:
    */
   void run(std::vector<uint32_t> originating_cluster, std::vector<uint32_t> all_destination_cluster,
            std::vector<uint32_t> healthy_destination_cluster) {
-    local_priority_set_ = new PrioritySetImpl;
+    local_priority_set_ = new PrioritySetImpl(true);
     // TODO(mattklein123): make load balancer per originating cluster host.
     RandomLoadBalancer lb(priority_set_, local_priority_set_, stats_, runtime_, random_,
                           common_config_);

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -451,7 +451,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   setupFromJson(json);
 
-  PrioritySetImpl second;
+  PrioritySetImpl second{true};
   cluster_->prioritySet().addPriorityUpdateCb(
       [&](uint32_t, const HostVector& added, const HostVector& removed) -> void {
         // Update second hostset accordingly;

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -385,7 +385,7 @@ public:
   NiceMock<Runtime::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
-  PrioritySetImpl local_priority_set_;
+  PrioritySetImpl local_priority_set_{true};
   HostVectorSharedPtr local_hosts_;
   HostsPerLocalitySharedPtr local_hosts_per_locality_;
   std::shared_ptr<SubsetLoadBalancer> lb_;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1500,7 +1500,7 @@ TEST(ClusterImplTest, CloseConnectionsOnHostHealthFailure) {
 
 // Test creating and extending a priority set.
 TEST(PrioritySet, Extend) {
-  PrioritySetImpl priority_set;
+  PrioritySetImpl priority_set(true);
   priority_set.getOrCreateHostSet(0);
 
   uint32_t priority_changes = 0;

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -77,6 +77,20 @@ void MockPrioritySet::runUpdateCallbacks(uint32_t priority, const HostVector& ho
 
 MockRetryPriority::~MockRetryPriority() = default;
 
+MockClusterRealPrioritySet::MockClusterRealPrioritySet(bool manage_membership_updates)
+    : priority_set_(manage_membership_updates) {
+  ON_CALL(*this, prioritySet()).WillByDefault(ReturnRef(priority_set_));
+  ON_CALL(testing::Const(*this), prioritySet()).WillByDefault(ReturnRef(priority_set_));
+  ON_CALL(*this, info()).WillByDefault(Return(info_));
+  ON_CALL(*this, initialize(_))
+      .WillByDefault(Invoke([this](std::function<void()> callback) -> void {
+        EXPECT_EQ(nullptr, initialize_callback_);
+        initialize_callback_ = callback;
+      }));
+}
+
+MockClusterRealPrioritySet::~MockClusterRealPrioritySet() = default;
+
 MockCluster::MockCluster() {
   ON_CALL(*this, prioritySet()).WillByDefault(ReturnRef(priority_set_));
   ON_CALL(testing::Const(*this), prioritySet()).WillByDefault(ReturnRef(priority_set_));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -141,6 +141,30 @@ private:
   const MockRetryPriority& retry_priority_;
 };
 
+// A mocked Cluster that uses a real PrioritySetImpl
+class MockClusterRealPrioritySet : public Cluster {
+public:
+  MockClusterRealPrioritySet(bool manage_membership_updates = false);
+  ~MockClusterRealPrioritySet();
+
+  // Upstream::Cluster
+  MOCK_METHOD0(healthChecker, HealthChecker*());
+  MOCK_CONST_METHOD0(info, ClusterInfoConstSharedPtr());
+  MOCK_METHOD0(outlierDetector, Outlier::Detector*());
+  MOCK_CONST_METHOD0(outlierDetector, const Outlier::Detector*());
+  MOCK_METHOD1(initialize, void(std::function<void()> callback));
+  MOCK_CONST_METHOD0(initializePhase, InitializePhase());
+  MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_METHOD0(prioritySet, PrioritySetImpl&());
+  MOCK_CONST_METHOD0(prioritySet, const PrioritySet&());
+  MOCK_CONST_METHOD0(manageMembershipUpdates, bool());
+
+  std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
+  std::function<void()> initialize_callback_;
+  Network::Address::InstanceConstSharedPtr source_address_;
+  PrioritySetImpl priority_set_;
+};
+
 class MockCluster : public Cluster {
 public:
   MockCluster();
@@ -156,6 +180,7 @@ public:
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
   MOCK_METHOD0(prioritySet, MockPrioritySet&());
   MOCK_CONST_METHOD0(prioritySet, const PrioritySet&());
+  MOCK_CONST_METHOD0(manageMembershipUpdates, bool());
 
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   std::function<void()> initialize_callback_;


### PR DESCRIPTION
Allows configuring a subclass of `ClusterImplBase` to disable membership
updates triggered by changes in individual `HostSet`s, relying instead of
`runUpdateCallbacks` being called manually. The intent here is to allow
batch updates of host memberships to be made across priorities, and to
allow the source of truth for what hosts are members of a cluster to
live outside of the `HostSet`s (to facilitate #4280).

This PR should be a noop, as all cluster types still use the old behavior. EDS
will be updated in a follow-up to make use of the batch update
semantics, then later on named endpoints will be added (#4280).

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium, should not affect current behavior
*Testing*: UTs verifying TLS behavior of membership update cb
*Docs Changes*: n/a
*Release Notes*: n/a
