### PR TITLE
upstream: control TLS conn pool drains from the main thread

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -297,6 +297,17 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
   }
 
   // Now setup for cross-thread updates.
+  cluster.prioritySet().addMemberUpdateCb(
+      [&cluster, this](const HostVector&, const HostVector& hosts_removed) -> void {
+        // TODO(snowp): Should this be subject to merge windows?
+
+        // Whenever hosts are removed from the cluster, we make each TLS cluster drain it's
+        // connection pools for the removed hosts.
+        if (!hosts_removed.empty()) {
+          postThreadLocalHostRemoval(cluster, hosts_removed);
+        }
+      });
+
   cluster.prioritySet().addPriorityUpdateCb([&cluster, this](uint32_t priority,
                                                              const HostVector& hosts_added,
                                                              const HostVector& hosts_removed) {
@@ -647,6 +658,13 @@ Tcp::ConnectionPool::Instance* ClusterManagerImpl::tcpConnPoolForCluster(
   return entry->second->tcpConnPool(priority, context, transport_socket_options);
 }
 
+void ClusterManagerImpl::postThreadLocalHostRemoval(const Cluster& cluster,
+                                                    const HostVector& hosts_removed) {
+  tls_->runOnAllThreads([this, name = cluster.info()->name(), hosts_removed]() {
+    ThreadLocalClusterManagerImpl::removeHosts(name, hosts_removed, *tls_);
+  });
+}
+
 void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
                                                       const HostVector& hosts_added,
                                                       const HostVector& hosts_removed) {
@@ -925,6 +943,21 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::removeTcpConn(
   }
 }
 
+void ClusterManagerImpl::ThreadLocalClusterManagerImpl::removeHosts(const std::string& name,
+                                                                    const HostVector& hosts_removed,
+                                                                    ThreadLocal::Slot& tls) {
+  ThreadLocalClusterManagerImpl& config = tls.getTyped<ThreadLocalClusterManagerImpl>();
+
+  ASSERT(config.thread_local_clusters_.find(name) != config.thread_local_clusters_.end());
+  const auto& cluster_entry = config.thread_local_clusters_[name];
+  ENVOY_LOG(debug, "removing hosts for TLS cluster {} removed {}", name, hosts_removed.size());
+
+  // We need to go through and purge any connection pools for hosts that got deleted.
+  // Even if two hosts actually point to the same address this will be safe, since if a
+  // host is readded it will be a different physical HostSharedPtr.
+  cluster_entry->parent_.drainConnPools(hosts_removed);
+}
+
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
     const std::string& name, uint32_t priority,
     PrioritySet::UpdateHostsParams&& update_hosts_params,
@@ -1067,14 +1100,6 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
     }
     }
   }
-
-  priority_set_.addMemberUpdateCb(
-      [this](const HostVector&, const HostVector& hosts_removed) -> void {
-        // We need to go through and purge any connection pools for hosts that got deleted.
-        // Even if two hosts actually point to the same address this will be safe, since if a
-        // host is readded it will be a different physical HostSharedPtr.
-        parent_.drainConnPools(hosts_removed);
-      });
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry() {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -220,6 +220,7 @@ public:
   ClusterManagerFactory& clusterManagerFactory() override { return factory_; }
 
 protected:
+  virtual void postThreadLocalHostRemoval(const Cluster& cluster, const HostVector& hosts_removed);
   virtual void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
                                             const HostVector& hosts_added,
                                             const HostVector& hosts_removed);
@@ -316,6 +317,8 @@ private:
     void clearContainer(HostSharedPtr old_host, ConnPoolsContainer& container);
     void drainTcpConnPools(HostSharedPtr old_host, TcpConnPoolsContainer& container);
     void removeTcpConn(const HostConstSharedPtr& host, Network::ClientConnection& connection);
+    static void removeHosts(const std::string& name, const HostVector& hosts_removed,
+                            ThreadLocal::Slot& tls);
     static void updateClusterMembership(const std::string& name, uint32_t priority,
                                         PrioritySet::UpdateHostsParams&& update_hosts_params,
                                         LocalityWeightsConstSharedPtr locality_weights,

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -132,6 +132,11 @@ public:
                           const HostVector& hosts_removed));
 };
 
+class MockLocalHostsRemoved {
+public:
+  MOCK_METHOD1(post, void(const HostVector&));
+};
+
 // A test version of ClusterManagerImpl that provides a way to get a non-const handle to the
 // clusters, which is necessary in order to call updateHosts on the priority set.
 class TestClusterManagerImpl : public ClusterManagerImpl {
@@ -158,10 +163,11 @@ public:
                                   const LocalInfo::LocalInfo& local_info,
                                   AccessLog::AccessLogManager& log_manager,
                                   Event::Dispatcher& main_thread_dispatcher, Server::Admin& admin,
-                                  Api::Api& api, MockLocalClusterUpdate& local_cluster_update)
+                                  Api::Api& api, MockLocalClusterUpdate& local_cluster_update,
+                                  MockLocalHostsRemoved& local_hosts_removed)
       : TestClusterManagerImpl(bootstrap, factory, stats, tls, runtime, random, local_info,
                                log_manager, main_thread_dispatcher, admin, api, http_context_),
-        local_cluster_update_(local_cluster_update) {}
+        local_cluster_update_(local_cluster_update), local_hosts_removed_(local_hosts_removed) {}
 
 protected:
   void postThreadLocalClusterUpdate(const Cluster&, uint32_t priority,
@@ -169,8 +175,14 @@ protected:
                                     const HostVector& hosts_removed) override {
     local_cluster_update_.post(priority, hosts_added, hosts_removed);
   }
+
+  void postThreadLocalHostRemoval(const Cluster&, const HostVector& hosts_removed) override {
+    local_hosts_removed_.post(hosts_removed);
+  }
+
   Http::ContextImpl http_context_;
   MockLocalClusterUpdate& local_cluster_update_;
+  MockLocalHostsRemoved& local_hosts_removed_;
 };
 
 envoy::config::bootstrap::v2::Bootstrap parseBootstrapFromV2Yaml(const std::string& yaml) {
@@ -221,7 +233,7 @@ public:
     cluster_manager_ = std::make_unique<MockedUpdatedClusterManagerImpl>(
         bootstrap, factory_, factory_.stats_, factory_.tls_, factory_.runtime_, factory_.random_,
         factory_.local_info_, log_manager_, factory_.dispatcher_, admin_, *api_,
-        local_cluster_update_);
+        local_cluster_update_, local_hosts_removed_);
   }
 
   void checkStats(uint64_t added, uint64_t modified, uint64_t removed, uint64_t active,
@@ -262,6 +274,7 @@ public:
   AccessLog::MockAccessLogManager log_manager_;
   NiceMock<Server::MockAdmin> admin_;
   MockLocalClusterUpdate local_cluster_update_;
+  MockLocalHostsRemoved local_hosts_removed_;
   Http::ContextImpl http_context_;
 };
 
@@ -2096,6 +2109,16 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
         EXPECT_EQ(1, hosts_removed.size());
       }));
 
+  EXPECT_CALL(local_hosts_removed_, post(_))
+      .WillOnce(Invoke([](const auto& hosts_removed) {
+        // 1st removal.
+        EXPECT_EQ(1, hosts_removed.size());
+      }))
+      .WillOnce(Invoke([](const auto& hosts_removed) {
+        // 2nd removal.
+        EXPECT_EQ(1, hosts_removed.size());
+      }));
+
   Event::MockTimer* timer = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
   HostVectorSharedPtr hosts(
@@ -2289,6 +2312,11 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
         EXPECT_EQ(0, hosts_added.size());
         EXPECT_EQ(1, hosts_removed.size());
       }));
+
+  EXPECT_CALL(local_hosts_removed_, post(_)).WillOnce(Invoke([](const auto& hosts_removed) {
+    // 1st removal.
+    EXPECT_EQ(1, hosts_removed.size());
+  }));
 
   Event::MockTimer* timer = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2110,14 +2110,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
       }));
 
   EXPECT_CALL(local_hosts_removed_, post(_))
-      .WillOnce(Invoke([](const auto& hosts_removed) {
-        // 1st removal.
-        EXPECT_EQ(1, hosts_removed.size());
-      }))
-      .WillOnce(Invoke([](const auto& hosts_removed) {
-        // 2nd removal.
-        EXPECT_EQ(1, hosts_removed.size());
-      }));
+      .Times(2)
+      .WillRepeatedly(
+          Invoke([](const auto& hosts_removed) { EXPECT_EQ(1, hosts_removed.size()); }));
 
   Event::MockTimer* timer = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
   Cluster& cluster = cluster_manager_->activeClusters().begin()->second;


### PR DESCRIPTION
This reworks how TLS clusters are notified of host removals to trigger
connection pool drains.

The previous behavior relied on changes to a
`HostSet` on the main thread triggering a `postThreadLocalClusterUpdate` to
update TLS `HostSet`s. Each of these updates would trigger a `MembershipUpdateCb`
on the TLS `PrioritySet` which would cause the TLS cluster to drain
connections for removed hosts.

The new approach uses a `MembershipUpdateCb` on the main PrioritySet to
trigger a per thread update to each TLS cluster to drain the
connections. This has the benefit of allowing the main thread to fully
control when connection pools are drained, making it possible to use
batch updates (#5948) to avoid draining connections when hosts are moved
between priorities.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: High, changes how connection pools are cleaned up 
*Testing*: Existing integration tests + additional verifications to existing CM tests.
*Docs Changes*: n/a
*Release Notes*: n/a
Part of #4280 
