### PR TITLE
api: fix wrong java_package option in a proto file

### DIFF
--- a/api/envoy/config/common/tap/v2alpha/common.proto
+++ b/api/envoy/config/common/tap/v2alpha/common.proto
@@ -8,7 +8,7 @@ package envoy.config.common.tap.v2alpha;
 
 option java_outer_classname = "CommonProto";
 option java_multiple_files = true;
-option java_package = "io.envoyproxy.envoy.service.tap.v2alpha";
+option java_package = "io.envoyproxy.envoy.config.common.tap.v2alpha";
 
 // [#protodoc-title: Common tap extension configuration]
 


### PR DESCRIPTION
Signed-off-by: Penn (Dapeng) Zhang <zdapeng@google.com>

*Description*:
The `java_package` option in `api/envoy/config/common/tap/v2alpha/common.proto` was wrong and conflicts with the other file `api/envoy/service/tap/v2alpha/common.proto`.

*Risk Level*: Low
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
