### PR TITLE
Wrap std::string constructor around pair argument.

### DIFF
--- a/source/server/init_manager_impl.cc
+++ b/source/server/init_manager_impl.cc
@@ -53,10 +53,10 @@ void InitManagerImpl::initializeTarget(TargetWithDescription& target) {
 void InitManagerImpl::registerTarget(Init::Target& target, absl::string_view description) {
   TRACE_INIT_MANAGER("registerTarget {}", description);
   ASSERT(state_ != State::Initialized);
-  ASSERT(std::find(targets_.begin(), targets_.end(), TargetWithDescription{&target, description}) ==
-             targets_.end(),
+  ASSERT(std::find(targets_.begin(), targets_.end(),
+                   TargetWithDescription{&target, std::string(description)}) == targets_.end(),
          "Registered duplicate Init::Target");
-  targets_.emplace_back(&target, description);
+  targets_.emplace_back(&target, std::string(description));
   if (state_ == State::Initializing) {
     initializeTarget(targets_.back());
   }


### PR DESCRIPTION
Description: This is a bad PR, and I feel bad. Perhaps related to the finally occurring deprecation of our string troubles at Google, we have a compilation failure around these lines because `absl::string_view` to `std::string` conversion is broken in this subtle way when used to initialize an `std::pair` with a string member. Explicitly call the `std::string` constructor to avoid this compilation error. Hopefully we can remove this hack in about a month when we can finally clean up the rest of the silly string hacks.

Risk Level: Low
Testing: bazel test //test/...
Docs Changes: None
Release Notes: None

Signed-off-by: Dan Noé <dpn@google.com>
