### PR TITLE
Adding '/usr/bin/env bash' as a shebang line

### DIFF
--- a/configs/original-dst-cluster/netns_cleanup.sh
+++ b/configs/original-dst-cluster/netns_cleanup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Cleanup network namespace after testing Envoy original_dst cluster
 #


### PR DESCRIPTION
This commit aims to add '/usr/bin/env bash' as a shebang line
to indicates scripts use bash shell for interpreting

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Adding shebang line for bash script
*Risk Level*: LOW
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
