### PR TITLE
Alphabetically sorted modules import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,9 @@
 # serve to show the default.
 
 from datetime import datetime
+import os
 import sphinx_rtd_theme
 import sys
-import os
 
 
 def setup(app):


### PR DESCRIPTION
Modules which are imported to python are sorted alphabetically are
quicker to read and searchable.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
