### PR TITLE
ci: allow running bazel.compile_time_options locally

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -7,7 +7,7 @@ set -e
 build_setup_args=""
 if [[ "$1" == "fix_format" || "$1" == "check_format" || "$1" == "check_repositories" || \
         "$1" == "check_spelling" || "$1" == "fix_spelling" || "$1" == "bazel.clang_tidy" || \
-        "$1" == "check_spelling_pedantic" || "$1" == "fix_spelling_pedantic" ]]; then
+        "$1" == "check_spelling_pedantic" || "$1" == "fix_spelling_pedantic" || "$1" == "bazel.compile_time_options" ]]; then
   build_setup_args="-nofetch"
 fi
 


### PR DESCRIPTION
Description:
This allows running the bazel.compile_time_options test using `./ci/run_envoy_docker.sh "./ci/do_ci.sh bazel.compile_time_options"` locally. We used PR #5597 as a reference.

Risk Level:
Low

Testing:
Ran `./ci/run_envoy_docker.sh "./ci/do_ci.sh bazel.compile_time_options"`

Docs Changes:
N/A

Release Notes:
N/A