### PR TITLE
Revert "build: use `configure_make` to build gperftools (#6007)"

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -174,7 +174,8 @@ def envoy_external_dep_path(dep):
 def tcmalloc_external_dep(repository):
     return select({
         repository + "//bazel:disable_tcmalloc": None,
-        "//conditions:default": envoy_external_dep_path("gperftools"),
+        repository + "//bazel:debug_tcmalloc": envoy_external_dep_path("tcmalloc_debug"),
+        "//conditions:default": envoy_external_dep_path("tcmalloc_and_profiler"),
     })
 
 # As above, but wrapped in list form for adding to dep lists. This smell seems needed as
@@ -183,7 +184,8 @@ def tcmalloc_external_dep(repository):
 def tcmalloc_external_deps(repository):
     return select({
         repository + "//bazel:disable_tcmalloc": [],
-        "//conditions:default": [envoy_external_dep_path("gperftools")],
+        repository + "//bazel:debug_tcmalloc": [envoy_external_dep_path("tcmalloc_debug")],
+        "//conditions:default": [envoy_external_dep_path("tcmalloc_and_profiler")],
     })
 
 # Transform the package path (e.g. include/envoy/common) into a path for

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -1,33 +1,8 @@
 licenses(["notice"])  # Apache 2
 
 load("//bazel:envoy_build_system.bzl", "envoy_cmake_external", "envoy_package")
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 envoy_package()
-
-configure_make(
-    name = "gperftools_build",
-    configure_options = [
-        "--enable-shared=no",
-        "--enable-frame-pointers",
-        "--disable-libunwind",
-    ],
-    lib_source = "@com_github_gperftools_gperftools//:all",
-    linkopts = ["-lpthread"],
-    make_commands = ["make install-libLTLIBRARIES install-perftoolsincludeHEADERS"],
-    static_libraries = select({
-        "//bazel:debug_tcmalloc": ["libtcmalloc_debug.a"],
-        "//conditions:default": ["libtcmalloc_and_profiler.a"],
-    }),
-)
-
-# Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/227
-cc_library(
-    name = "gperftools",
-    deps = [
-        "gperftools_build",
-    ],
-)
 
 envoy_cmake_external(
     name = "ares",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -287,7 +287,6 @@ def envoy_dependencies(path = "@envoy_deps//", skip_targets = []):
     _com_github_grpc_grpc()
     _com_github_google_benchmark()
     _com_github_google_jwt_verify()
-    _com_github_gperftools_gperftools()
     _com_github_jbeder_yaml_cpp()
     _com_github_libevent_libevent()
     _com_github_madler_zlib()
@@ -718,20 +717,6 @@ def _com_github_google_jwt_verify():
     native.bind(
         name = "jwt_verify_lib",
         actual = "@com_github_google_jwt_verify//:jwt_verify_lib",
-    )
-
-def _com_github_gperftools_gperftools():
-    location = REPOSITORY_LOCATIONS["com_github_gperftools_gperftools"]
-    http_archive(
-        name = "com_github_gperftools_gperftools",
-        build_file_content = BUILD_ALL_CONTENT,
-        patch_cmds = ["./autogen.sh"],
-        **location
-    )
-
-    native.bind(
-        name = "gperftools",
-        actual = "@envoy//bazel/foreign_cc:gperftools",
     )
 
 def _foreign_cc_dependencies():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -73,14 +73,6 @@ REPOSITORY_LOCATIONS = dict(
         # 2018-03-06
         urls = ["https://github.com/google/libprotobuf-mutator/archive/c3d2faf04a1070b0b852b0efdef81e1a81ba925e.tar.gz"],
     ),
-    com_github_gperftools_gperftools = dict(
-        # TODO(cmluciano): Bump to release 2.8
-        # This sha is specifically chosen to fix ppc64le builds that require inclusion
-        # of asm/ptrace.h
-        sha256 = "18574813a062eee487bc1b761e8024a346075a7cb93da19607af362dc09565ef",
-        strip_prefix = "gperftools-fc00474ddc21fff618fc3f009b46590e241e425e",
-        urls = ["https://github.com/gperftools/gperftools/archive/fc00474ddc21fff618fc3f009b46590e241e425e.tar.gz"],
-    ),
     com_github_grpc_grpc = dict(
         sha256 = "a5342629fe1b689eceb3be4d4f167b04c70a84b9d61cf8b555e968bc500bdb5a",
         strip_prefix = "grpc-1.16.1",
@@ -222,9 +214,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
     ),
     rules_foreign_cc = dict(
-        sha256 = "e1b67e1fda647c7713baac11752573bfd4c2d45ef09afb4d4de9eb9bd4e5ac76",
-        strip_prefix = "rules_foreign_cc-8648b0446092ef2a34d45b02c8dc4c35c3a8df79",
-        urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/8648b0446092ef2a34d45b02c8dc4c35c3a8df79.tar.gz"],
+        sha256 = "78cbd1a8134b2f0ead8e637228d8ac1ac7c0ab3f0fbcd149a85e55330697d9a3",
+        strip_prefix = "rules_foreign_cc-216ded8acb95d81e312b228dce3c39872c7a7c34",
+        urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/216ded8acb95d81e312b228dce3c39872c7a7c34.tar.gz"],
     ),
     six_archive = dict(
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",

--- a/bazel/target_recipes.bzl
+++ b/bazel/target_recipes.bzl
@@ -2,5 +2,7 @@
 # target in //ci/prebuilt/BUILD to the underlying build recipe in
 # ci/build_container/build_recipes.
 TARGET_RECIPES = {
+    "tcmalloc_and_profiler": "gperftools",
+    "tcmalloc_debug": "gperftools",
     "luajit": "luajit",
 }

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${OS}" == "Windows_NT" ]]; then
+  exit 0
+fi
+
+# TODO(cmluciano): Bump to release 2.8
+# This sha is specifically chosen to fix ppc64le builds that require inclusion
+# of asm/ptrace.h
+VERSION=fc00474ddc21fff618fc3f009b46590e241e425e
+SHA256=18574813a062eee487bc1b761e8024a346075a7cb93da19607af362dc09565ef
+
+curl https://github.com/gperftools/gperftools/archive/${VERSION}.tar.gz -sLo gperftools-"$VERSION".tar.gz \
+  && echo "$SHA256" gperftools-"$VERSION".tar.gz | sha256sum --check
+
+tar xf gperftools-"$VERSION".tar.gz
+cd gperftools-"${VERSION}"
+
+./autogen.sh
+
+export LDFLAGS="${LDFLAGS} -lpthread"
+./configure --prefix="$THIRDPARTY_BUILD" --enable-shared=no --enable-frame-pointers --disable-libunwind
+
+# Don't build tests, since malloc_extension_c_test hardcodes -lstdc++, which breaks build when linking against libc++.
+make V=1 install-libLTLIBRARIES install-perftoolsincludeHEADERS


### PR DESCRIPTION
This reverts commit 5fa54cf2e5b381f8fc3a0f3d92a8b6676490dbcd.

This commit was responsible for a bunch of CI flakes in
compilation_time_options.

To replicate locally:

bazel test --config libc++ --define signal_trace=disabled  --define \
  hot_restart=disabled --define google_grpc=disabled --define \
  boringssl=fips --define log_debug_assert_in_release=enabled  --define
  \
  tcmalloc=debug --define quiche=enabled \
  //test/extensions/transport_sockets/tls:ssl_socket_test \
  --test_output=all --runs_per_test=50

I couldn't quickly root cause it, it seems to be some heisenbug that is
resilient to running under gdb. Examples crash at:

https://circleci.com/gh/envoyproxy/envoy/169349?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Signed-off-by: Harvey Tuch <htuch@google.com>