### PR TITLE
tap: refactor tap matchers to keep track of change potential

### DIFF
--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -61,7 +61,7 @@ bool HttpPerRequestTapperImpl::onDestroyLog(const Http::HeaderMap* request_heade
                                             const Http::HeaderMap* request_trailers,
                                             const Http::HeaderMap* response_headers,
                                             const Http::HeaderMap* response_trailers) {
-  if (!config_->rootMatcher().matches(statuses_)) {
+  if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
     return false;
   }
 

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -47,7 +47,7 @@ public:
 private:
   HttpTapConfigImplSharedPtr config_;
   const uint64_t stream_id_;
-  std::vector<bool> statuses_;
+  Extensions::Common::Tap::Matcher::MatchStatusVector statuses_;
   // Must be a shared_ptr because of submitBufferedTrace().
   std::shared_ptr<envoy::data::tap::v2alpha::BufferedTraceWrapper> trace_;
 };

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -16,7 +16,7 @@ PerSocketTapperImpl::PerSocketTapperImpl(SocketTapConfigImplSharedPtr config,
 }
 
 void PerSocketTapperImpl::closeSocket(Network::ConnectionEvent) {
-  if (!config_->rootMatcher().matches(statuses_)) {
+  if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
     return;
   }
 
@@ -39,7 +39,7 @@ envoy::data::tap::v2alpha::SocketEvent& PerSocketTapperImpl::createEvent() {
 }
 
 void PerSocketTapperImpl::onRead(const Buffer::Instance& data, uint32_t bytes_read) {
-  if (!config_->rootMatcher().matches(statuses_)) {
+  if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
     return;
   }
 
@@ -58,7 +58,7 @@ void PerSocketTapperImpl::onRead(const Buffer::Instance& data, uint32_t bytes_re
 
 void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_written,
                                   bool end_stream) {
-  if (!config_->rootMatcher().matches(statuses_)) {
+  if (!config_->rootMatcher().matchStatus(statuses_).matches_) {
     return;
   }
 

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -27,7 +27,7 @@ private:
 
   SocketTapConfigImplSharedPtr config_;
   const Network::Connection& connection_;
-  std::vector<bool> statuses_;
+  Extensions::Common::Tap::Matcher::MatchStatusVector statuses_;
   std::shared_ptr<envoy::data::tap::v2alpha::BufferedTraceWrapper> trace_;
   uint32_t rx_bytes_buffered_{};
   uint32_t tx_bytes_buffered_{};

--- a/test/extensions/common/tap/tap_matcher_test.cc
+++ b/test/extensions/common/tap/tap_matcher_test.cc
@@ -15,7 +15,7 @@ namespace {
 class TapMatcherTest : public testing::Test {
 public:
   std::vector<MatcherPtr> matchers_;
-  std::vector<bool> statuses_;
+  Matcher::MatchStatusVector statuses_;
   envoy::service::tap::v2alpha::MatchPredicate config_;
   Http::TestHeaderMapImpl headers_;
 };
@@ -30,10 +30,16 @@ any_match: true
   buildMatcher(config_, matchers_);
   EXPECT_EQ(1, matchers_.size());
   statuses_.resize(matchers_.size());
-  EXPECT_TRUE(matchers_[0]->onNewStream(statuses_));
-  EXPECT_TRUE(matchers_[0]->onHttpRequestHeaders(headers_, statuses_));
-  EXPECT_TRUE(matchers_[0]->onHttpResponseHeaders(headers_, statuses_));
-  EXPECT_TRUE(matchers_[0]->matches(statuses_));
+  matchers_[0]->onNewStream(statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpRequestHeaders(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpRequestTrailers(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpResponseHeaders(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpResponseTrailers(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
 }
 
 TEST_F(TapMatcherTest, Not) {
@@ -47,10 +53,43 @@ not_match:
   buildMatcher(config_, matchers_);
   EXPECT_EQ(2, matchers_.size());
   statuses_.resize(matchers_.size());
-  EXPECT_FALSE(matchers_[0]->onNewStream(statuses_));
-  EXPECT_FALSE(matchers_[0]->onHttpRequestHeaders(headers_, statuses_));
-  EXPECT_FALSE(matchers_[0]->onHttpResponseHeaders(headers_, statuses_));
-  EXPECT_FALSE(matchers_[0]->matches(statuses_));
+  matchers_[0]->onNewStream(statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpRequestHeaders(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpRequestTrailers(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpResponseHeaders(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpResponseTrailers(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
+}
+
+TEST_F(TapMatcherTest, AndMightChangeStatus) {
+  const std::string matcher_yaml =
+      R"EOF(
+and_match:
+  rules:
+    - http_response_headers_match:
+        headers:
+          - name: bar
+            exact_match: baz
+)EOF";
+
+  MessageUtil::loadFromYaml(matcher_yaml, config_);
+  buildMatcher(config_, matchers_);
+  EXPECT_EQ(2, matchers_.size());
+  statuses_.resize(matchers_.size());
+  matchers_[0]->onNewStream(statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, true}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpRequestHeaders(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, true}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpRequestTrailers(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, true}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpResponseHeaders(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
+  matchers_[0]->onHttpResponseTrailers(headers_, statuses_);
+  EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
 }
 
 } // namespace


### PR DESCRIPTION
Required for streaming tapping.

*Risk Level*: Low
*Testing*: New UTs
*Docs Changes*: N/A
*Release Notes*: N/A
