### PR TITLE
Add link to ejection event logging config

### DIFF
--- a/docs/root/intro/arch_overview/outlier.rst
+++ b/docs/root/intro/arch_overview/outlier.rst
@@ -79,6 +79,7 @@ A log of outlier ejection events can optionally be produced by Envoy. This is ex
 during daily operations since global stats do not provide enough information on which hosts are
 being ejected and for what reasons. The log is structured as protobuf-based dumps of
 :ref:`OutlierDetectionEvent messages <envoy_api_msg_data.cluster.v2alpha.OutlierDetectionEvent>`.
+Ejection event logging is configured in the Cluster manager :ref:`outlier detection configuration <envoy_api_field_config.bootstrap.v2.ClusterManager.outlier_detection>`.
 
 Configuration reference
 -----------------------


### PR DESCRIPTION
*Description*: Add a link to ejection event logging.
*Risk Level*: low
*Testing*: none
*Docs Changes*: Only doc changes!
*Release Notes*: none

When reading docs it wasn't immediately clear where to configure the Ejection event logging. This change explicitly links to it.
