### PR TITLE
udp: implement recvfrom(2) in os_sys_calls_impl

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -66,6 +66,11 @@ public:
   virtual SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) PURE;
 
   /**
+   * @see recv (man 2 recvfrom)
+   */
+  virtual SysCallSizeResult recvfrom(int sockfd, void* buffer, size_t length, int flags,
+                                     struct sockaddr* addr, socklen_t* addrlen) PURE;
+  /**
    * Release all resources allocated for fd.
    * @return zero on success, -1 returned otherwise.
    */

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -38,6 +38,12 @@ SysCallSizeResult OsSysCallsImpl::recv(int socket, void* buffer, size_t length, 
   return {rc, errno};
 }
 
+SysCallSizeResult OsSysCallsImpl::recvfrom(int sockfd, void* buffer, size_t length, int flags,
+                                           struct sockaddr* addr, socklen_t* addrlen) {
+  const ssize_t rc = ::recvfrom(sockfd, buffer, length, flags, addr, addrlen);
+  return {rc, errno};
+}
+
 SysCallIntResult OsSysCallsImpl::shmOpen(const char* name, int oflag, mode_t mode) {
   const int rc = ::shm_open(name, oflag, mode);
   return {rc, errno};

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -15,6 +15,8 @@ public:
   SysCallSizeResult writev(int fd, const iovec* iovec, int num_iovec) override;
   SysCallSizeResult readv(int fd, const iovec* iovec, int num_iovec) override;
   SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) override;
+  SysCallSizeResult recvfrom(int sockfd, void* buffer, size_t length, int flags,
+                             struct sockaddr* addr, socklen_t* addrlen) override;
   SysCallIntResult close(int fd) override;
   SysCallIntResult shmOpen(const char* name, int oflag, mode_t mode) override;
   SysCallIntResult shmUnlink(const char* name) override;

--- a/source/common/network/udp_listener_impl.cc
+++ b/source/common/network/udp_listener_impl.cc
@@ -5,6 +5,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/fmt.h"
@@ -56,17 +57,19 @@ UdpListenerImpl::ReceiveResult UdpListenerImpl::doRecvFrom(sockaddr_storage& pee
   const uint64_t num_slices = buffer->reserve(read_length, &slice, 1);
 
   ASSERT(num_slices == 1);
-  // TODO(conqerAtapple): Use os_syscalls
-  const ssize_t rc = ::recvfrom(socket_.ioHandle().fd(), slice.mem_, read_length, 0,
-                                reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
-  if (rc < 0) {
-    return ReceiveResult{Api::SysCallIntResult{static_cast<int>(rc), errno}, nullptr};
-  }
 
-  slice.len_ = std::min(slice.len_, static_cast<size_t>(rc));
+  auto& os_sys_calls = Api::OsSysCallsSingleton::get();
+  const Api::SysCallSizeResult result =
+      os_sys_calls.recvfrom(socket_.ioHandle().fd(), slice.mem_, read_length, 0,
+                            reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+  if (result.rc_ < 0) {
+    return ReceiveResult{Api::SysCallIntResult{static_cast<int>(result.rc_), result.errno_},
+                         nullptr};
+  }
+  slice.len_ = std::min(slice.len_, static_cast<size_t>(result.rc_));
   buffer->commit(&slice, 1);
 
-  return ReceiveResult{Api::SysCallIntResult{static_cast<int>(rc), 0}, std::move(buffer)};
+  return ReceiveResult{Api::SysCallIntResult{static_cast<int>(result.rc_), 0}, std::move(buffer)};
 }
 
 void UdpListenerImpl::onSocketEvent(short flags) {

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -56,6 +56,8 @@ public:
   MOCK_METHOD3(writev, SysCallSizeResult(int, const iovec*, int));
   MOCK_METHOD3(readv, SysCallSizeResult(int, const iovec*, int));
   MOCK_METHOD4(recv, SysCallSizeResult(int socket, void* buffer, size_t length, int flags));
+  MOCK_METHOD6(recvfrom, SysCallSizeResult(int sockfd, void* buffer, size_t length, int flags,
+                                           struct sockaddr* addr, socklen_t* addrlen));
 
   MOCK_METHOD3(shmOpen, SysCallIntResult(const char*, int, mode_t));
   MOCK_METHOD1(shmUnlink, SysCallIntResult(const char*));


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

Description: implement recvfrom(2) in os_sys_calls and use in udp_listener_impl
Risk Level: Low - same functionality but different implementation
Testing: `bazel test //test/common/network:udp_listener_impl_test`
Docs Changes: N/A
Release Notes: N/A
