### PR TITLE
refactor retry state impl API

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -228,9 +228,8 @@ public:
   virtual bool enabled() PURE;
 
   /**
-   * Determine whether a request should be retried based on the response.
-   * @param response_headers supplies the response headers if available.
-   * @param reset_reason supplies the reset reason if available.
+   * Determine whether a request should be retried based on the response headers.
+   * @param response_headers supplies the response headers.
    * @param callback supplies the callback that will be invoked when the retry should take place.
    *                 This is used to add timed backoff, etc. The callback will never be called
    *                 inline.
@@ -238,8 +237,20 @@ public:
    *         in the future. Otherwise a retry should not take place and the callback will never be
    *         called. Calling code should proceed with error handling.
    */
-  virtual RetryStatus shouldRetry(const Http::HeaderMap* response_headers,
-                                  const absl::optional<Http::StreamResetReason>& reset_reason,
+  virtual RetryStatus shouldRetryHeaders(const Http::HeaderMap* response_headers,
+                                  DoRetryCallback callback) PURE;
+
+  /**
+   * Determine whether a request should be retried after a reset based on the reason for the rest.
+   * @param reset_reason supplies the reset reason.
+   * @param callback supplies the callback that will be invoked when the retry should take place.
+   *                 This is used to add timed backoff, etc. The callback will never be called
+   *                 inline.
+   * @return RetryStatus if a retry should take place. @param callback will be called at some point
+   *         in the future. Otherwise a retry should not take place and the callback will never be
+   *         called. Calling code should proceed with error handling.
+   */
+  virtual RetryStatus shouldRetryReset(const Http::StreamResetReason reset_reason,
                                   DoRetryCallback callback) PURE;
 
   /**

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -238,7 +238,7 @@ public:
    *         called. Calling code should proceed with error handling.
    */
   virtual RetryStatus shouldRetryHeaders(const Http::HeaderMap* response_headers,
-                                  DoRetryCallback callback) PURE;
+                                         DoRetryCallback callback) PURE;
 
   /**
    * Determine whether a request should be retried after a reset based on the reason for the rest.
@@ -251,7 +251,7 @@ public:
    *         called. Calling code should proceed with error handling.
    */
   virtual RetryStatus shouldRetryReset(const Http::StreamResetReason reset_reason,
-                                  DoRetryCallback callback) PURE;
+                                       DoRetryCallback callback) PURE;
 
   /**
    * Called when a host was attempted but the request failed and is eligible for another retry.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -237,11 +237,11 @@ public:
    *         in the future. Otherwise a retry should not take place and the callback will never be
    *         called. Calling code should proceed with error handling.
    */
-  virtual RetryStatus shouldRetryHeaders(const Http::HeaderMap* response_headers,
+  virtual RetryStatus shouldRetryHeaders(const Http::HeaderMap& response_headers,
                                          DoRetryCallback callback) PURE;
 
   /**
-   * Determine whether a request should be retried after a reset based on the reason for the rest.
+   * Determine whether a request should be retried after a reset based on the reason for the reset.
    * @param reset_reason supplies the reset reason.
    * @param callback supplies the callback that will be invoked when the retry should take place.
    *                 This is used to add timed backoff, etc. The callback will never be called

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -35,7 +35,7 @@ RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
                                      Upstream::ResourcePriority priority) {
   RetryStatePtr ret;
 
-  // We short circuit here and do not both with an allocation if there is no chance we will retry.
+  // We short circuit here and do not bother with an allocation if there is no chance we will retry.
   if (request_headers.EnvoyRetryOn() || request_headers.EnvoyRetryGrpcOn() ||
       route_policy.retryOn()) {
     ret.reset(new RetryStateImpl(route_policy, request_headers, cluster, runtime, random,
@@ -147,13 +147,8 @@ void RetryStateImpl::resetRetry() {
   }
 }
 
-RetryStatus RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
-                                        const absl::optional<Http::StreamResetReason>& reset_reason,
-                                        DoRetryCallback callback) {
-
-  ASSERT((response_headers != nullptr) ^ reset_reason.has_value());
-
-  if (callback_ && !wouldRetry(response_headers, reset_reason)) {
+RetryStatus RetryStateImpl::shouldRetry(RetryPredicate would_retry, DoRetryCallback callback) {
+  if (callback_ && !would_retry()) {
     cluster_.stats().upstream_rq_retry_success_.inc();
   }
 
@@ -164,7 +159,7 @@ RetryStatus RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
   }
 
   retries_remaining_--;
-  if (!wouldRetry(response_headers, reset_reason)) {
+  if (!would_retry()) {
     return RetryStatus::No;
   }
 
@@ -185,7 +180,25 @@ RetryStatus RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
   return RetryStatus::Yes;
 }
 
+RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::HeaderMap* response_headers, DoRetryCallback callback) {
+  ASSERT(response_headers != nullptr);
+  return shouldRetry([this, response_headers]() -> bool { return wouldRetryFromHeaders(*response_headers); }, callback);
+}
+
+RetryStatus RetryStateImpl::shouldRetryReset(const Http::StreamResetReason reset_reason, DoRetryCallback callback) {
+  return shouldRetry([this, reset_reason]() -> bool { return wouldRetryFromReset(reset_reason); }, callback);
+}
+
 bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_headers) {
+  if (response_headers.EnvoyOverloaded() != nullptr) {
+    return false;
+  }
+
+  // We never retry if the request is rate limited.
+  if (response_headers.EnvoyRateLimited() != nullptr) {
+    return false;
+  }
+
   if (retry_on_ & RetryPolicy::RETRY_ON_5XX) {
     if (Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(response_headers))) {
       return true;
@@ -237,7 +250,20 @@ bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_heade
   return false;
 }
 
-bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason& reset_reason) {
+bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason reset_reason) {
+  // First check "never retry" conditions so we can short circuit (we never
+  // retry if the reset reason is overflow).
+  if (reset_reason == Http::StreamResetReason::Overflow) {
+    return false;
+  }
+
+  if (retry_on_ & (RetryPolicy::RETRY_ON_5XX | RetryPolicy::RETRY_ON_GATEWAY_ERROR)) {
+    // Currently we count an upstream reset as a "5xx" (since it will result in
+    // one). We may eventually split this out into its own type. I.e.,
+    // RETRY_ON_RESET.
+    return true;
+  }
+
   if ((retry_on_ & RetryPolicy::RETRY_ON_REFUSED_STREAM) &&
       reset_reason == Http::StreamResetReason::RemoteRefusedStreamReset) {
     return true;
@@ -249,40 +275,6 @@ bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason& reset_re
   }
 
   return false;
-}
-
-bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
-                                const absl::optional<Http::StreamResetReason>& reset_reason) {
-  // First check "never retry" conditions so we can short circuit, then delegate to
-  // helper methods for checks dependent on retry policy.
-
-  // we never retry if the reset reason is overflow.
-  if (reset_reason && reset_reason.value() == Http::StreamResetReason::Overflow) {
-    return false;
-  }
-
-  if (response_headers != nullptr) {
-    // We never retry if the overloaded header is set.
-    if (response_headers->EnvoyOverloaded() != nullptr) {
-      return false;
-    }
-
-    // We never retry if the request is rate limited.
-    if (response_headers->EnvoyRateLimited() != nullptr) {
-      return false;
-    }
-
-    if (wouldRetryFromHeaders(*response_headers)) {
-      return true;
-    }
-  } else if (retry_on_ & (RetryPolicy::RETRY_ON_5XX | RetryPolicy::RETRY_ON_GATEWAY_ERROR)) {
-    // wouldRetry() is passed null headers when there was an upstream reset. Currently we count an
-    // upstream reset as a "5xx" (since it will result in one). We may eventually split this out
-    // into its own type. I.e., RETRY_ON_RESET.
-    return true;
-  }
-
-  return reset_reason && wouldRetryFromReset(*reset_reason);
 }
 
 } // namespace Router

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -180,13 +180,18 @@ RetryStatus RetryStateImpl::shouldRetry(RetryPredicate would_retry, DoRetryCallb
   return RetryStatus::Yes;
 }
 
-RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::HeaderMap* response_headers, DoRetryCallback callback) {
+RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::HeaderMap* response_headers,
+                                               DoRetryCallback callback) {
   ASSERT(response_headers != nullptr);
-  return shouldRetry([this, response_headers]() -> bool { return wouldRetryFromHeaders(*response_headers); }, callback);
+  return shouldRetry(
+      [this, response_headers]() -> bool { return wouldRetryFromHeaders(*response_headers); },
+      callback);
 }
 
-RetryStatus RetryStateImpl::shouldRetryReset(const Http::StreamResetReason reset_reason, DoRetryCallback callback) {
-  return shouldRetry([this, reset_reason]() -> bool { return wouldRetryFromReset(reset_reason); }, callback);
+RetryStatus RetryStateImpl::shouldRetryReset(const Http::StreamResetReason reset_reason,
+                                             DoRetryCallback callback) {
+  return shouldRetry([this, reset_reason]() -> bool { return wouldRetryFromReset(reset_reason); },
+                     callback);
 }
 
 bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_headers) {

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -36,8 +36,10 @@ public:
 
   // Router::RetryState
   bool enabled() override { return retry_on_ != 0; }
-  RetryStatus shouldRetryHeaders(const Http::HeaderMap* response_headers, DoRetryCallback callback) override;
-  RetryStatus shouldRetryReset(const Http::StreamResetReason reset_reason, DoRetryCallback callback) override;
+  RetryStatus shouldRetryHeaders(const Http::HeaderMap* response_headers,
+                                 DoRetryCallback callback) override;
+  RetryStatus shouldRetryReset(const Http::StreamResetReason reset_reason,
+                               DoRetryCallback callback) override;
 
   void onHostAttempted(Upstream::HostDescriptionConstSharedPtr host) override {
     std::for_each(retry_host_predicates_.begin(), retry_host_predicates_.end(),

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -36,7 +36,7 @@ public:
 
   // Router::RetryState
   bool enabled() override { return retry_on_ != 0; }
-  RetryStatus shouldRetryHeaders(const Http::HeaderMap* response_headers,
+  RetryStatus shouldRetryHeaders(const Http::HeaderMap& response_headers,
                                  DoRetryCallback callback) override;
   RetryStatus shouldRetryReset(const Http::StreamResetReason reset_reason,
                                DoRetryCallback callback) override;
@@ -67,8 +67,6 @@ public:
   uint32_t hostSelectionMaxAttempts() const override { return host_selection_max_attempts_; }
 
 private:
-  typedef std::function<bool()> RetryPredicate;
-
   RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
                  const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
@@ -78,7 +76,7 @@ private:
   void resetRetry();
   bool wouldRetryFromReset(const Http::StreamResetReason reset_reason);
   bool wouldRetryFromHeaders(const Http::HeaderMap& response_headers);
-  RetryStatus shouldRetry(RetryPredicate would_retry, DoRetryCallback callback);
+  RetryStatus shouldRetry(bool would_retry, DoRetryCallback callback);
 
   const Upstream::ClusterInfo& cluster_;
   Runtime::Loader& runtime_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -556,6 +556,9 @@ void Filter::onUpstreamReset(UpstreamResetType type,
       retry_state_->onHostAttempted(upstream_host);
     }
 
+    // There must be a value for reset_reason because the only case where it's
+    // empty is when type == UpstreamResetType::GlobalTimeout.
+    ASSERT(reset_reason.has_value());
     RetryStatus retry_status =
         retry_state_->shouldRetryReset(reset_reason.value(), [this]() -> void { doRetry(); });
     if (retry_status == RetryStatus::Yes && setupRetry(true)) {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -688,7 +688,8 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
     // Notify retry modifiers about the attempted host.
     retry_state_->onHostAttempted(upstream_request_->upstream_host_);
 
-    RetryStatus retry_status = retry_state_->shouldRetryHeaders(headers.get(), [this]() -> void { doRetry(); });
+    RetryStatus retry_status =
+        retry_state_->shouldRetryHeaders(headers.get(), [this]() -> void { doRetry(); });
     // Capture upstream_host since setupRetry() in the following line will clear
     // upstream_request_.
     const auto upstream_host = upstream_request_->upstream_host_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -532,7 +532,7 @@ void Filter::onResponseTimeout() {
 }
 
 void Filter::onUpstreamReset(UpstreamResetType type,
-                             const absl::optional<Http::StreamResetReason>& reset_reason) {
+                             const absl::optional<Http::StreamResetReason> reset_reason) {
   ASSERT(type == UpstreamResetType::GlobalTimeout || upstream_request_);
   if (type == UpstreamResetType::Reset) {
     ENVOY_STREAM_LOG(debug, "upstream reset: reset reason {}", *callbacks_,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -689,7 +689,7 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
     retry_state_->onHostAttempted(upstream_request_->upstream_host_);
 
     RetryStatus retry_status =
-        retry_state_->shouldRetryHeaders(headers.get(), [this]() -> void { doRetry(); });
+        retry_state_->shouldRetryHeaders(*headers, [this]() -> void { doRetry(); });
     // Capture upstream_host since setupRetry() in the following line will clear
     // upstream_request_.
     const auto upstream_host = upstream_request_->upstream_host_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -557,7 +557,7 @@ void Filter::onUpstreamReset(UpstreamResetType type,
     }
 
     RetryStatus retry_status =
-        retry_state_->shouldRetry(nullptr, reset_reason, [this]() -> void { doRetry(); });
+        retry_state_->shouldRetryReset(reset_reason.value(), [this]() -> void { doRetry(); });
     if (retry_status == RetryStatus::Yes && setupRetry(true)) {
       if (upstream_host) {
         upstream_host->stats().rq_error_.inc();
@@ -688,8 +688,7 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
     // Notify retry modifiers about the attempted host.
     retry_state_->onHostAttempted(upstream_request_->upstream_host_);
 
-    RetryStatus retry_status = retry_state_->shouldRetry(
-        headers.get(), absl::optional<Http::StreamResetReason>(), [this]() -> void { doRetry(); });
+    RetryStatus retry_status = retry_state_->shouldRetryHeaders(headers.get(), [this]() -> void { doRetry(); });
     // Capture upstream_host since setupRetry() in the following line will clear
     // upstream_request_.
     const auto upstream_host = upstream_request_->upstream_host_;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -379,7 +379,7 @@ private:
   void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map);
   void onUpstreamComplete();
   void onUpstreamReset(UpstreamResetType type,
-                       const absl::optional<Http::StreamResetReason>& reset_reason);
+                       const absl::optional<Http::StreamResetReason> reset_reason);
   void sendNoHealthyUpstreamResponse();
   bool setupRetry(bool end_stream);
   bool setupRedirect(const Http::HeaderMap& headers);

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -109,12 +109,12 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote503) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "503"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote503Overloaded) {
@@ -123,7 +123,7 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote503Overloaded) {
   EXPECT_TRUE(state_->enabled());
 
   Http::TestHeaderMapImpl response_headers{{":status", "503"}, {"x-envoy-overloaded", "true"}};
-  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyResourceExhaustedRemoteRateLimited) {
@@ -133,7 +133,7 @@ TEST_F(RouterRetryStateImplTest, PolicyResourceExhaustedRemoteRateLimited) {
 
   Http::TestHeaderMapImpl response_headers{
       {":status", "200"}, {"grpc-status", "8"}, {"x-envoy-ratelimited", "true"}};
-  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote502) {
@@ -143,12 +143,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote502) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "502"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote503) {
@@ -158,12 +158,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote503) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "503"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote504) {
@@ -173,12 +173,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote504) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "504"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorResetOverflow) {
@@ -208,12 +208,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcDeadlineExceeded) {
@@ -223,12 +223,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcDeadlineExceeded) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "4"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
@@ -238,12 +238,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "8"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcUnavilable) {
@@ -253,12 +253,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcUnavilable) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "14"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcInternal) {
@@ -268,12 +268,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcInternal) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "13"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
@@ -282,7 +282,7 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
 
@@ -321,7 +321,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxRetry) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "409"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 }
@@ -332,7 +332,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxNoRetry) {
   EXPECT_TRUE(state_->enabled());
 
   Http::TestHeaderMapImpl response_headers{{":status", "400"}};
-  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxReset) {
@@ -352,7 +352,7 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodes) {
   expectTimerCreateAndEnable();
 
   Http::TestHeaderMapImpl response_headers{{":status", "409"}};
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, RetriableStatusCodesUpstreamReset) {
@@ -373,7 +373,7 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodesHeader) {
     expectTimerCreateAndEnable();
 
     Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
   {
     Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"},
@@ -384,7 +384,7 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodesHeader) {
     expectTimerCreateAndEnable();
 
     Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
   {
     Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"},
@@ -395,7 +395,7 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodesHeader) {
     expectTimerCreateAndEnable();
 
     Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(&response_headers, callback_));
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
   {
     Http::TestHeaderMapImpl request_headers{
@@ -405,7 +405,7 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodesHeader) {
     EXPECT_TRUE(state_->enabled());
 
     Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(&response_headers, callback_));
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
   }
 }
 
@@ -494,7 +494,7 @@ TEST_F(RouterRetryStateImplTest, Backoff) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(&response_headers, callback_));
+            state_->shouldRetryHeaders(response_headers, callback_));
 
   EXPECT_EQ(3UL, cluster_.stats().upstream_rq_retry_.value());
   EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_success_.value());

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -56,7 +56,8 @@ public:
   RetryState::DoRetryCallback callback_;
 
   const Http::StreamResetReason remote_reset_{Http::StreamResetReason::RemoteReset};
-  const Http::StreamResetReason remote_refused_stream_reset_{Http::StreamResetReason::RemoteRefusedStreamReset};
+  const Http::StreamResetReason remote_refused_stream_reset_{
+      Http::StreamResetReason::RemoteRefusedStreamReset};
   const Http::StreamResetReason overflow_reset_{Http::StreamResetReason::Overflow};
   const Http::StreamResetReason connect_failure_{Http::StreamResetReason::ConnectionFailure};
 };
@@ -73,8 +74,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRefusedStream) {
   EXPECT_TRUE(state_->enabled());
 
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes,
-            state_->shouldRetryReset(remote_refused_stream_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_refused_stream_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
@@ -99,8 +99,7 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemoteReset) {
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryReset(remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote503) {
@@ -199,8 +198,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemoteReset) {
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryReset(remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
@@ -285,8 +283,7 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
   EXPECT_TRUE(state_->enabled());
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(&response_headers, callback_));
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryReset(remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, RuntimeGuard) {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -137,7 +137,7 @@ public:
     HttpTestUtility::addDefaultHeaders(headers);
     router_->decodeHeaders(headers, true);
 
-    EXPECT_CALL(*router_->retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+    EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
 
     Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl(response_headers_init));
     response_headers->insertStatus().value(response_code);
@@ -172,7 +172,7 @@ public:
     HttpTestUtility::addDefaultHeaders(headers);
     router_->decodeHeaders(headers, true);
 
-    router_->retry_state_->expectRetry();
+    router_->retry_state_->expectResetRetry();
     EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
                 putHttpResponseCode(504));
     per_try_timeout_->callback_();
@@ -191,7 +191,7 @@ public:
     router_->retry_state_->callback_();
 
     // Normal response.
-    EXPECT_CALL(*router_->retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+    EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
     Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
     EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
                 putHttpResponseCode(200));

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -20,9 +20,14 @@ MockDirectResponseEntry::~MockDirectResponseEntry() {}
 
 MockRetryState::MockRetryState() {}
 
-void MockRetryState::expectRetry() {
-  EXPECT_CALL(*this, shouldRetry(_, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&callback_), Return(RetryStatus::Yes)));
+void MockRetryState::expectHeadersRetry() {
+  EXPECT_CALL(*this, shouldRetryHeaders(_, _))
+      .WillOnce(DoAll(SaveArg<1>(&callback_), Return(RetryStatus::Yes)));
+}
+
+void MockRetryState::expectResetRetry() {
+  EXPECT_CALL(*this, shouldRetryReset(_, _))
+      .WillOnce(DoAll(SaveArg<1>(&callback_), Return(RetryStatus::Yes)));
 }
 
 MockRetryState::~MockRetryState() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -110,7 +110,7 @@ public:
 
   MOCK_METHOD0(enabled, bool());
   MOCK_METHOD2(shouldRetryHeaders,
-               RetryStatus(const Http::HeaderMap* response_headers, DoRetryCallback callback));
+               RetryStatus(const Http::HeaderMap& response_headers, DoRetryCallback callback));
   MOCK_METHOD2(shouldRetryReset,
                RetryStatus(const Http::StreamResetReason reset_reason, DoRetryCallback callback));
   MOCK_METHOD1(onHostAttempted, void(Upstream::HostDescriptionConstSharedPtr));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -109,10 +109,10 @@ public:
   void expectResetRetry();
 
   MOCK_METHOD0(enabled, bool());
-  MOCK_METHOD2(shouldRetryHeaders, RetryStatus(const Http::HeaderMap* response_headers,
-                                        DoRetryCallback callback));
-  MOCK_METHOD2(shouldRetryReset, RetryStatus(const Http::StreamResetReason reset_reason,
-                                        DoRetryCallback callback));
+  MOCK_METHOD2(shouldRetryHeaders,
+               RetryStatus(const Http::HeaderMap* response_headers, DoRetryCallback callback));
+  MOCK_METHOD2(shouldRetryReset,
+               RetryStatus(const Http::StreamResetReason reset_reason, DoRetryCallback callback));
   MOCK_METHOD1(onHostAttempted, void(Upstream::HostDescriptionConstSharedPtr));
   MOCK_METHOD1(shouldSelectAnotherHost, bool(const Upstream::Host& host));
   MOCK_METHOD2(priorityLoadForRetry,

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -105,11 +105,13 @@ public:
   MockRetryState();
   ~MockRetryState();
 
-  void expectRetry();
+  void expectHeadersRetry();
+  void expectResetRetry();
 
   MOCK_METHOD0(enabled, bool());
-  MOCK_METHOD3(shouldRetry, RetryStatus(const Http::HeaderMap* response_headers,
-                                        const absl::optional<Http::StreamResetReason>& reset_reason,
+  MOCK_METHOD2(shouldRetryHeaders, RetryStatus(const Http::HeaderMap* response_headers,
+                                        DoRetryCallback callback));
+  MOCK_METHOD2(shouldRetryReset, RetryStatus(const Http::StreamResetReason reset_reason,
                                         DoRetryCallback callback));
   MOCK_METHOD1(onHostAttempted, void(Upstream::HostDescriptionConstSharedPtr));
   MOCK_METHOD1(shouldSelectAnotherHost, bool(const Upstream::Host& host));


### PR DESCRIPTION
Previously there was a single shouldRetry() method which takes a HTTP
header map and a stream reset reason and asserts that only one is set.
In anticipation of adding a new retry case for #5841, this commit breaks
apart this function into shouldRetryHeaders and shouldRetryReset. This
leads to fewer asserts and more intentional code.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

Description: Refactor public API for RetryState.
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
This was done in anticipation of #5841 which will be adding a new retry condition (per try timeout) that does not result from a stream reset or response headers
