### PR TITLE
config_validation/server: fix initialization order redux.

### DIFF
--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -139,10 +139,12 @@ private:
   void initialize(const Options& options, Network::Address::InstanceConstSharedPtr local_address,
                   ComponentFactory& component_factory);
 
-  // init_manager_ must come before any member that participates in initialization, since
-  // initialization continuation can potentially occur at any point during member lifetime.
+  // init_manager_ must come before any member that participates in initialization, and destructed
+  // only after referencing members are gone, since initialization continuation can potentially
+  // occur at any point during member lifetime.
   InitManagerImpl init_manager_;
-  // secret_manager_ must come before listener_manager_, config_ and dispatcher_, since:
+  // secret_manager_ must come before listener_manager_, config_ and dispatcher_, and destructed
+  // only after these members can no longer reference it, since:
   // - There may be active filter chains referencing it in listener_manager_.
   // - There may be active clusters referencing it in config_.cluster_manager_.
   // - There may be active connections referencing it.

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -139,6 +139,14 @@ private:
   void initialize(const Options& options, Network::Address::InstanceConstSharedPtr local_address,
                   ComponentFactory& component_factory);
 
+  // init_manager_ must come before any member that participates in initialization, since
+  // initialization continuation can potentially occur at any point during member lifetime.
+  InitManagerImpl init_manager_;
+  // secret_manager_ must come before listener_manager_, config_ and dispatcher_, since:
+  // - There may be active filter chains referencing it in listener_manager_.
+  // - There may be active clusters referencing it in config_.cluster_manager_.
+  // - There may be active connections referencing it.
+  std::unique_ptr<Secret::SecretManager> secret_manager_;
   const Options& options_;
   Stats::IsolatedStoreImpl& stats_store_;
   ThreadLocal::InstanceImpl thread_local_;
@@ -153,10 +161,6 @@ private:
   LocalInfo::LocalInfoPtr local_info_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::unique_ptr<Upstream::ValidationClusterManagerFactory> cluster_manager_factory_;
-  InitManagerImpl init_manager_;
-  // secret_manager_ must come before listener_manager_, since there may be active filter chains
-  // referencing it, so need to destruct these first.
-  std::unique_ptr<Secret::SecretManager> secret_manager_;
   std::unique_ptr<ListenerManagerImpl> listener_manager_;
   std::unique_ptr<OverloadManager> overload_manager_;
   MutexTracer* mutex_tracer_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -52,11 +52,11 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
                            ComponentFactory& component_factory,
                            Runtime::RandomGeneratorPtr&& random_generator,
                            ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory)
-    : shutdown_(false), options_(options), time_source_(time_system), restarter_(restarter),
+    : secret_manager_(std::make_unique<Secret::SecretManagerImpl>()), shutdown_(false),
+      options_(options), time_source_(time_system), restarter_(restarter),
       start_time_(time(nullptr)), original_start_time_(start_time_), stats_store_(store),
       thread_local_(tls),
       api_(new Api::Impl(options.fileFlushIntervalMsec(), thread_factory, store, time_system)),
-      secret_manager_(std::make_unique<Secret::SecretManagerImpl>()),
       dispatcher_(api_->allocateDispatcher()),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory().currentThreadId())),
       handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -200,10 +200,12 @@ private:
   void startWorkers();
   void terminate();
 
-  // init_manager_ must come before any member that participates in initialization, since
-  // initialization continuation can potentially occur at any point during member lifetime.
+  // init_manager_ must come before any member that participates in initialization, and destructed
+  // only after referencing members are gone, since initialization continuation can potentially
+  // occur at any point during member lifetime.
   InitManagerImpl init_manager_;
-  // secret_manager_ must come before listener_manager_, config_ and dispatcher_, since:
+  // secret_manager_ must come before listener_manager_, config_ and dispatcher_, and destructed
+  // only after these members can no longer reference it, since:
   // - There may be active filter chains referencing it in listener_manager_.
   // - There may be active clusters referencing it in config_.cluster_manager_.
   // - There may be active connections referencing it.

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5666128418832384
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5666128418832384
@@ -1,0 +1,323 @@
+node {   id: " "   cluster: "              "   build_version: " " } static_resources {   clusters {     name: "              "     type: STRICT_DNS     connect_timeout {       nanos:  82893184     }     per_connection_buffer_limit_bytes {       value: 268435456     }     lb_policy: RING_HASH     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: " "       }     }     tls_context {       common_tls_context {       }     }   }   clusters {     name: " "     connect_timeout {       seconds: 2304     }     lb_policy: RING_HASH     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: "             "       }     }     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: " "       }     }     hosts {       pipe {         path: " "
+      }
+    }
+    hosts {
+      pipe {
+        path: "2"
+      }
+    }
+    hosts {
+      pipe {
+        path: "s"
+      }
+    }
+    hosts {
+      pipe {
+        path: "4"
+      }
+    }
+    hosts {
+      pipe {
+        path: "5"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: "0"
+      }
+    }
+    hosts {
+      pipe {
+        path: "]"
+      }
+    }
+    hosts {
+      pipe {
+        path: "8"
+      }
+    }
+    hosts {
+      pipe {
+        path: "{"
+      }
+    }
+    hosts {
+      pipe {
+        path: "*"
+      }
+    }
+    hosts {
+      pipe {
+        path: "4"
+      }
+    }
+    hosts {
+      pipe {
+        path: " "
+      }
+    }
+    hosts {
+      pipe {
+        path: "{"
+      }
+    }
+    health_checks {
+      timeout {
+        seconds: 4294901763
+        nanos: 25
+      }
+      interval {
+        nanos: 25
+      }
+      unhealthy_threshold {
+        value: 268435456
+      }
+      healthy_threshold {
+        value: 655360
+      }
+      http_health_check {
+        path: ":"
+        service_name: "0"
+        use_http2: true
+      }
+      event_log_path: "c"
+    }
+    tls_context {
+      common_tls_context {
+        validation_context {
+        }
+        tls_certificate_sds_secret_configs {
+          sds_config {
+            path: "/"
+          }
+        }
+      }
+    }
+    alt_stat_name: "o"
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "tsy.googtati"
+  config {
+    fields {
+      key: "\177"
+      value {
+      }
+    }
+  }
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/googlalue"
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+  config {
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "["
+}
+stats_sinks {
+  typed_config {
+    type_url: "["
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "toogti"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "q"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "!"
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "2"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "2"
+}
+stats_sinks {
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "2"
+}
+stats_sinks {
+  name: "6"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}


### PR DESCRIPTION
Another heap-user-after-free, this time we were missing a fix that had been applied to server.h but
not config_validation/server.h (#4940). While working on this, attempted to make fully consistent and as
simple/clear as possible the constraints on member ordering.

This PR is in the tradition (!) of #5847, #4940, #4937. I think long-term we might want to think of
more dynamic and explicit declaration of ordering constraints, it's evidently pretty fragile. Also,
the lack of single-source-of-truth and duplication across prod and config server code bites again.

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13228.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>