### PR TITLE
 network: add logging statement on socket failure assertion

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -160,9 +160,10 @@ IoHandlePtr InstanceBase::socketFromSocketType(SocketType socketType) const {
     domain = AF_UNIX;
   }
 
-  IoHandlePtr io_handle = std::make_unique<IoSocketHandle>(::socket(domain, flags, 0));
-  RELEASE_ASSERT(io_handle->fd() != -1,
-                 fmt::format("socket(2) failed, got error: {}", strerror(errno)));
+  const Api::SysCallIntResult result = Api::OsSysCallsSingleton::get().socket(domain, flags, 0);
+  RELEASE_ASSERT(result.rc_ != -1,
+                 fmt::format("socket(2) failed, got error: {}", strerror(result.errno_)));
+  IoHandlePtr io_handle = std::make_unique<IoSocketHandle>(result.rc_);
 
 #ifdef __APPLE__
   // Cannot set SOCK_NONBLOCK as a ::socket flag.

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -161,7 +161,8 @@ IoHandlePtr InstanceBase::socketFromSocketType(SocketType socketType) const {
   }
 
   IoHandlePtr io_handle = std::make_unique<IoSocketHandle>(::socket(domain, flags, 0));
-  RELEASE_ASSERT(io_handle->fd() != -1, "");
+  RELEASE_ASSERT(
+      io_handle->fd() != -1, fmt::format("socket(2) failed, got error: {}", strerror(errno)));
 
 #ifdef __APPLE__
   // Cannot set SOCK_NONBLOCK as a ::socket flag.

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -161,8 +161,8 @@ IoHandlePtr InstanceBase::socketFromSocketType(SocketType socketType) const {
   }
 
   IoHandlePtr io_handle = std::make_unique<IoSocketHandle>(::socket(domain, flags, 0));
-  RELEASE_ASSERT(
-      io_handle->fd() != -1, fmt::format("socket(2) failed, got error: {}", strerror(errno)));
+  RELEASE_ASSERT(io_handle->fd() != -1,
+                 fmt::format("socket(2) failed, got error: {}", strerror(errno)));
 
 #ifdef __APPLE__
   // Cannot set SOCK_NONBLOCK as a ::socket flag.

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -1,3 +1,5 @@
+#include <sys/socket.h>
+
 #include "common/network/addr_family_aware_socket_option_impl.h"
 #include "common/network/io_socket_handle_impl.h"
 #include "common/network/utility.h"
@@ -8,7 +10,14 @@ namespace Envoy {
 namespace Network {
 namespace {
 
-class AddrFamilyAwareSocketOptionImplTest : public SocketOptionTest {};
+class AddrFamilyAwareSocketOptionImplTest : public SocketOptionTest {
+ protected:
+  void SetUp() override {
+    EXPECT_CALL(os_sys_calls_, socket).WillRepeatedly(Invoke([](int domain, int type, int protocol) {
+      return Api::SysCallIntResult{::socket(domain, type, protocol), 0};
+    }));
+  }
+};
 
 // We fail to set the option when the underlying setsockopt syscall fails.
 TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
@@ -64,7 +73,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
                           socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
 }
 
-// If a platform suppports IPv4 and IPv6 socket option variants for an IPv4 address, we apply the
+// If a platform supports IPv4 and IPv6 socket option variants for an IPv4 address, we apply the
 // IPv4 variant
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
@@ -80,7 +89,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
-// If a platform suppports IPv6 socket option variant for an IPv6 address it works
+// If a platform supports IPv6 socket option variant for an IPv6 address it works
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   IoHandlePtr io_handle = address.socket(Address::SocketType::Stream);
@@ -95,7 +104,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
-// If a platform suppports only the IPv4 variant for an IPv6 address,
+// If a platform supports only the IPv4 variant for an IPv6 address,
 // we apply the IPv4 variant.
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
@@ -111,7 +120,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
-// If a platform suppports IPv4 and IPv6 socket option variants for an IPv6 address,
+// If a platform supports IPv4 and IPv6 socket option variants for an IPv6 address,
 // AddrFamilyAwareSocketOptionImpl::setIpSocketOption() works with the IPv6 variant.
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Precedence) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -11,11 +11,12 @@ namespace Network {
 namespace {
 
 class AddrFamilyAwareSocketOptionImplTest : public SocketOptionTest {
- protected:
+protected:
   void SetUp() override {
-    EXPECT_CALL(os_sys_calls_, socket).WillRepeatedly(Invoke([](int domain, int type, int protocol) {
-      return Api::SysCallIntResult{::socket(domain, type, protocol), 0};
-    }));
+    EXPECT_CALL(os_sys_calls_, socket)
+        .WillRepeatedly(Invoke([](int domain, int type, int protocol) {
+          return Api::SysCallIntResult{::socket(domain, type, protocol), 0};
+        }));
   }
 };
 


### PR DESCRIPTION
*Description*: Adds a logging statement to help debug issues with creating sockets. This was helpful to me when debugging IPv6 environment issues.
*Risk Level*: Low
*Testing*: Used this when testing another change, generated a log statement like:  `[2019-02-05 20:23:26.312][507][critical][assert] [../source/common/network/address_impl.cc:161] assert failure: io_handle->fd() != -1. Details: socket(2) failed, got error: Address family not supported by protocol`
*Docs Changes*: N/A
*Release Notes*: N/A