### PR TITLE
For QUICHE integration, add --experimental_remap_main_repo to bazelrc.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,7 +5,7 @@
 # Limiting JVM heapsize here to let it do GC more when approaching the limit to
 # leave room for compiler/linker.
 startup --host_jvm_args=-Xmx512m
-build --workspace_status_command=bazel/get_workspace_status
+build --workspace_status_command=bazel/get_workspace_status --experimental_remap_main_repo
 
 # Basic ASAN/UBSAN that works for gcc
 build:asan --define ENVOY_CONFIG_ASAN=1


### PR DESCRIPTION
*Description*:

To allow source/extensions/quic_listeners/quiche/platform:quic_platform_impl_lib to depend on envoy build rules, add --experimental_remap_main_repo to bazelrc.

See https://github.com/envoyproxy/envoy/pull/5548/#issuecomment-455240776 for context.

*Risk Level*: minimal: build only
*Testing*: Tested build with PR #5758
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
