### PR TITLE
conn manager: Change header limit field to max_request_headers_kb

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -136,7 +136,7 @@ message HttpConnectionManager {
   // block in nghttp2 is 64K. The max configurable setting is 63K in order to
   // stay under both codec limits.
   // Requests that exceed this size will receive a 431 response.
-  google.protobuf.UInt32Value max_request_headers_size_kb = 29
+  google.protobuf.UInt32Value max_request_headers_kb = 29
       [(validate.rules).uint32.gt = 0, (validate.rules).uint32.lte = 63];
 
   // The idle timeout for connections managed by the connection manager. The

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -20,7 +20,7 @@ Version history
   All the control header lists now support :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>` instead of standard string.
 * http: added new grpc_http1_reverse_bridge filter for converting gRPC requests into HTTP/1.1 requests.
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to ::ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
-* http: added :ref:`max request headers size <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_size_kb>`. The default behaviour is unchanged.
+* http: added :ref:`max request headers size <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_kb>`. The default behaviour is unchanged.
 * redis: added :ref:`success and error stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
 * router: added ability to configure a :ref:`retry policy <envoy_api_msg_route.RetryPolicy>` at the

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -141,7 +141,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       http1_settings_(Http::Utility::parseHttp1Settings(config.http_protocol_options())),
       max_request_headers_size_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          config, max_request_headers_size_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB)),
+          config, max_request_headers_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB)),
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config, idle_timeout)),
       stream_idle_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, stream_idle_timeout, StreamIdleTimeoutMs)),

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -169,7 +169,7 @@ TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersSizeDefault) {
 TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersSizeConfigured) {
   const std::string yaml_string = R"EOF(
   stat_prefix: ingress_http
-  max_request_headers_size_kb: 16
+  max_request_headers_kb: 16
   route_config:
     name: local_route
   http_filters:

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1873,7 +1873,7 @@ void HttpIntegrationTest::testLargeRequestHeaders(uint32_t size, uint32_t max_si
 
   config_helper_.addConfigModifier(
       [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
-          -> void { hcm.mutable_max_request_headers_size_kb()->set_value(max_size); });
+          -> void { hcm.mutable_max_request_headers_kb()->set_value(max_size); });
 
   Http::TestHeaderMapImpl big_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};


### PR DESCRIPTION
Signed-off-by: Auni Ahsan <auni@google.com>

I was working on follow-ups to #5654 and it just occurred to me that kilobytes can't refer to anything except size...

So I renamed the field max_request_headers_size_kb to max_request_headers_kb. It just merged today so hopefully no one is using it yet. (I'll rename all the other vars in a separate PR, just wanted to propose the proto change ASAP.)

Risk Level: Low.
Testing/docs: Updated docs and config test from #5654.