### PR TITLE
Add OSX trash to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ TAGS
 .vs
 .vscode
 .idea/
+# OSX trash
+.DS_Store


### PR DESCRIPTION
Description:
Add OSX trash to .gitignore
Risk Level: low
Testing: NA
Docs Changes: .gitignore
Release Notes: NA
[Optional Fixes #Issue]
[Optional Deprecated:]

Signed-off-by: Do Anh Tuan [datuanmac@gmail.com](mailto:datuanmac@gmail.com)

