### PR TITLE
cds: continue with remaining clusters if one addOrUpdateCluster fails

### DIFF
--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -48,9 +48,9 @@ void CdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
     }
   }
   for (const auto& cluster : resources) {
-    MessageUtil::validate(cluster);
+   MessageUtil::validate(cluster);
   }
-  // We need to keep track of which clusters we might need to remove.
+  //We need to keep track of which clusters we might need to remove.
   ClusterManager::ClusterInfoMap clusters_to_remove = cm_.clusters();
   for (auto& cluster : resources) {
     const std::string cluster_name = cluster.name();

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -46,7 +46,6 @@ private:
              Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
              const LocalInfo::LocalInfo& local_info, Stats::Scope& scope, Api::Api& api);
   void runInitializeCallbackIfAny();
-  void throwIfExceptionOccured(const std::list<std::string>&);
 
   ClusterManager& cm_;
   std::unique_ptr<Config::Subscription<envoy::api::v2::Cluster>> subscription_;

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -46,6 +46,7 @@ private:
              Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
              const LocalInfo::LocalInfo& local_info, Stats::Scope& scope, Api::Api& api);
   void runInitializeCallbackIfAny();
+  void throwIfExceptionOccured(const std::list<std::string>&);
 
   ClusterManager& cm_;
   std::unique_ptr<Config::Subscription<envoy::api::v2::Cluster>> subscription_;

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -198,8 +198,12 @@ TEST_F(CdsApiImplTest, ConfigUpdateAddsSecondClusterEvenIfFirstThrows) {
   cluster_2->set_name("cluster_2");
   expectAdd("cluster_2");
 
+  auto* cluster_3 = clusters.Add();
+  cluster_3->set_name("cluster_3");
+  expectAddToThrow("cluster_3", "Another exception");
+
   EXPECT_THROW_WITH_MESSAGE(dynamic_cast<CdsApiImpl*>(cds_.get())->onConfigUpdate(clusters, ""),
-                            EnvoyException, "An exception");
+                            EnvoyException, "An exception\nAnother exception");
 }
 
 TEST_F(CdsApiImplTest, InvalidOptions) {


### PR DESCRIPTION
Co-authored-by: Ulrich Kramer <u.kramer@sap.com>
Signed-off-by: Ulrich Kramer <u.kramer@sap.com>
Signed-off-by: Holger Oehm <holger.oehm@sap.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Currently when multiple clusters are changed with CDS, the first cluster in error aborts the application of these changes. This means that all changes before a cluster with an error are applied, but all changes after that cluster are not. This fix changes the behaviour so that exceptions in addOrUpdateCluster are collected and reported after the loop over all clusters. 
*Risk Level*: Low
*Testing*: We did a manual test with the change in place
*Docs Changes*: N/A
*Release Notes*: N/A
