### PR TITLE
Add heap profiler to global admin endpoint

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -25,6 +25,7 @@ modify different aspects of the server:
 
     admin:
       access_log_path: /tmp/admin_access.log
+      profile_path: /tmp/envoy.prof
       address:
         socket_address: { address: 127.0.0.1, port_value: 9901 }
 
@@ -135,7 +136,11 @@ modify different aspects of the server:
 
 .. http:post:: /cpuprofiler
 
-  Enable or disable the CPU profiler. Requires compiling with gperftools.
+  Enable or disable the CPU profiler. Requires compiling with gperftools. The output file can be configured by admin.profile_path.
+
+.. http:post:: /heapprofiler
+
+  Enable or disable the Heap profiler. Requires compiling with gperftools. The output file can be configured by admin.profile_path.
 
 .. _operations_admin_interface_healthcheck_fail:
 

--- a/source/common/profiler/profiler.cc
+++ b/source/common/profiler/profiler.cc
@@ -19,14 +19,12 @@ bool Cpu::startProfiler(const std::string& output_path) {
 void Cpu::stopProfiler() { ProfilerStop(); }
 
 bool Heap::profilerEnabled() {
-  // check tcmalloc
-  return IsHeapProfilerRunning();
+  // determined by PROFILER_AVAILABLE
+  return true;
 }
 
+bool Heap::isProfilerStarted() { return IsHeapProfilerRunning(); }
 bool Heap::startProfiler(const std::string& output_file_name_prefix) {
-  if (IsHeapProfilerRunning()) {
-    return false;
-  }
   HeapProfilerStart(output_file_name_prefix.c_str());
   return true;
 }
@@ -60,6 +58,7 @@ bool Cpu::startProfiler(const std::string&) { return false; }
 void Cpu::stopProfiler() {}
 
 bool Heap::profilerEnabled() { return false; }
+bool Heap::isProfilerStarted() { return false; }
 bool Heap::startProfiler(const std::string&) { return false; }
 bool Heap::stopProfiler() { return false; }
 } // namespace Profiler

--- a/source/common/profiler/profiler.cc
+++ b/source/common/profiler/profiler.cc
@@ -18,6 +18,28 @@ bool Cpu::startProfiler(const std::string& output_path) {
 
 void Cpu::stopProfiler() { ProfilerStop(); }
 
+bool Heap::profilerEnabled() {
+  // check tcmalloc
+  return IsHeapProfilerRunning();
+}
+
+bool Heap::startProfiler(const std::string& output_file_name_prefix) {
+  if (IsHeapProfilerRunning()) {
+    return false;
+  }
+  HeapProfilerStart(output_file_name_prefix.c_str());
+  return true;
+}
+
+bool Heap::stopProfiler() {
+  if (!IsHeapProfilerRunning()) {
+    return false;
+  }
+  HeapProfilerDump("stop and dump");
+  HeapProfilerStop();
+  return true;
+}
+
 void Heap::forceLink() {
   // Currently this is here to force the inclusion of the heap profiler during static linking.
   // Without this call the heap profiler will not be included and cannot be started via env
@@ -37,6 +59,9 @@ bool Cpu::profilerEnabled() { return false; }
 bool Cpu::startProfiler(const std::string&) { return false; }
 void Cpu::stopProfiler() {}
 
+bool Heap::profilerEnabled() { return false; }
+bool Heap::startProfiler(const std::string&) { return false; }
+bool Heap::stopProfiler() { return false; }
 } // namespace Profiler
 } // namespace Envoy
 

--- a/source/common/profiler/profiler.h
+++ b/source/common/profiler/profiler.h
@@ -38,6 +38,24 @@ public:
  * Process wide heap profiling
  */
 class Heap {
+public:
+  /**
+   * @return whether the profiler is enabled or not.
+   */
+  static bool profilerEnabled();
+
+  /**
+   * Start the profiler and write to the specified path.
+   * @return bool whether the call to start the profiler succeeded.
+   */
+  static bool startProfiler(const std::string& output_path);
+
+  /**
+   * Stop the profiler.
+   * @return bool whether the file is dumped
+   */
+  static bool stopProfiler();
+
 private:
   static void forceLink();
 };

--- a/source/common/profiler/profiler.h
+++ b/source/common/profiler/profiler.h
@@ -40,9 +40,14 @@ public:
 class Heap {
 public:
   /**
-   * @return whether the profiler is enabled or not.
+   * @return whether the profiler is enabled in this build or not.
    */
   static bool profilerEnabled();
+
+  /**
+   * @return whether the profiler is started or not
+   */
+  static bool isProfilerStarted();
 
   /**
    * Start the profiler and write to the specified path.

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -535,8 +535,8 @@ Http::Code AdminImpl::handlerHeapProfiler(absl::string_view url, Http::HeaderMap
       response.add("Fail to start heap profiler: already started");
       res = Http::Code::BadRequest;
     } else if (!Profiler::Heap::startProfiler(profile_path_)) {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE
       // GCOVR_EXCL_START
+      // TODO(silentdai) remove the GCOVR when startProfiler is better implemented
       response.add("Fail to start the heap profiler");
       res = Http::Code::InternalServerError;
       // GCOVR_EXCL_END

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -535,6 +535,7 @@ Http::Code AdminImpl::handlerHeapProfiler(absl::string_view url, Http::HeaderMap
       response.add("Fail to start heap profiler: already started");
       res = Http::Code::BadRequest;
     } else if (!Profiler::Heap::startProfiler(profile_path_)) {
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE
       response.add("Fail to start the heap profiler");
       res = Http::Code::InternalServerError;
     } else {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -514,6 +514,29 @@ Http::Code AdminImpl::handlerCpuProfiler(absl::string_view url, Http::HeaderMap&
   return Http::Code::OK;
 }
 
+Http::Code AdminImpl::handlerHeapProfiler(absl::string_view url, Http::HeaderMap&,
+                                          Buffer::Instance& response, AdminStream&) {
+  Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
+  if (query_params.size() != 1 || query_params.begin()->first != "enable" ||
+      (query_params.begin()->second != "y" && query_params.begin()->second != "n")) {
+    response.add("?enable=<y|n>\n");
+    return Http::Code::BadRequest;
+  }
+
+  bool enable = query_params.begin()->second == "y";
+  if (enable && !Profiler::Heap::profilerEnabled()) {
+    if (!Profiler::Heap::startProfiler(profile_path_)) {
+      response.add("failure to start the heap profiler");
+      return Http::Code::InternalServerError;
+    }
+  } else if (!enable && Profiler::Heap::profilerEnabled()) {
+    Profiler::Heap::stopProfiler();
+  }
+
+  response.add("OK\n");
+  return Http::Code::OK;
+}
+
 Http::Code AdminImpl::handlerHealthcheckFail(absl::string_view, Http::HeaderMap&,
                                              Buffer::Instance& response, AdminStream&) {
   server_.failHealthcheck(true);
@@ -1076,6 +1099,8 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
            MAKE_ADMIN_HANDLER(handlerContention), false, false},
           {"/cpuprofiler", "enable/disable the CPU profiler",
            MAKE_ADMIN_HANDLER(handlerCpuProfiler), false, true},
+          {"/heapprofiler", "enable/disable the heap profiler",
+           MAKE_ADMIN_HANDLER(handlerHeapProfiler), false, true},
           {"/healthcheck/fail", "cause the server to fail health checks",
            MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false, true},
           {"/healthcheck/ok", "cause the server to pass health checks",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -549,9 +549,10 @@ Http::Code AdminImpl::handlerHeapProfiler(absl::string_view url, Http::HeaderMap
       res = Http::Code::BadRequest;
     } else {
       Profiler::Heap::stopProfiler();
-      response.add(fmt::format("Heap profiler stopped. Please checkout {}. See "
-                               "http://goog-perftools.sourceforge.net/doc/heap_profiler.html",
-                               profile_path_));
+      response.add(
+          fmt::format("Heap profiler stopped and data written to {}. See "
+                      "http://goog-perftools.sourceforge.net/doc/heap_profiler.html for details.",
+                      profile_path_));
       res = Http::Code::OK;
     }
   }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -536,8 +536,10 @@ Http::Code AdminImpl::handlerHeapProfiler(absl::string_view url, Http::HeaderMap
       res = Http::Code::BadRequest;
     } else if (!Profiler::Heap::startProfiler(profile_path_)) {
       NOT_IMPLEMENTED_GCOVR_EXCL_LINE
+      // GCOVR_EXCL_START
       response.add("Fail to start the heap profiler");
       res = Http::Code::InternalServerError;
+      // GCOVR_EXCL_END
     } else {
       response.add("Starting heap profiler");
       res = Http::Code::OK;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -209,6 +209,9 @@ private:
                                Buffer::Instance& response, AdminStream&);
   Http::Code handlerCpuProfiler(absl::string_view path_and_query, Http::HeaderMap& response_headers,
                                 Buffer::Instance& response, AdminStream&);
+  Http::Code handlerHeapProfiler(absl::string_view path_and_query,
+                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                 AdminStream&);
   Http::Code handlerHealthcheckFail(absl::string_view path_and_query,
                                     Http::HeaderMap& response_headers, Buffer::Instance& response,
                                     AdminStream&);

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -678,15 +678,11 @@ TEST_P(AdminInstanceTest, AdminHeapProfiler) {
 
 #ifdef PROFILER_AVAILABLE
   EXPECT_EQ(Http::Code::OK, postCallback("/heapprofiler?enable=y", header_map, data));
-  EXPECT_TRUE(Profiler::Heap::profilerEnabled());
-#else
-  EXPECT_EQ(Http::Code::NotImplemented, postCallback("/heapprofiler?enable=y", header_map, data));
-  EXPECT_FALSE(Profiler::Heap::profilerEnabled());
-#endif
-
-#ifdef PROFILER_AVAILABLE
+  EXPECT_TRUE(Profiler::Heap::isProfilerStarted());
   EXPECT_EQ(Http::Code::OK, postCallback("/heapprofiler?enable=n", header_map, data));
 #else
+  EXPECT_EQ(Http::Code::NotImplemented, postCallback("/heapprofiler?enable=y", header_map, data));
+  EXPECT_FALSE(Profiler::Heap::isProfilerStarted());
   EXPECT_EQ(Http::Code::NotImplemented, postCallback("/heapprofiler?enable=n", header_map, data));
 #endif
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -635,7 +635,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-TEST_P(AdminInstanceTest, AdminProfiler) {
+TEST_P(AdminInstanceTest, AdminCpuProfiler) {
   Buffer::OwnedImpl data;
   Http::HeaderMapImpl header_map;
 
@@ -652,6 +652,23 @@ TEST_P(AdminInstanceTest, AdminProfiler) {
 
   EXPECT_EQ(Http::Code::OK, postCallback("/cpuprofiler?enable=n", header_map, data));
   EXPECT_FALSE(Profiler::Cpu::profilerEnabled());
+}
+
+TEST_P(AdminInstanceTest, AdminHeapProfiler) {
+  Buffer::OwnedImpl data;
+  Http::HeaderMapImpl header_map;
+
+#ifdef PROFILER_AVAILABLE
+  EXPECT_EQ(Http::Code::OK, postCallback("/heapprofiler?enable=y", header_map, data));
+  EXPECT_TRUE(Profiler::Heap::profilerEnabled());
+#else
+  EXPECT_EQ(Http::Code::InternalServerError,
+            postCallback("/heapprofiler?enable=y", header_map, data));
+  EXPECT_FALSE(Profiler::Heap::profilerEnabled());
+#endif
+
+  EXPECT_EQ(Http::Code::OK, postCallback("/heapprofiler?enable=n", header_map, data));
+  EXPECT_FALSE(Profiler::Heap::profilerEnabled());
 }
 
 TEST_P(AdminInstanceTest, MutatesErrorWithGet) {


### PR DESCRIPTION
Description:
Add heap profiler to global admin endpoint
Why? Envoy is usually deployed in container where very limited tools are provided. Not many users fully understand envoy when reporting issues. This PR provides an simple approach to extract a heap profile.

Usage:
configfile: https://gist.github.com/silentdai/d00d0cf49e1bf84b723bb0b5214a5b31
- bazel-bin/source/exe/envoy-static -l debug -c <CONFIG_FILE_PATH>
- curl -X POST "localhost:9999/heapprofiler?enable=y"
OK
- generate load: http://localhost:9999/memory
- curl -X POST "localhost:9999/heapprofiler?enable=n"
Heap profiler stopped. Please checkout /tmp/envoy.prof. See http://goog-perftools.sourceforge.net/doc/heap_profiler.html
- verify the generate file:  /tmp/envoy.prof.*
- pprof --gv bazel-bin/source/exe/envoy-static /tmp/envoy.prof.0001.heap

Risk Level: LOW
Testing: bazel test //test/... and bazel  test --define tcmalloc=disabled
Docs Changes:
Release Notes:
