### PR TITLE
Remove include of assert.h from io_handle.h.

### DIFF
--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -4,8 +4,6 @@
 
 #include "envoy/common/pure.h"
 
-#include "common/common/assert.h"
-
 namespace Envoy {
 namespace Network {
 


### PR DESCRIPTION
Description: Remove include of assert.h from io_handle.h. It appears to be unused, and is causing problems with transitive dependencies for Google import.
Risk Level: Low
Testing: bazel test //test/...

Signed-off-by: Dan Noé <dpn@google.com>

