### PR TITLE
router: fix null-terminator issue in path replacement.

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -493,7 +493,7 @@ void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
     return;
   }
 
-  std::string path = headers.Path()->value().c_str();
+  std::string path = std::string(headers.Path()->value().c_str(), headers.Path()->value().size());
   if (insert_envoy_original_path) {
     headers.insertEnvoyOriginalPath().value(*headers.Path());
   }

--- a/test/common/router/route_corpus/clusterfuzz-testcase-route_fuzz_test-5137346677178368
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-route_fuzz_test-5137346677178368
@@ -1,0 +1,21 @@
+config {
+  virtual_hosts {
+    name: " "
+    domains: "*"
+    routes {
+      match {
+        regex: ".*"
+      }
+      route {
+        cluster: "}"
+        prefix_rewrite: "%"
+      }
+    }
+  }
+}
+headers {
+  headers {
+    key: ":path"
+    value: "\001\000"
+  }
+}


### PR DESCRIPTION
Fixes oss-fuzz issue
https://oss-fuzz.com/testcase-detail/5137346677178368.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>
