### PR TITLE
build: not build yaml-cpp tools

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -58,6 +58,7 @@ cmake_external(
     name = "yaml",
     cache_entries = {
         "YAML_CPP_BUILD_TESTS": "off",
+        "YAML_CPP_BUILD_TOOLS": "off",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
     },
     cmake_options = ["-GNinja"],


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
YAML tools build with bazel cmake from #5218 (it pulls our cc_configure and I think that is the reason) requires newer version of GLIBCXX that CentOS doesn't have. It also speed up build so lets just turn off building them.

*Risk Level*: Low
*Testing*: CI
*Docs Changes*:
*Release Notes*:
