### PR TITLE
time: Change most interfaces from TimeSystem to TimeSource.

### DIFF
--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -43,7 +43,6 @@ public:
 
   /**
    * TODO(jmarantz): This is exposed for now only for the dispatcher. We will
-   *
    * do a refactor in the future to remove the need for this accessor.
    * @return a reference to the time-system
    */

--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -37,10 +37,17 @@ public:
   virtual Filesystem::Instance& fileSystem() PURE;
 
   /**
-   * @return a reference to the TimeSystem
-   * TODO(jmarantz): change this to return a TimeSource.
+   * @return a reference to the TimeSource
    */
-  virtual Event::TimeSystem& timeSystem() PURE;
+  virtual TimeSource& timeSource() PURE;
+
+  /**
+   * TODO(jmarantz): This is exposed for now only for the dispatcher. We will
+   *
+   * do a refactor in the future to remove the need for this accessor.
+   * @return a reference to the time-system
+   */
+  virtual Event::TimeSystem& timeSystemForDispatcher() PURE;
 };
 
 typedef std::unique_ptr<Api> ApiPtr;

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -37,7 +37,7 @@ public:
   /**
    * Returns a time-source to use with this dispatcher.
    */
-  virtual TimeSystem& timeSystem() PURE;
+  virtual TimeSource& timeSource() PURE;
 
   /**
    * Clear any items in the deferred deletion queue.

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -199,9 +199,9 @@ public:
   virtual const LocalInfo::LocalInfo& localInfo() PURE;
 
   /**
-   * @return the time system used for the server.
+   * @return the time source used for the server.
    */
-  virtual Event::TimeSystem& timeSystem() PURE;
+  virtual TimeSource& timeSource() PURE;
 
   /**
    * @return the flush interval of stats sinks.

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -22,10 +22,11 @@ public:
        Stats::Store& stats_store, Event::TimeSystem& time_system);
 
   // Api::Api
-  Event::DispatcherPtr allocateDispatcher() override;
   Thread::ThreadFactory& threadFactory() override { return thread_factory_; }
   Filesystem::Instance& fileSystem() override { return file_system_; }
-  Event::TimeSystem& timeSystem() override { return time_system_; }
+  Event::DispatcherPtr allocateDispatcher() override;
+  TimeSource& timeSource() override { return time_system_; }
+  Event::TimeSystem& timeSystemForDispatcher() override { return time_system_; }
 
 private:
   Thread::ThreadFactory& thread_factory_;

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -22,9 +22,9 @@ public:
        Stats::Store& stats_store, Event::TimeSystem& time_system);
 
   // Api::Api
+  Event::DispatcherPtr allocateDispatcher() override;
   Thread::ThreadFactory& threadFactory() override { return thread_factory_; }
   Filesystem::Instance& fileSystem() override { return file_system_; }
-  Event::DispatcherPtr allocateDispatcher() override;
   TimeSource& timeSource() override { return time_system_; }
   Event::TimeSystem& timeSystemForDispatcher() override { return time_system_; }
 

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -24,7 +24,7 @@ public:
              const RateLimitSettings& rate_limit_settings)
       : async_client_(std::move(async_client)), service_method_(service_method),
         control_plane_stats_(generateControlPlaneStats(scope)), random_(random),
-        time_source_(dispatcher.timeSystem()),
+        time_source_(dispatcher.timeSource()),
         rate_limiting_enabled_(rate_limit_settings.enabled_) {
     retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
     if (rate_limiting_enabled_) {

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -34,7 +34,7 @@ DispatcherImpl::DispatcherImpl(Api::Api& api)
 
 DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory, Api::Api& api)
     : api_(api), buffer_factory_(std::move(factory)), base_(event_base_new()),
-      scheduler_(api.timeSystem().createScheduler(base_)),
+      scheduler_(api.timeSystemForDispatcher().createScheduler(base_)),
       deferred_delete_timer_(createTimer([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimer([this]() -> void { runPostCallbacks(); })),
       current_to_delete_(&to_delete_1_) {

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -33,7 +33,7 @@ public:
   event_base& base() { return *base_; }
 
   // Event::Dispatcher
-  TimeSystem& timeSystem() override { return api_.timeSystem(); }
+  TimeSource& timeSource() override { return api_.timeSource(); }
   void clearDeferredDeleteList() override;
   Network::ConnectionPtr
   createServerConnection(Network::ConnectionSocketPtr&& socket,

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -167,7 +167,7 @@ public:
   AsyncStream* start(const Protobuf::MethodDescriptor& service_method,
                      AsyncStreamCallbacks& callbacks) override;
 
-  TimeSource& timeSource() { return dispatcher_.timeSystem(); }
+  TimeSource& timeSource() { return dispatcher_.timeSource(); }
 
 private:
   static std::shared_ptr<grpc::Channel>

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -40,7 +40,7 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
                                  Http::Context& http_context)
     : cluster_(cluster),
       config_("http.async-client.", local_info, stats_store, cm, runtime, random,
-              std::move(shadow_writer), true, false, false, dispatcher.timeSystem(), http_context),
+              std::move(shadow_writer), true, false, false, dispatcher.timeSource(), http_context),
       dispatcher_(dispatcher) {}
 
 AsyncClientImpl::~AsyncClientImpl() {
@@ -76,7 +76,7 @@ AsyncClient::Stream* AsyncClientImpl::start(AsyncClient::StreamCallbacks& callba
 AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
                                  const AsyncClient::StreamOptions& options)
     : parent_(parent), stream_callbacks_(callbacks), stream_id_(parent.config_.random_.random()),
-      router_(parent.config_), stream_info_(Protocol::Http11, parent.dispatcher().timeSystem()),
+      router_(parent.config_), stream_info_(Protocol::Http11, parent.dispatcher().timeSource()),
       tracing_config_(Tracing::EgressConfig::get()),
       route_(std::make_shared<RouteImpl>(parent_.cluster_->name(), options.timeout)),
       send_xff_(options.send_xff) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -63,9 +63,9 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
                                              const LocalInfo::LocalInfo& local_info,
                                              Upstream::ClusterManager& cluster_manager,
                                              Server::OverloadManager* overload_manager,
-                                             TimeSource& time_system)
+                                             TimeSource& time_source)
     : config_(config), stats_(config_.stats()),
-      conn_length_(new Stats::Timespan(stats_.named_.downstream_cx_length_ms_, time_system)),
+      conn_length_(new Stats::Timespan(stats_.named_.downstream_cx_length_ms_, time_source)),
       drain_close_(drain_close), random_generator_(random_generator), http_context_(http_context),
       runtime_(runtime), local_info_(local_info), cluster_manager_(cluster_manager),
       listener_stats_(config_.listenerStats()),
@@ -77,7 +77,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
           overload_manager ? overload_manager->getThreadLocalOverloadState().getState(
                                  Server::OverloadActionNames::get().DisableHttpKeepAlive)
                            : Server::OverloadManager::getInactiveState()),
-      time_source_(time_system) {}
+      time_source_(time_source) {}
 
 const HeaderMapImpl& ConnectionManagerImpl::continueHeader() {
   CONSTRUCT_ON_FIRST_USE(HeaderMapImpl,

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -63,7 +63,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
                                              const LocalInfo::LocalInfo& local_info,
                                              Upstream::ClusterManager& cluster_manager,
                                              Server::OverloadManager* overload_manager,
-                                             Event::TimeSystem& time_system)
+                                             TimeSource& time_system)
     : config_(config), stats_(config_.stats()),
       conn_length_(new Stats::Timespan(stats_.named_.downstream_cx_length_ms_, time_system)),
       drain_close_(drain_close), random_generator_(random_generator), http_context_(http_context),
@@ -77,7 +77,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
           overload_manager ? overload_manager->getThreadLocalOverloadState().getState(
                                  Server::OverloadActionNames::get().DisableHttpKeepAlive)
                            : Server::OverloadManager::getInactiveState()),
-      time_system_(time_system) {}
+      time_source_(time_system) {}
 
 const HeaderMapImpl& ConnectionManagerImpl::continueHeader() {
   CONSTRUCT_ON_FIRST_USE(HeaderMapImpl,
@@ -369,8 +369,8 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
       snapped_route_config_(connection_manager.config_.routeConfigProvider().config()),
       stream_id_(connection_manager.random_generator_.random()),
       request_response_timespan_(new Stats::Timespan(
-          connection_manager_.stats_.named_.downstream_rq_time_, connection_manager_.timeSystem())),
-      stream_info_(connection_manager_.codec_->protocol(), connection_manager_.timeSystem()) {
+          connection_manager_.stats_.named_.downstream_rq_time_, connection_manager_.timeSource())),
+      stream_info_(connection_manager_.codec_->protocol(), connection_manager_.timeSource()) {
   connection_manager_.stats_.named_.downstream_rq_total_.inc();
   connection_manager_.stats_.named_.downstream_rq_active_.inc();
   if (connection_manager_.codec_->protocol() == Protocol::Http2) {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -51,7 +51,7 @@ public:
                         Runtime::RandomGenerator& random_generator, Http::Context& http_context,
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info,
                         Upstream::ClusterManager& cluster_manager,
-                        Server::OverloadManager* overload_manager, Event::TimeSystem& time_system);
+                        Server::OverloadManager* overload_manager, TimeSource& time_system);
   ~ConnectionManagerImpl();
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -85,7 +85,7 @@ public:
     codec_->onUnderlyingConnectionBelowWriteBufferLowWatermark();
   }
 
-  Event::TimeSystem& timeSystem() { return time_system_; }
+  TimeSource& timeSource() { return time_source_; }
 
 private:
   struct ActiveStream;
@@ -489,7 +489,7 @@ private:
   // lookup in the hot path of processing each request.
   const Server::OverloadActionState& overload_stop_accepting_requests_ref_;
   const Server::OverloadActionState& overload_disable_keepalive_ref_;
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
 };
 
 } // namespace Http

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -10,7 +10,7 @@ DateFormatter DateProviderImplBase::date_formatter_("%a, %d %b %Y %H:%M:%S GMT")
 
 TlsCachingDateProviderImpl::TlsCachingDateProviderImpl(Event::Dispatcher& dispatcher,
                                                        ThreadLocal::SlotAllocator& tls)
-    : DateProviderImplBase(dispatcher.timeSystem()), tls_(tls.allocateSlot()),
+    : DateProviderImplBase(dispatcher.timeSource()), tls_(tls.allocateSlot()),
       refresh_timer_(dispatcher.createTimer([this]() -> void { onRefreshDate(); })) {
 
   onRefreshDate();

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -285,7 +285,7 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
       remaining_requests_(parent_.host_->cluster().maxRequestsPerConnection()) {
 
   parent_.conn_connect_ms_ = std::make_unique<Stats::Timespan>(
-      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem());
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSource());
   Upstream::Host::CreateConnectionData data =
       parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_, nullptr);
   real_host_description_ = data.host_description_;
@@ -298,7 +298,7 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->stats().cx_total_.inc();
   parent_.host_->stats().cx_active_.inc();
   conn_length_ = std::make_unique<Stats::Timespan>(
-      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSystem());
+      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSource());
   connect_timer_->enableTimer(parent_.host_->cluster().connectTimeout());
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().inc();
 

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -260,7 +260,7 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
     : parent_(parent),
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })) {
   parent_.conn_connect_ms_ = std::make_unique<Stats::Timespan>(
-      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem());
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSource());
   Upstream::Host::CreateConnectionData data =
       parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_, nullptr);
   real_host_description_ = data.host_description_;
@@ -276,7 +276,7 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_active_.inc();
   parent_.host_->cluster().stats().upstream_cx_http2_total_.inc();
   conn_length_ = std::make_unique<Stats::Timespan>(
-      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSystem());
+      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSource());
 
   client_->setConnectionStats({parent_.host_->cluster().stats().upstream_cx_rx_bytes_total_,
                                parent_.host_->cluster().stats().upstream_cx_rx_bytes_buffered_,

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -47,7 +47,7 @@ std::atomic<uint64_t> ConnectionImpl::next_global_id_;
 ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPtr&& socket,
                                TransportSocketPtr&& transport_socket, bool connected)
     : transport_socket_(std::move(transport_socket)), socket_(std::move(socket)),
-      filter_manager_(*this, *this), stream_info_(dispatcher.timeSystem()),
+      filter_manager_(*this, *this), stream_info_(dispatcher.timeSource()),
       write_buffer_(
           dispatcher.getWatermarkFactory().create([this]() -> void { this->onLowWatermark(); },
                                                   [this]() -> void { this->onHighWatermark(); })),

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -338,7 +338,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       direct_response_body_(ConfigUtility::parseDirectResponseBody(route, factory_context.api())),
       per_filter_configs_(route.typed_per_filter_config(), route.per_filter_config(),
                           factory_context),
-      time_system_(factory_context.dispatcher().timeSystem()),
+      time_source_(factory_context.dispatcher().timeSource()),
       internal_redirect_action_(convertInternalRedirectAction(route.route())) {
   if (route.route().has_metadata_match()) {
     const auto filter_it = route.route().metadata_match().filter_metadata().find(

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -603,7 +603,7 @@ private:
   const absl::optional<Http::Code> direct_response_code_;
   std::string direct_response_body_;
   PerFilterConfigs per_filter_configs_;
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
   InternalRedirectAction internal_redirect_action_;
 };
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -493,7 +493,7 @@ void Filter::maybeDoShadowing() {
 void Filter::onRequestComplete() {
   downstream_end_stream_ = true;
   Event::Dispatcher& dispatcher = callbacks_->dispatcher();
-  downstream_request_complete_time_ = dispatcher.timeSystem().monotonicTime();
+  downstream_request_complete_time_ = dispatcher.timeSource().monotonicTime();
 
   // Possible that we got an immediate reset.
   if (upstream_request_) {
@@ -719,7 +719,7 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
   // premature response.
   if (DateUtil::timePointValid(downstream_request_complete_time_)) {
     Event::Dispatcher& dispatcher = callbacks_->dispatcher();
-    MonotonicTime response_received_time = dispatcher.timeSystem().monotonicTime();
+    MonotonicTime response_received_time = dispatcher.timeSource().monotonicTime();
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         response_received_time - downstream_request_complete_time_);
     if (!config_.suppress_envoy_headers_) {
@@ -792,7 +792,7 @@ void Filter::onUpstreamComplete() {
       DateUtil::timePointValid(downstream_request_complete_time_)) {
     Event::Dispatcher& dispatcher = callbacks_->dispatcher();
     std::chrono::milliseconds response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-        dispatcher.timeSystem().monotonicTime() - downstream_request_complete_time_);
+        dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
 
     upstream_request_->upstream_host_->outlierDetector().putResponseTime(response_time);
 
@@ -925,7 +925,7 @@ void Filter::doRetry() {
 
 Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::Instance& pool)
     : parent_(parent), conn_pool_(pool), grpc_rq_success_deferred_(false),
-      stream_info_(pool.protocol(), parent_.callbacks_->dispatcher().timeSystem()),
+      stream_info_(pool.protocol(), parent_.callbacks_->dispatcher().timeSource()),
       calling_encode_headers_(false), upstream_canary_(false), encode_complete_(false),
       encode_trailers_(false) {
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -112,7 +112,7 @@ public:
                      context.runtime(), context.random(), std::move(shadow_writer),
                      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, dynamic_stats, true),
                      config.start_child_span(), config.suppress_envoy_headers(),
-                     context.api().timeSystem(), context.httpContext()) {
+                     context.api().timeSource(), context.httpContext()) {
     for (const auto& upstream_log : config.upstream_log()) {
       upstream_logs_.push_back(AccessLog::AccessLogFactory::fromProto(upstream_log, context));
     }

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -356,7 +356,7 @@ ConnPoolImpl::ActiveConn::ActiveConn(ConnPoolImpl& parent)
       remaining_requests_(parent_.host_->cluster().maxRequestsPerConnection()), timed_out_(false) {
 
   parent_.conn_connect_ms_ = std::make_unique<Stats::Timespan>(
-      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem());
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSource());
 
   Upstream::Host::CreateConnectionData data = parent_.host_->createConnection(
       parent_.dispatcher_, parent_.socket_options_, parent_.transport_socket_options_);
@@ -376,7 +376,7 @@ ConnPoolImpl::ActiveConn::ActiveConn(ConnPoolImpl& parent)
   parent_.host_->stats().cx_total_.inc();
   parent_.host_->stats().cx_active_.inc();
   conn_length_ = std::make_unique<Stats::Timespan>(
-      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSystem());
+      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSource());
   connect_timer_->enableTimer(parent_.host_->cluster().connectTimeout());
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().inc();
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -178,7 +178,7 @@ ClusterManagerImpl::ClusterManagerImpl(
       init_helper_([this](Cluster& cluster) { onClusterInit(cluster); }),
       config_tracker_entry_(
           admin.getConfigTracker().add("clusters", [this] { return dumpClusterConfigs(); })),
-      time_source_(main_thread_dispatcher.timeSystem()), dispatcher_(main_thread_dispatcher),
+      time_source_(main_thread_dispatcher.timeSource()), dispatcher_(main_thread_dispatcher),
       http_context_(http_context) {
   async_client_manager_ =
       std::make_unique<Grpc::AsyncClientManagerImpl>(*this, tls, time_source_, api);

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -52,7 +52,7 @@ HealthCheckerFactory::create(const envoy::api::v2::core::HealthCheck& health_che
   HealthCheckEventLoggerPtr event_logger;
   if (!health_check_config.event_log_path().empty()) {
     event_logger = std::make_unique<HealthCheckEventLoggerImpl>(
-        log_manager, dispatcher.timeSystem(), health_check_config.event_log_path());
+        log_manager, dispatcher.timeSource(), health_check_config.event_log_path());
   }
   switch (health_check_config.health_checker_case()) {
   case envoy::api::v2::core::HealthCheck::HealthCheckerCase::kHttpHealthCheck:
@@ -156,7 +156,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
       {Http::Headers::get().Path, parent_.path_},
       {Http::Headers::get().UserAgent, Http::Headers::get().UserAgentValues.EnvoyHealthChecker}};
   Router::FilterUtility::setUpstreamScheme(request_headers, *parent_.cluster_.info());
-  StreamInfo::StreamInfoImpl stream_info(protocol_, parent_.dispatcher_.timeSystem());
+  StreamInfo::StreamInfoImpl stream_info(protocol_, parent_.dispatcher_.timeSource());
   stream_info.setDownstreamLocalAddress(local_address_);
   stream_info.setDownstreamRemoteAddress(local_address_);
   stream_info.onUpstreamHostSelected(host_);

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -16,7 +16,7 @@ LoadStatsReporter::LoadStatsReporter(const LocalInfo::LocalInfo& local_info,
       async_client_(std::move(async_client)),
       service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
           "envoy.service.load_stats.v2.LoadReportingService.StreamLoadStats")),
-      time_source_(dispatcher.timeSystem()) {
+      time_source_(dispatcher.timeSource()) {
   request_.mutable_node()->MergeFrom(local_info.node());
   retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   response_timer_ = dispatcher.createTimer([this]() -> void { sendLoadStatsRequest(); });

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -27,7 +27,7 @@ DetectorSharedPtr DetectorImplFactory::createForCluster(
   if (cluster_config.has_outlier_detection()) {
 
     return DetectorImpl::create(cluster, cluster_config.outlier_detection(), dispatcher, runtime,
-                                dispatcher.timeSystem(), std::move(event_logger));
+                                dispatcher.timeSource(), std::move(event_logger));
   } else {
     return nullptr;
   }

--- a/source/extensions/filters/http/dynamo/config.cc
+++ b/source/extensions/filters/http/dynamo/config.cc
@@ -16,7 +16,7 @@ DynamoFilterConfig::createFilter(const std::string& stat_prefix,
                                  Server::Configuration::FactoryContext& context) {
   return [&context, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new Dynamo::DynamoFilter(
-        context.runtime(), stat_prefix, context.scope(), context.dispatcher().timeSystem())});
+        context.runtime(), stat_prefix, context.scope(), context.dispatcher().timeSource())});
   };
 }
 

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -24,7 +24,7 @@ namespace Dynamo {
 
 Http::FilterHeadersStatus DynamoFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   if (enabled_) {
-    start_decode_ = time_system_.monotonicTime();
+    start_decode_ = time_source_.monotonicTime();
     operation_ = RequestParser::parseOperation(headers);
     return Http::FilterHeadersStatus::StopIteration;
   } else {
@@ -173,7 +173,7 @@ void DynamoFilter::chargeBasicStats(uint64_t status) {
 void DynamoFilter::chargeStatsPerEntity(const std::string& entity, const std::string& entity_type,
                                         uint64_t status) {
   std::chrono::milliseconds latency = std::chrono::duration_cast<std::chrono::milliseconds>(
-      time_system_.monotonicTime() - start_decode_);
+      time_source_.monotonicTime() - start_decode_);
 
   std::string group_string =
       Http::CodeUtility::groupStringForResponseCode(static_cast<Http::Code>(status));

--- a/source/extensions/filters/http/dynamo/dynamo_filter.h
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.h
@@ -25,9 +25,9 @@ namespace Dynamo {
 class DynamoFilter : public Http::StreamFilter {
 public:
   DynamoFilter(Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Scope& scope,
-               Event::TimeSystem& time_system)
+               TimeSource& time_system)
       : runtime_(runtime), stat_prefix_(stat_prefix + "dynamodb."), scope_(scope),
-        time_system_(time_system) {
+        time_source_(time_system) {
     enabled_ = runtime_.snapshot().featureEnabled("dynamodb.filter_enabled", 100);
   }
 
@@ -79,7 +79,7 @@ private:
   Http::HeaderMap* response_headers_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
 };
 
 } // namespace Dynamo

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -65,7 +65,7 @@ public:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
       : proto_config_(proto_config), stats_(generateStats(stats_prefix, context.scope())),
         tls_(context.threadLocal().allocateSlot()), cm_(context.clusterManager()),
-        time_source_(context.dispatcher().timeSystem()), api_(context.api()) {
+        time_source_(context.dispatcher().timeSource()), api_(context.api()) {
     ENVOY_LOG(info, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
     tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
       return std::make_shared<ThreadLocalCache>(proto_config_, time_source_, api_);

--- a/source/extensions/filters/network/dubbo_proxy/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/config.cc
@@ -19,7 +19,7 @@ Network::FilterFactoryCb DubboProxyFilterConfigFactory::createFilterFactoryFromP
   return [stat_prefix, &proto_config, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<Filter>(
         stat_prefix, proto_config.protocol_type(), proto_config.serialization_type(),
-        context.scope(), context.dispatcher().timeSystem()));
+        context.scope(), context.dispatcher().timeSource()));
   };
 }
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -99,7 +99,7 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoTyped(
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
         *filter_config, context.drainDecision(), context.random(), context.httpContext(),
         context.runtime(), context.localInfo(), context.clusterManager(),
-        &context.overloadManager(), context.dispatcher().timeSystem())});
+        &context.overloadManager(), context.dispatcher().timeSource())});
   };
 }
 

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -24,7 +24,7 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
   AccessLogSharedPtr access_log;
   if (!proto_config.access_log().empty()) {
     access_log.reset(new AccessLog(proto_config.access_log(), context.accessLogManager(),
-                                   context.dispatcher().timeSystem()));
+                                   context.dispatcher().timeSource()));
   }
 
   FaultConfigSharedPtr fault_config;
@@ -39,7 +39,7 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
           emit_dynamic_metadata](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<ProdProxyFilter>(
         stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
-        context.drainDecision(), context.random(), context.dispatcher().timeSystem(),
+        context.drainDecision(), context.random(), context.dispatcher().timeSource(),
         emit_dynamic_metadata));
   };
 }

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -58,11 +58,11 @@ ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope,
                          Runtime::Loader& runtime, AccessLogSharedPtr access_log,
                          const FaultConfigSharedPtr& fault_config,
                          const Network::DrainDecision& drain_decision,
-                         Runtime::RandomGenerator& generator, Event::TimeSystem& time_system,
+                         Runtime::RandomGenerator& generator, TimeSource& time_system,
                          bool emit_dynamic_metadata)
     : stat_prefix_(stat_prefix), scope_(scope), stats_(generateStats(stat_prefix, scope)),
       runtime_(runtime), drain_decision_(drain_decision), generator_(generator),
-      access_log_(access_log), fault_config_(fault_config), time_system_(time_system),
+      access_log_(access_log), fault_config_(fault_config), time_source_(time_system),
       emit_dynamic_metadata_(emit_dynamic_metadata) {
   if (!runtime_.snapshot().featureEnabled(MongoRuntimeConfig::get().ConnectionLoggingEnabled,
                                           100)) {
@@ -283,7 +283,7 @@ void ProxyFilter::chargeReplyStats(ActiveQuery& active_query, const std::string&
   scope_.histogram(fmt::format("{}.reply_size", prefix)).recordValue(reply_documents_byte_size);
   scope_.histogram(fmt::format("{}.reply_time_ms", prefix))
       .recordValue(std::chrono::duration_cast<std::chrono::milliseconds>(
-                       time_system_.monotonicTime() - active_query.start_time_)
+                       time_source_.monotonicTime() - active_query.start_time_)
                        .count());
 }
 

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -58,11 +58,11 @@ ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope,
                          Runtime::Loader& runtime, AccessLogSharedPtr access_log,
                          const FaultConfigSharedPtr& fault_config,
                          const Network::DrainDecision& drain_decision,
-                         Runtime::RandomGenerator& generator, TimeSource& time_system,
+                         Runtime::RandomGenerator& generator, TimeSource& time_source,
                          bool emit_dynamic_metadata)
     : stat_prefix_(stat_prefix), scope_(scope), stats_(generateStats(stat_prefix, scope)),
       runtime_(runtime), drain_decision_(drain_decision), generator_(generator),
-      access_log_(access_log), fault_config_(fault_config), time_source_(time_system),
+      access_log_(access_log), fault_config_(fault_config), time_source_(time_source),
       emit_dynamic_metadata_(emit_dynamic_metadata) {
   if (!runtime_.snapshot().featureEnabled(MongoRuntimeConfig::get().ConnectionLoggingEnabled,
                                           100)) {

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -128,7 +128,7 @@ public:
   ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope, Runtime::Loader& runtime,
               AccessLogSharedPtr access_log, const FaultConfigSharedPtr& fault_config,
               const Network::DrainDecision& drain_decision, Runtime::RandomGenerator& generator,
-              Event::TimeSystem& time_system, bool emit_dynamic_metadata);
+              TimeSource& time_system, bool emit_dynamic_metadata);
   ~ProxyFilter();
 
   virtual DecoderPtr createDecoder(DecoderCallbacks& callbacks) PURE;
@@ -163,7 +163,7 @@ public:
 private:
   struct ActiveQuery {
     ActiveQuery(ProxyFilter& parent, const QueryMessage& query)
-        : parent_(parent), query_info_(query), start_time_(parent_.time_system_.monotonicTime()) {
+        : parent_(parent), query_info_(query), start_time_(parent_.time_source_.monotonicTime()) {
       parent_.stats_.op_query_active_.inc();
     }
 
@@ -208,7 +208,7 @@ private:
   const FaultConfigSharedPtr fault_config_;
   Event::TimerPtr delay_timer_;
   Event::TimerPtr drain_close_timer_;
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
   const bool emit_dynamic_metadata_;
 };
 

--- a/source/extensions/filters/network/tcp_proxy/config.cc
+++ b/source/extensions/filters/network/tcp_proxy/config.cc
@@ -30,7 +30,7 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
       std::make_shared<Envoy::TcpProxy::Config>(proto_config, context));
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(std::make_shared<Envoy::TcpProxy::Filter>(
-        filter_config, context.clusterManager(), context.dispatcher().timeSystem()));
+        filter_config, context.clusterManager(), context.dispatcher().timeSource()));
   };
 }
 

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -109,7 +109,7 @@ Network::FilterFactoryCb ThriftProxyFilterConfigFactory::createFilterFactoryFrom
 
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(std::make_shared<ConnectionManager>(
-        *filter_config, context.random(), context.dispatcher().timeSystem()));
+        *filter_config, context.random(), context.dispatcher().timeSource()));
   };
 }
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -13,11 +13,11 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 
 ConnectionManager::ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
-                                     TimeSource& time_system)
+                                     TimeSource& time_source)
     : config_(config), stats_(config_.stats()), transport_(config.createTransport()),
       protocol_(config.createProtocol()),
       decoder_(std::make_unique<Decoder>(*transport_, *protocol_, *this)),
-      random_generator_(random_generator), time_source_(time_system) {}
+      random_generator_(random_generator), time_source_(time_source) {}
 
 ConnectionManager::~ConnectionManager() {}
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -13,11 +13,11 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 
 ConnectionManager::ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
-                                     Event::TimeSystem& time_system)
+                                     TimeSource& time_system)
     : config_(config), stats_(config_.stats()), transport_(config.createTransport()),
       protocol_(config.createProtocol()),
       decoder_(std::make_unique<Decoder>(*transport_, *protocol_, *this)),
-      random_generator_(random_generator), time_system_(time_system) {}
+      random_generator_(random_generator), time_source_(time_system) {}
 
 ConnectionManager::~ConnectionManager() {}
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -60,7 +60,7 @@ class ConnectionManager : public Network::ReadFilter,
                           Logger::Loggable<Logger::Id::thrift> {
 public:
   ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
-                    Event::TimeSystem& time_system);
+                    TimeSource& time_system);
   ~ConnectionManager();
 
   // Network::ReadFilter
@@ -154,9 +154,9 @@ private:
                      public ThriftFilters::FilterChainFactoryCallbacks {
     ActiveRpc(ConnectionManager& parent)
         : parent_(parent), request_timer_(new Stats::Timespan(parent_.stats_.request_time_ms_,
-                                                              parent_.time_system_)),
+                                                              parent_.time_source_)),
           stream_id_(parent_.random_generator_.random()),
-          stream_info_(parent_.time_system_), local_response_sent_{false}, pending_transport_end_{
+          stream_info_(parent_.time_source_), local_response_sent_{false}, pending_transport_end_{
                                                                                false} {
       parent_.stats_.request_active_.inc();
 
@@ -267,7 +267,7 @@ private:
   Runtime::RandomGenerator& random_generator_;
   bool stopped_{false};
   bool half_closed_{false};
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
 };
 
 } // namespace ThriftProxy

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -153,7 +153,7 @@ void HystrixSink::addHystrixCommand(ClusterStatsCache& cluster_stats_cache,
                                     std::chrono::milliseconds rolling_window_ms,
                                     const QuantileLatencyMap& histogram, std::stringstream& ss) {
 
-  std::time_t currentTime = std::chrono::system_clock::to_time_t(server_.timeSystem().systemTime());
+  std::time_t currentTime = std::chrono::system_clock::to_time_t(server_.timeSource().systemTime());
 
   ss << "data: {";
   addStringToStream("type", "HystrixCommand", ss, true);

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -29,7 +29,7 @@ Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Messag
               grpc_service, server.stats(), false),
           server.localInfo());
 
-  return std::make_unique<MetricsServiceSink>(grpc_metrics_streamer, server.timeSystem());
+  return std::make_unique<MetricsServiceSink>(grpc_metrics_streamer, server.timeSource());
 }
 
 ProtobufTypes::MessagePtr MetricsServiceSinkFactory::createEmptyConfigProto() {

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -34,8 +34,8 @@ void GrpcMetricsStreamerImpl::send(envoy::service::metrics::v2::StreamMetricsMes
 }
 
 MetricsServiceSink::MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_metrics_streamer,
-                                       TimeSource& time_system)
-    : grpc_metrics_streamer_(grpc_metrics_streamer), time_source_(time_system) {}
+                                       TimeSource& time_source)
+    : grpc_metrics_streamer_(grpc_metrics_streamer), time_source_(time_source) {}
 
 void MetricsServiceSink::flushCounter(const Stats::Counter& counter) {
   io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -34,8 +34,8 @@ void GrpcMetricsStreamerImpl::send(envoy::service::metrics::v2::StreamMetricsMes
 }
 
 MetricsServiceSink::MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_metrics_streamer,
-                                       Event::TimeSystem& time_system)
-    : grpc_metrics_streamer_(grpc_metrics_streamer), time_system_(time_system) {}
+                                       TimeSource& time_system)
+    : grpc_metrics_streamer_(grpc_metrics_streamer), time_source_(time_system) {}
 
 void MetricsServiceSink::flushCounter(const Stats::Counter& counter) {
   io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
@@ -43,7 +43,7 @@ void MetricsServiceSink::flushCounter(const Stats::Counter& counter) {
   metrics_family->set_name(counter.name());
   auto* metric = metrics_family->add_metric();
   metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                               time_system_.systemTime().time_since_epoch())
+                               time_source_.systemTime().time_since_epoch())
                                .count());
   auto* counter_metric = metric->mutable_counter();
   counter_metric->set_value(counter.value());
@@ -55,7 +55,7 @@ void MetricsServiceSink::flushGauge(const Stats::Gauge& gauge) {
   metrics_family->set_name(gauge.name());
   auto* metric = metrics_family->add_metric();
   metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                               time_system_.systemTime().time_since_epoch())
+                               time_source_.systemTime().time_since_epoch())
                                .count());
   auto* gauage_metric = metric->mutable_gauge();
   gauage_metric->set_value(gauge.value());
@@ -66,7 +66,7 @@ void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& histogram)
   metrics_family->set_name(histogram.name());
   auto* metric = metrics_family->add_metric();
   metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                               time_system_.systemTime().time_since_epoch())
+                               time_source_.systemTime().time_since_epoch())
                                .count());
   auto* summary_metric = metric->mutable_summary();
   const Stats::HistogramStatistics& hist_stats = histogram.intervalStatistics();

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -72,7 +72,7 @@ class MetricsServiceSink : public Stats::Sink {
 public:
   // MetricsService::Sink
   MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_metrics_streamer,
-                     Event::TimeSystem& time_system);
+                     TimeSource& time_system);
   void flush(Stats::Source& source) override;
   void onHistogramComplete(const Stats::Histogram&, uint64_t) override {}
 
@@ -83,7 +83,7 @@ public:
 private:
   GrpcMetricsStreamerSharedPtr grpc_metrics_streamer_;
   envoy::service::metrics::v2::StreamMetricsMessage message_;
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
 };
 
 } // namespace MetricsService

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -19,7 +19,7 @@ Tracing::HttpTracerPtr ZipkinTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v2::ZipkinConfig& proto_config, Server::Instance& server) {
   Tracing::DriverPtr zipkin_driver = std::make_unique<Zipkin::Driver>(
       proto_config, server.clusterManager(), server.stats(), server.threadLocal(), server.runtime(),
-      server.localInfo(), server.random(), server.timeSystem());
+      server.localInfo(), server.random(), server.timeSource());
 
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(zipkin_driver), server.localInfo());
 }

--- a/source/extensions/transport_sockets/tap/config.cc
+++ b/source/extensions/transport_sockets/tap/config.cc
@@ -17,18 +17,18 @@ namespace Tap {
 
 class SocketTapConfigFactoryImpl : public Extensions::Common::Tap::TapConfigFactory {
 public:
-  SocketTapConfigFactoryImpl(Event::TimeSystem& time_system) : time_system_(time_system) {}
+  SocketTapConfigFactoryImpl(TimeSource& time_system) : time_source_(time_system) {}
 
   // TapConfigFactory
   Extensions::Common::Tap::TapConfigSharedPtr
   createConfigFromProto(envoy::service::tap::v2alpha::TapConfig&& proto_config,
                         Extensions::Common::Tap::Sink* admin_streamer) override {
     return std::make_shared<SocketTapConfigImpl>(std::move(proto_config), admin_streamer,
-                                                 time_system_);
+                                                 time_source_);
   }
 
 private:
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
 };
 
 Network::TransportSocketFactoryPtr UpstreamTapSocketConfigFactory::createTransportSocketFactory(
@@ -45,7 +45,7 @@ Network::TransportSocketFactoryPtr UpstreamTapSocketConfigFactory::createTranspo
   auto inner_transport_factory =
       inner_config_factory.createTransportSocketFactory(*inner_factory_config, context);
   return std::make_unique<TapSocketFactory>(
-      outer_config, std::make_unique<SocketTapConfigFactoryImpl>(context.dispatcher().timeSystem()),
+      outer_config, std::make_unique<SocketTapConfigFactoryImpl>(context.dispatcher().timeSource()),
       context.admin(), context.singletonManager(), context.threadLocal(), context.dispatcher(),
       std::move(inner_transport_factory));
 }
@@ -64,7 +64,7 @@ Network::TransportSocketFactoryPtr DownstreamTapSocketConfigFactory::createTrans
   auto inner_transport_factory = inner_config_factory.createTransportSocketFactory(
       *inner_factory_config, context, server_names);
   return std::make_unique<TapSocketFactory>(
-      outer_config, std::make_unique<SocketTapConfigFactoryImpl>(context.dispatcher().timeSystem()),
+      outer_config, std::make_unique<SocketTapConfigFactoryImpl>(context.dispatcher().timeSource()),
       context.admin(), context.singletonManager(), context.threadLocal(), context.dispatcher(),
       std::move(inner_transport_factory));
 }

--- a/source/extensions/transport_sockets/tap/config.cc
+++ b/source/extensions/transport_sockets/tap/config.cc
@@ -17,7 +17,7 @@ namespace Tap {
 
 class SocketTapConfigFactoryImpl : public Extensions::Common::Tap::TapConfigFactory {
 public:
-  SocketTapConfigFactoryImpl(TimeSource& time_system) : time_source_(time_system) {}
+  SocketTapConfigFactoryImpl(TimeSource& time_source) : time_source_(time_source) {}
 
   // TapConfigFactory
   Extensions::Common::Tap::TapConfigSharedPtr

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -36,7 +36,7 @@ void PerSocketTapperImpl::onRead(const Buffer::Instance& data, uint32_t bytes_re
   auto* event = trace_->mutable_socket_buffered_trace()->add_events();
   event->mutable_timestamp()->MergeFrom(Protobuf::util::TimeUtil::NanosecondsToTimestamp(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
-          config_->time_system_.systemTime().time_since_epoch())
+          config_->time_source_.systemTime().time_since_epoch())
           .count()));
   // TODO(mattklein123): Avoid linearize/toString here.
   const std::string linearized_data = data.toString();
@@ -53,7 +53,7 @@ void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_w
   auto* event = trace_->mutable_socket_buffered_trace()->add_events();
   event->mutable_timestamp()->MergeFrom(Protobuf::util::TimeUtil::NanosecondsToTimestamp(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
-          config_->time_system_.systemTime().time_since_epoch())
+          config_->time_source_.systemTime().time_since_epoch())
           .count()));
   // TODO(mattklein123): Avoid linearize/toString here.
   const std::string linearized_data = data.toString();

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -38,9 +38,9 @@ class SocketTapConfigImpl : public Extensions::Common::Tap::TapConfigBaseImpl,
                             public std::enable_shared_from_this<SocketTapConfigImpl> {
 public:
   SocketTapConfigImpl(envoy::service::tap::v2alpha::TapConfig&& proto_config,
-                      Extensions::Common::Tap::Sink* admin_streamer, Event::TimeSystem& time_system)
+                      Extensions::Common::Tap::Sink* admin_streamer, TimeSource& time_system)
       : Extensions::Common::Tap::TapConfigBaseImpl(std::move(proto_config), admin_streamer),
-        time_system_(time_system) {}
+        time_source_(time_system) {}
 
   // SocketTapConfig
   PerSocketTapperPtr createPerSocketTapper(const Network::Connection& connection) override {
@@ -48,7 +48,7 @@ public:
   }
 
 private:
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
 
   friend class PerSocketTapperImpl;
 };

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -88,7 +88,7 @@ void ValidationInstance::initialize(Options& options,
   runtime_loader_ = component_factory.createRuntime(*this, initial_config);
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>();
   ssl_context_manager_ =
-      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(api_->timeSystem());
+      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(api_->timeSource());
   cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       admin(), runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(),
       dispatcher(), localInfo(), *secret_manager_, *api_, http_context_, accessLogManager(),

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -92,7 +92,7 @@ public:
   Http::Context& httpContext() override { return http_context_; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
-  Event::TimeSystem& timeSystem() override { return api_->timeSystem(); }
+  TimeSource& timeSource() override { return api_->timeSource(); }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
 
   std::chrono::milliseconds statsFlushInterval() const override {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -259,7 +259,7 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
   // If the connection is already closed, we can just let this connection immediately die.
   if (new_connection->state() != Network::Connection::State::Closed) {
     ActiveConnectionPtr active_connection(
-        new ActiveConnection(*this, std::move(new_connection), parent_.dispatcher_.timeSystem()));
+        new ActiveConnection(*this, std::move(new_connection), parent_.dispatcher_.timeSource()));
     active_connection->moveIntoList(std::move(active_connection), connections_);
     parent_.num_connections_++;
   }
@@ -267,7 +267,7 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
 
 ConnectionHandlerImpl::ActiveConnection::ActiveConnection(ActiveListener& listener,
                                                           Network::ConnectionPtr&& new_connection,
-                                                          Event::TimeSystem& time_system)
+                                                          TimeSource& time_system)
     : listener_(listener), connection_(std::move(new_connection)),
       conn_length_(new Stats::Timespan(listener_.stats_.downstream_cx_length_ms_, time_system)) {
   // We just universally set no delay on connections. Theoretically we might at some point want

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -267,9 +267,9 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
 
 ConnectionHandlerImpl::ActiveConnection::ActiveConnection(ActiveListener& listener,
                                                           Network::ConnectionPtr&& new_connection,
-                                                          TimeSource& time_system)
+                                                          TimeSource& time_source)
     : listener_(listener), connection_(std::move(new_connection)),
-      conn_length_(new Stats::Timespan(listener_.stats_.downstream_cx_length_ms_, time_system)) {
+      conn_length_(new Stats::Timespan(listener_.stats_.downstream_cx_length_ms_, time_source)) {
   // We just universally set no delay on connections. Theoretically we might at some point want
   // to make this configurable.
   connection_->noDelay(true);

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -116,7 +116,7 @@ private:
                             public Event::DeferredDeletable,
                             public Network::ConnectionCallbacks {
     ActiveConnection(ActiveListener& listener, Network::ConnectionPtr&& new_connection,
-                     Event::TimeSystem& time_system);
+                     TimeSource& time_system);
     ~ActiveConnection();
 
     // Network::ConnectionCallbacks

--- a/source/server/guarddog_impl.h
+++ b/source/server/guarddog_impl.h
@@ -76,7 +76,7 @@ private:
     bool megamiss_alerted_{};
   };
 
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
   const std::chrono::milliseconds miss_timeout_;
   const std::chrono::milliseconds megamiss_timeout_;
   const std::chrono::milliseconds kill_timeout_;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1059,7 +1059,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats("http.admin.", no_op_store_)),
-      route_config_provider_(server.timeSystem()),
+      route_config_provider_(server.timeSource()),
       // TODO(jsedgwick) add /runtime_reset endpoint that removes all admin-set values
       handlers_{
           {"/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false, false},
@@ -1099,7 +1099,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
           {"/runtime_modify", "modify runtime values", MAKE_ADMIN_HANDLER(handlerRuntimeModify),
            false, true},
       },
-      date_provider_(server.dispatcher().timeSystem()),
+      date_provider_(server.dispatcher().timeSource()),
       admin_filter_chain_(std::make_shared<AdminFilterChain>()) {}
 
 Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection,
@@ -1116,7 +1116,7 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   // the envoy is overloaded.
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
       *this, server_.drainManager(), server_.random(), server_.httpContext(), server_.runtime(),
-      server_.localInfo(), server_.clusterManager(), nullptr, server_.timeSystem())});
+      server_.localInfo(), server_.clusterManager(), nullptr, server_.timeSource())});
   return true;
 }
 

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -281,7 +281,7 @@ public:
   const envoy::api::v2::core::Metadata& listenerMetadata() const override {
     return config_.metadata();
   };
-  TimeSource& timeSource() override { return api().timeSystem(); }
+  TimeSource& timeSource() override { return api().timeSource(); }
   void ensureSocketOptions() {
     if (!listen_socket_options_) {
       listen_socket_options_ =

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -52,7 +52,7 @@ InstanceImpl::InstanceImpl(Options& options, Event::TimeSystem& time_system,
                            ComponentFactory& component_factory,
                            Runtime::RandomGeneratorPtr&& random_generator,
                            ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory)
-    : shutdown_(false), options_(options), time_system_(time_system), restarter_(restarter),
+    : shutdown_(false), options_(options), time_source_(time_system), restarter_(restarter),
       start_time_(time(nullptr)), original_start_time_(start_time_), stats_store_(store),
       thread_local_(tls),
       api_(new Api::Impl(options.fileFlushIntervalMsec(), thread_factory, store, time_system)),
@@ -225,7 +225,7 @@ void InstanceImpl::initialize(Options& options,
 
   // Handle configuration that needs to take place prior to the main configuration load.
   InstanceUtil::loadBootstrapConfig(bootstrap_, options, api());
-  bootstrap_config_update_time_ = time_system_.systemTime();
+  bootstrap_config_update_time_ = time_source_.systemTime();
 
   // Needs to happen as early as possible in the instantiation to preempt the objects that require
   // stats.
@@ -304,7 +304,7 @@ void InstanceImpl::initialize(Options& options,
 
   // Once we have runtime we can initialize the SSL context manager.
   ssl_context_manager_ =
-      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_system_);
+      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_source_);
 
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
       admin(), runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(),
@@ -327,7 +327,7 @@ void InstanceImpl::initialize(Options& options,
   if (bootstrap_.has_hds_config()) {
     const auto& hds_config = bootstrap_.hds_config();
     async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
-        clusterManager(), thread_local_, time_system_, api());
+        clusterManager(), thread_local_, time_source_, api());
     hds_delegate_ = std::make_unique<Upstream::HdsDelegate>(
         stats(),
         Config::Utility::factoryForGrpcApiConfigSource(*async_client_manager_, hds_config, stats())

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -183,7 +183,7 @@ public:
   Http::Context& httpContext() override { return http_context_; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
-  Event::TimeSystem& timeSystem() override { return time_system_; }
+  TimeSource& timeSource() override { return time_source_; }
 
   std::chrono::milliseconds statsFlushInterval() const override {
     return config_.statsFlushInterval();
@@ -201,7 +201,7 @@ private:
 
   bool shutdown_;
   Options& options_;
-  Event::TimeSystem& time_system_;
+  TimeSource& time_source_;
   HotRestart& restarter_;
   const time_t start_time_;
   time_t original_start_time_;

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -290,7 +290,7 @@ public:
     envoy::api::v2::core::GrpcService config;
     config.mutable_envoy_grpc()->set_cluster_name(fake_cluster_name_);
     fillServiceWideInitialMetadata(config);
-    return std::make_unique<AsyncClientImpl>(cm_, config, dispatcher_.timeSystem());
+    return std::make_unique<AsyncClientImpl>(cm_, config, dispatcher_.timeSource());
   }
 
   virtual envoy::api::v2::core::GrpcService createGoogleGrpcConfig() {

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -244,7 +244,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   TcpProxy::ConfigSharedPtr tcp_proxy_config(new TcpProxy::Config(tcp_proxy, factory_context));
   manager.addReadFilter(
       std::make_shared<TcpProxy::Filter>(tcp_proxy_config, factory_context.cluster_manager_,
-                                         factory_context.dispatcher().timeSystem()));
+                                         factory_context.dispatcher().timeSource()));
 
   Extensions::Filters::Common::RateLimit::RequestCallbacks* request_callbacks{};
   EXPECT_CALL(*rl_client, limit(_, "foo",

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -116,7 +116,7 @@ public:
   NiceMock<Runtime::MockRandomGenerator> random_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   Extensions::TransportSockets::Tls::ContextManagerImpl ssl_context_manager_{
-      dispatcher_.timeSystem()};
+      dispatcher_.timeSource()};
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Server::MockAdmin> admin_;
   NiceMock<Secret::MockSecretManager> secret_manager_;

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -47,7 +47,7 @@ protected:
   HdsTest()
       : retry_timer_(new Event::MockTimer()), server_response_timer_(new Event::MockTimer()),
         async_client_(new Grpc::MockAsyncClient()), api_(Api::createApiForTest(stats_store_)),
-        ssl_context_manager_(api_->timeSystem()) {
+        ssl_context_manager_(api_->timeSource()) {
     node_.set_id("hds-node");
   }
 

--- a/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
@@ -34,7 +34,7 @@ public:
     EXPECT_CALL(loader_.snapshot_, featureEnabled("dynamodb.filter_enabled", 100));
 
     filter_ = std::make_unique<DynamoFilter>(loader_, stat_prefix_, stats_,
-                                             decoder_callbacks_.dispatcher().timeSystem());
+                                             decoder_callbacks_.dispatcher().timeSource());
 
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);

--- a/test/extensions/filters/network/dubbo_proxy/filter_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/filter_test.cc
@@ -27,7 +27,7 @@ using ConfigSerializationType =
 
 class DubboFilterTest : public TestBase {
 public:
-  TimeSource& timeSystem() { return factory_context_.dispatcher().timeSystem(); }
+  TimeSource& timeSource() { return factory_context_.dispatcher().timeSource(); }
 
   void initializeFilter() {
     for (const auto& counter : store_.counters()) {
@@ -35,7 +35,7 @@ public:
     }
 
     filter_ = std::make_unique<Filter>("test.", ConfigProtocolType::Dubbo,
-                                       ConfigSerializationType::Hessian2, store_, timeSystem());
+                                       ConfigSerializationType::Hessian2, store_, timeSource());
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -46,7 +46,7 @@ parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
 class HttpConnectionManagerConfigTest : public TestBase {
 public:
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  Http::SlowDateProviderImpl date_provider_{context_.dispatcher().timeSystem()};
+  Http::SlowDateProviderImpl date_provider_{context_.dispatcher().timeSource()};
   NiceMock<Router::MockRouteConfigProviderManager> route_config_provider_manager_;
 };
 

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -78,13 +78,13 @@ public:
         .WillRepeatedly(ReturnRef(stream_info_));
 
     EXPECT_CALL(log_manager_, createAccessLog(_)).WillOnce(Return(file_));
-    access_log_.reset(new AccessLog("test", log_manager_, dispatcher_.timeSystem()));
+    access_log_.reset(new AccessLog("test", log_manager_, dispatcher_.timeSource()));
   }
 
   void initializeFilter(bool emit_dynamic_metadata = false) {
     filter_ = std::make_unique<TestProxyFilter>("test.", store_, runtime_, access_log_,
                                                 fault_config_, drain_decision_, generator_,
-                                                dispatcher_.timeSystem(), emit_dynamic_metadata);
+                                                dispatcher_.timeSource(), emit_dynamic_metadata);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -111,7 +111,7 @@ public:
 
     ON_CALL(random_, random()).WillByDefault(Return(42));
     filter_ = std::make_unique<ConnectionManager>(
-        *config_, random_, filter_callbacks_.connection_.dispatcher_.timeSystem());
+        *config_, random_, filter_callbacks_.connection_.dispatcher_.timeSource());
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -264,7 +264,7 @@ public:
           callback_ready_event.notifyOne();
         });
     Event::TestTimeSystem& time_system =
-        dynamic_cast<Event::TestTimeSystem&>(connection_.dispatcher().timeSystem());
+        dynamic_cast<Event::TestTimeSystem&>(connection_.dispatcher().timeSource());
     Thread::CondVar::WaitStatus status = time_system.waitFor(lock_, callback_ready_event, timeout);
     if (status == Thread::CondVar::WaitStatus::Timeout) {
       return testing::AssertionFailure() << "Timed out while executing on dispatcher.";

--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -18,7 +18,7 @@ MockApi::MockApi() { ON_CALL(*this, fileSystem()).WillByDefault(ReturnRef(file_s
 MockApi::~MockApi() {}
 
 Event::DispatcherPtr MockApi::allocateDispatcher() {
-  return Event::DispatcherPtr{allocateDispatcher_(timeSystem())};
+  return Event::DispatcherPtr{allocateDispatcher_(time_system_)};
 }
 
 MockOsSysCalls::MockOsSysCalls() { num_writes_ = num_open_ = 0; }

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -26,7 +26,8 @@ public:
 
   // Api::Api
   Event::DispatcherPtr allocateDispatcher() override;
-  Event::TimeSystem& timeSystem() override { return time_system_; }
+  Event::TimeSystem& timeSystemForDispatcher() override { return time_system_; }
+  TimeSource& timeSource() override { return time_system_; }
 
   MOCK_METHOD1(allocateDispatcher_, Event::Dispatcher*(Event::TimeSystem&));
   MOCK_METHOD0(fileSystem, Filesystem::Instance&());

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -31,7 +31,7 @@ public:
   ~MockDispatcher();
 
   // Dispatcher
-  TimeSystem& timeSystem() override { return time_system_; }
+  TimeSource& timeSource() override { return time_system_; }
   Network::ConnectionPtr
   createServerConnection(Network::ConnectionSocketPtr&& socket,
                          Network::TransportSocketPtr&& transport_socket) override {

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -123,8 +123,8 @@ MockWorker::MockWorker() {
 MockWorker::~MockWorker() = default;
 
 MockInstance::MockInstance()
-    : secret_manager_(new Secret::SecretManagerImpl()), cluster_manager_(timeSystem()),
-      ssl_context_manager_(timeSystem()), singleton_manager_(new Singleton::ManagerImpl(
+    : secret_manager_(new Secret::SecretManagerImpl()), cluster_manager_(timeSource()),
+      ssl_context_manager_(timeSource()), singleton_manager_(new Singleton::ManagerImpl(
                                               Thread::threadFactoryForTest().currentThreadId())) {
   ON_CALL(*this, threadLocal()).WillByDefault(ReturnRef(thread_local_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_store_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -355,7 +355,7 @@ public:
   MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_CONST_METHOD0(statsFlushInterval, std::chrono::milliseconds());
 
-  Event::TestTimeSystem& timeSystem() override { return time_system_; }
+  TimeSource& timeSource() override { return time_system_; }
 
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   testing::NiceMock<ThreadLocal::MockInstance> thread_local_;

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -32,7 +32,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
   NiceMock<Runtime::MockRandomGenerator> random;
   testing::NiceMock<Secret::MockSecretManager> secret_manager;
   auto dns_resolver = std::make_shared<NiceMock<Network::MockDnsResolver>>();
-  Extensions::TransportSockets::Tls::ContextManagerImpl ssl_context_manager{api->timeSystem()};
+  Extensions::TransportSockets::Tls::ContextManagerImpl ssl_context_manager{api->timeSource()};
   NiceMock<Event::MockDispatcher> dispatcher;
   LocalInfo::MockLocalInfo local_info;
   NiceMock<Server::MockAdmin> admin;

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -160,7 +160,7 @@ bool RouterCheckTool::compareVirtualHost(ToolConfig& tool_config, const std::str
 bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
-                                                factory_context_->dispatcher().timeSystem());
+                                                factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
     tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
                                                              true);
@@ -172,7 +172,7 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
 bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
-                                                factory_context_->dispatcher().timeSystem());
+                                                factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
     tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
                                                              true);
@@ -200,7 +200,7 @@ bool RouterCheckTool::compareCustomHeaderField(ToolConfig& tool_config, const st
                                                const std::string& expected) {
   std::string actual = "";
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
-                                                factory_context_->dispatcher().timeSystem());
+                                                factory_context_->dispatcher().timeSource());
   stream_info.setDownstreamRemoteAddress(Network::Utility::getCanonicalIpv4LoopbackAddress());
   if (tool_config.route_->routeEntry() != nullptr) {
     tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,


### PR DESCRIPTION
*Description*: In most cases -- at least outside of tests -- we do not need the TimeSystem API, which exposes some libevent internals. We only need this in tests to manipulate time, and in the Dispatcher in order to make a scheduler.

This partially addresses #5820 but squirrels out of completely implementing the inversion of control it suggests for now. That can be done in a follow-up.

*Risk Level*: low -- this is a pure refactor, semi-automated.
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

