### PR TITLE
stream_info: include common/assert.h to fix build

### DIFF
--- a/include/envoy/stream_info/BUILD
+++ b/include/envoy/stream_info/BUILD
@@ -18,6 +18,7 @@ envoy_cc_library(
         "//include/envoy/http:protocol_interface",
         "//include/envoy/upstream:host_description_interface",
         "//source/common/protobuf",
+        "//source/common/common:assert_lib",
     ],
 )
 

--- a/include/envoy/stream_info/BUILD
+++ b/include/envoy/stream_info/BUILD
@@ -17,8 +17,8 @@ envoy_cc_library(
         "//include/envoy/common:time_interface",
         "//include/envoy/http:protocol_interface",
         "//include/envoy/upstream:host_description_interface",
-        "//source/common/protobuf",
         "//source/common/common:assert_lib",
+        "//source/common/protobuf",
     ],
 )
 

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -11,8 +11,8 @@
 #include "envoy/stream_info/filter_state.h"
 #include "envoy/upstream/host_description.h"
 
-#include "common/protobuf/protobuf.h"
 #include "common/common/assert.h"
+#include "common/protobuf/protobuf.h"
 
 #include "absl/types/optional.h"
 

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -12,6 +12,7 @@
 #include "envoy/upstream/host_description.h"
 
 #include "common/protobuf/protobuf.h"
+#include "common/common/assert.h"
 
 #include "absl/types/optional.h"
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -2307,7 +2307,7 @@ TEST_F(RouterTest, UpstreamTimingRetry) {
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, false);
 
-  router_.retry_state_->expectRetry();
+  router_.retry_state_->expectHeadersRetry();
 
   test_time_.sleep(std::chrono::milliseconds(32));
   Buffer::OwnedImpl data;
@@ -2332,7 +2332,7 @@ TEST_F(RouterTest, UpstreamTimingRetry) {
   EXPECT_FALSE(stream_info.lastUpstreamRxByteReceived().has_value());
 
   router_.retry_state_->callback_();
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+  EXPECT_CALL(*router_.retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
   MonotonicTime retry_time = test_time_.monotonicTime();
 
   Http::HeaderMapPtr good_response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});


### PR DESCRIPTION
Bad merge caused this to no longer be included, causing build breakage

Also fixes some other merge conflicts in router_test

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
