### PR TITLE
(codec) Increase max_request_headers_kb limit to 64 and add http2 codec checks

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -133,11 +133,11 @@ message HttpConnectionManager {
   // The maximum request headers size for incoming connections. The default max
   // is 60K, based on default settings for http codecs. For HTTP1, the current
   // limit set by http_parser is 80K. for HTTP2, the default allowed header
-  // block in nghttp2 is 64K. The max configurable setting is 63K in order to
+  // block in nghttp2 is 64K. The max configurable setting is 64K in order to
   // stay under both codec limits.
   // Requests that exceed this size will receive a 431 response.
   google.protobuf.UInt32Value max_request_headers_kb = 29
-      [(validate.rules).uint32.gt = 0, (validate.rules).uint32.lte = 63];
+      [(validate.rules).uint32.gt = 0, (validate.rules).uint32.lte = 64];
 
   // The idle timeout for connections managed by the connection manager. The
   // idle timeout is defined as the period in which there are no active

--- a/docs/root/configuration/http_conn_man/stats.rst
+++ b/docs/root/configuration/http_conn_man/stats.rst
@@ -109,7 +109,7 @@ All http2 statistics are rooted at *http2.*
    :header: Name, Type, Description
    :widths: 1, 1, 2
 
-   header_overflow, Counter, Total number of connections reset due to the headers being larger than configured value.
+   header_overflow, Counter, Total number of connections reset due to the headers being larger than the configured value.
    headers_cb_no_stream, Counter, Total number of errors where a header callback is called without an associated stream. This tracks an unexpected occurrence due to an as yet undiagnosed bug
    rx_messaging_error, Counter, Total number of invalid received frames that violated `section 8 <https://tools.ietf.org/html/rfc7540#section-8>`_ of the HTTP/2 spec. This will result in a *tx_reset*
    rx_reset, Counter, Total number of reset stream frames received by Envoy

--- a/docs/root/configuration/http_conn_man/stats.rst
+++ b/docs/root/configuration/http_conn_man/stats.rst
@@ -109,7 +109,7 @@ All http2 statistics are rooted at *http2.*
    :header: Name, Type, Description
    :widths: 1, 1, 2
 
-   header_overflow, Counter, Total number of connections reset due to the headers being larger than `Envoy::Http::Http2::ConnectionImpl::StreamImpl::MAX_HEADER_SIZE` (63k)
+   header_overflow, Counter, Total number of connections reset due to the headers being larger than configured value.
    headers_cb_no_stream, Counter, Total number of errors where a header callback is called without an associated stream. This tracks an unexpected occurrence due to an as yet undiagnosed bug
    rx_messaging_error, Counter, Total number of invalid received frames that violated `section 8 <https://tools.ietf.org/html/rfc7540#section-8>`_ of the HTTP/2 spec. This will result in a *tx_reset*
    rx_reset, Counter, Total number of reset stream frames received by Envoy

--- a/docs/root/configuration/http_conn_man/stats.rst
+++ b/docs/root/configuration/http_conn_man/stats.rst
@@ -109,7 +109,7 @@ All http2 statistics are rooted at *http2.*
    :header: Name, Type, Description
    :widths: 1, 1, 2
 
-   header_overflow, Counter, Total number of connections reset due to the headers being larger than the configured value.
+   header_overflow, Counter, Total number of connections reset due to the headers being larger than the :ref:`configured value <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_kb>`.
    headers_cb_no_stream, Counter, Total number of errors where a header callback is called without an associated stream. This tracks an unexpected occurrence due to an as yet undiagnosed bug
    rx_messaging_error, Counter, Total number of invalid received frames that violated `section 8 <https://tools.ietf.org/html/rfc7540#section-8>`_ of the HTTP/2 spec. This will result in a *tx_reset*
    rx_reset, Counter, Total number of reset stream frames received by Envoy

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -14,7 +14,7 @@ namespace Envoy {
 namespace Http {
 
 // Legacy default value of 60K is safely under both codec default limits.
-static const uint32_t DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB = 60;
+static const uint32_t DEFAULT_MAX_REQUEST_HEADERS_SIZE = 60;
 
 class Stream;
 

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -14,7 +14,7 @@ namespace Envoy {
 namespace Http {
 
 // Legacy default value of 60K is safely under both codec default limits.
-static const uint32_t DEFAULT_MAX_REQUEST_HEADERS_SIZE = 60;
+static const uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
 
 class Stream;
 

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -146,7 +146,7 @@ CodecClientProd::CodecClientProd(Type type, Network::ClientConnectionPtr&& conne
   case Type::HTTP2: {
     codec_ = std::make_unique<Http2::ClientConnectionImpl>(
         *connection_, *this, host->cluster().statsScope(), host->cluster().http2Settings(),
-        Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB);
+        Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE);
     break;
   }
   }

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -146,7 +146,7 @@ CodecClientProd::CodecClientProd(Type type, Network::ClientConnectionPtr&& conne
   case Type::HTTP2: {
     codec_ = std::make_unique<Http2::ClientConnectionImpl>(
         *connection_, *this, host->cluster().statsScope(), host->cluster().http2Settings(),
-        Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE);
+        Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
     break;
   }
   }

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -145,7 +145,8 @@ CodecClientProd::CodecClientProd(Type type, Network::ClientConnectionPtr&& conne
   }
   case Type::HTTP2: {
     codec_ = std::make_unique<Http2::ClientConnectionImpl>(
-        *connection_, *this, host->cluster().statsScope(), host->cluster().http2Settings());
+        *connection_, *this, host->cluster().statsScope(), host->cluster().http2Settings(),
+        Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB);
     break;
   }
   }

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -231,7 +231,7 @@ public:
   /**
    * @return maximum request headers size the connection manager will accept.
    */
-  virtual uint32_t maxRequestHeadersSizeKb() const PURE;
+  virtual uint32_t maxRequestHeadersKb() const PURE;
 
   /**
    * @return per-stream idle timeout for incoming connection manager connections. Zero indicates a

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -618,8 +618,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   ASSERT(connection_manager_.config_.maxRequestHeadersKb() > 0);
-  if (request_headers_->byteSize() >
-      (connection_manager_.config_.maxRequestHeadersKb() * 1024)) {
+  if (request_headers_->byteSize() > (connection_manager_.config_.maxRequestHeadersKb() * 1024)) {
     sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_),
                    Code::RequestHeaderFieldsTooLarge, "", nullptr, is_head_request_, absl::nullopt);
     return;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -617,9 +617,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     }
   }
 
-  ASSERT(connection_manager_.config_.maxRequestHeadersSizeKb() > 0);
+  ASSERT(connection_manager_.config_.maxRequestHeadersKb() > 0);
   if (request_headers_->byteSize() >
-      (connection_manager_.config_.maxRequestHeadersSizeKb() * 1024)) {
+      (connection_manager_.config_.maxRequestHeadersKb() * 1024)) {
     sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_),
                    Code::RequestHeaderFieldsTooLarge, "", nullptr, is_head_request_, absl::nullopt);
     return;

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -36,15 +36,13 @@ std::string ConnectionManagerUtility::determineNextProtocol(Network::Connection&
   return "";
 }
 
-ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(Network::Connection& connection,
-                                                              const Buffer::Instance& data,
-                                                              ServerConnectionCallbacks& callbacks,
-                                                              Stats::Scope& scope,
-                                                              const Http1Settings& http1_settings,
-                                                              const Http2Settings& http2_settings) {
+ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
+    Network::Connection& connection, const Buffer::Instance& data,
+    ServerConnectionCallbacks& callbacks, Stats::Scope& scope, const Http1Settings& http1_settings,
+    const Http2Settings& http2_settings, uint32_t max_request_headers_kb) {
   if (determineNextProtocol(connection, data) == Http2::ALPN_STRING) {
-    return ServerConnectionPtr{
-        new Http2::ServerConnectionImpl(connection, callbacks, scope, http2_settings)};
+    return ServerConnectionPtr{new Http2::ServerConnectionImpl(
+        connection, callbacks, scope, http2_settings, max_request_headers_kb)};
   } else {
     return ServerConnectionPtr{
         new Http1::ServerConnectionImpl(connection, callbacks, http1_settings)};

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -39,7 +39,7 @@ std::string ConnectionManagerUtility::determineNextProtocol(Network::Connection&
 ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
     Network::Connection& connection, const Buffer::Instance& data,
     ServerConnectionCallbacks& callbacks, Stats::Scope& scope, const Http1Settings& http1_settings,
-    const Http2Settings& http2_settings, uint32_t max_request_headers_kb) {
+    const Http2Settings& http2_settings, const uint32_t max_request_headers_kb) {
   if (determineNextProtocol(connection, data) == Http2::ALPN_STRING) {
     return ServerConnectionPtr{new Http2::ServerConnectionImpl(
         connection, callbacks, scope, http2_settings, max_request_headers_kb)};

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -37,7 +37,7 @@ public:
   autoCreateCodec(Network::Connection& connection, const Buffer::Instance& data,
                   ServerConnectionCallbacks& callbacks, Stats::Scope& scope,
                   const Http1Settings& http1_settings, const Http2Settings& http2_settings,
-                  uint32_t max_request_headers_kb);
+                  const uint32_t max_request_headers_kb);
 
   /**
    * Mutates request headers in various ways. This functionality is broken out because of its

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -36,7 +36,8 @@ public:
   static ServerConnectionPtr
   autoCreateCodec(Network::Connection& connection, const Buffer::Instance& data,
                   ServerConnectionCallbacks& callbacks, Stats::Scope& scope,
-                  const Http1Settings& http1_settings, const Http2Settings& http2_settings);
+                  const Http1Settings& http1_settings,
+                  const Http2Settings& http2_settings, uint32_t max_request_headers_kb);
 
   /**
    * Mutates request headers in various ways. This functionality is broken out because of its

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -36,8 +36,8 @@ public:
   static ServerConnectionPtr
   autoCreateCodec(Network::Connection& connection, const Buffer::Instance& data,
                   ServerConnectionCallbacks& callbacks, Stats::Scope& scope,
-                  const Http1Settings& http1_settings,
-                  const Http2Settings& http2_settings, uint32_t max_request_headers_kb);
+                  const Http1Settings& http1_settings, const Http2Settings& http2_settings,
+                  uint32_t max_request_headers_kb);
 
   /**
    * Mutates request headers in various ways. This functionality is broken out because of its

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -878,8 +878,8 @@ ConnectionImpl::ClientHttp2Options::ClientHttp2Options(const Http2Settings& http
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection,
                                            Http::ConnectionCallbacks& callbacks,
                                            Stats::Scope& stats, const Http2Settings& http2_settings,
-                                           uint32_t max_request_headers)
-    : ConnectionImpl(connection, stats, http2_settings, max_request_headers),
+                                           uint32_t max_request_headers_kb)
+    : ConnectionImpl(connection, stats, http2_settings, max_request_headers_kb),
       callbacks_(callbacks) {
   ClientHttp2Options client_http2_options(http2_settings);
   nghttp2_session_client_new2(&session_, http2_callbacks_.callbacks(), base(),
@@ -927,8 +927,8 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 ServerConnectionImpl::ServerConnectionImpl(Network::Connection& connection,
                                            Http::ServerConnectionCallbacks& callbacks,
                                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                                           uint32_t max_request_headers)
-    : ConnectionImpl(connection, scope, http2_settings, max_request_headers),
+                                           uint32_t max_request_headers_kb)
+    : ConnectionImpl(connection, scope, http2_settings, max_request_headers_kb),
       callbacks_(callbacks) {
   Http2Options http2_options(http2_settings);
   nghttp2_session_server_new2(&session_, http2_callbacks_.callbacks(), base(),

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -641,7 +641,7 @@ int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
   }
 
   stream->saveHeader(std::move(name), std::move(value));
-  if (stream->headers_->byteSize() > StreamImpl::MAX_HEADER_SIZE) {
+  if (stream->headers_->byteSize() > max_request_headers_kb_ * 1024) {
     // This will cause the library to reset/close the stream.
     stats_.header_overflow_.inc();
     return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
@@ -877,8 +877,10 @@ ConnectionImpl::ClientHttp2Options::ClientHttp2Options(const Http2Settings& http
 
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection,
                                            Http::ConnectionCallbacks& callbacks,
-                                           Stats::Scope& stats, const Http2Settings& http2_settings)
-    : ConnectionImpl(connection, stats, http2_settings), callbacks_(callbacks) {
+                                           Stats::Scope& stats, const Http2Settings& http2_settings,
+                                           uint32_t max_request_headers)
+    : ConnectionImpl(connection, stats, http2_settings, max_request_headers),
+      callbacks_(callbacks) {
   ClientHttp2Options client_http2_options(http2_settings);
   nghttp2_session_client_new2(&session_, http2_callbacks_.callbacks(), base(),
                               client_http2_options.options());
@@ -924,8 +926,10 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 
 ServerConnectionImpl::ServerConnectionImpl(Network::Connection& connection,
                                            Http::ServerConnectionCallbacks& callbacks,
-                                           Stats::Scope& scope, const Http2Settings& http2_settings)
-    : ConnectionImpl(connection, scope, http2_settings), callbacks_(callbacks) {
+                                           Stats::Scope& scope, const Http2Settings& http2_settings,
+                                           uint32_t max_request_headers)
+    : ConnectionImpl(connection, scope, http2_settings, max_request_headers),
+      callbacks_(callbacks) {
   Http2Options http2_options(http2_settings);
   nghttp2_session_server_new2(&session_, http2_callbacks_.callbacks(), base(),
                               http2_options.options());

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -878,7 +878,7 @@ ConnectionImpl::ClientHttp2Options::ClientHttp2Options(const Http2Settings& http
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection,
                                            Http::ConnectionCallbacks& callbacks,
                                            Stats::Scope& stats, const Http2Settings& http2_settings,
-                                           uint32_t max_request_headers_kb)
+                                           const uint32_t max_request_headers_kb)
     : ConnectionImpl(connection, stats, http2_settings, max_request_headers_kb),
       callbacks_(callbacks) {
   ClientHttp2Options client_http2_options(http2_settings);
@@ -927,7 +927,7 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 ServerConnectionImpl::ServerConnectionImpl(Network::Connection& connection,
                                            Http::ServerConnectionCallbacks& callbacks,
                                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                                           uint32_t max_request_headers_kb)
+                                           const uint32_t max_request_headers_kb)
     : ConnectionImpl(connection, scope, http2_settings, max_request_headers_kb),
       callbacks_(callbacks) {
   Http2Options http2_options(http2_settings);

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -316,7 +316,7 @@ class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, ConnectionCallbacks& callbacks,
                        Stats::Scope& stats, const Http2Settings& http2_settings,
-                       uint32_t max_request_headers);
+                       uint32_t max_request_headers_kb);
 
   // Http::ClientConnection
   Http::StreamEncoder& newStream(StreamDecoder& response_decoder) override;
@@ -337,7 +337,7 @@ class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
   ServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
                        Stats::Scope& scope, const Http2Settings& http2_settings,
-                       uint32_t max_request_headers);
+                       uint32_t max_request_headers_kb);
 
 private:
   // ConnectionImpl

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -74,7 +74,7 @@ public:
 class ConnectionImpl : public virtual Connection, protected Logger::Loggable<Logger::Id::http2> {
 public:
   ConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
-                 const Http2Settings& http2_settings, uint32_t max_request_headers_kb)
+                 const Http2Settings& http2_settings, const uint32_t max_request_headers_kb)
       : stats_{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http2."))},
         connection_(connection), max_request_headers_kb_(max_request_headers_kb),
         per_stream_buffer_limit_(http2_settings.initial_stream_window_size_), dispatching_(false),
@@ -286,7 +286,7 @@ protected:
   nghttp2_session* session_{};
   CodecStats stats_;
   Network::Connection& connection_;
-  uint32_t max_request_headers_kb_;
+  const uint32_t max_request_headers_kb_;
   uint32_t per_stream_buffer_limit_;
   bool allow_metadata_;
 
@@ -316,7 +316,7 @@ class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, ConnectionCallbacks& callbacks,
                        Stats::Scope& stats, const Http2Settings& http2_settings,
-                       uint32_t max_request_headers_kb);
+                       const uint32_t max_request_headers_kb);
 
   // Http::ClientConnection
   Http::StreamEncoder& newStream(StreamDecoder& response_decoder) override;
@@ -337,7 +337,7 @@ class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
   ServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
                        Stats::Scope& scope, const Http2Settings& http2_settings,
-                       uint32_t max_request_headers_kb);
+                       const uint32_t max_request_headers_kb);
 
 private:
   // ConnectionImpl

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -74,9 +74,9 @@ public:
 class ConnectionImpl : public virtual Connection, protected Logger::Loggable<Logger::Id::http2> {
 public:
   ConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
-                 const Http2Settings& http2_settings)
+                 const Http2Settings& http2_settings, uint32_t max_request_headers_kb)
       : stats_{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http2."))},
-        connection_(connection),
+        connection_(connection), max_request_headers_kb_(max_request_headers_kb),
         per_stream_buffer_limit_(http2_settings.initial_stream_window_size_), dispatching_(false),
         raised_goaway_(false), pending_deferred_reset_(false) {}
 
@@ -291,6 +291,7 @@ protected:
   nghttp2_session* session_{};
   CodecStats stats_;
   Network::Connection& connection_;
+  uint32_t max_request_headers_kb_;
   uint32_t per_stream_buffer_limit_;
   bool allow_metadata_;
 
@@ -319,7 +320,8 @@ private:
 class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, ConnectionCallbacks& callbacks,
-                       Stats::Scope& stats, const Http2Settings& http2_settings);
+                       Stats::Scope& stats, const Http2Settings& http2_settings,
+                       uint32_t max_request_headers);
 
   // Http::ClientConnection
   Http::StreamEncoder& newStream(StreamDecoder& response_decoder) override;
@@ -339,7 +341,8 @@ private:
 class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
   ServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
-                       Stats::Scope& scope, const Http2Settings& http2_settings);
+                       Stats::Scope& scope, const Http2Settings& http2_settings,
+                       uint32_t max_request_headers);
 
 private:
   // ConnectionImpl

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -185,11 +185,6 @@ protected:
     void pendingSendBufferHighWatermark();
     void pendingSendBufferLowWatermark();
 
-    // Max header size of 63K. This is arbitrary but makes it easier to test since nghttp2 doesn't
-    // appear to transmit headers greater than approximately 64K (NGHTTP2_MAX_HEADERSLEN) for
-    // reasons I don't fully understand.
-    static const uint64_t MAX_HEADER_SIZE = 63 * 1024;
-
     // Does any necessary WebSocket/Upgrade conversion, then passes the headers
     // to the decoder_.
     void decodeHeaders();

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -328,9 +328,9 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
     return Http::ServerConnectionPtr{new Http::Http2::ServerConnectionImpl(
         connection, callbacks, context_.scope(), http2_settings_, maxRequestHeadersKb())};
   case CodecType::AUTO:
-    return Http::ConnectionManagerUtility::autoCreateCodec(
-        connection, data, callbacks, context_.scope(), http1_settings_, http2_settings_,
-        maxRequestHeadersKb());
+    return Http::ConnectionManagerUtility::autoCreateCodec(connection, data, callbacks,
+                                                           context_.scope(), http1_settings_,
+                                                           http2_settings_, maxRequestHeadersKb());
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -141,7 +141,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       http1_settings_(Http::Utility::parseHttp1Settings(config.http_protocol_options())),
       max_request_headers_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          config, max_request_headers_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB)),
+          config, max_request_headers_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_KB)),
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config, idle_timeout)),
       stream_idle_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, stream_idle_timeout, StreamIdleTimeoutMs)),

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -326,10 +326,11 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
         new Http::Http1::ServerConnectionImpl(connection, callbacks, http1_settings_)};
   case CodecType::HTTP2:
     return Http::ServerConnectionPtr{new Http::Http2::ServerConnectionImpl(
-        connection, callbacks, context_.scope(), http2_settings_)};
+        connection, callbacks, context_.scope(), http2_settings_, max_request_headers_size_kb_)};
   case CodecType::AUTO:
     return Http::ConnectionManagerUtility::autoCreateCodec(
-        connection, data, callbacks, context_.scope(), http1_settings_, http2_settings_);
+        connection, data, callbacks, context_.scope(), http1_settings_, http2_settings_,
+        max_request_headers_size_kb_);
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -140,7 +140,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       route_config_provider_manager_(route_config_provider_manager),
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       http1_settings_(Http::Utility::parseHttp1Settings(config.http_protocol_options())),
-      max_request_headers_size_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+      max_request_headers_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, max_request_headers_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB)),
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config, idle_timeout)),
       stream_idle_timeout_(
@@ -326,11 +326,11 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
         new Http::Http1::ServerConnectionImpl(connection, callbacks, http1_settings_)};
   case CodecType::HTTP2:
     return Http::ServerConnectionPtr{new Http::Http2::ServerConnectionImpl(
-        connection, callbacks, context_.scope(), http2_settings_, max_request_headers_size_kb_)};
+        connection, callbacks, context_.scope(), http2_settings_, max_request_headers_kb_)};
   case CodecType::AUTO:
     return Http::ConnectionManagerUtility::autoCreateCodec(
         connection, data, callbacks, context_.scope(), http1_settings_, http2_settings_,
-        max_request_headers_size_kb_);
+        max_request_headers_kb_);
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -326,11 +326,11 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
         new Http::Http1::ServerConnectionImpl(connection, callbacks, http1_settings_)};
   case CodecType::HTTP2:
     return Http::ServerConnectionPtr{new Http::Http2::ServerConnectionImpl(
-        connection, callbacks, context_.scope(), http2_settings_, max_request_headers_kb_)};
+        connection, callbacks, context_.scope(), http2_settings_, maxRequestHeadersKb())};
   case CodecType::AUTO:
     return Http::ConnectionManagerUtility::autoCreateCodec(
         connection, data, callbacks, context_.scope(), http1_settings_, http2_settings_,
-        max_request_headers_kb_);
+        maxRequestHeadersKb());
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -95,7 +95,7 @@ public:
   const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
-                                        Http::ServerConnectionCallbacks& callbacks, uint32_t max_request_headers) override;
+                                        Http::ServerConnectionCallbacks& callbacks) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return drain_timeout_; }
   FilterChainFactory& filterFactory() override { return *this; }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -158,7 +158,7 @@ private:
   std::string server_name_;
   Http::TracingConnectionManagerConfigPtr tracing_config_;
   absl::optional<std::string> user_agent_;
-  uint32_t max_request_headers_kb_;
+  const uint32_t max_request_headers_kb_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_;
   std::chrono::milliseconds request_timeout_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -101,7 +101,7 @@ public:
   FilterChainFactory& filterFactory() override { return *this; }
   bool reverseEncodeOrder() override { return reverse_encode_order_; }
   bool generateRequestId() override { return generate_request_id_; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_size_kb_; }
+  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -158,7 +158,7 @@ private:
   std::string server_name_;
   Http::TracingConnectionManagerConfigPtr tracing_config_;
   absl::optional<std::string> user_agent_;
-  uint32_t max_request_headers_size_kb_;
+  uint32_t max_request_headers_kb_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_;
   std::chrono::milliseconds request_timeout_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -95,13 +95,13 @@ public:
   const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
-                                        Http::ServerConnectionCallbacks& callbacks) override;
+                                        Http::ServerConnectionCallbacks& callbacks, uint32_t max_request_headers) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return drain_timeout_; }
   FilterChainFactory& filterFactory() override { return *this; }
   bool reverseEncodeOrder() override { return reverse_encode_order_; }
   bool generateRequestId() override { return generate_request_id_; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1106,7 +1106,7 @@ Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection
                                                  const Buffer::Instance& data,
                                                  Http::ServerConnectionCallbacks& callbacks) {
   return Http::ConnectionManagerUtility::autoCreateCodec(
-      connection, data, callbacks, server_.stats(), Http::Http1Settings(), Http::Http2Settings());
+      connection, data, callbacks, server_.stats(), Http::Http1Settings(), Http::Http2Settings(), maxRequestHeadersKb());
 }
 
 bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1106,7 +1106,8 @@ Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection
                                                  const Buffer::Instance& data,
                                                  Http::ServerConnectionCallbacks& callbacks) {
   return Http::ConnectionManagerUtility::autoCreateCodec(
-      connection, data, callbacks, server_.stats(), Http::Http1Settings(), Http::Http2Settings(), maxRequestHeadersKb());
+      connection, data, callbacks, server_.stats(), Http::Http1Settings(), Http::Http2Settings(),
+      maxRequestHeadersKb());
 }
 
 bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -100,7 +100,7 @@ public:
   bool reverseEncodeOrder() override { return false; }
   bool generateRequestId() override { return false; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_size_kb_; }
+  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return {}; }
   std::chrono::milliseconds requestTimeout() const override { return {}; }
   std::chrono::milliseconds delayedCloseTimeout() const override { return {}; }
@@ -305,7 +305,7 @@ private:
   Http::ConnectionManagerTracingStats tracing_stats_;
   NullRouteConfigProvider route_config_provider_;
   std::list<UrlHandler> handlers_;
-  uint32_t max_request_headers_size_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB};
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::string> user_agent_;
   Http::SlowDateProviderImpl date_provider_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -93,14 +93,14 @@ public:
   const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
-                                        Http::ServerConnectionCallbacks& callbacks) override;
+                                        Http::ServerConnectionCallbacks& callbacks, uint32_t max_request_headers_kb) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   Http::FilterChainFactory& filterFactory() override { return *this; }
   bool reverseEncodeOrder() override { return false; }
   bool generateRequestId() override { return false; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return {}; }
   std::chrono::milliseconds requestTimeout() const override { return {}; }
   std::chrono::milliseconds delayedCloseTimeout() const override { return {}; }
@@ -305,7 +305,7 @@ private:
   Http::ConnectionManagerTracingStats tracing_stats_;
   NullRouteConfigProvider route_config_provider_;
   std::list<UrlHandler> handlers_;
-  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE};
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::string> user_agent_;
   Http::SlowDateProviderImpl date_provider_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -305,7 +305,7 @@ private:
   Http::ConnectionManagerTracingStats tracing_stats_;
   NullRouteConfigProvider route_config_provider_;
   std::list<UrlHandler> handlers_;
-  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
+  const uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::string> user_agent_;
   Http::SlowDateProviderImpl date_provider_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -93,7 +93,7 @@ public:
   const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
-                                        Http::ServerConnectionCallbacks& callbacks, uint32_t max_request_headers_kb) override;
+                                        Http::ServerConnectionCallbacks& callbacks) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   Http::FilterChainFactory& filterFactory() override { return *this; }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -91,7 +91,7 @@ public:
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool reverseEncodeOrder() override { return true; }
   bool generateRequestId() override { return true; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -132,7 +132,7 @@ public:
   ConnectionManagerStats stats_;
   ConnectionManagerTracingStats tracing_stats_;
   ConnectionManagerListenerStats listener_stats_;
-  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE};
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_{};
   std::chrono::milliseconds request_timeout_{};

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -91,7 +91,7 @@ public:
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool reverseEncodeOrder() override { return true; }
   bool generateRequestId() override { return true; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_size_kb_; }
+  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -132,7 +132,7 @@ public:
   ConnectionManagerStats stats_;
   ConnectionManagerTracingStats tracing_stats_;
   ConnectionManagerListenerStats listener_stats_;
-  uint32_t max_request_headers_size_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB};
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_{};
   std::chrono::milliseconds request_timeout_{};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -230,7 +230,7 @@ public:
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool reverseEncodeOrder() override { return reverse_encode_order_; }
   bool generateRequestId() override { return true; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -281,7 +281,7 @@ public:
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   absl::optional<std::string> user_agent_;
-  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE};
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_{};
   std::chrono::milliseconds request_timeout_{};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -230,7 +230,7 @@ public:
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool reverseEncodeOrder() override { return reverse_encode_order_; }
   bool generateRequestId() override { return true; }
-  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_size_kb_; }
+  uint32_t maxRequestHeadersSizeKb() const override { return max_request_headers_kb_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -281,7 +281,7 @@ public:
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   absl::optional<std::string> user_agent_;
-  uint32_t max_request_headers_size_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB};
+  uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_{};
   std::chrono::milliseconds request_timeout_{};
@@ -3624,7 +3624,7 @@ TEST_F(HttpConnectionManagerImplTest, OverlyLongHeadersRejected) {
 }
 
 TEST_F(HttpConnectionManagerImplTest, OverlyLongHeadersAcceptedIfConfigured) {
-  max_request_headers_size_kb_ = 62;
+  max_request_headers_kb_ = 62;
   setup(false, "");
 
   EXPECT_CALL(*codec_, dispatch(_)).Times(1).WillOnce(Invoke([&](Buffer::Instance&) -> void {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -51,7 +51,7 @@ public:
   MOCK_METHOD0(filterFactory, FilterChainFactory&());
   MOCK_METHOD0(reverseEncodeOrder, bool());
   MOCK_METHOD0(generateRequestId, bool());
-  MOCK_CONST_METHOD0(maxRequestHeadersSizeKb, uint32_t());
+  MOCK_CONST_METHOD0(maxRequestHeadersKb, uint32_t());
   MOCK_CONST_METHOD0(idleTimeout, absl::optional<std::chrono::milliseconds>());
   MOCK_CONST_METHOD0(streamIdleTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(requestTimeout, std::chrono::milliseconds());

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
+    "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
 )
@@ -22,6 +23,7 @@ envoy_cc_fuzz_test(
     corpus = "codec_impl_corpus",
     deps = [
         ":codec_impl_fuzz_proto_cc",
+        ":codec_impl_test_util",
         "//source/common/http:header_map_lib",
         "//source/common/http/http2:codec_lib",
         "//test/fuzz:utility_lib",
@@ -35,6 +37,7 @@ envoy_cc_test(
     srcs = ["codec_impl_test.cc"],
     shard_count = 5,
     deps = [
+        ":codec_impl_test_util",
         "//source/common/event:dispatcher_lib",
         "//source/common/http:exception_lib",
         "//source/common/http:header_map_lib",
@@ -45,6 +48,14 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "codec_impl_test_util",
+    hdrs = ["codec_impl_test_util.h"],
+    deps = [
+        "//source/common/http/http2:codec_lib",
     ],
 )
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -148,7 +148,7 @@ public:
   StreamEncoder* response_encoder_{};
   MockStreamCallbacks server_stream_callbacks_;
   bool corrupt_data_ = false;
-  uint32_t max_request_headers_ = Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE;
+  uint32_t max_request_headers_ = Http::DEFAULT_MAX_REQUEST_HEADERS_KB;
 };
 
 TEST_P(Http2CodecImplTest, ShutdownNotice) {

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -148,7 +148,7 @@ public:
   StreamEncoder* response_encoder_{};
   MockStreamCallbacks server_stream_callbacks_;
   bool corrupt_data_ = false;
-  uint32_t max_request_headers_ = Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB;
+  uint32_t max_request_headers_ = Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE;
 };
 
 TEST_P(Http2CodecImplTest, ShutdownNotice) {

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -890,6 +890,29 @@ TEST_P(Http2CodecImplTest, TestLargeHeadersAcceptedIfConfigured) {
   request_encoder_->encodeHeaders(request_headers, false);
 }
 
+TEST_P(Http2CodecImplTest, TestLargeHeadersAtLimitAccepted) {
+  uint32_t codec_limit_kb = 64;
+  max_request_headers_kb_ = codec_limit_kb;
+  initialize();
+
+  TestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  std::string key = "big";
+  uint32_t head_room = 77;
+  uint32_t long_string_length =
+      codec_limit_kb * 1024 - request_headers.byteSize() - key.length() - head_room;
+  std::string long_string = std::string(long_string_length, 'q');
+  request_headers.addCopy(key, long_string);
+
+  // The amount of data sent to the codec is not equivalent to the size of the
+  // request headers that Envoy computes, as the codec limits based on the
+  // entire http2 frame. The exact head room needed (76) was found through iteration.
+  ASSERT_EQ(request_headers.byteSize() + head_room, codec_limit_kb * 1024);
+
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _));
+  request_encoder_->encodeHeaders(request_headers, true);
+}
+
 TEST_P(Http2CodecImplTest, TestCodecHeaderCompression) {
   initialize();
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -15,6 +15,7 @@
 #include "test/test_common/test_base.h"
 #include "test/test_common/utility.h"
 
+#include "codec_impl_test_util.h"
 #include "gmock/gmock.h"
 
 using testing::_;
@@ -32,26 +33,6 @@ namespace Http2 {
 
 using Http2SettingsTuple = ::testing::tuple<uint32_t, uint32_t, uint32_t, uint32_t>;
 using Http2SettingsTestParam = ::testing::tuple<Http2SettingsTuple, Http2SettingsTuple>;
-
-class TestServerConnectionImpl : public ServerConnectionImpl {
-public:
-  TestServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
-                           Stats::Scope& scope, const Http2Settings& http2_settings,
-                           uint32_t max_request_headers)
-      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers) {}
-  nghttp2_session* session() { return session_; }
-  using ServerConnectionImpl::getStream;
-};
-
-class TestClientConnectionImpl : public ClientConnectionImpl {
-public:
-  TestClientConnectionImpl(Network::Connection& connection, Http::ConnectionCallbacks& callbacks,
-                           Stats::Scope& scope, const Http2Settings& http2_settings,
-                           uint32_t max_request_headers)
-      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers) {}
-  nghttp2_session* session() { return session_; }
-  using ClientConnectionImpl::getStream;
-};
 
 class Http2CodecImplTest : public TestBaseWithParam<Http2SettingsTestParam> {
 public:

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -57,10 +57,10 @@ public:
     Http2SettingsFromTuple(server_http2settings_, ::testing::get<1>(GetParam()));
     client_ = std::make_unique<TestClientConnectionImpl>(client_connection_, client_callbacks_,
                                                          stats_store_, client_http2settings_,
-                                                         max_request_headers_);
+                                                         max_request_headers_kb_);
     server_ = std::make_unique<TestServerConnectionImpl>(server_connection_, server_callbacks_,
                                                          stats_store_, server_http2settings_,
-                                                         max_request_headers_);
+                                                         max_request_headers_kb_);
 
     request_encoder_ = &client_->newStream(response_decoder_);
     setupDefaultConnectionMocks();
@@ -129,7 +129,7 @@ public:
   StreamEncoder* response_encoder_{};
   MockStreamCallbacks server_stream_callbacks_;
   bool corrupt_data_ = false;
-  uint32_t max_request_headers_ = Http::DEFAULT_MAX_REQUEST_HEADERS_KB;
+  uint32_t max_request_headers_kb_ = Http::DEFAULT_MAX_REQUEST_HEADERS_KB;
 };
 
 TEST_P(Http2CodecImplTest, ShutdownNotice) {
@@ -762,10 +762,10 @@ TEST_P(Http2CodecImplStreamLimitTest, MaxClientStreams) {
   Http2SettingsFromTuple(server_http2settings_, ::testing::get<1>(GetParam()));
   client_ = std::make_unique<TestClientConnectionImpl>(client_connection_, client_callbacks_,
                                                        stats_store_, client_http2settings_,
-                                                       max_request_headers_);
+                                                       max_request_headers_kb_);
   server_ = std::make_unique<TestServerConnectionImpl>(server_connection_, server_callbacks_,
                                                        stats_store_, server_http2settings_,
-                                                       max_request_headers_);
+                                                       max_request_headers_kb_);
 
   for (int i = 0; i < 101; ++i) {
     request_encoder_ = &client_->newStream(response_decoder_);
@@ -877,7 +877,7 @@ TEST_P(Http2CodecImplTest, TestLargeHeadersInvokeResetStream) {
 }
 
 TEST_P(Http2CodecImplTest, TestLargeHeadersAcceptedIfConfigured) {
-  max_request_headers_ = 64;
+  max_request_headers_kb_ = 64;
   initialize();
 
   TestHeaderMapImpl request_headers;

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -11,7 +11,8 @@ public:
   TestServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
                            Stats::Scope& scope, const Http2Settings& http2_settings,
                            uint32_t max_request_headers_kb)
-      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {}
+      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {
+  }
   nghttp2_session* session() { return session_; }
   using ServerConnectionImpl::getStream;
 };
@@ -21,7 +22,8 @@ public:
   TestClientConnectionImpl(Network::Connection& connection, Http::ConnectionCallbacks& callbacks,
                            Stats::Scope& scope, const Http2Settings& http2_settings,
                            uint32_t max_request_headers_kb)
-      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {}
+      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {
+  }
   nghttp2_session* session() { return session_; }
   using ClientConnectionImpl::getStream;
 };

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -10,8 +10,8 @@ class TestServerConnectionImpl : public ServerConnectionImpl {
 public:
   TestServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                           uint32_t max_request_headers)
-      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers) {}
+                           uint32_t max_request_headers_kb)
+      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {}
   nghttp2_session* session() { return session_; }
   using ServerConnectionImpl::getStream;
 };
@@ -20,8 +20,8 @@ class TestClientConnectionImpl : public ClientConnectionImpl {
 public:
   TestClientConnectionImpl(Network::Connection& connection, Http::ConnectionCallbacks& callbacks,
                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                           uint32_t max_request_headers)
-      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers) {}
+                           uint32_t max_request_headers_kb)
+      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {}
   nghttp2_session* session() { return session_; }
   using ClientConnectionImpl::getStream;
 };

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -1,0 +1,31 @@
+#include "envoy/http/codec.h"
+
+#include "common/http/http2/codec_impl.h"
+
+namespace Envoy {
+namespace Http {
+namespace Http2 {
+
+class TestServerConnectionImpl : public ServerConnectionImpl {
+public:
+  TestServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
+                           Stats::Scope& scope, const Http2Settings& http2_settings,
+                           uint32_t max_request_headers)
+      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers) {}
+  nghttp2_session* session() { return session_; }
+  using ServerConnectionImpl::getStream;
+};
+
+class TestClientConnectionImpl : public ClientConnectionImpl {
+public:
+  TestClientConnectionImpl(Network::Connection& connection, Http::ConnectionCallbacks& callbacks,
+                           Stats::Scope& scope, const Http2Settings& http2_settings,
+                           uint32_t max_request_headers)
+      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers) {}
+  nghttp2_session* session() { return session_; }
+  using ClientConnectionImpl::getStream;
+};
+
+} // namespace Http2
+} // namespace Http
+} // namespace Envoy

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -163,7 +163,7 @@ TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersSizeDefault) {
 
   HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
                                      date_provider_, route_config_provider_manager_);
-  EXPECT_EQ(60, config.maxRequestHeadersSizeKb());
+  EXPECT_EQ(60, config.maxRequestHeadersKb());
 }
 
 TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersSizeConfigured) {
@@ -178,7 +178,7 @@ TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersSizeConfigured) {
 
   HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
                                      date_provider_, route_config_provider_manager_);
-  EXPECT_EQ(16, config.maxRequestHeadersSizeKb());
+  EXPECT_EQ(16, config.maxRequestHeadersKb());
 }
 
 // Validated that an explicit zero stream idle timeout disables.

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -217,8 +217,9 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
     auto settings = Http::Http2Settings();
     settings.allow_connect_ = true;
     settings.allow_metadata_ = true;
-    codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(shared_connection_.connection(),
-                                                                 *this, store, settings, Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
+    codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(
+        shared_connection_.connection(), *this, store, settings,
+        Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
     ASSERT(type == Type::HTTP2);
   }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -218,7 +218,7 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
     settings.allow_connect_ = true;
     settings.allow_metadata_ = true;
     codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(shared_connection_.connection(),
-                                                                 *this, store, settings, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE);
+                                                                 *this, store, settings, Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
     ASSERT(type == Type::HTTP2);
   }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -218,7 +218,7 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
     settings.allow_connect_ = true;
     settings.allow_metadata_ = true;
     codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(shared_connection_.connection(),
-                                                                 *this, store, settings, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB);
+                                                                 *this, store, settings, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE);
     ASSERT(type == Type::HTTP2);
   }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -218,7 +218,7 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
     settings.allow_connect_ = true;
     settings.allow_metadata_ = true;
     codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(shared_connection_.connection(),
-                                                                 *this, store, settings);
+                                                                 *this, store, settings, Http::DEFAULT_MAX_REQUEST_HEADERS_SIZE_KB);
     ASSERT(type == Type::HTTP2);
   }
 

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -467,9 +467,9 @@ TEST_P(Http2IntegrationTest, RetryPriority) { testRetryPriority(); }
 
 TEST_P(Http2IntegrationTest, GrpcRetry) { testGrpcRetry(); }
 
-TEST_P(Http2IntegrationTest, LargeHeadersInvokeResetStream) { testLargeRequestHeaders(62, 60); }
+TEST_P(Http2IntegrationTest, LargeHeadersInvokeResetStream) { testLargeRequestHeaders(63, 60); }
 
-TEST_P(Http2IntegrationTest, LargeHeadersAcceptedIfConfigured) { testLargeRequestHeaders(62, 63); }
+TEST_P(Http2IntegrationTest, LargeHeadersAcceptedIfConfigured) { testLargeRequestHeaders(63, 64); }
 
 TEST_P(Http2IntegrationTest, EncodingHeaderOnlyResponse) { testHeadersOnlyFilterEncoding(); }
 

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -490,9 +490,9 @@ TEST_P(IntegrationTest, InvalidContentLength) { testInvalidContentLength(); }
 
 TEST_P(IntegrationTest, MultipleContentLengths) { testMultipleContentLengths(); }
 
-TEST_P(IntegrationTest, LargeHeadersRejected) { testLargeRequestHeaders(62, 60); }
+TEST_P(IntegrationTest, LargeHeadersRejected) { testLargeRequestHeaders(63, 60); }
 
-TEST_P(IntegrationTest, LargeHeadersAccepted) { testLargeRequestHeaders(62, 63); }
+TEST_P(IntegrationTest, LargeHeadersAcceptedIfConfigured) { testLargeRequestHeaders(63, 64); }
 
 TEST_P(IntegrationTest, UpstreamProtocolError) {
   initialize();


### PR DESCRIPTION
*Description*: Extra http2 codec check hard-coded at 63KB has been removed. Instead, the codec max_request_headers_kb is based on the http conn manager config value, or the default value from codec.h. In addition, change instances of ~max_request_headers_size_kb -> ~max_request_headers_kb. Also, split http2/codec_impl_[fuzz_]test.cc connection testing classes into common util.

*Risk Level*: Medium, touches codec instantiation which is in a lot of places. (There are a lot of call sites on the codec instantiation so please review carefully in case I plugged the default value somewhere I shouldn't have.)

Part of #5626.