### PR TITLE
test: fix reference to missing class

### DIFF
--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -12,7 +12,7 @@ public:
   IntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), realTime()) {}
 };
 
-class UpstreamEndpointIntegrationTest : public TestBaseWithParam<Network::Address::IpVersion>,
+class UpstreamEndpointIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                         public HttpIntegrationTest {
 public:
   UpstreamEndpointIntegrationTest()


### PR DESCRIPTION
Fixes a bag logical merge that references an old class.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
