### PR TITLE
Update QUICHE tarball to 2019-02-26 snapshot.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -230,8 +230,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/subpar/archive/1.3.0.tar.gz"],
     ),
     com_googlesource_quiche = dict(
-        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/dc5ce1a82e342bfd366a1ccdf2a2717edb46e4ec.tar.gz
-        sha256 = "ed4aec9af6b251385b720d3a23a22a4264d649806ff95dc0b29dab9f786387a0",
-        urls = ["https://storage.googleapis.com/quiche-envoy-integration/dc5ce1a82e342bfd366a1ccdf2a2717edb46e4ec.tar.gz"],
+        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/2bfc754a599cdbdb2a6875a515713648b92ddb97.tar.gz
+        sha256 = "218870c37ebf8d29d5015dc746884d621634e825931f81551b5779fc0ee27cee",
+        urls = ["https://storage.googleapis.com/quiche-envoy-integration/2bfc754a599cdbdb2a6875a515713648b92ddb97.tar.gz"],
     ),
 )


### PR DESCRIPTION
Description:
Update QUICHE tarball to static copy of https://quiche.googlesource.com/quiche/+archive/2bfc754a599cdbdb2a6875a515713648b92ddb97.tar.gz

Tested with:
$ bazel test --test_output=all --define quiche=enabled --experimental_remap_main_repo //test/extensions/quic_listeners/quiche/... @com_googlesource_quiche//...

Risk Level: low (code not used in Envoy yet)
Testing: existing unit tests in //test/extensions/quic_listeners/quiche/... and @com_googlesource_quiche//...
Docs Changes: none
Release Notes: none
[Optional Fixes #Issue]
[Optional Deprecated:]
