### PR TITLE
dubbo: fix segfault in filter initialization

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/config.cc
@@ -16,9 +16,12 @@ Network::FilterFactoryCb DubboProxyFilterConfigFactory::createFilterFactoryFromP
 
   const std::string stat_prefix = fmt::format("dubbo.{}.", proto_config.stat_prefix());
 
-  return [stat_prefix, &proto_config, &context](Network::FilterManager& filter_manager) -> void {
+  Filter::ConfigProtocolType protocol_type = proto_config.protocol_type();
+  Filter::ConfigSerializationType serialization_type = proto_config.serialization_type();
+
+  return [stat_prefix,protocol_type,serialization_type,&context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<Filter>(
-        stat_prefix, proto_config.protocol_type(), proto_config.serialization_type(),
+        stat_prefix, protocol_type, serialization_type,
         context.scope(), context.dispatcher().timeSource()));
   };
 }

--- a/source/extensions/filters/network/dubbo_proxy/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/config.cc
@@ -19,10 +19,11 @@ Network::FilterFactoryCb DubboProxyFilterConfigFactory::createFilterFactoryFromP
   Filter::ConfigProtocolType protocol_type = proto_config.protocol_type();
   Filter::ConfigSerializationType serialization_type = proto_config.serialization_type();
 
-  return [stat_prefix,protocol_type,serialization_type,&context](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addFilter(std::make_shared<Filter>(
-        stat_prefix, protocol_type, serialization_type,
-        context.scope(), context.dispatcher().timeSource()));
+  return [stat_prefix, protocol_type, serialization_type,
+          &context](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addFilter(std::make_shared<Filter>(stat_prefix, protocol_type,
+                                                      serialization_type, context.scope(),
+                                                      context.dispatcher().timeSource()));
   };
 }
 


### PR DESCRIPTION
Signed-off-by: zengyuxing <hzzengyuxing@corp.netease.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description:

send a dubbo request to envoy （using dubbo filter) , which will cause envoy segmentation fault (core dumped)

Then Dubbo Filter create callback:
``` cpp
  DubboProxyFilterConfigFactory::createFilterFactoryFromProtoTyped

```
using a lambada ,but captures a referenced -- local variables---  

 auto message = Config::Utility::translateToFactoryConfig(proto_config, factory);         

``` cpp
std::vector<Network::FilterFactoryCb> ProdListenerComponentFactory::createNetworkFilterFactoryList_(                                                                                       
    const Protobuf::RepeatedPtrField<envoy::api::v2::listener::Filter>& filters,                                                                                                           
    Configuration::FactoryContext& context) {                                                                                                                                              
  std::vector<Network::FilterFactoryCb> ret;                                                                                                                                               
  for (ssize_t i = 0; i < filters.size(); i++) {                                                                                                                                           
    const auto& proto_config = filters[i];                                                                                                                                                 
    const ProtobufTypes::String string_name = proto_config.name();                                                                                                                         
    ENVOY_LOG(debug, "  filter #{}:", i);                                                                                                                                                  
    ENVOY_LOG(debug, "    name: {}", string_name);                                                                                                                                         
    const Json::ObjectSharedPtr filter_config =                                                                                                                                            
        MessageUtil::getJsonObjectFromMessage(proto_config.config());                                                                                                                      
    ENVOY_LOG(debug, "  config: {}", filter_config->asJsonString());                                                                                                                       
                                                                                                                                                                                           
    // Now see if there is a factory that will accept the config.                                                                                                                          
    auto& factory =                                                                                                                                                                        
        Config::Utility::getAndCheckFactory<Configuration::NamedNetworkFilterConfigFactory>(                                                                                               
            string_name);                                                                                                                                                                  
    Network::FilterFactoryCb callback;                                                                                                                                                     
    if (filter_config->getBoolean("deprecated_v1", false)) {                                                                                                                               
      callback = factory.createFilterFactory(*filter_config->getObject("value", true), context);                                                                                           
    } else {                                                                                                                                                                               
      auto message = Config::Utility::translateToFactoryConfig(proto_config, factory);                                                                                                     
      callback = factory.createFilterFactoryFromProto(*message, context);                                                                                                                  
    }                                                                                                                                                                                      
    ret.push_back(callback);                                                                                                                                                               
  }                                                                                                                                                                                        
  return ret;                                                                                                                                                                              
}

....

Network::FilterFactoryCb DubboProxyFilterConfigFactory::createFilterFactoryFromProtoTyped(
    const envoy::config::filter::network::dubbo_proxy::v2alpha1::DubboProxy& proto_config,
    Server::Configuration::FactoryContext& context) {
  ASSERT(!proto_config.stat_prefix().empty());

  const std::string stat_prefix = fmt::format("dubbo.{}.", proto_config.stat_prefix());

  return [stat_prefix, &proto_config, &context](Network::FilterManager& filter_manager) -> void {
    filter_manager.addFilter(std::make_shared<Filter>(
        stat_prefix, proto_config.protocol_type(), proto_config.serialization_type(),
        context.scope(), context.dispatcher().timeSource()));
  };
}
```

Risk Level:
  low (extension only)

