### PR TITLE
upstream: move HostSet updates to PrioritySet

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -376,20 +376,6 @@ public:
                            LocalityWeightsConstSharedPtr locality_weights,
                            const HostVector& hosts_added, const HostVector& hosts_removed,
                            absl::optional<uint32_t> overprovisioning_factor) PURE;
-  /**
-   * Updates the hosts in a given host set.
-   *
-   * @param priority the priority of the host set to update.
-   * @param update_hosts_param supplies the list of hosts and hosts per locality.
-   * @param locality_weights supplies a map from locality to associated weight.
-   * @param hosts_added supplies the hosts added since the last update.
-   * @param hosts_removed supplies the hosts removed since the last update.
-   * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
-   */
-  virtual void updateHosts(uint32_t priority, UpdateHostsParams&& update_host_params,
-                           LocalityWeightsConstSharedPtr locality_weights,
-                           const HostVector& hosts_added, const HostVector& hosts_removed,
-                           absl::optional<uint32_t> overprovisioning_factor) const PURE;
 };
 
 /**

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -376,6 +376,20 @@ public:
                            LocalityWeightsConstSharedPtr locality_weights,
                            const HostVector& hosts_added, const HostVector& hosts_removed,
                            absl::optional<uint32_t> overprovisioning_factor) PURE;
+  /**
+   * Updates the hosts in a given host set.
+   *
+   * @param priority the priority of the host set to update.
+   * @param update_hosts_param supplies the list of hosts and hosts per locality.
+   * @param locality_weights supplies a map from locality to associated weight.
+   * @param hosts_added supplies the hosts added since the last update.
+   * @param hosts_removed supplies the hosts removed since the last update.
+   * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
+   */
+  virtual void updateHosts(uint32_t priority, UpdateHostsParams&& update_host_params,
+                           LocalityWeightsConstSharedPtr locality_weights,
+                           const HostVector& hosts_added, const HostVector& hosts_removed,
+                           absl::optional<uint32_t> overprovisioning_factor) const PURE;
 };
 
 /**

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -297,32 +297,6 @@ public:
   virtual absl::optional<uint32_t> chooseLocality() PURE;
 
   /**
-   * Parameter class for updateHosts.
-   */
-  struct UpdateHostsParams {
-    HostVectorConstSharedPtr hosts;
-    HostVectorConstSharedPtr healthy_hosts;
-    HostVectorConstSharedPtr degraded_hosts;
-    HostsPerLocalityConstSharedPtr hosts_per_locality;
-    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality;
-    HostsPerLocalityConstSharedPtr degraded_hosts_per_locality;
-  };
-
-  /**
-   * Updates the hosts in a given host set.
-   *
-   * @param update_hosts_param supplies the list of hosts and hosts per locality.
-   * @param locality_weights supplies a map from locality to associated weight.
-   * @param hosts_added supplies the hosts added since the last update.
-   * @param hosts_removed supplies the hosts removed since the last update.
-   * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
-   */
-  virtual void updateHosts(UpdateHostsParams&& update_host_params,
-                           LocalityWeightsConstSharedPtr locality_weights,
-                           const HostVector& hosts_added, const HostVector& hosts_removed,
-                           absl::optional<uint32_t> overprovisioning_factor) PURE;
-
-  /**
    * @return uint32_t the priority of this host set.
    */
   virtual uint32_t priority() const PURE;
@@ -372,17 +346,36 @@ public:
   virtual Common::CallbackHandle* addPriorityUpdateCb(PriorityUpdateCb callback) const PURE;
 
   /**
-   * Returns the host sets for this priority set, ordered by priority.
-   * The first element in the vector is the host set for priority 0, and so on.
-   *
-   * @return std::vector<HostSetPtr>& the host sets for this priority set.
-   */
-  virtual std::vector<HostSetPtr>& hostSetsPerPriority() PURE;
-
-  /**
    * @return const std::vector<HostSetPtr>& the host sets, ordered by priority.
    */
   virtual const std::vector<HostSetPtr>& hostSetsPerPriority() const PURE;
+
+  /**
+   * Parameter class for updateHosts.
+   */
+  struct UpdateHostsParams {
+    HostVectorConstSharedPtr hosts;
+    HostVectorConstSharedPtr healthy_hosts;
+    HostVectorConstSharedPtr degraded_hosts;
+    HostsPerLocalityConstSharedPtr hosts_per_locality;
+    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality;
+    HostsPerLocalityConstSharedPtr degraded_hosts_per_locality;
+  };
+
+  /**
+   * Updates the hosts in a given host set.
+   *
+   * @param priority the priority of the host set to update.
+   * @param update_hosts_param supplies the list of hosts and hosts per locality.
+   * @param locality_weights supplies a map from locality to associated weight.
+   * @param hosts_added supplies the hosts added since the last update.
+   * @param hosts_removed supplies the hosts removed since the last update.
+   * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
+   */
+  virtual void updateHosts(uint32_t priority, UpdateHostsParams&& update_host_params,
+                           LocalityWeightsConstSharedPtr locality_weights,
+                           const HostVector& hosts_added, const HostVector& hosts_removed,
+                           absl::optional<uint32_t> overprovisioning_factor) PURE;
 };
 
 /**

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -914,7 +914,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::removeTcpConn(
 }
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
-    const std::string& name, uint32_t priority, HostSet::UpdateHostsParams&& update_hosts_params,
+    const std::string& name, uint32_t priority,
+    PrioritySet::UpdateHostsParams&& update_hosts_params,
     LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
     const HostVector& hosts_removed, ThreadLocal::Slot& tls) {
 
@@ -924,9 +925,9 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
   const auto& cluster_entry = config.thread_local_clusters_[name];
   ENVOY_LOG(debug, "membership update for TLS cluster {} added {} removed {}", name,
             hosts_added.size(), hosts_removed.size());
-  cluster_entry->priority_set_.getOrCreateHostSet(priority).updateHosts(
-      std::move(update_hosts_params), std::move(locality_weights), hosts_added, hosts_removed,
-      absl::nullopt);
+  cluster_entry->priority_set_.updateHosts(priority, std::move(update_hosts_params),
+                                           std::move(locality_weights), hosts_added, hosts_removed,
+                                           absl::nullopt);
 
   // If an LB is thread aware, create a new worker local LB on membership changes.
   if (cluster_entry->lb_factory_ != nullptr) {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -310,7 +310,7 @@ private:
     void drainTcpConnPools(HostSharedPtr old_host, TcpConnPoolsContainer& container);
     void removeTcpConn(const HostConstSharedPtr& host, Network::ClientConnection& connection);
     static void updateClusterMembership(const std::string& name, uint32_t priority,
-                                        HostSet::UpdateHostsParams&& update_hosts_params,
+                                        PrioritySet::UpdateHostsParams&& update_hosts_params,
                                         LocalityWeightsConstSharedPtr locality_weights,
                                         const HostVector& hosts_added,
                                         const HostVector& hosts_removed, ThreadLocal::Slot& tls);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -423,8 +423,10 @@ private:
   Stats::Store& stats_;
   ThreadLocal::SlotPtr tls_;
   Runtime::RandomGenerator& random_;
+
 protected:
   ClusterMap active_clusters_;
+
 private:
   ClusterMap warming_clusters_;
   envoy::api::v2::core::BindConfig bind_config_;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -423,7 +423,9 @@ private:
   Stats::Store& stats_;
   ThreadLocal::SlotPtr tls_;
   Runtime::RandomGenerator& random_;
+protected:
   ClusterMap active_clusters_;
+private:
   ClusterMap warming_clusters_;
   envoy::api::v2::core::BindConfig bind_config_;
   Outlier::EventLoggerSharedPtr outlier_event_logger_;

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -251,10 +251,8 @@ void HdsCluster::initialize(std::function<void()> callback) {
     host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   }
 
-  auto& first_host_set = priority_set_.getOrCreateHostSet(0);
-
-  first_host_set.updateHosts(
-      HostSetImpl::partitionHosts(initial_hosts_, HostsPerLocalityImpl::empty()), {},
+  priority_set_.updateHosts(
+      0, HostSetImpl::partitionHosts(initial_hosts_, HostsPerLocalityImpl::empty()), {},
       *initial_hosts_, {}, absl::nullopt);
 }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -145,11 +145,12 @@ OriginalDstCluster::OriginalDstCluster(
 void OriginalDstCluster::addHost(HostSharedPtr& host) {
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
-  auto& first_host_set = priority_set_.getOrCreateHostSet(0);
+  const auto& first_host_set = priority_set_.getOrCreateHostSet(0);
   HostVectorSharedPtr new_hosts(new HostVector(first_host_set.hosts()));
   new_hosts->emplace_back(host);
-  first_host_set.updateHosts(HostSetImpl::partitionHosts(new_hosts, HostsPerLocalityImpl::empty()),
-                             {}, {std::move(host)}, {}, absl::nullopt);
+  priority_set_.updateHosts(0,
+                            HostSetImpl::partitionHosts(new_hosts, HostsPerLocalityImpl::empty()),
+                            {}, {std::move(host)}, {}, absl::nullopt);
 }
 
 void OriginalDstCluster::cleanup() {
@@ -157,7 +158,7 @@ void OriginalDstCluster::cleanup() {
   HostVector to_be_removed;
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
-  auto& host_set = priority_set_.getOrCreateHostSet(0);
+  const auto& host_set = priority_set_.getOrCreateHostSet(0);
 
   ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
   for (const HostSharedPtr& host : host_set.hosts()) {
@@ -172,8 +173,9 @@ void OriginalDstCluster::cleanup() {
   }
 
   if (to_be_removed.size() > 0) {
-    host_set.updateHosts(HostSetImpl::partitionHosts(new_hosts, HostsPerLocalityImpl::empty()), {},
-                         {}, to_be_removed, absl::nullopt);
+    priority_set_.updateHosts(0,
+                              HostSetImpl::partitionHosts(new_hosts, HostsPerLocalityImpl::empty()),
+                              {}, {}, to_be_removed, absl::nullopt);
   }
 
   cleanup_timer_->enableTimer(cleanup_interval_ms_);

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -603,7 +603,7 @@ HostSetImplPtr SubsetLoadBalancer::PrioritySubsetImpl::createHostSet(
 void SubsetLoadBalancer::PrioritySubsetImpl::update(uint32_t priority,
                                                     const HostVector& hosts_added,
                                                     const HostVector& hosts_removed) {
-  HostSubsetImpl* host_subset = getOrCreateHostSubset(priority);
+  HostSubsetImpl* host_subset = getOrCreateMutableHostSubset(priority);
   host_subset->update(hosts_added, hosts_removed, predicate_);
 
   if (host_subset->hosts().empty() != empty_) {

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -603,10 +603,10 @@ HostSetImplPtr SubsetLoadBalancer::PrioritySubsetImpl::createHostSet(
 void SubsetLoadBalancer::PrioritySubsetImpl::update(uint32_t priority,
                                                     const HostVector& hosts_added,
                                                     const HostVector& hosts_removed) {
-  HostSubsetImpl* host_subset = getOrCreateMutableHostSubset(priority);
-  host_subset->update(hosts_added, hosts_removed, predicate_);
+  const auto& host_subset = getOrCreateHostSet(priority);
+  updateSubset(priority, hosts_added, hosts_removed, predicate_);
 
-  if (host_subset->hosts().empty() != empty_) {
+  if (host_subset.hosts().empty() != empty_) {
     empty_ = true;
     for (auto& host_set : hostSetsPerPriority()) {
       empty_ &= host_set->hosts().empty();

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -69,13 +69,13 @@ private:
 
     bool empty() { return empty_; }
 
-    HostSubsetImpl* getOrCreateHostSubset(uint32_t priority) {
-      return reinterpret_cast<HostSubsetImpl*>(&getOrCreateHostSet(priority));
+    const HostSubsetImpl* getOrCreateHostSubset(uint32_t priority) {
+      return reinterpret_cast<const HostSubsetImpl*>(&getOrCreateMutableHostSet(priority));
     }
 
     void triggerCallbacks() {
       for (size_t i = 0; i < hostSetsPerPriority().size(); ++i) {
-        getOrCreateHostSubset(i)->triggerCallbacks();
+        getOrCreateMutableHostSubset(i)->triggerCallbacks();
       }
     }
 
@@ -87,6 +87,10 @@ private:
   protected:
     HostSetImplPtr createHostSet(uint32_t priority,
                                  absl::optional<uint32_t> overprovisioning_factor) override;
+
+    HostSubsetImpl* getOrCreateMutableHostSubset(uint32_t priority) {
+      return reinterpret_cast<HostSubsetImpl*>(&getOrCreateMutableHostSet(priority));
+    }
 
   private:
     const PrioritySet& original_priority_set_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -397,13 +397,6 @@ PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
   return *host_sets_[priority];
 }
 
-HostSet&
-PrioritySetImpl::getOrCreateMutableHostSet(uint32_t priority,
-                                           absl::optional<uint32_t> overprovisioning_factor) {
-  getOrCreateHostSet(priority, overprovisioning_factor);
-  return *host_sets_[priority];
-}
-
 void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
                                   LocalityWeightsConstSharedPtr locality_weights,
                                   const HostVector& hosts_added, const HostVector& hosts_removed,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -233,7 +233,7 @@ HostsPerLocalityImpl::filter(std::function<bool(const Host&)> predicate) const {
   return shared_filtered_clone;
 }
 
-void HostSetImpl::updateHosts(UpdateHostsParams&& update_hosts_params,
+void HostSetImpl::updateHosts(PrioritySet::UpdateHostsParams&& update_hosts_params,
                               LocalityWeightsConstSharedPtr locality_weights,
                               const HostVector& hosts_added, const HostVector& hosts_removed,
                               absl::optional<uint32_t> overprovisioning_factor) {
@@ -314,14 +314,14 @@ absl::optional<uint32_t> HostSetImpl::chooseLocality() {
   return locality->index_;
 }
 
-HostSetImpl::UpdateHostsParams
+PrioritySet::UpdateHostsParams
 HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,
                                HostsPerLocalityConstSharedPtr hosts_per_locality) {
   return updateHostsParams(std::move(hosts), std::move(hosts_per_locality),
                            std::make_shared<const HostVector>(), HostsPerLocalityImpl::empty());
 }
 
-HostSetImpl::UpdateHostsParams
+PrioritySet::UpdateHostsParams
 HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,
                                HostsPerLocalityConstSharedPtr hosts_per_locality,
                                HostVectorConstSharedPtr healthy_hosts,
@@ -331,22 +331,22 @@ HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,
                            std::make_shared<const HostVector>(), HostsPerLocalityImpl::empty());
 }
 
-HostSetImpl::UpdateHostsParams
+PrioritySet::UpdateHostsParams
 HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,
                                HostsPerLocalityConstSharedPtr hosts_per_locality,
                                HostVectorConstSharedPtr healthy_hosts,
                                HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
                                HostVectorConstSharedPtr degraded_hosts,
                                HostsPerLocalityConstSharedPtr degraded_hosts_per_locality) {
-  return UpdateHostsParams{std::move(hosts),
-                           std::move(healthy_hosts),
-                           std::move(degraded_hosts),
-                           std::move(hosts_per_locality),
-                           std::move(healthy_hosts_per_locality),
-                           std::move(degraded_hosts_per_locality)};
+  return PrioritySet::UpdateHostsParams{std::move(hosts),
+                                        std::move(healthy_hosts),
+                                        std::move(degraded_hosts),
+                                        std::move(hosts_per_locality),
+                                        std::move(healthy_hosts_per_locality),
+                                        std::move(degraded_hosts_per_locality)};
 }
 
-HostSetImpl::UpdateHostsParams
+PrioritySet::UpdateHostsParams
 HostSetImpl::partitionHosts(HostVectorConstSharedPtr hosts,
                             HostsPerLocalityConstSharedPtr hosts_per_locality) {
   auto healthy_hosts = ClusterImplBase::createHostList(*hosts, Host::Health::Healthy);
@@ -381,20 +381,36 @@ double HostSetImpl::effectiveLocalityWeight(uint32_t index,
   return weight * effective_locality_availability_ratio;
 }
 
-HostSet& PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
-                                             absl::optional<uint32_t> overprovisioning_factor) {
+const HostSet&
+PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
+                                    absl::optional<uint32_t> overprovisioning_factor) {
   if (host_sets_.size() < priority + 1) {
     for (size_t i = host_sets_.size(); i <= priority; ++i) {
       HostSetImplPtr host_set = createHostSet(i, overprovisioning_factor);
       host_set->addPriorityUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
                                            const HostVector& hosts_removed) {
-        runUpdateCallbacks(hosts_added, hosts_removed);
         runReferenceUpdateCallbacks(priority, hosts_added, hosts_removed);
       });
       host_sets_.push_back(std::move(host_set));
     }
   }
   return *host_sets_[priority];
+}
+
+void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
+                                  LocalityWeightsConstSharedPtr locality_weights,
+                                  const HostVector& hosts_added, const HostVector& hosts_removed,
+                                  absl::optional<uint32_t> overprovisioning_factor) {
+  // TODO(snowp): Add a batched update mode that allows updating multiple HostSet and invoke the
+  // membership update cb for the resulting host diff.
+
+  // Ensure that we have a HostSet for the given priority.
+  getOrCreateHostSet(priority, overprovisioning_factor);
+
+  static_cast<HostSetImpl*>(host_sets_[priority].get())
+      ->updateHosts(std::move(update_hosts_params), std::move(locality_weights), hosts_added,
+                    hosts_removed, overprovisioning_factor);
+  runUpdateCallbacks(hosts_added, hosts_removed);
 }
 
 ClusterStats ClusterInfoImpl::generateStats(Stats::Scope& scope) {
@@ -758,12 +774,15 @@ void ClusterImplBase::reloadHealthyHosts() {
     return;
   }
 
-  for (auto& host_set : prioritySet().hostSetsPerPriority()) {
+  const auto& host_sets = prioritySet().hostSetsPerPriority();
+  for (size_t priority = 0; priority < host_sets.size(); ++priority) {
+    const auto& host_set = host_sets[priority];
     // TODO(htuch): Can we skip these copies by exporting out const shared_ptr from HostSet?
     HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
     HostsPerLocalityConstSharedPtr hosts_per_locality_copy = host_set->hostsPerLocality().clone();
-    host_set->updateHosts(HostSetImpl::partitionHosts(hosts_copy, hosts_per_locality_copy),
-                          host_set->localityWeights(), {}, {}, absl::nullopt);
+    prioritySet().updateHosts(priority,
+                              HostSetImpl::partitionHosts(hosts_copy, hosts_per_locality_copy),
+                              host_set->localityWeights(), {}, {}, absl::nullopt);
   }
 }
 
@@ -956,11 +975,10 @@ void PriorityStateManager::updateClusterPrioritySet(
   auto per_locality_shared =
       std::make_shared<HostsPerLocalityImpl>(std::move(per_locality), non_empty_local_locality);
 
-  auto& host_set = static_cast<PrioritySetImpl&>(parent_.prioritySet())
-                       .getOrCreateHostSet(priority, overprovisioning_factor);
-  host_set.updateHosts(HostSetImpl::partitionHosts(hosts, per_locality_shared),
-                       std::move(locality_weights), hosts_added.value_or(*hosts),
-                       hosts_removed.value_or<HostVector>({}), overprovisioning_factor);
+  parent_.prioritySet().updateHosts(
+      priority, HostSetImpl::partitionHosts(hosts, per_locality_shared),
+      std::move(locality_weights), hosts_added.value_or(*hosts),
+      hosts_removed.value_or<HostVector>({}), overprovisioning_factor);
 }
 
 StaticClusterImpl::StaticClusterImpl(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -410,28 +410,13 @@ void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_
                                   absl::optional<uint32_t> overprovisioning_factor) {
   // Ensure that we have a HostSet for the given priority.
   getOrCreateHostSet(priority, overprovisioning_factor);
-  static_cast<const PrioritySetImpl*>(this)->updateHosts(priority, std::move(update_hosts_params),
-                                                         std::move(locality_weights), hosts_added,
-                                                         hosts_removed, overprovisioning_factor);
-  // TODO(snowp): We only run this for the non-const overload, which might be errorprone. This is
-  // only used in test, so there's probably a better way of exposing that doesn't expose the HostSet
-  // directly.
-  runUpdateCallbacks(hosts_added, hosts_removed);
-}
-
-void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
-                                  LocalityWeightsConstSharedPtr locality_weights,
-                                  const HostVector& hosts_added, const HostVector& hosts_removed,
-                                  absl::optional<uint32_t> overprovisioning_factor) const {
-  // If we're modifying through the const accessor, we can't make a new HostSet, so just ASSERT.
-  ASSERT(host_sets_.size() >= priority);
-  //
   // TODO(snowp): Add a batched update mode that allows updating multiple HostSet and invoke the
   // membership update cb for the resulting host diff.
-
   static_cast<HostSetImpl*>(host_sets_[priority].get())
       ->updateHosts(std::move(update_hosts_params), std::move(locality_weights), hosts_added,
                     hosts_removed, overprovisioning_factor);
+
+  runUpdateCallbacks(hosts_added, hosts_removed);
 }
 
 ClusterStats ClusterInfoImpl::generateStats(Stats::Scope& scope) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -397,20 +397,41 @@ PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
   return *host_sets_[priority];
 }
 
+HostSet&
+PrioritySetImpl::getOrCreateMutableHostSet(uint32_t priority,
+                                           absl::optional<uint32_t> overprovisioning_factor) {
+  getOrCreateHostSet(priority, overprovisioning_factor);
+  return *host_sets_[priority];
+}
+
 void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
                                   LocalityWeightsConstSharedPtr locality_weights,
                                   const HostVector& hosts_added, const HostVector& hosts_removed,
                                   absl::optional<uint32_t> overprovisioning_factor) {
-  // TODO(snowp): Add a batched update mode that allows updating multiple HostSet and invoke the
-  // membership update cb for the resulting host diff.
-
   // Ensure that we have a HostSet for the given priority.
   getOrCreateHostSet(priority, overprovisioning_factor);
+  static_cast<const PrioritySetImpl*>(this)->updateHosts(priority, std::move(update_hosts_params),
+                                                         std::move(locality_weights), hosts_added,
+                                                         hosts_removed, overprovisioning_factor);
+  // TODO(snowp): We only run this for the non-const overload, which might be errorprone. This is
+  // only used in test, so there's probably a better way of exposing that doesn't expose the HostSet
+  // directly.
+  runUpdateCallbacks(hosts_added, hosts_removed);
+}
+
+void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
+                                  LocalityWeightsConstSharedPtr locality_weights,
+                                  const HostVector& hosts_added, const HostVector& hosts_removed,
+                                  absl::optional<uint32_t> overprovisioning_factor) const {
+  // If we're modifying through the const accessor, we can't make a new HostSet, so just ASSERT.
+  ASSERT(host_sets_.size() >= priority);
+  //
+  // TODO(snowp): Add a batched update mode that allows updating multiple HostSet and invoke the
+  // membership update cb for the resulting host diff.
 
   static_cast<HostSetImpl*>(host_sets_[priority].get())
       ->updateHosts(std::move(update_hosts_params), std::move(locality_weights), hosts_added,
                     hosts_removed, overprovisioning_factor);
-  runUpdateCallbacks(hosts_added, hosts_removed);
 }
 
 ClusterStats ClusterInfoImpl::generateStats(Stats::Scope& scope) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -409,12 +409,22 @@ public:
                    const HostVector& hosts_removed,
                    absl::optional<uint32_t> overprovisioning_factor = absl::nullopt) override;
 
+  void updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
+                   LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
+                   const HostVector& hosts_removed,
+                   absl::optional<uint32_t> overprovisioning_factor = absl::nullopt) const override;
+
 protected:
   // Allows subclasses of PrioritySetImpl to create their own type of HostSetImpl.
   virtual HostSetImplPtr createHostSet(uint32_t priority,
                                        absl::optional<uint32_t> overprovisioning_factor) {
     return std::make_unique<HostSetImpl>(priority, overprovisioning_factor);
   }
+
+  // Get the host set for this priority level, creating it if necessary.
+  HostSet&
+  getOrCreateMutableHostSet(uint32_t priority,
+                            absl::optional<uint32_t> overprovisioning_factor = absl::nullopt);
 
 private:
   virtual void runUpdateCallbacks(const HostVector& hosts_added, const HostVector& hosts_removed) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -409,11 +409,6 @@ public:
                    const HostVector& hosts_removed,
                    absl::optional<uint32_t> overprovisioning_factor = absl::nullopt) override;
 
-  void updateHosts(uint32_t priority, UpdateHostsParams&& update_hosts_params,
-                   LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
-                   const HostVector& hosts_removed,
-                   absl::optional<uint32_t> overprovisioning_factor = absl::nullopt) const override;
-
 protected:
   // Allows subclasses of PrioritySetImpl to create their own type of HostSetImpl.
   virtual HostSetImplPtr createHostSet(uint32_t priority,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -416,12 +416,7 @@ protected:
     return std::make_unique<HostSetImpl>(priority, overprovisioning_factor);
   }
 
-  // Get the host set for this priority level, creating it if necessary.
-  HostSet&
-  getOrCreateMutableHostSet(uint32_t priority,
-                            absl::optional<uint32_t> overprovisioning_factor = absl::nullopt);
-
-private:
+protected:
   virtual void runUpdateCallbacks(const HostVector& hosts_added, const HostVector& hosts_removed) {
     member_update_cb_helper_.runCallbacks(hosts_added, hosts_removed);
   }
@@ -433,6 +428,8 @@ private:
   // It will expand as host sets are added but currently does not shrink to
   // avoid any potential lifetime issues.
   std::vector<std::unique_ptr<HostSet>> host_sets_;
+
+private:
   // TODO(mattklein123): Remove mutable.
   mutable Common::CallbackManager<const HostVector&, const HostVector&> member_update_cb_helper_;
   mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -202,7 +202,7 @@ TEST_F(SubscriptionFactoryTest, LegacySubscription) {
   api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::UNSUPPORTED_REST_LEGACY);
   api_config_source->add_cluster_names("static_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
@@ -220,7 +220,7 @@ TEST_F(SubscriptionFactoryTest, HttpSubscriptionCustomRequestTimeout) {
   api_config_source->mutable_refresh_delay()->set_seconds(1);
   api_config_source->mutable_request_timeout()->set_seconds(5);
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
@@ -240,7 +240,7 @@ TEST_F(SubscriptionFactoryTest, HttpSubscription) {
   api_config_source->add_cluster_names("static_cluster");
   api_config_source->mutable_refresh_delay()->set_seconds(1);
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
@@ -267,7 +267,7 @@ TEST_F(SubscriptionFactoryTest, HttpSubscriptionNoRefreshDelay) {
   api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
   api_config_source->add_cluster_names("static_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
@@ -338,7 +338,7 @@ TEST_P(SubscriptionFactoryTestApiConfigSource, DynamicCluster) {
     api_config_source->add_cluster_names("static_cluster");
   }
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info());
@@ -360,7 +360,7 @@ TEST_P(SubscriptionFactoryTestApiConfigSource, EDSClusterBackingEDSCluster) {
     api_config_source->add_cluster_names("static_cluster");
   }
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -85,7 +85,7 @@ TEST_F(SubscriptionFactoryTest, GrpcClusterEmpty) {
 TEST_F(SubscriptionFactoryTest, RestClusterSingleton) {
   envoy::api::v2::core::ConfigSource config;
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
 
   config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
   config.mutable_api_config_source()->mutable_refresh_delay()->set_seconds(1);
@@ -102,7 +102,7 @@ TEST_F(SubscriptionFactoryTest, RestClusterSingleton) {
 TEST_F(SubscriptionFactoryTest, GrpcClusterSingleton) {
   envoy::api::v2::core::ConfigSource config;
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
 
   config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
   config.mutable_api_config_source()->mutable_refresh_delay()->set_seconds(1);
@@ -134,7 +134,7 @@ TEST_F(SubscriptionFactoryTest, GrpcClusterSingleton) {
 TEST_F(SubscriptionFactoryTest, RestClusterMultiton) {
   envoy::api::v2::core::ConfigSource config;
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
 
   config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
 
@@ -155,7 +155,7 @@ TEST_F(SubscriptionFactoryTest, RestClusterMultiton) {
 TEST_F(SubscriptionFactoryTest, GrpcClusterMultiton) {
   envoy::api::v2::core::ConfigSource config;
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
 
   config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
 
@@ -285,7 +285,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   envoy::api::v2::core::GrpcService expected_grpc_service;
   expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("static_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   cluster_map.emplace("static_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -358,7 +358,7 @@ TEST(CheckApiConfigSourceSubscriptionBackingClusterTest, GrpcClusterTestAcrossTy
       "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
   // Dynamic Cluster.
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("foo_cluster", cluster);
   EXPECT_CALL(cluster, info());
   EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(true));
@@ -407,7 +407,7 @@ TEST(CheckApiConfigSourceSubscriptionBackingClusterTest, RestClusterTestAcrossTy
       "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
   // Dynamic Cluster.
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("foo_cluster", cluster);
   EXPECT_CALL(cluster, info());
   EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(true));

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -34,7 +34,7 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcOk) {
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("foo", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info());
@@ -59,7 +59,7 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcDynamicCluster) {
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("foo", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info());

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -104,7 +104,7 @@ public:
     )EOF";
 
     Upstream::ClusterManager::ClusterInfoMap cluster_map;
-    Upstream::MockCluster cluster;
+    Upstream::MockClusterMockPrioritySet cluster;
     cluster_map.emplace("foo_cluster", cluster);
     EXPECT_CALL(factory_context_.cluster_manager_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info());
@@ -378,7 +378,7 @@ public:
 
     // Get a RouteConfigProvider. This one should create an entry in the RouteConfigProviderManager.
     Upstream::ClusterManager::ClusterInfoMap cluster_map;
-    Upstream::MockCluster cluster;
+    Upstream::MockClusterMockPrioritySet cluster;
     cluster_map.emplace("foo_cluster", cluster);
     EXPECT_CALL(factory_context_.cluster_manager_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info()).Times(2);
@@ -567,7 +567,7 @@ virtual_hosts:
   Envoy::Config::Utility::translateRdsConfig(*config2, rds2, stats_options_);
 
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("bar_cluster", cluster);
   EXPECT_CALL(factory_context_.cluster_manager_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -45,7 +45,7 @@ protected:
     cds_config.mutable_api_config_source()->set_api_type(
         envoy::api::v2::core::ApiConfigSource::REST);
     Upstream::ClusterManager::ClusterInfoMap cluster_map;
-    Upstream::MockCluster cluster;
+    Upstream::MockClusterMockPrioritySet cluster;
     cluster_map.emplace("foo_cluster", cluster);
     EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info());

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -143,7 +143,7 @@ public:
     for (auto& cluster : active_clusters_) {
       clusters.emplace(cluster.first, *cluster.second->cluster_);
     }
-    return clusters; 
+    return clusters;
   }
 };
 
@@ -152,15 +152,17 @@ public:
 class MockedUpdatedClusterManagerImpl : public TestClusterManagerImpl {
 public:
   MockedUpdatedClusterManagerImpl(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,
-                         ClusterManagerFactory& factory, Stats::Store& stats,
-                         ThreadLocal::Instance& tls, Runtime::Loader& runtime,
-                         Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
-                         AccessLog::AccessLogManager& log_manager,
-                         Event::Dispatcher& main_thread_dispatcher, Server::Admin& admin,
-                         Api::Api& api, MockLocalClusterUpdate& local_cluster_update)
-      : TestClusterManagerImpl(bootstrap, factory, stats, tls, runtime, random, local_info, log_manager,
-                           main_thread_dispatcher, admin, api, http_context_),
+                                  ClusterManagerFactory& factory, Stats::Store& stats,
+                                  ThreadLocal::Instance& tls, Runtime::Loader& runtime,
+                                  Runtime::RandomGenerator& random,
+                                  const LocalInfo::LocalInfo& local_info,
+                                  AccessLog::AccessLogManager& log_manager,
+                                  Event::Dispatcher& main_thread_dispatcher, Server::Admin& admin,
+                                  Api::Api& api, MockLocalClusterUpdate& local_cluster_update)
+      : TestClusterManagerImpl(bootstrap, factory, stats, tls, runtime, random, local_info,
+                               log_manager, main_thread_dispatcher, admin, api, http_context_),
         local_cluster_update_(local_cluster_update) {}
+
 protected:
   void postThreadLocalClusterUpdate(const Cluster&, uint32_t priority,
                                     const HostVector& hosts_added,
@@ -782,7 +784,9 @@ TEST_F(ClusterManagerImplTest, ShutdownOrder) {
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
   EXPECT_EQ("cluster_1", cluster.info()->name());
   EXPECT_EQ(cluster.info(), cluster_manager_->get("cluster_1")->info());
-  EXPECT_EQ(1UL, cluster_manager_->get("cluster_1")->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+  EXPECT_EQ(
+      1UL,
+      cluster_manager_->get("cluster_1")->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0],
             cluster_manager_->get("cluster_1")->loadBalancer().chooseHost(nullptr));
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -607,7 +607,8 @@ public:
     const std::string json =
         fmt::sprintf("{%s}", clustersJson({defaultStaticClusterJson("cluster_0")}));
 
-    std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+    std::shared_ptr<MockClusterMockPrioritySet> cluster1(
+        new NiceMock<MockClusterMockPrioritySet>());
     cluster1->info_->name_ = "cluster_0";
     cluster1->info_->lb_type_ = lb_type;
 
@@ -797,10 +798,11 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
           {defaultStaticClusterJson("fake_cluster"), defaultStaticClusterJson("fake_cluster2")}));
 
   MockCdsApi* cds = new MockCdsApi();
-  std::shared_ptr<MockCluster> cds_cluster(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cds_cluster(
+      new NiceMock<MockClusterMockPrioritySet>());
   cds_cluster->info_->name_ = "cds_cluster";
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
-  std::shared_ptr<MockCluster> cluster2(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster2(new NiceMock<MockClusterMockPrioritySet>());
   cluster2->info_->name_ = "fake_cluster2";
   cluster2->info_->lb_type_ = LoadBalancerType::RingHash;
 
@@ -830,11 +832,11 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
   cluster2->initialize_callback_();
 
   // This part tests CDS init.
-  std::shared_ptr<MockCluster> cluster3(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster3(new NiceMock<MockClusterMockPrioritySet>());
   cluster3->info_->name_ = "cluster3";
-  std::shared_ptr<MockCluster> cluster4(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster4(new NiceMock<MockClusterMockPrioritySet>());
   cluster4->info_->name_ = "cluster4";
-  std::shared_ptr<MockCluster> cluster5(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster5(new NiceMock<MockClusterMockPrioritySet>());
   cluster5->info_->name_ = "cluster5";
 
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster3));
@@ -959,7 +961,7 @@ TEST_F(ClusterManagerImplTest, DynamicRemoveWithLocalCluster) {
   )EOF",
                                         clustersJson({defaultStaticClusterJson("fake")}));
 
-  std::shared_ptr<MockCluster> foo(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> foo(new NiceMock<MockClusterMockPrioritySet>());
   foo->info_->name_ = "foo";
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, false)).WillOnce(Return(foo));
   ON_CALL(*foo, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
@@ -970,7 +972,7 @@ TEST_F(ClusterManagerImplTest, DynamicRemoveWithLocalCluster) {
 
   // Now add a dynamic cluster. This cluster will have a member update callback from the local
   // cluster in its load balancer.
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   cluster1->info_->name_ = "cluster1";
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, true)).WillOnce(Return(cluster1));
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
@@ -1016,7 +1018,7 @@ TEST_F(ClusterManagerImplTest, RemoveWarmingCluster) {
   EXPECT_CALL(initialized, ready());
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));
   EXPECT_CALL(*cluster1, initializePhase()).Times(0);
   EXPECT_CALL(*cluster1, initialize(_));
@@ -1064,7 +1066,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   ClusterUpdateCallbacksHandlePtr cb =
       cluster_manager_->addThreadLocalClusterUpdateCallbacks(*callbacks);
 
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));
   EXPECT_CALL(*cluster1, initializePhase()).Times(0);
   EXPECT_CALL(*cluster1, initialize(_));
@@ -1084,7 +1086,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   auto update_cluster = defaultStaticCluster("fake_cluster");
   update_cluster.mutable_per_connection_buffer_limit_bytes()->set_value(12345);
 
-  std::shared_ptr<MockCluster> cluster2(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster2(new NiceMock<MockClusterMockPrioritySet>());
   cluster2->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster2->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster2));
@@ -1151,7 +1153,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
 TEST_F(ClusterManagerImplTest, addOrUpdateClusterStaticExists) {
   const std::string json =
       fmt::sprintf("{%s}", clustersJson({defaultStaticClusterJson("some_cluster")}));
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   InSequence s;
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
@@ -1179,7 +1181,7 @@ TEST_F(ClusterManagerImplTest, addOrUpdateClusterStaticExists) {
 TEST_F(ClusterManagerImplTest, HostsPostedToTlsCluster) {
   const std::string json =
       fmt::sprintf("{%s}", clustersJson({defaultStaticClusterJson("fake_cluster")}));
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterRealPrioritySet> cluster1(new NiceMock<MockClusterRealPrioritySet>());
   InSequence s;
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
@@ -1203,14 +1205,9 @@ TEST_F(ClusterManagerImplTest, HostsPostedToTlsCluster) {
   HostVector hosts{host1, host2, host3};
   auto hosts_ptr = std::make_shared<HostVector>(hosts);
 
-  cluster1->priority_set_.host_sets_[0] = std::make_unique<HostSetImpl>(0, absl::nullopt);
-  cluster1->priority_set_.host_sets_[0]->updateHosts(
-      HostSetImpl::partitionHosts(hosts_ptr, HostsPerLocalityImpl::empty()), nullptr, hosts, {},
+  cluster1->priority_set_.updateHosts(
+      0, HostSetImpl::partitionHosts(hosts_ptr, HostsPerLocalityImpl::empty()), nullptr, hosts, {},
       {});
-
-  // Trigger a per thread cluster update. Normally this is called whenever the HostSet is modified,
-  // but since we mock out PrioritySet the callbacks aren't wired up.
-  cluster1->priority_set_.runUpdateCallbacks(0, hosts, {});
 
   auto* tls_cluster = cluster_manager_->get(cluster1->info_->name());
 
@@ -1230,7 +1227,7 @@ TEST_F(ClusterManagerImplTest, HostsPostedToTlsCluster) {
 TEST_F(ClusterManagerImplTest, CloseHttpConnectionsOnHealthFailure) {
   const std::string json =
       fmt::sprintf("{%s}", clustersJson({defaultStaticClusterJson("some_cluster")}));
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   cluster1->info_->name_ = "some_cluster";
   HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
@@ -1292,7 +1289,7 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsOnHealthFailure) {
 TEST_F(ClusterManagerImplTest, CloseTcpConnectionPoolsOnHealthFailure) {
   const std::string json =
       fmt::sprintf("{%s}", clustersJson({defaultStaticClusterJson("some_cluster")}));
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   cluster1->info_->name_ = "some_cluster";
   HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
   cluster1->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
@@ -1361,7 +1358,7 @@ TEST_F(ClusterManagerImplTest, CloseTcpConnectionsOnHealthFailure) {
       lb_policy: ROUND_ROBIN
       close_connections_on_host_health_failure: true
   )EOF";
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   EXPECT_CALL(*cluster1->info_, features())
       .WillRepeatedly(Return(ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE));
   cluster1->info_->name_ = "some_cluster";
@@ -1438,7 +1435,7 @@ TEST_F(ClusterManagerImplTest, DoNotCloseTcpConnectionsOnHealthFailure) {
       lb_policy: ROUND_ROBIN
       close_connections_on_host_health_failure: false
   )EOF";
-  std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> cluster1(new NiceMock<MockClusterMockPrioritySet>());
   EXPECT_CALL(*cluster1->info_, features()).WillRepeatedly(Return(0));
   cluster1->info_->name_ = "some_cluster";
   HostSharedPtr test_host = makeTestHost(cluster1->info_, "tcp://127.0.0.1:80");
@@ -2070,8 +2067,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2079,11 +2076,11 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2098,8 +2095,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   // Add the host back, the update should be immediately applied.
   hosts_removed.clear();
   hosts_added.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2109,18 +2106,18 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   hosts_added.clear();
 
   (*hosts)[0]->metadata(buildMetadata("v1"));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
 
   (*hosts)[0]->healthFlagSet(Host::HealthFlag::FAILED_EDS_HEALTH);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
 
   (*hosts)[0]->weight(100);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
 
   // Updates not delivered yet.
@@ -2130,8 +2127,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // Remove the host again, should cancel the scheduled update and be delivered immediately.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
 
   EXPECT_EQ(3, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -2164,8 +2161,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   // it's outside the default merge window of 3 seconds (found in debugger as value of
   // cluster.info()->lbConfig().update_merge_window() in ClusterManagerImpl::scheduleUpdate.
   time_system_.sleep(std::chrono::seconds(60));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2189,8 +2186,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesInsideWindow) {
   // in ClusterManagerImpl::scheduleUpdate. Note that initially the update-time is
   // default-initialized to a monotonic time of 0, as is SimulatedTimeSystem::monotonic_time_.
   time_system_.sleep(std::chrono::seconds(2));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2222,8 +2219,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindowDisabled) {
 
   // The first update should be applied immediately, because even though it's mergeable
   // and outside a merge window, merging is disabled.
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2280,8 +2277,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2289,18 +2286,18 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
   // Update the cluster, which should cancel the pending updates.
-  std::shared_ptr<MockCluster> updated(new NiceMock<MockCluster>());
+  std::shared_ptr<MockClusterMockPrioritySet> updated(new NiceMock<MockClusterMockPrioritySet>());
   updated->info_->name_ = "new_cluster";
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, true)).WillOnce(Return(updated));
 
@@ -2346,7 +2343,7 @@ public:
 TEST_F(ClusterManagerInitHelperTest, ImmediateInitialize) {
   InSequence s;
 
-  NiceMock<MockCluster> cluster1;
+  NiceMock<MockClusterMockPrioritySet> cluster1;
   ON_CALL(cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(cluster1, initialize(_));
   init_helper_.addCluster(cluster1);
@@ -2363,14 +2360,14 @@ TEST_F(ClusterManagerInitHelperTest, ImmediateInitialize) {
 TEST_F(ClusterManagerInitHelperTest, StaticSdsInitialize) {
   InSequence s;
 
-  NiceMock<MockCluster> sds;
+  NiceMock<MockClusterMockPrioritySet> sds;
   ON_CALL(sds, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(sds, initialize(_));
   init_helper_.addCluster(sds);
   EXPECT_CALL(*this, onClusterInit(Ref(sds)));
   sds.initialize_callback_();
 
-  NiceMock<MockCluster> cluster1;
+  NiceMock<MockClusterMockPrioritySet> cluster1;
   ON_CALL(cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
   init_helper_.addCluster(cluster1);
 
@@ -2391,12 +2388,12 @@ TEST_F(ClusterManagerInitHelperTest, UpdateAlreadyInitialized) {
   ReadyWatcher cm_initialized;
   init_helper_.setInitializedCb([&]() -> void { cm_initialized.ready(); });
 
-  NiceMock<MockCluster> cluster1;
+  NiceMock<MockClusterMockPrioritySet> cluster1;
   ON_CALL(cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(cluster1, initialize(_));
   init_helper_.addCluster(cluster1);
 
-  NiceMock<MockCluster> cluster2;
+  NiceMock<MockClusterMockPrioritySet> cluster2;
   ON_CALL(cluster2, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(cluster2, initialize(_));
   init_helper_.addCluster(cluster2);
@@ -2418,12 +2415,12 @@ TEST_F(ClusterManagerInitHelperTest, AddSecondaryAfterSecondaryInit) {
   ReadyWatcher cm_initialized;
   init_helper_.setInitializedCb([&]() -> void { cm_initialized.ready(); });
 
-  NiceMock<MockCluster> cluster1;
+  NiceMock<MockClusterMockPrioritySet> cluster1;
   ON_CALL(cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(cluster1, initialize(_));
   init_helper_.addCluster(cluster1);
 
-  NiceMock<MockCluster> cluster2;
+  NiceMock<MockClusterMockPrioritySet> cluster2;
   ON_CALL(cluster2, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
   init_helper_.addCluster(cluster2);
 
@@ -2433,7 +2430,7 @@ TEST_F(ClusterManagerInitHelperTest, AddSecondaryAfterSecondaryInit) {
   EXPECT_CALL(cluster2, initialize(_));
   cluster1.initialize_callback_();
 
-  NiceMock<MockCluster> cluster3;
+  NiceMock<MockClusterMockPrioritySet> cluster3;
   ON_CALL(cluster3, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
   EXPECT_CALL(cluster3, initialize(_));
   init_helper_.addCluster(cluster3);
@@ -2449,7 +2446,7 @@ TEST_F(ClusterManagerInitHelperTest, AddSecondaryAfterSecondaryInit) {
 // the secondary init list while traversing the list.
 TEST_F(ClusterManagerInitHelperTest, RemoveClusterWithinInitLoop) {
   InSequence s;
-  NiceMock<MockCluster> cluster;
+  NiceMock<MockClusterMockPrioritySet> cluster;
   ON_CALL(cluster, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
   init_helper_.addCluster(cluster);
 

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -52,7 +52,7 @@ protected:
     local_info_.node_.mutable_locality()->set_zone("us-east-1a");
     eds_cluster_ = parseClusterFromV2Yaml(yaml_config);
     Upstream::ClusterManager::ClusterInfoMap cluster_map;
-    Upstream::MockCluster cluster;
+    Upstream::MockClusterMockPrioritySet cluster;
     cluster_map.emplace("eds", cluster);
     EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info()).Times(2);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -56,7 +56,7 @@ envoy::api::v2::core::HealthCheck createGrpcHealthCheckConfig() {
 }
 
 TEST(HealthCheckerFactoryTest, GrpcHealthCheckHTTP2NotConfiguredException) {
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   EXPECT_CALL(*cluster.info_, features()).WillRepeatedly(Return(0));
 
   Runtime::MockLoader runtime;
@@ -72,7 +72,7 @@ TEST(HealthCheckerFactoryTest, GrpcHealthCheckHTTP2NotConfiguredException) {
 
 TEST(HealthCheckerFactoryTest, createGrpc) {
 
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   EXPECT_CALL(*cluster.info_, features())
       .WillRepeatedly(Return(Upstream::ClusterInfo::Features::HTTP2));
 
@@ -121,7 +121,7 @@ public:
       HostWithHealthCheckMap;
 
   HttpHealthCheckerImplTest()
-      : cluster_(new NiceMock<MockCluster>()), event_logger_(new MockHealthCheckEventLogger()) {}
+      : cluster_(new NiceMock<MockClusterMockPrioritySet>()), event_logger_(new MockHealthCheckEventLogger()) {}
 
   void setupNoServiceValidationHCWithHttp2() {
     const std::string yaml = R"EOF(
@@ -314,7 +314,7 @@ public:
     return config;
   }
 
-  void appendTestHosts(std::shared_ptr<MockCluster> cluster, const HostWithHealthCheckMap& hosts,
+  void appendTestHosts(std::shared_ptr<MockClusterMockPrioritySet> cluster, const HostWithHealthCheckMap& hosts,
                        const std::string& protocol = "tcp://", const uint32_t priority = 0) {
     for (const auto& host : hosts) {
       cluster->prioritySet().getMockHostSet(priority)->hosts_.emplace_back(
@@ -539,7 +539,7 @@ public:
 
   MOCK_METHOD2(onHostStatus, void(HostSharedPtr host, HealthTransition changed_state));
 
-  std::shared_ptr<MockCluster> cluster_;
+  std::shared_ptr<MockClusterMockPrioritySet> cluster_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::vector<TestSessionPtr> test_sessions_;
   std::shared_ptr<TestHttpHealthCheckerImpl> health_checker_;
@@ -1972,7 +1972,7 @@ TEST(TcpHealthCheckMatcher, match) {
 class TcpHealthCheckerImplTest : public testing::Test {
 public:
   TcpHealthCheckerImplTest()
-      : cluster_(new NiceMock<MockCluster>()), event_logger_(new MockHealthCheckEventLogger()) {}
+      : cluster_(new NiceMock<MockClusterMockPrioritySet>()), event_logger_(new MockHealthCheckEventLogger()) {}
 
   void setupData() {
     std::string json = R"EOF(
@@ -2048,7 +2048,7 @@ public:
     EXPECT_CALL(*connection_, addReadFilter(_)).WillOnce(SaveArg<0>(&read_filter_));
   }
 
-  std::shared_ptr<MockCluster> cluster_;
+  std::shared_ptr<MockClusterMockPrioritySet> cluster_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<TcpHealthCheckerImpl> health_checker_;
   MockHealthCheckEventLogger* event_logger_{};
@@ -2474,7 +2474,7 @@ public:
   };
 
   GrpcHealthCheckerImplTestBase()
-      : cluster_(new NiceMock<MockCluster>()), event_logger_(new MockHealthCheckEventLogger()) {
+      : cluster_(new NiceMock<MockClusterMockPrioritySet>()), event_logger_(new MockHealthCheckEventLogger()) {
     EXPECT_CALL(*cluster_->info_, features())
         .WillRepeatedly(Return(Upstream::ClusterInfo::Features::HTTP2));
   }
@@ -2742,7 +2742,7 @@ public:
 
   MOCK_METHOD2(onHostStatus, void(HostSharedPtr host, HealthTransition changed_state));
 
-  std::shared_ptr<MockCluster> cluster_;
+  std::shared_ptr<MockClusterMockPrioritySet> cluster_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::vector<TestSessionPtr> test_sessions_;
   std::shared_ptr<TestGrpcHealthCheckerImpl> health_checker_;

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -121,7 +121,8 @@ public:
       HostWithHealthCheckMap;
 
   HttpHealthCheckerImplTest()
-      : cluster_(new NiceMock<MockClusterMockPrioritySet>()), event_logger_(new MockHealthCheckEventLogger()) {}
+      : cluster_(new NiceMock<MockClusterMockPrioritySet>()),
+        event_logger_(new MockHealthCheckEventLogger()) {}
 
   void setupNoServiceValidationHCWithHttp2() {
     const std::string yaml = R"EOF(
@@ -314,8 +315,9 @@ public:
     return config;
   }
 
-  void appendTestHosts(std::shared_ptr<MockClusterMockPrioritySet> cluster, const HostWithHealthCheckMap& hosts,
-                       const std::string& protocol = "tcp://", const uint32_t priority = 0) {
+  void appendTestHosts(std::shared_ptr<MockClusterMockPrioritySet> cluster,
+                       const HostWithHealthCheckMap& hosts, const std::string& protocol = "tcp://",
+                       const uint32_t priority = 0) {
     for (const auto& host : hosts) {
       cluster->prioritySet().getMockHostSet(priority)->hosts_.emplace_back(
           makeTestHost(cluster->info_, fmt::format("{}{}", protocol, host.first), host.second));
@@ -1972,7 +1974,8 @@ TEST(TcpHealthCheckMatcher, match) {
 class TcpHealthCheckerImplTest : public testing::Test {
 public:
   TcpHealthCheckerImplTest()
-      : cluster_(new NiceMock<MockClusterMockPrioritySet>()), event_logger_(new MockHealthCheckEventLogger()) {}
+      : cluster_(new NiceMock<MockClusterMockPrioritySet>()),
+        event_logger_(new MockHealthCheckEventLogger()) {}
 
   void setupData() {
     std::string json = R"EOF(
@@ -2474,7 +2477,8 @@ public:
   };
 
   GrpcHealthCheckerImplTestBase()
-      : cluster_(new NiceMock<MockClusterMockPrioritySet>()), event_logger_(new MockHealthCheckEventLogger()) {
+      : cluster_(new NiceMock<MockClusterMockPrioritySet>()),
+        event_logger_(new MockHealthCheckEventLogger()) {
     EXPECT_CALL(*cluster_->info_, features())
         .WillRepeatedly(Return(Upstream::ClusterInfo::Features::HTTP2));
   }

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -22,8 +22,6 @@ public:
 
   // We weight the first weighted_subset_percent of hosts with weight.
   BaseTester(uint64_t num_hosts, uint32_t weighted_subset_percent, uint32_t weight) {
-    HostSet& host_set = priority_set_.getOrCreateHostSet(0);
-
     HostVector hosts;
     ASSERT(num_hosts < 65536);
     for (uint64_t i = 0; i < num_hosts; i++) {
@@ -32,9 +30,9 @@ public:
                                    should_weight ? weight : 1));
     }
     HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
-    host_set.updateHosts(
-        HostSetImpl::updateHostsParams(updated_hosts, nullptr, updated_hosts, nullptr), {}, hosts,
-        {}, absl::nullopt);
+    priority_set_.updateHosts(
+        0, HostSetImpl::updateHostsParams(updated_hosts, nullptr, updated_hosts, nullptr), {},
+        hosts, {}, absl::nullopt);
   }
 
   PrioritySetImpl priority_set_;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -52,9 +52,10 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   }
   HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
   HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
-  priority_set.updateHosts(0, HostSetImpl::updateHostsParams(updated_hosts, updated_locality_hosts,
-                                                      updated_hosts, updated_locality_hosts),
-                       {}, hosts, {}, absl::nullopt);
+  priority_set.updateHosts(0,
+                           HostSetImpl::updateHostsParams(updated_hosts, updated_locality_hosts,
+                                                          updated_hosts, updated_locality_hosts),
+                           {}, hosts, {}, absl::nullopt);
 
   Stats::IsolatedStoreImpl stats_store;
   ClusterStats stats{ClusterInfoImpl::generateStats(stats_store)};
@@ -155,7 +156,8 @@ public:
         per_zone_local.push_back(local_per_zone_hosts->get()[zone]);
       }
       auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
-      local_priority_set_->updateHosts(0,
+      local_priority_set_->updateHosts(
+          0,
           HostSetImpl::updateHostsParams(originating_hosts, per_zone_local_shared,
                                          originating_hosts, per_zone_local_shared),
           {}, empty_vector_, empty_vector_, absl::nullopt);

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -41,7 +41,6 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
 
   PrioritySetImpl priority_set;
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
-  HostSet& host_set = priority_set.getOrCreateHostSet(0);
   HostVector hosts;
   for (uint64_t i = 0; i < num_hosts; i++) {
     const bool should_weight = i < num_hosts * (weighted_subset_percent / 100.0);
@@ -53,7 +52,7 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   }
   HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
   HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
-  host_set.updateHosts(HostSetImpl::updateHostsParams(updated_hosts, updated_locality_hosts,
+  priority_set.updateHosts(0, HostSetImpl::updateHostsParams(updated_hosts, updated_locality_hosts,
                                                       updated_hosts, updated_locality_hosts),
                        {}, hosts, {}, absl::nullopt);
 
@@ -156,7 +155,7 @@ public:
         per_zone_local.push_back(local_per_zone_hosts->get()[zone]);
       }
       auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
-      local_priority_set_->getOrCreateHostSet(0).updateHosts(
+      local_priority_set_->updateHosts(0,
           HostSetImpl::updateHostsParams(originating_hosts, per_zone_local_shared,
                                          originating_hosts, per_zone_local_shared),
           {}, empty_vector_, empty_vector_, absl::nullopt);

--- a/test/common/upstream/load_stats_reporter_test.cc
+++ b/test/common/upstream/load_stats_reporter_test.cc
@@ -115,9 +115,9 @@ TEST_F(LoadStatsReporterTest, ExistingClusters) {
   createLoadStatsReporter();
   time_system_.setMonotonicTime(std::chrono::microseconds(3));
   // Start reporting on foo.
-  NiceMock<MockCluster> foo_cluster;
+  NiceMock<MockClusterMockPrioritySet> foo_cluster;
   foo_cluster.info_->load_report_stats_.upstream_rq_dropped_.add(2);
-  NiceMock<MockCluster> bar_cluster;
+  NiceMock<MockClusterMockPrioritySet> bar_cluster;
   MockClusterManager::ClusterInfoMap cluster_info{{"foo", foo_cluster}, {"bar", bar_cluster}};
   ON_CALL(cm_, clusters()).WillByDefault(Return(cluster_info));
   deliverLoadStatsResponse({"foo"});

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -464,10 +464,10 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
             new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
         const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
 
-        second.getOrCreateHostSet(0).updateHosts(
-            HostSetImpl::updateHostsParams(new_hosts, empty_hosts_per_locality, healthy_hosts,
-                                           empty_hosts_per_locality),
-            {}, added, removed, absl::nullopt);
+        second.updateHosts(0,
+                           HostSetImpl::updateHostsParams(new_hosts, empty_hosts_per_locality,
+                                                          healthy_hosts, empty_hosts_per_locality),
+                           {}, added, removed, absl::nullopt);
       });
 
   EXPECT_CALL(membership_updated_, ready());

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -32,7 +32,7 @@ namespace Upstream {
 namespace Outlier {
 
 TEST(OutlierDetectorImplFactoryTest, NoDetector) {
-  NiceMock<MockCluster> cluster;
+  NiceMock<MockClusterMockPrioritySet> cluster;
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_EQ(nullptr,
@@ -44,7 +44,7 @@ TEST(OutlierDetectorImplFactoryTest, Detector) {
   auto fake_cluster = defaultStaticCluster("fake_cluster");
   fake_cluster.mutable_outlier_detection();
 
-  NiceMock<MockCluster> cluster;
+  NiceMock<MockClusterMockPrioritySet> cluster;
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_NE(nullptr, DetectorImplFactory::createForCluster(cluster, fake_cluster, dispatcher,
@@ -90,7 +90,7 @@ public:
     }
   }
 
-  NiceMock<MockCluster> cluster_;
+  NiceMock<MockClusterMockPrioritySet> cluster_;
   HostVector& hosts_ = cluster_.prioritySet().getMockHostSet(0)->hosts_;
   HostVector& failover_hosts_ = cluster_.prioritySet().getMockHostSet(1)->hosts_;
   NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -214,7 +214,8 @@ public:
     }
     local_hosts_per_locality_ = makeHostsPerLocality(std::move(local_hosts_per_locality_vector));
 
-    local_priority_set_.getOrCreateHostSet(0).updateHosts(
+    local_priority_set_.updateHosts(
+        0,
         HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
                                        local_hosts_per_locality_),
         {}, {}, {}, absl::nullopt);
@@ -311,7 +312,8 @@ public:
     }
 
     if (GetParam() == REMOVES_FIRST && !remove.empty()) {
-      local_priority_set_.getOrCreateHostSet(0).updateHosts(
+      local_priority_set_.updateHosts(
+          0,
           HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
                                          local_hosts_per_locality_),
           {}, {}, remove, absl::nullopt);
@@ -326,13 +328,15 @@ public:
 
     if (GetParam() == REMOVES_FIRST) {
       if (!add.empty()) {
-        local_priority_set_.getOrCreateHostSet(0).updateHosts(
+        local_priority_set_.updateHosts(
+            0,
             HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
                                            local_hosts_per_locality_),
             {}, add, {}, absl::nullopt);
       }
     } else if (!add.empty() || !remove.empty()) {
-      local_priority_set_.getOrCreateHostSet(0).updateHosts(
+      local_priority_set_.updateHosts(
+          0,
           HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
                                          local_hosts_per_locality_),
           {}, add, remove, absl::nullopt);

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -779,7 +779,7 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {
 }
 
 TEST(HostImplTest, HostCluster) {
-  MockCluster cluster;
+  MockClusterMockPrioritySet cluster;
   HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   EXPECT_EQ(cluster.info_.get(), &host->cluster());
   EXPECT_EQ("", host->hostname());
@@ -788,7 +788,7 @@ TEST(HostImplTest, HostCluster) {
 }
 
 TEST(HostImplTest, Weight) {
-  MockCluster cluster;
+  MockClusterMockPrioritySet cluster;
 
   EXPECT_EQ(1U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 0)->weight());
   EXPECT_EQ(128U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 128)->weight());
@@ -805,7 +805,7 @@ TEST(HostImplTest, Weight) {
 }
 
 TEST(HostImplTest, HostnameCanaryAndLocality) {
-  MockCluster cluster;
+  MockClusterMockPrioritySet cluster;
   envoy::api::v2::core::Metadata metadata;
   Config::Metadata::mutableMetadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
                                          Config::MetadataEnvoyLbKeys::get().CANARY)
@@ -827,7 +827,7 @@ TEST(HostImplTest, HostnameCanaryAndLocality) {
 }
 
 TEST(HostImplTest, HealthFlags) {
-  MockCluster cluster;
+  MockClusterMockPrioritySet cluster;
   HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
 
   // To begin with, no flags are set so we're healthy.
@@ -1927,7 +1927,7 @@ TEST(HostsPerLocalityImpl, Cons) {
     EXPECT_EQ(0, hosts_per_locality.get().size());
   }
 
-  MockCluster cluster;
+  MockClusterMockPrioritySet cluster;
   HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
 
@@ -1949,7 +1949,7 @@ TEST(HostsPerLocalityImpl, Cons) {
 }
 
 TEST(HostsPerLocalityImpl, Filter) {
-  MockCluster cluster;
+  MockClusterMockPrioritySet cluster;
   HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1517,8 +1517,8 @@ TEST(PrioritySet, Extend) {
   HostVector hosts_added{hosts->front()};
   HostVector hosts_removed{};
 
-  priority_set.hostSetsPerPriority()[1]->updateHosts(
-      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+  priority_set.updateHosts(
+      1, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
       hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, priority_changes);
   EXPECT_EQ(1, membership_changes);

--- a/test/extensions/health_checkers/redis/config_test.cc
+++ b/test/extensions/health_checkers/redis/config_test.cc
@@ -100,7 +100,7 @@ TEST(HealthCheckerFactoryTest, createRedisViaUpstreamHealthCheckerFactory) {
         key: foo
     )EOF";
 
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   Runtime::MockLoader runtime;
   Runtime::MockRandomGenerator random;
   Event::MockDispatcher dispatcher;
@@ -123,7 +123,7 @@ TEST(HealthCheckerFactoryTest, createRedisWithDeprecatedV1JsonConfig) {
     }
     )EOF";
 
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   Runtime::MockLoader runtime;
   Runtime::MockRandomGenerator random;
   Event::MockDispatcher dispatcher;
@@ -149,7 +149,7 @@ TEST(HealthCheckerFactoryTest, createRedisWithDeprecatedV1JsonConfigWithKey) {
     }
     )EOF";
 
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   Runtime::MockLoader runtime;
   Runtime::MockRandomGenerator random;
   Event::MockDispatcher dispatcher;

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -29,7 +29,7 @@ class RedisHealthCheckerTest
       public Extensions::NetworkFilters::RedisProxy::ConnPool::ClientFactory {
 public:
   RedisHealthCheckerTest()
-      : cluster_(new NiceMock<Upstream::MockCluster>()),
+      : cluster_(new NiceMock<Upstream::MockClusterMockPrioritySet>()),
         event_logger_(new Upstream::MockHealthCheckEventLogger()) {}
 
   void setup() {
@@ -150,7 +150,7 @@ public:
     EXPECT_CALL(*timeout_timer_, enableTimer(_));
   }
 
-  std::shared_ptr<Upstream::MockCluster> cluster_;
+  std::shared_ptr<Upstream::MockClusterMockPrioritySet> cluster_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -82,7 +82,7 @@ public:
     cluster_info_->stats().upstream_rq_pending_overflow_.add(rejected_step);
   }
 
-  NiceMock<Upstream::MockCluster> cluster_;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster_;
   Upstream::MockClusterInfo* cluster_info_ = new NiceMock<Upstream::MockClusterInfo>();
   Upstream::ClusterInfoConstSharedPtr cluster_info_ptr_{cluster_info_};
 
@@ -136,7 +136,7 @@ public:
     return buffer;
   }
 
-  void addClusterToMap(const std::string& cluster_name, NiceMock<Upstream::MockCluster>& cluster) {
+  void addClusterToMap(const std::string& cluster_name, NiceMock<Upstream::MockClusterMockPrioritySet>& cluster) {
     cluster_map_.emplace(cluster_name, cluster);
     // Redefining since cluster_map_ is returned by value.
     ON_CALL(cluster_manager_, clusters()).WillByDefault(Return(cluster_map_));

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -136,7 +136,8 @@ public:
     return buffer;
   }
 
-  void addClusterToMap(const std::string& cluster_name, NiceMock<Upstream::MockClusterMockPrioritySet>& cluster) {
+  void addClusterToMap(const std::string& cluster_name,
+                       NiceMock<Upstream::MockClusterMockPrioritySet>& cluster) {
     cluster_map_.emplace(cluster_name, cluster);
     // Redefining since cluster_map_ is returned by value.
     ON_CALL(cluster_manager_, clusters()).WillByDefault(Return(cluster_map_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -512,7 +512,7 @@ public:
     return Upstream::HealthCheckEventLoggerPtr(eventLogger_());
   }
 
-  testing::NiceMock<Upstream::MockCluster> cluster_;
+  testing::NiceMock<Upstream::MockClusterMockPrioritySet> cluster_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   testing::NiceMock<Envoy::Runtime::MockRandomGenerator> random_;
   testing::NiceMock<Envoy::Runtime::MockLoader> runtime_;

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -78,8 +78,6 @@ void MockPrioritySet::runUpdateCallbacks(uint32_t priority, const HostVector& ho
 MockRetryPriority::~MockRetryPriority() = default;
 
 MockCluster::MockCluster() {
-  ON_CALL(*this, prioritySet()).WillByDefault(ReturnRef(priority_set_));
-  ON_CALL(testing::Const(*this), prioritySet()).WillByDefault(ReturnRef(priority_set_));
   ON_CALL(*this, info()).WillByDefault(Return(info_));
   ON_CALL(*this, initialize(_))
       .WillByDefault(Invoke([this](std::function<void()> callback) -> void {
@@ -89,6 +87,12 @@ MockCluster::MockCluster() {
 }
 
 MockCluster::~MockCluster() = default;
+
+MockClusterRealPrioritySet::MockClusterRealPrioritySet() = default;
+MockClusterRealPrioritySet::~MockClusterRealPrioritySet() = default;
+
+MockClusterMockPrioritySet::MockClusterMockPrioritySet() = default;
+MockClusterMockPrioritySet::~MockClusterMockPrioritySet() = default;
 
 MockLoadBalancer::MockLoadBalancer() { ON_CALL(*this, chooseHost(_)).WillByDefault(Return(host_)); }
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -93,6 +93,11 @@ public:
                                  LocalityWeightsConstSharedPtr locality_weights,
                                  const HostVector& hosts_added, const HostVector& hosts_removed,
                                  absl::optional<uint32_t> overprovisioning_factor));
+  MOCK_CONST_METHOD6(updateHosts,
+                     void(uint32_t priority, UpdateHostsParams&& update_hosts_params,
+                          LocalityWeightsConstSharedPtr locality_weights,
+                          const HostVector& hosts_added, const HostVector& hosts_removed,
+                          absl::optional<uint32_t> overprovisioning_factor));
 
   MockHostSet* getMockHostSet(uint32_t priority) {
     getHostSet(priority); // Ensure the host set exists.
@@ -154,12 +159,39 @@ public:
   MOCK_METHOD1(initialize, void(std::function<void()> callback));
   MOCK_CONST_METHOD0(initializePhase, InitializePhase());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
-  MOCK_METHOD0(prioritySet, MockPrioritySet&());
-  MOCK_CONST_METHOD0(prioritySet, const PrioritySet&());
 
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   std::function<void()> initialize_callback_;
   Network::Address::InstanceConstSharedPtr source_address_;
+};
+
+// Note that we could template the two implementations below, but to avoid having to define the
+// ctor/dtor (which is fairly expensive for mocks) in the header file we duplicate the code instead.
+
+// Use this when interaction with a real PrioritySet is neeeded, e.g. when update callbacks
+// needs to be triggered.
+class MockClusterRealPrioritySet : public MockCluster {
+public:
+  MockClusterRealPrioritySet();
+  ~MockClusterRealPrioritySet();
+
+  // Upstream::Cluster
+  PrioritySetImpl& prioritySet() override { return priority_set_; }
+  const PrioritySet& prioritySet() const override { return priority_set_; }
+
+  PrioritySetImpl priority_set_;
+};
+
+// Use this for additional convenience methods provided by MockPrioritySet.
+class MockClusterMockPrioritySet : public MockCluster {
+public:
+  MockClusterMockPrioritySet();
+  ~MockClusterMockPrioritySet();
+
+  // Upstream::Cluster
+  MockPrioritySet& prioritySet() override { return priority_set_; }
+  const PrioritySet& prioritySet() const override { return priority_set_; }
+
   NiceMock<MockPrioritySet> priority_set_;
 };
 
@@ -184,7 +216,7 @@ public:
   MOCK_METHOD0(info, ClusterInfoConstSharedPtr());
   MOCK_METHOD0(loadBalancer, LoadBalancer&());
 
-  NiceMock<MockCluster> cluster_;
+  NiceMock<MockClusterMockPrioritySet> cluster_;
   NiceMock<MockLoadBalancer> lb_;
 };
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -57,10 +57,6 @@ public:
   MOCK_CONST_METHOD0(degradedHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(localityWeights, LocalityWeightsConstSharedPtr());
   MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
-  MOCK_METHOD5(updateHosts, void(HostSet::UpdateHostsParams&& update_hosts_params,
-                                 LocalityWeightsConstSharedPtr locality_weights,
-                                 const HostVector& hosts_added, const HostVector& hosts_removed,
-                                 absl::optional<uint32_t> overprovisioning_factor));
   MOCK_CONST_METHOD0(priority, uint32_t());
   uint32_t overprovisioningFactor() const override { return overprovisioning_factor_; }
   void setOverprovisioningFactor(const uint32_t overprovisioning_factor) {
@@ -93,6 +89,10 @@ public:
   MOCK_CONST_METHOD1(addPriorityUpdateCb, Common::CallbackHandle*(PriorityUpdateCb callback));
   MOCK_CONST_METHOD0(hostSetsPerPriority, const std::vector<HostSetPtr>&());
   MOCK_METHOD0(hostSetsPerPriority, std::vector<HostSetPtr>&());
+  MOCK_METHOD6(updateHosts, void(uint32_t priority, UpdateHostsParams&& update_hosts_params,
+                                 LocalityWeightsConstSharedPtr locality_weights,
+                                 const HostVector& hosts_added, const HostVector& hosts_removed,
+                                 absl::optional<uint32_t> overprovisioning_factor));
 
   MockHostSet* getMockHostSet(uint32_t priority) {
     getHostSet(priority); // Ensure the host set exists.

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -992,7 +992,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_map));
 
-  NiceMock<Upstream::MockCluster> cluster;
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   cluster_map.emplace(cluster.info_->name_, cluster);
 
   NiceMock<Upstream::Outlier::MockDetector> outlier_detector;

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -41,7 +41,7 @@ public:
     lds_config.mutable_api_config_source()->set_api_type(
         envoy::api::v2::core::ApiConfigSource::REST);
     Upstream::ClusterManager::ClusterInfoMap cluster_map;
-    Upstream::MockCluster cluster;
+    Upstream::MockClusterMockPrioritySet cluster;
     cluster_map.emplace("foo_cluster", cluster);
     EXPECT_CALL(cluster_manager_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info());
@@ -218,7 +218,7 @@ TEST_F(LdsApiTest, BadLocalInfo) {
   envoy::api::v2::core::ConfigSource lds_config;
   Config::Utility::translateLdsConfig(*config, lds_config);
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  Upstream::MockCluster cluster;
+  Upstream::MockClusterMockPrioritySet cluster;
   cluster_map.emplace("foo_cluster", cluster);
   EXPECT_CALL(cluster_manager_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);


### PR DESCRIPTION
This is a refactoring step to allow additional logic to be added when
determining what hosts are pass to the membership update callback.
Notably, this will allow EDS to process multiple priorities at once
without triggering intermediate membership update callbacks and allow
named/duplicated endpoints (#4280) to be used safely.

`HostSet` updating is moved to `PrioritySet`, which introduces a shared code
path that is used for all `HostSet` updates. `HostSet`s are now only exposed
as const refs, ensuring that they are not updated without going through
the `PrioritySet` interface. The key is moving the trigger for membership
update out of the `HostSet` so that multiple calls can be made to
`HostSetImpl::updateHost` without triggering an update.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, refactoring only
*Testing*: Current test suite
*Docs Changes*: n/a
*Release Notes*: n/a
[Optional Fixes #Issue]
[Optional *Deprecated*:]
