### PR TITLE
add assertion for null/reset connection file event

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -386,6 +386,7 @@ void ConnectionImpl::write(Buffer::Instance& data, bool end_stream) {
     // doWriteReady into thinking the socket is connected. On macOS, the underlying write may fail
     // with a connection error if a call to write(2) occurs before the connection is completed.
     if (!connecting_) {
+      ASSERT(file_event_ != nullptr, "ConnectionImpl file event was unexpectedly reset");
       file_event_->activate(Event::FileReadyType::Write);
     }
   }


### PR DESCRIPTION
Signed-off-by: William DeCoste <bdecoste@gmail.com>

Description: Add assertion to catch unexpected null file_event_ when connection is closed for openssl TLS_1.2 with Server RSA/ECDSA and Client ECDSA. 
Risk Level: Low
Testing: All standard tests pass
Docs Changes: None
Release Notes: None

