### PR TITLE
Fix a redundant test case in config_impl_test

### DIFF
--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2315,7 +2315,7 @@ TEST_F(RouteMatcherTest, Retry) {
                 .retryOn());
 
   EXPECT_EQ(std::chrono::milliseconds(0),
-            config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
+            config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
                 ->routeEntry()
                 ->retryPolicy()
                 .perTryTimeout());


### PR DESCRIPTION
Signed-off-by: Michael Puncel <mpuncel@squareup.com>

*Description*: Fixing a redundant test case, likely an error due to copy/paste
*Risk Level*: low
*Testing*: unit test
*Docs Changes*: N/A
*Release Notes*: N/A
