### PR TITLE
http: Rename H1 ConnPoolImplProd to match H2 ProdConnPoolImpl

### DIFF
--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -329,7 +329,7 @@ void ConnPoolImpl::ActiveClient::onConnectTimeout() {
   codec_client_->close();
 }
 
-CodecClientPtr ConnPoolImplProd::createCodecClient(Upstream::Host::CreateConnectionData& data) {
+CodecClientPtr ProdConnPoolImpl::createCodecClient(Upstream::Host::CreateConnectionData& data) {
   CodecClientPtr codec{new CodecClientProd(CodecClient::Type::HTTP1, std::move(data.connection_),
                                            data.host_description_, dispatcher_)};
   return codec;

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -126,9 +126,9 @@ protected:
 /**
  * Production implementation of the ConnPoolImpl.
  */
-class ConnPoolImplProd : public ConnPoolImpl {
+class ProdConnPoolImpl : public ConnPoolImpl {
 public:
-  ConnPoolImplProd(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
+  ProdConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                    Upstream::ResourcePriority priority,
                    const Network::ConnectionSocket::OptionsSharedPtr& options)
       : ConnPoolImpl(dispatcher, host, priority, options) {}

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1224,7 +1224,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
         new Http::Http2::ProdConnPoolImpl(dispatcher, host, priority, options)};
   } else {
     return Http::ConnectionPool::InstancePtr{
-        new Http::Http1::ConnPoolImplProd(dispatcher, host, priority, options)};
+        new Http::Http1::ProdConnPoolImpl(dispatcher, host, priority, options)};
   }
 }
 


### PR DESCRIPTION
Description: The production implementation of the ConnPoolImpl class has different names between H1/H2. The H1 version is called  `ConnPoolImplProd`, while the H2 version is called `ProdConnPoolImpl`. This PR changes H1 to be called `ProdConnPoolImpl` to match H2. I think `Impl` as a modifier makes more sense at the end than `Prod` does. We have many classes in Envoy that end in `Impl` and this is the only one that ends in `Prod`.
Risk Level: Low
Testing: Ran `bazel test/...` successfully
Docs Changes: N/A
Release Notes: N/A
