### PR TITLE
subset: avoid crashing out when doing scaled locality aware on static…

### DIFF
--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -563,6 +563,11 @@ LocalityWeightsConstSharedPtr SubsetLoadBalancer::HostSubsetImpl::determineLocal
   if (locality_weight_aware_) {
     if (scale_locality_weight_) {
       const auto& original_hosts_per_locality = original_host_set_.hostsPerLocality().get();
+      // E.g. we can be here in static clusters with actual locality weighting before pre-init
+      // completes.
+      if (!original_host_set_.localityWeights()) {
+        return {};
+      }
       const auto& original_weights = *original_host_set_.localityWeights();
 
       auto scaled_locality_weights = std::make_shared<LocalityWeights>(original_weights.size());

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -462,6 +462,13 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
+  if (config.lb_subset_config().locality_weight_aware() &&
+      !config.common_lb_config().has_locality_weighted_lb_config()) {
+    throw EnvoyException(fmt::format(
+        "Locality weight aware subset LB requires that a locality_weighted_lb_config be set in {}",
+        name_));
+  }
+
   if (config.protocol_selection() == envoy::api::v2::Cluster::USE_CONFIGURED_PROTOCOL) {
     // Make sure multiple protocol configurations are not present
     if (config.has_http_protocol_options() && config.has_http2_protocol_options()) {

--- a/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-5747944989392896
+++ b/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-5747944989392896
@@ -1,0 +1,269 @@
+static_resources {
+  clusters {
+    name: "servi_e_ervile"
+    connect_timeout {
+      seconds: 2304
+      nanos: 250000000
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "\000\000\020\000\000\000\000\000"
+      }
+    }
+    hosts {
+      pipe {
+        path: "{"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+      subset_selectors {
+      }
+    }
+    common_lb_config {
+      healthy_panic_threshold {
+        value: 9.88131291682493e-324
+      }
+      locality_weighted_lb_config {}
+    }
+    drain_connections_on_host_removal: true
+  }
+  clusters {
+    name: "{"
+    connect_timeout {
+      seconds: 2304
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: "A"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: "A"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    dns_lookup_family: V6_ONLY
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 589951
+      }
+    }
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+    }
+    common_lb_config {
+      locality_weighted_lb_config {}
+    }
+    upstream_connection_options {
+      tcp_keepalive {
+        keepalive_probes {
+          value: 589951
+        }
+      }
+    }
+    drain_connections_on_host_removal: true
+  }
+  clusters {
+    name: "|"
+    connect_timeout {
+      seconds: 2304
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "j"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: "6"
+      }
+    }
+    hosts {
+      pipe {
+        path: "A"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 4294443006
+      }
+    }
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+      locality_weight_aware: true
+    }
+    common_lb_config {
+      locality_weighted_lb_config {}
+    }
+    upstream_connection_options {
+      tcp_keepalive {
+        keepalive_probes {
+          value: 589951
+        }
+      }
+    }
+    drain_connections_on_host_removal: true
+  }
+  clusters {
+    name: "z"
+    connect_timeout {
+      seconds: 2304
+    }
+    lb_policy: RANDOM
+    hosts {
+      pipe {
+        path: "\001"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: "@"
+      }
+    }
+    hosts {
+      pipe {
+        path: "{"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    upstream_connection_options {
+    }
+  }
+  clusters {
+    name: "8"
+    connect_timeout {
+      seconds: 2304
+      nanos: 250000000
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "{"
+      }
+    }
+    hosts {
+      pipe {
+        path: "\001"
+      }
+    }
+    circuit_breakers {
+      thresholds {
+        max_requests {
+          value: 4294443006
+        }
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 589951
+      }
+    }
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+      locality_weight_aware: true
+      scale_locality_weight: true
+    }
+    common_lb_config {
+      locality_weighted_lb_config {}
+    }
+    alt_stat_name: "B"
+    upstream_connection_options {
+    }
+    drain_connections_on_host_removal: true
+  }
+  clusters {
+    name: "\001"
+    connect_timeout {
+      seconds: 2304
+      nanos: 250000111
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "\001"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: "\001"
+      }
+    }
+    hosts {
+      pipe {
+        path: "@"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+      subset_selectors {
+      }
+      locality_weight_aware: true
+    }
+    common_lb_config {
+      locality_weighted_lb_config {}
+    }
+    upstream_connection_options {
+    }
+  }
+}
+admin {
+  access_log_path: "/tmpoadmin_access.log"
+  address {
+    pipe {
+      path: "name"
+    }
+  }
+}


### PR DESCRIPTION
… clusters.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11558.

Risk level: Low
Testing: Corpus entry and unit tests added.

Signed-off-by: Harvey Tuch <htuch@google.com>