### PR TITLE
owners: ggreenway to emeritus

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -17,8 +17,6 @@ routing PRs, questions, etc. to the right place.
 * Stephan Zuercher ([zuercher](https://github.com/zuercher)) (zuercher@gmail.com)
   * Load balancing, upstream clusters and cluster manager, logging, complex HTTP routing
     (metadata, etc.), and macOS build.
-* Greg Greenway ([ggreenway](https://github.com/ggreenway)) (ggreenway@apple.com)
-  * TCP proxy, TLS, logging, and core networking (listeners, connections, etc.).
 
 # Maintainers
 
@@ -40,6 +38,7 @@ routing PRs, questions, etc. to the right place.
 * Constance Caramanolis ([ccaraman](https://github.com/ccaraman)) (ccaramanolis@lyft.com)
 * Roman Dzhabarov ([RomanDzhabarov](https://github.com/RomanDzhabarov)) (rdzhabarov@lyft.com)
 * Bill Gallagher ([wgallagher](https://github.com/wgallagher)) (bgallagher@lyft.com)
+* Greg Greenway ([ggreenway](https://github.com/ggreenway)) (greg.greenway@gmail.com, formerly ggreenway@apple.com)
 
 # Friends of Envoy
 


### PR DESCRIPTION
Sadly, I am moving on to different things. The Envoy maintainers and community
have been great to work with. I wish you the best going forward.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Up for debate
*Testing*: None
*Docs Changes*: Done
*Deprecated*: myself
