### PR TITLE
examples: Fix the Jaeger Native Tracing example

### DIFF
--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine:latest
 
-RUN apk update && apk add python3 bash
+RUN apk update && apk add python3 bash curl
 RUN pip3 install -q Flask==0.11.1 requests==2.18.4
 RUN mkdir /code
 ADD ./service.py /code

--- a/examples/jaeger-native-tracing/install-jaeger-plugin.sh
+++ b/examples/jaeger-native-tracing/install-jaeger-plugin.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 JAEGER_VERSION=v0.4.2
-wget -O /usr/local/lib/libjaegertracing_plugin.so https://github.com/jaegertracing/jaeger-client-cpp/releases/download/$JAEGER_VERSION/libjaegertracing_plugin.linux_amd64.so
+curl -Lo /usr/local/lib/libjaegertracing_plugin.so https://github.com/jaegertracing/jaeger-client-cpp/releases/download/$JAEGER_VERSION/libjaegertracing_plugin.linux_amd64.so


### PR DESCRIPTION
*Description*: 
Currently the Jaeger Native Tracing example doesn't work. When running it, I realized that the container built by`Dockerfile-frontenvoy` doesn't have `wget` installed. 

Because `curl` is already being installed by `Dockerfile-frontenvoy`, I decided to install it in `Dockerfile-service` as well and switch the `install-jaeger-plugin.sh` to `curl` instead of `wget`

*Risk Level*: Low
*Testing*:  Follow the instruction here to run the example: https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/jaeger_native_tracing
*Docs Changes*: N/A
*Release Notes*: N/A