### PR TITLE
test: removing a rare flake in tcp proxy integraion test

### DIFF
--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -183,6 +183,7 @@ TEST_P(TcpProxyIntegrationTest, TcpProxyUpstreamFlush) {
   test_server_->waitForGaugeEq("tcp.tcp_stats.upstream_flush_active", 1);
   ASSERT_TRUE(fake_upstream_connection->readDisable(false));
   ASSERT_TRUE(fake_upstream_connection->waitForData(data.size()));
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
   tcp_client->waitForHalfClose();
 


### PR DESCRIPTION
Occasionally we read all the data but not the FIN in waitForData()
waitForDisconnect() would get the half close, and trigger the notification in FakeRawConnection::ReadFilter::onData

Unfortunately this results in a race because in ConnectionImpl we do the onRead, passing data to the filters, before checking bothSidesHalfClosed and actually closing the socket, so when waitForDisconnect() checked connection status it could occasionally still look connected.

I was going to solve in the fake upstream by simply not calling connection_.notifyOne() for a 0 byte onData with fin = true but that would break waitForHalfClose 

*Risk Level*: low (test only)
*Testing*: 1k runs pass
*Docs Changes*: n/a
*Release Notes*: n/a