### PR TITLE
build: fix sqlparser build on Windows

### DIFF
--- a/bazel/external/sqlparser.BUILD
+++ b/bazel/external/sqlparser.BUILD
@@ -8,4 +8,8 @@ cc_library(
         "src/**/*.h",
     ]),
     visibility = ["//visibility:public"],
+    defines = select({
+        "@envoy//bazel:windows_x86_64": ["YY_NO_UNISTD_H"],
+        "//conditions:default": [],
+    }),
 )

--- a/bazel/external/sqlparser.BUILD
+++ b/bazel/external/sqlparser.BUILD
@@ -7,9 +7,9 @@ cc_library(
         "include/**/*.h",
         "src/**/*.h",
     ]),
-    visibility = ["//visibility:public"],
     defines = select({
         "@envoy//bazel:windows_x86_64": ["YY_NO_UNISTD_H"],
         "//conditions:default": [],
     }),
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
*Description*:
Windows doesn't have <unistd.h>

*Risk Level*:
Low

*Testing*:
`bazel build //source/... && bazel test //test/...`

*Docs Changes*:
N/A
*Release Notes*:
N/A