### PR TITLE
build: update libevent to 2.1.9-beta.

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -25,13 +25,17 @@ envoy_cmake_external(
     cache_entries = {
         "EVENT__DISABLE_OPENSSL": "on",
         "EVENT__DISABLE_REGRESS": "on",
+        "EVENT__LIBRARY_TYPE": "STATIC",
         "CMAKE_BUILD_TYPE": "Release",
     },
     copy_pdb = True,
     lib_source = "@com_github_libevent_libevent//:all",
     static_libraries = select({
         "//bazel:windows_x86_64": ["event.lib"],
-        "//conditions:default": ["libevent.a"],
+        "//conditions:default": [
+            "libevent.a",
+            "libevent_pthreads.a",
+        ],
     }),
 )
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -116,9 +116,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/benchmark/archive/505be96ab23056580a3a2315abba048f4428b04e.tar.gz"],
     ),
     com_github_libevent_libevent = dict(
-        sha256 = "316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d",
-        strip_prefix = "libevent-release-2.1.8-stable",
-        urls = ["https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"],
+        sha256 = "0ab250abac1def3d1e20e23e05ce827efa81db65c9004ccfff58d16404e3e369",
+        strip_prefix = "libevent-release-2.1.9-beta",
+        urls = ["https://github.com/libevent/libevent/archive/release-2.1.9-beta.tar.gz"],
     ),
     com_github_madler_zlib = dict(
         sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",


### PR DESCRIPTION
Fixes #6081 by pulling in https://github.com/libevent/libevent/pull/543.

Risk level: Medium (timers, signals, dispatchers, buffers may be affected).
Testing: CI, verified #6081 is fixed with local TSAN.

Signed-off-by: Harvey Tuch <htuch@google.com>