### PR TITLE
Remove deadlink in lightstep_tracer_impl file's comment

### DIFF
--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -78,7 +78,6 @@ void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& respons
     active_request_ = nullptr;
     Grpc::Common::validateResponse(*response);
 
-    // http://www.grpc.io/docs/guides/wire.html
     // First 5 bytes contain the message header.
     response->body()->drain(5);
     Buffer::ZeroCopyInputStreamImpl stream{std::move(response->body())};


### PR DESCRIPTION
The link http://www.grpc.io/docs/guides/wire.html in light_step_tracer file is not found. We should remove it.