### PR TITLE
build: fix oss-fuzz build.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -357,10 +357,15 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         }),
         tags = tags,
     )
+
+    # This target exists only for
+    # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield
+    # anything useful on its own, as it expects to be run in an environment where the linker options
+    # provide a path to FuzzingEngine.
     native.cc_binary(
         name = name + "_driverless",
         copts = envoy_copts("@envoy", test = True),
-        linkopts = envoy_test_linkopts(),
+        linkopts = ["-lFuzzingEngine"] + envoy_test_linkopts(),
         linkstatic = 1,
         testonly = 1,
         deps = [":" + test_lib_name],


### PR DESCRIPTION
Due to the external_cmake changes (amongst others), we've regressed on
the fuzzer build. We need to do the final link now inside the cc_binary,
as external_cmake has issues with transitivity and unrelated binaries
(see https://github.com/bazelbuild/rules_foreign_cc/issues/222).

Risk level: Low
Testing: oss-fuzz Docker build for Envoy's fuzzers.

Signed-off-by: Harvey Tuch <htuch@google.com>