### PR TITLE
socket_option: don't set socket IP socket options on pipes.

### DIFF
--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -19,6 +19,15 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
   EXPECT_LOG_CONTAINS("warning", "Failed to set IP socket option on non-IP socket",
                       EXPECT_FALSE(socket_option.setOption(
                           socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
+
+  Address::InstanceConstSharedPtr pipe_address =
+      std::make_shared<Network::Address::PipeInstance>("/foo");
+  {
+    EXPECT_CALL(socket_, localAddress).WillRepeatedly(testing::ReturnRef(pipe_address));
+    EXPECT_LOG_CONTAINS("warning", "Failed to set IP socket option on non-IP socket",
+                        EXPECT_FALSE(socket_option.setOption(
+                            socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
+  }
 }
 
 // If a platform supports IPv4 socket option variant for an IPv4 address, it works

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5755877701713920
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5755877701713920
@@ -1,0 +1,12 @@
+static_resources {
+  listeners {
+    address {
+      pipe {
+      }
+    }
+    filter_chains {
+    }
+    freebind {
+    }
+  }
+}


### PR DESCRIPTION
Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12293.

Risk level: Low
Testing: Corpus entry and unit test added.

Signed-off-by: Harvey Tuch <htuch@google.com>