### PR TITLE
Rearrange unsorted imports

### DIFF
--- a/api/test/build/go_build_test.go
+++ b/api/test/build/go_build_test.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 
 	_ "github.com/envoyproxy/data-plane-api/api/ads"
+	_ "github.com/envoyproxy/data-plane-api/api/als"
 	_ "github.com/envoyproxy/data-plane-api/api/bootstrap"
 	_ "github.com/envoyproxy/data-plane-api/api/cds"
 	_ "github.com/envoyproxy/data-plane-api/api/cert"
 	_ "github.com/envoyproxy/data-plane-api/api/eds"
 	_ "github.com/envoyproxy/data-plane-api/api/hds"
 	_ "github.com/envoyproxy/data-plane-api/api/lds"
+	_ "github.com/envoyproxy/data-plane-api/api/metrics_service"
 	_ "github.com/envoyproxy/data-plane-api/api/rds"
 	_ "github.com/envoyproxy/data-plane-api/api/rls"
 	_ "github.com/envoyproxy/data-plane-api/api/sds"
-	_ "github.com/envoyproxy/data-plane-api/api/als"
-	_ "github.com/envoyproxy/data-plane-api/api/metrics_service"
 	_ "github.com/envoyproxy/data-plane-api/api/trace_service"
 )
 


### PR DESCRIPTION
Imports should be sorted by Golang coding convention. So this commit aims to resort the imports that do not follow alphabetically arrangement

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Resort the imports that do not follow alphabetically arrangement
*Risk Level*: LOW
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
