### PR TITLE
Allow any host when fallback policy fails

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -386,7 +386,7 @@ message Cluster {
     // subset predicate.
     bool scale_locality_weight = 5;
 
-    // If a fallback policy is set but still no host is selected, chose any.
+    // If a fallback policy is set but still no host is selected, select any.
     bool panic_mode_any = 6;
   }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -386,7 +386,9 @@ message Cluster {
     // subset predicate.
     bool scale_locality_weight = 5;
 
-    // If a fallback policy is set but still no host is selected, select any.
+    // If true, when a fallback policy is configured and it fails to find any host this will
+    // cause any host to be selected instead. This is useful when using the default subset
+    // as the fallback subset, given the default subset might become empty.
     bool panic_mode_any = 6;
   }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -386,7 +386,7 @@ message Cluster {
     // subset predicate.
     bool scale_locality_weight = 5;
 
-    // If true, when a fallback policy is configured and it fails to find any host this will
+    // If true, when a fallback policy is configured and it fails to find a host this will
     // cause any host to be selected instead. This is useful when using the default subset
     // as the fallback subset, given the default subset might become empty.
     bool panic_mode_any = 6;

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -386,9 +386,11 @@ message Cluster {
     // subset predicate.
     bool scale_locality_weight = 5;
 
-    // If true, when a fallback policy is configured and it fails to find a host this will
-    // cause any host to be selected instead. This is useful when using the default subset
-    // as the fallback subset, given the default subset might become empty.
+    // If true, when a fallback policy is configured and its corresponding subset fails to find
+    // a host this will cause any host to be selected instead.
+    //
+    // This is useful when using the default subset as the fallback policy, given the default
+    // subset might become empty which would cause requests to fail unless this option is enabled.
     bool panic_mode_any = 6;
   }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -392,7 +392,6 @@ message Cluster {
     // This is useful when using the default subset as the fallback policy, given the default
     // subset might become empty. With this option enabled, if that happens the LB will attempt
     // to select a host from the entire cluster.
-    which would cause requests to fail unless this option is enabled.
     bool panic_mode_any = 6;
   }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -390,7 +390,9 @@ message Cluster {
     // a host this will cause any host to be selected instead.
     //
     // This is useful when using the default subset as the fallback policy, given the default
-    // subset might become empty which would cause requests to fail unless this option is enabled.
+    // subset might become empty. With this option enabled, if that happens the LB will attempt
+    // to select a host from the entire cluster.
+    which would cause requests to fail unless this option is enabled.
     bool panic_mode_any = 6;
   }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -385,6 +385,9 @@ message Cluster {
     // going to an individual locality if said locality is disproportionally affected by the
     // subset predicate.
     bool scale_locality_weight = 5;
+
+    // If a fallback policy is set but still no host is selected, chose any.
+    bool panic_mode_any = 6;
   }
 
   // Configuration for load balancing subsetting.

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -247,6 +247,7 @@ decisions. Stats are rooted at *cluster.<name>.* and contain the following stati
   lb_subsets_removed, Counter, Number of subsets removed due to no hosts
   lb_subsets_selected, Counter, Number of times any subset was selected for load balancing
   lb_subsets_fallback, Counter, Number of times the fallback policy was invoked
+  lb_subsets_fallback_panic, Counter, Number of times the fallback policy failed so any host was selected
 
 .. _config_cluster_manager_cluster_stats_ring_hash_lb:
 

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -247,7 +247,7 @@ decisions. Stats are rooted at *cluster.<name>.* and contain the following stati
   lb_subsets_removed, Counter, Number of subsets removed due to no hosts
   lb_subsets_selected, Counter, Number of times any subset was selected for load balancing
   lb_subsets_fallback, Counter, Number of times the fallback policy was invoked
-  lb_subsets_fallback_panic, Counter, Number of times the fallback policy failed so any host was selected
+  lb_subsets_fallback_panic, Counter, Number of times the subset panic mode triggered
 
 .. _config_cluster_manager_cluster_stats_ring_hash_lb:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -50,7 +50,7 @@ Version history
 * upstream: added :ref:`degraded health value<arch_overview_load_balancing_degraded>` which allows
   routing to certain hosts only when there are insufficient healthy hosts available.
 * upstream: added support for host weighting and :ref:`locality weighting <arch_overview_load_balancing_locality_weighted_lb>` in the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`, and added a :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>` config parameter to strictly bound the ring size.
-* upstream: added configuration option to select any host when the fallback policy fails
+* upstream: added configuration option to select any host when the fallback policy fails.
 
 1.9.0 (Dec 20, 2018)
 ====================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -50,6 +50,7 @@ Version history
 * upstream: added :ref:`degraded health value<arch_overview_load_balancing_degraded>` which allows
   routing to certain hosts only when there are insufficient healthy hosts available.
 * upstream: added support for host weighting and :ref:`locality weighting <arch_overview_load_balancing_locality_weighted_lb>` in the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`, and added a :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>` config parameter to strictly bound the ring size.
+* upstream: added configuration option to select any host when the fallback policy fails
 
 1.9.0 (Dec 20, 2018)
 ====================

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -58,6 +58,11 @@ public:
    * fraction of hosts removed from the original host set.
    */
   virtual bool scaleLocalityWeight() const PURE;
+
+  /*
+   * @return bool whether to pick any host if the fallback policy fails to find a host.
+   */
+  virtual bool panicModeAny() const PURE;
 };
 
 } // namespace Upstream

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -60,7 +60,8 @@ public:
   virtual bool scaleLocalityWeight() const PURE;
 
   /*
-   * @return bool whether to pick any host if the fallback policy fails to find a host.
+   * @return bool whether to attempt to select a host from the entire cluster if host
+   * selection from the fallback subset fails.
    */
   virtual bool panicModeAny() const PURE;
 };

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -446,6 +446,7 @@ public:
   COUNTER  (lb_subsets_removed)                                                                    \
   COUNTER  (lb_subsets_selected)                                                                   \
   COUNTER  (lb_subsets_fallback)                                                                   \
+  COUNTER  (lb_subsets_fallback_panic)                                                             \
   COUNTER  (original_dst_host_invalid)                                                             \
   COUNTER  (upstream_cx_total)                                                                     \
   GAUGE    (upstream_cx_active)                                                                    \

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -482,7 +482,8 @@ public:
         fallback_policy_(subset_config.fallback_policy()),
         default_subset_(subset_config.default_subset()),
         locality_weight_aware_(subset_config.locality_weight_aware()),
-        scale_locality_weight_(subset_config.scale_locality_weight()) {
+        scale_locality_weight_(subset_config.scale_locality_weight()),
+        panic_mode_any_(subset_config.panic_mode_any()) {
     for (const auto& subset : subset_config.subset_selectors()) {
       if (!subset.keys().empty()) {
         subset_keys_.emplace_back(
@@ -500,6 +501,7 @@ public:
   const std::vector<std::set<std::string>>& subsetKeys() const override { return subset_keys_; }
   bool localityWeightAware() const override { return locality_weight_aware_; }
   bool scaleLocalityWeight() const override { return scale_locality_weight_; }
+  bool panicModeAny() const override { return panic_mode_any_; }
 
 private:
   const bool enabled_;
@@ -508,6 +510,7 @@ private:
   std::vector<std::set<std::string>> subset_keys_;
   const bool locality_weight_aware_;
   const bool scale_locality_weight_;
+  const bool panic_mode_any_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -35,6 +35,14 @@ SubsetLoadBalancer::SubsetLoadBalancer(
       scale_locality_weight_(subsets.scaleLocalityWeight()) {
   ASSERT(subsets.isEnabled());
 
+  if (subsets.panicModeAny()) {
+    HostPredicate predicate = [](const Host&) -> bool { return true; };
+
+    panic_mode_subset_.reset(new LbSubsetEntry());
+    panic_mode_subset_->priority_subset_.reset(
+        new PrioritySubsetImpl(*this, predicate, locality_weight_aware_, scale_locality_weight_));
+  }
+
   // Create filtered default subset (if necessary) and other subsets based on current hosts.
   refreshSubsets();
 
@@ -96,8 +104,21 @@ HostConstSharedPtr SubsetLoadBalancer::chooseHost(LoadBalancerContext* context) 
     return nullptr;
   }
 
-  stats_.lb_subsets_fallback_.inc();
-  return fallback_subset_->priority_subset_->lb_->chooseHost(context);
+  HostConstSharedPtr host = fallback_subset_->priority_subset_->lb_->chooseHost(context);
+  if (host != nullptr) {
+    stats_.lb_subsets_fallback_.inc();
+    return host;
+  }
+
+  if (panic_mode_subset_ != nullptr) {
+    HostConstSharedPtr host = panic_mode_subset_->priority_subset_->lb_->chooseHost(context);
+    if (host != nullptr) {
+      stats_.lb_subsets_fallback_panic_.inc();
+      return host;
+    }
+  }
+
+  return nullptr;
 }
 
 // Find a host from the subsets. Sets host_chosen to false and returns nullptr if the context has

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -38,9 +38,9 @@ SubsetLoadBalancer::SubsetLoadBalancer(
   if (subsets.panicModeAny()) {
     HostPredicate predicate = [](const Host&) -> bool { return true; };
 
-    panic_mode_subset_.reset(new LbSubsetEntry());
-    panic_mode_subset_->priority_subset_.reset(
-        new PrioritySubsetImpl(*this, predicate, locality_weight_aware_, scale_locality_weight_));
+    panic_mode_subset_ = std::make_unique<LbSubsetEntry>();
+    panic_mode_subset_->priority_subset_ = std::make_unique<PrioritySubsetImpl>(
+        *this, predicate, locality_weight_aware_, scale_locality_weight_);
   }
 
   // Create filtered default subset (if necessary) and other subsets based on current hosts.

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -175,6 +175,7 @@ private:
   Common::CallbackHandle* original_priority_set_callback_handle_;
 
   LbSubsetEntryPtr fallback_subset_;
+  LbSubsetEntryPtr panic_mode_subset_;
 
   // Forms a trie-like structure. Requires lexically sorted Host and Route metadata.
   LbSubsetMap subsets_;

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -470,11 +470,12 @@ TEST_F(SubsetLoadBalancerTest, FallbackDefaultSubset) {
   EXPECT_EQ(0U, stats_.lb_subsets_selected_.value());
 }
 
-TEST_F(SubsetLoadBalancerTest, FallbackPanicModeSubset) {
+TEST_F(SubsetLoadBalancerTest, FallbackPanicMode) {
   EXPECT_CALL(subset_info_, fallbackPolicy())
       .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET));
   EXPECT_CALL(subset_info_, panicModeAny()).WillRepeatedly(Return(true));
 
+  // The default subset will be empty.
   const ProtobufWkt::Struct default_subset = makeDefaultSubset({{"version", "none"}});
   EXPECT_CALL(subset_info_, defaultSubset()).WillRepeatedly(ReturnRef(default_subset));
 

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -472,17 +472,16 @@ TEST_F(SubsetLoadBalancerTest, FallbackDefaultSubset) {
 
 TEST_F(SubsetLoadBalancerTest, FallbackPanicModeSubset) {
   EXPECT_CALL(subset_info_, fallbackPolicy())
-    .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET));
-  EXPECT_CALL(subset_info_, panicModeAny())
-    .WillRepeatedly(Return(true));
+      .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET));
+  EXPECT_CALL(subset_info_, panicModeAny()).WillRepeatedly(Return(true));
 
   const ProtobufWkt::Struct default_subset = makeDefaultSubset({{"version", "none"}});
   EXPECT_CALL(subset_info_, defaultSubset()).WillRepeatedly(ReturnRef(default_subset));
 
   init({
-        {"tcp://127.0.0.1:80", {{"version", "new"}}},
-        {"tcp://127.0.0.1:81", {{"version", "default"}}},
-    });
+      {"tcp://127.0.0.1:80", {{"version", "new"}}},
+      {"tcp://127.0.0.1:81", {{"version", "default"}}},
+  });
 
   EXPECT_TRUE(lb_->chooseHost(nullptr) != nullptr);
   EXPECT_EQ(1U, stats_.lb_subsets_fallback_panic_.value());

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -470,6 +470,26 @@ TEST_F(SubsetLoadBalancerTest, FallbackDefaultSubset) {
   EXPECT_EQ(0U, stats_.lb_subsets_selected_.value());
 }
 
+TEST_F(SubsetLoadBalancerTest, FallbackPanicModeSubset) {
+  EXPECT_CALL(subset_info_, fallbackPolicy())
+    .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET));
+  EXPECT_CALL(subset_info_, panicModeAny())
+    .WillRepeatedly(Return(true));
+
+  const ProtobufWkt::Struct default_subset = makeDefaultSubset({{"version", "none"}});
+  EXPECT_CALL(subset_info_, defaultSubset()).WillRepeatedly(ReturnRef(default_subset));
+
+  init({
+        {"tcp://127.0.0.1:80", {{"version", "new"}}},
+        {"tcp://127.0.0.1:81", {{"version", "default"}}},
+    });
+
+  EXPECT_TRUE(lb_->chooseHost(nullptr) != nullptr);
+  EXPECT_EQ(1U, stats_.lb_subsets_fallback_panic_.value());
+  EXPECT_EQ(0U, stats_.lb_subsets_fallback_.value());
+  EXPECT_EQ(0U, stats_.lb_subsets_selected_.value());
+}
+
 TEST_P(SubsetLoadBalancerTest, FallbackDefaultSubsetAfterUpdate) {
   EXPECT_CALL(subset_info_, fallbackPolicy())
       .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -36,6 +36,7 @@ public:
   MOCK_CONST_METHOD0(subsetKeys, const std::vector<std::set<std::string>>&());
   MOCK_CONST_METHOD0(localityWeightAware, bool());
   MOCK_CONST_METHOD0(scaleLocalityWeight, bool());
+  MOCK_CONST_METHOD0(panicModeAny, bool());
 
   std::vector<std::set<std::string>> subset_keys_;
 };


### PR DESCRIPTION
We use the default subset as our fallback policy. However, if there's
a problem with our metadata it's possible for the default subset
to become empty. In this case, we'd like any host to be selected.

This change adds a `panic_mode_any` boolean option to LbSubsetConfig
to enable this behavior.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
