### PR TITLE
bazel: update remote cache docs to recommend go modules

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -561,8 +561,8 @@ You may use any [Remote Caching](https://docs.bazel.build/versions/master/remote
 as an alternative to this.
 
 This requires Go 1.11+, follow the [instructions](https://golang.org/doc/install#install) to install
-if you don't have one. The command must run with Go modules enabled, and should work when ran from within the
-Envoy repository.
+if you don't have one. The command must run with Go modules enabled, and should work when run from
+the root of the Envoy repository.
 
 ```
 go run github.com/buchgr/bazel-remote --dir ${HOME}/bazel_cache --host 127.0.0.1 --port 28080 --max_size 64

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -561,8 +561,8 @@ You may use any [Remote Caching](https://docs.bazel.build/versions/master/remote
 as an alternative to this.
 
 This requires Go 1.11+, follow the [instructions](https://golang.org/doc/install#install) to install
-if you don't have one. The command must run with Go modules enabled, and should work when run from
-the root of the Envoy repository.
+if you don't have one. To start the cache, run the following from the root of the Envoy repository (or anywhere else
+that the Go toolchain can find the necessary dependencies):
 
 ```
 go run github.com/buchgr/bazel-remote --dir ${HOME}/bazel_cache --host 127.0.0.1 --port 28080 --max_size 64

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -564,7 +564,7 @@ This requires Go 1.11+, follow the [instructions](https://golang.org/doc/install
 if you don't have one.
 
 ```
-go run github.com/buchgr/bazel-remote --dir ${HOME}/bazel_cache --host 127.0.0.1 --port 28080 --max_size 64
+GO111MODULE=on go run github.com/buchgr/bazel-remote --dir ${HOME}/bazel_cache --host 127.0.0.1 --port 28080 --max_size 64
 ```
 
 See [Bazel remote cache](github.com/buchgr/bazel-remote) for more information on the parameters.

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -561,10 +561,11 @@ You may use any [Remote Caching](https://docs.bazel.build/versions/master/remote
 as an alternative to this.
 
 This requires Go 1.11+, follow the [instructions](https://golang.org/doc/install#install) to install
-if you don't have one.
+if you don't have one. The command must run with Go modules enabled, and should work when ran from within the
+Envoy repository.
 
 ```
-GO111MODULE=on go run github.com/buchgr/bazel-remote --dir ${HOME}/bazel_cache --host 127.0.0.1 --port 28080 --max_size 64
+go run github.com/buchgr/bazel-remote --dir ${HOME}/bazel_cache --host 127.0.0.1 --port 28080 --max_size 64
 ```
 
 See [Bazel remote cache](github.com/buchgr/bazel-remote) for more information on the parameters.


### PR DESCRIPTION
The remote cache requires Go modules, so enable it explicitly in the
example.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
