### PR TITLE
eds: use batched host set updates

### DIFF
--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -18,6 +18,7 @@ namespace Upstream {
  */
 class EdsClusterImpl : public BaseDynamicClusterImpl,
                        Config::SubscriptionCallbacks<envoy::api::v2::ClusterLoadAssignment> {
+
 public:
   EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
                  Server::Configuration::TransportSocketFactoryContext& factory_context,
@@ -44,6 +45,20 @@ private:
 
   // ClusterImplBase
   void startPreInit() override;
+
+  class BatchUpdateHelper : public PrioritySet::BatchUpdateCb {
+  public:
+    BatchUpdateHelper(EdsClusterImpl& parent,
+                      const envoy::api::v2::ClusterLoadAssignment& cluster_load_assignment)
+        : parent_(parent), cluster_load_assignment_(cluster_load_assignment) {}
+
+    // Upstream::PrioritySet::BatchUpdateCb
+    void batchUpdate(PrioritySet::HostUpdateCb& host_update_cb) override;
+
+  private:
+    EdsClusterImpl& parent_;
+    const envoy::api::v2::ClusterLoadAssignment& cluster_load_assignment_;
+  };
 
   const ClusterManager& cm_;
   std::unique_ptr<Config::Subscription<envoy::api::v2::ClusterLoadAssignment>> subscription_;

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -110,7 +110,7 @@ void LogicalDnsCluster::startResolve() {
               break;
             }
             const auto& locality_lb_endpoint = localityLbEndpoint();
-            PriorityStateManager priority_state_manager(*this, local_info_);
+            PriorityStateManager priority_state_manager(*this, local_info_, nullptr);
             priority_state_manager.initializePriorityFor(locality_lb_endpoint);
             priority_state_manager.registerHostForPriority(logical_host_, locality_lb_endpoint);
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -695,7 +695,8 @@ private:
  */
 class PriorityStateManager : protected Logger::Loggable<Logger::Id::upstream> {
 public:
-  PriorityStateManager(ClusterImplBase& cluster, const LocalInfo::LocalInfo& local_info);
+  PriorityStateManager(ClusterImplBase& cluster, const LocalInfo::LocalInfo& local_info,
+                       PrioritySet::HostUpdateCb* update_cb);
 
   // Initializes the PriorityState vector based on the priority specified in locality_lb_endpoint.
   void
@@ -733,6 +734,7 @@ private:
   ClusterImplBase& parent_;
   PriorityState priority_state_;
   const envoy::api::v2::core::Node& local_info_node_;
+  PrioritySet::HostUpdateCb* update_cb_;
 };
 
 typedef std::unique_ptr<PriorityStateManager> PriorityStateManagerPtr;

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -128,7 +128,7 @@ TEST_P(EdsIntegrationTest, OverprovisioningFactorUpdate) {
 TEST_P(EdsIntegrationTest, BatchMemberUpdateCb) {
   initialize();
 
-  uint32_t member_update_count;
+  uint32_t member_update_count{};
 
   auto& priority_set = test_server_->server()
                            .clusterManager()

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -124,5 +124,46 @@ TEST_P(EdsIntegrationTest, OverprovisioningFactorUpdate) {
   get_and_compare(200);
 }
 
+// Verifies that EDS update only triggers member update callbacks once per update.
+TEST_P(EdsIntegrationTest, BatchMemberUpdateCb) {
+  initialize();
+
+  uint32_t member_update_count;
+
+  auto& priority_set = test_server_->server()
+                           .clusterManager()
+                           .clusters()
+                           .find("cluster_0")
+                           ->second.get()
+                           .prioritySet();
+
+  // Keep track of how many times we're seeing a member update callback.
+  priority_set.addMemberUpdateCb([&](const auto& hosts_added, const auto&) {
+    // We should see both hosts present in the member update callback.
+    EXPECT_EQ(2, hosts_added.size());
+    member_update_count++;
+  });
+
+  envoy::api::v2::ClusterLoadAssignment cluster_load_assignment;
+  cluster_load_assignment.set_cluster_name("cluster_0");
+
+  {
+    auto* locality_lb_endpoints = cluster_load_assignment.add_endpoints();
+
+    auto* endpoint = locality_lb_endpoints->add_lb_endpoints();
+    setUpstreamAddress(0, *endpoint);
+  }
+
+  auto* locality_lb_endpoints = cluster_load_assignment.add_endpoints();
+  locality_lb_endpoints->set_priority(1);
+
+  auto* endpoint = locality_lb_endpoints->add_lb_endpoints();
+  setUpstreamAddress(1, *endpoint);
+
+  eds_helper_.setEds({cluster_load_assignment}, *test_server_);
+
+  EXPECT_EQ(1, member_update_count);
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
This changes EDS to use the newly introduced batched host update. This
ensures that all host set updates are applied before triggering
membership callbacks. The benefit of this is that connection pools
will no longer be drained if a host is moved between priorities.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Medium
Testing: Integration test
Docs Changes: n/a
Release Notes: n/a
