### PR TITLE
IoHandle interface

### DIFF
--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -64,7 +64,11 @@ class IoHandle {
 public:
   enum class ShutdownType { Read = 0, Write, Both };
 
-  enum class IoHandleFlag { NonBlock = 0b1, Append = 0b10 };
+  enum class IoHandleFlag {
+    // Each of these maps to a unique bit.
+    NonBlock = 0b01,
+    Append = 0b10
+  };
 
   virtual ~IoHandle() {}
 

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -9,7 +9,7 @@ namespace Network {
 
 namespace Address {
 class Instance;
-}  // namespace Address
+} // namespace Address
 
 template <typename T> struct IoHandleCallResult {
   T rc_;

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -11,7 +11,13 @@ namespace Address {
 class Instance;
 } // namespace Address
 
+/**
+ * Basic type for return result which has a return code and error code defined
+ * according to different implementation.
+ */
 template <typename T> struct IoHandleCallResult {
+  virtual ~IoHandleCallResult() {}
+
   T rc_;
   int errno_;
 };

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -3,6 +3,9 @@
 #include <memory>
 
 #include "envoy/common/pure.h"
+#include "envoy/network/address.h"
+
+class Network::Address::Instance;
 
 namespace Envoy {
 namespace Network {

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -9,7 +9,7 @@ namespace Envoy {
 
 namespace Buffer {
 struct RawSlice;
-}
+} // namespace Buffer
 
 namespace Network {
 
@@ -20,12 +20,19 @@ class Instance;
 class IoError {
 public:
   enum class IoErrorCode {
+    // Success.
     NoError = 0,
+    // No data available right now, try again later.
     Again,
+    // Not supported.
     NoSupport,
+    // Address family not supported.
     AddressFamilyNoSupport,
+    // During non-blocking connect, the connection cannot be completed immediately.
     InProgress,
+    // Permission denied.
     Permission,
+    // Other error codes cannot be mapped to any one above in getErrorCode().
     UnknownError
   };
   virtual ~IoError() {}
@@ -114,6 +121,10 @@ public:
 
   /**
    * Wrap fcntl(fd_, F_SETFL...)
+   * @param flag each bit stands for a flag in enum IoHandleFlag. From low bit
+   * to high bit:
+   * 1st -- NonBlock
+   * 2nd -- Append
    */
   virtual IoHandleCallIntResult setIoHandleFlag(std::bitset<2> flag) PURE;
   /**

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -19,14 +19,14 @@ class Instance;
 
 class IoError {
 public:
-  enum IoErrorCode {
-    IO_NO_ERROR = 0,
-    IO_EAGAIN,
-    IO_ENOTSUP,
-    IO_EAFNOSUPPORT,
-    IO_EINPROGRESS,
-    IO_EPERM,
-    IO_UNKNOWN_ERROR
+  enum class IoErrorCode {
+    NoError = 0,
+    Again,
+    NoSupport,
+    AddressFamilyNoSupport,
+    InProgress,
+    Permission,
+    UnknownError
   };
   virtual ~IoError() {}
 
@@ -38,7 +38,7 @@ public:
 
 /**
  * Basic type for return result which has a return code and error code defined
- * according to different implementation.
+ * according to different implementations.
  */
 template <typename T> struct IoHandleCallResult {
   virtual ~IoHandleCallResult() {}
@@ -55,9 +55,9 @@ using IoHandleCallSizeResult = IoHandleCallResult<ssize_t>;
  */
 class IoHandle {
 public:
-  enum ShutdownType { READ = 0, WRITE, BOTH };
+  enum class ShutdownType { Read = 0, Write, Both };
 
-  enum IoHandleFlag { NONBLOCK = 1, APPEND = 2 };
+  enum class IoHandleFlag { NonBlock = 1, Append = 2 };
 
   virtual ~IoHandle() {}
 

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -31,9 +31,9 @@ public:
   virtual ~IoError() {}
 
   // Map platform specific error into IoErrorCode.
-  virtual IoErrorCode getErrorCode() PURE;
+  virtual IoErrorCode getErrorCode() const PURE;
 
-  virtual std::string getErrorDetails() PURE;
+  virtual std::string getErrorDetails() const PURE;
 };
 
 /**

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -3,12 +3,13 @@
 #include <memory>
 
 #include "envoy/common/pure.h"
-#include "envoy/network/address.h"
-
-class Network::Address::Instance;
 
 namespace Envoy {
 namespace Network {
+
+namespace Address {
+class Instance;
+}  // namespace Address
 
 template <typename T> struct IoHandleCallResult {
   T rc_;
@@ -24,6 +25,16 @@ typedef IoHandleCallResult<ssize_t> IoHandleCallSizeResult;
 class IoHandle {
 public:
   virtual ~IoHandle() {}
+
+  /**
+   * Return data associated with IoHandle.
+   *
+   * TODO(sbelair2) remove fd() method
+   * We probably still need some method similar to this one for
+   * evconnlistener_new(). Or We can move it to IoSocketHandle and down cast the
+   * IoHandle to IoSocketHandle wherever needed.
+   */
+  virtual int fd() const PURE;
 
   /**
    * Clean up IoHandle resources

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -69,7 +69,7 @@ public:
   /**
    * Wrap dup()
    */
-  virtual IoHandlePtr dup() PURE;
+  virtual std::unique_ptr<IoHandle> dup() PURE;
 
   virtual IoHandleCallIntResult shutdown(int how) PURE;
 };

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -17,11 +17,17 @@ namespace Address {
 class Instance;
 } // namespace Address
 
+class IoError;
+
+// IoErrorCode::Again is used frequently. Define it to be a distinguishable address to avoid
+// frequent memory allocation of IoError instance.
+// If this is used, IoHandleCallResult has to be instantiated with a deleter that does not
+// deallocate memory for this error.
+#define ENVOY_ERROR_AGAIN reinterpret_cast<IoError*>(0x01)
+
 class IoError {
 public:
   enum class IoErrorCode {
-    // Success.
-    NoError = 0,
     // No data available right now, try again later.
     Again,
     // Not supported.
@@ -38,20 +44,44 @@ public:
   virtual ~IoError() {}
 
   // Map platform specific error into IoErrorCode.
+  // Needed to hide errorCode() in case of ENVOY_ERROR_AGAIN.
+  static IoErrorCode getErrorCode(const IoError& err) {
+    if (&err == ENVOY_ERROR_AGAIN) {
+      return IoErrorCode::Again;
+    }
+    return err.errorCode();
+  }
+
+  static std::string getErrorDetails(const IoError& err) {
+    if (&err == ENVOY_ERROR_AGAIN) {
+      return "Try again later";
+    }
+    return err.errorDetails();
+  }
+
+protected:
+  // Map platform specific error into IoErrorCode.
   virtual IoErrorCode getErrorCode() const PURE;
 
   virtual std::string getErrorDetails() const PURE;
 };
 
+using IoErrorDeleterType = void (*)(IoError*);
+using IoErrorPtr = std::unique_ptr<IoError, IoErrorDeleterType>;
+
 /**
  * Basic type for return result which has a return code and error code defined
  * according to different implementations.
+ * If the call succeeds, |err_| is nullptr and |rc_| is valid. Otherwise |err_|
+ * can be passed into IoError::getErrorCode() to extract the error. In this
+ * case, |rc_| is invalid.
  */
 template <typename T> struct IoHandleCallResult {
+  IoHandleCallResult(T rc, IoErrorPtr err) : rc_(rc), err_(std::move(err)) {}
   virtual ~IoHandleCallResult() {}
 
   T rc_;
-  std::unique_ptr<IoError> err_;
+  IoErrorPtr err_;
 };
 
 using IoHandleCallIntResult = IoHandleCallResult<int>;

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -7,27 +7,73 @@
 namespace Envoy {
 namespace Network {
 
+template <typename T> struct IoHandleCallResult {
+  T rc_;
+  int errno_;
+};
+
+typedef IoHandleCallResult<int> IoHandleCallIntResult;
+typedef IoHandleCallResult<ssize_t> IoHandleCallSizeResult;
+
 /**
  * IoHandle: an abstract interface for all I/O operations
  */
 class IoHandle {
 public:
-  IoHandle() {}
-
   virtual ~IoHandle() {}
-
-  /**
-   * Return data associated with IoHandle.
-   *
-   * TODO(sbelair2) remove fd() method
-   */
-  virtual int fd() const PURE;
 
   /**
    * Clean up IoHandle resources
    */
-  virtual void close() PURE;
+  virtual IoHandleCallIntResult close() PURE;
+
+  virtual bool isClosed() PURE;
+
+  virtual IoHandleCallSizeResult readv(const iovec* iovec, int num_iovec) PURE;
+
+  virtual IoHandleCallSizeResult writev(const iovec* iovec, int num_iovec) PURE;
+
+  virtual IoHandleCallIntResult bind(const Network::Address::Instance& address) PURE;
+
+  virtual IoHandleCallIntResult connect(const Network::Address::Instance& server_address) PURE;
+
+  /**
+   * Wrap setsockopt()
+   */
+  virtual IoHandleCallIntResult setIoHandleOption(int level, int optname, const void* optval,
+                                                  socklen_t optlen) PURE;
+  /**
+   * Wrap getsockopt()
+   */
+  virtual IoHandleCallIntResult getIoHandleOption(int level, int optname, void* optval,
+                                                  socklen_t* optlen) PURE;
+
+  /**
+   * Wrap getsockname()
+   */
+  virtual IoHandleCallIntResult getIoHandleName(const Network::Address::Instance& address) PURE;
+
+  virtual IoHandleCallIntResult getPeerName(const Network::Address::Instance& address) PURE;
+
+  /**
+   * Wrap fcntl(fd_, F_SETFL...)
+   */
+  virtual IoHandleCallIntResult setIoHandleFlag(int flag) PURE;
+  /**
+   * Wrap fcntl(fd_, F_GETFL...)
+   */
+  virtual IoHandleCallIntResult getIoHandleFlag() PURE;
+
+  virtual IoHandleCallIntResult listen(int backlog) PURE;
+
+  /**
+   * Wrap dup()
+   */
+  virtual IoHandlePtr dup() PURE;
+
+  virtual IoHandleCallIntResult shutdown(int how) PURE;
 };
+
 typedef std::unique_ptr<IoHandle> IoHandlePtr;
 
 } // namespace Network

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -64,17 +64,15 @@ class IoHandle {
 public:
   enum class ShutdownType { Read = 0, Write, Both };
 
-  enum class IoHandleFlag { NonBlock = 1, Append = 2 };
+  enum class IoHandleFlag { NonBlock = 0b1, Append = 0b10 };
 
   virtual ~IoHandle() {}
 
   /**
    * Return data associated with IoHandle.
    *
-   * TODO(sbelair2) remove fd() method
-   * We probably still need some method similar to this one for
-   * evconnlistener_new(). Or We can move it to IoSocketHandle and down cast the
-   * IoHandle to IoSocketHandle wherever needed.
+   * TODO(danzh) move it to IoSocketHandle after replacing the calls to it with
+   * calls to IoHandle API's everywhere.
    */
   virtual int fd() const PURE;
 
@@ -121,10 +119,7 @@ public:
 
   /**
    * Wrap fcntl(fd_, F_SETFL...)
-   * @param flag each bit stands for a flag in enum IoHandleFlag. From low bit
-   * to high bit:
-   * 1st -- NonBlock
-   * 2nd -- Append
+   * @param flag each bit stands for a flag in enum IoHandleFlag.
    */
   virtual IoHandleCallIntResult setIoHandleFlag(std::bitset<2> flag) PURE;
   /**

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -32,7 +32,7 @@ public:
 
   // Map platform specific error into IoErrorCode.
   virtual IoErrorCode getErrorCode() PURE;
-  
+
   virtual std::string getErrorDetails() PURE;
 };
 
@@ -55,16 +55,9 @@ using IoHandleCallSizeResult = IoHandleCallResult<ssize_t>;
  */
 class IoHandle {
 public:
-  enum ShutdownType {
-    READ = 0,
-    WRITE,
-    BOTH
-  };
+  enum ShutdownType { READ = 0, WRITE, BOTH };
 
-  enum IoHandleFlag {
-    NONBLOCK = 1,
-    APPEND = 2
-  };
+  enum IoHandleFlag { NONBLOCK = 1, APPEND = 2 };
 
   virtual ~IoHandle() {}
 
@@ -87,13 +80,12 @@ public:
 
   virtual IoHandleCallSizeResult readv(Buffer::RawSlice* iovecs, int num_iovec) PURE;
 
-  virtual IoHandleCallIntResult recvmmsg(struct mmsghdr *msgvec, unsigned int vlen,
-                    int flags, struct timespec *timeout) PURE;
+  virtual IoHandleCallIntResult recvmmsg(struct mmsghdr* msgvec, unsigned int vlen, int flags,
+                                         struct timespec* timeout) PURE;
 
   virtual IoHandleCallSizeResult writev(const Buffer::RawSlice* iovec, int num_iovec) PURE;
 
-  virtual IoHandleCallIntResult sendmmsg(struct mmsghdr* msgvec, unsigned int vlen,
-                    int flags) PURE;
+  virtual IoHandleCallIntResult sendmmsg(struct mmsghdr* msgvec, unsigned int vlen, int flags) PURE;
 
   virtual IoHandleCallIntResult bind(const Network::Address::Instance& address) PURE;
 

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -1,15 +1,40 @@
 #pragma once
 
+#include <bitset>
 #include <memory>
 
 #include "envoy/common/pure.h"
 
 namespace Envoy {
+
+namespace Buffer {
+struct RawSlice;
+}
+
 namespace Network {
 
 namespace Address {
 class Instance;
 } // namespace Address
+
+class IoError {
+public:
+  enum IoErrorCode {
+    IO_NO_ERROR = 0,
+    IO_EAGAIN,
+    IO_ENOTSUP,
+    IO_EAFNOSUPPORT,
+    IO_EINPROGRESS,
+    IO_EPERM,
+    IO_UNKNOWN_ERROR
+  };
+  virtual ~IoError() {}
+
+  // Map platform specific error into IoErrorCode.
+  virtual IoErrorCode getErrorCode() PURE;
+  
+  virtual std::string getErrorDetails() PURE;
+};
 
 /**
  * Basic type for return result which has a return code and error code defined
@@ -19,17 +44,28 @@ template <typename T> struct IoHandleCallResult {
   virtual ~IoHandleCallResult() {}
 
   T rc_;
-  int errno_;
+  std::unique_ptr<IoError> err_;
 };
 
-typedef IoHandleCallResult<int> IoHandleCallIntResult;
-typedef IoHandleCallResult<ssize_t> IoHandleCallSizeResult;
+using IoHandleCallIntResult = IoHandleCallResult<int>;
+using IoHandleCallSizeResult = IoHandleCallResult<ssize_t>;
 
 /**
  * IoHandle: an abstract interface for all I/O operations
  */
 class IoHandle {
 public:
+  enum ShutdownType {
+    READ = 0,
+    WRITE,
+    BOTH
+  };
+
+  enum IoHandleFlag {
+    NONBLOCK = 1,
+    APPEND = 2
+  };
+
   virtual ~IoHandle() {}
 
   /**
@@ -49,9 +85,15 @@ public:
 
   virtual bool isClosed() PURE;
 
-  virtual IoHandleCallSizeResult readv(const iovec* iovec, int num_iovec) PURE;
+  virtual IoHandleCallSizeResult readv(Buffer::RawSlice* iovecs, int num_iovec) PURE;
 
-  virtual IoHandleCallSizeResult writev(const iovec* iovec, int num_iovec) PURE;
+  virtual IoHandleCallIntResult recvmmsg(struct mmsghdr *msgvec, unsigned int vlen,
+                    int flags, struct timespec *timeout) PURE;
+
+  virtual IoHandleCallSizeResult writev(const Buffer::RawSlice* iovec, int num_iovec) PURE;
+
+  virtual IoHandleCallIntResult sendmmsg(struct mmsghdr* msgvec, unsigned int vlen,
+                    int flags) PURE;
 
   virtual IoHandleCallIntResult bind(const Network::Address::Instance& address) PURE;
 
@@ -69,20 +111,23 @@ public:
                                                   socklen_t* optlen) PURE;
 
   /**
-   * Wrap getsockname()
+   * Wrap Address::addressFromFd()
    */
-  virtual IoHandleCallIntResult getIoHandleName(const Network::Address::Instance& address) PURE;
+  virtual IoHandleCallIntResult getBindToAddress(Network::Address::Instance** address) PURE;
 
-  virtual IoHandleCallIntResult getPeerName(const Network::Address::Instance& address) PURE;
+  /**
+   * Wrap Address::peerAddressFromFd()
+   */
+  virtual IoHandleCallIntResult getPeerAddress(Network::Address::Instance** address) PURE;
 
   /**
    * Wrap fcntl(fd_, F_SETFL...)
    */
-  virtual IoHandleCallIntResult setIoHandleFlag(int flag) PURE;
+  virtual IoHandleCallIntResult setIoHandleFlag(std::bitset<2> flag) PURE;
   /**
    * Wrap fcntl(fd_, F_GETFL...)
    */
-  virtual IoHandleCallIntResult getIoHandleFlag() PURE;
+  virtual IoHandleCallResult<std::bitset<2>> getIoHandleFlags() PURE;
 
   virtual IoHandleCallIntResult listen(int backlog) PURE;
 
@@ -91,7 +136,7 @@ public:
    */
   virtual std::unique_ptr<IoHandle> dup() PURE;
 
-  virtual IoHandleCallIntResult shutdown(int how) PURE;
+  virtual IoHandleCallIntResult shutdown(ShutdownType how) PURE;
 };
 
 typedef std::unique_ptr<IoHandle> IoHandlePtr;


### PR DESCRIPTION
Propose changes to IoHandle interface to wrap socket system calls. This PR is for discussion purpose, so that the IoHandle interface can be used as base class for both socket and non-socket implementations. It won't be checked in as the implementation for these interfaces will go in one by one in following PR's.
Part of #4546 #2557