### PR TITLE
Move common parts of redis connection interface to common

### DIFF
--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -39,7 +39,7 @@ envoy_cc_library(
     name = "client_interface",
     hdrs = ["client.h"],
     deps = [
+        ":codec_lib",
         "//include/envoy/upstream:cluster_manager_interface",
-        ":codec_interface",
     ],
 )

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -49,8 +49,8 @@ envoy_cc_library(
     srcs = ["client_impl.cc"],
     hdrs = ["client_impl.h"],
     deps = [
-        ":codec_lib",
         ":client_interface",
+        ":codec_lib",
         "//include/envoy/router:router_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -43,3 +43,22 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "client_lib",
+    srcs = ["client_impl.cc"],
+    hdrs = ["client_impl.h"],
+    deps = [
+        ":codec_lib",
+        ":client_interface",
+        "//include/envoy/router:router_interface",
+        "//include/envoy/thread_local:thread_local_interface",
+        "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/network:filter_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/upstream:load_balancer_lib",
+        "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
+    ],
+)

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -34,3 +34,12 @@ envoy_cc_library(
         "//source/common/common:macros",
     ],
 )
+
+envoy_cc_library(
+    name = "client_interface",
+    hdrs = ["client.h"],
+    deps = [
+        "//include/envoy/upstream:cluster_manager_interface",
+        ":codec_interface",
+    ],
+)

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -9,6 +9,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Common {
 namespace Redis {
+namespace Client {
 
 /**
  * A handle to an outbound request.
@@ -116,6 +117,7 @@ public:
                            const Config& config) PURE;
 };
 
+} // namespace Client 
 } // namespace Redis
 } // namespace Common
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -2,6 +2,8 @@
 
 #include "envoy/upstream/cluster_manager.h"
 
+#include "extensions/filters/network/common/redis/codec_impl.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -64,8 +66,7 @@ public:
    * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
    *         for some reason.
    */
-  virtual PoolRequest* makeRequest(const RespValue& request,
-                                   PoolCallbacks& callbacks) PURE;
+  virtual PoolRequest* makeRequest(const RespValue& request, PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Client> ClientPtr;
@@ -114,7 +115,6 @@ public:
   virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                            const Config& config) PURE;
 };
-
 
 } // namespace Redis
 } // namespace Common

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -117,7 +117,7 @@ public:
                            const Config& config) PURE;
 };
 
-} // namespace Client 
+} // namespace Client
 } // namespace Redis
 } // namespace Common
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "envoy/upstream/cluster_manager.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+
+/**
+ * A handle to an outbound request.
+ */
+class PoolRequest {
+public:
+  virtual ~PoolRequest() {}
+
+  /**
+   * Cancel the request. No further request callbacks will be called.
+   */
+  virtual void cancel() PURE;
+};
+
+/**
+ * Outbound request callbacks.
+ */
+class PoolCallbacks {
+public:
+  virtual ~PoolCallbacks() {}
+
+  /**
+   * Called when a pipelined response is received.
+   * @param value supplies the response which is now owned by the callee.
+   */
+  virtual void onResponse(RespValuePtr&& value) PURE;
+
+  /**
+   * Called when a network/protocol error occurs and there is no response.
+   */
+  virtual void onFailure() PURE;
+};
+
+/**
+ * A single redis client connection.
+ */
+class Client : public Event::DeferredDeletable {
+public:
+  virtual ~Client() {}
+
+  /**
+   * Adds network connection callbacks to the underlying network connection.
+   */
+  virtual void addConnectionCallbacks(Network::ConnectionCallbacks& callbacks) PURE;
+
+  /**
+   * Closes the underlying network connection.
+   */
+  virtual void close() PURE;
+
+  /**
+   * Make a pipelined request to the remote redis server.
+   * @param request supplies the RESP request to make.
+   * @param callbacks supplies the request callbacks.
+   * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
+   *         for some reason.
+   */
+  virtual PoolRequest* makeRequest(const RespValue& request,
+                                   PoolCallbacks& callbacks) PURE;
+};
+
+typedef std::unique_ptr<Client> ClientPtr;
+
+/**
+ * Configuration for a redis connection pool.
+ */
+class Config {
+public:
+  virtual ~Config() {}
+
+  /**
+   * @return std::chrono::milliseconds the timeout for an individual redis operation. Currently,
+   *         all operations use the same timeout.
+   */
+  virtual std::chrono::milliseconds opTimeout() const PURE;
+
+  /**
+   * @return bool disable outlier events even if the cluster has it enabled. This is used by the
+   * healthchecker's connection pool to avoid double counting active healthcheck operations as
+   * passive healthcheck operations.
+   */
+  virtual bool disableOutlierEvents() const PURE;
+
+  /**
+   * @return when enabled, a hash tagging function will be used to guarantee that keys with the
+   * same hash tag will be forwarded to the same upstream.
+   */
+  virtual bool enableHashtagging() const PURE;
+};
+
+/**
+ * A factory for individual redis client connections.
+ */
+class ClientFactory {
+public:
+  virtual ~ClientFactory() {}
+
+  /**
+   * Create a client given an upstream host.
+   * @param host supplies the upstream host.
+   * @param dispatcher supplies the owning thread's dispatcher.
+   * @param config supplies the connection pool configuration.
+   * @return ClientPtr a new connection pool client.
+   */
+  virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+                           const Config& config) PURE;
+};
+
+
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -1,0 +1,199 @@
+#include "extensions/filters/network/common/redis/client_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+namespace Client {
+
+ConfigImpl::ConfigImpl(
+    const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config)
+    : op_timeout_(PROTOBUF_GET_MS_REQUIRED(config, op_timeout)),
+      enable_hashtagging_(config.enable_hashtagging()) {}
+
+ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host,
+                                            Event::Dispatcher& dispatcher,
+                                            EncoderPtr&& encoder,
+                                            DecoderFactory& decoder_factory,
+                                            const Config& config) {
+
+  std::unique_ptr<ClientImpl> client(
+      new ClientImpl(host, dispatcher, std::move(encoder), decoder_factory, config));
+  client->connection_ = host->createConnection(dispatcher, nullptr, nullptr).connection_;
+  client->connection_->addConnectionCallbacks(*client);
+  client->connection_->addReadFilter(Network::ReadFilterSharedPtr{new UpstreamReadFilter(*client)});
+  client->connection_->connect();
+  client->connection_->noDelay(true);
+  return std::move(client);
+}
+
+ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+                       EncoderPtr&& encoder,
+                       DecoderFactory& decoder_factory,
+                       const Config& config)
+    : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
+      config_(config),
+      connect_or_op_timer_(dispatcher.createTimer([this]() -> void { onConnectOrOpTimeout(); })) {
+  host->cluster().stats().upstream_cx_total_.inc();
+  host->stats().cx_total_.inc();
+  host->cluster().stats().upstream_cx_active_.inc();
+  host->stats().cx_active_.inc();
+  connect_or_op_timer_->enableTimer(host->cluster().connectTimeout());
+}
+
+ClientImpl::~ClientImpl() {
+  ASSERT(pending_requests_.empty());
+  ASSERT(connection_->state() == Network::Connection::State::Closed);
+  host_->cluster().stats().upstream_cx_active_.dec();
+  host_->stats().cx_active_.dec();
+}
+
+void ClientImpl::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
+
+PoolRequest* ClientImpl::makeRequest(const RespValue& request,
+                                                    PoolCallbacks& callbacks) {
+  ASSERT(connection_->state() == Network::Connection::State::Open);
+
+  pending_requests_.emplace_back(*this, callbacks);
+  encoder_->encode(request, encoder_buffer_);
+  connection_->write(encoder_buffer_, false);
+
+  // Only boost the op timeout if:
+  // - We are not already connected. Otherwise, we are governed by the connect timeout and the timer
+  //   will be reset when/if connection occurs. This allows a relatively long connection spin up
+  //   time for example if TLS is being used.
+  // - This is the first request on the pipeline. Otherwise the timeout would effectively start on
+  //   the last operation.
+  if (connected_ && pending_requests_.size() == 1) {
+    connect_or_op_timer_->enableTimer(config_.opTimeout());
+  }
+
+  return &pending_requests_.back();
+}
+
+void ClientImpl::onConnectOrOpTimeout() {
+  putOutlierEvent(Upstream::Outlier::Result::TIMEOUT);
+  if (connected_) {
+    host_->cluster().stats().upstream_rq_timeout_.inc();
+    host_->stats().rq_timeout_.inc();
+  } else {
+    host_->cluster().stats().upstream_cx_connect_timeout_.inc();
+    host_->stats().cx_connect_fail_.inc();
+  }
+
+  connection_->close(Network::ConnectionCloseType::NoFlush);
+}
+
+void ClientImpl::onData(Buffer::Instance& data) {
+  try {
+    decoder_->decode(data);
+  } catch (ProtocolError&) {
+    putOutlierEvent(Upstream::Outlier::Result::REQUEST_FAILED);
+    host_->cluster().stats().upstream_cx_protocol_error_.inc();
+    host_->stats().rq_error_.inc();
+    connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+}
+
+void ClientImpl::putOutlierEvent(Upstream::Outlier::Result result) {
+  if (!config_.disableOutlierEvents()) {
+    host_->outlierDetector().putResult(result);
+  }
+}
+
+void ClientImpl::onEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::RemoteClose ||
+      event == Network::ConnectionEvent::LocalClose) {
+    if (!pending_requests_.empty()) {
+      host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
+      if (event == Network::ConnectionEvent::RemoteClose) {
+        putOutlierEvent(Upstream::Outlier::Result::SERVER_FAILURE);
+        host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
+      }
+      if (event == Network::ConnectionEvent::LocalClose) {
+        host_->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
+      }
+    }
+
+    while (!pending_requests_.empty()) {
+      PendingRequest& request = pending_requests_.front();
+      if (!request.canceled_) {
+        request.callbacks_.onFailure();
+      } else {
+        host_->cluster().stats().upstream_rq_cancelled_.inc();
+      }
+      pending_requests_.pop_front();
+    }
+
+    connect_or_op_timer_->disableTimer();
+  } else if (event == Network::ConnectionEvent::Connected) {
+    connected_ = true;
+    ASSERT(!pending_requests_.empty());
+    connect_or_op_timer_->enableTimer(config_.opTimeout());
+  }
+
+  if (event == Network::ConnectionEvent::RemoteClose && !connected_) {
+    host_->cluster().stats().upstream_cx_connect_fail_.inc();
+    host_->stats().cx_connect_fail_.inc();
+  }
+}
+
+void ClientImpl::onRespValue(RespValuePtr&& value) {
+  ASSERT(!pending_requests_.empty());
+  PendingRequest& request = pending_requests_.front();
+  if (!request.canceled_) {
+    request.callbacks_.onResponse(std::move(value));
+  } else {
+    host_->cluster().stats().upstream_rq_cancelled_.inc();
+  }
+  pending_requests_.pop_front();
+
+  // If there are no remaining ops in the pipeline we need to disable the timer.
+  // Otherwise we boost the timer since we are receiving responses and there are more to flush out.
+  if (pending_requests_.empty()) {
+    connect_or_op_timer_->disableTimer();
+  } else {
+    connect_or_op_timer_->enableTimer(config_.opTimeout());
+  }
+
+  putOutlierEvent(Upstream::Outlier::Result::SUCCESS);
+}
+
+ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent,
+                                           PoolCallbacks& callbacks)
+    : parent_(parent), callbacks_(callbacks) {
+  parent.host_->cluster().stats().upstream_rq_total_.inc();
+  parent.host_->stats().rq_total_.inc();
+  parent.host_->cluster().stats().upstream_rq_active_.inc();
+  parent.host_->stats().rq_active_.inc();
+}
+
+ClientImpl::PendingRequest::~PendingRequest() {
+  parent_.host_->cluster().stats().upstream_rq_active_.dec();
+  parent_.host_->stats().rq_active_.dec();
+}
+
+void ClientImpl::PendingRequest::cancel() {
+  // If we get a cancellation, we just mark the pending request as cancelled, and then we drop
+  // the response as it comes through. There is no reason to blow away the connection when the
+  // remote is already responding as fast as possible.
+  canceled_ = true;
+}
+
+ClientFactoryImpl ClientFactoryImpl::instance_;
+
+ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
+                                                   Event::Dispatcher& dispatcher,
+                                                   const Config& config) {
+  return ClientImpl::create(host, dispatcher,
+                            EncoderPtr{new EncoderImpl()},
+                            decoder_factory_, config);
+}
+
+} // namespace Client 
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -38,15 +38,11 @@ private:
   const bool enable_hashtagging_;
 };
 
-class ClientImpl : public Client,
-                   public DecoderCallbacks,
-                   public Network::ConnectionCallbacks {
+class ClientImpl : public Client, public DecoderCallbacks, public Network::ConnectionCallbacks {
 public:
-  static ClientPtr create(Upstream::HostConstSharedPtr host,
-                                         Event::Dispatcher& dispatcher,
-                                         EncoderPtr&& encoder,
-                                         DecoderFactory& decoder_factory,
-                                         const Config& config);
+  static ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+                          EncoderPtr&& encoder, DecoderFactory& decoder_factory,
+                          const Config& config);
 
   ~ClientImpl();
 
@@ -55,8 +51,7 @@ public:
     connection_->addConnectionCallbacks(callbacks);
   }
   void close() override;
-  PoolRequest* makeRequest(const RespValue& request,
-                                          PoolCallbacks& callbacks) override;
+  PoolRequest* makeRequest(const RespValue& request, PoolCallbacks& callbacks) override;
 
 private:
   struct UpstreamReadFilter : public Network::ReadFilterBaseImpl {
@@ -83,9 +78,8 @@ private:
     bool canceled_{};
   };
 
-  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-             EncoderPtr&& encoder, DecoderFactory& decoder_factory,
-             const Config& config);
+  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, EncoderPtr&& encoder,
+             DecoderFactory& decoder_factory, const Config& config);
   void onConnectOrOpTimeout();
   void onData(Buffer::Instance& data);
   void putOutlierEvent(Upstream::Outlier::Result result);
@@ -113,7 +107,7 @@ class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
   ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                                  const Config& config) override;
+                   const Config& config) override;
 
   static ClientFactoryImpl instance_;
 
@@ -121,7 +115,7 @@ private:
   DecoderFactoryImpl decoder_factory_;
 };
 
-} // namespace Client 
+} // namespace Client
 } // namespace Redis
 } // namespace Common
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <chrono>
+
+#include "envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.h"
+#include "envoy/thread_local/thread_local.h"
+#include "envoy/upstream/cluster_manager.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/hash.h"
+#include "common/network/filter_impl.h"
+#include "common/protobuf/utility.h"
+#include "common/upstream/load_balancer_impl.h"
+
+#include "extensions/filters/network/common/redis/client.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+namespace Client {
+
+// TODO(mattklein123): Circuit breaking
+// TODO(rshriram): Fault injection
+
+class ConfigImpl : public Config {
+public:
+  ConfigImpl(
+      const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config);
+
+  bool disableOutlierEvents() const override { return false; }
+  std::chrono::milliseconds opTimeout() const override { return op_timeout_; }
+  bool enableHashtagging() const override { return enable_hashtagging_; }
+
+private:
+  const std::chrono::milliseconds op_timeout_;
+  const bool enable_hashtagging_;
+};
+
+class ClientImpl : public Client,
+                   public DecoderCallbacks,
+                   public Network::ConnectionCallbacks {
+public:
+  static ClientPtr create(Upstream::HostConstSharedPtr host,
+                                         Event::Dispatcher& dispatcher,
+                                         EncoderPtr&& encoder,
+                                         DecoderFactory& decoder_factory,
+                                         const Config& config);
+
+  ~ClientImpl();
+
+  // Client
+  void addConnectionCallbacks(Network::ConnectionCallbacks& callbacks) override {
+    connection_->addConnectionCallbacks(callbacks);
+  }
+  void close() override;
+  PoolRequest* makeRequest(const RespValue& request,
+                                          PoolCallbacks& callbacks) override;
+
+private:
+  struct UpstreamReadFilter : public Network::ReadFilterBaseImpl {
+    UpstreamReadFilter(ClientImpl& parent) : parent_(parent) {}
+
+    // Network::ReadFilter
+    Network::FilterStatus onData(Buffer::Instance& data, bool) override {
+      parent_.onData(data);
+      return Network::FilterStatus::Continue;
+    }
+
+    ClientImpl& parent_;
+  };
+
+  struct PendingRequest : public PoolRequest {
+    PendingRequest(ClientImpl& parent, PoolCallbacks& callbacks);
+    ~PendingRequest();
+
+    // PoolRequest
+    void cancel() override;
+
+    ClientImpl& parent_;
+    PoolCallbacks& callbacks_;
+    bool canceled_{};
+  };
+
+  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+             EncoderPtr&& encoder, DecoderFactory& decoder_factory,
+             const Config& config);
+  void onConnectOrOpTimeout();
+  void onData(Buffer::Instance& data);
+  void putOutlierEvent(Upstream::Outlier::Result result);
+
+  // DecoderCallbacks
+  void onRespValue(RespValuePtr&& value) override;
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+  Upstream::HostConstSharedPtr host_;
+  Network::ClientConnectionPtr connection_;
+  EncoderPtr encoder_;
+  Buffer::OwnedImpl encoder_buffer_;
+  DecoderPtr decoder_;
+  const Config& config_;
+  std::list<PendingRequest> pending_requests_;
+  Event::TimerPtr connect_or_op_timer_;
+  bool connected_{};
+};
+
+class ClientFactoryImpl : public ClientFactory {
+public:
+  // RedisProxy::ConnPool::ClientFactoryImpl
+  ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+                                  const Config& config) override;
+
+  static ClientFactoryImpl instance_;
+
+private:
+  DecoderFactoryImpl decoder_factory_;
+};
+
+} // namespace Client 
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
     hdrs = ["conn_pool.h"],
     deps = [
         "//include/envoy/upstream:cluster_manager_interface",
+        "//source/extensions/filters/network/common/redis:client_interface",
         "//source/extensions/filters/network/common/redis:codec_interface",
     ],
 )

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -61,8 +61,8 @@ envoy_cc_library(
         "//source/common/network:filter_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/upstream:load_balancer_lib",
-        "//source/extensions/filters/network/common/redis:codec_lib",
         "//source/extensions/filters/network/common/redis:client_interface",
+        "//source/extensions/filters/network/common/redis:codec_lib",
         "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
     ],
 )

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -43,7 +43,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:to_lower_table_lib",
         "//source/common/common:utility_lib",
-        "//source/extensions/filters/network/common/redis:client_interface",
+        "//source/extensions/filters/network/common/redis:client_lib",
         "//source/extensions/filters/network/common/redis:supported_commands_lib",
     ],
 )
@@ -62,8 +62,7 @@ envoy_cc_library(
         "//source/common/network:filter_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/upstream:load_balancer_lib",
-        "//source/extensions/filters/network/common/redis:client_interface",
-        "//source/extensions/filters/network/common/redis:codec_lib",
+        "//source/extensions/filters/network/common/redis:client_lib",
         "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
     ],
 )

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:to_lower_table_lib",
         "//source/common/common:utility_lib",
+        "//source/extensions/filters/network/common/redis:client_interface",
         "//source/extensions/filters/network/common/redis:supported_commands_lib",
     ],
 )
@@ -61,6 +62,7 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "//source/common/upstream:load_balancer_lib",
         "//source/extensions/filters/network/common/redis:codec_lib",
+        "//source/extensions/filters/network/common/redis:client_interface",
         "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
     ],
 )

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -14,9 +14,8 @@
 #include "common/common/utility.h"
 #include "common/singleton/const_singleton.h"
 
-#include "extensions/filters/network/redis_proxy/command_splitter.h"
-
 #include "extensions/filters/network/common/redis/client.h"
+#include "extensions/filters/network/redis_proxy/command_splitter.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
 namespace Envoy {

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -15,6 +15,7 @@
 #include "common/singleton/const_singleton.h"
 
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
+
 #include "extensions/filters/network/common/redis/client.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -15,6 +15,7 @@
 #include "common/singleton/const_singleton.h"
 
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
+#include "extensions/filters/network/common/redis/client.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
 namespace Envoy {
@@ -87,11 +88,11 @@ protected:
 /**
  * SingleServerRequest is a base class for commands that hash to a single backend.
  */
-class SingleServerRequest : public SplitRequestBase, public ConnPool::PoolCallbacks {
+class SingleServerRequest : public SplitRequestBase, public Common::Redis::PoolCallbacks {
 public:
   ~SingleServerRequest();
 
-  // RedisProxy::ConnPool::PoolCallbacks
+  // Common::Redis::PoolCallbacks
   void onResponse(Common::Redis::RespValuePtr&& response) override;
   void onFailure() override;
 
@@ -104,7 +105,7 @@ protected:
       : SplitRequestBase(command_stats, time_source), callbacks_(callbacks) {}
 
   SplitCallbacks& callbacks_;
-  ConnPool::PoolRequest* handle_{};
+  Common::Redis::PoolRequest* handle_{};
 };
 
 /**
@@ -151,10 +152,10 @@ protected:
   FragmentedRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source)
       : SplitRequestBase(command_stats, time_source), callbacks_(callbacks) {}
 
-  struct PendingRequest : public ConnPool::PoolCallbacks {
+  struct PendingRequest : public Common::Redis::PoolCallbacks {
     PendingRequest(FragmentedRequest& parent, uint32_t index) : parent_(parent), index_(index) {}
 
-    // RedisProxy::ConnPool::PoolCallbacks
+    // Common::Redis::PoolCallbacks
     void onResponse(Common::Redis::RespValuePtr&& value) override {
       parent_.onChildResponse(std::move(value), index_);
     }
@@ -162,7 +163,7 @@ protected:
 
     FragmentedRequest& parent_;
     const uint32_t index_;
-    ConnPool::PoolRequest* handle_{};
+    Common::Redis::PoolRequest* handle_{};
   };
 
   virtual void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) PURE;

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -29,9 +29,10 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
 
   ProxyFilterConfigSharedPtr filter_config(std::make_shared<ProxyFilterConfig>(
       proto_config, context.scope(), context.drainDecision(), context.runtime()));
-  ConnPool::InstancePtr conn_pool(new ConnPool::InstanceImpl(
-      filter_config->cluster_name_, context.clusterManager(),
-      Common::Redis::Client::ClientFactoryImpl::instance_, context.threadLocal(), proto_config.settings()));
+  ConnPool::InstancePtr conn_pool(
+      new ConnPool::InstanceImpl(filter_config->cluster_name_, context.clusterManager(),
+                                 Common::Redis::Client::ClientFactoryImpl::instance_,
+                                 context.threadLocal(), proto_config.settings()));
   std::shared_ptr<CommandSplitter::Instance> splitter(new CommandSplitter::InstanceImpl(
       std::move(conn_pool), context.scope(), filter_config->stat_prefix_, context.timeSource()));
   return [splitter, filter_config](Network::FilterManager& filter_manager) -> void {

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -8,6 +8,7 @@
 
 #include "common/config/filter_json.h"
 
+#include "extensions/filters/network/common/redis/client_impl.h"
 #include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/redis_proxy/command_splitter_impl.h"
 #include "extensions/filters/network/redis_proxy/conn_pool_impl.h"
@@ -30,7 +31,7 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
       proto_config, context.scope(), context.drainDecision(), context.runtime()));
   ConnPool::InstancePtr conn_pool(new ConnPool::InstanceImpl(
       filter_config->cluster_name_, context.clusterManager(),
-      ConnPool::ClientFactoryImpl::instance_, context.threadLocal(), proto_config.settings()));
+      Common::Redis::Client::ClientFactoryImpl::instance_, context.threadLocal(), proto_config.settings()));
   std::shared_ptr<CommandSplitter::Instance> splitter(new CommandSplitter::InstanceImpl(
       std::move(conn_pool), context.scope(), filter_config->stat_prefix_, context.timeSource()));
   return [splitter, filter_config](Network::FilterManager& filter_manager) -> void {

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -31,8 +31,8 @@ public:
    *         for some reason.
    */
   virtual Common::Redis::PoolRequest* makeRequest(const std::string& hash_key,
-                                   const Common::Redis::RespValue& request,
-                                   Common::Redis::PoolCallbacks& callbacks) PURE;
+                                                  const Common::Redis::RespValue& request,
+                                                  Common::Redis::PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -31,9 +31,9 @@ public:
    * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
    *         for some reason.
    */
-  virtual Common::Redis::Client::PoolRequest* makeRequest(const std::string& hash_key,
-                                                  const Common::Redis::RespValue& request,
-                                                  Common::Redis::Client::PoolCallbacks& callbacks) PURE;
+  virtual Common::Redis::Client::PoolRequest*
+  makeRequest(const std::string& hash_key, const Common::Redis::RespValue& request,
+              Common::Redis::Client::PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -6,6 +6,7 @@
 
 #include "envoy/upstream/cluster_manager.h"
 
+#include "extensions/filters/network/common/redis/client.h"
 #include "extensions/filters/network/common/redis/codec.h"
 
 namespace Envoy {

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -31,9 +31,9 @@ public:
    * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
    *         for some reason.
    */
-  virtual Common::Redis::PoolRequest* makeRequest(const std::string& hash_key,
+  virtual Common::Redis::Client::PoolRequest* makeRequest(const std::string& hash_key,
                                                   const Common::Redis::RespValue& request,
-                                                  Common::Redis::PoolCallbacks& callbacks) PURE;
+                                                  Common::Redis::Client::PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -15,113 +15,6 @@ namespace RedisProxy {
 namespace ConnPool {
 
 /**
- * A handle to an outbound request.
- */
-class PoolRequest {
-public:
-  virtual ~PoolRequest() {}
-
-  /**
-   * Cancel the request. No further request callbacks will be called.
-   */
-  virtual void cancel() PURE;
-};
-
-/**
- * Outbound request callbacks.
- */
-class PoolCallbacks {
-public:
-  virtual ~PoolCallbacks() {}
-
-  /**
-   * Called when a pipelined response is received.
-   * @param value supplies the response which is now owned by the callee.
-   */
-  virtual void onResponse(Common::Redis::RespValuePtr&& value) PURE;
-
-  /**
-   * Called when a network/protocol error occurs and there is no response.
-   */
-  virtual void onFailure() PURE;
-};
-
-/**
- * A single redis client connection.
- */
-class Client : public Event::DeferredDeletable {
-public:
-  virtual ~Client() {}
-
-  /**
-   * Adds network connection callbacks to the underlying network connection.
-   */
-  virtual void addConnectionCallbacks(Network::ConnectionCallbacks& callbacks) PURE;
-
-  /**
-   * Closes the underlying network connection.
-   */
-  virtual void close() PURE;
-
-  /**
-   * Make a pipelined request to the remote redis server.
-   * @param request supplies the RESP request to make.
-   * @param callbacks supplies the request callbacks.
-   * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
-   *         for some reason.
-   */
-  virtual PoolRequest* makeRequest(const Common::Redis::RespValue& request,
-                                   PoolCallbacks& callbacks) PURE;
-};
-
-typedef std::unique_ptr<Client> ClientPtr;
-
-/**
- * Configuration for a redis connection pool.
- */
-class Config {
-public:
-  virtual ~Config() {}
-
-  /**
-   * @return std::chrono::milliseconds the timeout for an individual redis operation. Currently,
-   *         all operations use the same timeout.
-   */
-  virtual std::chrono::milliseconds opTimeout() const PURE;
-
-  /**
-   * @return bool disable outlier events even if the cluster has it enabled. This is used by the
-   * healthchecker's connection pool to avoid double counting active healthcheck operations as
-   * passive healthcheck operations.
-   */
-  virtual bool disableOutlierEvents() const PURE;
-
-  /**
-   * @return when enabled, a hash tagging function will be used to guarantee that keys with the
-   * same hash tag will be forwarded to the same upstream.
-   */
-  virtual bool enableHashtagging() const PURE;
-};
-
-/**
- * A factory for individual redis client connections.
- */
-class ClientFactory {
-public:
-  virtual ~ClientFactory() {}
-
-  /**
-   * Create a client given an upstream host.
-   * @param host supplies the upstream host.
-   * @param dispatcher supplies the owning thread's dispatcher.
-   * @param config supplies the connection pool configuration.
-   * @return ClientPtr a new connection pool client.
-   */
-  virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                           const Config& config) PURE;
-};
-
-/**
  * A redis connection pool. Wraps M connections to N upstream hosts, consistent hashing,
  * pipelining, failure handling, etc.
  */
@@ -137,9 +30,9 @@ public:
    * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
    *         for some reason.
    */
-  virtual PoolRequest* makeRequest(const std::string& hash_key,
+  virtual Common::Redis::PoolRequest* makeRequest(const std::string& hash_key,
                                    const Common::Redis::RespValue& request,
-                                   PoolCallbacks& callbacks) PURE;
+                                   Common::Redis::PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -24,9 +24,9 @@ InstanceImpl::InstanceImpl(
   });
 }
 
-Common::Redis::Client::PoolRequest* InstanceImpl::makeRequest(const std::string& key,
-                                                      const Common::Redis::RespValue& value,
-                                                      Common::Redis::Client::PoolCallbacks& callbacks) {
+Common::Redis::Client::PoolRequest*
+InstanceImpl::makeRequest(const std::string& key, const Common::Redis::RespValue& value,
+                          Common::Redis::Client::PoolCallbacks& callbacks) {
   return tls_->getTyped<ThreadLocalPool>().makeRequest(key, value, callbacks);
 }
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -13,193 +13,9 @@ namespace NetworkFilters {
 namespace RedisProxy {
 namespace ConnPool {
 
-ConfigImpl::ConfigImpl(
-    const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config)
-    : op_timeout_(PROTOBUF_GET_MS_REQUIRED(config, op_timeout)),
-      enable_hashtagging_(config.enable_hashtagging()) {}
-
-Common::Redis::ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host,
-                                            Event::Dispatcher& dispatcher,
-                                            Common::Redis::EncoderPtr&& encoder,
-                                            Common::Redis::DecoderFactory& decoder_factory,
-                                            const Common::Redis::Config& config) {
-
-  std::unique_ptr<ClientImpl> client(
-      new ClientImpl(host, dispatcher, std::move(encoder), decoder_factory, config));
-  client->connection_ = host->createConnection(dispatcher, nullptr, nullptr).connection_;
-  client->connection_->addConnectionCallbacks(*client);
-  client->connection_->addReadFilter(Network::ReadFilterSharedPtr{new UpstreamReadFilter(*client)});
-  client->connection_->connect();
-  client->connection_->noDelay(true);
-  return std::move(client);
-}
-
-ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                       Common::Redis::EncoderPtr&& encoder,
-                       Common::Redis::DecoderFactory& decoder_factory,
-                       const Common::Redis::Config& config)
-    : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
-      config_(config),
-      connect_or_op_timer_(dispatcher.createTimer([this]() -> void { onConnectOrOpTimeout(); })) {
-  host->cluster().stats().upstream_cx_total_.inc();
-  host->stats().cx_total_.inc();
-  host->cluster().stats().upstream_cx_active_.inc();
-  host->stats().cx_active_.inc();
-  connect_or_op_timer_->enableTimer(host->cluster().connectTimeout());
-}
-
-ClientImpl::~ClientImpl() {
-  ASSERT(pending_requests_.empty());
-  ASSERT(connection_->state() == Network::Connection::State::Closed);
-  host_->cluster().stats().upstream_cx_active_.dec();
-  host_->stats().cx_active_.dec();
-}
-
-void ClientImpl::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
-
-Common::Redis::PoolRequest* ClientImpl::makeRequest(const Common::Redis::RespValue& request,
-                                                    Common::Redis::PoolCallbacks& callbacks) {
-  ASSERT(connection_->state() == Network::Connection::State::Open);
-
-  pending_requests_.emplace_back(*this, callbacks);
-  encoder_->encode(request, encoder_buffer_);
-  connection_->write(encoder_buffer_, false);
-
-  // Only boost the op timeout if:
-  // - We are not already connected. Otherwise, we are governed by the connect timeout and the timer
-  //   will be reset when/if connection occurs. This allows a relatively long connection spin up
-  //   time for example if TLS is being used.
-  // - This is the first request on the pipeline. Otherwise the timeout would effectively start on
-  //   the last operation.
-  if (connected_ && pending_requests_.size() == 1) {
-    connect_or_op_timer_->enableTimer(config_.opTimeout());
-  }
-
-  return &pending_requests_.back();
-}
-
-void ClientImpl::onConnectOrOpTimeout() {
-  putOutlierEvent(Upstream::Outlier::Result::TIMEOUT);
-  if (connected_) {
-    host_->cluster().stats().upstream_rq_timeout_.inc();
-    host_->stats().rq_timeout_.inc();
-  } else {
-    host_->cluster().stats().upstream_cx_connect_timeout_.inc();
-    host_->stats().cx_connect_fail_.inc();
-  }
-
-  connection_->close(Network::ConnectionCloseType::NoFlush);
-}
-
-void ClientImpl::onData(Buffer::Instance& data) {
-  try {
-    decoder_->decode(data);
-  } catch (Common::Redis::ProtocolError&) {
-    putOutlierEvent(Upstream::Outlier::Result::REQUEST_FAILED);
-    host_->cluster().stats().upstream_cx_protocol_error_.inc();
-    host_->stats().rq_error_.inc();
-    connection_->close(Network::ConnectionCloseType::NoFlush);
-  }
-}
-
-void ClientImpl::putOutlierEvent(Upstream::Outlier::Result result) {
-  if (!config_.disableOutlierEvents()) {
-    host_->outlierDetector().putResult(result);
-  }
-}
-
-void ClientImpl::onEvent(Network::ConnectionEvent event) {
-  if (event == Network::ConnectionEvent::RemoteClose ||
-      event == Network::ConnectionEvent::LocalClose) {
-    if (!pending_requests_.empty()) {
-      host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
-      if (event == Network::ConnectionEvent::RemoteClose) {
-        putOutlierEvent(Upstream::Outlier::Result::SERVER_FAILURE);
-        host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
-      }
-      if (event == Network::ConnectionEvent::LocalClose) {
-        host_->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
-      }
-    }
-
-    while (!pending_requests_.empty()) {
-      PendingRequest& request = pending_requests_.front();
-      if (!request.canceled_) {
-        request.callbacks_.onFailure();
-      } else {
-        host_->cluster().stats().upstream_rq_cancelled_.inc();
-      }
-      pending_requests_.pop_front();
-    }
-
-    connect_or_op_timer_->disableTimer();
-  } else if (event == Network::ConnectionEvent::Connected) {
-    connected_ = true;
-    ASSERT(!pending_requests_.empty());
-    connect_or_op_timer_->enableTimer(config_.opTimeout());
-  }
-
-  if (event == Network::ConnectionEvent::RemoteClose && !connected_) {
-    host_->cluster().stats().upstream_cx_connect_fail_.inc();
-    host_->stats().cx_connect_fail_.inc();
-  }
-}
-
-void ClientImpl::onRespValue(Common::Redis::RespValuePtr&& value) {
-  ASSERT(!pending_requests_.empty());
-  PendingRequest& request = pending_requests_.front();
-  if (!request.canceled_) {
-    request.callbacks_.onResponse(std::move(value));
-  } else {
-    host_->cluster().stats().upstream_rq_cancelled_.inc();
-  }
-  pending_requests_.pop_front();
-
-  // If there are no remaining ops in the pipeline we need to disable the timer.
-  // Otherwise we boost the timer since we are receiving responses and there are more to flush out.
-  if (pending_requests_.empty()) {
-    connect_or_op_timer_->disableTimer();
-  } else {
-    connect_or_op_timer_->enableTimer(config_.opTimeout());
-  }
-
-  putOutlierEvent(Upstream::Outlier::Result::SUCCESS);
-}
-
-ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent,
-                                           Common::Redis::PoolCallbacks& callbacks)
-    : parent_(parent), callbacks_(callbacks) {
-  parent.host_->cluster().stats().upstream_rq_total_.inc();
-  parent.host_->stats().rq_total_.inc();
-  parent.host_->cluster().stats().upstream_rq_active_.inc();
-  parent.host_->stats().rq_active_.inc();
-}
-
-ClientImpl::PendingRequest::~PendingRequest() {
-  parent_.host_->cluster().stats().upstream_rq_active_.dec();
-  parent_.host_->stats().rq_active_.dec();
-}
-
-void ClientImpl::PendingRequest::cancel() {
-  // If we get a cancellation, we just mark the pending request as cancelled, and then we drop
-  // the response as it comes through. There is no reason to blow away the connection when the
-  // remote is already responding as fast as possible.
-  canceled_ = true;
-}
-
-ClientFactoryImpl ClientFactoryImpl::instance_;
-
-Common::Redis::ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
-                                                   Event::Dispatcher& dispatcher,
-                                                   const Common::Redis::Config& config) {
-  return ClientImpl::create(host, dispatcher,
-                            Common::Redis::EncoderPtr{new Common::Redis::EncoderImpl()},
-                            decoder_factory_, config);
-}
-
 InstanceImpl::InstanceImpl(
     const std::string& cluster_name, Upstream::ClusterManager& cm,
-    Common::Redis::ClientFactory& client_factory, ThreadLocal::SlotAllocator& tls,
+    Common::Redis::Client::ClientFactory& client_factory, ThreadLocal::SlotAllocator& tls,
     const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config)
     : cm_(cm), client_factory_(client_factory), tls_(tls.allocateSlot()), config_(config) {
   tls_->set([this, cluster_name](
@@ -208,9 +24,9 @@ InstanceImpl::InstanceImpl(
   });
 }
 
-Common::Redis::PoolRequest* InstanceImpl::makeRequest(const std::string& key,
+Common::Redis::Client::PoolRequest* InstanceImpl::makeRequest(const std::string& key,
                                                       const Common::Redis::RespValue& value,
-                                                      Common::Redis::PoolCallbacks& callbacks) {
+                                                      Common::Redis::Client::PoolCallbacks& callbacks) {
   return tls_->getTyped<ThreadLocalPool>().makeRequest(key, value, callbacks);
 }
 
@@ -282,10 +98,10 @@ void InstanceImpl::ThreadLocalPool::onHostsRemoved(
   }
 }
 
-Common::Redis::PoolRequest*
+Common::Redis::Client::PoolRequest*
 InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key,
                                            const Common::Redis::RespValue& request,
-                                           Common::Redis::PoolCallbacks& callbacks) {
+                                           Common::Redis::Client::PoolCallbacks& callbacks) {
   if (cluster_ == nullptr) {
     ASSERT(client_map_.empty());
     ASSERT(host_set_member_update_cb_handle_ == nullptr);

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -18,9 +18,9 @@ ConfigImpl::ConfigImpl(
     : op_timeout_(PROTOBUF_GET_MS_REQUIRED(config, op_timeout)),
       enable_hashtagging_(config.enable_hashtagging()) {}
 
-ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
+Common::Redis::ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                              Common::Redis::EncoderPtr&& encoder,
-                             Common::Redis::DecoderFactory& decoder_factory, const Config& config) {
+                             Common::Redis::DecoderFactory& decoder_factory, const Common::Redis::Config& config) {
 
   std::unique_ptr<ClientImpl> client(
       new ClientImpl(host, dispatcher, std::move(encoder), decoder_factory, config));
@@ -34,7 +34,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                        Common::Redis::EncoderPtr&& encoder,
-                       Common::Redis::DecoderFactory& decoder_factory, const Config& config)
+                       Common::Redis::DecoderFactory& decoder_factory, const Common::Redis::Config& config)
     : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
       config_(config),
       connect_or_op_timer_(dispatcher.createTimer([this]() -> void { onConnectOrOpTimeout(); })) {
@@ -54,8 +54,8 @@ ClientImpl::~ClientImpl() {
 
 void ClientImpl::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
 
-PoolRequest* ClientImpl::makeRequest(const Common::Redis::RespValue& request,
-                                     PoolCallbacks& callbacks) {
+Common::Redis::PoolRequest* ClientImpl::makeRequest(const Common::Redis::RespValue& request,
+                                     Common::Redis::PoolCallbacks& callbacks) {
   ASSERT(connection_->state() == Network::Connection::State::Open);
 
   pending_requests_.emplace_back(*this, callbacks);
@@ -163,7 +163,7 @@ void ClientImpl::onRespValue(Common::Redis::RespValuePtr&& value) {
   putOutlierEvent(Upstream::Outlier::Result::SUCCESS);
 }
 
-ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent, PoolCallbacks& callbacks)
+ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent, Common::Redis::PoolCallbacks& callbacks)
     : parent_(parent), callbacks_(callbacks) {
   parent.host_->cluster().stats().upstream_rq_total_.inc();
   parent.host_->stats().rq_total_.inc();
@@ -185,15 +185,15 @@ void ClientImpl::PendingRequest::cancel() {
 
 ClientFactoryImpl ClientFactoryImpl::instance_;
 
-ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
-                                    Event::Dispatcher& dispatcher, const Config& config) {
+Common::Redis::ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
+                                    Event::Dispatcher& dispatcher, const Common::Redis::Config& config) {
   return ClientImpl::create(host, dispatcher,
                             Common::Redis::EncoderPtr{new Common::Redis::EncoderImpl()},
                             decoder_factory_, config);
 }
 
 InstanceImpl::InstanceImpl(
-    const std::string& cluster_name, Upstream::ClusterManager& cm, ClientFactory& client_factory,
+    const std::string& cluster_name, Upstream::ClusterManager& cm, Common::Redis::ClientFactory& client_factory,
     ThreadLocal::SlotAllocator& tls,
     const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config)
     : cm_(cm), client_factory_(client_factory), tls_(tls.allocateSlot()), config_(config) {
@@ -203,9 +203,9 @@ InstanceImpl::InstanceImpl(
   });
 }
 
-PoolRequest* InstanceImpl::makeRequest(const std::string& key,
+Common::Redis::PoolRequest* InstanceImpl::makeRequest(const std::string& key,
                                        const Common::Redis::RespValue& value,
-                                       PoolCallbacks& callbacks) {
+                                       Common::Redis::PoolCallbacks& callbacks) {
   return tls_->getTyped<ThreadLocalPool>().makeRequest(key, value, callbacks);
 }
 
@@ -277,9 +277,9 @@ void InstanceImpl::ThreadLocalPool::onHostsRemoved(
   }
 }
 
-PoolRequest* InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key,
+Common::Redis::PoolRequest* InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key,
                                                         const Common::Redis::RespValue& request,
-                                                        PoolCallbacks& callbacks) {
+                                                        Common::Redis::PoolCallbacks& callbacks) {
   if (cluster_ == nullptr) {
     ASSERT(client_map_.empty());
     ASSERT(host_set_member_update_cb_handle_ == nullptr);

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -19,6 +19,7 @@
 #include "common/upstream/load_balancer_impl.h"
 
 #include "extensions/filters/network/common/redis/codec_impl.h"
+
 #include "extensions/filters/network/common/redis/client.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -39,9 +39,9 @@ public:
       const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config);
 
   // RedisProxy::ConnPool::Instance
-  Common::Redis::Client::PoolRequest* makeRequest(const std::string& key,
-                                          const Common::Redis::RespValue& request,
-                                          Common::Redis::Client::PoolCallbacks& callbacks) override;
+  Common::Redis::Client::PoolRequest*
+  makeRequest(const std::string& key, const Common::Redis::RespValue& request,
+              Common::Redis::Client::PoolCallbacks& callbacks) override;
 
 private:
   struct ThreadLocalPool;
@@ -65,9 +65,9 @@ private:
                            public Upstream::ClusterUpdateCallbacks {
     ThreadLocalPool(InstanceImpl& parent, Event::Dispatcher& dispatcher, std::string cluster_name);
     ~ThreadLocalPool();
-    Common::Redis::Client::PoolRequest* makeRequest(const std::string& key,
-                                            const Common::Redis::RespValue& request,
-                                            Common::Redis::Client::PoolCallbacks& callbacks);
+    Common::Redis::Client::PoolRequest*
+    makeRequest(const std::string& key, const Common::Redis::RespValue& request,
+                Common::Redis::Client::PoolCallbacks& callbacks);
     void onClusterAddOrUpdateNonVirtual(Upstream::ThreadLocalCluster& cluster);
     void onHostsRemoved(const std::vector<Upstream::HostSharedPtr>& hosts_removed);
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -18,9 +18,8 @@
 #include "common/protobuf/utility.h"
 #include "common/upstream/load_balancer_impl.h"
 
-#include "extensions/filters/network/common/redis/codec_impl.h"
-
 #include "extensions/filters/network/common/redis/client.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
 namespace Envoy {
@@ -50,9 +49,11 @@ class ClientImpl : public Common::Redis::Client,
                    public Common::Redis::DecoderCallbacks,
                    public Network::ConnectionCallbacks {
 public:
-  static Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                          Common::Redis::EncoderPtr&& encoder,
-                          Common::Redis::DecoderFactory& decoder_factory, const Common::Redis::Config& config);
+  static Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host,
+                                         Event::Dispatcher& dispatcher,
+                                         Common::Redis::EncoderPtr&& encoder,
+                                         Common::Redis::DecoderFactory& decoder_factory,
+                                         const Common::Redis::Config& config);
 
   ~ClientImpl();
 
@@ -62,7 +63,7 @@ public:
   }
   void close() override;
   Common::Redis::PoolRequest* makeRequest(const Common::Redis::RespValue& request,
-                           Common::Redis::PoolCallbacks& callbacks) override;
+                                          Common::Redis::PoolCallbacks& callbacks) override;
 
 private:
   struct UpstreamReadFilter : public Network::ReadFilterBaseImpl {
@@ -119,7 +120,7 @@ class ClientFactoryImpl : public Common::Redis::ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
   Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                   const Common::Redis::Config& config) override;
+                                  const Common::Redis::Config& config) override;
 
   static ClientFactoryImpl instance_;
 
@@ -130,13 +131,14 @@ private:
 class InstanceImpl : public Instance {
 public:
   InstanceImpl(
-      const std::string& cluster_name, Upstream::ClusterManager& cm, Common::Redis::ClientFactory& client_factory,
-      ThreadLocal::SlotAllocator& tls,
+      const std::string& cluster_name, Upstream::ClusterManager& cm,
+      Common::Redis::ClientFactory& client_factory, ThreadLocal::SlotAllocator& tls,
       const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config);
 
   // RedisProxy::ConnPool::Instance
-  Common::Redis::PoolRequest* makeRequest(const std::string& key, const Common::Redis::RespValue& request,
-                           Common::Redis::PoolCallbacks& callbacks) override;
+  Common::Redis::PoolRequest* makeRequest(const std::string& key,
+                                          const Common::Redis::RespValue& request,
+                                          Common::Redis::PoolCallbacks& callbacks) override;
 
 private:
   struct ThreadLocalPool;
@@ -160,8 +162,9 @@ private:
                            public Upstream::ClusterUpdateCallbacks {
     ThreadLocalPool(InstanceImpl& parent, Event::Dispatcher& dispatcher, std::string cluster_name);
     ~ThreadLocalPool();
-    Common::Redis::PoolRequest* makeRequest(const std::string& key, const Common::Redis::RespValue& request,
-                             Common::Redis::PoolCallbacks& callbacks);
+    Common::Redis::PoolRequest* makeRequest(const std::string& key,
+                                            const Common::Redis::RespValue& request,
+                                            Common::Redis::PoolCallbacks& callbacks);
     void onClusterAddOrUpdateNonVirtual(Upstream::ThreadLocalCluster& cluster);
     void onHostsRemoved(const std::vector<Upstream::HostSharedPtr>& hosts_removed);
 

--- a/source/extensions/health_checkers/redis/BUILD
+++ b/source/extensions/health_checkers/redis/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     hdrs = ["redis.h"],
     deps = [
         "//source/common/upstream:health_checker_base_lib",
+        "//source/extensions/filters/network/common/redis:client_lib",
         "//source/extensions/filters/network/redis_proxy:conn_pool_lib",
         "@envoy_api//envoy/api/v2/core:health_check_cc",
         "@envoy_api//envoy/config/health_checker/redis/v2:redis_cc",

--- a/source/extensions/health_checkers/redis/config.cc
+++ b/source/extensions/health_checkers/redis/config.cc
@@ -17,7 +17,7 @@ Upstream::HealthCheckerSharedPtr RedisHealthCheckerFactory::createCustomHealthCh
   return std::make_shared<RedisHealthChecker>(
       context.cluster(), config, getRedisHealthCheckConfig(config), context.dispatcher(),
       context.runtime(), context.random(), context.eventLogger(),
-      NetworkFilters::RedisProxy::ConnPool::ClientFactoryImpl::instance_);
+      NetworkFilters::Common::Redis::Client::ClientFactoryImpl::instance_);
 };
 
 /**

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -10,7 +10,7 @@ RedisHealthChecker::RedisHealthChecker(
     const envoy::config::health_checker::redis::v2::Redis& redis_config,
     Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
     Upstream::HealthCheckEventLoggerPtr&& event_logger,
-    Extensions::NetworkFilters::Common::Redis::ClientFactory& client_factory)
+    Extensions::NetworkFilters::Common::Redis::Client::ClientFactory& client_factory)
     : HealthCheckerImplBase(cluster, config, dispatcher, runtime, random, std::move(event_logger)),
       client_factory_(client_factory), key_(redis_config.key()) {
   if (!key_.empty()) {

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -10,7 +10,7 @@ RedisHealthChecker::RedisHealthChecker(
     const envoy::config::health_checker::redis::v2::Redis& redis_config,
     Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
     Upstream::HealthCheckEventLoggerPtr&& event_logger,
-    Extensions::NetworkFilters::RedisProxy::ConnPool::ClientFactory& client_factory)
+    Extensions::NetworkFilters::Common::Redis::ClientFactory& client_factory)
     : HealthCheckerImplBase(cluster, config, dispatcher, runtime, random, std::move(event_logger)),
       client_factory_(client_factory), key_(redis_config.key()) {
   if (!key_.empty()) {

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -17,13 +17,12 @@ namespace RedisHealthChecker {
  */
 class RedisHealthChecker : public Upstream::HealthCheckerImplBase {
 public:
-  RedisHealthChecker(const Upstream::Cluster& cluster,
-                     const envoy::api::v2::core::HealthCheck& config,
-                     const envoy::config::health_checker::redis::v2::Redis& redis_config,
-                     Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
-                     Runtime::RandomGenerator& random,
-                     Upstream::HealthCheckEventLoggerPtr&& event_logger,
-                     Extensions::NetworkFilters::Common::Redis::Client::ClientFactory& client_factory);
+  RedisHealthChecker(
+      const Upstream::Cluster& cluster, const envoy::api::v2::core::HealthCheck& config,
+      const envoy::config::health_checker::redis::v2::Redis& redis_config,
+      Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+      Upstream::HealthCheckEventLoggerPtr&& event_logger,
+      Extensions::NetworkFilters::Common::Redis::Client::ClientFactory& client_factory);
 
   static const NetworkFilters::Common::Redis::RespValue& pingHealthCheckRequest() {
     static HealthCheckRequest* request = new HealthCheckRequest();

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -16,12 +16,13 @@ namespace RedisHealthChecker {
  */
 class RedisHealthChecker : public Upstream::HealthCheckerImplBase {
 public:
-  RedisHealthChecker(
-      const Upstream::Cluster& cluster, const envoy::api::v2::core::HealthCheck& config,
-      const envoy::config::health_checker::redis::v2::Redis& redis_config,
-      Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-      Upstream::HealthCheckEventLoggerPtr&& event_logger,
-      Extensions::NetworkFilters::Common::Redis::ClientFactory& client_factory);
+  RedisHealthChecker(const Upstream::Cluster& cluster,
+                     const envoy::api::v2::core::HealthCheck& config,
+                     const envoy::config::health_checker::redis::v2::Redis& redis_config,
+                     Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
+                     Runtime::RandomGenerator& random,
+                     Upstream::HealthCheckEventLoggerPtr&& event_logger,
+                     Extensions::NetworkFilters::Common::Redis::ClientFactory& client_factory);
 
   static const NetworkFilters::Common::Redis::RespValue& pingHealthCheckRequest() {
     static HealthCheckRequest* request = new HealthCheckRequest();

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -21,7 +21,7 @@ public:
       const envoy::config::health_checker::redis::v2::Redis& redis_config,
       Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
       Upstream::HealthCheckEventLoggerPtr&& event_logger,
-      Extensions::NetworkFilters::RedisProxy::ConnPool::ClientFactory& client_factory);
+      Extensions::NetworkFilters::Common::Redis::ClientFactory& client_factory);
 
   static const NetworkFilters::Common::Redis::RespValue& pingHealthCheckRequest() {
     static HealthCheckRequest* request = new HealthCheckRequest();
@@ -42,8 +42,8 @@ protected:
 private:
   struct RedisActiveHealthCheckSession
       : public ActiveHealthCheckSession,
-        public Extensions::NetworkFilters::RedisProxy::ConnPool::Config,
-        public Extensions::NetworkFilters::RedisProxy::ConnPool::PoolCallbacks,
+        public Extensions::NetworkFilters::Common::Redis::Config,
+        public Extensions::NetworkFilters::Common::Redis::PoolCallbacks,
         public Network::ConnectionCallbacks {
     RedisActiveHealthCheckSession(RedisHealthChecker& parent, const Upstream::HostSharedPtr& host);
     ~RedisActiveHealthCheckSession();
@@ -51,7 +51,7 @@ private:
     void onInterval() override;
     void onTimeout() override;
 
-    // Extensions::NetworkFilters::RedisProxy::ConnPool::Config
+    // Extensions::NetworkFilters::Common::Redis::Config
     bool disableOutlierEvents() const override { return true; }
     std::chrono::milliseconds opTimeout() const override {
       // Allow the main Health Check infra to control timeout.
@@ -59,7 +59,7 @@ private:
     }
     bool enableHashtagging() const override { return false; }
 
-    // Extensions::NetworkFilters::RedisProxy::ConnPool::PoolCallbacks
+    // Extensions::NetworkFilters::Common::Redis::PoolCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;
 
@@ -69,8 +69,8 @@ private:
     void onBelowWriteBufferLowWatermark() override {}
 
     RedisHealthChecker& parent_;
-    Extensions::NetworkFilters::RedisProxy::ConnPool::ClientPtr client_;
-    Extensions::NetworkFilters::RedisProxy::ConnPool::PoolRequest* current_request_{};
+    Extensions::NetworkFilters::Common::Redis::ClientPtr client_;
+    Extensions::NetworkFilters::Common::Redis::PoolRequest* current_request_{};
   };
 
   enum class Type { Ping, Exists };
@@ -89,7 +89,7 @@ private:
     return std::make_unique<RedisActiveHealthCheckSession>(*this, host);
   }
 
-  Extensions::NetworkFilters::RedisProxy::ConnPool::ClientFactory& client_factory_;
+  Extensions::NetworkFilters::Common::Redis::ClientFactory& client_factory_;
   Type type_;
   const std::string key_;
 };

--- a/test/extensions/filters/network/common/redis/BUILD
+++ b/test/extensions/filters/network/common/redis/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",
     "envoy_cc_test",
+    "envoy_cc_test_library",
     "envoy_package",
 )
 
@@ -15,8 +16,22 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//source/common/common:assert_lib",
-        "//source/extensions/filters/network/common/redis:codec_lib",
         "//source/extensions/filters/network/common/redis:client_lib",
+        "//source/extensions/filters/network/common/redis:codec_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "test_utils_lib",
+    hdrs = ["test_utils.h"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
+        "//source/extensions/filters/network/common/redis:client_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
     ],
 )
 
@@ -37,6 +52,7 @@ envoy_cc_test(
     srcs = ["client_impl_test.cc"],
     deps = [
         ":redis_mocks",
+        ":test_utils_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/network:utility_lib",
         "//source/common/upstream:upstream_includes",
@@ -47,4 +63,3 @@ envoy_cc_test(
         "//test/mocks/upstream:upstream_mocks",
     ],
 )
-

--- a/test/extensions/filters/network/common/redis/BUILD
+++ b/test/extensions/filters/network/common/redis/BUILD
@@ -16,6 +16,7 @@ envoy_cc_mock(
     deps = [
         "//source/common/common:assert_lib",
         "//source/extensions/filters/network/common/redis:codec_lib",
+        "//source/extensions/filters/network/common/redis:client_lib",
     ],
 )
 
@@ -30,3 +31,20 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "client_impl_test",
+    srcs = ["client_impl_test.cc"],
+    deps = [
+        ":redis_mocks",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
+        "//source/extensions/filters/network/common/redis:client_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+    ],
+)
+

--- a/test/extensions/filters/network/common/redis/BUILD
+++ b/test/extensions/filters/network/common/redis/BUILD
@@ -25,13 +25,8 @@ envoy_cc_test_library(
     name = "test_utils_lib",
     hdrs = ["test_utils.h"],
     deps = [
-        "//source/common/event:dispatcher_lib",
-        "//source/common/network:utility_lib",
-        "//source/common/upstream:upstream_includes",
-        "//source/common/upstream:upstream_lib",
-        "//source/extensions/filters/network/common/redis:client_lib",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/thread_local:thread_local_mocks",
+        "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
     ],
 )
 

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -2,13 +2,13 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
-
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "extensions/filters/network/common/redis/client_impl.h"
 
 #include "test/extensions/filters/network/common/redis/mocks.h"
+#include "test/extensions/filters/network/common/redis/test_utils.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -34,14 +34,6 @@ namespace NetworkFilters {
 namespace Common {
 namespace Redis {
 namespace Client {
-
-envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings
-createConnPoolSettings() {
-  envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings setting{};
-  setting.mutable_op_timeout()->CopyFrom(Protobuf::util::TimeUtil::MillisecondsToDuration(20));
-  setting.set_enable_hashtagging(true);
-  return setting;
-}
 
 class RedisClientImplTest : public testing::Test, public Common::Redis::DecoderFactory {
 public:
@@ -111,7 +103,6 @@ public:
   std::unique_ptr<Config> config_;
   ClientPtr client_;
 };
-
 
 TEST_F(RedisClientImplTest, Basic) {
   InSequence s;
@@ -387,7 +378,7 @@ TEST(RedisClientFactoryImplTest, Basic) {
   client->close();
 }
 
-} // namespace Client 
+} // namespace Client
 } // namespace Redis
 } // namespace Common
 } // namespace NetworkFilters

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -1,0 +1,395 @@
+#include <vector>
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/assert.h"
+
+#include "common/network/utility.h"
+#include "common/upstream/upstream_impl.h"
+
+#include "extensions/filters/network/common/redis/client_impl.h"
+
+#include "test/extensions/filters/network/common/redis/mocks.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Eq;
+using testing::InSequence;
+using testing::Invoke;
+using testing::Ref;
+using testing::Return;
+using testing::ReturnNew;
+using testing::ReturnRef;
+using testing::SaveArg;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+namespace Client {
+
+envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings
+createConnPoolSettings() {
+  envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings setting{};
+  setting.mutable_op_timeout()->CopyFrom(Protobuf::util::TimeUtil::MillisecondsToDuration(20));
+  setting.set_enable_hashtagging(true);
+  return setting;
+}
+
+class RedisClientImplTest : public testing::Test, public Common::Redis::DecoderFactory {
+public:
+  // Commmon::Redis::DecoderFactory
+  Common::Redis::DecoderPtr create(Common::Redis::DecoderCallbacks& callbacks) override {
+    callbacks_ = &callbacks;
+    return Common::Redis::DecoderPtr{decoder_};
+  }
+
+  ~RedisClientImplTest() {
+    client_.reset();
+
+    // Make sure all gauges are 0.
+    for (const Stats::GaugeSharedPtr& gauge : host_->cluster_.stats_store_.gauges()) {
+      EXPECT_EQ(0U, gauge->value());
+    }
+    for (const Stats::GaugeSharedPtr& gauge : host_->stats_store_.gauges()) {
+      EXPECT_EQ(0U, gauge->value());
+    }
+  }
+
+  void setup() {
+    config_ = std::make_unique<ConfigImpl>(createConnPoolSettings());
+    finishSetup();
+  }
+
+  void setup(std::unique_ptr<Config>&& config) {
+    config_ = std::move(config);
+    finishSetup();
+  }
+
+  void finishSetup() {
+    upstream_connection_ = new NiceMock<Network::MockClientConnection>();
+    Upstream::MockHost::MockCreateConnectionData conn_info;
+    conn_info.connection_ = upstream_connection_;
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+    EXPECT_CALL(*host_, createConnection_(_, _)).WillOnce(Return(conn_info));
+    EXPECT_CALL(*upstream_connection_, addReadFilter(_))
+        .WillOnce(SaveArg<0>(&upstream_read_filter_));
+    EXPECT_CALL(*upstream_connection_, connect());
+    EXPECT_CALL(*upstream_connection_, noDelay(true));
+
+    client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
+                                 *config_);
+    EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_total_.value());
+    EXPECT_EQ(1UL, host_->stats_.cx_total_.value());
+
+    // NOP currently.
+    upstream_connection_->runHighWatermarkCallbacks();
+    upstream_connection_->runLowWatermarkCallbacks();
+  }
+
+  void onConnected() {
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+    upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  }
+
+  const std::string cluster_name_{"foo"};
+  std::shared_ptr<Upstream::MockHost> host_{new NiceMock<Upstream::MockHost>()};
+  Event::MockDispatcher dispatcher_;
+  Event::MockTimer* connect_or_op_timer_{new Event::MockTimer(&dispatcher_)};
+  MockEncoder* encoder_{new MockEncoder()};
+  MockDecoder* decoder_{new MockDecoder()};
+  Common::Redis::DecoderCallbacks* callbacks_{};
+  NiceMock<Network::MockClientConnection>* upstream_connection_{};
+  Network::ReadFilterSharedPtr upstream_read_filter_;
+  std::unique_ptr<Config> config_;
+  ClientPtr client_;
+};
+
+
+TEST_F(RedisClientImplTest, Basic) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  Common::Redis::RespValue request2;
+  MockPoolCallbacks callbacks2;
+  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
+  PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_total_.value());
+  EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_active_.value());
+  EXPECT_EQ(2UL, host_->stats_.rq_total_.value());
+  EXPECT_EQ(2UL, host_->stats_.rq_active_.value());
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    InSequence s;
+    Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+    EXPECT_CALL(callbacks1, onResponse_(Ref(response1)));
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
+    callbacks_->onRespValue(std::move(response1));
+
+    Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+    EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
+    EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
+    callbacks_->onRespValue(std::move(response2));
+  }));
+  upstream_read_filter_->onData(fake_data, false);
+
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  client_->close();
+}
+
+TEST_F(RedisClientImplTest, Cancel) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  Common::Redis::RespValue request2;
+  MockPoolCallbacks callbacks2;
+  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
+  PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  handle1->cancel();
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    InSequence s;
+
+    Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+    EXPECT_CALL(callbacks1, onResponse_(_)).Times(0);
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
+    callbacks_->onRespValue(std::move(response1));
+
+    Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+    EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
+    EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
+    callbacks_->onRespValue(std::move(response2));
+  }));
+  upstream_read_filter_->onData(fake_data, false);
+
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  client_->close();
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_cancelled_.value());
+}
+
+TEST_F(RedisClientImplTest, FailAll) {
+  InSequence s;
+
+  setup();
+
+  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
+  client_->addConnectionCallbacks(connection_callbacks);
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_remote_with_active_rq_.value());
+}
+
+TEST_F(RedisClientImplTest, FailAllWithCancel) {
+  InSequence s;
+
+  setup();
+
+  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
+  client_->addConnectionCallbacks(connection_callbacks);
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+  handle1->cancel();
+
+  EXPECT_CALL(callbacks1, onFailure()).Times(0);
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_local_with_active_rq_.value());
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_cancelled_.value());
+}
+
+TEST_F(RedisClientImplTest, ProtocolError) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    throw Common::Redis::ProtocolError("error");
+  }));
+  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::REQUEST_FAILED));
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  upstream_read_filter_->onData(fake_data, false);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_protocol_error_.value());
+  EXPECT_EQ(1UL, host_->stats_.rq_error_.value());
+}
+
+TEST_F(RedisClientImplTest, ConnectFail) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_fail_.value());
+  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
+}
+
+class ConfigOutlierDisabled : public Config {
+  bool disableOutlierEvents() const override { return true; }
+  std::chrono::milliseconds opTimeout() const override { return std::chrono::milliseconds(25); }
+  bool enableHashtagging() const override { return false; }
+};
+
+TEST_F(RedisClientImplTest, OutlierDisabled) {
+  InSequence s;
+
+  setup(std::make_unique<ConfigOutlierDisabled>());
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(host_->outlier_detector_, putResult(_)).Times(0);
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_fail_.value());
+  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
+}
+
+TEST_F(RedisClientImplTest, ConnectTimeout) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::TIMEOUT));
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  connect_or_op_timer_->callback_();
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_timeout_.value());
+  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
+}
+
+TEST_F(RedisClientImplTest, OpTimeout) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::TIMEOUT));
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  connect_or_op_timer_->callback_();
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_timeout_.value());
+  EXPECT_EQ(1UL, host_->stats_.rq_timeout_.value());
+}
+
+TEST(RedisClientFactoryImplTest, Basic) {
+  ClientFactoryImpl factory;
+  Upstream::MockHost::MockCreateConnectionData conn_info;
+  conn_info.connection_ = new NiceMock<Network::MockClientConnection>();
+  std::shared_ptr<Upstream::MockHost> host(new NiceMock<Upstream::MockHost>());
+  EXPECT_CALL(*host, createConnection_(_, _)).WillOnce(Return(conn_info));
+  NiceMock<Event::MockDispatcher> dispatcher;
+  ConfigImpl config(createConnPoolSettings());
+  ClientPtr client = factory.create(host, dispatcher, config);
+  client->close();
+}
+
+} // namespace Client 
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/common/redis/mocks.cc
+++ b/test/extensions/filters/network/common/redis/mocks.cc
@@ -87,7 +87,7 @@ MockPoolRequest::~MockPoolRequest() {}
 MockPoolCallbacks::MockPoolCallbacks() {}
 MockPoolCallbacks::~MockPoolCallbacks() {}
 
-} // namespace Client 
+} // namespace Client
 
 } // namespace Redis
 } // namespace Common

--- a/test/extensions/filters/network/common/redis/mocks.cc
+++ b/test/extensions/filters/network/common/redis/mocks.cc
@@ -54,6 +54,41 @@ bool operator==(const RespValue& lhs, const RespValue& rhs) {
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
+MockEncoder::MockEncoder() {
+  ON_CALL(*this, encode(_, _))
+      .WillByDefault(
+          Invoke([this](const Common::Redis::RespValue& value, Buffer::Instance& out) -> void {
+            real_encoder_.encode(value, out);
+          }));
+}
+
+MockEncoder::~MockEncoder() {}
+
+MockDecoder::MockDecoder() {}
+MockDecoder::~MockDecoder() {}
+
+namespace Client {
+
+MockClient::MockClient() {
+  ON_CALL(*this, addConnectionCallbacks(_))
+      .WillByDefault(Invoke([this](Network::ConnectionCallbacks& callbacks) -> void {
+        callbacks_.push_back(&callbacks);
+      }));
+  ON_CALL(*this, close()).WillByDefault(Invoke([this]() -> void {
+    raiseEvent(Network::ConnectionEvent::LocalClose);
+  }));
+}
+
+MockClient::~MockClient() {}
+
+MockPoolRequest::MockPoolRequest() {}
+MockPoolRequest::~MockPoolRequest() {}
+
+MockPoolCallbacks::MockPoolCallbacks() {}
+MockPoolCallbacks::~MockPoolCallbacks() {}
+
+} // namespace Client 
+
 } // namespace Redis
 } // namespace Common
 } // namespace NetworkFilters

--- a/test/extensions/filters/network/common/redis/mocks.h
+++ b/test/extensions/filters/network/common/redis/mocks.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "extensions/filters/network/common/redis/codec_impl.h"
+#include "extensions/filters/network/common/redis/client_impl.h"
 
 #include "test/test_common/printers.h"
 
@@ -23,6 +24,80 @@ namespace Redis {
 void PrintTo(const RespValue& value, std::ostream* os);
 void PrintTo(const RespValuePtr& value, std::ostream* os);
 bool operator==(const RespValue& lhs, const RespValue& rhs);
+
+class MockEncoder : public Common::Redis::Encoder {
+public:
+  MockEncoder();
+  ~MockEncoder();
+
+  MOCK_METHOD2(encode, void(const Common::Redis::RespValue& value, Buffer::Instance& out));
+
+private:
+  Common::Redis::EncoderImpl real_encoder_;
+};
+
+class MockDecoder : public Common::Redis::Decoder {
+public:
+  MockDecoder();
+  ~MockDecoder();
+
+  MOCK_METHOD1(decode, void(Buffer::Instance& data));
+};
+
+namespace Client {
+
+class MockClient : public Client {
+public:
+  MockClient();
+  ~MockClient();
+
+  void raiseEvent(Network::ConnectionEvent event) {
+    for (Network::ConnectionCallbacks* callbacks : callbacks_) {
+      callbacks->onEvent(event);
+    }
+  }
+
+  void runHighWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onAboveWriteBufferHighWatermark();
+    }
+  }
+
+  void runLowWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onBelowWriteBufferLowWatermark();
+    }
+  }
+
+  MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
+  MOCK_METHOD0(close, void());
+  MOCK_METHOD2(makeRequest, PoolRequest*(const Common::Redis::RespValue& request,
+                                                        PoolCallbacks& callbacks));
+
+  std::list<Network::ConnectionCallbacks*> callbacks_;
+};
+
+class MockPoolRequest : public PoolRequest {
+public:
+  MockPoolRequest();
+  ~MockPoolRequest();
+
+  MOCK_METHOD0(cancel, void());
+};
+
+class MockPoolCallbacks : public PoolCallbacks {
+public:
+  MockPoolCallbacks();
+  ~MockPoolCallbacks();
+
+  void onResponse(Common::Redis::RespValuePtr&& value) override { onResponse_(value); }
+
+  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
+  MOCK_METHOD0(onFailure, void());
+};
+
+
+} // namespace Client
 
 } // namespace Redis
 } // namespace Common

--- a/test/extensions/filters/network/common/redis/mocks.h
+++ b/test/extensions/filters/network/common/redis/mocks.h
@@ -4,8 +4,8 @@
 #include <list>
 #include <string>
 
-#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/common/redis/client_impl.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 
 #include "test/test_common/printers.h"
 
@@ -71,8 +71,8 @@ public:
 
   MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
   MOCK_METHOD0(close, void());
-  MOCK_METHOD2(makeRequest, PoolRequest*(const Common::Redis::RespValue& request,
-                                                        PoolCallbacks& callbacks));
+  MOCK_METHOD2(makeRequest,
+               PoolRequest*(const Common::Redis::RespValue& request, PoolCallbacks& callbacks));
 
   std::list<Network::ConnectionCallbacks*> callbacks_;
 };
@@ -95,7 +95,6 @@ public:
   MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
   MOCK_METHOD0(onFailure, void());
 };
-
 
 } // namespace Client
 

--- a/test/extensions/filters/network/common/redis/test_utils.h
+++ b/test/extensions/filters/network/common/redis/test_utils.h
@@ -4,9 +4,9 @@
 #include <list>
 #include <string>
 
-#include "test/test_common/printers.h"
+#include "envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.h"
 
-#include "gmock/gmock.h"
+#include "common/protobuf/utility.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/network/common/redis/test_utils.h
+++ b/test/extensions/filters/network/common/redis/test_utils.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <list>
+#include <string>
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+namespace Client {
+
+inline envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings
+createConnPoolSettings() {
+  envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings setting{};
+  setting.mutable_op_timeout()->CopyFrom(Protobuf::util::TimeUtil::MillisecondsToDuration(20));
+  setting.set_enable_hashtagging(true);
+  return setting;
+}
+
+} // namespace Client
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -41,6 +41,7 @@ envoy_extension_cc_test(
         "//source/common/upstream:upstream_lib",
         "//source/extensions/filters/network/redis_proxy:conn_pool_lib",
         "//test/extensions/filters/network/common/redis:redis_mocks",
+        "//test/extensions/filters/network/common/redis:test_utils_lib",
         "//test/mocks/network:network_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -70,8 +70,8 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//source/common/common:assert_lib",
-        "//source/extensions/filters/network/common/redis:codec_lib",
         "//source/extensions/filters/network/common/redis:client_interface",
+        "//source/extensions/filters/network/common/redis:codec_lib",
         "//source/extensions/filters/network/redis_proxy:command_splitter_interface",
         "//source/extensions/filters/network/redis_proxy:conn_pool_interface",
     ],

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -71,6 +71,7 @@ envoy_cc_mock(
     deps = [
         "//source/common/common:assert_lib",
         "//source/extensions/filters/network/common/redis:codec_lib",
+        "//source/extensions/filters/network/common/redis:client_interface",
         "//source/extensions/filters/network/redis_proxy:command_splitter_interface",
         "//source/extensions/filters/network/redis_proxy:conn_pool_interface",
     ],

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -31,8 +31,9 @@ public:
 };
 
 class NullInstanceImpl : public ConnPool::Instance {
-  Common::Redis::PoolRequest* makeRequest(const std::string&, const Common::Redis::RespValue&,
-                                          Common::Redis::PoolCallbacks&) override {
+  Common::Redis::Client::PoolRequest* makeRequest(const std::string&,
+                                                  const Common::Redis::RespValue&,
+                                                  Common::Redis::Client::PoolCallbacks&) override {
     return nullptr;
   }
 };

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -32,7 +32,7 @@ public:
 
 class NullInstanceImpl : public ConnPool::Instance {
   Common::Redis::PoolRequest* makeRequest(const std::string&, const Common::Redis::RespValue&,
-                                     Common::Redis::PoolCallbacks&) override {
+                                          Common::Redis::PoolCallbacks&) override {
     return nullptr;
   }
 };

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -31,8 +31,8 @@ public:
 };
 
 class NullInstanceImpl : public ConnPool::Instance {
-  ConnPool::PoolRequest* makeRequest(const std::string&, const Common::Redis::RespValue&,
-                                     ConnPool::PoolCallbacks&) override {
+  Common::Redis::PoolRequest* makeRequest(const std::string&, const Common::Redis::RespValue&,
+                                     Common::Redis::PoolCallbacks&) override {
     return nullptr;
   }
 };

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -130,8 +130,8 @@ public:
     pool_callbacks_->onResponse(std::move(response1));
   }
 
-  Common::Redis::PoolCallbacks* pool_callbacks_;
-  ConnPool::MockPoolRequest pool_request_;
+  Common::Redis::Client::PoolCallbacks* pool_callbacks_;
+  Common::Redis::Client::MockPoolRequest pool_request_;
 };
 
 TEST_P(RedisSingleServerRequestTest, Success) {
@@ -349,11 +349,11 @@ public:
     std::vector<Common::Redis::RespValue> tmp_expected_requests(num_gets);
     expected_requests_.swap(tmp_expected_requests);
     pool_callbacks_.resize(num_gets);
-    std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_gets);
+    std::vector<Common::Redis::Client::MockPoolRequest> tmp_pool_requests(num_gets);
     pool_requests_.swap(tmp_pool_requests);
     for (uint32_t i = 0; i < num_gets; i++) {
       makeBulkStringArray(expected_requests_[i], {"get", std::to_string(i)});
-      Common::Redis::PoolRequest* request_to_use = nullptr;
+      Common::Redis::Client::PoolRequest* request_to_use = nullptr;
       if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
           null_handle_indexes.end()) {
         request_to_use = &pool_requests_[i];
@@ -366,8 +366,8 @@ public:
   }
 
   std::vector<Common::Redis::RespValue> expected_requests_;
-  std::vector<Common::Redis::PoolCallbacks*> pool_callbacks_;
-  std::vector<ConnPool::MockPoolRequest> pool_requests_;
+  std::vector<Common::Redis::Client::PoolCallbacks*> pool_callbacks_;
+  std::vector<Common::Redis::Client::MockPoolRequest> pool_requests_;
 };
 
 TEST_F(RedisMGETCommandHandlerTest, Normal) {
@@ -552,11 +552,11 @@ public:
     std::vector<Common::Redis::RespValue> tmp_expected_requests(num_sets);
     expected_requests_.swap(tmp_expected_requests);
     pool_callbacks_.resize(num_sets);
-    std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_sets);
+    std::vector<Common::Redis::Client::MockPoolRequest> tmp_pool_requests(num_sets);
     pool_requests_.swap(tmp_pool_requests);
     for (uint32_t i = 0; i < num_sets; i++) {
       makeBulkStringArray(expected_requests_[i], {"set", std::to_string(i), std::to_string(i)});
-      Common::Redis::PoolRequest* request_to_use = nullptr;
+      Common::Redis::Client::PoolRequest* request_to_use = nullptr;
       if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
           null_handle_indexes.end()) {
         request_to_use = &pool_requests_[i];
@@ -569,8 +569,8 @@ public:
   }
 
   std::vector<Common::Redis::RespValue> expected_requests_;
-  std::vector<Common::Redis::PoolCallbacks*> pool_callbacks_;
-  std::vector<ConnPool::MockPoolRequest> pool_requests_;
+  std::vector<Common::Redis::Client::PoolCallbacks*> pool_callbacks_;
+  std::vector<Common::Redis::Client::MockPoolRequest> pool_requests_;
 };
 
 TEST_F(RedisMSETCommandHandlerTest, Normal) {
@@ -675,11 +675,11 @@ public:
     std::vector<Common::Redis::RespValue> tmp_expected_requests(num_commands);
     expected_requests_.swap(tmp_expected_requests);
     pool_callbacks_.resize(num_commands);
-    std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_commands);
+    std::vector<Common::Redis::Client::MockPoolRequest> tmp_pool_requests(num_commands);
     pool_requests_.swap(tmp_pool_requests);
     for (uint32_t i = 0; i < num_commands; i++) {
       makeBulkStringArray(expected_requests_[i], {GetParam(), std::to_string(i)});
-      Common::Redis::PoolRequest* request_to_use = nullptr;
+      Common::Redis::Client::PoolRequest* request_to_use = nullptr;
       if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
           null_handle_indexes.end()) {
         request_to_use = &pool_requests_[i];
@@ -692,8 +692,8 @@ public:
   }
 
   std::vector<Common::Redis::RespValue> expected_requests_;
-  std::vector<Common::Redis::PoolCallbacks*> pool_callbacks_;
-  std::vector<ConnPool::MockPoolRequest> pool_requests_;
+  std::vector<Common::Redis::Client::PoolCallbacks*> pool_callbacks_;
+  std::vector<Common::Redis::Client::MockPoolRequest> pool_requests_;
 };
 
 TEST_P(RedisSplitKeysSumResultHandlerTest, Normal) {

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -130,7 +130,7 @@ public:
     pool_callbacks_->onResponse(std::move(response1));
   }
 
-  ConnPool::PoolCallbacks* pool_callbacks_;
+  Common::Redis::PoolCallbacks* pool_callbacks_;
   ConnPool::MockPoolRequest pool_request_;
 };
 
@@ -353,7 +353,7 @@ public:
     pool_requests_.swap(tmp_pool_requests);
     for (uint32_t i = 0; i < num_gets; i++) {
       makeBulkStringArray(expected_requests_[i], {"get", std::to_string(i)});
-      ConnPool::PoolRequest* request_to_use = nullptr;
+      Common::Redis::PoolRequest* request_to_use = nullptr;
       if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
           null_handle_indexes.end()) {
         request_to_use = &pool_requests_[i];
@@ -366,7 +366,7 @@ public:
   }
 
   std::vector<Common::Redis::RespValue> expected_requests_;
-  std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
+  std::vector<Common::Redis::PoolCallbacks*> pool_callbacks_;
   std::vector<ConnPool::MockPoolRequest> pool_requests_;
 };
 
@@ -556,7 +556,7 @@ public:
     pool_requests_.swap(tmp_pool_requests);
     for (uint32_t i = 0; i < num_sets; i++) {
       makeBulkStringArray(expected_requests_[i], {"set", std::to_string(i), std::to_string(i)});
-      ConnPool::PoolRequest* request_to_use = nullptr;
+      Common::Redis::PoolRequest* request_to_use = nullptr;
       if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
           null_handle_indexes.end()) {
         request_to_use = &pool_requests_[i];
@@ -569,7 +569,7 @@ public:
   }
 
   std::vector<Common::Redis::RespValue> expected_requests_;
-  std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
+  std::vector<Common::Redis::PoolCallbacks*> pool_callbacks_;
   std::vector<ConnPool::MockPoolRequest> pool_requests_;
 };
 
@@ -679,7 +679,7 @@ public:
     pool_requests_.swap(tmp_pool_requests);
     for (uint32_t i = 0; i < num_commands; i++) {
       makeBulkStringArray(expected_requests_[i], {GetParam(), std::to_string(i)});
-      ConnPool::PoolRequest* request_to_use = nullptr;
+      Common::Redis::PoolRequest* request_to_use = nullptr;
       if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
           null_handle_indexes.end()) {
         request_to_use = &pool_requests_[i];
@@ -692,7 +692,7 @@ public:
   }
 
   std::vector<Common::Redis::RespValue> expected_requests_;
-  std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
+  std::vector<Common::Redis::PoolCallbacks*> pool_callbacks_;
   std::vector<ConnPool::MockPoolRequest> pool_requests_;
 };
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -33,358 +33,7 @@ namespace NetworkFilters {
 namespace RedisProxy {
 namespace ConnPool {
 
-envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings
-createConnPoolSettings() {
-  envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings setting{};
-  setting.mutable_op_timeout()->CopyFrom(Protobuf::util::TimeUtil::MillisecondsToDuration(20));
-  setting.set_enable_hashtagging(true);
-  return setting;
-}
-
-class RedisClientImplTest : public testing::Test, public Common::Redis::DecoderFactory {
-public:
-  // Commmon::Redis::DecoderFactory
-  Common::Redis::DecoderPtr create(Common::Redis::DecoderCallbacks& callbacks) override {
-    callbacks_ = &callbacks;
-    return Common::Redis::DecoderPtr{decoder_};
-  }
-
-  ~RedisClientImplTest() {
-    client_.reset();
-
-    // Make sure all gauges are 0.
-    for (const Stats::GaugeSharedPtr& gauge : host_->cluster_.stats_store_.gauges()) {
-      EXPECT_EQ(0U, gauge->value());
-    }
-    for (const Stats::GaugeSharedPtr& gauge : host_->stats_store_.gauges()) {
-      EXPECT_EQ(0U, gauge->value());
-    }
-  }
-
-  void setup() {
-    config_ = std::make_unique<ConfigImpl>(createConnPoolSettings());
-    finishSetup();
-  }
-
-  void setup(std::unique_ptr<Common::Redis::Config>&& config) {
-    config_ = std::move(config);
-    finishSetup();
-  }
-
-  void finishSetup() {
-    upstream_connection_ = new NiceMock<Network::MockClientConnection>();
-    Upstream::MockHost::MockCreateConnectionData conn_info;
-    conn_info.connection_ = upstream_connection_;
-    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
-    EXPECT_CALL(*host_, createConnection_(_, _)).WillOnce(Return(conn_info));
-    EXPECT_CALL(*upstream_connection_, addReadFilter(_))
-        .WillOnce(SaveArg<0>(&upstream_read_filter_));
-    EXPECT_CALL(*upstream_connection_, connect());
-    EXPECT_CALL(*upstream_connection_, noDelay(true));
-
-    client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
-                                 *config_);
-    EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_total_.value());
-    EXPECT_EQ(1UL, host_->stats_.cx_total_.value());
-
-    // NOP currently.
-    upstream_connection_->runHighWatermarkCallbacks();
-    upstream_connection_->runLowWatermarkCallbacks();
-  }
-
-  void onConnected() {
-    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
-    upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
-  }
-
-  const std::string cluster_name_{"foo"};
-  std::shared_ptr<Upstream::MockHost> host_{new NiceMock<Upstream::MockHost>()};
-  Event::MockDispatcher dispatcher_;
-  Event::MockTimer* connect_or_op_timer_{new Event::MockTimer(&dispatcher_)};
-  MockEncoder* encoder_{new MockEncoder()};
-  MockDecoder* decoder_{new MockDecoder()};
-  Common::Redis::DecoderCallbacks* callbacks_{};
-  NiceMock<Network::MockClientConnection>* upstream_connection_{};
-  Network::ReadFilterSharedPtr upstream_read_filter_;
-  std::unique_ptr<Common::Redis::Config> config_;
-  Common::Redis::ClientPtr client_;
-};
-
-TEST_F(RedisClientImplTest, Basic) {
-  InSequence s;
-
-  setup();
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  onConnected();
-
-  Common::Redis::RespValue request2;
-  MockPoolCallbacks callbacks2;
-  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
-  Common::Redis::PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
-  EXPECT_NE(nullptr, handle2);
-
-  EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_total_.value());
-  EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_active_.value());
-  EXPECT_EQ(2UL, host_->stats_.rq_total_.value());
-  EXPECT_EQ(2UL, host_->stats_.rq_active_.value());
-
-  Buffer::OwnedImpl fake_data;
-  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
-    InSequence s;
-    Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
-    EXPECT_CALL(callbacks1, onResponse_(Ref(response1)));
-    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
-    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
-    callbacks_->onRespValue(std::move(response1));
-
-    Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
-    EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
-    EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
-    callbacks_->onRespValue(std::move(response2));
-  }));
-  upstream_read_filter_->onData(fake_data, false);
-
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  client_->close();
-}
-
-TEST_F(RedisClientImplTest, Cancel) {
-  InSequence s;
-
-  setup();
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  onConnected();
-
-  Common::Redis::RespValue request2;
-  MockPoolCallbacks callbacks2;
-  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
-  Common::Redis::PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
-  EXPECT_NE(nullptr, handle2);
-
-  handle1->cancel();
-
-  Buffer::OwnedImpl fake_data;
-  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
-    InSequence s;
-
-    Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
-    EXPECT_CALL(callbacks1, onResponse_(_)).Times(0);
-    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
-    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
-    callbacks_->onRespValue(std::move(response1));
-
-    Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
-    EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
-    EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
-    callbacks_->onRespValue(std::move(response2));
-  }));
-  upstream_read_filter_->onData(fake_data, false);
-
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  client_->close();
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_cancelled_.value());
-}
-
-TEST_F(RedisClientImplTest, FailAll) {
-  InSequence s;
-
-  setup();
-
-  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
-  client_->addConnectionCallbacks(connection_callbacks);
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  onConnected();
-
-  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE));
-  EXPECT_CALL(callbacks1, onFailure());
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_remote_with_active_rq_.value());
-}
-
-TEST_F(RedisClientImplTest, FailAllWithCancel) {
-  InSequence s;
-
-  setup();
-
-  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
-  client_->addConnectionCallbacks(connection_callbacks);
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  onConnected();
-  handle1->cancel();
-
-  EXPECT_CALL(callbacks1, onFailure()).Times(0);
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_local_with_active_rq_.value());
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_cancelled_.value());
-}
-
-TEST_F(RedisClientImplTest, ProtocolError) {
-  InSequence s;
-
-  setup();
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  onConnected();
-
-  Buffer::OwnedImpl fake_data;
-  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
-    throw Common::Redis::ProtocolError("error");
-  }));
-  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::REQUEST_FAILED));
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(callbacks1, onFailure());
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  upstream_read_filter_->onData(fake_data, false);
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_protocol_error_.value());
-  EXPECT_EQ(1UL, host_->stats_.rq_error_.value());
-}
-
-TEST_F(RedisClientImplTest, ConnectFail) {
-  InSequence s;
-
-  setup();
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE));
-  EXPECT_CALL(callbacks1, onFailure());
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_fail_.value());
-  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
-}
-
-class ConfigOutlierDisabled : public Common::Redis::Config {
-  bool disableOutlierEvents() const override { return true; }
-  std::chrono::milliseconds opTimeout() const override { return std::chrono::milliseconds(25); }
-  bool enableHashtagging() const override { return false; }
-};
-
-TEST_F(RedisClientImplTest, OutlierDisabled) {
-  InSequence s;
-
-  setup(std::make_unique<ConfigOutlierDisabled>());
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  EXPECT_CALL(host_->outlier_detector_, putResult(_)).Times(0);
-  EXPECT_CALL(callbacks1, onFailure());
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_fail_.value());
-  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
-}
-
-TEST_F(RedisClientImplTest, ConnectTimeout) {
-  InSequence s;
-
-  setup();
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::TIMEOUT));
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(callbacks1, onFailure());
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  connect_or_op_timer_->callback_();
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_timeout_.value());
-  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
-}
-
-TEST_F(RedisClientImplTest, OpTimeout) {
-  InSequence s;
-
-  setup();
-
-  Common::Redis::RespValue request1;
-  MockPoolCallbacks callbacks1;
-  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-  EXPECT_NE(nullptr, handle1);
-
-  onConnected();
-
-  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::TIMEOUT));
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(callbacks1, onFailure());
-  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  connect_or_op_timer_->callback_();
-
-  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_timeout_.value());
-  EXPECT_EQ(1UL, host_->stats_.rq_timeout_.value());
-}
-
-TEST(RedisClientFactoryImplTest, Basic) {
-  ClientFactoryImpl factory;
-  Upstream::MockHost::MockCreateConnectionData conn_info;
-  conn_info.connection_ = new NiceMock<Network::MockClientConnection>();
-  std::shared_ptr<Upstream::MockHost> host(new NiceMock<Upstream::MockHost>());
-  EXPECT_CALL(*host, createConnection_(_, _)).WillOnce(Return(conn_info));
-  NiceMock<Event::MockDispatcher> dispatcher;
-  ConfigImpl config(createConnPoolSettings());
-  Common::Redis::ClientPtr client = factory.create(host, dispatcher, config);
-  client->close();
-}
-
-class RedisConnPoolImplTest : public testing::Test, public Common::Redis::ClientFactory {
+class RedisConnPoolImplTest : public testing::Test, public Common::Redis::Client::ClientFactory {
 public:
   void setup(bool cluster_exists = true) {
     EXPECT_CALL(cm_, addThreadLocalClusterUpdateCallbacks_(_))
@@ -400,32 +49,32 @@ public:
   void makeSimpleRequest(bool create_client) {
     EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_));
     if (create_client) {
-      client_ = new NiceMock<MockClient>();
+      client_ = new NiceMock<Common::Redis::Client::MockClient>();
       EXPECT_CALL(*this, create_(_)).WillOnce(Return(client_));
     }
     Common::Redis::RespValue value;
-    MockPoolCallbacks callbacks;
-    MockPoolRequest active_request;
+    Common::Redis::Client::MockPoolCallbacks callbacks;
+    Common::Redis::Client::MockPoolRequest active_request;
     EXPECT_CALL(*client_, makeRequest(Ref(value), Ref(callbacks)))
         .WillOnce(Return(&active_request));
-    Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+    Common::Redis::Client::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
     EXPECT_EQ(&active_request, request);
   }
 
-  // Common::Redis::ClientFactory
-  Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher&,
-                                  const Common::Redis::Config&) override {
-    return Common::Redis::ClientPtr{create_(host)};
+  // Common::Redis::Client::ClientFactory
+  Common::Redis::Client::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher&,
+                                  const Common::Redis::Client::Config&) override {
+    return Common::Redis::Client::ClientPtr{create_(host)};
   }
 
-  MOCK_METHOD1(create_, Common::Redis::Client*(Upstream::HostConstSharedPtr host));
+  MOCK_METHOD1(create_, Common::Redis::Client::Client*(Upstream::HostConstSharedPtr host));
 
   const std::string cluster_name_{"fake_cluster"};
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   InstancePtr conn_pool_;
   Upstream::ClusterUpdateCallbacks* update_callbacks_{};
-  MockClient* client_{};
+  Common::Redis::Client::MockClient* client_{};
 };
 
 TEST_F(RedisConnPoolImplTest, Basic) {
@@ -434,9 +83,9 @@ TEST_F(RedisConnPoolImplTest, Basic) {
   setup();
 
   Common::Redis::RespValue value;
-  MockPoolRequest active_request;
-  MockPoolCallbacks callbacks;
-  MockClient* client = new NiceMock<MockClient>();
+  Common::Redis::Client::MockPoolRequest active_request;
+  Common::Redis::Client::MockPoolCallbacks callbacks;
+  Common::Redis::Client::MockClient* client = new NiceMock<Common::Redis::Client::MockClient>();
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
       .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
@@ -447,7 +96,7 @@ TEST_F(RedisConnPoolImplTest, Basic) {
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
   EXPECT_CALL(*client, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request));
-  Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::Client::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(&active_request, request);
 
   EXPECT_CALL(*client, close());
@@ -460,7 +109,7 @@ TEST_F(RedisConnPoolImplTest, Hashtagging) {
   setup();
 
   Common::Redis::RespValue value;
-  MockPoolCallbacks callbacks;
+  Common::Redis::Client::MockPoolCallbacks callbacks;
 
   auto expectHashKey = [](const std::string& s) {
     return [s](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
@@ -493,8 +142,8 @@ TEST_F(RedisConnPoolImplTest, NoClusterAtConstruction) {
   setup(false);
 
   Common::Redis::RespValue value;
-  MockPoolCallbacks callbacks;
-  Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::Client::MockPoolCallbacks callbacks;
+  Common::Redis::Client::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(nullptr, request);
 
   // Now add the cluster. Request to the cluster should succeed.
@@ -536,27 +185,27 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
 
   setup();
 
-  MockPoolCallbacks callbacks;
+  Common::Redis::Client::MockPoolCallbacks callbacks;
   Common::Redis::RespValue value;
   std::shared_ptr<Upstream::Host> host1(new Upstream::MockHost());
   std::shared_ptr<Upstream::Host> host2(new Upstream::MockHost());
-  MockClient* client1 = new NiceMock<MockClient>();
-  MockClient* client2 = new NiceMock<MockClient>();
+  Common::Redis::Client::MockClient* client1 = new NiceMock<Common::Redis::Client::MockClient>();
+  Common::Redis::Client::MockClient* client2 = new NiceMock<Common::Redis::Client::MockClient>();
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(host1));
   EXPECT_CALL(*this, create_(Eq(host1))).WillOnce(Return(client1));
 
-  MockPoolRequest active_request1;
+  Common::Redis::Client::MockPoolRequest active_request1;
   EXPECT_CALL(*client1, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request1));
-  Common::Redis::PoolRequest* request1 = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::Client::PoolRequest* request1 = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(&active_request1, request1);
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(host2));
   EXPECT_CALL(*this, create_(Eq(host2))).WillOnce(Return(client2));
 
-  MockPoolRequest active_request2;
+  Common::Redis::Client::MockPoolRequest active_request2;
   EXPECT_CALL(*client2, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request2));
-  Common::Redis::PoolRequest* request2 = conn_pool_->makeRequest("bar", value, callbacks);
+  Common::Redis::Client::PoolRequest* request2 = conn_pool_->makeRequest("bar", value, callbacks);
   EXPECT_EQ(&active_request2, request2);
 
   EXPECT_CALL(*client2, close());
@@ -580,9 +229,9 @@ TEST_F(RedisConnPoolImplTest, NoHost) {
   setup();
 
   Common::Redis::RespValue value;
-  MockPoolCallbacks callbacks;
+  Common::Redis::Client::MockPoolCallbacks callbacks;
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(nullptr));
-  Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::Client::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(nullptr, request);
 
   tls_.shutdownThread();
@@ -594,9 +243,9 @@ TEST_F(RedisConnPoolImplTest, RemoteClose) {
   setup();
 
   Common::Redis::RespValue value;
-  MockPoolRequest active_request;
-  MockPoolCallbacks callbacks;
-  MockClient* client = new NiceMock<MockClient>();
+  Common::Redis::Client::MockPoolRequest active_request;
+  Common::Redis::Client::MockPoolCallbacks callbacks;
+  Common::Redis::Client::MockClient* client = new NiceMock<Common::Redis::Client::MockClient>();
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -413,7 +413,8 @@ public:
   }
 
   // Common::Redis::ClientFactory
-  Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher&, const Common::Redis::Config&) override {
+  Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher&,
+                                  const Common::Redis::Config&) override {
     return Common::Redis::ClientPtr{create_(host)};
   }
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -66,7 +66,7 @@ public:
     finishSetup();
   }
 
-  void setup(std::unique_ptr<Config>&& config) {
+  void setup(std::unique_ptr<Common::Redis::Config>&& config) {
     config_ = std::move(config);
     finishSetup();
   }
@@ -106,8 +106,8 @@ public:
   Common::Redis::DecoderCallbacks* callbacks_{};
   NiceMock<Network::MockClientConnection>* upstream_connection_{};
   Network::ReadFilterSharedPtr upstream_read_filter_;
-  std::unique_ptr<Config> config_;
-  ClientPtr client_;
+  std::unique_ptr<Common::Redis::Config> config_;
+  Common::Redis::ClientPtr client_;
 };
 
 TEST_F(RedisClientImplTest, Basic) {
@@ -118,7 +118,7 @@ TEST_F(RedisClientImplTest, Basic) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   onConnected();
@@ -126,7 +126,7 @@ TEST_F(RedisClientImplTest, Basic) {
   Common::Redis::RespValue request2;
   MockPoolCallbacks callbacks2;
   EXPECT_CALL(*encoder_, encode(Ref(request2), _));
-  PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
+  Common::Redis::PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
   EXPECT_NE(nullptr, handle2);
 
   EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_total_.value());
@@ -164,7 +164,7 @@ TEST_F(RedisClientImplTest, Cancel) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   onConnected();
@@ -172,7 +172,7 @@ TEST_F(RedisClientImplTest, Cancel) {
   Common::Redis::RespValue request2;
   MockPoolCallbacks callbacks2;
   EXPECT_CALL(*encoder_, encode(Ref(request2), _));
-  PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
+  Common::Redis::PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
   EXPECT_NE(nullptr, handle2);
 
   handle1->cancel();
@@ -213,7 +213,7 @@ TEST_F(RedisClientImplTest, FailAll) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   onConnected();
@@ -239,7 +239,7 @@ TEST_F(RedisClientImplTest, FailAllWithCancel) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   onConnected();
@@ -263,7 +263,7 @@ TEST_F(RedisClientImplTest, ProtocolError) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   onConnected();
@@ -290,7 +290,7 @@ TEST_F(RedisClientImplTest, ConnectFail) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE));
@@ -302,7 +302,7 @@ TEST_F(RedisClientImplTest, ConnectFail) {
   EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
 }
 
-class ConfigOutlierDisabled : public Config {
+class ConfigOutlierDisabled : public Common::Redis::Config {
   bool disableOutlierEvents() const override { return true; }
   std::chrono::milliseconds opTimeout() const override { return std::chrono::milliseconds(25); }
   bool enableHashtagging() const override { return false; }
@@ -316,7 +316,7 @@ TEST_F(RedisClientImplTest, OutlierDisabled) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   EXPECT_CALL(host_->outlier_detector_, putResult(_)).Times(0);
@@ -336,7 +336,7 @@ TEST_F(RedisClientImplTest, ConnectTimeout) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::TIMEOUT));
@@ -357,7 +357,7 @@ TEST_F(RedisClientImplTest, OpTimeout) {
   Common::Redis::RespValue request1;
   MockPoolCallbacks callbacks1;
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  Common::Redis::PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
   onConnected();
@@ -380,11 +380,11 @@ TEST(RedisClientFactoryImplTest, Basic) {
   EXPECT_CALL(*host, createConnection_(_, _)).WillOnce(Return(conn_info));
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
-  ClientPtr client = factory.create(host, dispatcher, config);
+  Common::Redis::ClientPtr client = factory.create(host, dispatcher, config);
   client->close();
 }
 
-class RedisConnPoolImplTest : public testing::Test, public ClientFactory {
+class RedisConnPoolImplTest : public testing::Test, public Common::Redis::ClientFactory {
 public:
   void setup(bool cluster_exists = true) {
     EXPECT_CALL(cm_, addThreadLocalClusterUpdateCallbacks_(_))
@@ -408,16 +408,16 @@ public:
     MockPoolRequest active_request;
     EXPECT_CALL(*client_, makeRequest(Ref(value), Ref(callbacks)))
         .WillOnce(Return(&active_request));
-    PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+    Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
     EXPECT_EQ(&active_request, request);
   }
 
-  // RedisProxy::ConnPool::ClientFactory
-  ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher&, const Config&) override {
-    return ClientPtr{create_(host)};
+  // Common::Redis::ClientFactory
+  Common::Redis::ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher&, const Common::Redis::Config&) override {
+    return Common::Redis::ClientPtr{create_(host)};
   }
 
-  MOCK_METHOD1(create_, Client*(Upstream::HostConstSharedPtr host));
+  MOCK_METHOD1(create_, Common::Redis::Client*(Upstream::HostConstSharedPtr host));
 
   const std::string cluster_name_{"fake_cluster"};
   NiceMock<Upstream::MockClusterManager> cm_;
@@ -446,7 +446,7 @@ TEST_F(RedisConnPoolImplTest, Basic) {
       }));
   EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
   EXPECT_CALL(*client, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request));
-  PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(&active_request, request);
 
   EXPECT_CALL(*client, close());
@@ -493,7 +493,7 @@ TEST_F(RedisConnPoolImplTest, NoClusterAtConstruction) {
 
   Common::Redis::RespValue value;
   MockPoolCallbacks callbacks;
-  PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(nullptr, request);
 
   // Now add the cluster. Request to the cluster should succeed.
@@ -547,7 +547,7 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
 
   MockPoolRequest active_request1;
   EXPECT_CALL(*client1, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request1));
-  PoolRequest* request1 = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::PoolRequest* request1 = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(&active_request1, request1);
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(host2));
@@ -555,7 +555,7 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
 
   MockPoolRequest active_request2;
   EXPECT_CALL(*client2, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request2));
-  PoolRequest* request2 = conn_pool_->makeRequest("bar", value, callbacks);
+  Common::Redis::PoolRequest* request2 = conn_pool_->makeRequest("bar", value, callbacks);
   EXPECT_EQ(&active_request2, request2);
 
   EXPECT_CALL(*client2, close());
@@ -581,7 +581,7 @@ TEST_F(RedisConnPoolImplTest, NoHost) {
   Common::Redis::RespValue value;
   MockPoolCallbacks callbacks;
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(nullptr));
-  PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
+  Common::Redis::PoolRequest* request = conn_pool_->makeRequest("hash_key", value, callbacks);
   EXPECT_EQ(nullptr, request);
 
   tls_.shutdownThread();

--- a/test/extensions/filters/network/redis_proxy/mocks.cc
+++ b/test/extensions/filters/network/redis_proxy/mocks.cc
@@ -15,38 +15,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace RedisProxy {
 
-MockEncoder::MockEncoder() {
-  ON_CALL(*this, encode(_, _))
-      .WillByDefault(
-          Invoke([this](const Common::Redis::RespValue& value, Buffer::Instance& out) -> void {
-            real_encoder_.encode(value, out);
-          }));
-}
-
-MockEncoder::~MockEncoder() {}
-
-MockDecoder::MockDecoder() {}
-MockDecoder::~MockDecoder() {}
-
 namespace ConnPool {
-
-MockClient::MockClient() {
-  ON_CALL(*this, addConnectionCallbacks(_))
-      .WillByDefault(Invoke([this](Network::ConnectionCallbacks& callbacks) -> void {
-        callbacks_.push_back(&callbacks);
-      }));
-  ON_CALL(*this, close()).WillByDefault(Invoke([this]() -> void {
-    raiseEvent(Network::ConnectionEvent::LocalClose);
-  }));
-}
-
-MockClient::~MockClient() {}
-
-MockPoolRequest::MockPoolRequest() {}
-MockPoolRequest::~MockPoolRequest() {}
-
-MockPoolCallbacks::MockPoolCallbacks() {}
-MockPoolCallbacks::~MockPoolCallbacks() {}
 
 MockInstance::MockInstance() {}
 MockInstance::~MockInstance() {}

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -4,8 +4,8 @@
 #include <list>
 #include <string>
 
-#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/common/redis/client.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
@@ -64,8 +64,8 @@ public:
 
   MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
   MOCK_METHOD0(close, void());
-  MOCK_METHOD2(makeRequest,
-               Common::Redis::PoolRequest*(const Common::Redis::RespValue& request, Common::Redis::PoolCallbacks& callbacks));
+  MOCK_METHOD2(makeRequest, Common::Redis::PoolRequest*(const Common::Redis::RespValue& request,
+                                                        Common::Redis::PoolCallbacks& callbacks));
 
   std::list<Network::ConnectionCallbacks*> callbacks_;
 };
@@ -94,9 +94,9 @@ public:
   MockInstance();
   ~MockInstance();
 
-  MOCK_METHOD3(makeRequest,
-               Common::Redis::PoolRequest*(const std::string& hash_key, const Common::Redis::RespValue& request,
-                            Common::Redis::PoolCallbacks& callbacks));
+  MOCK_METHOD3(makeRequest, Common::Redis::PoolRequest*(const std::string& hash_key,
+                                                        const Common::Redis::RespValue& request,
+                                                        Common::Redis::PoolCallbacks& callbacks));
 };
 
 } // namespace ConnPool

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -25,9 +25,10 @@ public:
   MockInstance();
   ~MockInstance();
 
-  MOCK_METHOD3(makeRequest, Common::Redis::Client::PoolRequest*(const std::string& hash_key,
-                                                        const Common::Redis::RespValue& request,
-                                                        Common::Redis::Client::PoolCallbacks& callbacks));
+  MOCK_METHOD3(makeRequest,
+               Common::Redis::Client::PoolRequest*(
+                   const std::string& hash_key, const Common::Redis::RespValue& request,
+                   Common::Redis::Client::PoolCallbacks& callbacks));
 };
 
 } // namespace ConnPool

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -18,85 +18,16 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace RedisProxy {
 
-class MockEncoder : public Common::Redis::Encoder {
-public:
-  MockEncoder();
-  ~MockEncoder();
-
-  MOCK_METHOD2(encode, void(const Common::Redis::RespValue& value, Buffer::Instance& out));
-
-private:
-  Common::Redis::EncoderImpl real_encoder_;
-};
-
-class MockDecoder : public Common::Redis::Decoder {
-public:
-  MockDecoder();
-  ~MockDecoder();
-
-  MOCK_METHOD1(decode, void(Buffer::Instance& data));
-};
-
 namespace ConnPool {
-
-class MockClient : public Common::Redis::Client {
-public:
-  MockClient();
-  ~MockClient();
-
-  void raiseEvent(Network::ConnectionEvent event) {
-    for (Network::ConnectionCallbacks* callbacks : callbacks_) {
-      callbacks->onEvent(event);
-    }
-  }
-
-  void runHighWatermarkCallbacks() {
-    for (auto* callback : callbacks_) {
-      callback->onAboveWriteBufferHighWatermark();
-    }
-  }
-
-  void runLowWatermarkCallbacks() {
-    for (auto* callback : callbacks_) {
-      callback->onBelowWriteBufferLowWatermark();
-    }
-  }
-
-  MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
-  MOCK_METHOD0(close, void());
-  MOCK_METHOD2(makeRequest, Common::Redis::PoolRequest*(const Common::Redis::RespValue& request,
-                                                        Common::Redis::PoolCallbacks& callbacks));
-
-  std::list<Network::ConnectionCallbacks*> callbacks_;
-};
-
-class MockPoolRequest : public Common::Redis::PoolRequest {
-public:
-  MockPoolRequest();
-  ~MockPoolRequest();
-
-  MOCK_METHOD0(cancel, void());
-};
-
-class MockPoolCallbacks : public Common::Redis::PoolCallbacks {
-public:
-  MockPoolCallbacks();
-  ~MockPoolCallbacks();
-
-  void onResponse(Common::Redis::RespValuePtr&& value) override { onResponse_(value); }
-
-  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
-  MOCK_METHOD0(onFailure, void());
-};
 
 class MockInstance : public Instance {
 public:
   MockInstance();
   ~MockInstance();
 
-  MOCK_METHOD3(makeRequest, Common::Redis::PoolRequest*(const std::string& hash_key,
+  MOCK_METHOD3(makeRequest, Common::Redis::Client::PoolRequest*(const std::string& hash_key,
                                                         const Common::Redis::RespValue& request,
-                                                        Common::Redis::PoolCallbacks& callbacks));
+                                                        Common::Redis::Client::PoolCallbacks& callbacks));
 };
 
 } // namespace ConnPool

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "extensions/filters/network/common/redis/codec_impl.h"
+#include "extensions/filters/network/common/redis/client.h"
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
@@ -38,7 +39,7 @@ public:
 
 namespace ConnPool {
 
-class MockClient : public Client {
+class MockClient : public Common::Redis::Client {
 public:
   MockClient();
   ~MockClient();
@@ -64,12 +65,12 @@ public:
   MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
   MOCK_METHOD0(close, void());
   MOCK_METHOD2(makeRequest,
-               PoolRequest*(const Common::Redis::RespValue& request, PoolCallbacks& callbacks));
+               Common::Redis::PoolRequest*(const Common::Redis::RespValue& request, Common::Redis::PoolCallbacks& callbacks));
 
   std::list<Network::ConnectionCallbacks*> callbacks_;
 };
 
-class MockPoolRequest : public PoolRequest {
+class MockPoolRequest : public Common::Redis::PoolRequest {
 public:
   MockPoolRequest();
   ~MockPoolRequest();
@@ -77,7 +78,7 @@ public:
   MOCK_METHOD0(cancel, void());
 };
 
-class MockPoolCallbacks : public PoolCallbacks {
+class MockPoolCallbacks : public Common::Redis::PoolCallbacks {
 public:
   MockPoolCallbacks();
   ~MockPoolCallbacks();
@@ -94,8 +95,8 @@ public:
   ~MockInstance();
 
   MOCK_METHOD3(makeRequest,
-               PoolRequest*(const std::string& hash_key, const Common::Redis::RespValue& request,
-                            PoolCallbacks& callbacks));
+               Common::Redis::PoolRequest*(const std::string& hash_key, const Common::Redis::RespValue& request,
+                            Common::Redis::PoolCallbacks& callbacks));
 };
 
 } // namespace ConnPool

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -113,8 +113,8 @@ public:
     return Common::Redis::DecoderPtr{decoder_};
   }
 
-  MockEncoder* encoder_{new MockEncoder()};
-  MockDecoder* decoder_{new MockDecoder()};
+  Common::Redis::MockEncoder* encoder_{new Common::Redis::MockEncoder()};
+  Common::Redis::MockDecoder* decoder_{new Common::Redis::MockDecoder()};
   Common::Redis::DecoderCallbacks* decoder_callbacks_{};
   CommandSplitter::MockInstance splitter_;
   Stats::IsolatedStoreImpl store_;

--- a/test/extensions/health_checkers/redis/BUILD
+++ b/test/extensions/health_checkers/redis/BUILD
@@ -19,6 +19,8 @@ envoy_extension_cc_test(
         "//source/extensions/health_checkers/redis",
         "//source/extensions/health_checkers/redis:utility",
         "//test/common/upstream:utility_lib",
+        "//test/extensions/filters/network/common/redis:redis_mocks",
+        "//test/extensions/filters/network/common/redis:test_utils_lib",
         "//test/extensions/filters/network/redis_proxy:redis_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -25,9 +25,8 @@ namespace HealthCheckers {
 namespace RedisHealthChecker {
 namespace {
 
-class RedisHealthCheckerTest
-    : public testing::Test,
-      public Extensions::NetworkFilters::Common::Redis::ClientFactory {
+class RedisHealthCheckerTest : public testing::Test,
+                               public Extensions::NetworkFilters::Common::Redis::ClientFactory {
 public:
   RedisHealthCheckerTest()
       : cluster_(new NiceMock<Upstream::MockClusterMockPrioritySet>()),

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -4,6 +4,7 @@
 #include "extensions/health_checkers/redis/utility.h"
 
 #include "test/common/upstream/utility.h"
+#include "test/extensions/filters/network/common/redis/mocks.h"
 #include "test/extensions/filters/network/redis_proxy/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
@@ -25,8 +26,9 @@ namespace HealthCheckers {
 namespace RedisHealthChecker {
 namespace {
 
-class RedisHealthCheckerTest : public testing::Test,
-                               public Extensions::NetworkFilters::Common::Redis::ClientFactory {
+class RedisHealthCheckerTest
+    : public testing::Test,
+      public Extensions::NetworkFilters::Common::Redis::Client::ClientFactory {
 public:
   RedisHealthCheckerTest()
       : cluster_(new NiceMock<Upstream::MockClusterMockPrioritySet>()),
@@ -119,13 +121,13 @@ public:
                                random_, Upstream::HealthCheckEventLoggerPtr(event_logger_), *this));
   }
 
-  Extensions::NetworkFilters::Common::Redis::ClientPtr
+  Extensions::NetworkFilters::Common::Redis::Client::ClientPtr
   create(Upstream::HostConstSharedPtr, Event::Dispatcher&,
-         const Extensions::NetworkFilters::Common::Redis::Config&) override {
-    return Extensions::NetworkFilters::Common::Redis::ClientPtr{create_()};
+         const Extensions::NetworkFilters::Common::Redis::Client::Config&) override {
+    return Extensions::NetworkFilters::Common::Redis::Client::ClientPtr{create_()};
   }
 
-  MOCK_METHOD0(create_, Extensions::NetworkFilters::Common::Redis::Client*());
+  MOCK_METHOD0(create_, Extensions::NetworkFilters::Common::Redis::Client::Client*());
 
   void expectSessionCreate() {
     interval_timer_ = new Event::MockTimer(&dispatcher_);
@@ -133,7 +135,7 @@ public:
   }
 
   void expectClientCreate() {
-    client_ = new Extensions::NetworkFilters::RedisProxy::ConnPool::MockClient();
+    client_ = new Extensions::NetworkFilters::Common::Redis::Client::MockClient();
     EXPECT_CALL(*this, create_()).WillOnce(Return(client_));
     EXPECT_CALL(*client_, addConnectionCallbacks(_));
   }
@@ -157,9 +159,9 @@ public:
   Upstream::MockHealthCheckEventLogger* event_logger_{};
   Event::MockTimer* timeout_timer_{};
   Event::MockTimer* interval_timer_{};
-  Extensions::NetworkFilters::RedisProxy::ConnPool::MockClient* client_{};
-  Extensions::NetworkFilters::RedisProxy::ConnPool::MockPoolRequest pool_request_;
-  Extensions::NetworkFilters::Common::Redis::PoolCallbacks* pool_callbacks_{};
+  Extensions::NetworkFilters::Common::Redis::Client::MockClient* client_{};
+  Extensions::NetworkFilters::Common::Redis::Client::MockPoolRequest pool_request_;
+  Extensions::NetworkFilters::Common::Redis::Client::PoolCallbacks* pool_callbacks_{};
   std::shared_ptr<RedisHealthChecker> health_checker_;
 };
 

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -27,7 +27,7 @@ namespace {
 
 class RedisHealthCheckerTest
     : public testing::Test,
-      public Extensions::NetworkFilters::RedisProxy::ConnPool::ClientFactory {
+      public Extensions::NetworkFilters::Common::Redis::ClientFactory {
 public:
   RedisHealthCheckerTest()
       : cluster_(new NiceMock<Upstream::MockClusterMockPrioritySet>()),
@@ -120,13 +120,13 @@ public:
                                random_, Upstream::HealthCheckEventLoggerPtr(event_logger_), *this));
   }
 
-  Extensions::NetworkFilters::RedisProxy::ConnPool::ClientPtr
+  Extensions::NetworkFilters::Common::Redis::ClientPtr
   create(Upstream::HostConstSharedPtr, Event::Dispatcher&,
-         const Extensions::NetworkFilters::RedisProxy::ConnPool::Config&) override {
-    return Extensions::NetworkFilters::RedisProxy::ConnPool::ClientPtr{create_()};
+         const Extensions::NetworkFilters::Common::Redis::Config&) override {
+    return Extensions::NetworkFilters::Common::Redis::ClientPtr{create_()};
   }
 
-  MOCK_METHOD0(create_, Extensions::NetworkFilters::RedisProxy::ConnPool::Client*());
+  MOCK_METHOD0(create_, Extensions::NetworkFilters::Common::Redis::Client*());
 
   void expectSessionCreate() {
     interval_timer_ = new Event::MockTimer(&dispatcher_);
@@ -160,7 +160,7 @@ public:
   Event::MockTimer* interval_timer_{};
   Extensions::NetworkFilters::RedisProxy::ConnPool::MockClient* client_{};
   Extensions::NetworkFilters::RedisProxy::ConnPool::MockPoolRequest pool_request_;
-  Extensions::NetworkFilters::RedisProxy::ConnPool::PoolCallbacks* pool_callbacks_{};
+  Extensions::NetworkFilters::Common::Redis::PoolCallbacks* pool_callbacks_{};
   std::shared_ptr<RedisHealthChecker> health_checker_;
 };
 


### PR DESCRIPTION
This is part of the effort to build a proxy for Redis Cluster (#5697).

We want to make some of the connection interface common so we can share it with the cluster proxy. Specifically, we take `redis_proxy/conn_pool.h` and move much of it besides `Instance` to `common/redis/client.h`, and adjust the rest of the project to work with this. The formatting tool did some spacing stuff as well.

Following this, we will want to make an upstream command abstraction (for commands sent by Envoy upstream and that come back and terminate at Envoy) such as the health checks (exist, ping) and cluster (cluster slots).