### PR TITLE
http tap: add request/response trailer matching

### DIFF
--- a/api/envoy/data/tap/v2alpha/http.proto
+++ b/api/envoy/data/tap/v2alpha/http.proto
@@ -10,8 +10,14 @@ import "envoy/api/v2/core/base.proto";
 // A fully buffered HTTP trace message.
 message HttpBufferedTrace {
   // Request headers.
-  repeated api.v2.core.HeaderValue request_headers = 2;
+  repeated api.v2.core.HeaderValue request_headers = 1;
+
+  // Request trailers.
+  repeated api.v2.core.HeaderValue request_trailers = 2;
 
   // Response headers.
   repeated api.v2.core.HeaderValue response_headers = 3;
+
+  // Response trailers.
+  repeated api.v2.core.HeaderValue response_trailers = 4;
 }

--- a/api/envoy/data/tap/v2alpha/http.proto
+++ b/api/envoy/data/tap/v2alpha/http.proto
@@ -9,15 +9,18 @@ import "envoy/api/v2/core/base.proto";
 
 // A fully buffered HTTP trace message.
 message HttpBufferedTrace {
-  // Request headers.
-  repeated api.v2.core.HeaderValue request_headers = 1;
+  // HTTP message wrapper.
+  message Message {
+    // Message headers.
+    repeated api.v2.core.HeaderValue headers = 1;
 
-  // Request trailers.
-  repeated api.v2.core.HeaderValue request_trailers = 2;
+    // Message trailers.
+    repeated api.v2.core.HeaderValue trailers = 2;
+  }
 
-  // Response headers.
-  repeated api.v2.core.HeaderValue response_headers = 3;
+  // Request message.
+  Message request = 1;
 
-  // Response trailers.
-  repeated api.v2.core.HeaderValue response_trailers = 4;
+  // Response message.
+  Message response = 2;
 }

--- a/api/envoy/service/tap/v2alpha/common.proto
+++ b/api/envoy/service/tap/v2alpha/common.proto
@@ -48,23 +48,23 @@ message MatchPredicate {
     // The match configuration will always match.
     bool any_match = 4 [(validate.rules).bool.const = true];
 
-    // HTTP request match configuration.
-    HttpRequestMatch http_request_match = 5;
+    // HTTP request headers match configuration.
+    HttpHeadersMatch http_request_headers_match = 5;
 
-    // HTTP response match configuration.
-    HttpResponseMatch http_response_match = 6;
+    // HTTP request trailers match configuration.
+    HttpHeadersMatch http_request_trailers_match = 6;
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_response_headers_match = 7;
+
+    // HTTP response trailers match configuration.
+    HttpHeadersMatch http_response_trailers_match = 8;
   }
 }
 
-// HTTP request match configuration.
-message HttpRequestMatch {
-  // HTTP request headers to match.
-  repeated api.v2.route.HeaderMatcher headers = 1;
-}
-
-// HTTP response match configuration.
-message HttpResponseMatch {
-  // HTTP response headers to match.
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  // HTTP headers to match.
   repeated api.v2.route.HeaderMatcher headers = 1;
 }
 

--- a/docs/root/configuration/http_filters/tap_filter.rst
+++ b/docs/root/configuration/http_filters/tap_filter.rst
@@ -65,11 +65,11 @@ An example POST body:
     match_config:
       and_match:
         rules:
-          - http_request_match:
+          - http_request_headers_match:
               headers:
                 - name: foo
                   exact_match: bar
-          - http_response_match:
+          - http_response_headers_match:
               headers:
                 - name: bar
                   exact_match: baz
@@ -90,11 +90,11 @@ Another example POST body:
     match_config:
       or_match:
         rules:
-          - http_request_match:
+          - http_request_headers_match:
               headers:
                 - name: foo
                   exact_match: bar
-          - http_response_match:
+          - http_response_headers_match:
               headers:
                 - name: bar
                   exact_match: baz

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -447,6 +447,7 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
 }
 
 Http::FilterTrailersStatus Filter::decodeTrailers(Http::HeaderMap& trailers) {
+  ENVOY_STREAM_LOG(debug, "router decoding trailers:\n{}", *callbacks_, trailers);
   downstream_trailers_ = &trailers;
   upstream_request_->encodeTrailers(trailers);
   onRequestComplete();

--- a/source/extensions/filters/http/tap/tap_config.h
+++ b/source/extensions/filters/http/tap/tap_config.h
@@ -25,16 +25,28 @@ public:
   virtual void onRequestHeaders(const Http::HeaderMap& headers) PURE;
 
   /**
+   * Called when request trailers are received.
+   */
+  virtual void onRequestTrailers(const Http::HeaderMap& trailers) PURE;
+
+  /**
    * Called when response headers are received.
    */
   virtual void onResponseHeaders(const Http::HeaderMap& headers) PURE;
+
+  /**
+   * Called when response trailers are received.
+   */
+  virtual void onResponseTrailers(const Http::HeaderMap& headers) PURE;
 
   /**
    * Called when the request is being destroyed and is being logged.
    * @return whether the request was tapped or not.
    */
   virtual bool onDestroyLog(const Http::HeaderMap* request_headers,
-                            const Http::HeaderMap* response_headers) PURE;
+                            const Http::HeaderMap* request_trailers,
+                            const Http::HeaderMap* response_headers,
+                            const Http::HeaderMap* response_trailers) PURE;
 };
 
 using HttpPerRequestTapperPtr = std::unique_ptr<HttpPerRequestTapper>;

--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -22,8 +22,16 @@ void HttpPerRequestTapperImpl::onRequestHeaders(const Http::HeaderMap& headers) 
   config_->rootMatcher().onHttpRequestHeaders(headers, statuses_);
 }
 
+void HttpPerRequestTapperImpl::onRequestTrailers(const Http::HeaderMap& trailers) {
+  config_->rootMatcher().onHttpRequestTrailers(trailers, statuses_);
+}
+
 void HttpPerRequestTapperImpl::onResponseHeaders(const Http::HeaderMap& headers) {
   config_->rootMatcher().onHttpResponseHeaders(headers, statuses_);
+}
+
+void HttpPerRequestTapperImpl::onResponseTrailers(const Http::HeaderMap& trailers) {
+  config_->rootMatcher().onHttpResponseTrailers(trailers, statuses_);
 }
 
 namespace {
@@ -38,7 +46,9 @@ Http::HeaderMap::Iterate fillHeaderList(const Http::HeaderEntry& header, void* c
 } // namespace
 
 bool HttpPerRequestTapperImpl::onDestroyLog(const Http::HeaderMap* request_headers,
-                                            const Http::HeaderMap* response_headers) {
+                                            const Http::HeaderMap* request_trailers,
+                                            const Http::HeaderMap* response_headers,
+                                            const Http::HeaderMap* response_trailers) {
   if (!config_->rootMatcher().matches(statuses_)) {
     return false;
   }
@@ -46,8 +56,14 @@ bool HttpPerRequestTapperImpl::onDestroyLog(const Http::HeaderMap* request_heade
   auto trace = std::make_shared<envoy::data::tap::v2alpha::BufferedTraceWrapper>();
   auto& http_trace = *trace->mutable_http_buffered_trace();
   request_headers->iterate(fillHeaderList, http_trace.mutable_request_headers());
+  if (request_trailers != nullptr) {
+    request_trailers->iterate(fillHeaderList, http_trace.mutable_request_trailers());
+  }
   if (response_headers != nullptr) {
     response_headers->iterate(fillHeaderList, http_trace.mutable_response_headers());
+  }
+  if (response_trailers != nullptr) {
+    response_trailers->iterate(fillHeaderList, http_trace.mutable_response_trailers());
   }
 
   ENVOY_LOG(debug, "submitting buffered trace sink");

--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -55,15 +55,15 @@ bool HttpPerRequestTapperImpl::onDestroyLog(const Http::HeaderMap* request_heade
 
   auto trace = std::make_shared<envoy::data::tap::v2alpha::BufferedTraceWrapper>();
   auto& http_trace = *trace->mutable_http_buffered_trace();
-  request_headers->iterate(fillHeaderList, http_trace.mutable_request_headers());
+  request_headers->iterate(fillHeaderList, http_trace.mutable_request()->mutable_headers());
   if (request_trailers != nullptr) {
-    request_trailers->iterate(fillHeaderList, http_trace.mutable_request_trailers());
+    request_trailers->iterate(fillHeaderList, http_trace.mutable_request()->mutable_trailers());
   }
   if (response_headers != nullptr) {
-    response_headers->iterate(fillHeaderList, http_trace.mutable_response_headers());
+    response_headers->iterate(fillHeaderList, http_trace.mutable_response()->mutable_headers());
   }
   if (response_trailers != nullptr) {
-    response_trailers->iterate(fillHeaderList, http_trace.mutable_response_trailers());
+    response_trailers->iterate(fillHeaderList, http_trace.mutable_response()->mutable_trailers());
   }
 
   ENVOY_LOG(debug, "submitting buffered trace sink");

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -34,9 +34,12 @@ public:
 
   // TapFilter::HttpPerRequestTapper
   void onRequestHeaders(const Http::HeaderMap& headers) override;
+  void onRequestTrailers(const Http::HeaderMap& headers) override;
   void onResponseHeaders(const Http::HeaderMap& headers) override;
-  bool onDestroyLog(const Http::HeaderMap* request_headers,
-                    const Http::HeaderMap* response_headers) override;
+  void onResponseTrailers(const Http::HeaderMap& headers) override;
+  bool onDestroyLog(const Http::HeaderMap* request_headers, const Http::HeaderMap* request_trailers,
+                    const Http::HeaderMap* response_headers,
+                    const Http::HeaderMap* response_trailers) override;
 
 private:
   HttpTapConfigImplSharedPtr config_;

--- a/source/extensions/filters/http/tap/tap_filter.h
+++ b/source/extensions/filters/http/tap/tap_filter.h
@@ -86,9 +86,7 @@ public:
   Http::FilterDataStatus decodeData(Buffer::Instance&, bool) override {
     return Http::FilterDataStatus::Continue;
   }
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
-    return Http::FilterTrailersStatus::Continue;
-  }
+  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap& trailers) override;
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
     HttpTapConfigSharedPtr config = config_->currentConfig();
     tapper_ = config ? config->createPerRequestTapper(callbacks.streamId()) : nullptr;
@@ -102,9 +100,7 @@ public:
   Http::FilterDataStatus encodeData(Buffer::Instance&, bool) override {
     return Http::FilterDataStatus::Continue;
   }
-  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap&) override {
-    return Http::FilterTrailersStatus::Continue;
-  }
+  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap& trailers) override;
   Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap&) override {
     return Http::FilterMetadataStatus::Continue;
   }
@@ -118,6 +114,7 @@ public:
 private:
   FilterConfigSharedPtr config_;
   HttpPerRequestTapperPtr tapper_;
+  const Http::HeaderMap* request_trailers_{};
 };
 
 } // namespace TapFilter

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -16,7 +16,11 @@ public:
       // HTTP/1 on OSX. In this test we close the admin /tap stream when we don't want any
       // more data, and without immediate close detection we can't have a flake free test.
       // Thus, we use HTTP/2 for everything here.
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam(), realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam(), realTime()) {
+
+    // Also use HTTP/2 for upstream so that we can fully test trailers.
+    setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
+  }
 
   void initializeFilter(const std::string& filter_config) {
     config_helper_.addFilter(filter_config);
@@ -36,11 +40,36 @@ public:
   }
 
   void makeRequest(const Http::TestHeaderMapImpl& request_headers,
-                   const Http::TestHeaderMapImpl& response_headers) {
-    IntegrationStreamDecoderPtr decoder = codec_client_->makeHeaderOnlyRequest(request_headers);
+                   const Http::TestHeaderMapImpl* request_trailers,
+                   const Http::TestHeaderMapImpl& response_headers,
+                   const Http::TestHeaderMapImpl* response_trailers) {
+    IntegrationStreamDecoderPtr decoder;
+    if (request_trailers == nullptr) {
+      decoder = codec_client_->makeHeaderOnlyRequest(request_headers);
+    } else {
+      auto result = codec_client_->startRequest(request_headers);
+      decoder = std::move(result.second);
+      result.first.encodeTrailers(*request_trailers);
+    }
+
     waitForNextUpstreamRequest();
-    upstream_request_->encodeHeaders(response_headers, true);
+
+    upstream_request_->encodeHeaders(response_headers, response_trailers == nullptr);
+    if (response_trailers != nullptr) {
+      upstream_request_->encodeTrailers(*response_trailers);
+    }
+
     decoder->waitForEndStream();
+  }
+
+  void startAdminRequest(const std::string& admin_request_yaml) {
+    admin_client_ = makeHttpConnection(makeClientConnection(lookupPort("admin")));
+    const Http::TestHeaderMapImpl admin_request_headers{
+        {":method", "POST"}, {":path", "/tap"}, {":scheme", "http"}, {":authority", "host"}};
+    admin_response_ = admin_client_->makeRequestWithBody(admin_request_headers, admin_request_yaml);
+    admin_response_->waitForHeaders();
+    EXPECT_STREQ("200", admin_response_->headers().Status()->value().c_str());
+    EXPECT_FALSE(admin_response_->complete());
   }
 
   const Http::TestHeaderMapImpl request_headers_tap_{{":method", "GET"},
@@ -55,6 +84,18 @@ public:
   const Http::TestHeaderMapImpl response_headers_tap_{{":status", "200"}, {"bar", "baz"}};
 
   const Http::TestHeaderMapImpl response_headers_no_tap_{{":status", "200"}};
+
+  const std::string admin_filter_config_ =
+      R"EOF(
+name: envoy.filters.http.tap
+config:
+  common_config:
+    admin_config:
+      config_id: test_config_id
+)EOF";
+
+  IntegrationCodecClientPtr admin_client_;
+  IntegrationStreamDecoderPtr admin_response_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, TapIntegrationTest,
@@ -84,7 +125,7 @@ config:
 
   // Initial request/response with tap.
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  makeRequest(request_headers_tap_, response_headers_no_tap_);
+  makeRequest(request_headers_tap_, nullptr, response_headers_no_tap_, nullptr);
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
 
@@ -101,20 +142,11 @@ config:
 
 // Verify a basic tap flow using the admin handler.
 TEST_P(TapIntegrationTest, AdminBasicFlow) {
-  const std::string filter_config =
-      R"EOF(
-name: envoy.filters.http.tap
-config:
-  common_config:
-    admin_config:
-      config_id: test_config_id
-)EOF";
-
-  initializeFilter(filter_config);
+  initializeFilter(admin_filter_config_);
 
   // Initial request/response with no tap.
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  makeRequest(request_headers_tap_, response_headers_no_tap_);
+  makeRequest(request_headers_tap_, nullptr, response_headers_no_tap_, nullptr);
 
   const std::string admin_request_yaml =
       R"EOF(
@@ -123,11 +155,11 @@ tap_config:
   match_config:
     or_match:
       rules:
-        - http_request_match:
+        - http_request_headers_match:
             headers:
               - name: foo
                 exact_match: bar
-        - http_response_match:
+        - http_response_headers_match:
             headers:
               - name: bar
                 exact_match: baz
@@ -137,53 +169,41 @@ tap_config:
 )EOF";
 
   // Setup a tap and disconnect it without any request/response.
-  IntegrationCodecClientPtr admin_client_ =
-      makeHttpConnection(makeClientConnection(lookupPort("admin")));
-  const Http::TestHeaderMapImpl admin_request_headers{
-      {":method", "POST"}, {":path", "/tap"}, {":scheme", "http"}, {":authority", "host"}};
-  IntegrationStreamDecoderPtr admin_response =
-      admin_client_->makeRequestWithBody(admin_request_headers, admin_request_yaml);
-  admin_response->waitForHeaders();
-  EXPECT_STREQ("200", admin_response->headers().Status()->value().c_str());
-  EXPECT_FALSE(admin_response->complete());
+  startAdminRequest(admin_request_yaml);
   admin_client_->close();
   test_server_->waitForGaugeEq("http.admin.downstream_rq_active", 0);
 
   // Second request/response with no tap.
-  makeRequest(request_headers_tap_, response_headers_no_tap_);
+  makeRequest(request_headers_tap_, nullptr, response_headers_no_tap_, nullptr);
 
   // Setup the tap again and leave it open.
-  admin_client_ = makeHttpConnection(makeClientConnection(lookupPort("admin")));
-  admin_response = admin_client_->makeRequestWithBody(admin_request_headers, admin_request_yaml);
-  admin_response->waitForHeaders();
-  EXPECT_STREQ("200", admin_response->headers().Status()->value().c_str());
-  EXPECT_FALSE(admin_response->complete());
+  startAdminRequest(admin_request_yaml);
 
   // Do a request which should tap, matching on request headers.
-  makeRequest(request_headers_tap_, response_headers_no_tap_);
+  makeRequest(request_headers_tap_, nullptr, response_headers_no_tap_, nullptr);
 
   // Wait for the tap message.
-  admin_response->waitForBodyData(1);
+  admin_response_->waitForBodyData(1);
   envoy::data::tap::v2alpha::BufferedTraceWrapper trace;
-  MessageUtil::loadFromYaml(admin_response->body(), trace);
+  MessageUtil::loadFromYaml(admin_response_->body(), trace);
   EXPECT_EQ(trace.http_buffered_trace().request_headers().size(), 8);
-  EXPECT_EQ(trace.http_buffered_trace().response_headers().size(), 5);
-  admin_response->clearBody();
+  EXPECT_EQ(trace.http_buffered_trace().response_headers().size(), 4);
+  admin_response_->clearBody();
 
   // Do a request which should not tap.
-  makeRequest(request_headers_no_tap_, response_headers_no_tap_);
+  makeRequest(request_headers_no_tap_, nullptr, response_headers_no_tap_, nullptr);
 
   // Do a request which should tap, matching on response headers.
-  makeRequest(request_headers_no_tap_, response_headers_tap_);
+  makeRequest(request_headers_no_tap_, nullptr, response_headers_tap_, nullptr);
 
   // Wait for the tap message.
-  admin_response->waitForBodyData(1);
-  MessageUtil::loadFromYaml(admin_response->body(), trace);
+  admin_response_->waitForBodyData(1);
+  MessageUtil::loadFromYaml(admin_response_->body(), trace);
   EXPECT_EQ(trace.http_buffered_trace().request_headers().size(), 7);
   EXPECT_EQ(
       "http",
       findHeader("x-forwarded-proto", trace.http_buffered_trace().request_headers())->value());
-  EXPECT_EQ(trace.http_buffered_trace().response_headers().size(), 6);
+  EXPECT_EQ(trace.http_buffered_trace().response_headers().size(), 5);
   EXPECT_NE(nullptr, findHeader("date", trace.http_buffered_trace().response_headers()));
   EXPECT_EQ("baz", findHeader("bar", trace.http_buffered_trace().response_headers())->value());
 
@@ -198,11 +218,11 @@ tap_config:
   match_config:
     and_match:
       rules:
-        - http_request_match:
+        - http_request_headers_match:
             headers:
               - name: foo
                 exact_match: bar
-        - http_response_match:
+        - http_response_headers_match:
             headers:
               - name: bar
                 exact_match: baz
@@ -211,27 +231,66 @@ tap_config:
       - streaming_admin: {}
 )EOF";
 
-  admin_client_ = makeHttpConnection(makeClientConnection(lookupPort("admin")));
-  admin_response = admin_client_->makeRequestWithBody(admin_request_headers, admin_request_yaml2);
-  admin_response->waitForHeaders();
-  EXPECT_STREQ("200", admin_response->headers().Status()->value().c_str());
-  EXPECT_FALSE(admin_response->complete());
+  startAdminRequest(admin_request_yaml2);
 
   // Do a request that matches, but the response does not match. No tap.
-  makeRequest(request_headers_tap_, response_headers_no_tap_);
+  makeRequest(request_headers_tap_, nullptr, response_headers_no_tap_, nullptr);
 
   // Do a request that doesn't match, but the response does match. No tap.
-  makeRequest(request_headers_no_tap_, response_headers_tap_);
+  makeRequest(request_headers_no_tap_, nullptr, response_headers_tap_, nullptr);
 
   // Do a request that matches and a response that matches. Should tap.
-  makeRequest(request_headers_tap_, response_headers_tap_);
+  makeRequest(request_headers_tap_, nullptr, response_headers_tap_, nullptr);
 
   // Wait for the tap message.
-  admin_response->waitForBodyData(1);
-  MessageUtil::loadFromYaml(admin_response->body(), trace);
+  admin_response_->waitForBodyData(1);
+  MessageUtil::loadFromYaml(admin_response_->body(), trace);
 
   admin_client_->close();
   EXPECT_EQ(3UL, test_server_->counter("http.config_test.tap.rq_tapped")->value());
+}
+
+// Verify both request and response trailer matching works.
+TEST_P(TapIntegrationTest, AdminTrailers) {
+  initializeFilter(admin_filter_config_);
+
+  const std::string admin_request_yaml =
+      R"EOF(
+config_id: test_config_id
+tap_config:
+  match_config:
+    and_match:
+      rules:
+        - http_request_trailers_match:
+            headers:
+              - name: foo_trailer
+                exact_match: bar
+        - http_response_trailers_match:
+            headers:
+              - name: bar_trailer
+                exact_match: baz
+  output_config:
+    sinks:
+      - streaming_admin: {}
+)EOF";
+
+  startAdminRequest(admin_request_yaml);
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  const Http::TestHeaderMapImpl request_trailers{{"foo_trailer", "bar"}};
+  const Http::TestHeaderMapImpl response_trailers{{"bar_trailer", "baz"}};
+  makeRequest(request_headers_no_tap_, &request_trailers, response_headers_no_tap_,
+              &response_trailers);
+
+  envoy::data::tap::v2alpha::BufferedTraceWrapper trace;
+  admin_response_->waitForBodyData(1);
+  MessageUtil::loadFromYaml(admin_response_->body(), trace);
+  EXPECT_EQ("bar",
+            findHeader("foo_trailer", trace.http_buffered_trace().request_trailers())->value());
+  EXPECT_EQ("baz",
+            findHeader("bar_trailer", trace.http_buffered_trace().response_trailers())->value());
+
+  admin_client_->close();
 }
 
 } // namespace

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -186,8 +186,8 @@ tap_config:
   admin_response_->waitForBodyData(1);
   envoy::data::tap::v2alpha::BufferedTraceWrapper trace;
   MessageUtil::loadFromYaml(admin_response_->body(), trace);
-  EXPECT_EQ(trace.http_buffered_trace().request_headers().size(), 8);
-  EXPECT_EQ(trace.http_buffered_trace().response_headers().size(), 4);
+  EXPECT_EQ(trace.http_buffered_trace().request().headers().size(), 8);
+  EXPECT_EQ(trace.http_buffered_trace().response().headers().size(), 4);
   admin_response_->clearBody();
 
   // Do a request which should not tap.
@@ -199,13 +199,13 @@ tap_config:
   // Wait for the tap message.
   admin_response_->waitForBodyData(1);
   MessageUtil::loadFromYaml(admin_response_->body(), trace);
-  EXPECT_EQ(trace.http_buffered_trace().request_headers().size(), 7);
+  EXPECT_EQ(trace.http_buffered_trace().request().headers().size(), 7);
   EXPECT_EQ(
       "http",
-      findHeader("x-forwarded-proto", trace.http_buffered_trace().request_headers())->value());
-  EXPECT_EQ(trace.http_buffered_trace().response_headers().size(), 5);
-  EXPECT_NE(nullptr, findHeader("date", trace.http_buffered_trace().response_headers()));
-  EXPECT_EQ("baz", findHeader("bar", trace.http_buffered_trace().response_headers())->value());
+      findHeader("x-forwarded-proto", trace.http_buffered_trace().request().headers())->value());
+  EXPECT_EQ(trace.http_buffered_trace().response().headers().size(), 5);
+  EXPECT_NE(nullptr, findHeader("date", trace.http_buffered_trace().response().headers()));
+  EXPECT_EQ("baz", findHeader("bar", trace.http_buffered_trace().response().headers())->value());
 
   admin_client_->close();
   test_server_->waitForGaugeEq("http.admin.downstream_rq_active", 0);
@@ -286,9 +286,9 @@ tap_config:
   admin_response_->waitForBodyData(1);
   MessageUtil::loadFromYaml(admin_response_->body(), trace);
   EXPECT_EQ("bar",
-            findHeader("foo_trailer", trace.http_buffered_trace().request_trailers())->value());
+            findHeader("foo_trailer", trace.http_buffered_trace().request().trailers())->value());
   EXPECT_EQ("baz",
-            findHeader("bar_trailer", trace.http_buffered_trace().response_trailers())->value());
+            findHeader("bar_trailer", trace.http_buffered_trace().response().trailers())->value());
 
   admin_client_->close();
 }


### PR DESCRIPTION
1) Add request/response trailer matching
2) Output request/response trailers
3) Refactor matchers to reduce boilerplate and make it harder
   to make mistakes when adding new update functions.
4) Split out a match configuration for HTTP request and response
   into individual things like request headers, request trailers,
   etc. This will make it easier and more logical to add various
   types of body matching and wire it up using the existing and/or
   logic.

*Risk Level*: Low
*Testing*: New tests
*Docs Changes*: Complete
*Release Notes*: N/A
