### PR TITLE
Trivial fix: Remove the redundant words 'the the'

### DIFF
--- a/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -41,7 +41,7 @@ message ExtAuthz {
   // <config_http_filters_ext_authz_stats>`.
   bool failure_mode_allow = 2;
 
-  // Sets the package version the the gRPC service should use. This is particularly
+  // Sets the package version the gRPC service should use. This is particularly
   // useful when transitioning from alpha to release versions assuming that both definitions are
   // semantically compatible. Deprecation note: This field is deprecated and should only be used for
   // version upgrade. See release notes for more details.

--- a/api/envoy/service/auth/v2/external_auth.proto
+++ b/api/envoy/service/auth/v2/external_auth.proto
@@ -40,11 +40,11 @@ message DeniedHttpResponse {
   envoy.type.HttpStatus status = 1 [(validate.rules).message.required = true];
 
   // This field allows the authorization service to send HTTP response headers
-  // to the the downstream client.
+  // to the downstream client.
   repeated envoy.api.v2.core.HeaderValueOption headers = 2;
 
   // This field allows the authorization service to send a response body data
-  // to the the downstream client.
+  // to the downstream client.
   string body = 3;
 }
 

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -72,7 +72,7 @@ public:
 
   /**
    * Callback for admin URL handlers.
-   * @param path_and_query supplies the the path and query of the request URL.
+   * @param path_and_query supplies the path and query of the request URL.
    * @param response_headers enables setting of http headers (eg content-type, cache-control) in the
    * handler.
    * @param response supplies the buffer to fill in with the response body.
@@ -134,7 +134,7 @@ public:
    *
    * @param path_and_query the path and query of the admin URL.
    * @param method the HTTP method (POST or GET).
-   * @param response_headers populated the the response headers from executing the request,
+   * @param response_headers populated the response headers from executing the request,
    *     most notably content-type.
    * @param body populated with the response-body from the admin request.
    * @return Http::Code The HTTP response code from the admin request.

--- a/source/common/filesystem/inotify/watcher_impl.h
+++ b/source/common/filesystem/inotify/watcher_impl.h
@@ -16,7 +16,7 @@ namespace Filesystem {
 /**
  * Implementation of Watcher that uses inotify. inotify is an awful API. In order to make this work
  * in a somewhat sane way we always watch the directory that owns the thing being watched, and then
- * filter for events that are relevant to the the thing being watched.
+ * filter for events that are relevant to the thing being watched.
  */
 class WatcherImpl : public Watcher, Logger::Loggable<Logger::Id::file> {
 public:

--- a/source/common/network/cidr_range.h
+++ b/source/common/network/cidr_range.h
@@ -78,7 +78,7 @@ public:
    * TODO(ccaraman): Update CidrRange::create to support only constructing valid ranges.
    * @return a CidrRange instance with the specified address and length, modified so that the only
    *         bits that might be non-zero are in the high-order length bits, and so that length is
-   *         in the appropriate range (0 to 32 for IPv4, 0 to 128 for IPv6). If the the address or
+   *         in the appropriate range (0 to 32 for IPv4, 0 to 128 for IPv6). If the address or
    *         length is invalid, then the range will be invalid (i.e. length == -1).
    */
   static CidrRange create(InstanceConstSharedPtr address, int length);

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -731,7 +731,7 @@ LcTrie<T>::LcTrieInternal<IpType, address_size>::getData(const IpType& ip_addres
   }
 
   // The path taken through the trie to match the ip_address may have contained skips,
-  // so it is necessary to check whether the the matched prefix really contains the
+  // so it is necessary to check whether the matched prefix really contains the
   // ip_address.
   const auto& prefix = ip_prefixes_[address];
   if (prefix.contains(ip_address)) {

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -182,7 +182,7 @@ public:
   void mergeValues(const std::unordered_map<std::string, std::string>& values) override;
 
 protected:
-  // Identical the the public constructor but does not call loadSnapshot(). Subclasses must call
+  // Identical the public constructor but does not call loadSnapshot(). Subclasses must call
   // loadSnapshot() themselves to create the initial snapshot, since loadSnapshot calls the virtual
   // function createNewSnapshot() and is therefore unsuitable for use in a superclass constructor.
   struct DoNotLoadSnapshot {};

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -211,7 +211,7 @@ private:
 
     /**
      * Makes a stat either by looking it up in the central cache,
-     * generating it from the the parent allocator, or as a last
+     * generating it from the parent allocator, or as a last
      * result, creating it with the heap allocator.
      *
      * @param name the full name of the stat (not tag extracted).

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -82,13 +82,13 @@ public:
   const MatcherSharedPtr& requestHeaderMatchers() const { return request_header_matchers_; }
 
   /**
-   * Returns a list of matchers used for selecting the the authorization response headers that
+   * Returns a list of matchers used for selecting the authorization response headers that
    * should be send back to the client.
    */
   const MatcherSharedPtr& clientHeaderMatchers() const { return client_header_matchers_; }
 
   /**
-   *  Returns a list of matchers used for selecting the the authorization response headers that
+   *  Returns a list of matchers used for selecting the authorization response headers that
    * should be send to an the upstream server.
    */
   const MatcherSharedPtr& upstreamHeaderMatchers() const { return upstream_header_matchers_; }

--- a/test/test_common/network_utility_test.cc
+++ b/test/test_common/network_utility_test.cc
@@ -26,7 +26,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, NetworkUtilityTest,
 // Result: Zero failures, presumably because of the randomization of the address.
 //
 // Tested: IPv6 --gtest_repeats=1000 and kLimit=50 on Ubuntu with docker.
-// Result: In about 5% of runs, two of the 50 allocated ports were the the same, though not
+// Result: In about 5% of runs, two of the 50 allocated ports were the same, though not
 //         more than that.
 // The test is DISABLED as we don't want the occasional expected collisions to cause problems.
 TEST_P(NetworkUtilityTest, DISABLED_ValidateBindFreeLoopbackPort) {


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Fix duplicated words 'the the'
*Risk Level*: LOW
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
