### PR TITLE
buffer: fix handling of empty string prepends.

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5668091688648704
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5668091688648704
@@ -1,0 +1,1 @@
+actions {   target_index: 1   read: 1 } actions {   add_buffer_fragment: 1 } actions {   prepend_string: 0 } actions {   add_string: 4 } actions {   target_index: 1   move {     length: 1   } } actions {   target_index: 1   add_buffer_fragment: 1 }


### PR DESCRIPTION
Prepending an empty string seems to mess up libevent internally.
evbuffer_prepend doesn't have a check for empty (unlike evbuffer_prepend_buffer
which does). This then results in an allocation of an empty chain, which causes
problems with a following move/append. This only seems to happen the the
original buffer was created via addBufferFragment(), this forces the code
execution path in evbuffer_prepend related to immutable buffers.

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13263.

Risk level: Low
Testing: Corpus entry and unit test added.

Signed-off-by: Harvey Tuch <htuch@google.com>