### PR TITLE
ci: fix OS X CI issues.

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -3,6 +3,10 @@
 # Installs the dependencies required for a macOS build via homebrew.
 # Tools are not upgraded to new versions.
 
+# Setup bazelbuild tap
+brew tap bazelbuild/tap
+brew tap-pin bazelbuild/tap
+
 function is_installed {
     brew ls --versions "$1" >/dev/null
 }


### PR DESCRIPTION
E.g. from https://circleci.com/gh/envoyproxy/envoy/159452?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

we're seeing:

Error: No available formula with the name "bazelbuild/tap/bazel"
Please tap it and then try again: brew tap bazelbuild/tap

Looks like some additional steps are needed for the brew tap based on
https://docs.bazel.build/versions/master/install-os-x.html.

Risk Level: Low
Testing: CI

Fixes #5830

Signed-off-by: Harvey Tuch <htuch@google.com>