### PR TITLE
docs: nest config under "config:" key in envoy.ext_authz filter example

### DIFF
--- a/docs/root/configuration/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/network_filters/ext_authz_filter.rst
@@ -32,10 +32,11 @@ A sample filter configuration could be:
 
   filters:
     - name: envoy.ext_authz
-      stat_prefix: ext_authz
-      grpc_service:
-        envoy_grpc:
-          cluster_name: ext-authz
+      config:
+        stat_prefix: ext_authz
+        grpc_service:
+          envoy_grpc:
+            cluster_name: ext-authz
 
   clusters:
     - name: ext-authz


### PR DESCRIPTION
*Description*: The `envoy.ext_authz` filter example in the block at https://www.envoyproxy.io/docs/envoy/latest/configuration/network_filters/ext_authz_filter#example does not work because several of the config items need to be nested under a `config:` key.
*Risk Level*: low
*Testing*: manual
*Docs Changes*: See Description
*Release Notes*: N/A

