### PR TITLE
upstream: host weight ranges from 1 to 128

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -164,12 +164,14 @@ public:
   virtual void setOutlierDetector(Outlier::DetectorHostMonitorPtr&& outlier_detector) PURE;
 
   /**
-   * @return the current load balancing weight of the host, in the range 1-100.
+   * @return the current load balancing weight of the host, in the range 1-128 (see
+   * envoy.api.v2.endpoint.Endpoint.load_balancing_weight).
    */
   virtual uint32_t weight() const PURE;
 
   /**
-   * Set the current load balancing weight of the host, in the range 1-100.
+   * Set the current load balancing weight of the host, in the range 1-128 (see
+   * envoy.api.v2.endpoint.Endpoint.load_balancing_weight).
    */
   virtual void weight(uint32_t new_weight) PURE;
 

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -70,6 +70,7 @@ MaglevTable::MaglevTable(const HostsPerLocality& hosts_per_locality,
       // it had weight equal to backend_weight_scale / 3, then this would only
       // happen every 3 iterations, etc.
       if (iteration * entry.weight_ < entry.counts_) {
+        ASSERT(max_host_weight > 1);
         continue;
       }
       entry.counts_ += max_host_weight;

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -13,13 +13,21 @@ MaglevTable::MaglevTable(const HostsPerLocality& hosts_per_locality,
   // not good!).
   ASSERT(Primes::isPrime(table_size));
 
+  // Sanity-check that the locality weights, if provided, line up with the hosts per locality.
+  if (locality_weights != nullptr) {
+    ASSERT(locality_weights->size() == hosts_per_locality.get().size());
+  }
+
   // Compute host weight combined with locality weight where applicable.
   const auto effective_weight = [&locality_weights](uint32_t host_weight,
                                                     uint32_t locality_index) -> uint32_t {
-    if (locality_weights == nullptr || locality_weights->empty()) {
+    ASSERT(host_weight != 0);
+    if (locality_weights == nullptr) {
       return host_weight;
     } else {
-      return host_weight * (*locality_weights)[locality_index];
+      auto locality_weight = (*locality_weights)[locality_index];
+      ASSERT(locality_weight != 0);
+      return host_weight * locality_weight;
     }
   };
 


### PR DESCRIPTION
*Description*: Fix some incorrect comments about the range of valid host weights, and updated Maglev LB implementation to assume weights are always non-zero.
*Risk Level*: Low
*Testing*: Existing tests, including maglev_lb_test and upstream_impl_test.
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Dan Rosen <mergeconflict@google.com>
