### PR TITLE
Fix setReference() call in hystrix stats sink

### DIFF
--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -9,6 +9,7 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/logger.h"
+#include "common/common/macros.h"
 #include "common/config/well_known_names.h"
 #include "common/http/headers.h"
 
@@ -275,6 +276,8 @@ HystrixSink::HystrixSink(Server::Instance& server, const uint64_t num_buckets)
                    MAKE_ADMIN_HANDLER(handlerHystrixEventStream), false, false);
 }
 
+const std::string& HystrixSink::zeroValue() const { CONSTRUCT_ON_FIRST_USE(std::string, "0"); }
+
 Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
                                                   Http::HeaderMap& response_headers,
                                                   Buffer::Instance&,
@@ -290,7 +293,7 @@ Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
       AccessControlAllowHeadersValue.AllowHeadersHystrix);
   response_headers.insertAccessControlAllowOrigin().value().setReference(
       Http::Headers::get().AccessControlAllowOriginValue.All);
-  response_headers.insertNoChunks().value().setReference("0");
+  response_headers.insertNoChunks().value().setReference(zeroValue());
 
   Http::StreamDecoderFilterCallbacks& stream_decoder_filter_callbacks =
       admin_stream.getDecoderFilterCallbacks();

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -9,7 +9,6 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/logger.h"
-#include "common/common/macros.h"
 #include "common/config/well_known_names.h"
 #include "common/http/headers.h"
 
@@ -276,8 +275,6 @@ HystrixSink::HystrixSink(Server::Instance& server, const uint64_t num_buckets)
                    MAKE_ADMIN_HANDLER(handlerHystrixEventStream), false, false);
 }
 
-const std::string& HystrixSink::zeroValue() const { CONSTRUCT_ON_FIRST_USE(std::string, "0"); }
-
 Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
                                                   Http::HeaderMap& response_headers,
                                                   Buffer::Instance&,
@@ -293,7 +290,7 @@ Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
       AccessControlAllowHeadersValue.AllowHeadersHystrix);
   response_headers.insertAccessControlAllowOrigin().value().setReference(
       Http::Headers::get().AccessControlAllowOriginValue.All);
-  response_headers.insertNoChunks().value().setReference(zeroValue());
+  response_headers.insertNoChunks().value().setInteger(0);
 
   Http::StreamDecoderFilterCallbacks& stream_decoder_filter_callbacks =
       admin_stream.getDecoderFilterCallbacks();

--- a/source/extensions/stat_sinks/hystrix/hystrix.h
+++ b/source/extensions/stat_sinks/hystrix/hystrix.h
@@ -147,6 +147,8 @@ private:
                             uint64_t reporting_hosts, std::chrono::milliseconds rolling_window_ms,
                             std::stringstream& ss);
 
+  const std::string& zeroValue() const;
+
   std::vector<Http::StreamDecoderFilterCallbacks*> callbacks_list_;
   Server::Instance& server_;
   uint64_t current_index_;

--- a/source/extensions/stat_sinks/hystrix/hystrix.h
+++ b/source/extensions/stat_sinks/hystrix/hystrix.h
@@ -147,8 +147,6 @@ private:
                             uint64_t reporting_hosts, std::chrono::milliseconds rolling_window_ms,
                             std::stringstream& ss);
 
-  const std::string& zeroValue() const;
-
   std::vector<Http::StreamDecoderFilterCallbacks*> callbacks_list_;
   Server::Instance& server_;
   uint64_t current_index_;


### PR DESCRIPTION
Per:

https://github.com/envoyproxy/envoy/blob/master/include/envoy/http/header_map.h#L148

`setReference()` needs a std::string ref that will live beyond
the lifetime of a request/response, but it's currently receiving
a string literal which is used to construct a temporary
std::string.

So instead pass a static std::string.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
