### PR TITLE
utility: use absl::Time library

### DIFF
--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -19,7 +19,7 @@
 
 namespace Envoy {
 /**
- * Utility class for formatting dates given a strftime style format string.
+ * Utility class for formatting dates given an absl::FormatTime style format string.
  */
 class DateFormatter {
 public:
@@ -68,8 +68,9 @@ private:
     const size_t width_;
 
     // The string before the current specifier's position and after the previous found specifier. A
-    // segment may include strftime accepted specifiers. E.g. given "%3f-this-i%s-a-segment-%4f",
-    // the current specifier is "%4f" and the segment is "-this-i%s-a-segment-".
+    // segment may include absl::FormatTime accepted specifiers. E.g. given
+    // "%3f-this-i%s-a-segment-%4f", the current specifier is "%4f" and the segment is
+    // "-this-i%s-a-segment-".
     const std::string segment_;
 
     // As an indication that this specifier is a %s (expect to be replaced by seconds since the

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -533,14 +533,9 @@ TEST(AccessLogFormatterTest, JsonFormatterStartTimeTest) {
   SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
   EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
 
-  // Needed to take into account the behavior in non-GMT timezones.
-  struct tm time_val;
-  gmtime_r(&test_epoch, &time_val);
-  time_t expected_time_t = mktime(&time_val);
-
   std::unordered_map<std::string, std::string> expected_json_map = {
       {"simple_date", "2018/03/28"},
-      {"test_time", fmt::format("{}", expected_time_t)},
+      {"test_time", fmt::format("{}", test_epoch)},
       {"bad_format", "bad_format"},
       {"default", "2018-03-28T23:35:58.000Z"},
       {"all_zeroes", "000000000.0.00.000"}};
@@ -642,13 +637,8 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
     FormatterImpl formatter(format);
 
-    // Needed to take into account the behavior in non-GMT timezones.
-    struct tm time_val;
-    gmtime_r(&test_epoch, &time_val);
-    time_t expected_time_t = mktime(&time_val);
-
     EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z|000000000.0.00.000",
-                          expected_time_t),
+                          test_epoch),
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 
@@ -690,7 +680,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
 
   {
     // This tests START_TIME specifier that has shorter segments when formatted, i.e.
-    // strftime("%%%%"") equals "%%", %1f will have 1 as its size.
+    // absl::FormatTime("%%%%"") equals "%%", %1f will have 1 as its size.
     const std::string format = "%START_TIME(%%%%|%%%%%f|%s%%%%%3f|%1f%%%%%s)%";
     const SystemTime start_time(std::chrono::microseconds(1522796769123456));
     EXPECT_CALL(stream_info, startTime()).WillOnce(Return(start_time));

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -529,13 +529,13 @@ TEST(AccessLogFormatterTest, JsonFormatterStartTimeTest) {
   Http::TestHeaderMapImpl response_header;
   Http::TestHeaderMapImpl response_trailer;
 
-  time_t test_epoch = 1522280158;
-  SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
+  time_t expected_time_in_epoch = 1522280158;
+  SystemTime time = std::chrono::system_clock::from_time_t(expected_time_in_epoch);
   EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
 
   std::unordered_map<std::string, std::string> expected_json_map = {
       {"simple_date", "2018/03/28"},
-      {"test_time", fmt::format("{}", test_epoch)},
+      {"test_time", fmt::format("{}", expected_time_in_epoch)},
       {"bad_format", "bad_format"},
       {"default", "2018-03-28T23:35:58.000Z"},
       {"all_zeroes", "000000000.0.00.000"}};
@@ -632,13 +632,13 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     const std::string format = "%START_TIME(%Y/%m/%d)%|%START_TIME(%s)%|%START_TIME(bad_format)%|"
                                "%START_TIME%|%START_TIME(%f.%1f.%2f.%3f)%";
 
-    time_t test_epoch = 1522280158;
-    SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
+    time_t expected_time_in_epoch = 1522280158;
+    SystemTime time = std::chrono::system_clock::from_time_t(expected_time_in_epoch);
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
     FormatterImpl formatter(format);
 
     EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z|000000000.0.00.000",
-                          test_epoch),
+                          expected_time_in_epoch),
               formatter.format(request_header, response_header, response_trailer, stream_info));
   }
 

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -812,11 +812,9 @@ TEST(DateFormatter, FromTime) {
   const SystemTime time1(std::chrono::seconds(1522796769));
   EXPECT_EQ("2018-04-03T23:06:09.000Z", DateFormatter("%Y-%m-%dT%H:%M:%S.000Z").fromTime(time1));
   EXPECT_EQ("aaa23", DateFormatter(std::string(3, 'a') + "%H").fromTime(time1));
-  EXPECT_EQ("", DateFormatter(std::string(1022, 'a') + "%H").fromTime(time1));
   const SystemTime time2(std::chrono::seconds(0));
   EXPECT_EQ("1970-01-01T00:00:00.000Z", DateFormatter("%Y-%m-%dT%H:%M:%S.000Z").fromTime(time2));
   EXPECT_EQ("aaa00", DateFormatter(std::string(3, 'a') + "%H").fromTime(time2));
-  EXPECT_EQ("", DateFormatter(std::string(1022, 'a') + "%H").fromTime(time2));
 }
 
 // Verify that two DateFormatter patterns with the same ??? patterns but


### PR DESCRIPTION
*Description*: 
Replace strftime, mktime, gmtime with their absl::Time equivalents

Prohibit use of strftime, strptime, mktime, gmtime, gmtime_r, localtime, localtime_r, std::get_time and std::put_time

*Risk Level*: Low
*Testing*: `bazel build //source/... && bazel test //test/...`
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #5587
