### PR TITLE
Refactor onUpstreamReset in router filter.

### DIFF
--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -188,7 +188,7 @@ RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::HeaderMap& response_h
   return shouldRetry(wouldRetryFromHeaders(response_headers), callback);
 }
 
-RetryStatus RetryStateImpl::shouldRetryReset(const Http::StreamResetReason reset_reason,
+RetryStatus RetryStateImpl::shouldRetryReset(Http::StreamResetReason reset_reason,
                                              DoRetryCallback callback) {
   return shouldRetry(wouldRetryFromReset(reset_reason), callback);
 }

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -648,7 +648,7 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason) {
   }
 
   const StreamInfo::ResponseFlag response_flags = streamResetReasonToResponseFlag(reset_reason);
-  const absl::string_view body =
+  const std::string body =
       absl::StrCat("upstream connect error or disconnect/reset before headers. reset reason: ",
                    Http::Utility::resetReasonToString(reset_reason));
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -631,8 +631,7 @@ bool Filter::maybeRetryReset(Http::StreamResetReason reset_reason) {
   } else if (retry_status == RetryStatus::NoOverflow) {
     callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
   } else if (retry_status == RetryStatus::NoRetryLimitExceeded) {
-    callbacks_->streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded);
   }
 
   return false;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -547,7 +547,7 @@ void Filter::onPerTryTimeout() {
     return;
   }
 
-  const std::string body =
+  const absl::string_view body =
       timeout_response_code_ == Http::Code::GatewayTimeout ? "upstream request timeout" : "";
   onUpstreamAbort(timeout_response_code_, StreamInfo::ResponseFlag::UpstreamRequestTimeout, body,
                   false);
@@ -648,7 +648,7 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason) {
   }
 
   const StreamInfo::ResponseFlag response_flags = streamResetReasonToResponseFlag(reset_reason);
-  const std::string body =
+  const absl::string_view body =
       absl::StrCat("upstream connect error or disconnect/reset before headers. reset reason: ",
                    Http::Utility::resetReasonToString(reset_reason));
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -534,8 +534,10 @@ void Filter::onResponseTimeout() {
   }
 
   updateOutlierDetection(timeout_response_code_);
-  std::string body = timeout_response_code_ == Http::Code::GatewayTimeout ? "upstream request timeout" : "";
-  onUpstreamAbort(timeout_response_code_, StreamInfo::ResponseFlag::UpstreamRequestTimeout, body, false);
+  std::string body =
+      timeout_response_code_ == Http::Code::GatewayTimeout ? "upstream request timeout" : "";
+  onUpstreamAbort(timeout_response_code_, StreamInfo::ResponseFlag::UpstreamRequestTimeout, body,
+                  false);
 }
 
 void Filter::onPerTryTimeout() {
@@ -545,8 +547,10 @@ void Filter::onPerTryTimeout() {
     return;
   }
 
-  const std::string body = timeout_response_code_ == Http::Code::GatewayTimeout ? "upstream request timeout" : "";
-  onUpstreamAbort(timeout_response_code_, StreamInfo::ResponseFlag::UpstreamRequestTimeout, body, false);
+  const std::string body =
+      timeout_response_code_ == Http::Code::GatewayTimeout ? "upstream request timeout" : "";
+  onUpstreamAbort(timeout_response_code_, StreamInfo::ResponseFlag::UpstreamRequestTimeout, body,
+                  false);
 }
 
 void Filter::updateOutlierDetection(const Http::Code code) {
@@ -559,7 +563,8 @@ void Filter::updateOutlierDetection(const Http::Code code) {
   }
 }
 
-void Filter::onUpstreamAbort(const Http::Code code, const StreamInfo::ResponseFlag response_flags, const std::string& body, bool dropped) {
+void Filter::onUpstreamAbort(const Http::Code code, const StreamInfo::ResponseFlag response_flags,
+                             const std::string& body, bool dropped) {
   Upstream::HostDescriptionConstSharedPtr upstream_host;
   if (upstream_request_) {
     upstream_host = upstream_request_->upstream_host_;
@@ -650,9 +655,9 @@ void Filter::onUpstreamReset(const Http::StreamResetReason reset_reason) {
   }
 
   const StreamInfo::ResponseFlag response_flags = streamResetReasonToResponseFlag(reset_reason);
-  const std::string body = absl::StrCat(
-        "upstream connect error or disconnect/reset before headers. reset reason: ",
-        Http::Utility::resetReasonToString(reset_reason));
+  const std::string body =
+      absl::StrCat("upstream connect error or disconnect/reset before headers. reset reason: ",
+                   Http::Utility::resetReasonToString(reset_reason));
 
   const bool dropped = reset_reason == Http::StreamResetReason::Overflow;
   onUpstreamAbort(code, response_flags, body, dropped);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -534,7 +534,7 @@ void Filter::onResponseTimeout() {
   }
 
   updateOutlierDetection(timeout_response_code_);
-  std::string body =
+  const std::string body =
       timeout_response_code_ == Http::Code::GatewayTimeout ? "upstream request timeout" : "";
   onUpstreamAbort(timeout_response_code_, StreamInfo::ResponseFlag::UpstreamRequestTimeout, body,
                   false);
@@ -618,8 +618,8 @@ bool Filter::maybeRetryReset(const Http::StreamResetReason reset_reason) {
       retry_state_->onHostAttempted(upstream_host);
     }
 
-    RetryStatus retry_status =
-        retry_state_->shouldRetry(nullptr, reset_reason, [this]() -> void { doRetry(); });
+    const RetryStatus retry_status =
+        retry_state_->shouldRetryReset(reset_reason, [this]() -> void { doRetry(); });
     if (retry_status == RetryStatus::Yes && setupRetry(true)) {
       if (upstream_host) {
         upstream_host->stats().rq_error_.inc();
@@ -636,7 +636,7 @@ bool Filter::maybeRetryReset(const Http::StreamResetReason reset_reason) {
   return false;
 }
 
-void Filter::onUpstreamReset(const Http::StreamResetReason reset_reason) {
+void Filter::onUpstreamReset(Http::StreamResetReason reset_reason) {
   ASSERT(upstream_request_);
   ENVOY_STREAM_LOG(debug, "upstream reset: reset reason {}", *callbacks_,
                    Http::Utility::resetReasonToString(reset_reason));
@@ -730,7 +730,7 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
     // Notify retry modifiers about the attempted host.
     retry_state_->onHostAttempted(upstream_request_->upstream_host_);
 
-    RetryStatus retry_status =
+    const RetryStatus retry_status =
         retry_state_->shouldRetryHeaders(*headers, [this]() -> void { doRetry(); });
     // Capture upstream_host since setupRetry() in the following line will clear
     // upstream_request_.

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -374,6 +374,8 @@ private:
   void onRequestComplete();
   void onResponseTimeout();
   void onUpstream100ContinueHeaders(Http::HeaderMapPtr&& headers);
+  // Handle an upstream request aborted due to a local timeout.
+  void onUpstreamTimeoutAbort(StreamInfo::ResponseFlag response_flag);
   // Handle an "aborted" upstream request, meaning we didn't see response
   // headers (e.g. due to a reset). Handles recording stats and responding
   // downstream if appropriate.

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -41,7 +41,7 @@ namespace Router {
   COUNTER(rq_redirect)                                                                             \
   COUNTER(rq_direct_response)                                                                      \
   COUNTER(rq_total)                                                                                \
-  COUNTER(rq_reset_after_downstream_response_started)                                              \
+  COUNTER(rq_reset_after_downstream_response_started)
 // clang-format on
 
 /**

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -377,7 +377,8 @@ private:
   // Handle an "aborted" upstream request, meaning we didn't see response
   // headers (e.g. due to a reset). Handles recording stats and responding
   // downstream if appropriate.
-  void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag, absl::string_view body, bool dropped);
+  void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag,
+                       absl::string_view body, bool dropped);
   void onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& headers, bool end_stream);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -369,7 +369,7 @@ private:
                                          Upstream::ResourcePriority priority) PURE;
   Http::ConnectionPool::Instance* getConnPool();
   void maybeDoShadowing();
-  bool maybeRetryReset(const Http::StreamResetReason reset_reason);
+  bool maybeRetryReset(Http::StreamResetReason reset_reason);
   void onPerTryTimeout();
   void onRequestComplete();
   void onResponseTimeout();
@@ -377,7 +377,7 @@ private:
   // Handle an "aborted" upstream request, meaning we didn't see response
   // headers (e.g. due to a reset). Handles recording stats and responding
   // downstream if appropriate.
-  void onUpstreamAbort(const Http::Code code, const StreamInfo::ResponseFlag response_flag, const std::string& body, bool dropped);
+  void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag, absl::string_view body, bool dropped);
   void onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& headers, bool end_stream);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -353,8 +353,6 @@ private:
 
   typedef std::unique_ptr<UpstreamRequest> UpstreamRequestPtr;
 
-  enum class UpstreamResetType { Reset, GlobalTimeout, PerTryTimeout };
-
   StreamInfo::ResponseFlag streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason);
 
   static const std::string upstreamZone(Upstream::HostDescriptionConstSharedPtr upstream_host);
@@ -371,19 +369,22 @@ private:
                                          Upstream::ResourcePriority priority) PURE;
   Http::ConnectionPool::Instance* getConnPool();
   void maybeDoShadowing();
+  bool maybeRetryReset(const absl::optional<Http::StreamResetReason>& reset_reason);
+  void onPerTryTimeout();
   void onRequestComplete();
   void onResponseTimeout();
   void onUpstream100ContinueHeaders(Http::HeaderMapPtr&& headers);
+  void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag, std::string body, bool dropped);
   void onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& headers, bool end_stream);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);
   void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map);
   void onUpstreamComplete();
-  void onUpstreamReset(UpstreamResetType type,
-                       const absl::optional<Http::StreamResetReason> reset_reason);
+  void onUpstreamReset(const absl::optional<Http::StreamResetReason> reset_reason);
   void sendNoHealthyUpstreamResponse();
   bool setupRetry(bool end_stream);
   bool setupRedirect(const Http::HeaderMap& headers);
+  void updateOutlierDetection(Http::Code code);
   void doRetry();
   // Called immediately after a non-5xx header is received from upstream, performs stats accounting
   // and handle difference between gRPC and non-gRPC requests.

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -369,18 +369,21 @@ private:
                                          Upstream::ResourcePriority priority) PURE;
   Http::ConnectionPool::Instance* getConnPool();
   void maybeDoShadowing();
-  bool maybeRetryReset(const absl::optional<Http::StreamResetReason>& reset_reason);
+  bool maybeRetryReset(const Http::StreamResetReason reset_reason);
   void onPerTryTimeout();
   void onRequestComplete();
   void onResponseTimeout();
   void onUpstream100ContinueHeaders(Http::HeaderMapPtr&& headers);
-  void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag, std::string body, bool dropped);
+  // Handle an "aborted" upstream request, meaning we didn't see response
+  // headers (e.g. due to a reset). Handles recording stats and responding
+  // downstream if appropriate.
+  void onUpstreamAbort(const Http::Code code, const StreamInfo::ResponseFlag response_flag, const std::string& body, bool dropped);
   void onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& headers, bool end_stream);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);
   void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map);
   void onUpstreamComplete();
-  void onUpstreamReset(const absl::optional<Http::StreamResetReason> reset_reason);
+  void onUpstreamReset(const Http::StreamResetReason reset_reason);
   void sendNoHealthyUpstreamResponse();
   bool setupRetry(bool end_stream);
   bool setupRedirect(const Http::HeaderMap& headers);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -383,7 +383,7 @@ private:
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);
   void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map);
   void onUpstreamComplete();
-  void onUpstreamReset(const Http::StreamResetReason reset_reason);
+  void onUpstreamReset(Http::StreamResetReason reset_reason);
   void sendNoHealthyUpstreamResponse();
   bool setupRetry(bool end_stream);
   bool setupRedirect(const Http::HeaderMap& headers);


### PR DESCRIPTION
Previously onUpstreamReset handled 3 separate cases: per try timeout,
global timeout, and a stream reset by the upstream. In anticipation of
adding a new case for #5841, it might make things cleaner to pull it
out.

This commit extracts the functionality of the old onUpstreamReset into
separate methods, and then has onPerTryTimeout, onGlobalTimeout, and
onUpstreamReset call the helper functions with the the appropriate
arguments.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

Description: Refactor onUpstreamReset in the router filter from handling multiple cases (per try timeout, global timeout, upstream reset) and decompose it into helper functions called from case-specific handlers.
Risk Level: medium
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
This is a step toward #5841 which will have different handling for "soft" per try timeouts and normal per try timeout, which would make onUpstreamReset more complex than it already is.
