### PR TITLE
redis: update architecture doc features to add hash tagging

### DIFF
--- a/docs/root/intro/arch_overview/redis.rst
+++ b/docs/root/intro/arch_overview/redis.rst
@@ -21,6 +21,7 @@ The Redis project offers a thorough reference on partitioning as it relates to R
 * Ketama distribution.
 * Detailed command statistics.
 * Active and passive healthchecking.
+* Hash tagging.
 
 **Planned future enhancements**:
 
@@ -30,7 +31,6 @@ The Redis project offers a thorough reference on partitioning as it relates to R
 * Replication.
 * Built-in retry.
 * Tracing.
-* Hash tagging.
 
 .. _arch_overview_redis_configuration:
 


### PR DESCRIPTION
*Description*: Fixes https://github.com/envoyproxy/envoy/issues/6112. Hash tagging was added in https://github.com/envoyproxy/envoy/pull/5623, but I forgot to update the architecture document.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: Add hash tagging as a supported feature.
*Release Notes*: N/A
