### PR TITLE
Use memcpy instead of __builtin_memcpy on Windows

### DIFF
--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -57,10 +57,18 @@ public:
    */
   static uint64_t murmurHash2_64(absl::string_view key, uint64_t seed = STD_HASH_SEED);
 
+#ifdef _MSC_VER
+#pragma intrinsic(memcpy)
+#endif
+
 private:
   static inline uint64_t unaligned_load(const char* p) {
     uint64_t result;
+#ifdef _MSC_VER
+    memcpy(&result, p, sizeof(result));
+#else
     __builtin_memcpy(&result, p, sizeof(result));
+#endif
     return result;
   }
 

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -57,18 +57,10 @@ public:
    */
   static uint64_t murmurHash2_64(absl::string_view key, uint64_t seed = STD_HASH_SEED);
 
-#ifdef _MSC_VER
-#pragma intrinsic(memcpy)
-#endif
-
 private:
   static inline uint64_t unaligned_load(const char* p) {
     uint64_t result;
-#ifdef _MSC_VER
     memcpy(&result, p, sizeof(result));
-#else
-    __builtin_memcpy(&result, p, sizeof(result));
-#endif
     return result;
   }
 


### PR DESCRIPTION
*Description*:
__builtin_memcpy is not standard C++ code so we use memcpy instead on Windows.

*Risk Level*:
Low

*Testing*:
`bazel build //source/... && bazel test //test/...`

*Docs Changes*:
N/A

*Release Notes*:
N/A