### PR TITLE
fuzz: more bounding of buffer_fuzz_test to avoid OOM/timeouts.

### DIFF
--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -34,6 +34,7 @@ envoy_cc_fuzz_test(
         ":buffer_fuzz_proto_cc",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:stack_array",
+        "//source/common/memory:stats_lib",
     ],
 )
 

--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5644734729551872
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5644734729551872
@@ -1,0 +1,77 @@
+actions { } actions {
+} actions { } actions {   write {   } } actions { } actions { } actions { } actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_string: 2097152
+}
+actions {
+  target_index: 1
+  add_buffer: 0
+}
+actions {
+  target_index: 1
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  target_index: 1
+  add_buffer: 0
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  add_buffer: 268435456
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  target_index: 1
+  add_buffer: 0
+}
+actions {
+  target_index: 1
+  add_buffer: 0
+}
+actions {
+  add_buffer: 4
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  target_index: 1
+  add_buffer: 0
+}
+actions {
+  target_index: 1
+  add_buffer: 0
+}


### PR DESCRIPTION
It's not sufficient to bound the allocations, since buffer ops that copy
can amplify without addition allocations. So, just bail out when the
buffer gets to a reasonable length.

Fixes oss-fuzz issues:
- https://oss-fuzz.com/testcase-detail/5644734729551872
- https://oss-fuzz.com/testcase-detail/5653497805012992

Risk level: Low
Testing: Corpus entry added for OOM.

Signed-off-by: Harvey Tuch <htuch@google.com>