### PR TITLE
ci: select gcov-7 for consistency with gcc-7 in Docker image.

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -18,8 +18,10 @@ apt update
 apt install -y g++-7
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 1000
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 1000
+update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 1000
 update-alternatives --config gcc
 update-alternatives --config g++
+update-alternatives --config gcov
 # Bazel and related dependencies.
 apt-get install -y openjdk-8-jdk curl
 echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list


### PR DESCRIPTION
This is needed to enable Bazel native coverage (without, we don't get
coverage files generated).

Risk level: Low
Testing: bazel coverage run inside CI image.

Signed-off-by: Harvey Tuch <htuch@google.com>