### PR TITLE
Adding '/usr/bin/env bash'

### DIFF
--- a/configs/original-dst-cluster/netns_setup.sh
+++ b/configs/original-dst-cluster/netns_setup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Example setup network namespace for testing Envoy original_dst cluster
 # Clean up with the cleanup script with the same arguments.


### PR DESCRIPTION
This commit aims to add `/usr/bin/env bash` as a shebang line
to indicates the script uses bash shell for interpreting.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
