### PR TITLE
ci: add QUIC to bazel.compile_time_options.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -186,6 +186,7 @@ elif [[ "$1" == "bazel.compile_time_options" ]]; then
     --define boringssl=fips \
     --define log_debug_assert_in_release=enabled \
     --define tcmalloc=debug \
+    --define quiche=enabled \
   "
   setup_clang_toolchain
   # This doesn't go into CI but is available for developer convenience.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -178,6 +178,7 @@ elif [[ "$1" == "bazel.dev" ]]; then
 elif [[ "$1" == "bazel.compile_time_options" ]]; then
   # Right now, none of the available compile-time options conflict with each other. If this
   # changes, this build type may need to be broken up.
+  # TODO(mpwarres): remove quiche=enabled once QUICHE is built by default.
   COMPILE_TIME_OPTIONS="\
     --config libc++ \
     --define signal_trace=disabled \


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>