### PR TITLE
Add quic_client_stats_impl.h to QUICHE platform implementation

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -114,6 +114,7 @@ cc_library(
     hdrs = [
         "quiche/quic/platform/api/quic_aligned.h",
         "quiche/quic/platform/api/quic_arraysize.h",
+        "quiche/quic/platform/api/quic_client_stats.h",
         "quiche/quic/platform/api/quic_containers.h",
         "quiche/quic/platform/api/quic_endian.h",
         "quiche/quic/platform/api/quic_estimate_memory_usage.h",
@@ -130,7 +131,6 @@ cc_library(
         "quiche/quic/platform/api/quic_uint128.h",
         # TODO: uncomment the following files as implementations are added.
         # "quiche/quic/platform/api/quic_bug_tracker.h",
-        # "quiche/quic/platform/api/quic_client_stats.h",
         # "quiche/quic/platform/api/quic_clock.h",
         # "quiche/quic/platform/api/quic_expect_bug.h",
         # "quiche/quic/platform/api/quic_exported_stats.h",

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
     hdrs = [
         "quic_aligned_impl.h",
         "quic_arraysize_impl.h",
+        "quic_client_stats_impl.h",
         "quic_containers_impl.h",
         "quic_endian_impl.h",
         "quic_estimate_memory_usage_impl.h",

--- a/source/extensions/quic_listeners/quiche/platform/quic_client_stats_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_client_stats_impl.h
@@ -6,6 +6,8 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
+#include <string>
+
 #define QUIC_CLIENT_HISTOGRAM_ENUM_IMPL(name, sample, enum_size, docstring)                        \
   do {                                                                                             \
   } while (0)

--- a/source/extensions/quic_listeners/quiche/platform/quic_client_stats_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_client_stats_impl.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+//
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#define QUIC_CLIENT_HISTOGRAM_ENUM_IMPL(name, sample, enum_size, docstring)                        \
+  do {                                                                                             \
+  } while (0)
+#define QUIC_CLIENT_HISTOGRAM_BOOL_IMPL(name, sample, docstring)                                   \
+  do {                                                                                             \
+  } while (0)
+#define QUIC_CLIENT_HISTOGRAM_TIMES_IMPL(name, sample, min, max, num_buckets, docstring)           \
+  do {                                                                                             \
+  } while (0)
+#define QUIC_CLIENT_HISTOGRAM_COUNTS_IMPL(name, sample, min, max, num_buckets, docstring)          \
+  do {                                                                                             \
+  } while (0)
+
+namespace quic {
+
+inline void QuicClientSparseHistogramImpl(const std::string& /*name*/, int /*sample*/) {}
+
+} // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_client_stats_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_client_stats_impl.h
@@ -8,6 +8,10 @@
 
 #include <string>
 
+// NOTE(wub): These macros are currently NOOP because they are supposed to be
+// used by client-side stats. They should be implemented when QUIC client code
+// is used by Envoy to connect to backends.
+
 #define QUIC_CLIENT_HISTOGRAM_ENUM_IMPL(name, sample, enum_size, docstring)                        \
   do {                                                                                             \
   } while (0)

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -2,6 +2,7 @@
 
 #include "quiche/quic/platform/api/quic_aligned.h"
 #include "quiche/quic/platform/api/quic_arraysize.h"
+#include "quiche/quic/platform/api/quic_client_stats.h"
 #include "quiche/quic/platform/api/quic_containers.h"
 #include "quiche/quic/platform/api/quic_endian.h"
 #include "quiche/quic/platform/api/quic_estimate_memory_usage.h"
@@ -27,6 +28,19 @@ TEST(QuicPlatformTest, QuicAlignOf) { EXPECT_LT(0, QUIC_ALIGN_OF(int)); }
 TEST(QuicPlatformTest, QuicArraysize) {
   int array[] = {0, 1, 2, 3, 4};
   EXPECT_EQ(5, QUIC_ARRAYSIZE(array));
+}
+
+enum class TestEnum { ZERO = 0, ONE, TWO, COUNT };
+
+TEST(QuicPlatformTest, QuicClientStats) {
+  // Just make sure they compiles.
+  QUIC_CLIENT_HISTOGRAM_ENUM("my.enum.histogram", TestEnum::ONE, TestEnum::COUNT, "doc");
+  QUIC_CLIENT_HISTOGRAM_BOOL("my.bool.histogram", false, "doc");
+  QUIC_CLIENT_HISTOGRAM_TIMES("my.timing.histogram", quic::QuicTime::Delta::FromSeconds(5),
+                              quic::QuicTime::Delta::FromSeconds(1),
+                              quic::QuicTime::Delta::FromSecond(3600), 100, "doc");
+  QUIC_CLIENT_HISTOGRAM_COUNTS("my.count.histogram", 123, 0, 1000, 100, "doc");
+  quic::QuicClientSparseHistogram("my.sparse.histogram", 345);
 }
 
 TEST(QuicPlatformTest, QuicUnorderedMap) {

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -33,7 +33,7 @@ TEST(QuicPlatformTest, QuicArraysize) {
 enum class TestEnum { ZERO = 0, ONE, TWO, COUNT };
 
 TEST(QuicPlatformTest, QuicClientStats) {
-  // Just make sure they compiles.
+  // Just make sure they compile.
   QUIC_CLIENT_HISTOGRAM_ENUM("my.enum.histogram", TestEnum::ONE, TestEnum::COUNT, "doc");
   QUIC_CLIENT_HISTOGRAM_BOOL("my.bool.histogram", false, "doc");
   QUIC_CLIENT_HISTOGRAM_TIMES("my.timing.histogram", quic::QuicTime::Delta::FromSeconds(5),


### PR DESCRIPTION
*Description*:

Add quic_client_stats_impl.h to QUICHE platform implementation, with everything being no-op.

*Risk Level*: minimal: code not used yet
*Testing*: bazel test test/extensions/quic_listeners/quiche/platform:quic_platform_test --test_output=all
*Docs Changes*: none
*Release Notes*: none
[Optional Fixes #Issue]
[Optional *Deprecated*:]
