### PR TITLE
doc: update compiler requirement in docs

### DIFF
--- a/docs/root/install/building.rst
+++ b/docs/root/install/building.rst
@@ -20,7 +20,7 @@ recent Linux including Ubuntu 16 LTS.
 
 Building Envoy has the following requirements:
 
-* GCC 5+ (for C++14 support).
+* GCC 7+ or Clang/LLVM 7+ (for C++14 support).
 * These :repo:`pre-built </ci/build_container/build_recipes>` third party dependencies.
 * These :repo:`Bazel native <bazel/repository_locations.bzl>` dependencies.
 


### PR DESCRIPTION
Description:
We no longer have CI run with gcc-5 and the build doesn't work with gcc-5 anymore.

Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A