### PR TITLE
trivial fix: there are many wrong typos

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -83,10 +83,10 @@
   annotations](https://github.com/abseil/abseil-cpp/blob/master/absl/base/thread_annotations.h),
   such as `GUARDED_BY`, should be used for shared state guarded by
   locks/mutexes.
-* Functions intended to be local to a cc file should be declared in an anonymonus namespace,
+* Functions intended to be local to a cc file should be declared in an anonymous namespace,
   rather than using the 'static' keyword. Note that the
   [Google C++ style guide](https://google.github.io/styleguide/cppguide.html#Unnamed_Namespaces_and_Static_Variables)
-   allows either, but in Envoy we prefer annonymous namespaces.
+   allows either, but in Envoy we prefer anonymous namespaces.
 * Braces are required for all control statements include single line if, while, etc. statements.
 
 # Error handling

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -131,7 +131,7 @@ should be replaced by backslash-double-quote (\").
 The following keys are supported:
 
 1. ``By`` The Subject Alternative Name (URI type) of the current proxy's certificate.
-2. ``Hash`` The SHA 256 diguest of the current client certificate.
+2. ``Hash`` The SHA 256 digest of the current client certificate.
 3. ``Cert`` The entire client certificate in URL encoded PEM format.
 4. ``Subject`` The Subject field of the current client certificate. The value is always double-quoted.
 5. ``URI`` The URI type Subject Alternative Name field of the current client certificate.

--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -56,7 +56,7 @@ By *default* compression will be *skipped* when:
 - Neither *content-length* nor *transfer-encoding* headers are present in
   the response.
 - Response size is smaller than 30 bytes (only applicable when *transfer-encoding*
-  is not chuncked).
+  is not chunked).
 
 When compression is *applied*:
 

--- a/docs/root/configuration/tools/router_check.rst
+++ b/docs/root/configuration/tools/router_check.rst
@@ -137,7 +137,7 @@ input
 
 validate
   *(required, object)* The validate object specifies the returned route parameters to match. At least one
-  test parameter must be specificed. Use "" (empty string) to indicate that no return value is expected.
+  test parameter must be specified. Use "" (empty string) to indicate that no return value is expected.
   For example, to test that no cluster match is expected use {"cluster_name": ""}.
 
   cluster_name
@@ -161,7 +161,7 @@ validate
   header_fields
     *(optional, array)*  Match the listed header fields. Examples header fields include the ":path", "cookie",
     and "date" fields. The header fields are checked after all other test cases. Thus, the header fields checked
-    will be those of the redirected or rewriten routes when applicable.
+    will be those of the redirected or rewritten routes when applicable.
 
     field
       *(required, string)* The name of the header field to match.

--- a/docs/root/intro/arch_overview/http_connection_management.rst
+++ b/docs/root/intro/arch_overview/http_connection_management.rst
@@ -104,7 +104,7 @@ To configure retries to attempt other priorities during retries, the built-in
       config:
         update_frequency: 2
 
-This will target priorites in subsequent retry attempts that haven't been already used. The ``update_frequency`` parameter decides how
+This will target priorities in subsequent retry attempts that haven't been already used. The ``update_frequency`` parameter decides how
 often the priority load should be recalculated.
 
 These plugins can be combined, which will exclude both previously attempted hosts as well as

--- a/source/docs/repokitteh.md
+++ b/source/docs/repokitteh.md
@@ -37,7 +37,7 @@ Only organization members can assign or unassign other users, who must be organi
 [Demo PR](https://github.com/envoyproxy/envoybot/pull/6)
 
 ### [Review](https://github.com/repokitteh/modules/blob/master/review.star)
-Requests a a user to recview a pull request.
+Requests a a user to review a pull request.
 
 Examples:
 ```

--- a/source/docs/stats.md
+++ b/source/docs/stats.md
@@ -14,7 +14,7 @@ binary restarts. The metrics are tracked as:
 In order to support restarting the Envoy binary without losing counter and gauge
 values, they are stored in a shared-memory block, including stats that are
 created dynamically at runtime in response to discovery of new clusters at
-runtime. To simplify memmory management, each stat is allocated a fixed amount
+runtime. To simplify memory management, each stat is allocated a fixed amount
 of storage, controlled via [command-line
 flags](https://www.envoyproxy.io/docs/envoy/latest/operations/cli):
 `--max-stats` and `--max-obj-name-len`, which determine the size of the pre-allocated


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
