### PR TITLE
Remove deadlink in thread_local_store file's comment

### DIFF
--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -130,8 +130,7 @@ public:
 };
 
 /**
- * Store implementation with thread local caching. For design details see
- * https://github.com/envoyproxy/envoy/blob/master/docs/stats.md
+ * Store implementation with thread local caching.
  */
 class ThreadLocalStoreImpl : Logger::Loggable<Logger::Id::stats>, public StoreRoot {
 public:


### PR DESCRIPTION
Signed-off-by: Nguyen Hung Phuong <phuongnh@vn.fujitsu.com>

The comment in thread_local_store file is not correct so I remove it.