### PR TITLE
init: make debugging InitManagerImpl less insane.

### DIFF
--- a/include/envoy/init/init.h
+++ b/include/envoy/init/init.h
@@ -4,6 +4,8 @@
 
 #include "envoy/common/pure.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Init {
 
@@ -32,8 +34,10 @@ public:
   /**
    * Register a target to be initialized in the future. The manager will call initialize() on each
    * target at some point in the future. It is an error to register the same target more than once.
+   * @param target the Target to initialize.
+   * @param description a human-readable description of target used for logging and debugging.
    */
-  virtual void registerTarget(Target& target) PURE;
+  virtual void registerTarget(Target& target, absl::string_view description) PURE;
 
   enum class State {
     /**

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -36,6 +36,7 @@ namespace Logger {
   FUNCTION(http)                 \
   FUNCTION(http2)                \
   FUNCTION(hystrix)              \
+  FUNCTION(init)                 \
   FUNCTION(lua)                  \
   FUNCTION(main)                 \
   FUNCTION(misc)                 \

--- a/source/common/config/config_provider_impl.h
+++ b/source/common/config/config_provider_impl.h
@@ -211,7 +211,9 @@ protected:
   void runInitializeCallbackIfAny();
 
 private:
-  void registerInitTarget(Init::Manager& init_manager) { init_manager.registerTarget(*this); }
+  void registerInitTarget(Init::Manager& init_manager) {
+    init_manager.registerTarget(*this, fmt::format("ConfigSubscriptionInstanceBase {}", name_));
+  }
 
   void bindConfigProvider(MutableConfigProviderImplBase* provider);
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -129,7 +129,8 @@ void RdsRouteConfigSubscription::onConfigUpdateFailed(const EnvoyException*) {
 }
 
 void RdsRouteConfigSubscription::registerInitTarget(Init::Manager& init_manager) {
-  init_manager.registerTarget(*this);
+  init_manager.registerTarget(*this,
+                              fmt::format("RdsRouteConfigSubscription {}", route_config_name_));
 }
 
 void RdsRouteConfigSubscription::runInitializeCallbackIfAny() {

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -25,7 +25,7 @@ SdsApi::SdsApi(const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispat
   // can be chained together to behave as one init_manager. In that way, we let
   // two listeners which share same SdsApi to register at separate init managers, and
   // each init manager has a chance to initialize its targets.
-  init_manager.registerTarget(*this);
+  init_manager.registerTarget(*this, fmt::format("SdsApi {}", sds_config_name));
 }
 
 void SdsApi::initialize(std::function<void()> callback) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -679,7 +679,7 @@ ClusterImplBase::ClusterImplBase(
     const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api)
-    : runtime_(runtime) {
+    : runtime_(runtime), init_manager_(fmt::format("Cluster {}", cluster.name())) {
   factory_context.setInitManager(init_manager_);
   auto socket_factory = createTransportSocketFactory(cluster, factory_context);
   info_ = std::make_unique<ClusterInfoImpl>(cluster, factory_context.clusterManager().bindConfig(),

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -145,6 +145,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/init:init_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
     ],
 )
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -153,7 +153,7 @@ private:
   LocalInfo::LocalInfoPtr local_info_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::unique_ptr<Upstream::ValidationClusterManagerFactory> cluster_manager_factory_;
-  InitManagerImpl init_manager_;
+  InitManagerImpl init_manager_{"Validation server"};
   // secret_manager_ must come before listener_manager_, since there may be active filter chains
   // referencing it, so need to destruct these first.
   std::unique_ptr<Secret::SecretManager> secret_manager_;

--- a/source/server/init_manager_impl.cc
+++ b/source/server/init_manager_impl.cc
@@ -4,45 +4,61 @@
 
 #include "common/common/assert.h"
 
+#define TRACE_INIT_MANAGER(fmt, ...)                                                               \
+  ENVOY_LOG(debug, "InitManagerImpl({}): " fmt, description_, ##__VA_ARGS__)
+
 namespace Envoy {
 namespace Server {
+
+InitManagerImpl::InitManagerImpl(absl::string_view description) : description_(description) {
+  TRACE_INIT_MANAGER("constructor");
+}
+
+InitManagerImpl::~InitManagerImpl() { TRACE_INIT_MANAGER("destructor"); }
 
 void InitManagerImpl::initialize(std::function<void()> callback) {
   ASSERT(state_ == State::NotInitialized);
   if (targets_.empty()) {
+    TRACE_INIT_MANAGER("empty targets, initialized");
     callback();
     state_ = State::Initialized;
   } else {
+    TRACE_INIT_MANAGER("initializing");
     callback_ = callback;
     state_ = State::Initializing;
     // Target::initialize(...) method can modify the list to remove the item currently
     // being initialized, so we increment the iterator before calling initialize.
     for (auto iter = targets_.begin(); iter != targets_.end();) {
-      Init::Target* target = *iter;
+      TargetWithDescription& target = *iter;
       ++iter;
-      initializeTarget(*target);
+      initializeTarget(target);
     }
   }
 }
 
-void InitManagerImpl::initializeTarget(Init::Target& target) {
-  target.initialize([this, &target]() -> void {
-    ASSERT(std::find(targets_.begin(), targets_.end(), &target) != targets_.end());
-    targets_.remove(&target);
+void InitManagerImpl::initializeTarget(TargetWithDescription& target) {
+  TRACE_INIT_MANAGER("invoking initializeTarget {}", target.second);
+  target.first->initialize([this, &target]() -> void {
+    TRACE_INIT_MANAGER("completed initializeTarget {}", target.second);
+    ASSERT(std::find(targets_.begin(), targets_.end(), target) != targets_.end());
+    targets_.remove(target);
     if (targets_.empty()) {
+      TRACE_INIT_MANAGER("initialized");
       state_ = State::Initialized;
       callback_();
     }
   });
 }
 
-void InitManagerImpl::registerTarget(Init::Target& target) {
+void InitManagerImpl::registerTarget(Init::Target& target, absl::string_view description) {
+  TRACE_INIT_MANAGER("registerTarget {}", description);
   ASSERT(state_ != State::Initialized);
-  ASSERT(std::find(targets_.begin(), targets_.end(), &target) == targets_.end(),
+  ASSERT(std::find(targets_.begin(), targets_.end(), TargetWithDescription{&target, description}) ==
+             targets_.end(),
          "Registered duplicate Init::Target");
-  targets_.push_back(&target);
+  targets_.emplace_back(&target, description);
   if (state_ == State::Initializing) {
-    initializeTarget(target);
+    initializeTarget(targets_.back());
   }
 }
 

--- a/source/server/init_manager_impl.h
+++ b/source/server/init_manager_impl.h
@@ -4,6 +4,8 @@
 
 #include "envoy/init/init.h"
 
+#include "common/common/logger.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -11,20 +13,26 @@ namespace Server {
  * Implementation of Init::Manager for use during post cluster manager init / pre listening.
  * TODO(JimmyCYJ): Move InitManagerImpl into a new subdirectory in source/ called init/.
  */
-class InitManagerImpl : public Init::Manager {
+class InitManagerImpl : public Init::Manager, Logger::Loggable<Logger::Id::init> {
 public:
+  InitManagerImpl(absl::string_view description);
+  ~InitManagerImpl() override;
+
   void initialize(std::function<void()> callback);
 
   // Init::Manager
-  void registerTarget(Init::Target& target) override;
+  void registerTarget(Init::Target& target, absl::string_view description) override;
   State state() const override { return state_; }
 
 private:
-  void initializeTarget(Init::Target& target);
+  using TargetWithDescription = std::pair<Init::Target*, std::string>;
 
-  std::list<Init::Target*> targets_;
+  void initializeTarget(TargetWithDescription& target);
+
+  std::list<TargetWithDescription> targets_;
   State state_{State::NotInitialized};
   std::function<void()> callback_;
+  std::string description_; // For debug tracing.
 };
 
 } // namespace Server

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -27,7 +27,7 @@ LdsApiImpl::LdsApiImpl(const envoy::api::v2::core::ConfigSource& lds_config,
           "envoy.api.v2.ListenerDiscoveryService.FetchListeners",
           "envoy.api.v2.ListenerDiscoveryService.StreamListeners", api);
   Config::Utility::checkLocalInfo("lds", local_info);
-  init_manager.registerTarget(*this);
+  init_manager.registerTarget(*this, "LDS");
 }
 
 void LdsApiImpl::initialize(std::function<void()> callback) {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -167,6 +167,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       listener_tag_(parent_.factory_.nextListenerTag()), name_(name), modifiable_(modifiable),
       workers_started_(workers_started), hash_(hash),
+      dynamic_init_manager_(fmt::format("Listener {}", name)),
       local_drain_manager_(parent.factory_.createDrainManager(config.drain_type())),
       config_(config), version_info_(version_info),
       listener_filters_timeout_(

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -231,7 +231,7 @@ private:
   DrainManagerPtr drain_manager_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::unique_ptr<Upstream::ClusterManagerFactory> cluster_manager_factory_;
-  InitManagerImpl init_manager_;
+  InitManagerImpl init_manager_{"Server"};
   std::unique_ptr<Server::GuardDog> guard_dog_;
   bool terminated_;
   std::unique_ptr<Logger::FileSinkDelegate> file_logger_;

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -112,7 +112,7 @@ public:
     EXPECT_CALL(cluster, info());
     EXPECT_CALL(*cluster.info_, type());
     interval_timer_ = new Event::MockTimer(&factory_context_.dispatcher_);
-    EXPECT_CALL(factory_context_.init_manager_, registerTarget(_));
+    EXPECT_CALL(factory_context_.init_manager_, registerTarget(_, _));
     rds_ =
         RouteConfigProviderUtil::create(parseHttpConnectionManagerFromJson(config_json, scope_),
                                         factory_context_, "foo.", *route_config_provider_manager_);

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -39,7 +39,7 @@ TEST_F(SdsApiTest, BasicTest) {
   const envoy::service::discovery::v2::SdsDummy dummy;
   NiceMock<Server::MockInstance> server;
   NiceMock<Init::MockManager> init_manager;
-  EXPECT_CALL(init_manager, registerTarget(_));
+  EXPECT_CALL(init_manager, registerTarget(_, _));
 
   envoy::api::v2::core::ConfigSource config_source;
   config_source.mutable_api_config_source()->set_api_type(

--- a/test/mocks/init/mocks.cc
+++ b/test/mocks/init/mocks.cc
@@ -22,9 +22,9 @@ MockTarget::MockTarget() {
 MockTarget::~MockTarget() {}
 
 MockManager::MockManager() {
-  ON_CALL(*this, registerTarget(_)).WillByDefault(Invoke([this](Target& target) -> void {
-    targets_.push_back(&target);
-  }));
+  ON_CALL(*this, registerTarget(_, _))
+      .WillByDefault(Invoke(
+          [this](Target& target, absl::string_view) -> void { targets_.push_back(&target); }));
 }
 
 MockManager::~MockManager() {}

--- a/test/mocks/init/mocks.h
+++ b/test/mocks/init/mocks.h
@@ -34,7 +34,7 @@ public:
   }
 
   // Init::Manager
-  MOCK_METHOD1(registerTarget, void(Target& target));
+  MOCK_METHOD2(registerTarget, void(Target& target, absl::string_view description));
   MOCK_CONST_METHOD0(state, State());
 
   std::list<Target*> targets_;

--- a/test/server/init_manager_impl_test.cc
+++ b/test/server/init_manager_impl_test.cc
@@ -14,7 +14,7 @@ namespace Server {
 
 class InitManagerImplTest : public testing::Test {
 public:
-  InitManagerImpl manager_;
+  InitManagerImpl manager_{"test"};
   ReadyWatcher initialized_;
 };
 
@@ -27,7 +27,7 @@ TEST_F(InitManagerImplTest, Targets) {
   InSequence s;
   Init::MockTarget target;
 
-  manager_.registerTarget(target);
+  manager_.registerTarget(target, "");
   EXPECT_CALL(target, initialize(_));
   manager_.initialize([&]() -> void { initialized_.ready(); });
   EXPECT_CALL(initialized_, ready());
@@ -38,7 +38,7 @@ TEST_F(InitManagerImplTest, TargetRemoveWhileInitializing) {
   InSequence s;
   Init::MockTarget target;
 
-  manager_.registerTarget(target);
+  manager_.registerTarget(target, "");
   EXPECT_CALL(target, initialize(_)).WillOnce(Invoke([](std::function<void()> callback) -> void {
     callback();
   }));
@@ -51,12 +51,12 @@ TEST_F(InitManagerImplTest, TargetAfterInitializing) {
   Init::MockTarget target1;
   Init::MockTarget target2;
 
-  manager_.registerTarget(target1);
+  manager_.registerTarget(target1, "");
   EXPECT_CALL(target1, initialize(_));
   manager_.initialize([&]() -> void { initialized_.ready(); });
 
   EXPECT_CALL(target2, initialize(_));
-  manager_.registerTarget(target2);
+  manager_.registerTarget(target2, "");
 
   target2.callback_();
   EXPECT_CALL(initialized_, ready());

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -49,7 +49,7 @@ public:
     EXPECT_CALL(cluster, info());
     EXPECT_CALL(*cluster.info_, type());
     interval_timer_ = new Event::MockTimer(&dispatcher_);
-    EXPECT_CALL(init_, registerTarget(_));
+    EXPECT_CALL(init_, registerTarget(_, _));
     lds_ = std::make_unique<LdsApiImpl>(lds_config, cluster_manager_, dispatcher_, random_, init_,
                                         local_info_, store_, listener_manager_, *api_);
 

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -84,7 +84,7 @@ protected:
               std::shared_ptr<ListenerHandle> notifier(raw_listener);
               raw_listener->context_ = &context;
               if (need_init) {
-                context.initManager().registerTarget(notifier->target_);
+                context.initManager().registerTarget(notifier->target_, "");
               }
               return {[notifier](Network::FilterManager&) -> void {}};
             }));

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -78,7 +78,7 @@ public:
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
   NiceMock<MockOverloadManager> overload_manager_;
-  InitManagerImpl init_manager_;
+  InitManagerImpl init_manager_{""};
   ReadyWatcher start_workers_;
   std::unique_ptr<RunHelper> helper_;
   std::function<void()> cm_init_callback_;
@@ -104,7 +104,7 @@ TEST_F(RunHelperTest, ShutdownBeforeCmInitialize) {
 TEST_F(RunHelperTest, ShutdownBeforeInitManagerInit) {
   EXPECT_CALL(start_workers_, ready()).Times(0);
   Init::MockTarget target;
-  init_manager_.registerTarget(target);
+  init_manager_.registerTarget(target, "");
   EXPECT_CALL(target, initialize(_));
   cm_init_callback_();
   sigterm_->callback_();


### PR DESCRIPTION
InitManagerImpl is prone to subtle destruction ordering and resource dependency issues, since its
callback and continuation passing style creates action-at-a-distance. This in turn is hard to debug,
since it's hard to reconstruct a narrative for when callbacks are invoked and their respective
continuations occur.

This PR adds very explicit tracing support to provide this view when running at -l trace. There is a
bunch of debug-only code that gets included in prod, but because InitManagerImpl is not performance
sensitive, this seems a reasonable tradeoff.

Risk level: Low
Testing: I've been using these traces to hunt down a heap-use-after-free issue in the config validation
  server.

Signed-off-by: Harvey Tuch <htuch@google.com>