### PR TITLE
Insert *~ when using emacs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ TAGS
 .vs
 .vscode
 .idea/
+*~


### PR DESCRIPTION
Ignore temporary files *~ when editting source codes with
emacs.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
