### PR TITLE
trivia: fix typo in README

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -36,7 +36,6 @@ An example basic invocation to build a developer version of the Envoy static bin
 ```
 
 The build image defaults to `envoyproxy/envoy-build-ubuntu`, but you can choose build image by setting `IMAGE_NAME` in the environment.
-```
 
 In case your setup is behind a proxy, set `http_proxy` and `https_proxy` to the proxy servers before invoking the build.
 


### PR DESCRIPTION
Remove a superfluous line of three back-ticks that caused improper formatting of the http_proxy section.

*Description*: remove superfluous formatting line in README
*Risk Level*: zero
*Testing*: n/a
*Docs Changes*: precisely
*Release Notes*: n/a
