### PR TITLE
build: Update Apple platform conditionals

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -164,3 +164,64 @@ alias(
         "//conditions:default": "@boringssl//:ssl",
     }),
 )
+
+# Configuration settings to make doing selects for Apple vs non-Apple platforms
+# easier. More details: https://docs.bazel.build/versions/master/configurable-attributes.html#config_settingaliasing
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+)
+
+config_setting(
+    name = "ios_i386",
+    values = {"cpu": "ios_i386"},
+)
+
+config_setting(
+    name = "ios_x86_64",
+    values = {"cpu": "ios_x86_64"},
+)
+
+config_setting(
+    name = "ios_armv7",
+    values = {"cpu": "ios_armv7"},
+)
+
+config_setting(
+    name = "ios_armv7s",
+    values = {"cpu": "ios_armv7s"},
+)
+
+config_setting(
+    name = "ios_arm64",
+    values = {"cpu": "ios_arm64"},
+)
+
+config_setting(
+    name = "ios_arm64e",
+    values = {"cpu": "ios_arm64e"},
+)
+
+alias(
+    name = "apple",
+    actual = select(
+        {
+            ":darwin": ":darwin",
+            ":darwin_x86_64": ":darwin_x86_64",
+            ":ios_arm64": ":ios_arm64",
+            ":ios_arm64e": ":ios_arm64e",
+            ":ios_armv7": ":ios_armv7",
+            ":ios_armv7s": ":ios_armv7s",
+            ":ios_i386": ":ios_i386",
+            ":ios_x86_64": ":ios_x86_64",
+            # If we're not on an apple platform return a value that will never match in the select() statement calling this
+            # since it would have already been matched above
+            "//conditions:default": ":darwin",
+        },
+    ),
+)

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -79,7 +79,7 @@ def envoy_copts(repository, test = False):
                "//conditions:default": [],
            }) + select({
                # TCLAP command line parser needs this to support int64_t/uint64_t
-               "@bazel_tools//tools/osx:darwin": ["-DHAVE_LONG_LONG"],
+               repository + "//bazel:apple": ["-DHAVE_LONG_LONG"],
                "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
            envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
@@ -97,7 +97,7 @@ def envoy_static_link_libstdcpp_linkopts():
 def envoy_linkopts():
     return select({
                # The macOS system library transitively links common libraries (e.g., pthread).
-               "@bazel_tools//tools/osx:darwin": [
+               "@envoy//bazel:apple": [
                    # See note here: https://luajit.org/install.html
                    "-pagezero_size 10000",
                    "-image_base 100000000",
@@ -126,7 +126,7 @@ def _envoy_stamped_linkopts():
 
         # macOS doesn't have an official equivalent to the `.note.gnu.build-id`
         # ELF section, so just stuff the raw ID into a new text section.
-        "@bazel_tools//tools/osx:darwin": [
+        "@envoy//bazel:apple": [
             "-sectcreate __TEXT __build_id",
             "$(location @envoy//bazel:raw_build_id.ldscript)",
         ],
@@ -139,7 +139,7 @@ def _envoy_stamped_linkopts():
 
 def _envoy_stamped_deps():
     return select({
-        "@bazel_tools//tools/osx:darwin": [
+        "@envoy//bazel:apple": [
             "@envoy//bazel:raw_build_id.ldscript",
         ],
         "//conditions:default": [
@@ -150,7 +150,7 @@ def _envoy_stamped_deps():
 # Compute the test linkopts based on various options.
 def envoy_test_linkopts():
     return select({
-        "@bazel_tools//tools/osx:darwin": [
+        "@envoy//bazel:apple": [
             # See note here: https://luajit.org/install.html
             "-pagezero_size 10000",
             "-image_base 100000000",
@@ -407,7 +407,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         data = [corpus_name],
         # No fuzzing on macOS.
         deps = select({
-            "@bazel_tools//tools/osx:darwin": ["//test:dummy_main"],
+            "@envoy//bazel:apple": ["//test:dummy_main"],
             "//conditions:default": [
                 ":" + test_lib_name,
                 "//test/fuzz:main",
@@ -641,7 +641,7 @@ def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
 def envoy_select_hot_restart(xs, repository = ""):
     return select({
         repository + "//bazel:disable_hot_restart": [],
-        "@bazel_tools//tools/osx:darwin": [],
+        repository + "//bazel:apple": [],
         "//conditions:default": xs,
     })
 
@@ -668,7 +668,7 @@ def envoy_select_exported_symbols(xs):
 def envoy_select_force_libcpp(if_libcpp, default = None):
     return select({
         "@envoy//bazel:force_libcpp": if_libcpp,
-        "@bazel_tools//tools/osx:darwin": [],
+        "@envoy//bazel:apple": [],
         "@envoy//bazel:windows_x86_64": [],
         "//conditions:default": default or [],
     })

--- a/configs/BUILD
+++ b/configs/BUILD
@@ -24,7 +24,7 @@ filegroup(
     srcs = [
         "original-dst-cluster/proxy_config.yaml",
     ] + select({
-        "@bazel_tools//tools/osx:darwin": [],
+        "//bazel:apple": [],
         "//conditions:default": ["freebind/freebind.yaml"],
     }),
 )

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -50,7 +50,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "watcher_lib",
     srcs = select({
-        "@bazel_tools//tools/osx:darwin": [
+        "//bazel:apple": [
             "kqueue/watcher_impl.cc",
         ],
         "//conditions:default": [
@@ -58,7 +58,7 @@ envoy_cc_library(
         ],
     }),
     hdrs = select({
-        "@bazel_tools//tools/osx:darwin": [
+        "//bazel:apple": [
             "kqueue/watcher_impl.h",
         ],
         "//conditions:default": [
@@ -69,7 +69,7 @@ envoy_cc_library(
         "event",
     ],
     strip_include_prefix = select({
-        "@bazel_tools//tools/osx:darwin": "kqueue",
+        "//bazel:apple": "kqueue",
         "//conditions:default": "inotify",
     }),
     deps = [


### PR DESCRIPTION
Previously this only checked if the desired platform was the "darwin"
CPU. To build for iOS we need to expand any conditionals for macOS to
apply to iOS as well (in the future they may differ more). This new
alias makes it easier to check the Apple CPUs we care about without
having to duplicate the check at each call site.

Risk Level: Low
