### PR TITLE
stream info: move upstream timings into separate struct

### DIFF
--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -176,7 +176,7 @@ public:
   /**
    * Sets the upstream timing information for this stream. This is useful for
    * when multiple upstream requests are issued and we want to save timing
-   * information for the one that "wins"
+   * information for the one that "wins".
    */
   virtual void setUpstreamTiming(const UpstreamTiming& upstream_timing) PURE;
 

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -62,6 +62,45 @@ enum ResponseFlag {
   LastFlag = StreamIdleTimeout
 };
 
+struct UpstreamTiming {
+  /**
+   * Sets the time when the first byte of the request was sent upstream.
+   */
+  void onFirstUpstreamTxByteSent(TimeSource& time_source) {
+    ASSERT(!first_upstream_tx_byte_sent_);
+    first_upstream_tx_byte_sent_ = time_source.monotonicTime();
+  }
+
+  /**
+   * Sets the time when the first byte of the response is received from upstream.
+   */
+  void onLastUpstreamTxByteSent(TimeSource& time_source) {
+    ASSERT(!last_upstream_tx_byte_sent_);
+    last_upstream_tx_byte_sent_ = time_source.monotonicTime();
+  }
+
+  /**
+   * Sets the time when the last byte of the response is received from upstream.
+   */
+  void onFirstUpstreamRxByteReceived(TimeSource& time_source) {
+    ASSERT(!first_upstream_rx_byte_received_);
+    first_upstream_rx_byte_received_ = time_source.monotonicTime();
+  }
+
+  /**
+   * Sets the time when the last byte of the request was sent upstream.
+   */
+  void onLastUpstreamRxByteReceived(TimeSource& time_source) {
+    ASSERT(!last_upstream_rx_byte_received_);
+    last_upstream_rx_byte_received_ = time_source.monotonicTime();
+  }
+
+  absl::optional<MonotonicTime> first_upstream_tx_byte_sent_;
+  absl::optional<MonotonicTime> last_upstream_tx_byte_sent_;
+  absl::optional<MonotonicTime> first_upstream_rx_byte_received_;
+  absl::optional<MonotonicTime> last_upstream_rx_byte_received_;
+};
+
 /**
  * Additional information about a completed request for logging.
  */
@@ -135,16 +174,18 @@ public:
   virtual void onLastDownstreamRxByteReceived() PURE;
 
   /**
+   * Sets the upstream timing information for this stream. This is useful for
+   * when multiple upstream requests are issued and we want to save timing
+   * information for the one that "wins"
+   */
+  virtual void setUpstreamTiming(const UpstreamTiming& upstream_timing) PURE;
+
+  /**
    * @return the duration between the first byte of the request was sent upstream and the start of
    * the request. There may be a considerable delta between lastDownstreamByteReceived and this
    * value due to filters.
    */
   virtual absl::optional<std::chrono::nanoseconds> firstUpstreamTxByteSent() const PURE;
-
-  /**
-   * Sets the time when the first byte of the request was sent upstream.
-   */
-  virtual void onFirstUpstreamTxByteSent() PURE;
 
   /**
    * @return the duration between the last byte of the request was sent upstream and the start of
@@ -153,32 +194,16 @@ public:
   virtual absl::optional<std::chrono::nanoseconds> lastUpstreamTxByteSent() const PURE;
 
   /**
-   * Sets the time when the last byte of the request was sent upstream.
-   */
-  virtual void onLastUpstreamTxByteSent() PURE;
-
-  /**
    * @return the duration between the first byte of the response is received from upstream and the
    * start of the request.
    */
   virtual absl::optional<std::chrono::nanoseconds> firstUpstreamRxByteReceived() const PURE;
 
   /**
-   * Sets the time when the first byte of the response is received from upstream.
-   */
-  virtual void onFirstUpstreamRxByteReceived() PURE;
-
-  /**
    * @return the duration between the last byte of the response is received from upstream and the
    * start of the request.
    */
   virtual absl::optional<std::chrono::nanoseconds> lastUpstreamRxByteReceived() const PURE;
-
-  /**
-   * Sets the time when the last byte of the response is received from upstream.
-   */
-  virtual void onLastUpstreamRxByteReceived() PURE;
-
   /**
    * @return the duration between the first byte of the response is sent downstream and the start of
    * the request. There may be a considerable delta between lastUpstreamByteReceived and this value
@@ -213,11 +238,6 @@ public:
    * completed (i.e., when the request's ActiveStream is destroyed).
    */
   virtual void onRequestComplete() PURE;
-
-  /**
-   * Resets all timings related to the upstream in the event of a retry.
-   */
-  virtual void resetUpstreamTimings() PURE;
 
   /**
    * @param bytes_sent denotes the number of bytes to add to total sent bytes.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -463,7 +463,9 @@ void Filter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callb
 }
 
 void Filter::cleanup() {
-  callbacks_->streamInfo().setUpstreamTiming(upstream_request_->upstream_timing_);
+  if (upstream_request_) {
+    callbacks_->streamInfo().setUpstreamTiming(upstream_request_->upstream_timing_);
+  }
   upstream_request_.reset();
   retry_state_.reset();
   if (response_timeout_) {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -877,7 +877,7 @@ bool Filter::setupRedirect(const Http::HeaderMap& headers) {
   // completion here and check it in onDestroy. This is annoyingly complicated but is better than
   // needlessly resetting streams.
   attempting_internal_redirect_with_complete_stream_ =
-      upstream_request_->stream_info_.lastUpstreamRxByteReceived() && downstream_end_stream_;
+      upstream_request_->upstream_timing_.last_upstream_rx_byte_received_ && downstream_end_stream_;
 
   // As with setupRetry, redirects are not supported for streaming requests yet.
   if (downstream_end_stream_ &&

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -341,6 +341,7 @@ private:
     DownstreamWatermarkManager downstream_watermark_manager_{*this};
     Tracing::SpanPtr span_;
     StreamInfo::StreamInfoImpl stream_info_;
+    StreamInfo::UpstreamTiming upstream_timing_;
     Http::HeaderMap* upstream_headers_{};
     Http::HeaderMap* upstream_trailers_{};
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -15,7 +15,7 @@ namespace StreamInfo {
 struct StreamInfoImpl : public StreamInfo {
   explicit StreamInfoImpl(TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
-        start_time_monotonic_(time_source.monotonicTime()) {}
+        start_time_monotonic_(time_source.monotonicTime()), upstream_timing_() {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source) : StreamInfoImpl(time_source) {
     protocol_ = protocol;
@@ -43,40 +43,24 @@ struct StreamInfoImpl : public StreamInfo {
     last_downstream_rx_byte_received = time_source_.monotonicTime();
   }
 
-  absl::optional<std::chrono::nanoseconds> firstUpstreamTxByteSent() const override {
-    return duration(first_upstream_tx_byte_sent_);
+  void setUpstreamTiming(const UpstreamTiming& upstream_timing) override {
+    upstream_timing_ = upstream_timing;
   }
 
-  void onFirstUpstreamTxByteSent() override {
-    ASSERT(!first_upstream_tx_byte_sent_);
-    first_upstream_tx_byte_sent_ = time_source_.monotonicTime();
+  absl::optional<std::chrono::nanoseconds> firstUpstreamTxByteSent() const override {
+    return duration(upstream_timing_.first_upstream_tx_byte_sent_);
   }
 
   absl::optional<std::chrono::nanoseconds> lastUpstreamTxByteSent() const override {
-    return duration(last_upstream_tx_byte_sent_);
-  }
-
-  void onLastUpstreamTxByteSent() override {
-    ASSERT(!last_upstream_tx_byte_sent_);
-    last_upstream_tx_byte_sent_ = time_source_.monotonicTime();
+    return duration(upstream_timing_.last_upstream_tx_byte_sent_);
   }
 
   absl::optional<std::chrono::nanoseconds> firstUpstreamRxByteReceived() const override {
-    return duration(first_upstream_rx_byte_received_);
-  }
-
-  void onFirstUpstreamRxByteReceived() override {
-    ASSERT(!first_upstream_rx_byte_received_);
-    first_upstream_rx_byte_received_ = time_source_.monotonicTime();
+    return duration(upstream_timing_.first_upstream_rx_byte_received_);
   }
 
   absl::optional<std::chrono::nanoseconds> lastUpstreamRxByteReceived() const override {
-    return duration(last_upstream_rx_byte_received_);
-  }
-
-  void onLastUpstreamRxByteReceived() override {
-    ASSERT(!last_upstream_rx_byte_received_);
-    last_upstream_rx_byte_received_ = time_source_.monotonicTime();
+    return duration(upstream_timing_.last_upstream_rx_byte_received_);
   }
 
   absl::optional<std::chrono::nanoseconds> firstDownstreamTxByteSent() const override {
@@ -104,13 +88,6 @@ struct StreamInfoImpl : public StreamInfo {
   void onRequestComplete() override {
     ASSERT(!final_time_);
     final_time_ = time_source_.monotonicTime();
-  }
-
-  void resetUpstreamTimings() override {
-    first_upstream_tx_byte_sent_ = absl::optional<MonotonicTime>{};
-    last_upstream_tx_byte_sent_ = absl::optional<MonotonicTime>{};
-    first_upstream_rx_byte_received_ = absl::optional<MonotonicTime>{};
-    last_upstream_rx_byte_received_ = absl::optional<MonotonicTime>{};
   }
 
   void addBytesReceived(uint64_t bytes_received) override { bytes_received_ += bytes_received; }
@@ -206,10 +183,6 @@ struct StreamInfoImpl : public StreamInfo {
   const MonotonicTime start_time_monotonic_;
 
   absl::optional<MonotonicTime> last_downstream_rx_byte_received;
-  absl::optional<MonotonicTime> first_upstream_tx_byte_sent_;
-  absl::optional<MonotonicTime> last_upstream_tx_byte_sent_;
-  absl::optional<MonotonicTime> first_upstream_rx_byte_received_;
-  absl::optional<MonotonicTime> last_upstream_rx_byte_received_;
   absl::optional<MonotonicTime> first_downstream_tx_byte_sent_;
   absl::optional<MonotonicTime> last_downstream_tx_byte_sent_;
   absl::optional<MonotonicTime> final_time_;
@@ -231,6 +204,7 @@ private:
   Network::Address::InstanceConstSharedPtr downstream_direct_remote_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
   std::string requested_server_name_;
+  UpstreamTiming upstream_timing_;
 };
 
 } // namespace StreamInfo

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -15,7 +15,7 @@ namespace StreamInfo {
 struct StreamInfoImpl : public StreamInfo {
   explicit StreamInfoImpl(TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
-        start_time_monotonic_(time_source.monotonicTime()), upstream_timing_() {}
+        start_time_monotonic_(time_source.monotonicTime()) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source) : StreamInfoImpl(time_source) {
     protocol_ = protocol;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -2227,6 +2227,184 @@ TEST_F(RouterTest, DirectResponseWithBody) {
   EXPECT_EQ(1UL, config_.stats_.rq_direct_response_.value());
 }
 
+TEST_F(RouterTest, UpstreamTimingSingleRequest) {
+  NiceMock<Http::MockStreamEncoder> encoder;
+  Http::StreamDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
+                           -> Http::ConnectionPool::Cancellable* {
+        response_decoder = &decoder;
+        callbacks.onPoolReady(encoder, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+  expectResponseTimerCreate();
+
+  StreamInfo::StreamInfoImpl stream_info(test_time_.timeSystem());
+  ON_CALL(callbacks_, streamInfo()).WillByDefault(ReturnRef(stream_info));
+  EXPECT_FALSE(stream_info.firstUpstreamTxByteSent().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamTxByteSent().has_value());
+  EXPECT_FALSE(stream_info.firstUpstreamRxByteReceived().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamRxByteReceived().has_value());
+
+  Http::TestHeaderMapImpl headers{};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, false);
+
+  test_time_.sleep(std::chrono::milliseconds(32));
+  Buffer::OwnedImpl data;
+  router_.decodeData(data, true);
+
+  Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "503"}});
+  response_decoder->decodeHeaders(std::move(response_headers), false);
+  test_time_.sleep(std::chrono::milliseconds(43));
+
+  // Confirm we still have no upstream timing data. It won't be set until after the
+  // stream had ended.
+  EXPECT_FALSE(stream_info.firstUpstreamTxByteSent().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamTxByteSent().has_value());
+  EXPECT_FALSE(stream_info.firstUpstreamRxByteReceived().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamRxByteReceived().has_value());
+
+  response_decoder->decodeData(data, true);
+
+  // Now these should be set.
+  EXPECT_TRUE(stream_info.firstUpstreamTxByteSent().has_value());
+  EXPECT_TRUE(stream_info.lastUpstreamTxByteSent().has_value());
+  EXPECT_TRUE(stream_info.firstUpstreamRxByteReceived().has_value());
+  EXPECT_TRUE(stream_info.lastUpstreamRxByteReceived().has_value());
+
+  // Timings should match our sleep() calls.
+  EXPECT_EQ(stream_info.lastUpstreamRxByteReceived().value() -
+                stream_info.firstUpstreamRxByteReceived().value(),
+            std::chrono::milliseconds(43));
+  EXPECT_EQ(stream_info.lastUpstreamTxByteSent().value() -
+                stream_info.firstUpstreamTxByteSent().value(),
+            std::chrono::milliseconds(32));
+}
+
+TEST_F(RouterTest, UpstreamTimingRetry) {
+  NiceMock<Http::MockStreamEncoder> encoder;
+  Http::StreamDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
+                           -> Http::ConnectionPool::Cancellable* {
+        response_decoder = &decoder;
+        callbacks.onPoolReady(encoder, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+  expectResponseTimerCreate();
+
+  StreamInfo::StreamInfoImpl stream_info(test_time_);
+  ON_CALL(callbacks_, streamInfo()).WillByDefault(ReturnRef(stream_info));
+
+  // Check that upstream timing is updated after first request.
+  Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, false);
+
+  router_.retry_state_->expectRetry();
+
+  test_time_.sleep(std::chrono::milliseconds(32));
+  Buffer::OwnedImpl data;
+  router_.decodeData(data, true);
+
+  test_time_.sleep(std::chrono::milliseconds(43));
+
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
+                           -> Http::ConnectionPool::Cancellable* {
+        response_decoder = &decoder;
+        callbacks.onPoolReady(encoder, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+
+  // Check that upstream timing is not set when a retry will occur.
+  Http::HeaderMapPtr bad_response_headers(new Http::TestHeaderMapImpl{{":status", "503"}});
+  response_decoder->decodeHeaders(std::move(bad_response_headers), true);
+  EXPECT_FALSE(stream_info.firstUpstreamTxByteSent().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamTxByteSent().has_value());
+  EXPECT_FALSE(stream_info.firstUpstreamRxByteReceived().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamRxByteReceived().has_value());
+
+  router_.retry_state_->callback_();
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+  MonotonicTime retry_time = test_time_.monotonicTime();
+
+  Http::HeaderMapPtr good_response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
+  response_decoder->decodeHeaders(std::move(good_response_headers), false);
+
+  test_time_.sleep(std::chrono::milliseconds(153));
+
+  response_decoder->decodeData(data, true);
+
+  EXPECT_TRUE(stream_info.firstUpstreamTxByteSent().has_value());
+  EXPECT_TRUE(stream_info.lastUpstreamTxByteSent().has_value());
+  EXPECT_TRUE(stream_info.firstUpstreamRxByteReceived().has_value());
+  EXPECT_TRUE(stream_info.lastUpstreamRxByteReceived().has_value());
+
+  EXPECT_EQ(stream_info.lastUpstreamRxByteReceived().value() -
+                stream_info.firstUpstreamRxByteReceived().value(),
+            std::chrono::milliseconds(153));
+
+  // Time spent in upstream tx is 0 because we're using simulated time and
+  // don't have a good way to insert a "sleep" there, but values being present
+  // and equal to the time the retry was sent is good enough of a test.
+  EXPECT_EQ(stream_info.lastUpstreamTxByteSent().value() -
+                stream_info.firstUpstreamTxByteSent().value(),
+            std::chrono::milliseconds(0));
+  EXPECT_EQ(stream_info.lastUpstreamTxByteSent().value() +
+                stream_info.startTimeMonotonic().time_since_epoch(),
+            retry_time.time_since_epoch());
+  EXPECT_EQ(stream_info.firstUpstreamTxByteSent().value() +
+                stream_info.startTimeMonotonic().time_since_epoch(),
+            retry_time.time_since_epoch());
+}
+
+TEST_F(RouterTest, UpstreamTimingTimeout) {
+  NiceMock<Http::MockStreamEncoder> encoder;
+  Http::StreamDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
+                           -> Http::ConnectionPool::Cancellable* {
+        response_decoder = &decoder;
+        callbacks.onPoolReady(encoder, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+
+  StreamInfo::StreamInfoImpl stream_info(test_time_);
+  ON_CALL(callbacks_, streamInfo()).WillByDefault(ReturnRef(stream_info));
+
+  expectResponseTimerCreate();
+  test_time_.sleep(std::chrono::milliseconds(10));
+
+  // Check that upstream timing is updated after first request.
+  Http::TestHeaderMapImpl headers{{"x-envoy-upstream-rq-timeout-ms", "50"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, false);
+  EXPECT_FALSE(stream_info.lastUpstreamRxByteReceived().has_value());
+
+  test_time_.sleep(std::chrono::milliseconds(13));
+  Buffer::OwnedImpl data;
+  router_.decodeData(data, true);
+
+  test_time_.sleep(std::chrono::milliseconds(33));
+
+  Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
+  response_decoder->decodeHeaders(std::move(response_headers), false);
+
+  test_time_.sleep(std::chrono::milliseconds(99));
+  response_timeout_->callback_();
+
+  EXPECT_TRUE(stream_info.firstUpstreamTxByteSent().has_value());
+  EXPECT_TRUE(stream_info.lastUpstreamTxByteSent().has_value());
+  EXPECT_TRUE(stream_info.firstUpstreamRxByteReceived().has_value());
+  EXPECT_FALSE(stream_info.lastUpstreamRxByteReceived()
+                   .has_value()); // False because no end_stream was seen.
+  EXPECT_EQ(stream_info.firstUpstreamTxByteSent().value(), std::chrono::milliseconds(10));
+  EXPECT_EQ(stream_info.lastUpstreamTxByteSent().value(), std::chrono::milliseconds(23));
+  EXPECT_EQ(stream_info.firstUpstreamRxByteReceived().value(), std::chrono::milliseconds(56));
+}
+
 TEST(RouterFilterUtilityTest, FinalTimeout) {
   {
     NiceMock<MockRouteEntry> route;

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -35,6 +35,7 @@ protected:
 TEST_F(StreamInfoImplTest, TimingTest) {
   MonotonicTime pre_start = test_time_.timeSystem().monotonicTime();
   StreamInfoImpl info(Http::Protocol::Http2, test_time_.timeSystem());
+  Envoy::StreamInfo::UpstreamTiming upstream_timing;
   MonotonicTime post_start = test_time_.timeSystem().monotonicTime();
 
   const MonotonicTime& start = info.startTimeMonotonic();
@@ -48,19 +49,23 @@ TEST_F(StreamInfoImplTest, TimingTest) {
       checkDuration(std::chrono::nanoseconds{0}, info.lastDownstreamRxByteReceived());
 
   EXPECT_FALSE(info.firstUpstreamTxByteSent());
-  info.onFirstUpstreamTxByteSent();
+  upstream_timing.onFirstUpstreamTxByteSent(test_time_.timeSystem());
+  info.setUpstreamTiming(upstream_timing);
   dur = checkDuration(dur, info.firstUpstreamTxByteSent());
 
   EXPECT_FALSE(info.lastUpstreamTxByteSent());
-  info.onLastUpstreamTxByteSent();
+  upstream_timing.onLastUpstreamTxByteSent(test_time_.timeSystem());
+  info.setUpstreamTiming(upstream_timing);
   dur = checkDuration(dur, info.lastUpstreamTxByteSent());
 
   EXPECT_FALSE(info.firstUpstreamRxByteReceived());
-  info.onFirstUpstreamRxByteReceived();
+  upstream_timing.onFirstUpstreamRxByteReceived(test_time_.timeSystem());
+  info.setUpstreamTiming(upstream_timing);
   dur = checkDuration(dur, info.firstUpstreamRxByteReceived());
 
   EXPECT_FALSE(info.lastUpstreamRxByteReceived());
-  info.onLastUpstreamRxByteReceived();
+  upstream_timing.onLastUpstreamRxByteReceived(test_time_.timeSystem());
+  info.setUpstreamTiming(upstream_timing);
   dur = checkDuration(dur, info.lastUpstreamRxByteReceived());
 
   EXPECT_FALSE(info.firstDownstreamTxByteSent());

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -132,8 +132,8 @@ public:
 
   void onRequestComplete() override { end_time_ = timeSystem().monotonicTime(); }
 
-  void setUpstreamTiming(const UpstreamTiming& upstream_timing) override {
-    upstream_timing_ = upstream_timing);
+  void setUpstreamTiming(const Envoy::StreamInfo::UpstreamTiming& upstream_timing) override {
+    upstream_timing_ = upstream_timing;
   }
 
   absl::optional<std::chrono::nanoseconds> requestComplete() const override {

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -100,35 +100,18 @@ public:
   }
 
   absl::optional<std::chrono::nanoseconds> firstUpstreamTxByteSent() const override {
-    return duration(first_upstream_tx_byte_sent_);
-  }
-
-  void onFirstUpstreamTxByteSent() override {
-    first_upstream_tx_byte_sent_ = timeSystem().monotonicTime();
+    return duration(upstream_timing_.first_upstream_tx_byte_sent_);
   }
 
   absl::optional<std::chrono::nanoseconds> lastUpstreamTxByteSent() const override {
-    return duration(last_upstream_tx_byte_sent_);
+    return duration(upstream_timing_.last_upstream_tx_byte_sent_);
   }
-
-  void onLastUpstreamTxByteSent() override {
-    last_upstream_tx_byte_sent_ = timeSystem().monotonicTime();
-  }
-
   absl::optional<std::chrono::nanoseconds> firstUpstreamRxByteReceived() const override {
-    return duration(first_upstream_rx_byte_received_);
-  }
-
-  void onFirstUpstreamRxByteReceived() override {
-    first_upstream_rx_byte_received_ = timeSystem().monotonicTime();
+    return duration(upstream_timing_.first_upstream_rx_byte_received_);
   }
 
   absl::optional<std::chrono::nanoseconds> lastUpstreamRxByteReceived() const override {
-    return duration(last_upstream_rx_byte_received_);
-  }
-
-  void onLastUpstreamRxByteReceived() override {
-    last_upstream_rx_byte_received_ = timeSystem().monotonicTime();
+    return duration(upstream_timing_.last_upstream_rx_byte_received_);
   }
 
   absl::optional<std::chrono::nanoseconds> firstDownstreamTxByteSent() const override {
@@ -202,6 +185,7 @@ public:
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
   Envoy::StreamInfo::FilterStateImpl filter_state_{};
+  Envoy::StreamInfo::UpstreamTiming upstream_timing_;
   std::string requested_server_name_;
   DangerousDeprecatedTestTime test_time_;
 };

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -132,11 +132,8 @@ public:
 
   void onRequestComplete() override { end_time_ = timeSystem().monotonicTime(); }
 
-  void resetUpstreamTimings() override {
-    first_upstream_tx_byte_sent_ = absl::optional<MonotonicTime>{};
-    last_upstream_tx_byte_sent_ = absl::optional<MonotonicTime>{};
-    first_upstream_rx_byte_received_ = absl::optional<MonotonicTime>{};
-    last_upstream_rx_byte_received_ = absl::optional<MonotonicTime>{};
+  void setUpstreamTiming(const UpstreamTiming& upstream_timing) override {
+    upstream_timing_ = upstream_timing);
   }
 
   absl::optional<std::chrono::nanoseconds> requestComplete() const override {

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -24,6 +24,7 @@ public:
   MOCK_CONST_METHOD0(startTimeMonotonic, MonotonicTime());
   MOCK_CONST_METHOD0(lastDownstreamRxByteReceived, absl::optional<std::chrono::nanoseconds>());
   MOCK_METHOD0(onLastDownstreamRxByteReceived, void());
+  MOCK_METHOD1(setUpstreamTiming, void(const UpstreamTiming&));
   MOCK_CONST_METHOD0(firstUpstreamTxByteSent, absl::optional<std::chrono::nanoseconds>());
   MOCK_METHOD0(onFirstUpstreamTxByteSent, void());
   MOCK_CONST_METHOD0(lastUpstreamTxByteSent, absl::optional<std::chrono::nanoseconds>());

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -39,7 +39,6 @@ public:
   MOCK_METHOD0(onLastDownstreamTxByteSent, void());
   MOCK_METHOD0(onRequestComplete, void());
   MOCK_CONST_METHOD0(requestComplete, absl::optional<std::chrono::nanoseconds>());
-  MOCK_METHOD0(resetUpstreamTimings, void());
   MOCK_METHOD1(addBytesReceived, void(uint64_t));
   MOCK_CONST_METHOD0(bytesReceived, uint64_t());
   MOCK_CONST_METHOD0(protocol, absl::optional<Http::Protocol>());


### PR DESCRIPTION
Signed-off-by: Michael Puncel <mpuncel@squareup.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: Track upstream request timings in struct separate from StreamInfo
Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
This is a step toward #2784 and #5841 which both involve handling multiple simultaneous in-flight upstream requests in the router filter. This means that the StreamInfo on the callbacks_ cannot be used as scratch space for timing.
