### PR TITLE
listener_manager: detect and reject effectively equivalent filter cha…

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -417,6 +417,15 @@ void ListenerImpl::addFilterChainForSourceTypes(
     SourceTypesArray& source_types_array,
     const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
     const Network::FilterChainSharedPtr& filter_chain) {
+  if (source_types_array[source_type] != nullptr) {
+    // We should never get here once all fields in FilterChainMatch are implemented. At this point,
+    // this can become an ASSERT. In principle, we could verify the various missing fields earlier,
+    // but best to have defense-in-depth here, since any mistake leads to potential
+    // heap-use-after-free when filter chains are unexpectedly destructed.
+    throw EnvoyException(fmt::format("error adding listener '{}': multiple filter chains with "
+                                     "effectively equivalent matching rules are defined",
+                                     address_->asString()));
+  }
   source_types_array[source_type] = filter_chain;
 }
 

--- a/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-5664687524413440
+++ b/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-5664687524413440
@@ -1,0 +1,217 @@
+node {
+  id: ","
+  cluster: "0"
+  locality {
+    zone: "0"
+    sub_zone: "0"
+  }
+}
+static_resources {
+  listeners {
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        source_prefix_ranges {
+          address_prefix: "\177"
+        }
+        transport_protocol: "\177"
+      }
+    }
+    tcp_fast_open_queue_length {
+      value: 99
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+    }
+    tcp_fast_open_queue_length {
+      value: 99
+    }
+  }
+  listeners {
+    name: "listener_0"
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+      tls_context {
+        common_tls_context {
+          tls_params {
+            tls_minimum_protocol_version: TLSv1_2
+            tls_maximum_protocol_version: TLSv1_2
+          }
+          tls_certificate_sds_secret_configs {
+            sds_config {
+              api_config_source {
+                api_type: REST
+                grpc_services {
+                  google_grpc {
+                    target_uri: "name"
+                    stat_prefix: ":"
+                  }
+                }
+              }
+            }
+          }
+        }
+        require_client_certificate {
+        }
+        require_sni {
+        }
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        source_prefix_ranges {
+          address_prefix: "\177"
+        }
+      }
+    }
+    transparent {
+      value: true
+    }
+    listener_filters_timeout {
+      nanos: 1024
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        source_prefix_ranges {
+          address_prefix: "\177"
+        }
+      }
+      tls_context {
+        common_tls_context {
+          tls_params {
+            tls_minimum_protocol_version: TLSv1_2
+            tls_maximum_protocol_version: TLSv1_2
+          }
+          tls_certificate_sds_secret_configs {
+            name: "\177"
+            sds_config {
+              api_config_source {
+                api_type: REST
+                grpc_services {
+                  google_grpc {
+                    target_uri: "name"
+                    stat_prefix: ":"
+                  }
+                }
+              }
+            }
+          }
+        }
+        require_client_certificate {
+        }
+        require_sni {
+        }
+      }
+    }
+    tcp_fast_open_queue_length {
+      value: 99
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        source_prefix_ranges {
+          address_prefix: "\177"
+        }
+      }
+      tls_context {
+        common_tls_context {
+          tls_params {
+            tls_minimum_protocol_version: TLSv1_2
+            tls_maximum_protocol_version: TLSv1_2
+          }
+          tls_certificate_sds_secret_configs {
+            name: "\177"
+            sds_config {
+              api_config_source {
+                api_type: REST
+                grpc_services {
+                  google_grpc {
+                    target_uri: "name"
+                    stat_prefix: ":"
+                  }
+                }
+              }
+            }
+          }
+        }
+        require_client_certificate {
+        }
+        require_sni {
+        }
+      }
+    }
+    tcp_fast_open_queue_length {
+      value: 99
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        source_prefix_ranges {
+          address_prefix: "\177"
+        }
+      }
+    }
+    tcp_fast_open_queue_length {
+      value: 99
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "name"
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        source_prefix_ranges {
+          address_prefix: "\177"
+        }
+      }
+    }
+    tcp_fast_open_queue_length {
+      value: 99
+    }
+  }
+}
+flags_path: " "


### PR DESCRIPTION
…ins.

Previously, it was possible to have two filter chains that didn't have proto equivalent
FilterChainMatches, yet had semantically equivalent matchers. E.g. when one filter chain has a
not-yet-implemented field. This led to a situation where the first filter chain might register for
SDS (and corresponding initialization callbacks), then the second equivalent filter chain would
replace it, freeing up the callback target. When SDS initialized, the stale callback would be
invoked, resulting in heap-user-after-free.

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13221.

Risk level: Low
Testing: Corpus entry and unit test added.

Signed-off-by: Harvey Tuch <htuch@google.com>