### PR TITLE
lds: continue listener creation even after failures in between

### DIFF
--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -79,7 +79,7 @@ void LdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
       exception_msgs.push_back(fmt::format("{}: {}", listener_name, e.what()));
     }
   }
-  
+
   version_info_ = version_info;
   runInitializeCallbackIfAny();
   if (!exception_msgs.empty()) {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -76,13 +76,14 @@ void LdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
         ENVOY_LOG(debug, "lds: add/update listener '{}' skipped", listener_name);
       }
     } catch (const EnvoyException& e) {
-      exception_msgs.push_back(fmt::format("Error adding/updating listener {}: {}", listener_name, e.what()));
-  }
+      exception_msgs.push_back(fmt::format("{}: {}", listener_name, e.what()));
+    }
   }
   version_info_ = version_info;
   runInitializeCallbackIfAny();
-    if (!exception_msgs.empty()) {
-    throw EnvoyException(StringUtil::join(exception_msgs, "\n"));
+  if (!exception_msgs.empty()) {
+    throw EnvoyException(fmt::format("Error adding/updating listener(s) {}",
+                                     StringUtil::join(exception_msgs, ", ")));
   }
 }
 

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -38,6 +38,7 @@ void LdsApiImpl::initialize(std::function<void()> callback) {
 void LdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::string& version_info) {
   cm_.adsMux().pause(Config::TypeUrl::get().RouteConfiguration);
   Cleanup rds_resume([this] { cm_.adsMux().resume(Config::TypeUrl::get().RouteConfiguration); });
+  std::vector<std::string> exception_msgs;
   std::unordered_set<std::string> listener_names;
   for (const auto& listener : resources) {
     if (!listener_names.insert(listener.name()).second) {
@@ -75,13 +76,14 @@ void LdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
         ENVOY_LOG(debug, "lds: add/update listener '{}' skipped", listener_name);
       }
     } catch (const EnvoyException& e) {
-      throw EnvoyException(
-          fmt::format("Error adding/updating listener {}: {}", listener_name, e.what()));
-    }
+      exception_msgs.push_back(fmt::format("Error adding/updating listener {}: {}", listener_name, e.what()));
   }
-
+  }
   version_info_ = version_info;
   runInitializeCallbackIfAny();
+    if (!exception_msgs.empty()) {
+    throw EnvoyException(StringUtil::join(exception_msgs, "\n"));
+  }
 }
 
 void LdsApiImpl::onConfigUpdateFailed(const EnvoyException*) {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -79,6 +79,7 @@ void LdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
       exception_msgs.push_back(fmt::format("{}: {}", listener_name, e.what()));
     }
   }
+  
   version_info_ = version_info;
   runInitializeCallbackIfAny();
   if (!exception_msgs.empty()) {

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -198,6 +198,22 @@ TEST_F(LdsApiTest, MisconfiguredListenerNameIsPresentInException) {
   EXPECT_CALL(request_, cancel());
 }
 
+TEST_F(LdsApiTest, EmptyListenersUpdate) {
+  InSequence s;
+
+  setup();
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::Listener> listeners;
+  std::vector<std::reference_wrapper<Network::ListenerConfig>> existing_listeners;
+
+  EXPECT_CALL(listener_manager_, listeners()).WillOnce(Return(existing_listeners));
+
+  EXPECT_CALL(init_.initialized_, ready());
+  EXPECT_CALL(request_, cancel());
+
+  lds_->onConfigUpdate(listeners, "");
+}
+
 TEST_F(LdsApiTest, ListenerCreationContinuesEvenAfterException) {
   InSequence s;
 

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -107,6 +107,16 @@ public:
     EXPECT_CALL(listener_manager_, listeners()).WillOnce(Return(refs));
   }
 
+  void addListener(Protobuf::RepeatedPtrField<envoy::api::v2::Listener>& listeners,
+                   const std::string& listener_name) {
+    auto listener = listeners.Add();
+    listener->set_name(listener_name);
+    auto socket_address = listener->mutable_address()->mutable_socket_address();
+    socket_address->set_address(listener_name);
+    socket_address->set_port_value(1);
+    listener->add_filter_chains();
+  }
+
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
   Event::MockDispatcher dispatcher_;
   NiceMock<Runtime::MockRandomGenerator> random_;
@@ -180,9 +190,41 @@ TEST_F(LdsApiTest, MisconfiguredListenerNameIsPresentInException) {
 
   EXPECT_CALL(listener_manager_, addOrUpdateListener(_, _, true))
       .WillOnce(Throw(EnvoyException("something is wrong")));
+  EXPECT_CALL(init_.initialized_, ready());
+
+  EXPECT_THROW_WITH_MESSAGE(
+      lds_->onConfigUpdate(listeners, ""), EnvoyException,
+      "Error adding/updating listener(s) invalid-listener: something is wrong");
+  EXPECT_CALL(request_, cancel());
+}
+
+TEST_F(LdsApiTest, ListenerCreationContinuesEvenAfterException) {
+  InSequence s;
+
+  setup();
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::Listener> listeners;
+  std::vector<std::reference_wrapper<Network::ListenerConfig>> existing_listeners;
+
+  // Add 4 listeners - 2 valid and 2 invalid.
+  addListener(listeners, "valid-listener-1");
+  addListener(listeners, "invalid-listener-1");
+  addListener(listeners, "valid-listener-2");
+  addListener(listeners, "invalid-listener-2");
+
+  EXPECT_CALL(listener_manager_, listeners()).WillOnce(Return(existing_listeners));
+
+  EXPECT_CALL(listener_manager_, addOrUpdateListener(_, _, true))
+      .WillOnce(Return(true))
+      .WillOnce(Throw(EnvoyException("something is wrong")))
+      .WillOnce(Return(true))
+      .WillOnce(Throw(EnvoyException("something else is wrong")));
+
+  EXPECT_CALL(init_.initialized_, ready());
 
   EXPECT_THROW_WITH_MESSAGE(lds_->onConfigUpdate(listeners, ""), EnvoyException,
-                            "Error adding/updating listener invalid-listener: something is wrong");
+                            "Error adding/updating listener(s) invalid-listener-1: something is "
+                            "wrong, invalid-listener-2: something else is wrong");
   EXPECT_CALL(request_, cancel());
 }
 


### PR DESCRIPTION
*Description*: Continues listener creation even after listener creation fails for one of the listeners.
*Risk Level*: Low
*Testing*: Added automated tests
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #6010 
