### PR TITLE
Shift test_base library to testonly+basic_cc_library.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -416,9 +416,9 @@ def envoy_cc_test(
         shard_count = shard_count,
     )
 
-# Envoy C++ test related libraries (that want gtest, gmock) should be specified
-# with this function.
-def envoy_cc_test_library(
+# Envoy C++ related test infrastructure (that want gtest, gmock, but may be
+# relied on by envoy_cc_test_library) should use this function.
+def envoy_cc_test_infrastructure_library(
         name,
         srcs = [],
         hdrs = [],
@@ -436,12 +436,36 @@ def envoy_cc_test_library(
         testonly = 1,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             envoy_external_dep_path("googletest"),
-            repository + "//test/test_common:printers_includes",
-            repository + "//test/test_common:test_base",
         ],
         tags = tags,
         alwayslink = 1,
         linkstatic = 1,
+    )
+
+# Envoy C++ test related libraries (that want gtest, gmock) should be specified
+# with this function.
+def envoy_cc_test_library(
+        name,
+        srcs = [],
+        hdrs = [],
+        data = [],
+        external_deps = [],
+        deps = [],
+        repository = "",
+        tags = []):
+    deps = deps + [
+        repository + "//test/test_common:printers_includes",
+        repository + "//test/test_common:test_base",
+    ]
+    envoy_cc_test_infrastructure_library(
+        name,
+        srcs,
+        hdrs,
+        data,
+        external_deps,
+        deps,
+        repository,
+        tags,
     )
 
 # Envoy test binaries should be specified with this function.

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -6,7 +6,7 @@ load(
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_cc_test_library",
-    "envoy_copts",
+    "envoy_cc_test_infrastructure_library",
     "envoy_package",
 )
 
@@ -157,14 +157,11 @@ envoy_cc_test(
     ],
 )
 
-envoy_basic_cc_library(
+envoy_cc_test_infrastructure_library(
     name = "test_base",
-    testonly = 1,
     srcs = ["test_base.cc"],
     hdrs = ["test_base.h"],
-    copts = envoy_copts(""),
     deps = [
-        "//external:googletest",
         "//test/test_common:global_lib",
     ],
 )

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -6,6 +6,7 @@ load(
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_cc_test_library",
+    "envoy_copts",
     "envoy_package",
 )
 
@@ -156,10 +157,12 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_library(
+envoy_basic_cc_library(
     name = "test_base",
+    testonly = 1,
     srcs = ["test_base.cc"],
     hdrs = ["test_base.h"],
+    copts = envoy_copts(""),
     deps = [
         "//external:googletest",
         "//test/test_common:global_lib",

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -5,8 +5,8 @@ load(
     "envoy_basic_cc_library",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_cc_test_library",
     "envoy_cc_test_infrastructure_library",
+    "envoy_cc_test_library",
     "envoy_package",
 )
 


### PR DESCRIPTION
Signed-off-by: Randy Smith <rdsmith@google.com>

*Description*: Mark //test/test_common:test_base testonly for environments that enforce that bit.
*Risk Level*: Low: Build change, any errors should be quick to surface.
*Testing*: Built all of envoy.
*Docs Changes*: None.
*Release Notes*: n/a