### PR TITLE
For QUICHE integration, add --experimental_remap_main_repo to bazelrc.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,7 +5,7 @@
 # Limiting JVM heapsize here to let it do GC more when approaching the limit to
 # leave room for compiler/linker.
 startup --host_jvm_args=-Xmx512m
-build --workspace_status_command=bazel/get_workspace_status
+build --workspace_status_command=bazel/get_workspace_status --experimental_remap_main_repo
 
 # Basic ASAN/UBSAN that works for gcc
 build:asan --define ENVOY_CONFIG_ASAN=1


### PR DESCRIPTION
*Description*:

To allow source/extensions/quic_listeners/quiche/platform:quic_platform_impl_lib to depend on envoy build rules, add --experimental_remap_main_repo to bazelrc.

For context, this flag is temporarily necessary in order for the Envoy QUICHE platform implementation to be able to depend on Envoy libraries, without incurring link-time errors. More explanation in [this comment](https://github.com/envoyproxy/envoy/pull/5548#issuecomment-455240776). Bazel team's plan for graduating the flag-protected behavior is described [here](https://groups.google.com/d/msg/bazel-discuss/UCJ95z6q3Qg/53beHy0dEQAJ).

Note that the Bazel fix is only available in the most recent Bazel release, 0.22.0, which was released yesterday. @htuch , are there timing considerations around when a PR can assume the most recent version of Bazel?

*Risk Level*: minimal: build only
*Testing*: Tested build with PR #5758
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
