### PR TITLE
bazel: add note about binutils causing issues on os x

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -68,6 +68,10 @@ for how to update or override dependencies.
     Alternatively, you can pass `--action_env` on the command line when running
     `bazel build`/`bazel test`.
 
+    Having the binutils keg installed in Brew is known to cause issues due to putting an incompatible
+    version of `ar` on the PATH, so if you run into issues building third party code like luajit
+    consider uninstalling binutils.
+
 1. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
    and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.
 1. `go get -u github.com/bazelbuild/buildtools/buildifier` to install buildifier. You may need to set `BUILDIFIER_BIN` to `$GOPATH/bin/buildifier`


### PR DESCRIPTION
We've seen multiple compilation issues caused by binutils being installed, so
this adds a note to the README suggesting to uninstall it.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
