### PR TITLE
Alphabetically sorted modules import

### DIFF
--- a/configs/configgen.py
+++ b/configs/configgen.py
@@ -2,8 +2,8 @@ import jinja2
 import json
 from collections import OrderedDict
 import os
-import sys
 import shutil
+import sys
 
 SCRIPT_DIR = os.path.dirname(__file__)
 OUT_DIR = sys.argv[1]

--- a/examples/front-proxy/service.py
+++ b/examples/front-proxy/service.py
@@ -1,9 +1,9 @@
 from flask import Flask
 from flask import request
-import socket
 import os
-import sys
 import requests
+import socket
+import sys
 
 app = Flask(__name__)
 

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -8,9 +8,9 @@
 from __future__ import print_function
 
 import argparse
+import logging
 import os
 import shutil
-import logging
 import subprocess
 import sys
 

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import argparse
-import os
 import json
+import os
 import subprocess
 
 

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -9,8 +9,8 @@ import functools
 import os
 import pstats
 import StringIO
-import sys
 import re
+import sys
 
 from google.protobuf.compiler import plugin_pb2
 from validate import validate_pb2


### PR DESCRIPTION
Modules which are imported to python are sorted alphabetically are
quicker to read and searchable.

Co-Authored-By: Dao Cong Tien tiendc@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
