### PR TITLE
Return 503 from ext_authz on network failures

### DIFF
--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -74,7 +74,7 @@ void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::strin
   ASSERT(status != Grpc::Status::GrpcStatus::Ok);
   Response response{};
   response.status = CheckStatus::Error;
-  response.status_code = Http::Code::Forbidden;
+  response.status_code = Http::Code::ServiceUnavailable;
   callbacks_->onComplete(std::make_unique<Response>(response));
   callbacks_ = nullptr;
 }

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -170,8 +170,11 @@ TEST_P(ExtAuthzGrpcClientTest, UnknownError) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance());
 
-  EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+
+  EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
+                                      AuthzResponseNoAttributes(authz_response))));
   client_->onFailure(Grpc::Status::Unknown, "", span_);
 }
 
@@ -195,8 +198,11 @@ TEST_P(ExtAuthzGrpcClientTest, AuthorizationRequestTimeout) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance());
 
-  EXPECT_CALL(request_callbacks_,
-              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
+  auto authz_response = Response{};
+  authz_response.status = CheckStatus::Error;
+
+  EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
+                                      AuthzResponseNoAttributes(authz_response))));
   client_->onFailure(Grpc::Status::DeadlineExceeded, "", span_);
 }
 


### PR DESCRIPTION
Description: Return 503 from ext_authz on network failures

Risk Level: Low
Testing: CI
Docs Changes: n/a
Release Notes: n/a

Discussion thread: https://github.com/envoyproxy/envoy/issues/6119
