### PR TITLE
Update bash script file because the link is not available

### DIFF
--- a/bazel/gen_compilation_database.sh
+++ b/bazel/gen_compilation_database.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "archive directory is not availabe on https://github.com/grailbio/bazel-compilation-database. Please check again!"
+exit 1
+
 RELEASE_VERSION=0.3.1
 
 if [[ ! -d bazel-compilation-database-${RELEASE_VERSION} ]]; then


### PR DESCRIPTION
Update bash script file because the link is not available and the application may crash.