### PR TITLE
config: removing deprecated bugfix_reverse_write_filter_order

### DIFF
--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -177,11 +177,5 @@ message Listener {
   // To set the queue length on macOS, set the net.inet.tcp.fastopen_backlog kernel parameter.
   google.protobuf.UInt32Value tcp_fast_open_queue_length = 12;
 
-  // If true, the order of write filters will be reversed to that of filters
-  // configured in the filter chain. Otherwise, it will keep the existing
-  // order. Note: this is a bug fix for Envoy, which is designed to have the
-  // reversed order of write filters to that of read ones, (see
-  // https://github.com/envoyproxy/envoy/issues/4599 for details). When we
-  // remove this field, Envoy will have the same behavior when it sets true.
-  google.protobuf.BoolValue bugfix_reverse_write_filter_order = 14 [deprecated = true];
+  reserved 14;
 }

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -261,22 +261,6 @@ public:
    * @return std::chrono::milliseconds The delayed close timeout value.
    */
   virtual std::chrono::milliseconds delayedCloseTimeout() const PURE;
-
-  /**
-   * Set the order of the write filters, indicating whether it is reversed to the filter chain
-   * config.
-   */
-  // TODO(qiannawang): this method is deprecated and to be moved soon. See
-  // https://github.com/envoyproxy/envoy/pull/4889 for more details.
-  virtual void setWriteFilterOrder(bool reversed) PURE;
-
-  /**
-   * @return bool indicates whether write filters should be in the reversed order of the filter
-   *         chain config.
-   */
-  // TODO(qiannawang): this method is deprecated and to be moved soon. See
-  // https://github.com/envoyproxy/envoy/pull/4889 for more details.
-  virtual bool reverseWriteFilterOrder() const PURE;
 };
 
 typedef std::unique_ptr<Connection> ConnectionPtr;

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -80,14 +80,6 @@ public:
    * @return const std::string& the listener's name.
    */
   virtual const std::string& name() const PURE;
-
-  /**
-   * @return bool indicates whether write filters should be in the reversed order of the filter
-   *         chain config.
-   */
-  // TODO(qiannawang): this method is deprecated and to be moved soon. See
-  // https://github.com/envoyproxy/envoy/pull/4889 for more details.
-  virtual bool reverseWriteFilterOrder() const PURE;
 };
 
 /**

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -94,8 +94,6 @@ public:
   absl::string_view requestedServerName() const override { return socket_->requestedServerName(); }
   StreamInfo::StreamInfo& streamInfo() override { return stream_info_; }
   const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
-  void setWriteFilterOrder(bool reversed) override { reverse_write_filter_order_ = reversed; }
-  bool reverseWriteFilterOrder() const override { return reverse_write_filter_order_; }
 
   // Network::BufferSource
   BufferSource::StreamBuffer getReadBuffer() override { return {read_buffer_, read_end_stream_}; }
@@ -193,7 +191,6 @@ private:
   // readDisabled(true) this allows the connection to only resume reads when readDisabled(false)
   // has been called N times.
   uint32_t read_disable_count_{0};
-  bool reverse_write_filter_order_{false};
 };
 
 /**

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -11,11 +11,7 @@ namespace Network {
 
 void FilterManagerImpl::addWriteFilter(WriteFilterSharedPtr filter) {
   ASSERT(connection_.state() == Connection::State::Open);
-  if (connection_.reverseWriteFilterOrder()) {
-    downstream_filters_.emplace_front(filter);
-  } else {
-    downstream_filters_.emplace_back(filter);
-  }
+  downstream_filters_.emplace_front(filter);
 }
 
 void FilterManagerImpl::addFilter(FilterSharedPtr filter) {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -238,7 +238,6 @@ void ConnectionHandlerImpl::ActiveListener::newConnection(Network::ConnectionSoc
   Network::ConnectionPtr new_connection =
       parent_.dispatcher_.createServerConnection(std::move(socket), std::move(transport_socket));
   new_connection->setBufferLimits(config_.perConnectionBufferLimitBytes());
-  new_connection->setWriteFilterOrder(config_.reverseWriteFilterOrder());
 
   const bool empty_filter_chain = !config_.filterChainFactory().createNetworkFilterChain(
       *new_connection, filter_chain->networkFilterFactories());

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -268,7 +268,6 @@ private:
     Stats::Scope& listenerScope() override { return *scope_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }
-    bool reverseWriteFilterOrder() const override { return false; }
 
     AdminImpl& parent_;
     const std::string name_;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -165,10 +165,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_original_dst, false)),
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
-      listener_tag_(parent_.factory_.nextListenerTag()), name_(name),
-      reverse_write_filter_order_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, bugfix_reverse_write_filter_order, true)),
-      modifiable_(modifiable), workers_started_(workers_started), hash_(hash),
+      listener_tag_(parent_.factory_.nextListenerTag()), name_(name), modifiable_(modifiable),
+      workers_started_(workers_started), hash_(hash),
       local_drain_manager_(parent.factory_.createDrainManager(config.drain_type())),
       config_(config), version_info_(version_info),
       listener_filters_timeout_(

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -257,7 +257,6 @@ public:
   Stats::Scope& listenerScope() override { return *listener_scope_; }
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
-  bool reverseWriteFilterOrder() const override { return reverse_write_filter_order_; }
 
   // Server::Configuration::ListenerFactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {
@@ -398,7 +397,6 @@ private:
   const uint32_t per_connection_buffer_limit_bytes_;
   const uint64_t listener_tag_;
   const std::string name_;
-  const bool reverse_write_filter_order_;
   const bool modifiable_;
   const bool workers_started_;
   const uint64_t hash_;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -428,8 +428,8 @@ TEST_P(ConnectionImplTest, ConnectionStats) {
 
   std::shared_ptr<MockWriteFilter> write_filter(new MockWriteFilter());
   std::shared_ptr<MockFilter> filter(new MockFilter());
-  client_connection_->addWriteFilter(write_filter);
   client_connection_->addFilter(filter);
+  client_connection_->addWriteFilter(write_filter);
 
   Sequence s1;
   EXPECT_CALL(*write_filter, onWrite(_, _))
@@ -1523,8 +1523,8 @@ TEST_F(MockTransportConnectionImplTest, WriteEndStreamStopIteration) {
   std::shared_ptr<MockWriteFilter> write_filter1(new StrictMock<MockWriteFilter>());
   std::shared_ptr<MockWriteFilter> write_filter2(new StrictMock<MockWriteFilter>());
   connection_->enableHalfClose(true);
-  connection_->addWriteFilter(write_filter1);
   connection_->addWriteFilter(write_filter2);
+  connection_->addWriteFilter(write_filter1);
 
   EXPECT_CALL(*write_filter1, onWrite(BufferStringEqual(val), true))
       .WillOnce(Return(FilterStatus::StopIteration));

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -101,57 +101,6 @@ TEST_F(NetworkFilterManagerTest, All) {
   manager.onWrite();
 }
 
-// AllWithInorderedWriteFilters verifies the same case of All, except that the write filters are
-// placed in the same order to the configuration.
-TEST_F(NetworkFilterManagerTest, AllWithInorderedWriteFilters) {
-  InSequence s;
-
-  Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
-  MockReadFilter* read_filter(new MockReadFilter());
-  MockWriteFilter* write_filter(new MockWriteFilter());
-  MockFilter* filter(new LocalMockFilter());
-
-  NiceMock<MockConnection> connection;
-  connection.setWriteFilterOrder(false);
-  FilterManagerImpl manager(connection, *this);
-  manager.addReadFilter(ReadFilterSharedPtr{read_filter});
-  manager.addWriteFilter(WriteFilterSharedPtr{write_filter});
-  manager.addFilter(FilterSharedPtr{filter});
-
-  read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
-  EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
-
-  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::StopIteration));
-  EXPECT_EQ(manager.initializeReadFilters(), true);
-
-  EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
-  read_filter->callbacks_->continueReading();
-
-  read_buffer_.add("hello");
-  read_end_stream_ = false;
-  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), false))
-      .WillOnce(Return(FilterStatus::StopIteration));
-  manager.onRead();
-
-  read_buffer_.add("world");
-  EXPECT_CALL(*filter, onData(BufferStringEqual("helloworld"), false))
-      .WillOnce(Return(FilterStatus::Continue));
-  read_filter->callbacks_->continueReading();
-
-  write_buffer_.add("foo");
-  write_end_stream_ = false;
-  EXPECT_CALL(*write_filter, onWrite(BufferStringEqual("foo"), false))
-      .WillOnce(Return(FilterStatus::StopIteration));
-  manager.onWrite();
-
-  write_buffer_.add("bar");
-  EXPECT_CALL(*write_filter, onWrite(BufferStringEqual("foobar"), false))
-      .WillOnce(Return(FilterStatus::Continue));
-  EXPECT_CALL(*filter, onWrite(BufferStringEqual("foobar"), false))
-      .WillOnce(Return(FilterStatus::Continue));
-  manager.onWrite();
-}
-
 // Test that end_stream is delivered in the correct order with the data, even
 // if FilterStatus::StopIteration occurs.
 TEST_F(NetworkFilterManagerTest, EndStream) {

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -75,7 +75,6 @@ public:
   Stats::Scope& listenerScope() override { return stats_store_; }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }
-  bool reverseWriteFilterOrder() const override { return true; }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&) const override {
@@ -904,7 +903,6 @@ public:
   Stats::Scope& listenerScope() override { return stats_store_; }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }
-  bool reverseWriteFilterOrder() const override { return true; }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&) const override {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -584,7 +584,6 @@ private:
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }
-    bool reverseWriteFilterOrder() const override { return true; }
 
     FakeUpstream& parent_;
     std::string name_;

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -80,12 +80,6 @@ public:
   MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
   MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
   MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
-
-  void setWriteFilterOrder(bool reversed) override { reversed_write_filter_order_ = reversed; }
-  bool reverseWriteFilterOrder() const override { return reversed_write_filter_order_; }
-
-private:
-  bool reversed_write_filter_order_{true};
 };
 
 /**
@@ -129,8 +123,6 @@ public:
   MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
   MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
   MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
-  MOCK_METHOD1(setWriteFilterOrder, void(bool reversed));
-  bool reverseWriteFilterOrder() const override { return true; }
 
   // Network::ClientConnection
   MOCK_METHOD0(connect, void());

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -288,7 +288,6 @@ public:
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_CONST_METHOD0(listenerTag, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(reverseWriteFilterOrder, bool());
 
   testing::NiceMock<MockFilterChainFactory> filter_chain_factory_;
   testing::NiceMock<MockListenSocket> socket_;

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -56,7 +56,6 @@ public:
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return tag_; }
     const std::string& name() const override { return name_; }
-    bool reverseWriteFilterOrder() const override { return true; }
 
     ConnectionHandlerTest& parent_;
     Network::MockListenSocket socket_;

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -491,20 +491,6 @@ TEST_F(ListenerManagerImplTest, NotDefaultListenerFiltersTimeout) {
             manager_->listeners().front().get().listenerFiltersTimeout());
 }
 
-TEST_F(ListenerManagerImplTest, ReversedWriteFilterOrder) {
-  const std::string json = R"EOF(
-    name: "foo"
-    address:
-      socket_address: { address: 127.0.0.1, port_value: 10000 }
-    filter_chains:
-    - filters:
-  )EOF";
-
-  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, true));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(json), "", true));
-  EXPECT_TRUE(manager_->listeners().front().get().reverseWriteFilterOrder());
-}
-
 TEST_F(ListenerManagerImplTest, ModifyOnlyDrainType) {
   InSequence s;
 


### PR DESCRIPTION
*Risk Level*: Medium (code path being always true was not entirely obvious)
*Testing*: manually asserted it was true, removed deprecated tests
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #5380