### PR TITLE
config:connected state across hot restarts

### DIFF
--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -78,6 +78,10 @@ public:
   void onReceiveMessage(std::unique_ptr<ResponseProto>&& message) override {
     // Reset here so that it starts with fresh backoff interval on next disconnect.
     backoff_strategy_->reset();
+    // Some times during hot restarts this stat's value becomes inconsistent and will continue to
+    // have 0 till it is reconnected. Setting here ensures that it is consistent with the state of
+    // management server connection.
+    control_plane_stats_.connected_state_.set(1);
     handleResponse(std::move(message));
   }
 


### PR DESCRIPTION
Description: Some times during hot restart connected state stat has inconsistent value (probably because of how this gauge is updated in shared memory during hot restarts) and is not set to correct value till Envoy is disconnected and reconnected to management server. This PR ensures this is set on receiveMessage so that it stays consistent.
Risk Level: Low
Testing: Existing automated tests
Docs Changes: N/A
Release Notes: N/A
