### PR TITLE
server/test: enable nghttp2 tracing at startup in non-opt.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -208,7 +208,8 @@ def envoy_cmake_external(
         static_libraries = [],
         copy_pdb = False,
         pdb_name = "",
-        cmake_files_dir = "$BUILD_TMPDIR/CMakeFiles"):
+        cmake_files_dir = "$BUILD_TMPDIR/CMakeFiles",
+        **kwargs):
     # On Windows, we don't want to explicitly set CMAKE_BUILD_TYPE,
     # rules_foreign_cc will figure it out for us
     cache_entries_no_build_type = {key: cache_entries[key] for key in cache_entries.keys() if key != "CMAKE_BUILD_TYPE"}
@@ -244,6 +245,7 @@ def envoy_cmake_external(
         make_commands = make_commands,
         postfix_script = pf,
         static_libraries = static_libraries,
+        **kwargs
     )
 
 # Envoy C++ library targets that need no transformations or additional dependencies before being

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -45,6 +45,10 @@ envoy_cmake_external(
     },
     cmake_files_dir = "$BUILD_TMPDIR/lib/CMakeFiles",
     copy_pdb = True,
+    env_vars = select({
+        "//bazel:opt_build": {},
+        "//conditions:default": {"CFLAGS": "-DDEBUGBUILD"},
+    }),
     lib_source = "@com_github_nghttp2_nghttp2//:all",
     pdb_name = "nghttp2_static",
     static_libraries = select({

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -41,7 +41,7 @@ void initializeNghttp2Logging() {
   nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
     char buf[2048];
     const int n = ::vsnprintf(buf, sizeof(buf), format, args);
-    if (n >= 1 && buf[n - 1] == '\n') {
+    if (n >= 1 && static_cast<size_t>(n) < sizeof(buf) && buf[n - 1] == '\n') {
       buf[n - 1] = '\0';
     }
     ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::http2), trace, "nghttp2: {}", buf);

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -41,6 +41,8 @@ void initializeNghttp2Logging() {
   nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
     char buf[2048];
     const int n = ::vsnprintf(buf, sizeof(buf), format, args);
+    // nghttp2 inserts new lines, but we also insert a new line in the ENVOY_LOG
+    // below, so avoid double \n.
     if (n >= 1 && static_cast<size_t>(n) < sizeof(buf) && buf[n - 1] == '\n') {
       buf[n - 1] = '\0';
     }

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -69,6 +69,11 @@ public:
 };
 
 /**
+ * Setup nghttp2 trace-level logging for when debugging.
+ */
+void initializeNghttp2Logging();
+
+/**
  * Base class for HTTP/2 client and server codecs.
  */
 class ConnectionImpl : public virtual Connection, protected Logger::Loggable<Logger::Id::http2> {

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -68,6 +68,7 @@ envoy_cc_library(
         ":envoy_common_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:compiler_requirements_lib",
+        "//source/common/http/http2:codec_lib",
         "//source/common/common:perf_annotation_lib",
         "//source/common/thread:thread_factory_singleton_lib",
         "//source/server:hot_restart_lib",

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -7,6 +7,7 @@
 #include "common/common/compiler_requirements.h"
 #include "common/common/perf_annotation.h"
 #include "common/event/libevent.h"
+#include "common/http/http2/codec_impl.h"
 #include "common/network/utility.h"
 #include "common/stats/thread_local_store.h"
 
@@ -50,6 +51,7 @@ MainCommonBase::MainCommonBase(const OptionsImpl& options, Event::TimeSystem& ti
   ares_library_init(ARES_LIB_INIT_ALL);
   Event::Libevent::Global::initialize();
   RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
+  Http::Http2::initializeNghttp2Logging();
 
   switch (options_.mode()) {
   case Server::Mode::InitOnly:

--- a/test/BUILD
+++ b/test/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test_library(
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
+        "//source/common/http/http2:codec_lib",
         "//source/common/thread:thread_factory_singleton_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/test_common:environment_lib",

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -4,6 +4,7 @@
 #include "common/common/logger_delegates.h"
 #include "common/common/thread.h"
 #include "common/event/libevent.h"
+#include "common/http/http2/codec_impl.h"
 
 #include "test/mocks/access_log/mocks.h"
 #include "test/test_common/environment.h"
@@ -17,6 +18,7 @@ public:
   static int RunTests(int argc, char** argv) {
     ::testing::InitGoogleMock(&argc, argv);
     Event::Libevent::Global::initialize();
+    Http::Http2::initializeNghttp2Logging();
 
     // Add a test-listener so we can call a hook where we can do a quiescence
     // check after each method. See


### PR DESCRIPTION
Turned out to be useful when chasing down a rejected HEADERS due to
empty :authority.

[2019-02-13 12:52:51.965][209117][trace][http2] [source/common/http/http2/codec_impl.cc:340] [C0] dispatching 28 bytes
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: connection recv_window_size=1566707360, local_window=1566706096
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: stream: adjusting kept idle streams num_idle_streams=139935896178256, max=139935896176992
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: [IB_READ_HEAD]
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: payloadlen=139935896178336, type=1566706096, flags=0x3740e000, stream_id=544435553
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: HEADERS
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: no padding in payload
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: stream: dep_add dep_stream(0x7f455d620dd0)=1566705888, stream(0x13e68d1d3740e000)=1566706048
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: stream: adjusting kept closed streams num_closed_streams=139935896178224, num_incoming_streams=139935896176960, max_concurrent_streams=1433988687984648192
[2019-02-13 12:52:51.965][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: call on_begin_headers callback stream_id=1566707312
[2019-02-13 12:52:51.965][209117][debug][http] [source/common/http/conn_manager_impl.cc:210] [C0] new stream
[2019-02-13 12:52:51.966][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: [IB_READ_HEADER_BLOCK]
[2019-02-13 12:52:51.966][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: readlen=139935896178336, payloadleft=139935896177072
[2019-02-13 12:52:51.966][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: block final=1566707360
[2019-02-13 12:52:51.966][209117][trace][http2] [source/exe/main_common.cc:61] nghttp2: recv: decoding header block 139935896178336 bytes

Risk level: Low
Testing: Opt/fastbuild/dbg, observed outputs at -l trace and
  rules_foreign_cc invocation of cmake. Also verified both tests and
  envoy-static have the relevant nghttp2 trace lines.

Signed-off-by: Harvey Tuch <htuch@google.com>