### PR TITLE
util: change *toul functions to *toull

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -151,7 +151,7 @@ void AccessLogFormatParser::parseCommand(const std::string& token, const size_t 
     std::string length_str = token.substr(end_request + 2);
     uint64_t length_value;
 
-    if (!StringUtil::atoul(length_str.c_str(), length_value)) {
+    if (!StringUtil::atoull(length_str.c_str(), length_value)) {
       throw EnvoyException(fmt::format("Length must be an integer, given: {}", length_str));
     }
 

--- a/source/common/common/hex.cc
+++ b/source/common/common/hex.cc
@@ -35,7 +35,7 @@ std::vector<uint8_t> Hex::decode(const std::string& hex_string) {
   for (size_t i = 0; i < hex_string.size(); i += 2) {
     std::string hex_byte = hex_string.substr(i, 2);
     uint64_t out;
-    if (!StringUtil::atoul(hex_byte.c_str(), out, 16)) {
+    if (!StringUtil::atoull(hex_byte.c_str(), out, 16)) {
       return {};
     }
 

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -217,23 +217,23 @@ bool DateUtil::timePointValid(MonotonicTime time_point) {
 
 const char StringUtil::WhitespaceChars[] = " \t\f\v\n\r";
 
-const char* StringUtil::strtoul(const char* str, uint64_t& out, int base) {
+const char* StringUtil::strtoull(const char* str, uint64_t& out, int base) {
   if (strlen(str) == 0) {
     return nullptr;
   }
 
   char* end_ptr;
   errno = 0;
-  out = ::strtoul(str, &end_ptr, base);
-  if (end_ptr == str || (out == ULONG_MAX && errno == ERANGE)) {
+  out = std::strtoull(str, &end_ptr, base);
+  if (end_ptr == str || (out == ULLONG_MAX && errno == ERANGE)) {
     return nullptr;
   } else {
     return end_ptr;
   }
 }
 
-bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
-  const char* end_ptr = StringUtil::strtoul(str, out, base);
+bool StringUtil::atoull(const char* str, uint64_t& out, int base) {
+  const char* end_ptr = StringUtil::strtoull(str, out, base);
   if (end_ptr == nullptr || *end_ptr != '\0') {
     return false;
   } else {
@@ -241,15 +241,15 @@ bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
   }
 }
 
-bool StringUtil::atol(const char* str, int64_t& out, int base) {
+bool StringUtil::atoll(const char* str, int64_t& out, int base) {
   if (strlen(str) == 0) {
     return false;
   }
 
   char* end_ptr;
   errno = 0;
-  out = strtol(str, &end_ptr, base);
-  if (*end_ptr != '\0' || ((out == LONG_MAX || out == LONG_MIN) && errno == ERANGE)) {
+  out = std::strtoll(str, &end_ptr, base);
+  if (*end_ptr != '\0' || ((out == LLONG_MAX || out == LLONG_MIN) && errno == ERANGE)) {
     return false;
   } else {
     return true;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -149,19 +149,19 @@ public:
    * Convert a string to an unsigned long, checking for error.
    * @return pointer to the remainder of 'str' if successful, nullptr otherwise.
    */
-  static const char* strtoul(const char* str, uint64_t& out, int base = 10);
+  static const char* strtoull(const char* str, uint64_t& out, int base = 10);
 
   /**
    * Convert a string to an unsigned long, checking for error.
    * @param return true if successful, false otherwise.
    */
-  static bool atoul(const char* str, uint64_t& out, int base = 10);
+  static bool atoull(const char* str, uint64_t& out, int base = 10);
 
   /**
    * Convert a string to a long, checking for error.
    * @param return true if successful, false otherwise.
    */
-  static bool atol(const char* str, int64_t& out, int base = 10);
+  static bool atoll(const char* str, int64_t& out, int base = 10);
 
   /**
    * Convert an unsigned integer to a base 10 string as fast as possible.

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -57,7 +57,7 @@ void Common::chargeStat(const Upstream::ClusterInfo& cluster, const std::string&
       .inc();
   uint64_t grpc_status_code;
   const bool success =
-      StringUtil::atoul(grpc_status->value().c_str(), grpc_status_code) && grpc_status_code == 0;
+      StringUtil::atoull(grpc_status->value().c_str(), grpc_status_code) && grpc_status_code == 0;
   chargeStat(cluster, protocol, grpc_service, grpc_method, success);
 }
 
@@ -85,7 +85,7 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& 
   if (!grpc_status_header || grpc_status_header->value().empty()) {
     return absl::optional<Status::GrpcStatus>();
   }
-  if (!StringUtil::atoul(grpc_status_header->value().c_str(), grpc_status_code) ||
+  if (!StringUtil::atoull(grpc_status_header->value().c_str(), grpc_status_code) ||
       grpc_status_code > Status::GrpcStatus::MaximumValid) {
     return absl::optional<Status::GrpcStatus>(Status::GrpcStatus::InvalidCode);
   }
@@ -139,7 +139,7 @@ std::chrono::milliseconds Common::getGrpcTimeout(Http::HeaderMap& request_header
   if (header_grpc_timeout_entry) {
     uint64_t grpc_timeout;
     const char* unit =
-        StringUtil::strtoul(header_grpc_timeout_entry->value().c_str(), grpc_timeout);
+        StringUtil::strtoull(header_grpc_timeout_entry->value().c_str(), grpc_timeout);
     if (unit != nullptr && *unit != '\0') {
       switch (*unit) {
       case 'H':

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -96,7 +96,7 @@ bool HeaderUtility::matchHeaders(const Http::HeaderMap& request_headers,
     break;
   case HeaderMatchType::Range: {
     int64_t header_value = 0;
-    match = StringUtil::atol(header->value().c_str(), header_value, 10) &&
+    match = StringUtil::atoll(header->value().c_str(), header_value, 10) &&
             header_value >= header_data.range_.start() && header_value < header_data.range_.end();
     break;
   }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -229,7 +229,7 @@ bool Utility::hasSetCookie(const HeaderMap& headers, const std::string& key) {
 uint64_t Utility::getResponseStatus(const HeaderMap& headers) {
   const HeaderEntry* header = headers.Status();
   uint64_t response_code;
-  if (!header || !StringUtil::atoul(headers.Status()->value().c_str(), response_code)) {
+  if (!header || !StringUtil::atoull(headers.Status()->value().c_str(), response_code)) {
     throw CodecClientException(":status must be specified and a valid unsigned long");
   }
   return response_code;

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -129,7 +129,7 @@ CidrRange CidrRange::create(const std::string& range) {
     if (ptr->type() == Type::Ip) {
       uint64_t length64;
       const std::string part{parts[1]};
-      if (StringUtil::atoul(part.c_str(), length64, 10)) {
+      if (StringUtil::atoull(part.c_str(), length64, 10)) {
         if ((ptr->ip()->version() == IpVersion::v6 && length64 <= 128) ||
             (ptr->ip()->version() == IpVersion::v4 && length64 <= 32)) {
           return create(std::move(ptr), static_cast<uint32_t>(length64));

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -150,7 +150,7 @@ Address::InstanceConstSharedPtr Utility::parseInternetAddressAndPort(const std::
     const auto ip_str = ip_address.substr(1, pos - 1);
     const auto port_str = ip_address.substr(pos + 2);
     uint64_t port64 = 0;
-    if (port_str.empty() || !StringUtil::atoul(port_str.c_str(), port64, 10) || port64 > 65535) {
+    if (port_str.empty() || !StringUtil::atoull(port_str.c_str(), port64, 10) || port64 > 65535) {
       throwWithMalformedIp(ip_address);
     }
     sockaddr_in6 sa6;
@@ -170,7 +170,7 @@ Address::InstanceConstSharedPtr Utility::parseInternetAddressAndPort(const std::
   const auto ip_str = ip_address.substr(0, pos);
   const auto port_str = ip_address.substr(pos + 1);
   uint64_t port64 = 0;
-  if (port_str.empty() || !StringUtil::atoul(port_str.c_str(), port64, 10) || port64 > 65535) {
+  if (port_str.empty() || !StringUtil::atoull(port_str.c_str(), port64, 10) || port64 > 65535) {
     throwWithMalformedIp(ip_address);
   }
   sockaddr_in sa4;

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -66,7 +66,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
   if (retry_on_ != 0 && request_headers.EnvoyMaxRetries()) {
     const char* max_retries = request_headers.EnvoyMaxRetries()->value().c_str();
     uint64_t temp;
-    if (StringUtil::atoul(max_retries, temp)) {
+    if (StringUtil::atoull(max_retries, temp)) {
       retries_remaining_ = temp;
     }
   }
@@ -74,7 +74,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
     for (const auto code : StringUtil::splitToken(
              request_headers.EnvoyRetriableStatusCodes()->value().getStringView(), ",")) {
       uint64_t out;
-      if (StringUtil::atoul(std::string(code).c_str(), out)) {
+      if (StringUtil::atoull(std::string(code).c_str(), out)) {
         retriable_status_codes_.emplace_back(out);
       }
     }

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -138,7 +138,7 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
   Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
   uint64_t header_timeout;
   if (header_timeout_entry) {
-    if (StringUtil::atoul(header_timeout_entry->value().c_str(), header_timeout)) {
+    if (StringUtil::atoull(header_timeout_entry->value().c_str(), header_timeout)) {
       timeout.global_timeout_ = std::chrono::milliseconds(header_timeout);
     }
     request_headers.removeEnvoyUpstreamRequestTimeoutMs();
@@ -147,7 +147,7 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
   // See if there is a per try/retry timeout. If it's >= global we just ignore it.
   Http::HeaderEntry* per_try_timeout_entry = request_headers.EnvoyUpstreamRequestPerTryTimeoutMs();
   if (per_try_timeout_entry) {
-    if (StringUtil::atoul(per_try_timeout_entry->value().c_str(), header_timeout)) {
+    if (StringUtil::atoull(per_try_timeout_entry->value().c_str(), header_timeout)) {
       timeout.per_try_timeout_ = std::chrono::milliseconds(header_timeout);
     }
     request_headers.removeEnvoyUpstreamRequestPerTryTimeoutMs();

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -241,7 +241,7 @@ SnapshotImpl::Entry SnapshotImpl::createEntry(const std::string& value) {
 
 bool SnapshotImpl::parseEntryUintValue(Entry& entry) {
   uint64_t converted_uint64;
-  if (StringUtil::atoul(entry.raw_string_value_.c_str(), converted_uint64)) {
+  if (StringUtil::atoull(entry.raw_string_value_.c_str(), converted_uint64)) {
     entry.uint_value_ = converted_uint64;
     return true;
   }

--- a/source/common/runtime/uuid_util.cc
+++ b/source/common/runtime/uuid_util.cc
@@ -13,7 +13,7 @@ bool UuidUtils::uuidModBy(const std::string& uuid, uint64_t& out, uint64_t mod) 
   }
 
   uint64_t value;
-  if (!StringUtil::atoul(uuid.substr(0, 8).c_str(), value, 16)) {
+  if (!StringUtil::atoull(uuid.substr(0, 8).c_str(), value, 16)) {
     return false;
   }
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -199,7 +199,7 @@ ResponsePtr RawHttpClientImpl::toResponse(Http::MessagePtr message) {
   // Set an error status if parsing status code fails. A Forbidden response is sent to the client
   // if the filter has not been configured with failure_mode_allow.
   uint64_t status_code{};
-  if (!StringUtil::atoul(message->headers().Status()->value().c_str(), status_code)) {
+  if (!StringUtil::atoull(message->headers().Status()->value().c_str(), status_code)) {
     ENVOY_LOG(warn, "ext_authz HTTP client failed to parse the HTTP status code.");
     return std::make_unique<Response>(errorResponse());
   }

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -71,7 +71,7 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::HeaderMap& tr
     const Http::HeaderEntry* grpc_status_header = trailers.GrpcStatus();
     if (grpc_status_header) {
       uint64_t grpc_status_code;
-      if (!StringUtil::atoul(grpc_status_header->value().c_str(), grpc_status_code) ||
+      if (!StringUtil::atoull(grpc_status_header->value().c_str(), grpc_status_code) ||
           grpc_status_code != 0) {
         response_headers_->Status()->value(enumToInt(Http::Code::ServiceUnavailable));
       }

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -33,7 +33,7 @@ void adjustContentLength(Http::HeaderMap& headers,
   auto length_header = headers.ContentLength();
   if (length_header != nullptr) {
     uint64_t length;
-    if (StringUtil::atoul(length_header->value().c_str(), length)) {
+    if (StringUtil::atoull(length_header->value().c_str(), length)) {
       length_header->value(adjustment(length));
     }
   }

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -231,7 +231,7 @@ bool GzipFilter::isMinimumContentLength(Http::HeaderMap& headers) const {
   if (content_length) {
     uint64_t length;
     const bool is_minimum_content_length =
-        StringUtil::atoul(content_length->value().c_str(), length) &&
+        StringUtil::atoull(content_length->value().c_str(), length) &&
         length >= config_->minimumLength();
     if (!is_minimum_content_length) {
       config_->stats().content_length_too_small_.inc();

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -118,7 +118,7 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
 
   uint64_t status;
   if (headers->Status() == nullptr ||
-      !StringUtil::atoul(headers->Status()->value().c_str(), status) || status < 200 ||
+      !StringUtil::atoull(headers->Status()->value().c_str(), status) || status < 200 ||
       status >= 600) {
     luaL_error(state, ":status must be between 200-599");
   }

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
@@ -71,7 +71,7 @@ bool ParameterRouteEntryImpl::matchParameter(const std::string& request_data,
     return config_data.value_.empty() || request_data == config_data.value_;
   case Http::HeaderUtility::HeaderMatchType::Range: {
     int64_t value = 0;
-    return StringUtil::atol(request_data.c_str(), value, 10) &&
+    return StringUtil::atoll(request_data.c_str(), value, 10) &&
            value >= config_data.range_.start() && value < config_data.range_.end();
   }
   default:

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -90,24 +90,24 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
     if (b3_trace_id_entry->value().size() == 32) {
       const std::string high_tid = tid.substr(0, 16);
       const std::string low_tid = tid.substr(16, 16);
-      if (!StringUtil::atoul(high_tid.c_str(), trace_id_high, 16) ||
-          !StringUtil::atoul(low_tid.c_str(), trace_id, 16)) {
+      if (!StringUtil::atoull(high_tid.c_str(), trace_id_high, 16) ||
+          !StringUtil::atoull(low_tid.c_str(), trace_id, 16)) {
         throw ExtractorException(
             fmt::format("Invalid traceid_high {} or tracid {}", high_tid.c_str(), low_tid.c_str()));
       }
-    } else if (!StringUtil::atoul(tid.c_str(), trace_id, 16)) {
+    } else if (!StringUtil::atoull(tid.c_str(), trace_id, 16)) {
       throw ExtractorException(fmt::format("Invalid trace_id {}", tid.c_str()));
     }
 
     const std::string spid = b3_span_id_entry->value().c_str();
-    if (!StringUtil::atoul(spid.c_str(), span_id, 16)) {
+    if (!StringUtil::atoull(spid.c_str(), span_id, 16)) {
       throw ExtractorException(fmt::format("Invalid span id {}", spid.c_str()));
     }
 
     auto b3_parent_id_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
     if (b3_parent_id_entry) {
       const std::string pspid = b3_parent_id_entry->value().c_str();
-      if (!StringUtil::atoul(pspid.c_str(), parent_id, 16)) {
+      if (!StringUtil::atoull(pspid.c_str(), parent_id, 16)) {
         throw ExtractorException(fmt::format("Invalid parent span id {}", pspid.c_str()));
       }
     }
@@ -150,18 +150,18 @@ SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
 
   const std::string trace_id_str = b3.substr(pos, 16);
   if (b3[pos + 32] == '-') {
-    if (!StringUtil::atoul(trace_id_str.c_str(), trace_id_high, 16)) {
+    if (!StringUtil::atoull(trace_id_str.c_str(), trace_id_high, 16)) {
       throw ExtractorException(
           fmt::format("Invalid input: invalid trace id high {}", trace_id_str.c_str()));
     }
     pos += 16;
     const std::string trace_id_low_str = b3.substr(pos, 16);
-    if (!StringUtil::atoul(trace_id_low_str.c_str(), trace_id, 16)) {
+    if (!StringUtil::atoull(trace_id_low_str.c_str(), trace_id, 16)) {
       throw ExtractorException(
           fmt::format("Invalid input: invalid trace id {}", trace_id_low_str.c_str()));
     }
   } else {
-    if (!StringUtil::atoul(trace_id_str.c_str(), trace_id, 16)) {
+    if (!StringUtil::atoull(trace_id_str.c_str(), trace_id, 16)) {
       throw ExtractorException(
           fmt::format("Invalid input: invalid trace id {}", trace_id_str.c_str()));
     }
@@ -173,7 +173,7 @@ SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
   }
 
   const std::string span_id_str = b3.substr(pos, 16);
-  if (!StringUtil::atoul(span_id_str.c_str(), span_id, 16)) {
+  if (!StringUtil::atoull(span_id_str.c_str(), span_id, 16)) {
     throw ExtractorException(fmt::format("Invalid input: invalid span id {}", span_id_str.c_str()));
   }
   pos += 16; // spanId ended
@@ -212,7 +212,7 @@ SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
       pos++;
 
       const std::string parent_id_str = b3.substr(pos, b3.length() - pos);
-      if (!StringUtil::atoul(parent_id_str.c_str(), parent_id, 16)) {
+      if (!StringUtil::atoull(parent_id_str.c_str(), parent_id, 16)) {
         throw ExtractorException(
             fmt::format("Invalid input: invalid parent id {}", parent_id_str.c_str()));
       }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -246,7 +246,7 @@ void InstanceImpl::initialize(const Options& options,
   failHealthcheck(false);
 
   uint64_t version_int;
-  if (!StringUtil::atoul(VersionInfo::revision().substr(0, 6).c_str(), version_int, 16)) {
+  if (!StringUtil::atoull(VersionInfo::revision().substr(0, 6).c_str(), version_int, 16)) {
     throw EnvoyException("compiled GIT SHA is invalid. Invalid build.");
   }
 

--- a/test/common/common/utility_fuzz_test.cc
+++ b/test/common/common/utility_fuzz_test.cc
@@ -12,7 +12,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   {
     uint64_t out;
     const std::string string_buffer(reinterpret_cast<const char*>(buf), len);
-    StringUtil::atoul(string_buffer.c_str(), out);
+    StringUtil::atoull(string_buffer.c_str(), out);
   }
   {
     const std::string string_buffer(reinterpret_cast<const char*>(buf), len);

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -20,108 +20,108 @@ using testing::ContainerEq;
 
 namespace Envoy {
 
-TEST(StringUtil, strtoul) {
+TEST(StringUtil, strtoull) {
   uint64_t out;
   const char* rest;
 
   static const char* test_str = "12345b";
-  rest = StringUtil::strtoul(test_str, out);
+  rest = StringUtil::strtoull(test_str, out);
   EXPECT_NE(nullptr, rest);
   EXPECT_EQ('b', *rest);
   EXPECT_EQ(&test_str[5], rest);
   EXPECT_EQ(12345U, out);
 
-  EXPECT_EQ(nullptr, StringUtil::strtoul("", out));
-  EXPECT_EQ(nullptr, StringUtil::strtoul("b123", out));
+  EXPECT_EQ(nullptr, StringUtil::strtoull("", out));
+  EXPECT_EQ(nullptr, StringUtil::strtoull("b123", out));
 
-  rest = StringUtil::strtoul("123", out);
+  rest = StringUtil::strtoull("123", out);
   EXPECT_NE(nullptr, rest);
   EXPECT_EQ('\0', *rest);
   EXPECT_EQ(123U, out);
 
-  EXPECT_NE(nullptr, StringUtil::strtoul("  456", out));
+  EXPECT_NE(nullptr, StringUtil::strtoull("  456", out));
   EXPECT_EQ(456U, out);
 
-  EXPECT_NE(nullptr, StringUtil::strtoul("00789", out));
+  EXPECT_NE(nullptr, StringUtil::strtoull("00789", out));
   EXPECT_EQ(789U, out);
 
   // Hex
-  rest = StringUtil::strtoul("0x1234567890abcdefg", out, 16);
+  rest = StringUtil::strtoull("0x1234567890abcdefg", out, 16);
   EXPECT_NE(nullptr, rest);
   EXPECT_EQ('g', *rest);
   EXPECT_EQ(0x1234567890abcdefU, out);
 
   // Explicit decimal
-  rest = StringUtil::strtoul("01234567890A", out, 10);
+  rest = StringUtil::strtoull("01234567890A", out, 10);
   EXPECT_NE(nullptr, rest);
   EXPECT_EQ('A', *rest);
   EXPECT_EQ(1234567890U, out);
 
   // Octal
-  rest = StringUtil::strtoul("012345678", out, 8);
+  rest = StringUtil::strtoull("012345678", out, 8);
   EXPECT_NE(nullptr, rest);
   EXPECT_EQ('8', *rest);
   EXPECT_EQ(01234567U, out);
 
   // Binary
-  rest = StringUtil::strtoul("01010101012", out, 2);
+  rest = StringUtil::strtoull("01010101012", out, 2);
   EXPECT_NE(nullptr, rest);
   EXPECT_EQ('2', *rest);
   EXPECT_EQ(0b101010101U, out);
 
-  // Verify subsequent call to strtoul succeeds after the first one
+  // Verify subsequent call to strtoull succeeds after the first one
   // failed due to errno ERANGE
-  EXPECT_EQ(nullptr, StringUtil::strtoul("18446744073709551616", out));
-  EXPECT_NE(nullptr, StringUtil::strtoul("18446744073709551615", out));
+  EXPECT_EQ(nullptr, StringUtil::strtoull("18446744073709551616", out));
+  EXPECT_NE(nullptr, StringUtil::strtoull("18446744073709551615", out));
   EXPECT_EQ(18446744073709551615U, out);
 }
 
-TEST(StringUtil, atoul) {
+TEST(StringUtil, atoull) {
   uint64_t out;
-  EXPECT_FALSE(StringUtil::atoul("123b", out));
-  EXPECT_FALSE(StringUtil::atoul("", out));
-  EXPECT_FALSE(StringUtil::atoul("b123", out));
+  EXPECT_FALSE(StringUtil::atoull("123b", out));
+  EXPECT_FALSE(StringUtil::atoull("", out));
+  EXPECT_FALSE(StringUtil::atoull("b123", out));
 
-  EXPECT_TRUE(StringUtil::atoul("123", out));
+  EXPECT_TRUE(StringUtil::atoull("123", out));
   EXPECT_EQ(123U, out);
 
-  EXPECT_TRUE(StringUtil::atoul("  456", out));
+  EXPECT_TRUE(StringUtil::atoull("  456", out));
   EXPECT_EQ(456U, out);
 
-  EXPECT_TRUE(StringUtil::atoul("00789", out));
+  EXPECT_TRUE(StringUtil::atoull("00789", out));
   EXPECT_EQ(789U, out);
 
-  // Verify subsequent call to atoul succeeds after the first one
+  // Verify subsequent call to atoull succeeds after the first one
   // failed due to errno ERANGE
-  EXPECT_FALSE(StringUtil::atoul("18446744073709551616", out));
-  EXPECT_TRUE(StringUtil::atoul("18446744073709551615", out));
+  EXPECT_FALSE(StringUtil::atoull("18446744073709551616", out));
+  EXPECT_TRUE(StringUtil::atoull("18446744073709551615", out));
   EXPECT_EQ(18446744073709551615U, out);
 }
 
-TEST(StringUtil, atol) {
+TEST(StringUtil, atoll) {
   int64_t out;
-  EXPECT_FALSE(StringUtil::atol("-123b", out));
-  EXPECT_FALSE(StringUtil::atol("", out));
-  EXPECT_FALSE(StringUtil::atol("b123", out));
+  EXPECT_FALSE(StringUtil::atoll("-123b", out));
+  EXPECT_FALSE(StringUtil::atoll("", out));
+  EXPECT_FALSE(StringUtil::atoll("b123", out));
 
-  EXPECT_TRUE(StringUtil::atol("123", out));
+  EXPECT_TRUE(StringUtil::atoll("123", out));
   EXPECT_EQ(123, out);
-  EXPECT_TRUE(StringUtil::atol("-123", out));
+  EXPECT_TRUE(StringUtil::atoll("-123", out));
   EXPECT_EQ(-123, out);
-  EXPECT_TRUE(StringUtil::atol("+123", out));
+  EXPECT_TRUE(StringUtil::atoll("+123", out));
   EXPECT_EQ(123, out);
 
-  EXPECT_TRUE(StringUtil::atol("  456", out));
+  EXPECT_TRUE(StringUtil::atoll("  456", out));
   EXPECT_EQ(456, out);
 
-  EXPECT_TRUE(StringUtil::atol("00789", out));
+  EXPECT_TRUE(StringUtil::atoll("00789", out));
   EXPECT_EQ(789, out);
 
   // INT64_MAX + 1
-  EXPECT_FALSE(StringUtil::atol("9223372036854775808", out));
+  EXPECT_FALSE(StringUtil::atoll("9223372036854775808", out));
 
   // INT64_MIN
-  EXPECT_TRUE(StringUtil::atol("-9223372036854775808", out));
+  EXPECT_TRUE(StringUtil::atoll("-9223372036854775808", out));
   EXPECT_EQ(INT64_MIN, out);
 }
 

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -56,7 +56,7 @@ protected:
   void expectEqualInputSize(const std::string& footer_bytes, const uint32_t input_size) {
     const std::string size_bytes = footer_bytes.substr(footer_bytes.size() - 8, 8);
     uint64_t size;
-    StringUtil::atoul(size_bytes.c_str(), size, 16);
+    StringUtil::atoull(size_bytes.c_str(), size, 16);
     EXPECT_EQ(TestUtility::flipOrder<uint32_t>(size), input_size);
   }
 

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -84,7 +84,7 @@ public:
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
         .WillOnce(Invoke([=](Http::HeaderMap& headers, bool) {
           uint64_t code;
-          StringUtil::atoul(headers.Status()->value().c_str(), code);
+          StringUtil::atoull(headers.Status()->value().c_str(), code);
           EXPECT_EQ(static_cast<uint64_t>(expected_code), code);
         }));
     EXPECT_CALL(decoder_callbacks_, encodeData(_, _))

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -27,7 +27,8 @@ public:
   void doRequestAndCompression(Http::TestHeaderMapImpl&& request_headers,
                                Http::TestHeaderMapImpl&& response_headers) {
     uint64_t content_length;
-    ASSERT_TRUE(StringUtil::atoul(response_headers.get_("content-length").c_str(), content_length));
+    ASSERT_TRUE(
+        StringUtil::atoull(response_headers.get_("content-length").c_str(), content_length));
     const Buffer::OwnedImpl expected_response{std::string(content_length, 'a')};
     auto response =
         sendRequestAndWaitForResponse(request_headers, 0, response_headers, content_length);
@@ -52,7 +53,8 @@ public:
   void doRequestAndNoCompression(Http::TestHeaderMapImpl&& request_headers,
                                  Http::TestHeaderMapImpl&& response_headers) {
     uint64_t content_length;
-    ASSERT_TRUE(StringUtil::atoul(response_headers.get_("content-length").c_str(), content_length));
+    ASSERT_TRUE(
+        StringUtil::atoull(response_headers.get_("content-length").c_str(), content_length));
     auto response =
         sendRequestAndWaitForResponse(request_headers, 0, response_headers, content_length);
     EXPECT_TRUE(upstream_request_->complete());

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -92,7 +92,7 @@ protected:
 
   void doResponseCompression(Http::TestHeaderMapImpl&& headers) {
     uint64_t content_length;
-    ASSERT_TRUE(StringUtil::atoul(headers.get_("content-length").c_str(), content_length));
+    ASSERT_TRUE(StringUtil::atoull(headers.get_("content-length").c_str(), content_length));
     feedBuffer(content_length);
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
     EXPECT_EQ("", headers.get_("content-length"));
@@ -105,7 +105,7 @@ protected:
 
   void doResponseNoCompression(Http::TestHeaderMapImpl&& headers) {
     uint64_t content_length;
-    ASSERT_TRUE(StringUtil::atoul(headers.get_("content-length").c_str(), content_length));
+    ASSERT_TRUE(StringUtil::atoull(headers.get_("content-length").c_str(), content_length));
     feedBuffer(content_length);
     Http::TestHeaderMapImpl continue_headers;
     EXPECT_EQ(Http::FilterHeadersStatus::Continue,

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -8,7 +8,7 @@ void HeaderToInt(const char header_name[], int32_t& return_int, Http::TestHeader
   std::string header_value = headers.get_(header_name);
   if (!header_value.empty()) {
     uint64_t parsed_value;
-    RELEASE_ASSERT(StringUtil::atoul(header_value.c_str(), parsed_value, 10) &&
+    RELEASE_ASSERT(StringUtil::atoull(header_value.c_str(), parsed_value, 10) &&
                        parsed_value < std::numeric_limits<int32_t>::max(),
                    "");
     return_int = parsed_value;

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -285,7 +285,7 @@ ary
 async
 atomicly
 atomics
-atoul
+atoull
 aud
 auth
 authenticator
@@ -653,7 +653,7 @@ stmt
 str
 strftime
 stringified
-strtoul
+strtoull
 struct
 structs
 subexpr


### PR DESCRIPTION
*Description*:
long is only guaranteed to be at least 32 bits (and on Windows, is only 32 bits). Since these functions are taking 64 bit arguments, use the long long versions instead

*Risk Level*:
Low
*Testing*:
`bazel build //source/... && bazel test //test/...`

*Docs Changes*:
N/A
*Release Notes*:
N/A