### PR TITLE
Remove the redundant words in docs

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -287,7 +287,7 @@ The following command operators are supported:
 %DYNAMIC_METADATA(NAMESPACE:KEY*):Z%
   HTTP
     :ref:`Dynamic Metadata <envoy_api_msg_core.Metadata>` info,
-    where NAMESPACE is the the filter namespace used when setting the metadata, KEY is an optional
+    where NAMESPACE is the filter namespace used when setting the metadata, KEY is an optional
     lookup up key in the namespace with the option of specifying nested keys separated by ':',
     and Z is an optional parameter denoting string truncation up to Z characters long. Dynamic Metadata
     can be set by filters using the :repo:`StreamInfo <include/envoy/stream_info/stream_info.h>` API:

--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -74,7 +74,7 @@ more details on the supported API.
 
   -- Called on the response path.
   function envoy_on_response(response_handle)
-    -- Wait for the entire response body and a response header with the the body size.
+    -- Wait for the entire response body and a response header with the body size.
     response_handle:headers():add("response_body_size", response_handle:body():length())
     -- Remove a response header named 'foo'
     response_handle:headers():remove("foo")

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -619,7 +619,7 @@ likely to be at least partially implemented in Envoy but may have wire format
 breaking changes made prior to freezing.
 
 Protos tagged *experimental*, have the same caveats as draft protos
-and may have have major changes made prior to Envoy implementation and freezing.
+and may have major changes made prior to Envoy implementation and freezing.
 
 The current open v2 API issues are tracked `here
 <https://github.com/envoyproxy/envoy/issues?q=is%3Aopen+is%3Aissue+label%3A%22v2+API%22>`_.

--- a/docs/root/intro/arch_overview/ip_transparency.rst
+++ b/docs/root/intro/arch_overview/ip_transparency.rst
@@ -13,7 +13,7 @@ connection will be different from that of any proxied connections.
 Sometimes the upstream server or network may need to know the original IP address of the connection,
 called the *downstream remote address*, for many reasons. Some examples include:
 
-* the the IP address being used to form part of an identity,
+* the IP address being used to form part of an identity,
 * the IP address being used to enforce network policy, or
 * the IP address being included in an audit.
 


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading docs.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

*Description*: Remove duplicated words in docs
*Risk Level*: LOW
*Testing*: N/A
*Docs Changes*: YES
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
