### PR TITLE
test: clean up the quiche references to TestBase.

### DIFF
--- a/test/extensions/quic_listeners/quiche/dummy_test.cc
+++ b/test/extensions/quic_listeners/quiche/dummy_test.cc
@@ -1,7 +1,6 @@
 #include "extensions/quic_listeners/quiche/dummy.h"
 
-#include "test/test_common/test_base.h"
-
+#include "gtest/gtest.h"
 #include "quiche/http2/platform/api/http2_string.h"
 
 namespace Envoy {

--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
@@ -1,7 +1,6 @@
 #include <memory>
 
-#include "test/test_common/test_base.h"
-
+#include "gtest/gtest.h"
 #include "quiche/http2/platform/api/http2_arraysize.h"
 #include "quiche/http2/platform/api/http2_containers.h"
 #include "quiche/http2/platform/api/http2_estimate_memory_usage.h"

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -1,8 +1,8 @@
 #include "test/extensions/transport_sockets/tls/ssl_test_utility.h"
 #include "test/test_common/logging.h"
-#include "test/test_common/test_base.h"
 
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "quiche/quic/platform/api/quic_aligned.h"
 #include "quiche/quic/platform/api/quic_arraysize.h"
 #include "quiche/quic/platform/api/quic_cert_utils.h"

--- a/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
@@ -1,7 +1,6 @@
 #include <functional>
 
-#include "test/test_common/test_base.h"
-
+#include "gtest/gtest.h"
 #include "quiche/spdy/platform/api/spdy_arraysize.h"
 #include "quiche/spdy/platform/api/spdy_containers.h"
 #include "quiche/spdy/platform/api/spdy_endianness_util.h"


### PR DESCRIPTION
*Description*: Follow-up to #5936 which removes no-longer-needed TestBase. I had pulled the quiche changes out of that PR in a vain attempt to get clang-tidy to pass.
*Risk Level*: low
*Testing*: test/extensions/quic_listeners/...
*Docs Changes*: n/a
*Release Notes*: n/a

