### PR TITLE
stats: add usedonly option to prometheus output format

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -31,7 +31,7 @@ Version history
   virtual host level.
 * stats: added support for histograms in prometheus
 * stats: added usedonly flag to prometheus stats to only output metrics which have been
-  incremented/emitted at least once for the lifetime of the process.
+  updated at least once.
 * tap: added new alpha :ref:`HTTP tap filter <config_http_filters_tap>`.
 * tls: enabled TLS 1.3 on the server-side (non-FIPS builds).
 * router: added per-route configuration of :ref:`internal redirects <envoy_api_field_route.RouteAction.internal_redirect_action>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -30,6 +30,8 @@ Version history
 * router: added ability to configure a :ref:`retry policy <envoy_api_msg_route.RetryPolicy>` at the
   virtual host level.
 * stats: added support for histograms in prometheus
+* stats: added usedonly flag to prometheus stats to only output metrics which have been
+  incremented/emitted at least once for the lifetime of the process.
 * tap: added new alpha :ref:`HTTP tap filter <config_http_filters_tap>`.
 * tls: enabled TLS 1.3 on the server-side (non-FIPS builds).
 * router: added per-route configuration of :ref:`internal redirects <envoy_api_field_route.RouteAction.internal_redirect_action>`.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -312,6 +312,10 @@ explanation of the output.
   Outputs /stats in `Prometheus <https://prometheus.io/docs/instrumenting/exposition_formats/>`_
   v0.0.4 format. This can be used to integrate with a Prometheus server.
 
+  You can optionally pass the `usedonly` URL query argument to only get statistics that
+  Envoy has updated (counters incremented at least once, gauges changed at least once,
+  and histograms added to at least once)
+
 .. _operations_admin_interface_runtime:
 
 .. http:get:: /runtime

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -376,7 +376,7 @@ public:
   static uint64_t statsAsPrometheus(const std::vector<Stats::CounterSharedPtr>& counters,
                                     const std::vector<Stats::GaugeSharedPtr>& gauges,
                                     const std::vector<Stats::ParentHistogramSharedPtr>& histograms,
-                                    Buffer::Instance& response);
+                                    Buffer::Instance& response, const bool used_only);
   /**
    * Format the given tags, returning a string as a comma-separated list
    * of <tag_name>="<tag_value>" pairs.
@@ -392,6 +392,14 @@ private:
    * Take a string and sanitize it according to Prometheus conventions.
    */
   static std::string sanitizeName(const std::string& name);
+
+  /*
+   * Determine whether a metric has never been emitted and choose to
+   * not show it if we only wanted used metrics.
+   */
+  static bool shouldShowMetric(const std::shared_ptr<Stats::Metric>& metric, const bool used_only) {
+    return !used_only || metric->used();
+  }
 };
 
 } // namespace Server


### PR DESCRIPTION
*Description*: Adds support for the `usedonly` flag when outputting Prometheus stats. This will omit metrics which have never been updated by Envoy. 

*Risk Level*: Low
*Testing*: Added a few more unit tests to the admin side to ensure it works as intended
*Docs Changes*: Added a small sentence in the documentation about the `usedonly` flag
*Release Notes*: Added a release note item to version_history

We've been running with this at Monzo over the past couple days and it has drastically cut down on the sheer volume of metrics from each Envoy instance.