### PR TITLE
fuzz: H1 codec fuzz support.

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -71,6 +71,7 @@ envoy_cc_fuzz_test(
     deps = [
         ":codec_impl_fuzz_proto_cc",
         "//source/common/http:header_map_lib",
+        "//source/common/http/http1:codec_lib",
         "//source/common/http/http2:codec_lib",
         "//test/common/http/http2:codec_impl_test_util",
         "//test/fuzz:utility_lib",

--- a/test/common/http/codec_impl_fuzz.proto
+++ b/test/common/http/codec_impl_fuzz.proto
@@ -96,9 +96,9 @@ message Http2ClientServerSettings {
 }
 
 message CodecImplFuzzTestCase {
-  oneof settings_selector {
-    Http1ClientServerSettings h1_settings = 1;
-    Http2ClientServerSettings h2_settings = 2;
-  }
+  // The fuzzer will run actions on both H1 and H2 codecs. The settings below
+  // provide codec-specific parameters.
+  Http1ClientServerSettings h1_settings = 1;
+  Http2ClientServerSettings h2_settings = 2;
   repeated Action actions = 3;
 }


### PR DESCRIPTION
Risk level: Low
Testing: bazel test //test/common/http:codec_impl_fuzz_test. Will be looking into coverage reports
  and working to drive this higher in followup PR.

Signed-off-by: Harvey Tuch <htuch@google.com>