### PR TITLE
Remove some duplicated words in comment

### DIFF
--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -72,7 +72,7 @@ public:
 
   /**
    * Callback for admin URL handlers.
-   * @param path_and_query supplies the the path and query of the request URL.
+   * @param path_and_query supplies the path and query of the request URL.
    * @param response_headers enables setting of http headers (eg content-type, cache-control) in the
    * handler.
    * @param response supplies the buffer to fill in with the response body.
@@ -134,7 +134,7 @@ public:
    *
    * @param path_and_query the path and query of the admin URL.
    * @param method the HTTP method (POST or GET).
-   * @param response_headers populated the the response headers from executing the request,
+   * @param response_headers populated the response headers from executing the request,
    *     most notably content-type.
    * @param body populated with the response-body from the admin request.
    * @return Http::Code The HTTP response code from the admin request.

--- a/source/docs/repokitteh.md
+++ b/source/docs/repokitteh.md
@@ -37,7 +37,7 @@ Only organization members can assign or unassign other users, who must be organi
 [Demo PR](https://github.com/envoyproxy/envoybot/pull/6)
 
 ### [Review](https://github.com/repokitteh/modules/blob/master/review.star)
-Requests a a user to review a pull request.
+Requests a user to review a pull request.
 
 Examples:
 ```

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -63,7 +63,7 @@ protected:
    * The PID is needed to isolate namespaces between concurrent
    * processes in CI. The random number generator is needed
    * sequentially executed test methods fail with an error in
-   * bindDomainSocket if the the same base-id is re-used.
+   * bindDomainSocket if the same base-id is re-used.
    *
    * @return uint32_t a unique numeric ID based on the PID and a random number.
    */

--- a/test/test_common/network_utility_test.cc
+++ b/test/test_common/network_utility_test.cc
@@ -26,7 +26,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, NetworkUtilityTest,
 // Result: Zero failures, presumably because of the randomization of the address.
 //
 // Tested: IPv6 --gtest_repeats=1000 and kLimit=50 on Ubuntu with docker.
-// Result: In about 5% of runs, two of the 50 allocated ports were the the same, though not
+// Result: In about 5% of runs, two of the 50 allocated ports were the same, though not
 //         more than that.
 // The test is DISABLED as we don't want the occasional expected collisions to cause problems.
 TEST_P(NetworkUtilityTest, DISABLED_ValidateBindFreeLoopbackPort) {

--- a/tools/header_order.py
+++ b/tools/header_order.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Enforce header order in a a given file. This will only reorder in the first sequence of contiguous
+# Enforce header order in a given file. This will only reorder in the first sequence of contiguous
 # #include statements, so it will not play well with #ifdef.
 #
 # This attempts to enforce the guidelines at


### PR DESCRIPTION
*Description*: Correct spelling for code comment.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: 

- include/envoy/server/admin.h
- source/docs/repokitteh.md
- test/exe/main_common_test.cc
- test/test_common/network_utility_test.cc
- tools/header_order.py

*Release Notes*: N/A
