### PR TITLE
Update protodoc.bzl to Bazel 0.22 syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   ubuntu-build:
     description: "A regular build executor based on ubuntu image"
     docker:
-      - image: envoyproxy/envoy-build:5c97e3a4a12bd438a66d3016873d201fd3c5e702
+      - image: envoyproxy/envoy-build:111781fa2823535762e9c514db0c5c41a119b4b1
     resource_class: xlarge
     working_directory: /source
 

--- a/tools/protodoc/protodoc.bzl
+++ b/tools/protodoc/protodoc.bzl
@@ -34,7 +34,7 @@ def _proto_doc_aspect_impl(target, ctx):
     transitive_outputs = depset()
     for dep in ctx.rule.attr.deps:
         transitive_outputs = transitive_outputs | dep.output_groups["rst"]
-    proto_sources = target.proto.direct_sources
+    proto_sources = target[ProtoInfo].direct_sources
 
     # If this proto_library doesn't actually name any sources, e.g. //api:api,
     # but just glues together other libs, we just need to follow the graph.
@@ -46,7 +46,7 @@ def _proto_doc_aspect_impl(target, ctx):
     # these don't include source_code_info, which we need for comment
     # extractions. See https://github.com/bazelbuild/bazel/issues/3971.
     import_paths = []
-    for f in target.proto.transitive_sources:
+    for f in target[ProtoInfo].transitive_sources:
         if f.root.path:
             import_path = f.root.path + "/" + f.owner.workspace_root
         else:
@@ -65,11 +65,11 @@ def _proto_doc_aspect_impl(target, ctx):
     args = ["-I./" + ctx.label.workspace_root]
     args += ["-I" + import_path for import_path in import_paths]
     args += ["--plugin=protoc-gen-protodoc=" + ctx.executable._protodoc.path, "--protodoc_out=" + output_path]
-    args += [_proto_path(src) for src in target.proto.direct_sources]
+    args += [_proto_path(src) for src in target[ProtoInfo].direct_sources]
     ctx.action(
         executable = ctx.executable._protoc,
         arguments = args,
-        inputs = [ctx.executable._protodoc] + target.proto.transitive_sources.to_list(),
+        inputs = [ctx.executable._protodoc] + target[ProtoInfo].transitive_sources.to_list(),
         outputs = outputs,
         mnemonic = "ProtoDoc",
         use_default_shell_env = True,


### PR DESCRIPTION
*Description*: The new version of Bazel 0.22 (which runs on the config language [Starlark](https://docs.bazel.build/versions/master/skylark/language.html)) has a new expectation for how protoinfo is accessed. (`target.proto` => `target[ProtoInfo]`.) See the `proto_library` [documentation at master](https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library) vs. the [documentation for 0.21](https://docs.bazel.build/versions/0.21.0/be/protocol-buffer.html#proto_library). The current accessor style (`target.proto`) works with Bazel 0.22, but we can assume it will stop working in a later version.

I don't think there are any other instances of this accessor style in any other Starlark script in Envoy, so this is the only place we need to futureproof it.

*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A