### PR TITLE
Remove deadlink in BUILD file's comment

### DIFF
--- a/source/extensions/stat_sinks/hystrix/BUILD
+++ b/source/extensions/stat_sinks/hystrix/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-# Stats sink for the basic version of the hystrix protocol (https://github.com/b/hystrix_spec).
+# Stats sink for the basic version of the hystrix protocol.
 
 load(
     "//bazel:envoy_build_system.bzl",


### PR DESCRIPTION
a project on Github is not available so I remove it from BUILD file.