### PR TITLE
Use Envoy cpuset size to set the default number or worker threads

### DIFF
--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -128,4 +128,7 @@ message CommandLineOptions {
 
   // See :option:`--restart-epoch` for details.
   uint32 restart_epoch = 24;
+
+  // See :option:`--cpuset-threads` for details.
+  bool cpuset_threads = 25;
 }

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,6 +14,7 @@ Version history
 * config: removed deprecated --v2-config-only from command line config.
 * config: removed deprecated_v1 sds_config from :ref:`Bootstrap config <config_overview_v2_bootstrap>`.
 * config: removed REST_LEGACY as a valid :ref:`ApiType <envoy_api_field_core.ApiConfigSource.api_type>`.
+* config: use Envoy cpuset size to set the default number or worker threads if --cpuset-threads is enabled.
 * cors: added :ref:`filter_enabled & shadow_enabled RuntimeFractionalPercent flags <cors-runtime>` to filter.
 * ext_authz: added an configurable option to make the gRPC service cross-compatible with V2Alpha. Note that this feature is already deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version. 
 * ext_authz: migrated from V2alpha to V2 and improved the documentation.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,7 +14,7 @@ Version history
 * config: removed deprecated --v2-config-only from command line config.
 * config: removed deprecated_v1 sds_config from :ref:`Bootstrap config <config_overview_v2_bootstrap>`.
 * config: removed REST_LEGACY as a valid :ref:`ApiType <envoy_api_field_core.ApiConfigSource.api_type>`.
-* config: use Envoy cpuset size to set the default number or worker threads if --cpuset-threads is enabled.
+* config: use Envoy cpuset size to set the default number or worker threads if :option:`--cpuset-threads` is enabled.
 * cors: added :ref:`filter_enabled & shadow_enabled RuntimeFractionalPercent flags <cors-runtime>` to filter.
 * ext_authz: added an configurable option to make the gRPC service cross-compatible with V2Alpha. Note that this feature is already deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version. 
 * ext_authz: migrated from V2alpha to V2 and improved the documentation.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -213,7 +213,8 @@ modify different aspects of the server:
         "restart_epoch": 0,
         "file_flush_interval": "10s",
         "drain_time": "600s",
-        "parent_shutdown_time": "900s"
+        "parent_shutdown_time": "900s",
+        "cpuset_threads": false
       },
       "uptime_current_epoch": "6s",
       "uptime_all_epochs": "6s"

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -76,6 +76,14 @@ following are the command line options that Envoy supports.
   `connection` component to run at `trace` level, you should pass ``upstream:debug,connection:trace`` to 
   this flag. See ``ALL_LOGGER_IDS`` in :repo:`/source/common/common/logger.h` for a list of components.
 
+.. option:: --cpuset-threads
+
+   *(optional)* This flag is used to control the number of worker threads if :option:`--concurrency` is
+   not set. If enabled, the assigned cpuset size is used to determine the number of worker threads on
+   Linux-based systems. Otherwise the number of worker threads is set to the number of hardware threads
+   on the machine. You can read more about cpusets here:
+   https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt
+
 .. option:: --log-path <path string>
 
    *(optional)* The output file path where logs should be written. This file will be re-opened

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -81,8 +81,8 @@ following are the command line options that Envoy supports.
    *(optional)* This flag is used to control the number of worker threads if :option:`--concurrency` is
    not set. If enabled, the assigned cpuset size is used to determine the number of worker threads on
    Linux-based systems. Otherwise the number of worker threads is set to the number of hardware threads
-   on the machine. You can read more about cpusets here:
-   https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt
+   on the machine. You can read more about cpusets in the
+   `kernel documentation <https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt>`_.
 
 .. option:: --log-path <path string>
 

--- a/include/envoy/api/BUILD
+++ b/include/envoy/api/BUILD
@@ -25,5 +25,9 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "os_sys_calls_interface",
-    hdrs = ["os_sys_calls.h"],
+    hdrs = [
+        "os_sys_calls.h",
+        "os_sys_calls_common.h",
+        "os_sys_calls_linux.h",
+    ],
 )

--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -9,32 +9,11 @@
 #include <memory>
 #include <string>
 
+#include "envoy/api/os_sys_calls_common.h"
 #include "envoy/common/pure.h"
 
 namespace Envoy {
 namespace Api {
-
-/**
- * SysCallResult holds the rc and errno values resulting from a system call.
- */
-template <typename T> struct SysCallResult {
-
-  /**
-   * The return code from the system call.
-   */
-  T rc_;
-
-  /**
-   * The errno value as captured after the system call.
-   */
-  int errno_;
-};
-
-typedef SysCallResult<int> SysCallIntResult;
-typedef SysCallResult<ssize_t> SysCallSizeResult;
-typedef SysCallResult<void*> SysCallPtrResult;
-typedef SysCallResult<std::string> SysCallStringResult;
-typedef SysCallResult<bool> SysCallBoolResult;
 
 class OsSysCalls {
 public:

--- a/include/envoy/api/os_sys_calls_common.h
+++ b/include/envoy/api/os_sys_calls_common.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace Envoy {
+namespace Api {
+/**
+ * SysCallResult holds the rc and errno values resulting from a system call.
+ */
+template <typename T> struct SysCallResult {
+
+  /**
+   * The return code from the system call.
+   */
+  T rc_;
+
+  /**
+   * The errno value as captured after the system call.
+   */
+  int errno_;
+};
+
+typedef SysCallResult<int> SysCallIntResult;
+typedef SysCallResult<ssize_t> SysCallSizeResult;
+typedef SysCallResult<void*> SysCallPtrResult;
+typedef SysCallResult<std::string> SysCallStringResult;
+typedef SysCallResult<bool> SysCallBoolResult;
+
+} // namespace Api
+} // namespace Envoy

--- a/include/envoy/api/os_sys_calls_linux.h
+++ b/include/envoy/api/os_sys_calls_linux.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
 #include <sched.h>
 
 #include "envoy/api/os_sys_calls_common.h"

--- a/include/envoy/api/os_sys_calls_linux.h
+++ b/include/envoy/api/os_sys_calls_linux.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <sched.h>
+
+#include "envoy/api/os_sys_calls_common.h"
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Api {
+
+class LinuxOsSysCalls {
+public:
+  virtual ~LinuxOsSysCalls() {}
+
+  /**
+   * @see sched_getaffinity (man 2 sched_getaffinity)
+   */
+  virtual SysCallIntResult sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t* mask) PURE;
+};
+
+typedef std::unique_ptr<LinuxOsSysCalls> LinuxOsSysCallsPtr;
+
+} // namespace Api
+} // namespace Envoy

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -175,6 +175,11 @@ public:
   virtual bool mutexTracingEnabled() const PURE;
 
   /**
+   * @return bool indicating whether cpuset size should determine the number of worker threads.
+   */
+  virtual bool cpusetThreadsEnabled() const PURE;
+
+  /**
    * Converts the Options in to CommandLineOptions proto message defined in server_info.proto.
    * @return CommandLineOptionsPtr the protobuf representation of the options.
    */

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -22,8 +22,16 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "os_sys_calls_lib",
-    srcs = ["os_sys_calls_impl.cc"],
-    hdrs = ["os_sys_calls_impl.h"],
+    srcs = ["os_sys_calls_impl.cc"] + select({
+        "@bazel_tools//src/conditions:linux_x86_64": ["os_sys_calls_impl_linux.cc"],
+        "@bazel_tools//src/conditions:linux_aarch64": ["os_sys_calls_impl_linux.cc"],
+        "//conditions:default": [],
+    }),
+    hdrs = ["os_sys_calls_impl.h"] + select({
+        "@bazel_tools//src/conditions:linux_x86_64": ["os_sys_calls_impl_linux.h"],
+        "@bazel_tools//src/conditions:linux_aarch64": ["os_sys_calls_impl_linux.h"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//include/envoy/api:os_sys_calls_interface",
         "//source/common/singleton:threadsafe_singleton",

--- a/source/common/api/os_sys_calls_impl_linux.cc
+++ b/source/common/api/os_sys_calls_impl_linux.cc
@@ -1,3 +1,7 @@
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
 #include "common/api/os_sys_calls_impl_linux.h"
 
 #include <errno.h>

--- a/source/common/api/os_sys_calls_impl_linux.cc
+++ b/source/common/api/os_sys_calls_impl_linux.cc
@@ -10,63 +10,6 @@
 namespace Envoy {
 namespace Api {
 
-SysCallIntResult LinuxOsSysCallsImpl::bind(int sockfd, const sockaddr* addr, socklen_t addrlen) {
-  return os_sys_calls_.bind(sockfd, addr, addrlen);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::ioctl(int sockfd, unsigned long int request, void* argp) {
-  return os_sys_calls_.ioctl(sockfd, request, argp);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::close(int fd) { return os_sys_calls_.close(fd); }
-
-SysCallSizeResult LinuxOsSysCallsImpl::writev(int fd, const iovec* iovec, int num_iovec) {
-  return os_sys_calls_.writev(fd, iovec, num_iovec);
-}
-
-SysCallSizeResult LinuxOsSysCallsImpl::readv(int fd, const iovec* iovec, int num_iovec) {
-  return os_sys_calls_.readv(fd, iovec, num_iovec);
-}
-
-SysCallSizeResult LinuxOsSysCallsImpl::recv(int socket, void* buffer, size_t length, int flags) {
-  return os_sys_calls_.recv(socket, buffer, length, flags);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::shmOpen(const char* name, int oflag, mode_t mode) {
-  return os_sys_calls_.shmOpen(name, oflag, mode);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::shmUnlink(const char* name) {
-  return os_sys_calls_.shmUnlink(name);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::ftruncate(int fd, off_t length) {
-  return os_sys_calls_.ftruncate(fd, length);
-}
-
-SysCallPtrResult LinuxOsSysCallsImpl::mmap(void* addr, size_t length, int prot, int flags, int fd,
-                                           off_t offset) {
-  return os_sys_calls_.mmap(addr, length, prot, flags, fd, offset);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::stat(const char* pathname, struct stat* buf) {
-  return os_sys_calls_.stat(pathname, buf);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::setsockopt(int sockfd, int level, int optname,
-                                                 const void* optval, socklen_t optlen) {
-  return os_sys_calls_.setsockopt(sockfd, level, optname, optval, optlen);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::getsockopt(int sockfd, int level, int optname, void* optval,
-                                                 socklen_t* optlen) {
-  return os_sys_calls_.getsockopt(sockfd, level, optname, optval, optlen);
-}
-
-SysCallIntResult LinuxOsSysCallsImpl::socket(int domain, int type, int protocol) {
-  return os_sys_calls_.socket(domain, type, protocol);
-}
-
 SysCallIntResult LinuxOsSysCallsImpl::sched_getaffinity(pid_t pid, size_t cpusetsize,
                                                         cpu_set_t* mask) {
   const int rc = ::sched_getaffinity(pid, cpusetsize, mask);

--- a/source/common/api/os_sys_calls_impl_linux.cc
+++ b/source/common/api/os_sys_calls_impl_linux.cc
@@ -1,0 +1,73 @@
+#include "common/api/os_sys_calls_impl_linux.h"
+
+#include <errno.h>
+#include <sched.h>
+
+namespace Envoy {
+namespace Api {
+
+SysCallIntResult LinuxOsSysCallsImpl::bind(int sockfd, const sockaddr* addr, socklen_t addrlen) {
+  return os_sys_calls_.bind(sockfd, addr, addrlen);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::ioctl(int sockfd, unsigned long int request, void* argp) {
+  return os_sys_calls_.ioctl(sockfd, request, argp);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::close(int fd) { return os_sys_calls_.close(fd); }
+
+SysCallSizeResult LinuxOsSysCallsImpl::writev(int fd, const iovec* iovec, int num_iovec) {
+  return os_sys_calls_.writev(fd, iovec, num_iovec);
+}
+
+SysCallSizeResult LinuxOsSysCallsImpl::readv(int fd, const iovec* iovec, int num_iovec) {
+  return os_sys_calls_.readv(fd, iovec, num_iovec);
+}
+
+SysCallSizeResult LinuxOsSysCallsImpl::recv(int socket, void* buffer, size_t length, int flags) {
+  return os_sys_calls_.recv(socket, buffer, length, flags);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::shmOpen(const char* name, int oflag, mode_t mode) {
+  return os_sys_calls_.shmOpen(name, oflag, mode);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::shmUnlink(const char* name) {
+  return os_sys_calls_.shmUnlink(name);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::ftruncate(int fd, off_t length) {
+  return os_sys_calls_.ftruncate(fd, length);
+}
+
+SysCallPtrResult LinuxOsSysCallsImpl::mmap(void* addr, size_t length, int prot, int flags, int fd,
+                                           off_t offset) {
+  return os_sys_calls_.mmap(addr, length, prot, flags, fd, offset);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::stat(const char* pathname, struct stat* buf) {
+  return os_sys_calls_.stat(pathname, buf);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::setsockopt(int sockfd, int level, int optname,
+                                                 const void* optval, socklen_t optlen) {
+  return os_sys_calls_.setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::getsockopt(int sockfd, int level, int optname, void* optval,
+                                                 socklen_t* optlen) {
+  return os_sys_calls_.getsockopt(sockfd, level, optname, optval, optlen);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::socket(int domain, int type, int protocol) {
+  return os_sys_calls_.socket(domain, type, protocol);
+}
+
+SysCallIntResult LinuxOsSysCallsImpl::sched_getaffinity(pid_t pid, size_t cpusetsize,
+                                                        cpu_set_t* mask) {
+  const int rc = ::sched_getaffinity(pid, cpusetsize, mask);
+  return {rc, errno};
+}
+
+} // namespace Api
+} // namespace Envoy

--- a/source/common/api/os_sys_calls_impl_linux.h
+++ b/source/common/api/os_sys_calls_impl_linux.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "envoy/api/os_sys_calls_linux.h"
+
+#include "common/api/os_sys_calls_impl.h"
+#include "common/singleton/threadsafe_singleton.h"
+
+namespace Envoy {
+namespace Api {
+
+class LinuxOsSysCallsImpl : public OsSysCalls, LinuxOsSysCalls {
+public:
+  LinuxOsSysCallsImpl() : os_sys_calls_(OsSysCallsSingleton::get()) {}
+  // Api::OsSysCalls
+  SysCallIntResult bind(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
+  SysCallIntResult ioctl(int sockfd, unsigned long int request, void* argp) override;
+  SysCallSizeResult writev(int fd, const iovec* iovec, int num_iovec) override;
+  SysCallSizeResult readv(int fd, const iovec* iovec, int num_iovec) override;
+  SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) override;
+  SysCallIntResult close(int fd) override;
+  SysCallIntResult shmOpen(const char* name, int oflag, mode_t mode) override;
+  SysCallIntResult shmUnlink(const char* name) override;
+  SysCallIntResult ftruncate(int fd, off_t length) override;
+  SysCallPtrResult mmap(void* addr, size_t length, int prot, int flags, int fd,
+                        off_t offset) override;
+  SysCallIntResult stat(const char* pathname, struct stat* buf) override;
+  SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
+                              socklen_t optlen) override;
+  SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
+                              socklen_t* optlen) override;
+  SysCallIntResult socket(int domain, int type, int protocol) override;
+  // Api::LinuxOsSysCalls
+  SysCallIntResult sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t* mask) override;
+
+private:
+  OsSysCalls& os_sys_calls_;
+};
+
+typedef ThreadSafeSingleton<LinuxOsSysCallsImpl> LinuxOsSysCallsSingleton;
+
+} // namespace Api
+} // namespace Envoy

--- a/source/common/api/os_sys_calls_impl_linux.h
+++ b/source/common/api/os_sys_calls_impl_linux.h
@@ -6,38 +6,15 @@
 
 #include "envoy/api/os_sys_calls_linux.h"
 
-#include "common/api/os_sys_calls_impl.h"
 #include "common/singleton/threadsafe_singleton.h"
 
 namespace Envoy {
 namespace Api {
 
-class LinuxOsSysCallsImpl : public OsSysCalls, LinuxOsSysCalls {
+class LinuxOsSysCallsImpl : public LinuxOsSysCalls {
 public:
-  LinuxOsSysCallsImpl() : os_sys_calls_(OsSysCallsSingleton::get()) {}
-  // Api::OsSysCalls
-  SysCallIntResult bind(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
-  SysCallIntResult ioctl(int sockfd, unsigned long int request, void* argp) override;
-  SysCallSizeResult writev(int fd, const iovec* iovec, int num_iovec) override;
-  SysCallSizeResult readv(int fd, const iovec* iovec, int num_iovec) override;
-  SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) override;
-  SysCallIntResult close(int fd) override;
-  SysCallIntResult shmOpen(const char* name, int oflag, mode_t mode) override;
-  SysCallIntResult shmUnlink(const char* name) override;
-  SysCallIntResult ftruncate(int fd, off_t length) override;
-  SysCallPtrResult mmap(void* addr, size_t length, int prot, int flags, int fd,
-                        off_t offset) override;
-  SysCallIntResult stat(const char* pathname, struct stat* buf) override;
-  SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
-                              socklen_t optlen) override;
-  SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
-                              socklen_t* optlen) override;
-  SysCallIntResult socket(int domain, int type, int protocol) override;
   // Api::LinuxOsSysCalls
   SysCallIntResult sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t* mask) override;
-
-private:
-  OsSysCalls& os_sys_calls_;
 };
 
 typedef ThreadSafeSingleton<LinuxOsSysCallsImpl> LinuxOsSysCallsSingleton;

--- a/source/common/api/os_sys_calls_impl_linux.h
+++ b/source/common/api/os_sys_calls_impl_linux.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
 #include "envoy/api/os_sys_calls_linux.h"
 
 #include "common/api/os_sys_calls_impl.h"

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -151,13 +151,25 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "options_lib",
-    srcs = ["options_impl.cc"],
-    hdrs = ["options_impl.h"],
+    srcs = ["options_impl.cc"] + select({
+        "@bazel_tools//src/conditions:linux_x86_64": ["options_impl_platform_linux.cc"],
+        "@bazel_tools//src/conditions:linux_aarch64": ["options_impl_platform_linux.cc"],
+        "//conditions:default": ["options_impl_platform_default.cc"],
+    }),
+    hdrs = [
+        "options_impl.h",
+        "options_impl_platform.h",
+    ] + select({
+        "@bazel_tools//src/conditions:linux_x86_64": ["options_impl_platform_linux.h"],
+        "@bazel_tools//src/conditions:linux_aarch64": ["options_impl_platform_linux.h"],
+        "//conditions:default": [],
+    }),
     external_deps = ["tclap"],
     deps = [
         "//include/envoy/network:address_interface",
         "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
+        "//source/common/common:logger_lib",
         "//source/common/common:macros",
         "//source/common/common:version_lib",
         "//source/common/protobuf:utility_lib",

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -169,6 +169,7 @@ envoy_cc_library(
         "//include/envoy/network:address_interface",
         "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:logger_lib",
         "//source/common/common:macros",
         "//source/common/common:version_lib",

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -201,6 +201,10 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     // that can be known.
     concurrency_ = OptionsImplPlatform::getCpuCount();
   } else {
+    if (concurrency.isSet() && cpuset_threads_ && cpuset_threads.isSet()) {
+      ENVOY_LOG(warn, "Both --concurrency and --cpuset-threads options are set; not applying "
+                      "--cpuset-threads.");
+    }
     concurrency_ = std::max(1U, concurrency.getValue());
   }
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -11,6 +11,8 @@
 #include "common/common/version.h"
 #include "common/protobuf/utility.h"
 
+#include "server/options_impl_platform.h"
+
 #include "absl/strings/str_split.h"
 #include "spdlog/spdlog.h"
 #include "tclap/CmdLine.h"
@@ -117,6 +119,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                                        "Disable hot restart functionality", cmd, false);
   TCLAP::SwitchArg enable_mutex_tracing(
       "", "enable-mutex-tracing", "Enable mutex contention tracing functionality", cmd, false);
+  TCLAP::SwitchArg cpuset_threads(
+      "", "cpuset-threads", "Get the default # of worker threads from cpuset size", cmd, false);
 
   cmd.setExceptionHandling(false);
   try {
@@ -154,6 +158,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
 
   mutex_tracing_enabled_ = enable_mutex_tracing.getValue();
 
+  cpuset_threads_ = cpuset_threads.getValue();
+
   log_level_ = default_log_level;
   for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
     if (log_level.getValue() == spdlog::level::level_string_views[i]) {
@@ -188,7 +194,16 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
 
   // For base ID, scale what the user inputs by 10 so that we have spread for domain sockets.
   base_id_ = base_id.getValue() * 10;
-  concurrency_ = std::max(1U, concurrency.getValue());
+
+  if (!concurrency.isSet() && cpuset_threads_) {
+    // The 'concurrency' command line option wasn't set but the 'cpuset-threads'
+    // option was set. Use the number of CPUs assigned to the process cpuset, if
+    // that can be known.
+    concurrency_ = OptionsImplPlatform::getCpuCount();
+  } else {
+    concurrency_ = std::max(1U, concurrency.getValue());
+  }
+
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   allow_unknown_fields_ = allow_unknown_fields.getValue();
@@ -291,6 +306,7 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_max_obj_name_len(statsOptions().maxObjNameLength());
   command_line_options->set_disable_hot_restart(hotRestartDisabled());
   command_line_options->set_enable_mutex_tracing(mutexTracingEnabled());
+  command_line_options->set_cpuset_threads(cpusetThreadsEnabled());
   command_line_options->set_restart_epoch(restartEpoch());
   return command_line_options;
 }
@@ -303,6 +319,6 @@ OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& 
       service_cluster_(service_cluster), service_node_(service_node), service_zone_(service_zone),
       file_flush_interval_msec_(10000), drain_time_(600), parent_shutdown_time_(900),
       mode_(Server::Mode::Serve), max_stats_(ENVOY_DEFAULT_MAX_STATS), hot_restart_disabled_(false),
-      signal_handling_enabled_(true), mutex_tracing_enabled_(false) {}
+      signal_handling_enabled_(true), mutex_tracing_enabled_(false), cpuset_threads_(false) {}
 
 } // namespace Envoy

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -8,6 +8,7 @@
 #include "envoy/server/options.h"
 #include "envoy/stats/stats_options.h"
 
+#include "common/common/logger.h"
 #include "common/stats/stats_options_impl.h"
 
 #include "spdlog/spdlog.h"
@@ -16,7 +17,7 @@ namespace Envoy {
 /**
  * Implementation of Server::Options.
  */
-class OptionsImpl : public Server::Options {
+class OptionsImpl : public Server::Options, protected Logger::Loggable<Logger::Id::config> {
 public:
   /**
    * Parameters are max_num_stats, max_stat_name_len, hot_restart_enabled

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -73,6 +73,7 @@ public:
   void setSignalHandling(bool signal_handling_enabled) {
     signal_handling_enabled_ = signal_handling_enabled;
   }
+  void setCpusetThreads(bool cpuset_threads_enabled) { cpuset_threads_ = cpuset_threads_enabled; }
 
   // Server::Options
   uint64_t baseId() const override { return base_id_; }
@@ -107,6 +108,7 @@ public:
   bool mutexTracingEnabled() const override { return mutex_tracing_enabled_; }
   virtual Server::CommandLineOptionsPtr toCommandLineOptions() const override;
   void parseComponentLogLevels(const std::string& component_log_levels);
+  bool cpusetThreadsEnabled() const override { return cpuset_threads_; }
   uint32_t count() const;
 
 private:
@@ -137,6 +139,7 @@ private:
   bool hot_restart_disabled_;
   bool signal_handling_enabled_;
   bool mutex_tracing_enabled_;
+  bool cpuset_threads_;
   uint32_t count_;
 };
 

--- a/source/server/options_impl_platform.h
+++ b/source/server/options_impl_platform.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+#include "common/common/logger.h"
+
+namespace Envoy {
+class OptionsImplPlatform : protected Logger::Loggable<Logger::Id::config> {
+public:
+  static uint32_t getCpuCount();
+};
+} // namespace Envoy

--- a/source/server/options_impl_platform_default.cc
+++ b/source/server/options_impl_platform_default.cc
@@ -1,0 +1,14 @@
+#include <thread>
+
+#include "common/common/logger.h"
+
+#include "server/options_impl_platform.h"
+
+namespace Envoy {
+
+uint32_t OptionsImplPlatform::getCpuCount() {
+  ENVOY_LOG(warn, "CPU number provided by HW thread count (instead of cpuset).");
+  return std::thread::hardware_concurrency();
+}
+
+} // namespace Envoy

--- a/source/server/options_impl_platform_linux.cc
+++ b/source/server/options_impl_platform_linux.cc
@@ -1,0 +1,55 @@
+#include "server/options_impl_platform_linux.h"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <bitset>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "server/options_impl_platform.h"
+
+namespace Envoy {
+
+uint32_t OptionsImplPlatformLinux::getCpuCountFromPath(std::string& path, unsigned int hw_threads) {
+  std::string key("Cpus_allowed:");
+  std::ifstream file(path);
+  if (!file) {
+    // Fall back to number of hardware threads.
+    return hw_threads;
+  }
+
+  std::string statusLine;
+  unsigned int threads = 0;
+
+  while (std::getline(file, statusLine)) {
+    if (statusLine.compare(0, key.size(), key, 0, key.size()) == 0) {
+      std::string value = statusLine.substr(key.size());
+      for (std::string::iterator iter = value.begin(); iter != value.end(); iter++) {
+        if (std::isxdigit(*iter)) {
+          char buf[2];
+          buf[0] = *iter;
+          buf[1] = '\0';
+          std::bitset<4> cpus(strtol(buf, NULL, 16));
+          threads += cpus.count();
+        }
+      }
+      break;
+    }
+  }
+  // Sanity check.
+  if (threads > 0 && threads <= hw_threads) {
+    return threads;
+  }
+  return hw_threads;
+}
+
+uint32_t OptionsImplPlatform::getCpuCount() {
+  std::string path("/proc/self/status");
+  unsigned int hw_threads = std::max(1U, std::thread::hardware_concurrency());
+  return OptionsImplPlatformLinux::getCpuCountFromPath(path, hw_threads);
+}
+
+} // namespace Envoy

--- a/source/server/options_impl_platform_linux.cc
+++ b/source/server/options_impl_platform_linux.cc
@@ -4,6 +4,8 @@
 
 #include <thread>
 
+#include "common/api/os_sys_calls_impl_linux.h"
+
 #include "server/options_impl_platform.h"
 
 namespace Envoy {
@@ -12,9 +14,12 @@ uint32_t OptionsImplPlatformLinux::getCpuAffinityCount(unsigned int hw_threads) 
   unsigned int threads = 0;
   pid_t pid = getpid();
   cpu_set_t mask;
+  auto& linux_os_syscalls = Api::LinuxOsSysCallsSingleton::get();
 
   CPU_ZERO(&mask);
-  if (sched_getaffinity(pid, sizeof(cpu_set_t), &mask) == -1) {
+  const Api::SysCallIntResult result =
+      linux_os_syscalls.sched_getaffinity(pid, sizeof(cpu_set_t), &mask);
+  if (result.rc_ == -1) {
     // Fall back to number of hardware threads.
     return hw_threads;
   }

--- a/source/server/options_impl_platform_linux.cc
+++ b/source/server/options_impl_platform_linux.cc
@@ -1,3 +1,7 @@
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
 #include "server/options_impl_platform_linux.h"
 
 #include <sched.h>

--- a/source/server/options_impl_platform_linux.h
+++ b/source/server/options_impl_platform_linux.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace Envoy {
+class OptionsImplPlatformLinux {
+public:
+  static uint32_t getCpuCountFromPath(std::string& file, unsigned int hw_threads);
+};
+} // namespace Envoy

--- a/source/server/options_impl_platform_linux.h
+++ b/source/server/options_impl_platform_linux.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
 #include <cstdint>
 #include <string>
 

--- a/source/server/options_impl_platform_linux.h
+++ b/source/server/options_impl_platform_linux.h
@@ -6,6 +6,6 @@
 namespace Envoy {
 class OptionsImplPlatformLinux {
 public:
-  static uint32_t getCpuCountFromPath(std::string& file, unsigned int hw_threads);
+  static uint32_t getCpuAffinityCount(unsigned int hw_threads);
 };
 } // namespace Envoy

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -10,6 +10,10 @@
 
 #include "common/api/os_sys_calls_impl.h"
 
+#if defined(__linux__)
+#include "common/api/os_sys_calls_impl_linux.h"
+#endif
+
 #include "test/mocks/filesystem/mocks.h"
 #include "test/test_common/test_time.h"
 
@@ -73,6 +77,14 @@ public:
   using SockOptKey = std::tuple<int, int, int>;
   std::map<SockOptKey, bool> boolsockopts_;
 };
+
+#if defined(__linux__)
+class MockLinuxOsSysCalls : public LinuxOsSysCallsImpl {
+public:
+  // Api::LinuxOsSysCalls
+  MOCK_METHOD3(sched_getaffinity, SysCallIntResult(pid_t pid, size_t cpusetsize, cpu_set_t* mask));
+};
+#endif
 
 } // namespace Api
 } // namespace Envoy

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -34,6 +34,7 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
   ON_CALL(*this, hotRestartDisabled()).WillByDefault(ReturnPointee(&hot_restart_disabled_));
   ON_CALL(*this, signalHandlingEnabled()).WillByDefault(ReturnPointee(&signal_handling_enabled_));
   ON_CALL(*this, mutexTracingEnabled()).WillByDefault(ReturnPointee(&mutex_tracing_enabled_));
+  ON_CALL(*this, cpusetThreadsEnabled()).WillByDefault(ReturnPointee(&cpuset_threads_enabled_));
   ON_CALL(*this, toCommandLineOptions()).WillByDefault(Invoke([] {
     return std::make_unique<envoy::admin::v2alpha::CommandLineOptions>();
   }));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -79,6 +79,7 @@ public:
   MOCK_CONST_METHOD0(hotRestartDisabled, bool());
   MOCK_CONST_METHOD0(signalHandlingEnabled, bool());
   MOCK_CONST_METHOD0(mutexTracingEnabled, bool());
+  MOCK_CONST_METHOD0(cpusetThreadsEnabled, bool());
   MOCK_CONST_METHOD0(toCommandLineOptions, Server::CommandLineOptionsPtr());
 
   std::string config_path_;
@@ -95,6 +96,7 @@ public:
   bool hot_restart_disabled_{};
   bool signal_handling_enabled_{true};
   bool mutex_tracing_enabled_{};
+  bool cpuset_threads_enabled_{};
 };
 
 class MockConfigTracker : public ConfigTracker {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -115,6 +115,7 @@ envoy_cc_test(
         "//source/common/stats:stats_lib",
         "//source/server:options_lib",
         "//test/test_common:environment_lib",
+        "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -114,6 +114,7 @@ envoy_cc_test(
         "//source/common/common:utility_lib",
         "//source/common/stats:stats_lib",
         "//source/server:options_lib",
+        "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -114,8 +114,10 @@ envoy_cc_test(
         "//source/common/common:utility_lib",
         "//source/common/stats:stats_lib",
         "//source/server:options_lib",
+        "//test/mocks/api:api_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:logging_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -12,6 +12,7 @@
 #include "server/options_impl_platform_linux.h"
 
 #include "test/test_common/environment.h"
+#include "test/test_common/logging.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -315,6 +316,14 @@ TEST_F(OptionsImplTest, SaneTestConstructor) {
             test_options_impl.statsOptions().maxStatSuffixLength());
   EXPECT_EQ(regular_options_impl->hotRestartDisabled(), test_options_impl.hotRestartDisabled());
   EXPECT_EQ(regular_options_impl->cpusetThreadsEnabled(), test_options_impl.cpusetThreadsEnabled());
+}
+
+TEST_F(OptionsImplTest, SetBothConcurrencyAndCpuset) {
+  EXPECT_LOG_CONTAINS(
+      "warning",
+      "Both --concurrency and --cpuset-threads options are set; not applying --cpuset-threads.",
+      std::unique_ptr<OptionsImpl> options =
+          createOptionsImpl("envoy -c hello --concurrency 42 --cpuset-threads"));
 }
 
 #if defined(__linux__)

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -317,113 +317,37 @@ TEST_F(OptionsImplTest, SaneTestConstructor) {
   EXPECT_EQ(regular_options_impl->cpusetThreadsEnabled(), test_options_impl.cpusetThreadsEnabled());
 }
 
+#if defined(__linux__)
+
 class OptionsImplPlatformLinuxTest : public testing::Test {
 public:
 };
 
-TEST_F(OptionsImplPlatformLinuxTest, ReadStatusFile1) {
-  // Success case 1. 16 CPUs from status, 32 from hardware.
-  std::string statusFile = "Foo: bar\nCpus_allowed:   ffff\nBar: foo\n";
+TEST_F(OptionsImplPlatformLinuxTest, AffinityTest1) {
+  // Success case: cpuset size and hardware thread count are the same.
+  unsigned int fake_cpuset_size = std::thread::hardware_concurrency();
+  unsigned int fake_hw_threads = fake_cpuset_size;
 
-  std::string dirName = TestEnvironment::temporaryPath("envoy_cpu_status_test");
-  TestUtility::createDirectory(dirName);
-
-  std::string fileName = dirName + std::string("/status1");
-  std::ofstream file(fileName);
-
-  file << statusFile;
-  file.close();
-
-  EXPECT_EQ(OptionsImplPlatformLinux::getCpuCountFromPath(fileName, 16), 16);
-
-  TestEnvironment::removePath(fileName);
-  TestEnvironment::removePath(dirName);
+  EXPECT_EQ(OptionsImplPlatformLinux::getCpuAffinityCount(fake_hw_threads), fake_cpuset_size);
 }
 
-TEST_F(OptionsImplPlatformLinuxTest, ReadStatusFile2) {
-  // Success case 2. 29 CPUs from status, 32 from hardware.
-  // Core count: 1+1+2+1+3+3+2+3+3+3+3+4 = 29
-  //             1 2 3 4 d e a d b e e f
-  std::string statusFile = "Foo: bar\nCpus_allowed: 1234,dead,beef\nBar: foo\n";
-  std::string dirName = TestEnvironment::temporaryPath("envoy_cpu_status_test");
-  TestUtility::createDirectory(dirName);
+TEST_F(OptionsImplPlatformLinuxTest, AffinityTest2) {
+  // Success case: cpuset size is half of the hardware thread count.
+  unsigned int fake_cpuset_size = std::thread::hardware_concurrency();
+  unsigned int fake_hw_threads = 2 * fake_cpuset_size;
 
-  std::string fileName = dirName + std::string("/status2");
-  std::ofstream file(fileName);
-
-  file << statusFile;
-  file.close();
-
-  EXPECT_EQ(OptionsImplPlatformLinux::getCpuCountFromPath(fileName, 32), 29);
-
-  TestEnvironment::removePath(fileName);
-  TestEnvironment::removePath(dirName);
+  EXPECT_EQ(OptionsImplPlatformLinux::getCpuAffinityCount(fake_hw_threads), fake_cpuset_size);
 }
 
-TEST_F(OptionsImplPlatformLinuxTest, ReadStatusFile3) {
-  // Failure case 1. More CPUs than hardware threads (16 vs. 8).
-  std::string statusFile = "Foo: bar\nCpus_allowed:   ffff\nBar: foo\n";
+TEST_F(OptionsImplPlatformLinuxTest, AffinityTest3) {
+  // Failure case: cpuset size is bigger than the hardware thread count.
+  unsigned int fake_cpuset_size = std::thread::hardware_concurrency();
+  unsigned int fake_hw_threads = fake_cpuset_size - 1;
 
-  std::string dirName = TestEnvironment::temporaryPath("envoy_cpu_status_test");
-  TestUtility::createDirectory(dirName);
-
-  std::string fileName = dirName + std::string("/status3");
-  std::ofstream file(fileName);
-
-  file << statusFile;
-  file.close();
-
-  EXPECT_EQ(OptionsImplPlatformLinux::getCpuCountFromPath(fileName, 8), 8);
-
-  TestEnvironment::removePath(fileName);
-  TestEnvironment::removePath(dirName);
+  EXPECT_EQ(OptionsImplPlatformLinux::getCpuAffinityCount(fake_hw_threads), fake_hw_threads);
 }
 
-TEST_F(OptionsImplPlatformLinuxTest, ReadStatusFile4) {
-  // Failure case 2. Missing line.
-  std::string statusFile = "Foo: bar\nBar: foo\n";
-
-  std::string dirName = TestEnvironment::temporaryPath("envoy_cpu_status_test");
-  TestUtility::createDirectory(dirName);
-
-  std::string fileName = dirName + std::string("/status4");
-  std::ofstream file(fileName);
-
-  file << statusFile;
-  file.close();
-
-  EXPECT_EQ(OptionsImplPlatformLinux::getCpuCountFromPath(fileName, 8), 8);
-
-  TestEnvironment::removePath(fileName);
-  TestEnvironment::removePath(dirName);
-}
-
-TEST_F(OptionsImplPlatformLinuxTest, ReadStatusFile5) {
-  // Failure case 3. Corrupted line.
-  std::string statusFile = "Foo: bar\nCpus_allowed:   xyz\nBar: foo\n";
-
-  std::string dirName = TestEnvironment::temporaryPath("envoy_cpu_status_test");
-  TestUtility::createDirectory(dirName);
-
-  std::string fileName = dirName + std::string("/status5");
-  std::ofstream file(fileName);
-
-  file << statusFile;
-  file.close();
-
-  EXPECT_EQ(OptionsImplPlatformLinux::getCpuCountFromPath(fileName, 8), 8);
-
-  TestEnvironment::removePath(fileName);
-  TestEnvironment::removePath(dirName);
-}
-
-TEST_F(OptionsImplPlatformLinuxTest, ReadStatusFile6) {
-  // Failure case 4. Missing file.
-  std::string dirName = TestEnvironment::temporaryPath("envoy_cpu_status_test");
-  std::string fileName = dirName + std::string("/status6");
-
-  EXPECT_EQ(OptionsImplPlatformLinux::getCpuCountFromPath(fileName, 8), 8);
-}
+#endif
 
 } // namespace
 } // namespace Envoy

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -633,6 +633,7 @@ sanitization
 sanitizer
 scala
 scalability
+sched
 schemas
 serializable
 serializer


### PR DESCRIPTION
*Description*:

If `--concurrency` option is not specified, set the default number of worker threads based on the cpuset of the process.  This means that the amount of worker threads is not controlled by the hardware thread count but instead the cpu allocation.

For example, if Envoy is started in a Docker container like this, only four worker threads are created if `--concurrency` option is not specified:

    $ docker run --cpuset-cpus="0-3" ...

The original behavior was that the number of CPU threads in the system would be used to determine the number of worker threads. This number could be very large for servers with multiple physical CPUs and hyperthreading enabled.

This change has a potentially large performance impact, since it changes the default number of threads assigned to Envoy. However, since the original intent of the default concurrency value was to have the number of worker threads matching to the HW capabilities, after this change the Envoy behavior is probably closer to what is expected. Also, `std::thread::hardware_concurrency()` docs say that the returned value "should be considered only a hint".

There are no tests yet, because I wanted to have some input whether a change like this would be desirable before finalizing the work. Another potential improvement possibility would be monitoring the process cpuset and changing the amount of worker threads dynamically.

*Risk Level*: Medium
*Testing*: manual testing with `taskset` and `docker`
*Docs Changes*: Yes, explained the change of behavior
*Release Notes*: Yes

