### PR TITLE
hc filter: treat degraded hosts as healthy in non-passthrough mode

### DIFF
--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -32,7 +32,7 @@ message HealthCheck {
 
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
-  // must be healthy in order for the filter to return a 200.
+  // must be healthy or degraded in order for the filter to return a 200.
   map<string, envoy.type.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -91,9 +91,10 @@ operation:
   Envoy will respond with a 200 or a 503 depending on the current draining state of the server.
 * **No pass through, computed from upstream cluster health**: In this mode, the health checking
   filter will return a 200 or a 503 depending on whether at least a :ref:`specified percentage
-  <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` of the
-  servers are available in one or more upstream clusters. (If the Envoy server is in a draining
-  state, though, it will respond with a 503 regardless of the upstream cluster health.)
+  <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>`
+  of the servers are available (healthy + degraded) in one or more upstream clusters. (If the Envoy
+  server is in a draining state, though, it will respond with a 503 regardless of the upstream
+  cluster health.)
 * **Pass through**: In this mode, Envoy will pass every health check request to the local service.
   The service is expected to return a 200 or a 503 depending on its health state.
 * **Pass through with caching**: In this mode, Envoy will pass health check requests to the local

--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -92,7 +92,7 @@ operation:
 * **No pass through, computed from upstream cluster health**: In this mode, the health checking
   filter will return a 200 or a 503 depending on whether at least a :ref:`specified percentage
   <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` of the
-  servers are healthy in one or more upstream clusters. (If the Envoy server is in a draining
+  servers are available in one or more upstream clusters. (If the Envoy server is in a draining
   state, though, it will respond with a 503 regardless of the upstream cluster health.)
 * **Pass through**: In this mode, Envoy will pass every health check request to the local service.
   The service is expected to return a 200 or a 503 depending on its health state.

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -132,10 +132,11 @@ void HealthCheckFilter::onComplete() {
           }
         }
         // In the general case, consider the service unhealthy if fewer than the
-        // specified percentage of the servers in the cluster are healthy.
+        // specified percentage of the servers in the cluster are available.
         // TODO(brian-pane) switch to purely integer-based math here, because the
         //                  int-to-float conversions and floating point division are slow.
-        if (stats.membership_healthy_.value() < membership_total * min_healthy_percentage / 100.0) {
+        if ((stats.membership_healthy_.value() + stats.membership_degraded_.value()) <
+            membership_total * min_healthy_percentage / 100.0) {
           final_status = Http::Code::ServiceUnavailable;
           break;
         }

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -132,7 +132,7 @@ void HealthCheckFilter::onComplete() {
           }
         }
         // In the general case, consider the service unhealthy if fewer than the
-        // specified percentage of the servers in the cluster are available.
+        // specified percentage of the servers in the cluster are available (healthy + degraded).
         // TODO(brian-pane) switch to purely integer-based math here, because the
         //                  int-to-float conversions and floating point division are slow.
         if ((stats.membership_healthy_.value() + stats.membership_degraded_.value()) <

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -67,9 +67,11 @@ public:
 
   class MockHealthCheckCluster : public NiceMock<Upstream::MockThreadLocalCluster> {
   public:
-    MockHealthCheckCluster(uint64_t membership_total, uint64_t membership_healthy) {
+    MockHealthCheckCluster(uint64_t membership_total, uint64_t membership_healthy,
+                           uint64_t membership_degraded = 0) {
       info()->stats().membership_total_.set(membership_total);
       info()->stats().membership_healthy_.set(membership_healthy);
+      info()->stats().membership_degraded_.set(membership_degraded);
     }
   };
 };
@@ -180,6 +182,20 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     Http::TestHeaderMapImpl health_check_response{{":status", "200"}};
     MockHealthCheckCluster cluster_www1(0, 0);
     MockHealthCheckCluster cluster_www2(1000, 0);
+    EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(false));
+    EXPECT_CALL(context_, clusterManager());
+    EXPECT_CALL(context_.cluster_manager_, get("www1")).WillRepeatedly(Return(&cluster_www1));
+    EXPECT_CALL(context_.cluster_manager_, get("www2")).WillRepeatedly(Return(&cluster_www2));
+    EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
+    EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+              filter_->decodeHeaders(request_headers_, true));
+  }
+  {
+    // This should succeed, because each cluster has degraded + healthy hosts greater than the
+    // threshold.
+    Http::TestHeaderMapImpl health_check_response{{":status", "200"}};
+    MockHealthCheckCluster cluster_www1(100, 40, 20);
+    MockHealthCheckCluster cluster_www2(1000, 0, 800);
     EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(false));
     EXPECT_CALL(context_, clusterManager());
     EXPECT_CALL(context_.cluster_manager_, get("www1")).WillRepeatedly(Return(&cluster_www1));


### PR DESCRIPTION
Updates the health check filter to treat degraded hosts as healthy for
the purpose of computing the "health" of each cluster. This captures the
idea that these hosts are still available for routing: if the upstream
cluster is fully degraded it's still available, so there shouldn't be a
need for Envoy to declare itself unhealthy.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, small change to behavior
*Testing*: Added UT
*Docs Changes*: Updated filter docs + proto
*Release Notes*: n/a
