### PR TITLE
add configuration for (unimplemented) request hedging

### DIFF
--- a/api/envoy/api/v2/route/BUILD
+++ b/api/envoy/api/v2/route/BUILD
@@ -18,6 +18,7 @@ api_go_proto_library(
     proto = ":route",
     deps = [
         "//envoy/api/v2/core:base_go_proto",
+        "//envoy/type:percent_go_proto",
         "//envoy/type:range_go_proto",
     ],
 )

--- a/api/envoy/api/v2/route/BUILD
+++ b/api/envoy/api/v2/route/BUILD
@@ -8,6 +8,7 @@ api_proto_library_internal(
     visibility = ["//envoy/api/v2:friends"],
     deps = [
         "//envoy/api/v2/core:base",
+        "//envoy/type:percent",
         "//envoy/type:range",
     ],
 )

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -138,6 +138,12 @@ message VirtualHost {
   // route level entry will take precedence over this config and it'll be treated
   // independently (e.g.: values are not inherited).
   RetryPolicy retry_policy = 16;
+
+  // Indicates the hedge policy for all routes in this virtual host. Note that setting a
+  // route level entry will take precedence over this config and it'll be treated
+  // independently (e.g.: values are not inherited).
+  // [#not-implemented-hide:]
+  HedgePolicy hedge_policy = 17;
 }
 
 // A route is both a specification of how to match a request as well as an indication of what to do
@@ -781,6 +787,12 @@ message RouteAction {
     HANDLE_INTERNAL_REDIRECT = 1;
   }
   InternalRedirectAction internal_redirect_action = 26;
+
+  // Indicates that the route has a hedge policy. Note that if this is set,
+  // it'll take precedence over the virtual host level hedge policy entirely
+  // (e.g.: policies are not merged, most internal one becomes the enforced policy).
+  // [#not-implemented-hide:]
+  HedgePolicy hedge_policy = 27;
 }
 
 // HTTP retry :ref:`architecture overview <arch_overview_http_routing_retry>`.
@@ -844,6 +856,24 @@ message RetryPolicy {
 
   // HTTP status codes that should trigger a retry in addition to those specified by retry_on.
   repeated uint32 retriable_status_codes = 7;
+}
+
+// HTTP request hedging TODO(mpuncel) docs
+// [#not-implemented-hide:]
+message HedgePolicy {
+  // Specifies the number of initial requests that should be sent upstream.
+  // Must be at least 1. If the number is fractional, the number of requests
+  // sent will be at least the whole portion of the number, with the remainder
+  // used to decide probabilistically whether to send another request. For
+  // example, a value of 2.3 means that 2 requests will be sent 70% of the
+  // time, and 3 requests otherwise.
+  // Defaults to 1.
+  google.protobuf.FloatValue initial_requests = 1;
+
+  // Indicates that a hedged request should be sent when the per-try timeout
+  // is hit. This will only occur if the retry policy also indicates that a
+  // timed out request should be retried. Defaults to false.
+  bool hedge_on_per_try_timeout = 2;
 }
 
 message RedirectAction {

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -868,8 +868,9 @@ message HedgePolicy {
   google.protobuf.UInt32Value initial_requests = 1 [(validate.rules).uint32.gte = 1];
 
   // Specifies a probability that an additional upstream request should be sent
-  // on top of what is specified by initial_requests. Defaults to 0.
-  envoy.type.Percent additional_request_chance = 2;
+  // on top of what is specified by initial_requests.
+  // Defaults to 0.
+  envoy.type.FractionalPercent additional_request_chance = 2;
 
   // Indicates that a hedged request should be sent when the per-try timeout
   // is hit. This will only occur if the retry policy also indicates that a

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -9,6 +9,7 @@ option go_package = "route";
 option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";
+import "envoy/type/percent.proto";
 import "envoy/type/range.proto";
 
 import "google/protobuf/any.proto";
@@ -862,18 +863,18 @@ message RetryPolicy {
 // [#not-implemented-hide:]
 message HedgePolicy {
   // Specifies the number of initial requests that should be sent upstream.
-  // Must be at least 1. If the number is fractional, the number of requests
-  // sent will be at least the whole portion of the number, with the remainder
-  // used to decide probabilistically whether to send another request. For
-  // example, a value of 2.3 means that 2 requests will be sent 70% of the
-  // time, and 3 requests otherwise.
+  // Must be at least 1.
   // Defaults to 1.
-  google.protobuf.FloatValue initial_requests = 1;
+  google.protobuf.UInt32Value initial_requests = 1 [(validate.rules).uint32.gte = 1];
+
+  // Specifies a probability that an additional upstream request should be sent
+  // on top of what is specified by initial_requests. Defaults to 0.
+  envoy.type.Percent additional_request_chance = 2;
 
   // Indicates that a hedged request should be sent when the per-try timeout
   // is hit. This will only occur if the retry policy also indicates that a
   // timed out request should be retried. Defaults to false.
-  bool hedge_on_per_try_timeout = 2;
+  bool hedge_on_per_try_timeout = 3;
 }
 
 message RedirectAction {

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -427,7 +427,7 @@ public:
    * @return percent chance that an additional upstream request should be sent
    * on top of the value from initialRequests().
    */
-  virtual double additionalRequestChance() const PURE;
+  virtual const envoy::type::FractionalPercent& additionalRequestChance() const PURE;
 
   /**
    * @return bool indicating whether request hedging should occur when a request

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -421,7 +421,13 @@ public:
   /**
    * @return number of upstream requests that should be sent initially.
    */
-  virtual float initialRequests() const PURE;
+  virtual uint32_t initialRequests() const PURE;
+
+  /**
+   * @return percent chance that an additional upstream request should be sent
+   * on top of the value from initialRequests().
+   */
+  virtual double additionalRequestChance() const PURE;
 
   /**
    * @return bool indicating whether request hedging should occur when a request

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -411,6 +411,26 @@ public:
                AddCookieCallback add_cookie) const PURE;
 };
 
+/**
+ * Route level hedging policy.
+ */
+class HedgePolicy {
+public:
+  virtual ~HedgePolicy() {}
+
+  /**
+   * @return number of upstream requests that should be sent initially.
+   */
+  virtual float initialRequests() const PURE;
+
+  /**
+   * @return bool indicating whether request hedging should occur when a request
+   * is retried due to a per try timeout. The alternative is the original request
+   * will be canceled immediately.
+   */
+  virtual bool hedgeOnPerTryTimeout() const PURE;
+};
+
 class MetadataMatchCriterion {
 public:
   virtual ~MetadataMatchCriterion() {}
@@ -527,6 +547,12 @@ public:
    * @return const HashPolicy* the optional hash policy for the route.
    */
   virtual const HashPolicy* hashPolicy() const PURE;
+
+  /**
+   * @return const HedgePolicy& the hedge policy for the route. All routes have a hedge policy even
+   *         if it is empty and does not allow for hedged requests.
+   */
+  virtual const HedgePolicy& hedgePolicy() const PURE;
 
   /**
    * @return the priority of the route.

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -17,6 +17,7 @@ const std::list<std::regex> AsyncStreamImpl::NullCorsPolicy::allow_origin_regex_
 const absl::optional<bool> AsyncStreamImpl::NullCorsPolicy::allow_credentials_;
 const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>
     AsyncStreamImpl::NullRateLimitPolicy::rate_limit_policy_entry_;
+const AsyncStreamImpl::NullHedgePolicy AsyncStreamImpl::RouteEntryImpl::hedge_policy_;
 const AsyncStreamImpl::NullRateLimitPolicy AsyncStreamImpl::RouteEntryImpl::rate_limit_policy_;
 const AsyncStreamImpl::NullRetryPolicy AsyncStreamImpl::RouteEntryImpl::retry_policy_;
 const AsyncStreamImpl::NullShadowPolicy AsyncStreamImpl::RouteEntryImpl::shadow_policy_;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -111,7 +111,8 @@ private:
 
   struct NullHedgePolicy : public Router::HedgePolicy {
     // Router::HedgePolicy
-    float initialRequests() const override { return 1; }
+    uint32_t initialRequests() const override { return 1; }
+    double additionalRequestChance() const override { return 0; }
     bool hedgeOnPerTryTimeout() const override { return false; }
   };
 

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -112,8 +112,12 @@ private:
   struct NullHedgePolicy : public Router::HedgePolicy {
     // Router::HedgePolicy
     uint32_t initialRequests() const override { return 1; }
-    double additionalRequestChance() const override { return 0; }
+    const envoy::type::FractionalPercent& additionalRequestChance() const override {
+      return additional_request_chance_;
+    }
     bool hedgeOnPerTryTimeout() const override { return false; }
+
+    const envoy::type::FractionalPercent additional_request_chance_;
   };
 
   struct NullRateLimitPolicy : public Router::RateLimitPolicy {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -109,6 +109,12 @@ private:
     static const absl::optional<bool> allow_credentials_;
   };
 
+  struct NullHedgePolicy : public Router::HedgePolicy {
+    // Router::HedgePolicy
+    float initialRequests() const override { return 1; }
+    bool hedgeOnPerTryTimeout() const override { return false; }
+  };
+
   struct NullRateLimitPolicy : public Router::RateLimitPolicy {
     // Router::RateLimitPolicy
     const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>&
@@ -200,6 +206,7 @@ private:
                                 bool) const override {}
     void finalizeResponseHeaders(Http::HeaderMap&, const StreamInfo::StreamInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
+    const Router::HedgePolicy& hedgePolicy() const override { return hedge_policy_; }
     const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;
@@ -243,6 +250,7 @@ private:
       return Router::InternalRedirectAction::PassThrough;
     }
 
+    static const NullHedgePolicy hedge_policy_;
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;
     static const NullShadowPolicy shadow_policy_;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -57,6 +57,12 @@ std::string SslRedirector::newPath(const Http::HeaderMap& headers) const {
   return Http::Utility::createSslRedirectPath(headers);
 }
 
+HedgePolicyImpl::HedgePolicyImpl(const envoy::api::v2::route::HedgePolicy& hedge_policy)
+    : initial_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, initial_requests, 1)),
+      hedge_on_per_try_timeout_(hedge_policy.hedge_on_per_try_timeout()) {}
+
+HedgePolicyImpl::HedgePolicyImpl() : initial_requests_(1), hedge_on_per_try_timeout_(false) {}
+
 RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry_policy) {
   per_try_timeout_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_timeout, 0));
@@ -318,6 +324,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       https_redirect_(route.redirect().https_redirect()),
       prefix_rewrite_redirect_(route.redirect().prefix_rewrite()),
       strip_query_(route.redirect().strip_query()),
+      hedge_policy_(buildHedgePolicy(vhost.hedgePolicy(), route.route())),
       retry_policy_(buildRetryPolicy(vhost.retryPolicy(), route.route())),
       rate_limit_policy_(route.route().rate_limits()), shadow_policy_(route.route()),
       priority_(ConfigUtility::parsePriority(route.route().priority())),
@@ -602,6 +609,23 @@ RouteEntryImplBase::parseOpaqueConfig(const envoy::api::v2::route::Route& route)
   return ret;
 }
 
+HedgePolicyImpl RouteEntryImplBase::buildHedgePolicy(
+    const absl::optional<envoy::api::v2::route::HedgePolicy>& vhost_hedge_policy,
+    const envoy::api::v2::route::RouteAction& route_config) const {
+  // Route specific policy wins, if available.
+  if (route_config.has_hedge_policy()) {
+    return HedgePolicyImpl(route_config.hedge_policy());
+  }
+
+  // If not, we fall back to the virtual host policy if there is one.
+  if (vhost_hedge_policy) {
+    return HedgePolicyImpl(vhost_hedge_policy.value());
+  }
+
+  // Otherwise, an empty policy will do.
+  return HedgePolicyImpl();
+}
+
 RetryPolicyImpl RouteEntryImplBase::buildRetryPolicy(
     const absl::optional<envoy::api::v2::route::RetryPolicy>& vhost_retry_policy,
     const envoy::api::v2::route::RouteAction& route_config) const {
@@ -854,9 +878,12 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtu
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
-  // Retry Policy must be set before routes, since they may use it.
+  // Retry and Hedge policies must be set before routes, since they may use them.
   if (virtual_host.has_retry_policy()) {
     retry_policy_ = virtual_host.retry_policy();
+  }
+  if (virtual_host.has_hedge_policy()) {
+    hedge_policy_ = virtual_host.hedge_policy();
   }
 
   for (const auto& route : virtual_host.routes()) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -59,10 +59,12 @@ std::string SslRedirector::newPath(const Http::HeaderMap& headers) const {
 
 HedgePolicyImpl::HedgePolicyImpl(const envoy::api::v2::route::HedgePolicy& hedge_policy)
     : initial_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, initial_requests, 1)),
-      additional_request_chance_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, additional_request_chance, 0)),
+      additional_request_chance_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, additional_request_chance, 0)),
       hedge_on_per_try_timeout_(hedge_policy.hedge_on_per_try_timeout()) {}
 
-HedgePolicyImpl::HedgePolicyImpl() : initial_requests_(1), additional_request_chance_(0), hedge_on_per_try_timeout_(false) {}
+HedgePolicyImpl::HedgePolicyImpl()
+    : initial_requests_(1), additional_request_chance_(0), hedge_on_per_try_timeout_(false) {}
 
 RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry_policy) {
   per_try_timeout_ =

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -59,9 +59,10 @@ std::string SslRedirector::newPath(const Http::HeaderMap& headers) const {
 
 HedgePolicyImpl::HedgePolicyImpl(const envoy::api::v2::route::HedgePolicy& hedge_policy)
     : initial_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, initial_requests, 1)),
+      additional_request_chance_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, additional_request_chance, 0)),
       hedge_on_per_try_timeout_(hedge_policy.hedge_on_per_try_timeout()) {}
 
-HedgePolicyImpl::HedgePolicyImpl() : initial_requests_(1), hedge_on_per_try_timeout_(false) {}
+HedgePolicyImpl::HedgePolicyImpl() : initial_requests_(1), additional_request_chance_(0), hedge_on_per_try_timeout_(false) {}
 
 RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry_policy) {
   per_try_timeout_ =

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -59,12 +59,11 @@ std::string SslRedirector::newPath(const Http::HeaderMap& headers) const {
 
 HedgePolicyImpl::HedgePolicyImpl(const envoy::api::v2::route::HedgePolicy& hedge_policy)
     : initial_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, initial_requests, 1)),
-      additional_request_chance_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(hedge_policy, additional_request_chance, 0)),
+      additional_request_chance_(hedge_policy.additional_request_chance()),
       hedge_on_per_try_timeout_(hedge_policy.hedge_on_per_try_timeout()) {}
 
 HedgePolicyImpl::HedgePolicyImpl()
-    : initial_requests_(1), additional_request_chance_(0), hedge_on_per_try_timeout_(false) {}
+    : initial_requests_(1), additional_request_chance_({}), hedge_on_per_try_timeout_(false) {}
 
 RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry_policy) {
   per_try_timeout_ =

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -303,12 +303,14 @@ public:
 
   // Router::HedgePolicy
   uint32_t initialRequests() const override { return initial_requests_; }
-  double additionalRequestChance() const override { return additional_request_chance_; }
+  const envoy::type::FractionalPercent& additionalRequestChance() const override {
+    return additional_request_chance_;
+  }
   bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout_; }
 
 private:
   const uint32_t initial_requests_;
-  const double additional_request_chance_;
+  const envoy::type::FractionalPercent additional_request_chance_;
   const bool hedge_on_per_try_timeout_;
 };
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -302,11 +302,13 @@ public:
   HedgePolicyImpl();
 
   // Router::HedgePolicy
-  float initialRequests() const override { return initial_requests_; }
+  uint32_t initialRequests() const override { return initial_requests_; }
+  double additionalRequestChance() const override { return additional_request_chance_; }
   bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout_; }
 
 private:
-  const float initial_requests_;
+  const uint32_t initial_requests_;
+  const double additional_request_chance_;
   const bool hedge_on_per_try_timeout_;
 };
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -162,6 +162,9 @@ public:
   const absl::optional<envoy::api::v2::route::RetryPolicy>& retryPolicy() const {
     return retry_policy_;
   }
+  const absl::optional<envoy::api::v2::route::HedgePolicy>& hedgePolicy() const {
+    return hedge_policy_;
+  }
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
@@ -200,6 +203,7 @@ private:
   PerFilterConfigs per_filter_configs_;
   const bool include_attempt_count_;
   absl::optional<envoy::api::v2::route::RetryPolicy> retry_policy_;
+  absl::optional<envoy::api::v2::route::HedgePolicy> hedge_policy_;
 };
 
 typedef std::shared_ptr<VirtualHostImpl> VirtualHostSharedPtr;
@@ -289,6 +293,24 @@ private:
 };
 
 /**
+ * Implementation of HedgePolicy that reads from the proto route or virtual host config.
+ */
+class HedgePolicyImpl : public HedgePolicy {
+
+public:
+  explicit HedgePolicyImpl(const envoy::api::v2::route::HedgePolicy& hedge_policy);
+  HedgePolicyImpl();
+
+  // Router::HedgePolicy
+  float initialRequests() const override { return initial_requests_; }
+  bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout_; }
+
+private:
+  const float initial_requests_;
+  const bool hedge_on_per_try_timeout_;
+};
+
+/**
  * Implementation of Decorator that reads from the proto route decorator.
  */
 class DecoratorImpl : public Decorator {
@@ -345,6 +367,8 @@ public:
   void finalizeResponseHeaders(Http::HeaderMap& headers,
                                const StreamInfo::StreamInfo& stream_info) const override;
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
+
+  const HedgePolicy& hedgePolicy() const override { return hedge_policy_; }
 
   const MetadataMatchCriteria* metadataMatchCriteria() const override {
     return metadata_match_criteria_.get();
@@ -437,6 +461,7 @@ private:
 
     const CorsPolicy* corsPolicy() const override { return parent_->corsPolicy(); }
     const HashPolicy* hashPolicy() const override { return parent_->hashPolicy(); }
+    const HedgePolicy& hedgePolicy() const override { return parent_->hedgePolicy(); }
     Upstream::ResourcePriority priority() const override { return parent_->priority(); }
     const RateLimitPolicy& rateLimitPolicy() const override { return parent_->rateLimitPolicy(); }
     const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
@@ -550,6 +575,10 @@ private:
 
   bool evaluateRuntimeMatch(const uint64_t random_value) const;
 
+  HedgePolicyImpl
+  buildHedgePolicy(const absl::optional<envoy::api::v2::route::HedgePolicy>& vhost_hedge_policy,
+                   const envoy::api::v2::route::RouteAction& route_config) const;
+
   RetryPolicyImpl
   buildRetryPolicy(const absl::optional<envoy::api::v2::route::RetryPolicy>& vhost_retry_policy,
                    const envoy::api::v2::route::RouteAction& route_config) const;
@@ -576,6 +605,7 @@ private:
   const bool https_redirect_;
   const std::string prefix_rewrite_redirect_;
   const bool strip_query_;
+  const HedgePolicyImpl hedge_policy_;
   const RetryPolicyImpl retry_policy_;
   const RateLimitPolicyImpl rate_limit_policy_;
   const ShadowPolicyImpl shadow_policy_;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2533,9 +2533,9 @@ virtual_hosts:
                        ->hedgePolicy()
                        .hedgeOnPerTryTimeout());
   EXPECT_DOUBLE_EQ(0.4, config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
-                       ->routeEntry()
-                       ->hedgePolicy()
-                       .additionalRequestChance());
+                            ->routeEntry()
+                            ->hedgePolicy()
+                            .additionalRequestChance());
 
   EXPECT_EQ(1, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
                    ->routeEntry()
@@ -2546,9 +2546,9 @@ virtual_hosts:
                        ->hedgePolicy()
                        .hedgeOnPerTryTimeout());
   EXPECT_DOUBLE_EQ(0, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
-                       ->routeEntry()
-                       ->hedgePolicy()
-                       .additionalRequestChance());
+                          ->routeEntry()
+                          ->hedgePolicy()
+                          .additionalRequestChance());
 
   EXPECT_EQ(5, config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
                    ->routeEntry()
@@ -2559,9 +2559,9 @@ virtual_hosts:
                       ->hedgePolicy()
                       .hedgeOnPerTryTimeout());
   EXPECT_DOUBLE_EQ(40, config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
-                      ->routeEntry()
-                      ->hedgePolicy()
-                      .additionalRequestChance());
+                           ->routeEntry()
+                           ->hedgePolicy()
+                           .additionalRequestChance());
 }
 
 TEST_F(RouteMatcherTest, HedgeVirtualHostLevel) {
@@ -2596,9 +2596,9 @@ virtual_hosts:
                       ->hedgePolicy()
                       .hedgeOnPerTryTimeout());
   EXPECT_DOUBLE_EQ(0, config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
-                      ->routeEntry()
-                      ->hedgePolicy()
-                      .additionalRequestChance());
+                          ->routeEntry()
+                          ->hedgePolicy()
+                          .additionalRequestChance());
 
   // Virtual Host level hedge policy kicks in.
   EXPECT_EQ(1, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
@@ -2610,9 +2610,9 @@ virtual_hosts:
                        ->hedgePolicy()
                        .hedgeOnPerTryTimeout());
   EXPECT_DOUBLE_EQ(30, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
-                      ->routeEntry()
-                      ->hedgePolicy()
-                      .additionalRequestChance());
+                           ->routeEntry()
+                           ->hedgePolicy()
+                           .additionalRequestChance());
 
   EXPECT_EQ(3, config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
                    ->routeEntry()
@@ -2623,9 +2623,9 @@ virtual_hosts:
                        ->hedgePolicy()
                        .hedgeOnPerTryTimeout());
   EXPECT_DOUBLE_EQ(0, config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
-                      ->routeEntry()
-                      ->hedgePolicy()
-                      .additionalRequestChance());
+                          ->routeEntry()
+                          ->hedgePolicy()
+                          .additionalRequestChance());
 }
 
 TEST_F(RouteMatcherTest, TestBadDefaultConfig) {

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -77,6 +77,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, pathMatchCriterion()).WillByDefault(ReturnRef(path_match_criterion_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, upgradeMap()).WillByDefault(ReturnRef(upgrade_map_));
+  ON_CALL(*this, hedgePolicy()).WillByDefault(ReturnRef(hedge_policy_));
 }
 
 MockRouteEntry::~MockRouteEntry() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -66,6 +66,16 @@ public:
   bool shadow_enabled_{};
 };
 
+class TestHedgePolicy : public HedgePolicy {
+public:
+  // Router::HedgePolicy
+  float initialRequests() const override { return initial_requests_; }
+  bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout; }
+
+  float initial_requests_{};
+  bool hedge_on_per_try_timeout{};
+};
+
 class TestRetryPolicy : public RetryPolicy {
 public:
   // Router::RetryPolicy
@@ -244,6 +254,7 @@ public:
   MOCK_CONST_METHOD2(finalizeResponseHeaders,
                      void(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
+  MOCK_CONST_METHOD0(hedgePolicy, const HedgePolicy&());
   MOCK_CONST_METHOD0(metadataMatchCriteria, const Router::MetadataMatchCriteria*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
@@ -271,6 +282,7 @@ public:
   std::multimap<std::string, std::string> opaque_config_;
   TestVirtualCluster virtual_cluster_;
   TestRetryPolicy retry_policy_;
+  TestHedgePolicy hedge_policy_;
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;
   TestShadowPolicy shadow_policy_;
   testing::NiceMock<MockVirtualHost> virtual_host_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -69,10 +69,12 @@ public:
 class TestHedgePolicy : public HedgePolicy {
 public:
   // Router::HedgePolicy
-  float initialRequests() const override { return initial_requests_; }
+  uint32_t initialRequests() const override { return initial_requests_; }
+  double additionalRequestChance() const override { return additional_request_chance_; }
   bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout; }
 
-  float initial_requests_{};
+  uint32_t initial_requests_{};
+  double additional_request_chance_{};
   bool hedge_on_per_try_timeout{};
 };
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -70,11 +70,13 @@ class TestHedgePolicy : public HedgePolicy {
 public:
   // Router::HedgePolicy
   uint32_t initialRequests() const override { return initial_requests_; }
-  double additionalRequestChance() const override { return additional_request_chance_; }
+  const envoy::type::FractionalPercent& additionalRequestChance() const override {
+    return additional_request_chance_;
+  }
   bool hedgeOnPerTryTimeout() const override { return hedge_on_per_try_timeout; }
 
   uint32_t initial_requests_{};
-  double additional_request_chance_{};
+  envoy::type::FractionalPercent additional_request_chance_{};
   bool hedge_on_per_try_timeout{};
 };
 


### PR DESCRIPTION
This adds a new message HedgePolicy which is a field in VirtualHost and
RouteAction similar to RetryPolicy. The configuration is plumbed through
to the various classes but not used to affect behavior yet.

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Adds protobuf messages describing HedgePolicy config at virtual host and route level. Makes this configuration available on the various classes and handles route level hedge policy overriding virtual host level.
*Risk Level*: low
*Testing*: unit tests
*Docs Changes*: N/A
*Release Notes*:N/A
[Optional *Deprecated*:]
First step toward #2784 #5841 