### PR TITLE
upstream: add batch host update functionality to PrioritySetImpl

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -380,6 +380,19 @@ public:
                            LocalityWeightsConstSharedPtr locality_weights,
                            const HostVector& hosts_added, const HostVector& hosts_removed,
                            absl::optional<uint32_t> overprovisioning_factor) PURE;
+
+  typedef std::function<void(uint32_t, UpdateHostsParams&&, LocalityWeightsConstSharedPtr,
+                             const HostVector&, const HostVector&, absl::optional<uint32_t>)>
+      UpdateHostsCb;
+
+  /**
+   * Allows updating hosts for multiple priorities at once, deferring the MemberUpdateCb from
+   * triggering until all priorities have been updated. The resulting callback will take into
+   * account hosts moved from one priority to another.
+   *
+   * @param callback callback to use to add hosts.
+   */
+  virtual void batchHostUpdate(std::function<void(UpdateHostsCb)> callback) PURE;
 };
 
 /**

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -196,7 +196,7 @@ bool updateHealthFlag(const Host& updated_host, Host& existing_host, Host::Healt
 
 // Converts a set of hosts into a HostVector, excluding certain hosts.
 // @param hosts hosts to convert
-// @param excluded_hosts hosts to exlcude from the resulting vector.
+// @param excluded_hosts hosts to exclude from the resulting vector.
 HostVector filterHosts(const std::unordered_set<HostSharedPtr>& hosts,
                        const std::unordered_set<HostSharedPtr>& excluded_hosts) {
   HostVector net_hosts;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -462,8 +462,6 @@ void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_
                                   absl::optional<uint32_t> overprovisioning_factor) {
   // Ensure that we have a HostSet for the given priority.
   getOrCreateHostSet(priority, overprovisioning_factor);
-  // TODO(snowp): Add a batched update mode that allows updating multiple HostSet and invoke the
-  // membership update cb for the resulting host diff.
   static_cast<HostSetImpl*>(host_sets_[priority].get())
       ->updateHosts(std::move(update_hosts_params), std::move(locality_weights), hosts_added,
                     hosts_removed, overprovisioning_factor);
@@ -504,8 +502,6 @@ void PrioritySetImpl::batchHostUpdate(std::function<void(UpdateHostsCb)> callbac
   batch_update_ = false;
 
   // Now that all the updates have been complete, we can compute the diff.
-
-  // TODO(snowp): Would computing the union of added/removed first be more efficient?
   HostVector net_hosts_added = filterHosts(all_hosts_added, all_hosts_removed);
   HostVector net_hosts_removed = filterHosts(all_hosts_removed, all_hosts_added);
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -472,8 +472,7 @@ void PrioritySetImpl::updateHosts(uint32_t priority, UpdateHostsParams&& update_
 }
 
 void PrioritySetImpl::batchHostUpdate(std::function<void(UpdateHostsCb)> callback) {
-  ASSERT(!batch_update_);
-  batch_update_ = true;
+  BatchUpdateScope scope(*this);
 
   std::unordered_set<uint32_t> priorities;
   std::unordered_set<HostSharedPtr> all_hosts_added;
@@ -497,9 +496,6 @@ void PrioritySetImpl::batchHostUpdate(std::function<void(UpdateHostsCb)> callbac
     updateHosts(p, std::move(params), locality_weight, hosts_added, hosts_removed,
                 overprovisioning_factor);
   });
-
-  // TODO(snowp): Use RAII to make this exception safe?
-  batch_update_ = false;
 
   // Now that all the updates have been complete, we can compute the diff.
   HostVector net_hosts_added = filterHosts(all_hosts_added, all_hosts_removed);

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -458,22 +458,7 @@ private:
                              PrioritySet::UpdateHostsParams&& update_hosts_params,
                              LocalityWeightsConstSharedPtr locality_weights,
                              const HostVector& hosts_added, const HostVector& hosts_removed,
-                             absl::optional<uint32_t> overprovisioning_factor) override {
-      // We assume that each call updates a different priority.
-      ASSERT(priorities_.find(priority) == priorities_.end());
-      priorities_.insert(priority);
-
-      for (const auto& host : hosts_added) {
-        all_hosts_added_.insert(host);
-      }
-
-      for (const auto& host : hosts_removed) {
-        all_hosts_removed_.insert(host);
-      }
-
-      parent_.updateHosts(priority, std::move(update_hosts_params), locality_weights, hosts_added,
-                          hosts_removed, overprovisioning_factor);
-    }
+                             absl::optional<uint32_t> overprovisioning_factor) override;
 
     std::unordered_set<HostSharedPtr> all_hosts_added_;
     std::unordered_set<HostSharedPtr> all_hosts_removed_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -442,6 +442,19 @@ private:
   mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;
   bool batch_update_ : 1;
+
+  // Helper class that ensures that we're always reseting the batch_update_ flag.
+  class BatchUpdateScope {
+  public:
+    explicit BatchUpdateScope(PrioritySetImpl& parent) : parent_(parent) {
+      ASSERT(!parent_.batch_update_);
+      parent_.batch_update_ = true;
+    }
+    ~BatchUpdateScope() { parent_.batch_update_ = false; }
+
+  private:
+    PrioritySetImpl& parent_;
+  };
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -393,6 +393,7 @@ typedef std::unique_ptr<HostSetImpl> HostSetImplPtr;
 
 class PrioritySetImpl : public PrioritySet {
 public:
+  PrioritySetImpl() : batch_update_(false) {}
   // From PrioritySet
   Common::CallbackHandle* addMemberUpdateCb(MemberUpdateCb callback) const override {
     return member_update_cb_helper_.add(callback);
@@ -412,6 +413,8 @@ public:
                    LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
                    const HostVector& hosts_removed,
                    absl::optional<uint32_t> overprovisioning_factor = absl::nullopt) override;
+
+  void batchHostUpdate(std::function<void(UpdateHostsCb)> callback) override;
 
 protected:
   // Allows subclasses of PrioritySetImpl to create their own type of HostSetImpl.
@@ -438,6 +441,7 @@ private:
   mutable Common::CallbackManager<const HostVector&, const HostVector&> member_update_cb_helper_;
   mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;
+  bool batch_update_ : 1;
 };
 
 /**

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1572,12 +1572,14 @@ TEST(PrioritySet, Extend) {
   std::shared_ptr<MockClusterInfo> info{new NiceMock<MockClusterInfo>()};
   HostVectorSharedPtr hosts(new HostVector({makeTestHost(info, "tcp://127.0.0.1:80")}));
   HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
-  HostVector hosts_added{hosts->front()};
-  HostVector hosts_removed{};
+  {
+    HostVector hosts_added{hosts->front()};
+    HostVector hosts_removed{};
 
-  priority_set.updateHosts(
-      1, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
-      hosts_added, hosts_removed, absl::nullopt);
+    priority_set.updateHosts(
+        1, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+        hosts_added, hosts_removed, absl::nullopt);
+  }
   EXPECT_EQ(1, priority_changes);
   EXPECT_EQ(1, membership_changes);
   EXPECT_EQ(last_priority, 1);
@@ -1588,6 +1590,41 @@ TEST(PrioritySet, Extend) {
   for (auto& host_set : priority_set.hostSetsPerPriority()) {
     EXPECT_EQ(host_set.get(), priority_set.hostSetsPerPriority()[i++].get());
   }
+
+  // Test batch host updates. Verify that we can move a host without triggering intermediate host
+  // updates.
+
+  // We're going to do a noop host change, so add a callback to assert that we're not announcing any
+  // host changes.
+  priority_set.addMemberUpdateCb([&](const HostVector& added, const HostVector& removed) -> void {
+    EXPECT_TRUE(added.empty() && removed.empty());
+  });
+
+  priority_set.batchHostUpdate([&](auto update_hosts) {
+    // Add the host from P1 to P0.
+    {
+      HostVector hosts_added{hosts->front()};
+      HostVector hosts_removed{};
+      update_hosts(
+          0, HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality),
+          {}, hosts_added, hosts_removed, absl::nullopt);
+    }
+
+    // Remove the host from P1.
+    {
+      HostVectorSharedPtr empty_hosts = std::make_shared<HostVector>();
+      HostVector hosts_added{};
+      HostVector hosts_removed{hosts->front()};
+      update_hosts(1,
+                   HostSetImpl::updateHostsParams(empty_hosts, HostsPerLocalityImpl::empty(),
+                                                  empty_hosts, HostsPerLocalityImpl::empty()),
+                   {}, hosts_added, hosts_removed, absl::nullopt);
+    }
+  });
+
+  // We expect to see two priority changes, but only one membership change.
+  EXPECT_EQ(3, priority_changes);
+  EXPECT_EQ(2, membership_changes);
 }
 
 class ClusterInfoImplTest : public TestBase {

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -93,7 +93,7 @@ public:
                                  LocalityWeightsConstSharedPtr locality_weights,
                                  const HostVector& hosts_added, const HostVector& hosts_removed,
                                  absl::optional<uint32_t> overprovisioning_factor));
-  MOCK_METHOD1(batchHostUpdate, void(std::function<void(UpdateHostsCb)>));
+  MOCK_METHOD1(batchHostUpdate, void(BatchUpdateCb&));
   MOCK_CONST_METHOD6(updateHosts,
                      void(uint32_t priority, UpdateHostsParams&& update_hosts_params,
                           LocalityWeightsConstSharedPtr locality_weights,

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -93,6 +93,7 @@ public:
                                  LocalityWeightsConstSharedPtr locality_weights,
                                  const HostVector& hosts_added, const HostVector& hosts_removed,
                                  absl::optional<uint32_t> overprovisioning_factor));
+  MOCK_METHOD1(batchHostUpdate, void(std::function<void(UpdateHostsCb)>));
   MOCK_CONST_METHOD6(updateHosts,
                      void(uint32_t priority, UpdateHostsParams&& update_hosts_params,
                           LocalityWeightsConstSharedPtr locality_weights,

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -447,6 +447,7 @@ ie
 ifdef
 iff
 impl
+implementors
 impls
 incrementing
 ing


### PR DESCRIPTION
This adds a function to `PrioritySet` that allows issuing multiple
updateHost calls without triggering intermediate `MemberUpdateCb`s. This
will be used by EDS to allow hosts to be moved between priorities, as well as
to provide batching when named endpoints are introduced.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, not used yet
*Testing*: Added UTs
*Docs Changes*: n/a
*Release Notes*: n/a

Part of #4280 