### PR TITLE
ssl: functions to access peer cert issue/expire times in network filters

### DIFF
--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -11,6 +11,9 @@ envoy_package()
 envoy_cc_library(
     name = "connection_interface",
     hdrs = ["connection.h"],
+    deps = [
+        "//include/envoy/common:time_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -11,6 +11,7 @@ envoy_package()
 envoy_cc_library(
     name = "connection_interface",
     hdrs = ["connection.h"],
+    external_deps = ["abseil_optional"],
     deps = [
         "//include/envoy/common:time_interface",
     ],

--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "envoy/common/pure.h"
+#include "envoy/common/time.h"
 
 namespace Envoy {
 namespace Ssl {
@@ -73,6 +74,18 @@ public:
    *         Returns {} if there is no local certificate, or no SAN field, or no DNS.
    **/
   virtual std::vector<std::string> dnsSansLocalCertificate() const PURE;
+
+  /**
+   * @return SystemTime the time that the peer certificate was issued and should be considered valid
+   *         from. Returns zero value SystemTime if there is no peer certificate.
+   **/
+  virtual SystemTime validFromPeerCertificate() const PURE;
+
+  /**
+   * @return SystemTime the time that the peer certificate expires and should not be considered
+   *         valid after. Returns zero value SystemTime if there is no peer certificate.
+   **/
+  virtual SystemTime expirationPeerCertificate() const PURE;
 };
 
 } // namespace Ssl

--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -6,6 +6,8 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 
+#include "absl/types/optional.h"
+
 namespace Envoy {
 namespace Ssl {
 
@@ -76,16 +78,16 @@ public:
   virtual std::vector<std::string> dnsSansLocalCertificate() const PURE;
 
   /**
-   * @return SystemTime the time that the peer certificate was issued and should be considered valid
-   *         from. Returns zero value SystemTime if there is no peer certificate.
+   * @return absl::optional<SystemTime> the time that the peer certificate was issued and should be
+   *         considered valid from. Returns empty absl::optional if there is no peer certificate.
    **/
-  virtual SystemTime validFromPeerCertificate() const PURE;
+  virtual absl::optional<SystemTime> validFromPeerCertificate() const PURE;
 
   /**
-   * @return SystemTime the time that the peer certificate expires and should not be considered
-   *         valid after. Returns zero value SystemTime if there is no peer certificate.
+   * @return absl::optional<SystemTime> the time that the peer certificate expires and should not be
+   *         considered valid after. Returns empty absl::optional if there is no peer certificate.
    **/
-  virtual SystemTime expirationPeerCertificate() const PURE;
+  virtual absl::optional<SystemTime> expirationPeerCertificate() const PURE;
 };
 
 } // namespace Ssl

--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
     srcs = ["ssl_socket.cc"],
     hdrs = ["ssl_socket.h"],
     external_deps = [
+        "abseil_optional",
         "abseil_synchronization",
         "ssl",
     ],

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -364,7 +364,7 @@ std::string SslSocket::subjectLocalCertificate() const {
 absl::optional<SystemTime> SslSocket::validFromPeerCertificate() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
-    return absl::optional<SystemTime>();
+    return absl::nullopt;
   }
   return Utility::getValidFrom(*cert);
 }
@@ -372,7 +372,7 @@ absl::optional<SystemTime> SslSocket::validFromPeerCertificate() const {
 absl::optional<SystemTime> SslSocket::expirationPeerCertificate() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
-    return absl::optional<SystemTime>();
+    return absl::nullopt;
   }
   return Utility::getExpirationTime(*cert);
 }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -361,6 +361,22 @@ std::string SslSocket::subjectLocalCertificate() const {
   return Utility::getSubjectFromCertificate(*cert);
 }
 
+SystemTime SslSocket::validFromPeerCertificate() const {
+  X509* cert = SSL_get_certificate(ssl_.get());
+  if (!cert) {
+    return SystemTime();
+  }
+  return Utility::getValidFrom(*cert);
+}
+
+SystemTime SslSocket::expirationPeerCertificate() const {
+  X509* cert = SSL_get_certificate(ssl_.get());
+  if (!cert) {
+    return SystemTime();
+  }
+  return Utility::getExpirationTime(*cert);
+}
+
 namespace {
 SslSocketFactoryStats generateStats(const std::string& prefix, Stats::Scope& store) {
   return {

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -361,18 +361,18 @@ std::string SslSocket::subjectLocalCertificate() const {
   return Utility::getSubjectFromCertificate(*cert);
 }
 
-SystemTime SslSocket::validFromPeerCertificate() const {
+absl::optional<SystemTime> SslSocket::validFromPeerCertificate() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
-    return std::chrono::system_clock::from_time_t(0);
+    return absl::optional<SystemTime>();
   }
   return Utility::getValidFrom(*cert);
 }
 
-SystemTime SslSocket::expirationPeerCertificate() const {
+absl::optional<SystemTime> SslSocket::expirationPeerCertificate() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
-    return std::chrono::system_clock::from_time_t(0);
+    return absl::optional<SystemTime>();
   }
   return Utility::getExpirationTime(*cert);
 }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -364,7 +364,7 @@ std::string SslSocket::subjectLocalCertificate() const {
 SystemTime SslSocket::validFromPeerCertificate() const {
   X509* cert = SSL_get_certificate(ssl_.get());
   if (!cert) {
-    return SystemTime();
+    return std::chrono::system_clock::from_time_t(0);
   }
   return Utility::getValidFrom(*cert);
 }
@@ -372,7 +372,7 @@ SystemTime SslSocket::validFromPeerCertificate() const {
 SystemTime SslSocket::expirationPeerCertificate() const {
   X509* cert = SSL_get_certificate(ssl_.get());
   if (!cert) {
-    return SystemTime();
+    return std::chrono::system_clock::from_time_t(0);
   }
   return Utility::getExpirationTime(*cert);
 }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -362,7 +362,7 @@ std::string SslSocket::subjectLocalCertificate() const {
 }
 
 SystemTime SslSocket::validFromPeerCertificate() const {
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_peer_certificate(ssl_.get());
   if (!cert) {
     return std::chrono::system_clock::from_time_t(0);
   }
@@ -370,7 +370,7 @@ SystemTime SslSocket::validFromPeerCertificate() const {
 }
 
 SystemTime SslSocket::expirationPeerCertificate() const {
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_peer_certificate(ssl_.get());
   if (!cert) {
     return std::chrono::system_clock::from_time_t(0);
   }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -362,7 +362,7 @@ std::string SslSocket::subjectLocalCertificate() const {
 }
 
 SystemTime SslSocket::validFromPeerCertificate() const {
-  X509* cert = SSL_get_peer_certificate(ssl_.get());
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return std::chrono::system_clock::from_time_t(0);
   }
@@ -370,7 +370,7 @@ SystemTime SslSocket::validFromPeerCertificate() const {
 }
 
 SystemTime SslSocket::expirationPeerCertificate() const {
-  X509* cert = SSL_get_peer_certificate(ssl_.get());
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return std::chrono::system_clock::from_time_t(0);
   }

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -56,6 +56,8 @@ public:
   const std::string& urlEncodedPemEncodedPeerCertificate() const override;
   std::vector<std::string> dnsSansPeerCertificate() const override;
   std::vector<std::string> dnsSansLocalCertificate() const override;
+  SystemTime validFromPeerCertificate() const override;
+  SystemTime expirationPeerCertificate() const override;
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -15,6 +15,7 @@
 #include "extensions/transport_sockets/tls/utility.h"
 
 #include "absl/synchronization/mutex.h"
+#include "absl/types/optional.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -56,8 +57,8 @@ public:
   const std::string& urlEncodedPemEncodedPeerCertificate() const override;
   std::vector<std::string> dnsSansPeerCertificate() const override;
   std::vector<std::string> dnsSansLocalCertificate() const override;
-  SystemTime validFromPeerCertificate() const override;
-  SystemTime expirationPeerCertificate() const override;
+  absl::optional<SystemTime> validFromPeerCertificate() const override;
+  absl::optional<SystemTime> expirationPeerCertificate() const override;
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -94,7 +94,7 @@ public:
   TestUtilOptions(const std::string& client_ctx_yaml, const std::string& server_ctx_yaml,
                   bool expect_success, Network::Address::IpVersion version)
       : TestUtilOptionsBase(expect_success, version), client_ctx_yaml_(client_ctx_yaml),
-        server_ctx_yaml_(server_ctx_yaml) {
+        server_ctx_yaml_(server_ctx_yaml), expect_no_cert_(false) {
     if (expect_success) {
       setExpectedServerStats("ssl.handshake");
     } else {

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -282,12 +282,12 @@ void testUtil(const TestUtilOptions& options) {
       }
       if (!options.expectedValidFromTimePeerCert().empty()) {
         const std::string formatted = TestUtility::formatTime(
-            server_connection->ssl()->validFromPeerCertificate(), "%b %e %H:%M:%S %Y GMT");
+            server_connection->ssl()->validFromPeerCertificate().value(), "%b %e %H:%M:%S %Y GMT");
         EXPECT_EQ(options.expectedValidFromTimePeerCert(), formatted);
       }
       if (!options.expectedExpirationTimePeerCert().empty()) {
         const std::string formatted = TestUtility::formatTime(
-            server_connection->ssl()->expirationPeerCertificate(), "%b %e %H:%M:%S %Y GMT");
+            server_connection->ssl()->expirationPeerCertificate().value(), "%b %e %H:%M:%S %Y GMT");
         EXPECT_EQ(options.expectedExpirationTimePeerCert(), formatted);
       }
       server_connection->close(Network::ConnectionCloseType::NoFlush);

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -980,8 +980,8 @@ TEST_P(SslSocketTest, GetIssueExpireTimesPeerCert) {
 )EOF";
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
   testUtil(test_options.setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL)
-               .setExpectedValidFromTimePeerCert(TEST_SAN_URI_CERT_NOT_BEFORE)
-               .setExpectedExpirationTimePeerCert(TEST_SAN_URI_CERT_NOT_AFTER));
+               .setExpectedValidFromTimePeerCert(TEST_NO_SAN_CERT_NOT_BEFORE)
+               .setExpectedExpirationTimePeerCert(TEST_NO_SAN_CERT_NOT_AFTER));
 }
 
 TEST_P(SslSocketTest, FailedClientAuthCaVerificationNoClientCert) {

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -45,8 +45,8 @@ public:
   MOCK_CONST_METHOD0(urlEncodedPemEncodedPeerCertificate, std::string&());
   MOCK_CONST_METHOD0(dnsSansPeerCertificate, std::vector<std::string>());
   MOCK_CONST_METHOD0(dnsSansLocalCertificate, std::vector<std::string>());
-  MOCK_CONST_METHOD0(validFromPeerCertificate, SystemTime());
-  MOCK_CONST_METHOD0(expirationPeerCertificate, SystemTime());
+  MOCK_CONST_METHOD0(validFromPeerCertificate, absl::optional<SystemTime>());
+  MOCK_CONST_METHOD0(expirationPeerCertificate, absl::optional<SystemTime>());
 };
 
 class MockClientContext : public ClientContext {

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -45,6 +45,8 @@ public:
   MOCK_CONST_METHOD0(urlEncodedPemEncodedPeerCertificate, std::string&());
   MOCK_CONST_METHOD0(dnsSansPeerCertificate, std::vector<std::string>());
   MOCK_CONST_METHOD0(dnsSansLocalCertificate, std::vector<std::string>());
+  MOCK_CONST_METHOD0(validFromPeerCertificate, SystemTime());
+  MOCK_CONST_METHOD0(expirationPeerCertificate, SystemTime());
 };
 
 class MockClientContext : public ClientContext {


### PR DESCRIPTION
*Description*:

Adds functions to access the issue and expiration times of peer certificates, which can be used in network filters.

*Risk Level*: low
*Testing*: unit tests updated
*Docs Changes*: N/A
*Release Notes*: N/A
