### PR TITLE
python: use items instead of iteritems

### DIFF
--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -120,7 +120,7 @@ static_resources:
         address: collector-grpc.lightstep.com
         port_value: 443
     http2_protocol_options: {}
-  {% for service, options in clusters.iteritems() -%}
+  {% for service, options in clusters.items() -%}
   - {{ helper.internal_cluster_definition(service, options)|indent(2) }}
   {% endfor %}
 cluster_manager:

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -109,7 +109,7 @@ static_resources:
           route_config:
             name: local_route
             virtual_hosts:
-            {% for service, options in internal_virtual_hosts.iteritems() %}
+            {% for service, options in internal_virtual_hosts.items() %}
             - name: {{ service }}
               domains:
               - {{ service }}
@@ -281,7 +281,7 @@ static_resources:
               {% endif %}
   {% if (mongos_servers|length > 0) or (mongos_servers|length == 0 and not loop.last ) %}{% endif -%}
   {% endfor -%}
-  {% for key, value in mongos_servers.iteritems() -%}
+  {% for key, value in mongos_servers.items() -%}
   - name : "{{ value['address'] }}"
     address:
       socket_address:
@@ -310,7 +310,7 @@ static_resources:
       {% endif %}
   {% endfor -%}
   clusters:
-  {% for service, options in internal_virtual_hosts.iteritems() -%}
+  {% for service, options in internal_virtual_hosts.items() -%}
   - {{ helper.internal_cluster_definition(service, options)|indent(2)}}
   {% endfor -%}
   {% for mapping in external_virtual_hosts -%}
@@ -341,7 +341,7 @@ static_resources:
         protocol: {{ host['protocol'] }}
   {% endfor -%}
   {% endfor -%}
-  {% for key, value in mongos_servers.iteritems() -%}
+  {% for key, value in mongos_servers.items() -%}
   - name: mongo_{{ key }}
     connect_timeout: 0.25s
     type: STRICT_DNS

--- a/tools/gen_gdb_wrapper_script.py
+++ b/tools/gen_gdb_wrapper_script.py
@@ -17,7 +17,7 @@ GDB_RUNNER_SCRIPT = string.Template("""#!/usr/bin/env python
 import os
 
 env = ${b64env}
-for k, v in env.iteritems():
+for k, v in env.items():
   os.environ[k] = v
 
 os.system("${gdb} --fullname --args ${test_args}")


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
s/iteritems/items/ for Jinja2 templates and Python scripts. Those aren't performance critical, though items work both in Python 2 and 3. This helps build and test in systems where /usr/bin/python is Python 3 (e.g. Arch Linux). 

*Risk Level*: Low
*Testing*: CI
*Docs Changes*:
*Release Notes*: