### PR TITLE
Add quic_uint128_impl.h to QUICHE platform implementation.

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -123,6 +123,7 @@ cc_library(
         "quiche/quic/platform/api/quic_string.h",
         "quiche/quic/platform/api/quic_string_piece.h",
         "quiche/quic/platform/api/quic_ptr_util.h",
+        "quiche/quic/platform/api/quic_uint128.h",
         # TODO: uncomment the following files as implementations are added.
         # "quiche/quic/platform/api/quic_bug_tracker.h",
         # "quiche/quic/platform/api/quic_client_stats.h",
@@ -160,7 +161,6 @@ cc_library(
         # "quiche/quic/platform/api/quic_test_output.h",
         # "quiche/quic/platform/api/quic_text_utils.h",
         # "quiche/quic/platform/api/quic_thread.h",
-        # "quiche/quic/platform/api/quic_uint128.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -53,6 +53,7 @@ envoy_cc_library(
         "quic_ptr_util_impl.h",
         "quic_string_impl.h",
         "quic_string_piece_impl.h",
+        "quic_uint128_impl.h",
     ],
     external_deps = [
         "abseil_base",

--- a/source/extensions/quic_listeners/quiche/platform/quic_uint128_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_uint128_impl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+//
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "absl/numeric/int128.h"
+
+namespace quic {
+
+using QuicUint128Impl = absl::uint128;
+#define MakeQuicUint128Impl(hi, lo) absl::MakeUint128(hi, lo)
+#define QuicUint128Low64Impl(x) absl::Uint128Low64(x)
+#define QuicUint128High64Impl(x) absl::Uint128High64(x)
+
+} // namespace quic

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -7,6 +7,7 @@
 #include "quiche/quic/platform/api/quic_ptr_util.h"
 #include "quiche/quic/platform/api/quic_string.h"
 #include "quiche/quic/platform/api/quic_string_piece.h"
+#include "quiche/quic/platform/api/quic_uint128.h"
 
 // Basic tests to validate functioning of the QUICHE quic platform
 // implementation. For platform APIs in which the implementation is a simple
@@ -76,6 +77,12 @@ TEST(QuicPlatformTest, QuicStringPiece) {
   quic::QuicString s = "bar";
   quic::QuicStringPiece sp(s);
   EXPECT_EQ('b', sp[0]);
+}
+
+TEST(QuicPlatformTest, QuicUint128) {
+  quic::QuicUint128 i = MakeQuicUint128(16777216, 315);
+  EXPECT_EQ(315, QuicUint128Low64(i));
+  EXPECT_EQ(16777216, QuicUint128High64(i));
 }
 
 TEST(QuicPlatformTest, QuicPtrUtil) {


### PR DESCRIPTION
*Description*:

Add quic_uint128_impl.h to QUICHE platform implementation

*Risk Level*: minimal: code not used yet
*Testing*: bazel test test/extensions/quic_listeners/quiche/platform:quic_platform_test
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
