### PR TITLE
Update Datadog tracer version to v0.4.2

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -100,9 +100,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/googleapis/googleapis/archive/d6f78d948c53f3b400bb46996eb3084359914f9b.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "1798ce816e389ad89c379cb734487ed8b7db3d909be0c8548bd96538f78639b7",
-        strip_prefix = "dd-opentracing-cpp-0.4.1",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.4.1.tar.gz"],
+        sha256 = "a3d1c03e7af570fa64c01df259e6e9bb78637a6bd9c65c6bf7e8703e466dc22f",
+        strip_prefix = "dd-opentracing-cpp-0.4.2",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.4.2.tar.gz"],
     ),
     com_github_msgpack_msgpack_c = dict(
         sha256 = "bda49f996a73d2c6080ff0523e7b535917cd28c8a79c3a5da54fc29332d61d1e",


### PR DESCRIPTION
Signed-off-by: Caleb Gilmour <caleb.gilmour@datadoghq.com>

*Description*:
Updates the version of the Datadog tracing dependency to v0.4.2, which makes sure the operation name from envoy gets handled correctly in Datadog traces.

*Risk Level*: Low
*Testing*: unit tests and E2E
*Docs Changes*: N/A
*Release Notes*: N/A