### PR TITLE
Add the support of bypassing JWT authn for CORS preflight requests

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -32,7 +32,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   // http://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0, CORS
   // pre-flight requests shouldn't include user credentials.
   if (headers.Method() &&
-      Http::Headers::get().MethodValues.Options == headers.Method()->value().c_str()) {
+      Http::Headers::get().MethodValues.Options == headers.Method()->value().getStringView()) {
     ENVOY_LOG(debug, "CORS preflight request is passed through.");
     return Http::FilterHeadersStatus::Continue;
   }


### PR DESCRIPTION
Description: Per the spec http://www.w3.org/TR/cors/#cross-origin-request-with-preflight-0,
CORS pre-flight requests shouldn't include user credentials. This PR adds the support of bypassing JWT authn for CORS flight requests.

Risk Level: low

Testing: test is in test/extensions/filters/http/jwt_authn/filter_integration_test.cc

Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
