### PR TITLE
Add overload action to try shrink the heap

### DIFF
--- a/docs/root/configuration/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/overload_manager/overload_manager.rst
@@ -51,6 +51,7 @@ The following overload actions are supported:
   envoy.overload_actions.stop_accepting_requests, Envoy will immediately respond with a 503 response code to new requests
   envoy.overload_actions.disable_http_keepalive, Envoy will disable keepalive on HTTP/1.x responses
   envoy.overload_actions.stop_accepting_connections, Envoy will stop accepting new network connections on its configured listeners
+  envoy.overload_actions.shrink_heap, Envoy will periodically try to shrink the heap by releasing free memory to the system
 
 Statistics
 ----------

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -67,6 +67,9 @@ public:
 
   // Overload action to stop accepting new connections.
   const std::string StopAcceptingConnections = "envoy.overload_actions.stop_accepting_connections";
+
+  // Overload action to try to shrink the heap by releasing free memory.
+  const std::string ShrinkHeap = "envoy.overload_actions.shrink_heap";
 };
 
 typedef ConstSingleton<OverloadActionNameValues> OverloadActionNames;
@@ -93,8 +96,9 @@ public:
    * @param dispatcher Event::Dispatcher& the dispatcher on which callbacks will be posted
    * @param callback OverloadActionCb the callback to post when the overload action
    *        changes state
+   * @returns true if action was registered and false if no such action has been configured
    */
-  virtual void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
+  virtual bool registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                                  OverloadActionCb callback) PURE;
 
   /**

--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -14,3 +14,22 @@ envoy_cc_library(
     hdrs = ["stats.h"],
     tcmalloc_dep = 1,
 )
+
+envoy_cc_library(
+    name = "utils_lib",
+    srcs = ["utils.cc"],
+    hdrs = ["utils.h"],
+    tcmalloc_dep = 1,
+)
+
+envoy_cc_library(
+    name = "heap_shrinker_lib",
+    srcs = ["heap_shrinker.cc"],
+    hdrs = ["heap_shrinker.h"],
+    deps = [
+        ":utils_lib",
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/stats:stats_interface",
+    ],
+)

--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -13,6 +13,9 @@ envoy_cc_library(
     srcs = ["stats.cc"],
     hdrs = ["stats.h"],
     tcmalloc_dep = 1,
+    deps = [
+        "//source/common/common:logger_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/source/common/memory/heap_shrinker.cc
+++ b/source/common/memory/heap_shrinker.cc
@@ -1,0 +1,38 @@
+#include "common/memory/heap_shrinker.h"
+
+#include "common/memory/utils.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace Envoy {
+namespace Memory {
+
+// TODO(eziskind): make this configurable
+constexpr std::chrono::milliseconds kTimerInterval = std::chrono::milliseconds(10000);
+
+HeapShrinker::HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManager& overload_manager,
+                           Stats::Scope& stats)
+    : active_(false) {
+  const auto action_name = Server::OverloadActionNames::get().ShrinkHeap;
+  if (overload_manager.registerForAction(action_name, dispatcher,
+                                         [this](Server::OverloadActionState state) {
+                                           active_ = (state == Server::OverloadActionState::Active);
+                                         })) {
+    shrink_gauge_ = &stats.gauge(absl::StrCat("overload.", action_name, ".shrink_count"));
+    timer_ = dispatcher.createTimer([this] {
+      shrinkHeap();
+      timer_->enableTimer(kTimerInterval);
+    });
+    timer_->enableTimer(kTimerInterval);
+  }
+}
+
+void HeapShrinker::shrinkHeap() {
+  if (active_) {
+    Utils::ReleaseFreeMemory();
+    shrink_gauge_->inc();
+  }
+}
+
+} // namespace Memory
+} // namespace Envoy

--- a/source/common/memory/heap_shrinker.cc
+++ b/source/common/memory/heap_shrinker.cc
@@ -18,7 +18,7 @@ HeapShrinker::HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManage
                                          [this](Server::OverloadActionState state) {
                                            active_ = (state == Server::OverloadActionState::Active);
                                          })) {
-    shrink_gauge_ = &stats.gauge(absl::StrCat("overload.", action_name, ".shrink_count"));
+    shrink_counter_ = &stats.counter(absl::StrCat("overload.", action_name, ".shrink_count"));
     timer_ = dispatcher.createTimer([this] {
       shrinkHeap();
       timer_->enableTimer(kTimerInterval);
@@ -30,7 +30,7 @@ HeapShrinker::HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManage
 void HeapShrinker::shrinkHeap() {
   if (active_) {
     Utils::ReleaseFreeMemory();
-    shrink_gauge_->inc();
+    shrink_counter_->inc();
   }
 }
 

--- a/source/common/memory/heap_shrinker.cc
+++ b/source/common/memory/heap_shrinker.cc
@@ -29,7 +29,7 @@ HeapShrinker::HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManage
 
 void HeapShrinker::shrinkHeap() {
   if (active_) {
-    Utils::ReleaseFreeMemory();
+    Utils::releaseFreeMemory();
     shrink_counter_->inc();
   }
 }

--- a/source/common/memory/heap_shrinker.h
+++ b/source/common/memory/heap_shrinker.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/server/overload_manager.h"
+#include "envoy/stats/stats.h"
+
+namespace Envoy {
+namespace Memory {
+
+/**
+ * A utility class to periodically attempt to shrink the heap by releasing free memory
+ * to the system if the "shrink heap" overload action has been configured and triggered.
+ */
+class HeapShrinker {
+public:
+  HeapShrinker(Event::Dispatcher& dispatcher, Server::OverloadManager& overload_manager,
+               Stats::Scope& stats);
+
+private:
+  void shrinkHeap();
+
+  bool active_;
+  Stats::Gauge* shrink_gauge_;
+  Event::TimerPtr timer_;
+};
+
+} // namespace Memory
+} // namespace Envoy

--- a/source/common/memory/heap_shrinker.h
+++ b/source/common/memory/heap_shrinker.h
@@ -20,7 +20,7 @@ private:
   void shrinkHeap();
 
   bool active_;
-  Stats::Gauge* shrink_gauge_;
+  Stats::Counter* shrink_counter_;
   Event::TimerPtr timer_;
 };
 

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "common/common/logger.h"
+
 #ifdef TCMALLOC
 
 #include "gperftools/malloc_extension.h"
@@ -40,6 +42,13 @@ uint64_t Stats::totalPageHeapUnmapped() {
   return value;
 }
 
+void Stats::dumpStatsToLog() {
+  static const int kBufferSize = 3 << 20;
+  auto buffer = std::make_unique<char[]>(kBufferSize);
+  MallocExtension::instance()->GetStats(buffer.get(), kBufferSize);
+  ENVOY_LOG_MISC(info, "TCMalloc stats:\n{}", buffer.get());
+}
+
 } // namespace Memory
 } // namespace Envoy
 
@@ -53,6 +62,7 @@ uint64_t Stats::totalThreadCacheBytes() { return 0; }
 uint64_t Stats::totalCurrentlyReserved() { return 0; }
 uint64_t Stats::totalPageHeapUnmapped() { return 0; }
 uint64_t Stats::totalPageHeapFree() { return 0; }
+void Stats::dumpStatsToLog() {}
 
 } // namespace Memory
 } // namespace Envoy

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -43,10 +43,10 @@ uint64_t Stats::totalPageHeapUnmapped() {
 }
 
 void Stats::dumpStatsToLog() {
-  static const int kBufferSize = 3 << 20;
-  auto buffer = std::make_unique<char[]>(kBufferSize);
-  MallocExtension::instance()->GetStats(buffer.get(), kBufferSize);
-  ENVOY_LOG_MISC(info, "TCMalloc stats:\n{}", buffer.get());
+  constexpr int buffer_size = 3 << 20;
+  auto buffer = std::make_unique<char[]>(buffer_size);
+  MallocExtension::instance()->GetStats(buffer.get(), buffer_size);
+  ENVOY_LOG_MISC(debug, "TCMalloc stats:\n{}", buffer.get());
 }
 
 } // namespace Memory

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -43,7 +43,7 @@ uint64_t Stats::totalPageHeapUnmapped() {
 }
 
 void Stats::dumpStatsToLog() {
-  constexpr int buffer_size = 3 << 20;
+  constexpr int buffer_size = 100000;
   auto buffer = std::make_unique<char[]>(buffer_size);
   MallocExtension::instance()->GetStats(buffer.get(), buffer_size);
   ENVOY_LOG_MISC(debug, "TCMalloc stats:\n{}", buffer.get());

--- a/source/common/memory/stats.h
+++ b/source/common/memory/stats.h
@@ -39,6 +39,11 @@ public:
    *                  swapped out by the OS, they also count towards physical memory usage.
    */
   static uint64_t totalPageHeapFree();
+
+  /**
+   * Log detailed stats about current memory allocation. Intended for debugging purposes.
+   */
+  static void dumpStatsToLog();
 };
 
 } // namespace Memory

--- a/source/common/memory/utils.cc
+++ b/source/common/memory/utils.cc
@@ -7,7 +7,7 @@
 namespace Envoy {
 namespace Memory {
 
-void Utils::ReleaseFreeMemory() {
+void Utils::releaseFreeMemory() {
 #ifdef TCMALLOC
   MallocExtension::instance()->ReleaseFreeMemory();
 #endif

--- a/source/common/memory/utils.cc
+++ b/source/common/memory/utils.cc
@@ -1,0 +1,25 @@
+#include "common/memory/utils.h"
+
+#ifdef TCMALLOC
+
+#include "gperftools/malloc_extension.h"
+
+namespace Envoy {
+namespace Memory {
+
+void Utils::ReleaseFreeMemory() { MallocExtension::instance()->ReleaseFreeMemory(); }
+
+} // namespace Memory
+} // namespace Envoy
+
+#else
+
+namespace Envoy {
+namespace Memory {
+
+void Utils::ReleaseFreeMemory() {}
+
+} // namespace Memory
+} // namespace Envoy
+
+#endif // #ifdef TCMALLOC

--- a/source/common/memory/utils.cc
+++ b/source/common/memory/utils.cc
@@ -1,25 +1,15 @@
 #include "common/memory/utils.h"
 
-#ifdef TCMALLOC
-
 #include "gperftools/malloc_extension.h"
 
 namespace Envoy {
 namespace Memory {
 
-void Utils::ReleaseFreeMemory() { MallocExtension::instance()->ReleaseFreeMemory(); }
+void Utils::ReleaseFreeMemory() {
+#ifdef TCMALLOC
+  MallocExtension::instance()->ReleaseFreeMemory();
+#endif
+}
 
 } // namespace Memory
 } // namespace Envoy
-
-#else
-
-namespace Envoy {
-namespace Memory {
-
-void Utils::ReleaseFreeMemory() {}
-
-} // namespace Memory
-} // namespace Envoy
-
-#endif // #ifdef TCMALLOC

--- a/source/common/memory/utils.cc
+++ b/source/common/memory/utils.cc
@@ -1,6 +1,8 @@
 #include "common/memory/utils.h"
 
+#ifdef TCMALLOC
 #include "gperftools/malloc_extension.h"
+#endif
 
 namespace Envoy {
 namespace Memory {

--- a/source/common/memory/utils.h
+++ b/source/common/memory/utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace Envoy {
+namespace Memory {
+
+class Utils {
+public:
+  static void ReleaseFreeMemory();
+};
+
+} // namespace Memory
+} // namespace Envoy

--- a/source/common/memory/utils.h
+++ b/source/common/memory/utils.h
@@ -5,7 +5,7 @@ namespace Memory {
 
 class Utils {
 public:
-  static void ReleaseFreeMemory();
+  static void releaseFreeMemory();
 };
 
 } // namespace Memory

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -293,6 +293,7 @@ envoy_cc_library(
         "//source/common/http:codes_lib",
         "//source/common/http:context_lib",
         "//source/common/local_info:local_info_lib",
+        "//source/common/memory:heap_shrinker_lib",
         "//source/common/memory:stats_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/router:rds_lib",

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -162,18 +162,19 @@ void OverloadManagerImpl::stop() {
   resources_.clear();
 }
 
-void OverloadManagerImpl::registerForAction(const std::string& action,
+bool OverloadManagerImpl::registerForAction(const std::string& action,
                                             Event::Dispatcher& dispatcher,
                                             OverloadActionCb callback) {
   ASSERT(!started_);
 
   if (actions_.find(action) == actions_.end()) {
     ENVOY_LOG(debug, "No overload action is configured for {}.", action);
-    return;
+    return false;
   }
 
   action_to_callbacks_.emplace(std::piecewise_construct, std::forward_as_tuple(action),
                                std::forward_as_tuple(dispatcher, callback));
+  return true;
 }
 
 ThreadLocalOverloadState& OverloadManagerImpl::getThreadLocalOverloadState() {

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -58,7 +58,7 @@ public:
 
   // Server::OverloadManager
   void start() override;
-  void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
+  bool registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                          OverloadActionCb callback) override;
   ThreadLocalOverloadState& getThreadLocalOverloadState() override;
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -287,6 +287,8 @@ void InstanceImpl::initialize(const Options& options,
   overload_manager_ = std::make_unique<OverloadManagerImpl>(dispatcher(), stats(), threadLocal(),
                                                             bootstrap_.overload_manager(), api());
 
+  heap_shrinker_ = std::make_unique<Memory::HeapShrinker>(dispatcher(), overloadManager(), stats());
+
   // Workers get created first so they register for thread local updates.
   listener_manager_ =
       std::make_unique<ListenerManagerImpl>(*this, listener_component_factory_, worker_factory_);

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -21,6 +21,7 @@
 #include "common/common/logger_delegates.h"
 #include "common/grpc/async_client_manager_impl.h"
 #include "common/http/context_impl.h"
+#include "common/memory/heap_shrinker.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/secret/secret_manager_impl.h"
 #include "common/upstream/health_discovery_service.h"
@@ -244,6 +245,7 @@ private:
   std::unique_ptr<RunHelper> run_helper_;
   Envoy::MutexTracer* mutex_tracer_;
   Http::ContextImpl http_context_;
+  std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
 };
 
 } // namespace Server

--- a/test/common/memory/BUILD
+++ b/test/common/memory/BUILD
@@ -20,6 +20,7 @@ envoy_cc_test(
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/memory:heap_shrinker_lib",
+        "//source/common/memory:stats_lib",
         "//source/common/stats:isolated_store_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:server_mocks",

--- a/test/common/memory/BUILD
+++ b/test/common/memory/BUILD
@@ -13,3 +13,17 @@ envoy_cc_test(
     srcs = ["debug_test.cc"],
     deps = ["//source/common/memory:stats_lib"],
 )
+
+envoy_cc_test(
+    name = "heap_shrinker_test",
+    srcs = ["heap_shrinker_test.cc"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//source/common/memory:heap_shrinker_lib",
+        "//source/common/stats:isolated_store_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -1,0 +1,71 @@
+#include "common/event/dispatcher_impl.h"
+#include "common/memory/heap_shrinker.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/test_base.h"
+
+#include "gmock/gmock.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+
+namespace Envoy {
+namespace Memory {
+namespace {
+
+class HeapShrinkerTest : public TestBase {
+protected:
+  HeapShrinkerTest()
+      : api_(Api::createApiForTest(stats_, time_system_)), dispatcher_(*api_, time_system_) {}
+
+  void step() {
+    time_system_.sleep(std::chrono::milliseconds(10000));
+    dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  Stats::IsolatedStoreImpl stats_;
+  Event::SimulatedTimeSystem time_system_;
+  Api::ApiPtr api_;
+  Event::DispatcherImpl dispatcher_;
+  NiceMock<Server::MockOverloadManager> overload_manager_;
+  Event::TimerCb timer_cb_;
+};
+
+TEST_F(HeapShrinkerTest, DoNotShrinkWhenNotConfigured) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(overload_manager_, registerForAction(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(dispatcher, createTimer_(_)).Times(0);
+  HeapShrinker h(dispatcher, overload_manager_, stats_);
+}
+
+TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
+  Server::OverloadActionCb actionCb;
+  EXPECT_CALL(overload_manager_, registerForAction(_, _, _))
+      .WillOnce(Invoke([&](const std::string&, Event::Dispatcher&, Server::OverloadActionCb cb) {
+        actionCb = cb;
+        return true;
+      }));
+
+  HeapShrinker h(dispatcher_, overload_manager_, stats_);
+
+  Stats::Gauge& shrink_count =
+      stats_.gauge("overload.envoy.overload_actions.shrink_heap.shrink_count");
+  actionCb(Server::OverloadActionState::Active);
+  step();
+  EXPECT_EQ(1, shrink_count.value());
+  step();
+  EXPECT_EQ(2, shrink_count.value());
+
+  actionCb(Server::OverloadActionState::Inactive);
+  step();
+  step();
+  EXPECT_EQ(2, shrink_count.value());
+}
+
+} // namespace
+} // namespace Memory
+} // namespace Envoy

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -64,12 +64,14 @@ TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
   step();
   EXPECT_EQ(1, shrink_count.value());
 
-#ifdef TCMALLOC
   const uint64_t physical_mem_after_shrink =
       Stats::totalCurrentlyReserved() - Stats::totalPageHeapUnmapped();
+#ifdef TCMALLOC
   EXPECT_GT(physical_mem_before_shrink, physical_mem_after_shrink);
-  Stats::dumpStatsToLog();
+#else
+  EXPECT_GE(physical_mem_before_shrink, physical_mem_after_shrink);
 #endif
+  Stats::dumpStatsToLog();
 
   step();
   EXPECT_EQ(2, shrink_count.value());

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -67,7 +67,7 @@ TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
   const uint64_t physical_mem_after_shrink =
       Stats::totalCurrentlyReserved() - Stats::totalPageHeapUnmapped();
 #ifdef TCMALLOC
-  EXPECT_GT(physical_mem_before_shrink, physical_mem_after_shrink);
+  EXPECT_GE(physical_mem_before_shrink, physical_mem_after_shrink);
 #else
   EXPECT_EQ(physical_mem_before_shrink, physical_mem_after_shrink);
 #endif

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -43,24 +43,24 @@ TEST_F(HeapShrinkerTest, DoNotShrinkWhenNotConfigured) {
 }
 
 TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
-  Server::OverloadActionCb actionCb;
+  Server::OverloadActionCb action_cb;
   EXPECT_CALL(overload_manager_, registerForAction(_, _, _))
       .WillOnce(Invoke([&](const std::string&, Event::Dispatcher&, Server::OverloadActionCb cb) {
-        actionCb = cb;
+        action_cb = cb;
         return true;
       }));
 
   HeapShrinker h(dispatcher_, overload_manager_, stats_);
 
-  Stats::Gauge& shrink_count =
-      stats_.gauge("overload.envoy.overload_actions.shrink_heap.shrink_count");
-  actionCb(Server::OverloadActionState::Active);
+  Stats::Counter& shrink_count =
+      stats_.counter("overload.envoy.overload_actions.shrink_heap.shrink_count");
+  action_cb(Server::OverloadActionState::Active);
   step();
   EXPECT_EQ(1, shrink_count.value());
   step();
   EXPECT_EQ(2, shrink_count.value());
 
-  actionCb(Server::OverloadActionState::Inactive);
+  action_cb(Server::OverloadActionState::Inactive);
   step();
   step();
   EXPECT_EQ(2, shrink_count.value());

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -69,7 +69,7 @@ TEST_F(HeapShrinkerTest, ShrinkWhenTriggered) {
 #ifdef TCMALLOC
   EXPECT_GT(physical_mem_before_shrink, physical_mem_after_shrink);
 #else
-  EXPECT_GE(physical_mem_before_shrink, physical_mem_after_shrink);
+  EXPECT_EQ(physical_mem_before_shrink, physical_mem_after_shrink);
 #endif
   Stats::dumpStatsToLog();
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -309,7 +309,7 @@ public:
 
   // OverloadManager
   MOCK_METHOD0(start, void());
-  MOCK_METHOD3(registerForAction, void(const std::string& action, Event::Dispatcher& dispatcher,
+  MOCK_METHOD3(registerForAction, bool(const std::string& action, Event::Dispatcher& dispatcher,
                                        OverloadActionCb callback));
   MOCK_METHOD0(getThreadLocalOverloadState, ThreadLocalOverloadState&());
 


### PR DESCRIPTION
*Description*: add an overload action to try to shrink the heap by returning free memory to the system. This is intended to be used with the FixedHeap resource monitor which reports on heap memory pressure. In the case of posix systems this uses TCMalloc which does not eagerly return free memory to the system so an overloaded envoy may appear to remain overloaded  even when most of the memory usage is on the free list.
*Risk Level*: low - disabled by default
*Testing*: unit tests
*Docs Changes*: added reference to the new overload action

Signed-off-by: Elisha Ziskind <eziskind@google.com>
