### PR TITLE
fix EVP_MD_CTX instantiation for openssl

### DIFF
--- a/source/common/crypto/utility.cc
+++ b/source/common/crypto/utility.cc
@@ -13,19 +13,20 @@ namespace Crypto {
 
 std::vector<uint8_t> Utility::getSha256Digest(const Buffer::Instance& buffer) {
   std::vector<uint8_t> digest(SHA256_DIGEST_LENGTH);
-  EVP_MD_CTX ctx;
-  auto rc = EVP_DigestInit(&ctx, EVP_sha256());
+  EVP_MD_CTX* ctx(EVP_MD_CTX_new());
+  auto rc = EVP_DigestInit(ctx, EVP_sha256());
   RELEASE_ASSERT(rc == 1, "Failed to init digest context");
   const auto num_slices = buffer.getRawSlices(nullptr, 0);
   STACK_ARRAY(slices, Buffer::RawSlice, num_slices);
   buffer.getRawSlices(slices.begin(), num_slices);
   for (const auto& slice : slices) {
-    rc = EVP_DigestUpdate(&ctx, slice.mem_, slice.len_);
+    rc = EVP_DigestUpdate(ctx, slice.mem_, slice.len_);
     RELEASE_ASSERT(rc == 1, "Failed to update digest");
   }
   unsigned int len;
-  rc = EVP_DigestFinal(&ctx, digest.data(), &len);
+  rc = EVP_DigestFinal(ctx, digest.data(), &len);
   RELEASE_ASSERT(rc == 1, "Failed to finalize digest");
+  EVP_MD_CTX_free(ctx);
   return digest;
 }
 


### PR DESCRIPTION
Signed-off-by: William DeCoste <bdecoste@gmail.com>

Description: Modify EVP_MD_CTX instantiation in common/crypto to support openssl. Instantiating via "EVP_MD_CTX ctx" fails compilation. Openssl required EVP_MD_CTX_new(). 
Risk Level: Low
Testing: Standard tests pass
Docs Changes: None
Release Notes: None

