### PR TITLE
Disable quic_platform_test by default

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -149,6 +149,11 @@ config_setting(
     values = {"define": "boringssl=fips"},
 )
 
+config_setting(
+    name = "enable_quiche",
+    values = {"define": "enable_quiche=enabled"},
+)
+
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -591,3 +591,9 @@ def envoy_select_boringssl(if_fips, default = None):
         "@envoy//bazel:boringssl_fips": if_fips,
         "//conditions:default": default or [],
     })
+
+def envoy_select_quiche(xs, repository = ""):
+    return select({
+        repository + "//bazel:enable_quiche": xs,
+        "//conditions:default": [],
+    })

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -8,6 +8,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_quiche",
 )
 
 envoy_package()
@@ -23,7 +24,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "quic_platform_test",
-    srcs = ["quic_platform_test.cc"],
+    srcs = envoy_select_quiche(["quic_platform_test.cc"]),
     external_deps = ["quiche_quic_platform"],
     deps = [
         "//test/test_common:utility_lib",


### PR DESCRIPTION
*Description*:

Disable quic_platform_test by default. Enable it only when "--define enable_quiche=enabled" is specified in the bazel command line.

This is needed to workaround a issue with --experimental_remap_main_repo + ci asan build, see [here](https://github.com/envoyproxy/envoy/pull/5767#issuecomment-459339642) for details.

*Risk Level*: minimal: build only
*Testing*:

I introduced a failure in quic_platform_test, then confirmed quic_platform_test still passes by default(since it does nothing), and failed when "--define enable_quiche=enabled" is specified.

Also ran "./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.asan'" to confirm the ci issue is gone.

*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
