### PR TITLE
ci: re-enable GCS remote caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ executors:
       - image: envoyproxy/envoy-build:698009170e362f9ca0594f2b1927fbbee199bf98
     resource_class: xlarge
     working_directory: /source
+    environment:
+      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/envoy-circleci-bazel-cache/
 
 jobs:
    release:
@@ -162,6 +164,8 @@ jobs:
    mac:
      macos:
        xcode: "9.3.0"
+     environment:
+       BAZEL_REMOTE_CACHE: https://storage.googleapis.com/envoy-circleci-bazel-cache/
      steps:
        - run: sudo ntpdate -vu time.apple.com
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ executors:
       - image: envoyproxy/envoy-build:698009170e362f9ca0594f2b1927fbbee199bf98
     resource_class: xlarge
     working_directory: /source
-    environment:
-      BAZEL_REMOTE_CACHE: https://storage.googleapis.com/envoy-circleci-bazel-cache/
 
 jobs:
    release:
      executor: ubuntu-build
+     environment:
+       BAZEL_REMOTE_CACHE: https://storage.googleapis.com/envoy-circleci-bazel-cache/
      steps:
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
        - checkout


### PR DESCRIPTION
This reverts commit 384b823539d6354134f95ed8a6b6613236dcf86b.

See if 0.22 has fixed it, otherwise we can reach out to Bazel team.

Signed-off-by: Harvey Tuch <htuch@google.com>