### PR TITLE
add helper to ProtobufPercentHelper for evaluating FractionalPercent

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -34,10 +34,6 @@ uint64_t convertPercent(double percent, uint64_t max_value) {
 }
 
 bool evaluateFractionalPercent(envoy::type::FractionalPercent percent, uint64_t random_value) {
-  if (percent.numerator() == 0) {
-    return false;
-  }
-
   return random_value % fractionalPercentDenominatorToInt(percent.denominator()) <
          percent.numerator();
 }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -33,6 +33,15 @@ uint64_t convertPercent(double percent, uint64_t max_value) {
   return max_value * (percent / 100.0);
 }
 
+bool evaluateFractionalPercent(envoy::type::FractionalPercent percent, uint64_t random_value) {
+  if (percent.numerator() == 0) {
+    return false;
+  }
+
+  return random_value % fractionalPercentDenominatorToInt(percent.denominator()) <
+         percent.numerator();
+}
+
 uint64_t fractionalPercentDenominatorToInt(
     const envoy::type::FractionalPercent::DenominatorType& denominator) {
   switch (denominator) {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -60,6 +60,15 @@ uint64_t checkAndReturnDefault(uint64_t default_value, uint64_t max_value);
 uint64_t convertPercent(double percent, uint64_t max_value);
 
 /**
+ * Given a fractional percent chance of a given event occurring, evaluate to a yes/no decision
+ * based on a provided random value.
+ * @param percent the chance of a given event happening.
+ * @param random_value supplies a numerical value to use to evaluate the event.
+ * @return bool decision about whether the event should occur.
+ */
+bool evaluateFractionalPercent(envoy::type::FractionalPercent percent, uint64_t random_value);
+
+/**
  * Convert a fractional percent denominator enum into an integer.
  * @param denominator supplies denominator to convert.
  * @return the converted denominator.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -209,15 +209,16 @@ bool SnapshotImpl::featureEnabled(const std::string& key,
   if (entry != values_.end() && entry->second.fractional_percent_value_.has_value()) {
     percent = entry->second.fractional_percent_value_.value();
   } else if (entry != values_.end() && entry->second.uint_value_.has_value()) {
-    // The runtime value must have been specified as an integer rather than a
-    // fractional percent proto. To preserve legacy semantics, we'll assume
-    // this represents a percentage (i.e. denominator of 100).
+    // Check for > 100 because the runtime value is assumed to be specified as
+    // an integer, and it also ensures that truncating the uint64_t runtime
+    // value into a uint32_t percent numerator later is safe
     if (entry->second.uint_value_.value() > 100) {
       return true;
     }
 
-    // Putting the uint64_t runtime value into the uint32_t numerator is safe
-    // because of the > 100 check above
+    // The runtime value was specified as an integer rather than a fractional
+    // percent proto. To preserve legacy semantics, we treat it as a percentage
+    // (i.e. denominator of 100).
     percent.set_numerator(entry->second.uint_value_.value());
     percent.set_denominator(envoy::type::FractionalPercent::HUNDRED);
   } else {

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -205,23 +205,26 @@ bool SnapshotImpl::featureEnabled(const std::string& key,
                                   const envoy::type::FractionalPercent& default_value,
                                   uint64_t random_value) const {
   const auto& entry = values_.find(key);
-  uint64_t numerator, denominator;
+  envoy::type::FractionalPercent percent;
   if (entry != values_.end() && entry->second.fractional_percent_value_.has_value()) {
-    numerator = entry->second.fractional_percent_value_->numerator();
-    denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(
-        entry->second.fractional_percent_value_->denominator());
+    percent = entry->second.fractional_percent_value_.value();
   } else if (entry != values_.end() && entry->second.uint_value_.has_value()) {
-    // The runtime value must have been specified as an integer rather than a fractional percent
-    // proto. To preserve legacy semantics, we'll assume this represents a percentage.
-    numerator = entry->second.uint_value_.value();
-    denominator = 100;
+    // The runtime value must have been specified as an integer rather than a
+    // fractional percent proto. To preserve legacy semantics, we'll assume
+    // this represents a percentage (i.e. denominator of 100).
+    if (entry->second.uint_value_.value() > 100) {
+      return true;
+    }
+
+    // Putting the uint64_t runtime value into the uint32_t numerator is safe
+    // because of the > 100 check above
+    percent.set_numerator(entry->second.uint_value_.value());
+    percent.set_denominator(envoy::type::FractionalPercent::HUNDRED);
   } else {
-    numerator = default_value.numerator();
-    denominator =
-        ProtobufPercentHelper::fractionalPercentDenominatorToInt(default_value.denominator());
+    percent = default_value;
   }
 
-  return random_value % denominator < numerator;
+  return ProtobufPercentHelper::evaluateFractionalPercent(percent, random_value);
 }
 
 uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value) const {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -33,6 +33,83 @@ TEST_F(ProtobufUtilityTest, convertPercentNaN) {
                EnvoyException);
 }
 
+namespace ProtobufPercentHelper {
+
+TEST_F(ProtobufUtilityTest, evaluateFractionalPercent) {
+  { // 0/100 (default)
+    envoy::type::FractionalPercent percent;
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 0));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 50));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 100));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 1000));
+  }
+  { // 5/100
+    envoy::type::FractionalPercent percent;
+    percent.set_numerator(5);
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 0));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 4));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 5));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 50));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 100));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 104));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 105));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 204));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 1000));
+  }
+  { // 75/100
+    envoy::type::FractionalPercent percent;
+    percent.set_numerator(75);
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 0));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 4));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 5));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 74));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 80));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 100));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 104));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 105));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 200));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 274));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 280));
+  }
+  { // 5/10000
+    envoy::type::FractionalPercent percent;
+    percent.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+    percent.set_numerator(5);
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 0));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 4));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 5));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 50));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 100));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 9000));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 10000));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 10004));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 10005));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 20004));
+  }
+  { // 5/MILLION
+    envoy::type::FractionalPercent percent;
+    percent.set_denominator(envoy::type::FractionalPercent::MILLION);
+    percent.set_numerator(5);
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 0));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 4));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 5));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 50));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 100));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 9000));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 10000));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 10004));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 10005));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 900005));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 900000));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 1000000));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 1000004));
+    EXPECT_FALSE(evaluateFractionalPercent(percent, 1000005));
+    EXPECT_TRUE(evaluateFractionalPercent(percent, 2000004));
+  }
+}
+
+} // namespace ProtobufPercentHelper
+
 TEST_F(ProtobufUtilityTest, RepeatedPtrUtilDebugString) {
   Protobuf::RepeatedPtrField<ProtobufWkt::UInt32Value> repeated;
   EXPECT_EQ("[]", RepeatedPtrUtil::debugString(repeated));

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -203,6 +203,45 @@ TEST_F(DiskBackedLoaderImplTest, OverrideFolderDoesNotExist) {
   EXPECT_EQ("hello", loader->snapshot().get("file1"));
 }
 
+TEST_F(DiskBackedLoaderImplTest, PercentHandling) {
+  setup();
+  run("test/common/runtime/test_data/current", "envoy_override");
+
+  envoy::type::FractionalPercent default_value;
+
+  // Smoke test integer value of 0, should be interpreted as 0%
+  {
+    loader->mergeValues({{"foo", "0"}});
+
+    EXPECT_FALSE(loader->snapshot().featureEnabled("foo", default_value, 0));
+    EXPECT_FALSE(loader->snapshot().featureEnabled("foo", default_value, 5));
+  }
+
+  // Smoke test integer value of 5, should be interpreted as 5%
+  {
+    loader->mergeValues({{"foo", "5"}});
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 0));
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 4));
+    EXPECT_FALSE(loader->snapshot().featureEnabled("foo", default_value, 5));
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 100));
+  }
+
+  // Verify uint64 -> uint32 conversion by using a runtime value with all 0s in
+  // the bottom 32 bits. If it were to be naively treated as a uint32_t then it
+  // would appear as 0%, but it should be 100% because we assume the
+  // denominator is 100
+  {
+    uint64_t high_value = 1UL << 60;
+    std::string high_value_str = std::to_string(high_value);
+    loader->mergeValues({{"foo", high_value_str}});
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 0));
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 50));
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 100));
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 12389));
+    EXPECT_TRUE(loader->snapshot().featureEnabled("foo", default_value, 23859235));
+  }
+}
+
 void testNewOverrides(Loader& loader, Stats::Store& store) {
   // New string
   loader.mergeValues({{"foo", "bar"}});

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -231,6 +231,9 @@ TEST_F(DiskBackedLoaderImplTest, PercentHandling) {
   // would appear as 0%, but it should be 100% because we assume the
   // denominator is 100
   {
+    // NOTE: high_value has to have the property that the lowest 32 bits % 100
+    // is less than 100. If it's greater than 100 the test will pass whether or
+    // not the uint32 conversion is handled properly.
     uint64_t high_value = 1UL << 60;
     std::string high_value_str = std::to_string(high_value);
     loader->mergeValues({{"foo", high_value_str}});


### PR DESCRIPTION
This helper can be used to generate a binary decision from a
FractionalPercent and a random value. This simplifies some code in the
runtime library and also makes it easier to work with FractionalPercent
that are not part of a RuntimeFractionalPercent.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

*Description*: Add helper for FractionalPercent proto to ProtobufPercentHelper, and use it from runtime_impl.cc
*Risk Level*: low
*Testing*: unit tests
*Docs Changes*: N/A

