### PR TITLE
filesystem: path sanity checking for fileReadToEnd().

### DIFF
--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -51,6 +51,10 @@ ssize_t fileSize(const std::string& path) {
 }
 
 std::string fileReadToEnd(const std::string& path) {
+  if (illegalPath(path)) {
+    throw EnvoyException(fmt::format("Invalid path: {}", path));
+  }
+
   std::ios::sync_with_stdio(false);
 
   std::ifstream file(path);

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -89,7 +89,7 @@ ssize_t fileSize(const std::string& path);
 
 /**
  * @return full file content as a string.
- * @throw EnvoyException if the file cannot be read.
+ * @throw EnvoyException if the file cannot be read, or if the path is blacklisted.
  * Be aware, this is not most highly performing file reading method.
  */
 std::string fileReadToEnd(const std::string& path);

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -97,6 +97,10 @@ TEST_F(FileSystemImplTest, fileReadToEndDoesNotExist) {
                EnvoyException);
 }
 
+TEST_F(FileSystemImplTest, fileReadToEndBlacklisted) {
+  EXPECT_THROW(Filesystem::fileReadToEnd("/dev/urandom"), EnvoyException);
+}
+
 TEST_F(FileSystemImplTest, CanonicalPathSuccess) {
   EXPECT_EQ("/", Filesystem::canonicalPath("//"));
 }

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -99,7 +99,7 @@ TEST_F(InjectedResourceMonitorTest, ReportsErrorForOutOfRangePressure) {
 }
 
 TEST_F(InjectedResourceMonitorTest, ReportsErrorOnFileRead) {
-  EXPECT_CALL(cb_, onFailure(ExceptionContains("unable to read file")));
+  EXPECT_CALL(cb_, onFailure(ExceptionContains("Invalid path")));
   monitor_->updateResourceUsage(cb_);
 }
 


### PR DESCRIPTION
Do not allow Filesystem::fileReadToEnd() for files in
/dev, /proc and /sys.

Risk Level: Low
Testing: New unit test.
Fixes: #3170

Signed-off-by: Sergey Glushchenko <gsserge@gmail.com>