### PR TITLE
accesslog: Append a newline to returned log_lines in access_log

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -68,7 +68,7 @@ std::string FormatterImpl::format(const Http::HeaderMap& request_headers,
     log_line += provider->format(request_headers, response_headers, response_trailers, stream_info);
   }
 
-  return log_line;
+  return absl::StrCat(log_line, "\n");
 }
 
 JsonFormatterImpl::JsonFormatterImpl(std::unordered_map<std::string, std::string>& format_mapping) {

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -68,7 +68,7 @@ std::string FormatterImpl::format(const Http::HeaderMap& request_headers,
     log_line += provider->format(request_headers, response_headers, response_trailers, stream_info);
   }
 
-  return absl::StrCat(log_line, "\n");
+  return log_line;
 }
 
 JsonFormatterImpl::JsonFormatterImpl(std::unordered_map<std::string, std::string>& format_mapping) {
@@ -99,6 +99,7 @@ std::string JsonFormatterImpl::format(const Http::HeaderMap& request_headers,
   }
 
   return absl::StrCat(log_line, "\n");
+  //return log_line;
 }
 
 std::unordered_map<std::string, std::string> JsonFormatterImpl::toMap(
@@ -249,6 +250,11 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
 
   if (!current_token.empty()) {
     formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
+  }
+
+  auto newline_position = format.find('\n');
+  if (newline_position != std::string::npos) {
+    formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter("\n")});
   }
 
   return formatters;

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -99,7 +99,6 @@ std::string JsonFormatterImpl::format(const Http::HeaderMap& request_headers,
   }
 
   return absl::StrCat(log_line, "\n");
-  //return log_line;
 }
 
 std::unordered_map<std::string, std::string> JsonFormatterImpl::toMap(

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -253,7 +253,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
   }
 
   auto newline_position = format.find('\n');
-  if (newline_position != std::string::npos) {
+  if (newline_position == std::string::npos) {
     formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter("\n")});
   }
 

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -508,9 +508,12 @@ TEST(AccessLogFormatterTest, JsonFormatterDynamicMetadataTest) {
   EXPECT_CALL(Const(stream_info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
 
   std::unordered_map<std::string, std::string> expected_json_map = {
-      {"test_key", "\"test_value\"""\n"},
-      {"test_obj", "{\"inner_key\":\"inner_value\"}""\n"},
-      {"test_obj.inner_key", "\"inner_value\"""\n"}};
+      {"test_key", "\"test_value\""
+                   "\n"},
+      {"test_obj", "{\"inner_key\":\"inner_value\"}"
+                   "\n"},
+      {"test_obj.inner_key", "\"inner_value\""
+                             "\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {
       {"test_key", "%DYNAMIC_METADATA(com.test:test_key)%"},

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -410,7 +410,7 @@ TEST(AccessLogFormatterTest, JsonFormatterPlainStringTest) {
   EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
 
   std::unordered_map<std::string, std::string> expected_json_map = {
-      {"plain_string", "plain_string_value"}};
+      {"plain_string", "plain_string_value\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {
       {"plain_string", "plain_string_value"}};
@@ -431,7 +431,7 @@ TEST(AccessLogFormatterTest, JsonFormatterSingleOperatorTest) {
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
   EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
 
-  std::unordered_map<std::string, std::string> expected_json_map = {{"protocol", "HTTP/1.1"}};
+  std::unordered_map<std::string, std::string> expected_json_map = {{"protocol", "HTTP/1.1\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {{"protocol", "%PROTOCOL%"}};
   JsonFormatterImpl formatter(key_mapping);
@@ -447,10 +447,10 @@ TEST(AccessLogFormatterTest, JsonFormatterNonExistentHeaderTest) {
   Http::TestHeaderMapImpl response_trailer;
 
   std::unordered_map<std::string, std::string> expected_json_map = {
-      {"protocol", "HTTP/1.1"},
-      {"some_request_header", "SOME_REQUEST_HEADER"},
-      {"nonexistent_response_header", "-"},
-      {"some_response_header", "SOME_RESPONSE_HEADER"}};
+      {"protocol", "HTTP/1.1\n"},
+      {"some_request_header", "SOME_REQUEST_HEADER\n"},
+      {"nonexistent_response_header", "-\n"},
+      {"some_response_header", "SOME_RESPONSE_HEADER\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {
       {"protocol", "%PROTOCOL%"},
@@ -473,10 +473,10 @@ TEST(AccessLogFormatterTest, JsonFormatterAlternateHeaderTest) {
   Http::TestHeaderMapImpl response_trailer;
 
   std::unordered_map<std::string, std::string> expected_json_map = {
-      {"request_present_header_or_request_absent_header", "REQUEST_PRESENT_HEADER"},
-      {"request_absent_header_or_request_present_header", "REQUEST_PRESENT_HEADER"},
-      {"response_absent_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER"},
-      {"response_present_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER"}};
+      {"request_present_header_or_request_absent_header", "REQUEST_PRESENT_HEADER\n"},
+      {"request_absent_header_or_request_present_header", "REQUEST_PRESENT_HEADER\n"},
+      {"response_absent_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER\n"},
+      {"response_present_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {
       {"request_present_header_or_request_absent_header",
@@ -508,9 +508,9 @@ TEST(AccessLogFormatterTest, JsonFormatterDynamicMetadataTest) {
   EXPECT_CALL(Const(stream_info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
 
   std::unordered_map<std::string, std::string> expected_json_map = {
-      {"test_key", "\"test_value\""},
-      {"test_obj", "{\"inner_key\":\"inner_value\"}"},
-      {"test_obj.inner_key", "\"inner_value\""}};
+      {"test_key", "\"test_value\"""\n"},
+      {"test_obj", "{\"inner_key\":\"inner_value\"}""\n"},
+      {"test_obj.inner_key", "\"inner_value\"""\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {
       {"test_key", "%DYNAMIC_METADATA(com.test:test_key)%"},
@@ -539,11 +539,11 @@ TEST(AccessLogFormatterTest, JsonFormatterStartTimeTest) {
   time_t expected_time_t = mktime(&time_val);
 
   std::unordered_map<std::string, std::string> expected_json_map = {
-      {"simple_date", "2018/03/28"},
-      {"test_time", fmt::format("{}", expected_time_t)},
-      {"bad_format", "bad_format"},
-      {"default", "2018-03-28T23:35:58.000Z"},
-      {"all_zeroes", "000000000.0.00.000"}};
+      {"simple_date", "2018/03/28\n"},
+      {"test_time", fmt::format("{}\n", expected_time_t)},
+      {"bad_format", "bad_format\n"},
+      {"default", "2018-03-28T23:35:58.000Z\n"},
+      {"all_zeroes", "000000000.0.00.000\n"}};
 
   std::unordered_map<std::string, std::string> key_mapping = {
       {"simple_date", "%START_TIME(%Y/%m/%d)%"},
@@ -565,7 +565,7 @@ TEST(AccessLogFormatterTest, JsonFormatterMultiTokenTest) {
     Http::TestHeaderMapImpl response_trailer;
 
     std::unordered_map<std::string, std::string> expected_json_map = {
-        {"multi_token_field", "HTTP/1.1 plainstring SOME_REQUEST_HEADER SOME_RESPONSE_HEADER"}};
+        {"multi_token_field", "HTTP/1.1 plainstring SOME_REQUEST_HEADER SOME_RESPONSE_HEADER\n"}};
 
     std::unordered_map<std::string, std::string> key_mapping = {
         {"multi_token_field",

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -598,7 +598,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
     EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
 
-    EXPECT_EQ("{{HTTP/1.1}}   -++test GET PUT\t@POST@\ttest-2[]",
+    EXPECT_EQ("{{HTTP/1.1}}   -++test GET PUT\t@POST@\ttest-2[]\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -606,7 +606,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     const std::string format = "{}*JUST PLAIN string]";
     FormatterImpl formatter(format);
 
-    EXPECT_EQ(format,
+    EXPECT_EQ(absl::StrCat(format, "\n"),
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -616,7 +616,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
 
     FormatterImpl formatter(format);
 
-    EXPECT_EQ("GET|G|PU|GET|POS",
+    EXPECT_EQ("GET|G|PU|GET|POS\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -629,7 +629,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
                                "test_obj)%|%DYNAMIC_METADATA(com.test:test_obj:inner_key)%";
     FormatterImpl formatter(format);
 
-    EXPECT_EQ("\"test_value\"|{\"inner_key\":\"inner_value\"}|\"inner_value\"",
+    EXPECT_EQ("\"test_value\"|{\"inner_key\":\"inner_value\"}|\"inner_value\"\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -647,7 +647,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     gmtime_r(&test_epoch, &time_val);
     time_t expected_time_t = mktime(&time_val);
 
-    EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z|000000000.0.00.000",
+    EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z|000000000.0.00.000\n",
                           expected_time_t),
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
@@ -662,7 +662,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
     FormatterImpl formatter(format);
 
-    EXPECT_EQ("1970/01/01|0|bad_format|1970-01-01T00:00:00.000Z|000000000.0.00.000",
+    EXPECT_EQ("1970/01/01|0|bad_format|1970-01-01T00:00:00.000Z|000000000.0.00.000\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -673,7 +673,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     const SystemTime start_time(std::chrono::microseconds(1522796769123456));
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(start_time));
     FormatterImpl formatter(format);
-    EXPECT_EQ("1522796769.123|1522796769.1234|1522796769.12345|1522796769.123456",
+    EXPECT_EQ("1522796769.123|1522796769.1234|1522796769.12345|1522796769.123456\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -684,7 +684,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(start_time));
     FormatterImpl formatter(format);
     EXPECT_EQ("segment1:1522796769.123|segment2:1522796769.1234|seg3:1522796769.123456|1522796769-"
-              "123-asdf-123456000|.1234560:segm5:2018",
+              "123-asdf-123456000|.1234560:segm5:2018\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -695,7 +695,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     const SystemTime start_time(std::chrono::microseconds(1522796769123456));
     EXPECT_CALL(stream_info, startTime()).WillOnce(Return(start_time));
     FormatterImpl formatter(format);
-    EXPECT_EQ("%%|%%123456000|1522796769%%123|1%%1522796769",
+    EXPECT_EQ("%%|%%123456000|1522796769%%123|1%%1522796769\n",
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 }


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: Append a newline to returned log_line in access_log
*Risk Level*: Medium - Might be worked around by external consumers already that add a newline themselves
*Testing*: Adjusted tests to account for newline 
*Docs Changes*: TODO
*Release Notes*: TODO
Fixes #5193 

Notes for reviewer: 
- This change has the unfortunate side-effect of [breaking the verifyJsonOutput test](https://github.com/envoyproxy/envoy/blob/master/test/common/access_log/access_log_formatter_test.cc#L386-L399) since it expects only one ending terminator and does not expect the first pair to contain a newline. 
- Is it sufficient to drop some of these expects and update the strings in the JSON tests or have I gone about adding this the wrong way?
