### PR TITLE
upstream: trigger original dst clean only when hosts are there

### DIFF
--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -160,17 +160,15 @@ void OriginalDstCluster::cleanup() {
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
   const auto& host_set = priority_set_.getOrCreateHostSet(0);
-  if (!host_set.hosts().empty()) {
-    ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
-    for (const HostSharedPtr& host : host_set.hosts()) {
-      if (host->used()) {
-        ENVOY_LOG(debug, "Keeping active host {}.", host->address()->asString());
-        new_hosts->emplace_back(host);
-        host->used(false); // Mark to be removed during the next round.
-      } else {
-        ENVOY_LOG(debug, "Removing stale host {}.", host->address()->asString());
-        to_be_removed.emplace_back(host);
-      }
+  ENVOY_LOG(trace, "Cleaning up stale original dst hosts.");
+  for (const HostSharedPtr& host : host_set.hosts()) {
+    if (host->used()) {
+      ENVOY_LOG(trace, "Keeping active host {}.", host->address()->asString());
+      new_hosts->emplace_back(host);
+      host->used(false); // Mark to be removed during the next round.
+    } else {
+      ENVOY_LOG(trace, "Removing stale host {}.", host->address()->asString());
+      to_be_removed.emplace_back(host);
     }
   }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -160,15 +160,18 @@ void OriginalDstCluster::cleanup() {
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
   const auto& host_set = priority_set_.getOrCreateHostSet(0);
-  ENVOY_LOG(trace, "Cleaning up stale original dst hosts.");
-  for (const HostSharedPtr& host : host_set.hosts()) {
-    if (host->used()) {
-      ENVOY_LOG(trace, "Keeping active host {}.", host->address()->asString());
-      new_hosts->emplace_back(host);
-      host->used(false); // Mark to be removed during the next round.
-    } else {
-      ENVOY_LOG(trace, "Removing stale host {}.", host->address()->asString());
-      to_be_removed.emplace_back(host);
+  ENVOY_LOG(trace, "stale original dst hosts cleanup triggered");
+  if (!host_set.hosts().empty()) {
+    ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
+    for (const HostSharedPtr& host : host_set.hosts()) {
+      if (host->used()) {
+        ENVOY_LOG(debug, "Keeping active host {}.", host->address()->asString());
+        new_hosts->emplace_back(host);
+        host->used(false); // Mark to be removed during the next round.
+      } else {
+        ENVOY_LOG(debug, "Removing stale host {}.", host->address()->asString());
+        to_be_removed.emplace_back(host);
+      }
     }
   }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -160,7 +160,7 @@ void OriginalDstCluster::cleanup() {
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
   const auto& host_set = priority_set_.getOrCreateHostSet(0);
-  ENVOY_LOG(trace, "stale original dst hosts cleanup triggered");
+  ENVOY_LOG(trace, "Stale original dst hosts cleanup triggered.");
   if (!host_set.hosts().empty()) {
     ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
     for (const HostSharedPtr& host : host_set.hosts()) {

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -160,16 +160,17 @@ void OriginalDstCluster::cleanup() {
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
   const auto& host_set = priority_set_.getOrCreateHostSet(0);
-
-  ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
-  for (const HostSharedPtr& host : host_set.hosts()) {
-    if (host->used()) {
-      ENVOY_LOG(debug, "Keeping active host {}.", host->address()->asString());
-      new_hosts->emplace_back(host);
-      host->used(false); // Mark to be removed during the next round.
-    } else {
-      ENVOY_LOG(debug, "Removing stale host {}.", host->address()->asString());
-      to_be_removed.emplace_back(host);
+  if (!host_set.hosts().empty()) {
+    ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
+    for (const HostSharedPtr& host : host_set.hosts()) {
+      if (host->used()) {
+        ENVOY_LOG(debug, "Keeping active host {}.", host->address()->asString());
+        new_hosts->emplace_back(host);
+        host->used(false); // Mark to be removed during the next round.
+      } else {
+        ENVOY_LOG(debug, "Removing stale host {}.", host->address()->asString());
+        to_be_removed.emplace_back(host);
+      }
     }
   }
 


### PR DESCRIPTION
Description: The log line `Cleaning up stale original dst hosts` is triggering quite often when upstream log is enabled even there are no hosts. My intention was to control this log line, but I think it does not harm to guard whole cleanup logic with this condition.
Risk Level: Low
Testing: Low
Docs Changes: N/A
Release Notes: N/A

