### PR TITLE
fuzz: more buffer_fuzz_test robustness improvements.

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5654939127250944
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5654939127250944
@@ -1,0 +1,78 @@
+actions {
+  add_string: 11927552
+}
+actions {
+  target_index: 4
+  add_buffer: 0
+}
+actions {
+  prepend_string: 1869177088
+}
+actions {
+}
+actions {
+  move {
+    source_index: 4294967293
+  }
+}
+actions {
+}
+actions {
+  linearize: 8388608
+}
+actions {
+  prepend_string: 1869177088
+}
+actions {
+  linearize: 1
+}
+actions {
+  copy_out {
+    length: 4194304
+  }
+}
+actions {
+  drain: 1
+}
+actions {
+}
+actions {
+  add_string: 65534
+}
+actions {
+  target_index: 1769235297
+}
+actions {
+  add_string: 11927552
+}
+actions {
+  target_index: 3053453312
+  add_string: 11927552
+}
+actions {
+}
+actions {
+  target_index: 11927552
+  drain: 1
+}
+actions {
+  target_index: 1769235297
+}
+actions {
+  write {
+  }
+}
+actions {
+  target_index: 1769235297
+}
+actions {
+  linearize: 1
+}
+actions {
+  add_buffer_fragment: 1
+}
+actions {
+  copy_out {
+    length: 4194304
+  }
+}


### PR DESCRIPTION
Avoid stack overflows and bound actions to avoid timeouts.

Fixes oss-fuzz issues:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13493
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13494

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>