### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -50,20 +50,20 @@ message Http1ProtocolOptions {
 }
 
 message Http2ProtocolOptions {
-  // `Maximum table size <http://httpwg.org/specs/rfc7541.html#rfc.section.4.2>`_
+  // `Maximum table size <https://httpwg.org/specs/rfc7541.html#rfc.section.4.2>`_
   // (in octets) that the encoder is permitted to use for the dynamic HPACK table. Valid values
   // range from 0 to 4294967295 (2^32 - 1) and defaults to 4096. 0 effectively disables header
   // compression.
   google.protobuf.UInt32Value hpack_table_size = 1;
 
-  // `Maximum concurrent streams <http://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
+  // `Maximum concurrent streams <https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
   // allowed for peer on one HTTP/2 connection. Valid values range from 1 to 2147483647 (2^31 - 1)
   // and defaults to 2147483647.
   google.protobuf.UInt32Value max_concurrent_streams = 2
       [(validate.rules).uint32 = {gte: 1, lte: 2147483647}];
 
   // `Initial stream-level flow-control window
-  // <http://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
+  // <https://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
   // (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum) and defaults to 268435456
   // (256 * 1024 * 1024).
   //

--- a/source/docs/h2_metadata.md
+++ b/source/docs/h2_metadata.md
@@ -114,7 +114,7 @@ The METADATA frame uses a standard frame header, as described in the
 [HTTP/2 spec](https://httpwg.github.io/specs/rfc7540.html#FrameHeader.)
 The payload of the METADATA frame is a block of key-value pairs encoded using the [HPACK Literal
 Header Field Never Indexed representation](
-http://httpwg.org/specs/rfc7541.html#literal.header.never.indexed). Each
+https://httpwg.org/specs/rfc7541.html#literal.header.never.indexed). Each
 key-value pair represents one piece of metadata.
 
 The METADATA frame defines the following flags:


### PR DESCRIPTION
Currently, when we access **httpwg.org** with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **http://httpwg.org** by **https://httpwg.org** for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Change HTTP links to HTTPS links
*Risk Level*: LOW
*Testing*: N/A
*Docs Changes*: YES
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
