### PR TITLE
Making enum type Status::GrpcStatus hashable

### DIFF
--- a/source/common/access_log/BUILD
+++ b/source/common/access_log/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
     name = "access_log_lib",
     srcs = ["access_log_impl.cc"],
     hdrs = ["access_log_impl.h"],
+    external_deps = ["abseil_hash"],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/filesystem:filesystem_interface",

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -14,6 +14,8 @@
 #include "common/http/header_utility.h"
 #include "common/protobuf/protobuf.h"
 
+#include "absl/hash/hash.h"
+
 namespace Envoy {
 namespace AccessLog {
 
@@ -198,6 +200,9 @@ private:
  */
 class GrpcStatusFilter : public Filter {
 public:
+  using GrpcStatusHashSet =
+      std::unordered_set<Grpc::Status::GrpcStatus, absl::Hash<Grpc::Status::GrpcStatus>>;
+
   GrpcStatusFilter(const envoy::config::filter::accesslog::v2::GrpcStatusFilter& config);
 
   // AccessLog::Filter
@@ -206,7 +211,7 @@ public:
                 const Http::HeaderMap& response_trailers) override;
 
 private:
-  std::unordered_set<Grpc::Status::GrpcStatus> statuses_;
+  GrpcStatusHashSet statuses_;
   bool exclude_;
 
   /**


### PR DESCRIPTION
Signed-off-by: zyfjeff <tianqian.zyf@alibaba-inc.com>


Fixed under gcc5.5 because `Status::GrpcStatus` did not hashable cause compilation to fail

```
/usr/local/gcc55/lib/gcc/x86_64-unknown-linux-gnu/5.5.0/../../../../include/c++/5.5.0/bits/hashtable_policy.h:85:34: error: no match for call to '(const std::hash<Envoy::Grpc::Status::GrpcStatus>) (const Envoy::Grpc::Status::GrpcStatus&)'
  noexcept(declval<const _Hash&>()(declval<const _Key&>()))>
```

Description: Making enum type `Status::GrpcStatus` hashable
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

