### PR TITLE
config: implement incremental CDS in Envoy

### DIFF
--- a/api/XDS_PROTOCOL.md
+++ b/api/XDS_PROTOCOL.md
@@ -288,35 +288,33 @@ admin:
 
 ### Incremental xDS
 
-Incremental xDS is a separate xDS endpoint available for ADS, CDS and RDS that
-allows:
+Incremental xDS is a separate xDS endpoint that:
 
-  * Incremental updates of the list of tracked resources by the xDS client.
-    This supports Envoy on-demand / lazily requesting additional resources. For
-    example, this may occur when a request corresponding to an unknown cluster
-    arrives.
-  * The xDS server can incrementally update the resources on the client.
-    This supports the goal of scalability of xDS resources. Rather than deliver
-    all 100k clusters when a single cluster is modified, the management server
-    only needs to deliver the single cluster that changed.
+  * Allows the protocol to communicate on the wire in terms of resource/resource
+    name deltas ("Delta xDS"). This supports the goal of scalability of xDS
+    resources. Rather than deliver all 100k clusters when a single cluster is
+    modified, the management server only needs to deliver the single cluster
+    that changed.
+  * Allows the Envoy to on-demand / lazily request additional resources. For
+    example, requesting a cluster only when a request for that cluster arrives.
 
-An xDS incremental session is always in the context of a gRPC bidirectional
+An Incremental xDS session is always in the context of a gRPC bidirectional
 stream. This allows the xDS server to keep track of the state of xDS clients
-connected to it. There is no REST version of Incremental xDS.
+connected to it. There is no REST version of Incremental xDS yet.
 
-In incremental xDS the nonce field is required and used to pair a
-[`IncrementalDiscoveryResponse`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#discoveryrequest)
-to a [`IncrementalDiscoveryRequest`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#discoveryrequest)
+In the delta xDS wire protocol, the nonce field is required and used to pair a
+[`DeltaDiscoveryResponse`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#deltadiscoveryresponse)
+to a [`DeltaDiscoveryRequest`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#deltadiscoveryrequest)
 ACK or NACK.
 Optionally, a response message level system_version_info is present for
 debugging purposes only.
 
-`IncrementalDiscoveryRequest` can be sent in 3 situations:
+`DeltaDiscoveryRequest` can be sent in 3 situations:
   1. Initial message in a xDS bidirectional gRPC stream.
-  2. As an ACK or NACK response to a previous `IncrementalDiscoveryResponse`.
+  2. As an ACK or NACK response to a previous `DeltaDiscoveryResponse`.
      In this case the `response_nonce` is set to the nonce value in the Response.
      ACK or NACK is determined by the absence or presence of `error_detail`.
-  3. Spontaneous `IncrementalDiscoveryRequest` from the client.
+  3. Spontaneous `DeltaDiscoveryRequest` from the client.
      This can be done to dynamically add or remove elements from the tracked
      `resource_names` set. In this case `response_nonce` must be omitted.
 
@@ -326,8 +324,8 @@ client spontaneously requests the "wc" resource.
 
 ![Incremental session example](diagrams/incremental.svg)
 
-On reconnect the xDS Incremental client may tell the server of its known resources
-to avoid resending them over the network.
+On reconnect the Incremental xDS client may tell the server of its known
+resources to avoid resending them over the network.
 
 ![Incremental reconnect example](diagrams/incremental-reconnect.svg)
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -36,8 +36,7 @@ service ClusterDiscoveryService {
   rpc StreamClusters(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
   }
 
-  rpc IncrementalClusters(stream IncrementalDiscoveryRequest)
-      returns (stream IncrementalDiscoveryResponse) {
+  rpc DeltaClusters(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
   }
 
   rpc FetchClusters(DiscoveryRequest) returns (DiscoveryResponse) {

--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -32,6 +32,13 @@ message ApiConfigSource {
     REST = 1;
     // gRPC v2 API.
     GRPC = 2;
+    // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
+    // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
+    // with every update, the xDS server only sends what has changed since the last update.
+    //
+    // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
+    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    DELTA_GRPC = 3;
   }
   ApiType api_type = 1 [(validate.rules).enum.defined_only = true];
   // Cluster names should be used only with REST. If > 1

--- a/api/envoy/api/v2/discovery.proto
+++ b/api/envoy/api/v2/discovery.proto
@@ -102,33 +102,32 @@ message DiscoveryResponse {
   core.ControlPlane control_plane = 6;
 }
 
-// IncrementalDiscoveryRequest and IncrementalDiscoveryResponse are used in a
-// new gRPC endpoint for Incremental xDS. The feature is not supported for REST
-// management servers.
+// DeltaDiscoveryRequest and DeltaDiscoveryResponse are used in a new gRPC
+// endpoint for Delta xDS.
 //
-// With Incremental xDS, the IncrementalDiscoveryResponses do not need to
-// include a full snapshot of the tracked resources. Instead
-// IncrementalDiscoveryResponses are a diff to the state of a xDS client.
-// In Incremental XDS there are per resource versions which allows to track
-// state at the resource granularity.
-// An xDS Incremental session is always in the context of a gRPC bidirectional
+// With Delta xDS, the DeltaDiscoveryResponses do not need to include a full
+// snapshot of the tracked resources. Instead, DeltaDiscoveryResponses are a
+// diff to the state of a xDS client.
+// In Delta XDS there are per resource versions, which allow tracking state at
+// the resource granularity.
+// An xDS Delta session is always in the context of a gRPC bidirectional
 // stream. This allows the xDS server to keep track of the state of xDS clients
 // connected to it.
 //
-// In Incremental xDS the nonce field is required and used to pair
-// IncrementalDiscoveryResponse to a IncrementalDiscoveryRequest ACK or NACK.
+// In Delta xDS the nonce field is required and used to pair
+// DeltaDiscoveryResponse to a DeltaDiscoveryRequest ACK or NACK.
 // Optionally, a response message level system_version_info is present for
 // debugging purposes only.
 //
-// IncrementalDiscoveryRequest can be sent in 3 situations:
+// DeltaDiscoveryRequest can be sent in 3 situations:
 //   1. Initial message in a xDS bidirectional gRPC stream.
-//   2. As a ACK or NACK response to a previous IncrementalDiscoveryResponse.
+//   2. As a ACK or NACK response to a previous DeltaDiscoveryResponse.
 //      In this case the response_nonce is set to the nonce value in the Response.
 //      ACK or NACK is determined by the absence or presence of error_detail.
-//   3. Spontaneous IncrementalDiscoveryRequest from the client.
+//   3. Spontaneous DeltaDiscoveryRequest from the client.
 //      This can be done to dynamically add or remove elements from the tracked
 //      resource_names set. In this case response_nonce must be omitted.
-message IncrementalDiscoveryRequest {
+message DeltaDiscoveryRequest {
   // The node making the request.
   core.Node node = 1;
 
@@ -138,18 +137,18 @@ message IncrementalDiscoveryRequest {
   // required for ADS.
   string type_url = 2;
 
-  // IncrementalDiscoveryRequests allow the client to add or remove individual
+  // DeltaDiscoveryRequests allow the client to add or remove individual
   // resources to the set of tracked resources in the context of a stream.
   // All resource names in the resource_names_subscribe list are added to the
   // set of tracked resources and all resource names in the resource_names_unsubscribe
   // list are removed from the set of tracked resources.
-  // Unlike in non incremental xDS, an empty resource_names_subscribe or
+  // Unlike in state-of-the-world xDS, an empty resource_names_subscribe or
   // resource_names_unsubscribe list simply means that no resources are to be
   // added or removed to the resource list.
   // The xDS server must send updates for all tracked resources but can also
   // send updates for resources the client has not subscribed to. This behavior
-  // is similar to non incremental xDS.
-  // These two fields can be set for all types of IncrementalDiscoveryRequests
+  // is similar to state-of-the-world xDS.
+  // These two fields can be set for all types of DeltaDiscoveryRequests
   // (initial, ACK/NACK or spontaneous).
   //
   // A list of Resource names to add to the list of tracked resources.
@@ -158,15 +157,17 @@ message IncrementalDiscoveryRequest {
   // A list of Resource names to remove from the list of tracked resources.
   repeated string resource_names_unsubscribe = 4;
 
-  // This map must be populated when the IncrementalDiscoveryRequest is the
-  // first in a stream. The keys are the resources names of the xDS resources
+  // This map must be populated when the DeltaDiscoveryRequest is the
+  // first in a stream (assuming there are any resources - this field's purpose is to enable
+  // a session to continue in a reconnected gRPC stream, and so will not be used in the very
+  // first stream of a session). The keys are the resources names of the xDS resources
   // known to the xDS client. The values in the map are the associated resource
   // level version info.
   map<string, string> initial_resource_versions = 5;
 
-  // When the IncrementalDiscoveryRequest is a ACK or NACK message in response
-  // to a previous IncrementalDiscoveryResponse, the response_nonce must be the
-  // nonce in the IncrementalDiscoveryResponse.
+  // When the DeltaDiscoveryRequest is a ACK or NACK message in response
+  // to a previous DeltaDiscoveryResponse, the response_nonce must be the
+  // nonce in the DeltaDiscoveryResponse.
   // Otherwise response_nonce must be omitted.
   string response_nonce = 6;
 
@@ -176,24 +177,27 @@ message IncrementalDiscoveryRequest {
   google.rpc.Status error_detail = 7;
 }
 
-message IncrementalDiscoveryResponse {
+message DeltaDiscoveryResponse {
   // The version of the response data (used for debugging).
   string system_version_info = 1;
 
   // The response resources. These are typed resources that match the type url
-  // in the IncrementalDiscoveryRequest.
+  // in the DeltaDiscoveryRequest.
   repeated Resource resources = 2 [(gogoproto.nullable) = false];
 
   // Resources names of resources that have be deleted and to be removed from the xDS Client.
   // Removed resources for missing resources can be ignored.
   repeated string removed_resources = 6;
 
-  // The nonce provides a way for IncrementalDiscoveryRequests to uniquely
-  // reference a IncrementalDiscoveryResponse. The nonce is required.
+  // The nonce provides a way for DeltaDiscoveryRequests to uniquely
+  // reference a DeltaDiscoveryResponse. The nonce is required.
   string nonce = 5;
 }
 
 message Resource {
+  // The resource's name, to distinguish it from others of the same type of resource.
+  string name = 3;
+
   // The resource level version. It allows xDS to track the state of individual
   // resources.
   string version = 1;

--- a/api/envoy/api/v2/rds.proto
+++ b/api/envoy/api/v2/rds.proto
@@ -33,8 +33,7 @@ service RouteDiscoveryService {
   rpc StreamRoutes(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
   }
 
-  rpc IncrementalRoutes(stream IncrementalDiscoveryRequest)
-      returns (stream IncrementalDiscoveryResponse) {
+  rpc DeltaRoutes(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
   }
 
   rpc FetchRoutes(DiscoveryRequest) returns (DiscoveryResponse) {

--- a/api/envoy/service/discovery/v2/ads.proto
+++ b/api/envoy/service/discovery/v2/ads.proto
@@ -32,7 +32,7 @@ service AggregatedDiscoveryService {
       returns (stream envoy.api.v2.DiscoveryResponse) {
   }
 
-  rpc IncrementalAggregatedResources(stream envoy.api.v2.IncrementalDiscoveryRequest)
-      returns (stream envoy.api.v2.IncrementalDiscoveryResponse) {
+  rpc DeltaAggregatedResources(stream envoy.api.v2.DeltaDiscoveryRequest)
+      returns (stream envoy.api.v2.DeltaDiscoveryResponse) {
   }
 }

--- a/include/envoy/config/BUILD
+++ b/include/envoy/config/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/stats:stats_macros",
         "//source/common/protobuf",
+        "@envoy_api//envoy/api/v2:discovery_cc",
     ],
 )
 

--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/api/v2/discovery.pb.h"
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 #include "envoy/stats/stats_macros.h"
@@ -28,6 +29,22 @@ public:
    */
   virtual void onConfigUpdate(const ResourceVector& resources,
                               const std::string& version_info) PURE;
+
+  // TODO(fredlas) it is a HACK that there are two of these. After delta CDS is merged,
+  //               I intend to reimplement all state-of-the-world xDSes' use of onConfigUpdate
+  //               in terms of this delta-style one (and remove the original).
+  /**
+   * Called when a delta configuration update is received.
+   * @param added_resources resources newly added since the previous fetch.
+   * @param removed_resources names of resources that this fetch instructed to be removed.
+   * @param system_version_info aggregate response data "version", for debugging.
+   * @throw EnvoyException with reason if the config changes are rejected. Otherwise the changes
+   *        are accepted. Accepted changes have their version_info reflected in subsequent requests.
+   */
+  virtual void
+  onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>& added_resources,
+                 const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+                 const std::string& system_version_info) PURE;
 
   /**
    * Called when either the Subscription is unable to fetch a config update or when onConfigUpdate

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -98,6 +98,22 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "delta_subscription_lib",
+    hdrs = ["delta_subscription_impl.h"],
+    deps = [
+        ":grpc_stream_lib",
+        ":utility_lib",
+        "//include/envoy/config:subscription_interface",
+        "//include/envoy/grpc:async_client_interface",
+        "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/common:backoff_lib",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/common:token_bucket_impl_lib",
+        "//source/common/protobuf",
+    ],
+)
+
+envoy_cc_library(
     name = "grpc_stream_lib",
     hdrs = ["grpc_stream.h"],
     deps = [
@@ -303,6 +319,7 @@ envoy_cc_library(
     name = "subscription_factory_lib",
     hdrs = ["subscription_factory.h"],
     deps = [
+        ":delta_subscription_lib",
         ":filesystem_subscription_lib",
         ":grpc_mux_subscription_lib",
         ":grpc_subscription_lib",

--- a/source/common/config/delta_subscription_impl.h
+++ b/source/common/config/delta_subscription_impl.h
@@ -1,0 +1,213 @@
+#pragma once
+
+#include <queue>
+
+#include "envoy/api/v2/discovery.pb.h"
+#include "envoy/common/token_bucket.h"
+#include "envoy/config/subscription.h"
+
+#include "common/common/assert.h"
+#include "common/common/backoff_strategy.h"
+#include "common/common/logger.h"
+#include "common/common/token_bucket_impl.h"
+#include "common/config/grpc_stream.h"
+#include "common/config/utility.h"
+#include "common/grpc/common.h"
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+
+namespace Envoy {
+namespace Config {
+
+struct ResourceNameDiff {
+  std::vector<std::string> added_;
+  std::vector<std::string> removed_;
+};
+
+const char EmptyVersion[] = "";
+
+/**
+ * Manages the logic of a (non-aggregated) delta xDS subscription.
+ * TODO(fredlas) add aggregation support.
+ */
+template <class ResourceType>
+class DeltaSubscriptionImpl
+    : public Subscription<ResourceType>,
+      public GrpcStream<envoy::api::v2::DeltaDiscoveryRequest,
+                        envoy::api::v2::DeltaDiscoveryResponse, ResourceNameDiff> {
+public:
+  DeltaSubscriptionImpl(const LocalInfo::LocalInfo& local_info, Grpc::AsyncClientPtr async_client,
+                        Event::Dispatcher& dispatcher,
+                        const Protobuf::MethodDescriptor& service_method,
+                        Runtime::RandomGenerator& random, Stats::Scope& scope,
+                        const RateLimitSettings& rate_limit_settings, SubscriptionStats stats)
+      : GrpcStream<envoy::api::v2::DeltaDiscoveryRequest, envoy::api::v2::DeltaDiscoveryResponse,
+                   ResourceNameDiff>(std::move(async_client), service_method, random, dispatcher,
+                                     scope, rate_limit_settings),
+        type_url_(Grpc::Common::typeUrl(ResourceType().GetDescriptor()->full_name())),
+        local_info_(local_info), stats_(stats) {
+    request_.set_type_url(type_url_);
+    request_.mutable_node()->MergeFrom(local_info_.node());
+  }
+
+  // Enqueues and attempts to send a discovery request, (un)subscribing to resources missing from /
+  // added to the passed 'resources' argument, relative to resources_. Updates resources_ to
+  // 'resources'.
+  void buildAndQueueDiscoveryRequest(const std::vector<std::string>& resources) {
+    ResourceNameDiff diff;
+    std::set_difference(resources.begin(), resources.end(), resource_names_.begin(),
+                        resource_names_.end(), std::inserter(diff.added_, diff.added_.begin()));
+    std::set_difference(resource_names_.begin(), resource_names_.end(), resources.begin(),
+                        resources.end(), std::inserter(diff.removed_, diff.removed_.begin()));
+
+    for (const auto& added : diff.added_) {
+      resources_[added] = EmptyVersion;
+      resource_names_.insert(added);
+    }
+    for (const auto& removed : diff.removed_) {
+      resources_.erase(removed);
+      resource_names_.erase(removed);
+    }
+    queueDiscoveryRequest(diff);
+  }
+
+  void sendDiscoveryRequest(const ResourceNameDiff& diff) override {
+    if (!grpcStreamAvailable()) {
+      ENVOY_LOG(debug, "No stream available to sendDiscoveryRequest for {}", type_url_);
+      return; // Drop this request; the reconnect will enqueue a new one.
+    }
+    if (paused_) {
+      ENVOY_LOG(trace, "API {} paused during sendDiscoveryRequest().", type_url_);
+      pending_ = diff;
+      return; // The unpause will send this request.
+    }
+
+    request_.clear_resource_names_subscribe();
+    request_.clear_resource_names_unsubscribe();
+    std::copy(diff.added_.begin(), diff.added_.end(),
+              Protobuf::RepeatedFieldBackInserter(request_.mutable_resource_names_subscribe()));
+    std::copy(diff.removed_.begin(), diff.removed_.end(),
+              Protobuf::RepeatedFieldBackInserter(request_.mutable_resource_names_unsubscribe()));
+
+    ENVOY_LOG(trace, "Sending DiscoveryRequest for {}: {}", type_url_, request_.DebugString());
+    sendMessage(request_);
+    request_.clear_error_detail();
+    request_.clear_initial_resource_versions();
+  }
+
+  void subscribe(const std::vector<std::string>& resources) {
+    ENVOY_LOG(debug, "delta subscribe for " + type_url_);
+    buildAndQueueDiscoveryRequest(resources);
+  }
+
+  void pause() {
+    ENVOY_LOG(debug, "Pausing discovery requests for {}", type_url_);
+    ASSERT(!paused_);
+    paused_ = true;
+  }
+
+  void resume() {
+    ENVOY_LOG(debug, "Resuming discovery requests for {}", type_url_);
+    ASSERT(paused_);
+    paused_ = false;
+    if (pending_.has_value()) {
+      queueDiscoveryRequest(pending_.value());
+      pending_.reset();
+    }
+  }
+
+  // Config::SubscriptionCallbacks
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>& added_resources,
+                      const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+                      const std::string& version_info) {
+    callbacks_->onConfigUpdate(added_resources, removed_resources, version_info);
+    for (const auto& resource : added_resources) {
+      resources_[resource.name()] = resource.version();
+    }
+    stats_.update_success_.inc();
+    stats_.update_attempt_.inc();
+    stats_.version_.set(HashUtil::xxHash64(version_info));
+    ENVOY_LOG(debug, "Delta config for {} accepted with {} resources added, {} removed", type_url_,
+              added_resources.size(), removed_resources.size());
+  }
+
+  void handleResponse(std::unique_ptr<envoy::api::v2::DeltaDiscoveryResponse>&& message) override {
+    ENVOY_LOG(debug, "Received gRPC message for {} at version {}", type_url_,
+              message->system_version_info());
+
+    request_.set_response_nonce(message->nonce());
+
+    try {
+      onConfigUpdate(message->resources(), message->removed_resources(),
+                     message->system_version_info());
+    } catch (const EnvoyException& e) {
+      stats_.update_rejected_.inc();
+      ENVOY_LOG(warn, "delta config for {} rejected: {}", type_url_, e.what());
+      stats_.update_attempt_.inc();
+      callbacks_->onConfigUpdateFailed(&e);
+      ::google::rpc::Status* error_detail = request_.mutable_error_detail();
+      error_detail->set_code(Grpc::Status::GrpcStatus::Internal);
+      error_detail->set_message(e.what());
+    }
+    queueDiscoveryRequest(ResourceNameDiff()); // no change to subscribed resources
+  }
+
+  void handleStreamEstablished() override {
+    // initial_resource_versions "must be populated for first request in a stream", so guarantee
+    // that the initial version'd request we're about to enqueue is what gets sent.
+    clearRequestQueue();
+
+    request_.Clear();
+    for (auto const& resource : resources_) {
+      (*request_.mutable_initial_resource_versions())[resource.first] = resource.second;
+    }
+    request_.set_type_url(type_url_);
+    request_.mutable_node()->MergeFrom(local_info_.node());
+    queueDiscoveryRequest(ResourceNameDiff()); // no change to subscribed resources
+  }
+
+  void handleEstablishmentFailure() override {
+    stats_.update_failure_.inc();
+    ENVOY_LOG(debug, "delta update for {} failed", type_url_);
+    stats_.update_attempt_.inc();
+    callbacks_->onConfigUpdateFailed(nullptr);
+  }
+
+  // Config::DeltaSubscription
+  void start(const std::vector<std::string>& resources,
+             SubscriptionCallbacks<ResourceType>& callbacks) override {
+    callbacks_ = &callbacks;
+    establishNewStream();
+    subscribe(resources);
+    // The attempt stat here is maintained for the purposes of having consistency between ADS and
+    // individual DeltaSubscriptions. Since ADS is push based and muxed, the notion of an
+    // "attempt" for a given xDS API combined by ADS is not really that meaningful.
+    stats_.update_attempt_.inc();
+  }
+
+  void updateResources(const std::vector<std::string>& resources) override {
+    subscribe(resources);
+    stats_.update_attempt_.inc();
+  }
+
+private:
+  // A map from resource name to per-resource version.
+  std::unordered_map<std::string, std::string> resources_;
+  // The keys of resources_. Only tracked separately because std::map does not provide an iterator
+  // into just its keys, e.g. for use in std::set_difference.
+  std::unordered_set<std::string> resource_names_;
+  const std::string type_url_;
+  SubscriptionCallbacks<ResourceType>* callbacks_{};
+  // In-flight or previously sent request.
+  envoy::api::v2::DeltaDiscoveryRequest request_;
+  // Paused via pause()?
+  bool paused_{};
+  absl::optional<ResourceNameDiff> pending_;
+
+  const LocalInfo::LocalInfo& local_info_;
+
+  SubscriptionStats stats_;
+};
+
+} // namespace Config
+} // namespace Envoy

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -8,6 +8,7 @@
 #include "envoy/stats/scope.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/config/delta_subscription_impl.h"
 #include "common/config/filesystem_subscription_impl.h"
 #include "common/config/grpc_mux_subscription_impl.h"
 #include "common/config/grpc_subscription_impl.h"
@@ -67,15 +68,25 @@ public:
             Utility::apiConfigSourceRequestTimeout(api_config_source),
             *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats));
         break;
-      case envoy::api::v2::core::ApiConfigSource::GRPC: {
+      case envoy::api::v2::core::ApiConfigSource::GRPC:
         result.reset(new GrpcSubscriptionImpl<ResourceType>(
             local_info,
             Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
-                                                           config.api_config_source(), scope)
+                                                           api_config_source, scope)
                 ->create(),
             dispatcher, random,
             *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method), stats,
             scope, Utility::parseRateLimitSettings(api_config_source)));
+        break;
+      case envoy::api::v2::core::ApiConfigSource::DELTA_GRPC: {
+        Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
+        result.reset(new DeltaSubscriptionImpl<ResourceType>(
+            local_info,
+            Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
+                                                           api_config_source, scope)
+                ->create(),
+            dispatcher, *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
+            random, scope, Utility::parseRateLimitSettings(api_config_source), stats));
         break;
       }
       default:

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -107,7 +107,12 @@ public:
   }
 
   // Config::SubscriptionCallbacks
+  // TODO(fredlas) deduplicate
   void onConfigUpdate(const ResourceVector& resources, const std::string& version_info) override;
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>&,
+                      const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   void onConfigUpdateFailed(const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::RouteConfiguration>(resource).name();

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -40,7 +40,12 @@ public:
   void initialize(std::function<void()> callback) override;
 
   // Config::SubscriptionCallbacks
+  // TODO(fredlas) deduplicate
   void onConfigUpdate(const ResourceVector& resources, const std::string& version_info) override;
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>&,
+                      const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   void onConfigUpdateFailed(const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::auth::Secret>(resource).name();

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -138,7 +138,7 @@ public:
   }
   virtual void sub(uint64_t amount) override {
     ASSERT(data_.value_ >= amount);
-    ASSERT(used());
+    ASSERT(used() || amount == 0);
     data_.value_ -= amount;
   }
   virtual uint64_t value() const override { return data_.value_; }

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -32,10 +32,13 @@ public:
   void setInitializedCb(std::function<void()> callback) override {
     initialize_callback_ = callback;
   }
-  const std::string versionInfo() const override { return version_info_; }
+  const std::string versionInfo() const override { return system_version_info_; }
 
   // Config::SubscriptionCallbacks
+  // TODO(fredlas) deduplicate
   void onConfigUpdate(const ResourceVector& resources, const std::string& version_info) override;
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>&,
+                      const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override;
   void onConfigUpdateFailed(const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource).name();
@@ -49,7 +52,7 @@ private:
 
   ClusterManager& cm_;
   std::unique_ptr<Config::Subscription<envoy::api::v2::Cluster>> subscription_;
-  std::string version_info_;
+  std::string system_version_info_;
   std::function<void()> initialize_callback_;
   Stats::ScopePtr scope_;
 };

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -178,6 +178,7 @@ public:
   void setInitializedCb(std::function<void()> callback) override {
     init_helper_.setInitializedCb(callback);
   }
+
   ClusterInfoMap clusters() override {
     // TODO(mattklein123): Add ability to see warming clusters in admin output.
     ClusterInfoMap clusters_map;

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -28,7 +28,12 @@ public:
   InitializePhase initializePhase() const override { return InitializePhase::Secondary; }
 
   // Config::SubscriptionCallbacks
+  // TODO(fredlas) deduplicate
   void onConfigUpdate(const ResourceVector& resources, const std::string& version_info) override;
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>&,
+                      const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   void onConfigUpdateFailed(const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::ClusterLoadAssignment>(resource).cluster_name();

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -34,7 +34,12 @@ public:
   void initialize(std::function<void()> callback) override;
 
   // Config::SubscriptionCallbacks
+  // TODO(fredlas) deduplicate
   void onConfigUpdate(const ResourceVector& resources, const std::string& version_info) override;
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>&,
+                      const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   void onConfigUpdateFailed(const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::Listener>(resource).name();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -67,7 +67,6 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
       terminated_(false),
       mutex_tracer_(options.mutexTracingEnabled() ? &Envoy::MutexTracerImpl::getOrCreateTracer()
                                                   : nullptr) {
-
   try {
     if (!options.logPath().empty()) {
       try {

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -52,6 +52,7 @@ public:
   void start() override {}
 
   // Envoy::Config::SubscriptionCallbacks
+  // TODO(fredlas) deduplicate
   void onConfigUpdate(const ResourceVector& resources, const std::string& version_info) override {
     const auto& config = resources[0];
     if (checkAndApplyConfig(config, "dummy_config", version_info)) {
@@ -59,6 +60,10 @@ public:
     }
 
     ConfigSubscriptionInstanceBase::onConfigUpdate();
+  }
+  void onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>&,
+                      const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   // Envoy::Config::SubscriptionCallbacks

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -172,9 +172,9 @@ TEST_F(SubscriptionFactoryTest, GrpcClusterMultiton) {
   EXPECT_CALL(*cluster.info_, addedViaApi()).WillRepeatedly(Return(false));
   EXPECT_CALL(*cluster.info_, type()).WillRepeatedly(Return(envoy::api::v2::Cluster::STATIC));
 
-  EXPECT_THROW_WITH_REGEX(
-      subscriptionFromConfigSource(config), EnvoyException,
-      "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified:");
+  EXPECT_THROW_WITH_REGEX(subscriptionFromConfigSource(config), EnvoyException,
+                          "envoy::api::v2::core::ConfigSource::.DELTA_.GRPC must have a "
+                          "single gRPC service specified:");
 }
 
 TEST_F(SubscriptionFactoryTest, FilesystemSubscription) {

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -268,7 +268,8 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     EXPECT_THROW_WITH_REGEX(
         Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
         EnvoyException,
-        "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified:");
+        "envoy::api::v2::core::ConfigSource::.DELTA_.GRPC must have a single gRPC service "
+        "specified:");
   }
 
   {
@@ -279,7 +280,8 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     EXPECT_THROW_WITH_REGEX(
         Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
         EnvoyException,
-        "envoy::api::v2::core::ConfigSource::GRPC must not have a cluster name specified:");
+        "envoy::api::v2::core::ConfigSource::.DELTA_.GRPC must not have a cluster name "
+        "specified:");
   }
 
   {
@@ -290,7 +292,8 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     EXPECT_THROW_WITH_REGEX(
         Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
         EnvoyException,
-        "envoy::api::v2::core::ConfigSource::GRPC must not have a cluster name specified:");
+        "envoy::api::v2::core::ConfigSource::.DELTA_.GRPC must not have a cluster name "
+        "specified:");
   }
 
   {
@@ -301,7 +304,7 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     EXPECT_THROW_WITH_REGEX(
         Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
         EnvoyException,
-        "envoy::api::v2::core::ConfigSource, if not of type gRPC, must not have a gRPC service "
+        "envoy::api::v2::core::ConfigSource, if not a gRPC type, must not have a gRPC service "
         "specified:");
   }
 
@@ -311,7 +314,7 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     api_config_source.add_cluster_names("foo");
     EXPECT_THROW_WITH_REGEX(
         Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
-        EnvoyException, "envoy::api::v2::core::ConfigSource type must be GRPC:");
+        EnvoyException, "envoy::api::v2::core::ConfigSource type must be gRPC:");
   }
 
   {
@@ -388,7 +391,8 @@ TEST(CheckApiConfigSourceSubscriptionBackingClusterTest, GrpcClusterTestAcrossTy
   EXPECT_THROW_WITH_REGEX(
       Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
       EnvoyException,
-      "envoy::api::v2::core::ConfigSource::GRPC must not have a cluster name specified:");
+      "envoy::api::v2::core::ConfigSource::.DELTA_.GRPC must not have a cluster name "
+      "specified:");
 }
 
 TEST(CheckApiConfigSourceSubscriptionBackingClusterTest, RestClusterTestAcrossTypes) {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -96,6 +96,27 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "delta_cds_integration_test",
+    srcs = ["delta_cds_integration_test.cc"],
+    data = [
+        "//test/config/integration/certs",
+    ],
+    deps = [
+        ":http_integration_lib",
+        "//source/common/config:protobuf_link_hacks",
+        "//source/common/config:resources_lib",
+        "//source/common/protobuf:utility_lib",
+        "//test/common/grpc:grpc_client_integration_lib",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/api/v2:cds_cc",
+        "@envoy_api//envoy/api/v2:discovery_cc",
+    ],
+)
+
 exports_files(["test_utility.sh"])
 
 envoy_sh_test(

--- a/test/integration/delta_cds_integration_test.cc
+++ b/test/integration/delta_cds_integration_test.cc
@@ -1,0 +1,324 @@
+#include "envoy/api/v2/cds.pb.h"
+#include "envoy/api/v2/discovery.pb.h"
+#include "envoy/grpc/status.h"
+#include "envoy/stats/scope.h"
+
+#include "common/config/protobuf_link_hacks.h"
+#include "common/config/resources.h"
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+
+#include "test/common/grpc/grpc_client_integration.h"
+#include "test/integration/http_integration.h"
+#include "test/integration/utility.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
+
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+
+using testing::AssertionFailure;
+using testing::AssertionResult;
+using testing::AssertionSuccess;
+using testing::IsSubstring;
+
+namespace Envoy {
+namespace {
+
+// TODO(fredlas) Move to test/config/utility.cc once there are other xDS tests that use gRPC.
+const char Config[] = R"EOF(
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 0
+dynamic_resources:
+  cds_config:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: my_cds_cluster
+static_resources:
+  clusters:
+  - name: my_cds_cluster
+    http2_protocol_options: {}
+    hosts:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 0
+  listeners:
+    name: http
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 0
+    filter_chains:
+      filters:
+        name: envoy.http_connection_manager
+        config:
+          stat_prefix: config_test
+          http_filters:
+            name: envoy.router
+          codec_type: HTTP2
+          route_config:
+            name: route_config_0
+            validate_clusters: false
+            virtual_hosts:
+              name: integration
+              routes:
+              - route:
+                  cluster: cluster_1
+                match:
+                  prefix: "/cluster1"
+              - route:
+                  cluster: cluster_2
+                match:
+                  prefix: "/cluster2"
+              domains: "*"
+)EOF";
+const char ClusterName1[] = "cluster_1";
+const char ClusterName2[] = "cluster_2";
+const int UpstreamIndex1 = 1;
+const int UpstreamIndex2 = 2;
+
+class DeltaCdsIntegrationTest : public HttpIntegrationTest,
+                                public Grpc::GrpcClientIntegrationParamTest {
+public:
+  DeltaCdsIntegrationTest()
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), realTime(), Config) {}
+
+  void TearDown() override {
+    cleanUpXdsConnection();
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
+  // TODO(fredlas) Move to test/config/utility.cc once there are other xDS tests that use gRPC.
+  envoy::api::v2::Cluster buildCluster(const std::string& name, int upstream_index) {
+    return TestUtility::parseYaml<envoy::api::v2::Cluster>(
+        fmt::format(R"EOF(
+      name: {}
+      connect_timeout: 5s
+      type: STATIC
+      load_assignment:
+        cluster_name: {}
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: {}
+                  port_value: {}
+      lb_policy: ROUND_ROBIN
+      http2_protocol_options: {{}}
+    )EOF",
+                    name, name, Network::Test::getLoopbackAddressString(ipVersion()),
+                    fake_upstreams_[upstream_index]->localAddress()->ip()->port()));
+  }
+
+  // Overridden to insert this stuff into the initialize() at the very beginning of
+  // HttpIntegrationTest::testRouterRequestAndResponseWithBody().
+  void initialize() override {
+    // Controls how many fake_upstreams_.emplace_back(new FakeUpstream) will happen in
+    // BaseIntegrationTest::createUpstreams() (which is part of initialize()).
+    // Make sure this number matches the size of the 'clusters' repeated field in the bootstrap
+    // config that you use!
+    setUpstreamCount(1);                                  // the CDS cluster
+    setUpstreamProtocol(FakeHttpConnection::Type::HTTP2); // CDS uses gRPC uses HTTP2.
+
+    // BaseIntegrationTest::initialize() does many things:
+    // 1) It appends to fake_upstreams_ as many as you asked for via setUpstreamCount().
+    // 2) It updates your bootstrap config with the ports your fake upstreams are actually listening
+    //    on (since you're supposed to leave them as 0).
+    // 3) It creates and starts an IntegrationTestServer - the thing that wraps the almost-actual
+    //    Envoy used in the tests.
+    // 4) Bringing up the server usually entails waiting to ensure that any listeners specified in
+    //    the bootstrap config have come up, and registering them in a port map (see lookupPort()).
+    //    However, this test needs to defer all of that to later.
+    defer_listener_finalization_ = true;
+    HttpIntegrationTest::initialize();
+
+    // Create the regular (i.e. not an xDS server) upstream. We create it manually here after
+    // initialize() because finalize() expects all fake_upstreams_ to correspond to a static
+    // cluster in the bootstrap config - which we don't want since we're testing dynamic CDS!
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
+                                                  timeSystem(), enable_half_close_));
+    fake_upstreams_[UpstreamIndex1]->set_allow_unexpected_disconnects(false);
+
+    // Now that the upstream has been created, process Envoy's request to discover it.
+    // (First, we have to let Envoy establish its connection to the CDS server.)
+    acceptXdsConnection();
+
+    EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}));
+    sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>(
+        {buildCluster(ClusterName1, UpstreamIndex1)}, {}, "55");
+    // We can continue the test once we're sure that Envoy's ClusterManager has made use of
+    // the DiscoveryResponse describing cluster_1 that we sent.
+    // 2 because the statically specified CDS server itself counts as a cluster.
+    test_server_->waitForGaugeGe("cluster_manager.active_clusters", 2);
+
+    // Wait for our statically specified listener to become ready, and register its port in the
+    // test framework's downstream listener port map.
+    test_server_->waitUntilListenersReady();
+    registerTestServerPorts({"http"});
+  }
+
+  void acceptXdsConnection() {
+    AssertionResult result = // xds_connection_ is filled with the new FakeHttpConnection.
+        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, xds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    xds_stream_->startGrpcStream();
+    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersionsClientType, DeltaCdsIntegrationTest,
+                        GRPC_CLIENT_INTEGRATION_PARAMS);
+
+// 1) Envoy starts up with no static clusters (other than the CDS-over-gRPC server).
+// 2) Envoy is told of a cluster via CDS.
+// 3) We send Envoy a request, which we verify is properly proxied to and served by that cluster.
+// 4) Envoy is told that cluster is gone.
+// 5) We send Envoy a request, which should 503.
+// 6) Envoy is told that the cluster is back.
+// 7) We send Envoy a request, which we verify is properly proxied to and served by that cluster.
+TEST_P(DeltaCdsIntegrationTest, CdsClusterUpDownUp) {
+  // Calls our initialize(), which includes establishing a listener, route, and cluster.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+
+  // Tell Envoy that cluster_1 is gone.
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}));
+  sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>({}, {ClusterName1}, "42");
+  // We can continue the test once we're sure that Envoy's ClusterManager has made use of
+  // the DiscoveryResponse that says cluster_1 is gone.
+  test_server_->waitForCounterGe("cluster_manager.cluster_removed", 1);
+
+  // Now that cluster_1 is gone, the listener (with its routing to cluster_1) should 503.
+  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
+      lookupPort("http"), "GET", "/cluster1", "", downstream_protocol_, version_, "foo.com");
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
+
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+
+  // Tell Envoy that cluster_1 is back.
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}));
+  sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>({buildCluster(ClusterName1, UpstreamIndex1)},
+                                                      {}, "413");
+
+  // We can continue the test once we're sure that Envoy's ClusterManager has made use of
+  // the DiscoveryResponse describing cluster_1 that we sent. Again, 2 includes CDS server.
+  test_server_->waitForGaugeGe("cluster_manager.active_clusters", 2);
+
+  // Does *not* call our initialize().
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Tests adding a cluster, adding another, then removing the first.
+TEST_P(DeltaCdsIntegrationTest, TwoClusters) {
+  // Calls our initialize(), which includes establishing a listener, route, and cluster.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+
+  // Add another fake upstream, to be cluster_2.
+  fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
+                                                timeSystem(), enable_half_close_));
+  fake_upstreams_[UpstreamIndex2]->set_allow_unexpected_disconnects(false);
+
+  // Tell Envoy that cluster_2 is here.
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}));
+  sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>({buildCluster(ClusterName2, UpstreamIndex2)},
+                                                      {}, "42");
+  // The '3' includes the fake CDS server.
+  test_server_->waitForGaugeGe("cluster_manager.active_clusters", 3);
+
+  // A request for cluster_2 should be fine.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex2, "/cluster2");
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+
+  // Tell Envoy that cluster_1 is gone.
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}));
+  sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>({}, {ClusterName1}, "42");
+  // We can continue the test once we're sure that Envoy's ClusterManager has made use of
+  // the DiscoveryResponse that says cluster_1 is gone.
+  test_server_->waitForCounterGe("cluster_manager.cluster_removed", 1);
+
+  // Even with cluster_1 is gone, a request for cluster_2 should be fine.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex2, "/cluster2");
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+
+  // Tell Envoy that cluster_1 is back.
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}));
+  sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>({buildCluster(ClusterName1, UpstreamIndex1)},
+                                                      {}, "413");
+
+  // We can continue the test once we're sure that Envoy's ClusterManager has made use of
+  // the DiscoveryResponse describing cluster_1 that we sent. Again, 3 includes CDS server.
+  test_server_->waitForGaugeGe("cluster_manager.active_clusters", 3);
+
+  // Does *not* call our initialize().
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Tests that when Envoy's xDS gRPC stream dis/reconnects, Envoy can inform the server of the
+// resources it already has: the reconnected stream need not start with a state-of-the-world update.
+TEST_P(DeltaCdsIntegrationTest, VersionsRememberedAfterReconnect) {
+  // Calls our initialize(), which includes establishing a listener, route, and cluster.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+
+  // Close the connection carrying Envoy's xDS gRPC stream...
+  AssertionResult result = xds_connection_->close();
+  RELEASE_ASSERT(result, result.message());
+  result = xds_connection_->waitForDisconnect();
+  RELEASE_ASSERT(result, result.message());
+  xds_connection_.reset();
+  // ...and reconnect it.
+  acceptXdsConnection();
+
+  // Upon reconnecting, the Envoy should tell us its current resource versions.
+  envoy::api::v2::DeltaDiscoveryRequest request;
+  result = xds_stream_->waitForGrpcMessage(*dispatcher_, request);
+  RELEASE_ASSERT(result, result.message());
+  const auto& initial_resource_versions = request.initial_resource_versions();
+  EXPECT_EQ("55", initial_resource_versions.at(std::string(ClusterName1)));
+  EXPECT_EQ(1, initial_resource_versions.size());
+
+  // Add another fake upstream, to be cluster_2.
+  fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
+                                                timeSystem(), enable_half_close_));
+  fake_upstreams_[UpstreamIndex2]->set_allow_unexpected_disconnects(false);
+  // Tell Envoy that cluster_2 is here. This update does *not* need to include cluster_1,
+  // which Envoy should already know about despite the disconnect.
+  sendDeltaDiscoveryResponse<envoy::api::v2::Cluster>({buildCluster(ClusterName2, UpstreamIndex2)},
+                                                      {}, "42");
+  // The '3' includes the fake CDS server.
+  test_server_->waitForGaugeGe("cluster_manager.active_clusters", 3);
+
+  // A request for cluster_1 should be fine.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+  // A request for cluster_2 should be fine.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex2, "/cluster2");
+  cleanupUpstreamAndDownstream();
+  codec_client_->waitForDisconnect();
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/integration/delta_xds_integration_test_base.cc
+++ b/test/integration/delta_xds_integration_test_base.cc
@@ -1,0 +1,91 @@
+#include "test/integration/delta_xds_integration_test_base.h"
+
+#include "envoy/api/v2/discovery.pb.h"
+#include "envoy/grpc/status.h"
+#include "envoy/stats/scope.h"
+
+#include "common/config/resources.h"
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+
+#include "test/integration/http_integration.h"
+#include "test/integration/utility.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+using testing::AssertionFailure;
+using testing::AssertionResult;
+using testing::AssertionSuccess;
+using testing::IsSubstring;
+
+namespace Envoy {
+
+void DeltaXdsIntegrationTestBase::createXdsConnection(FakeUpstream& upstream) {
+  xds_upstream_ = &upstream;
+  AssertionResult result = xds_upstream_->waitForHttpConnection(*dispatcher_, xds_connection_);
+  RELEASE_ASSERT(result, result.message());
+}
+
+void DeltaXdsIntegrationTestBase::cleanUpXdsConnection() {
+  // Don't ASSERT fail if an xDS reconnect ends up unparented.
+  if (xds_upstream_) {
+    xds_upstream_->set_allow_unexpected_disconnects(true);
+  }
+  AssertionResult result = xds_connection_->close();
+  RELEASE_ASSERT(result, result.message());
+  result = xds_connection_->waitForDisconnect();
+  RELEASE_ASSERT(result, result.message());
+  xds_connection_.reset();
+}
+
+AssertionResult DeltaXdsIntegrationTestBase::compareDiscoveryRequest(
+    const std::string& expected_type_url,
+    const std::vector<std::string>& expected_resource_subscriptions,
+    const std::vector<std::string>& expected_resource_unsubscriptions,
+    const Protobuf::int32 expected_error_code, const std::string& expected_error_message) {
+  envoy::api::v2::DeltaDiscoveryRequest request;
+  VERIFY_ASSERTION(xds_stream_->waitForGrpcMessage(*dispatcher_, request));
+
+  EXPECT_TRUE(request.has_node());
+  EXPECT_FALSE(request.node().id().empty());
+  EXPECT_FALSE(request.node().cluster().empty());
+
+  // TODO(PiotrSikora): Remove this hack once fixed internally.
+  if (!(expected_type_url == request.type_url())) {
+    return AssertionFailure() << fmt::format("type_url {} does not match expected {}",
+                                             request.type_url(), expected_type_url);
+  }
+  if (!(expected_error_code == request.error_detail().code())) {
+    return AssertionFailure() << fmt::format("error_code {} does not match expected {}",
+                                             request.error_detail().code(), expected_error_code);
+  }
+  EXPECT_TRUE(IsSubstring("", "", expected_error_message, request.error_detail().message()));
+
+  const std::vector<std::string> resource_subscriptions(request.resource_names_subscribe().cbegin(),
+                                                        request.resource_names_subscribe().cend());
+  if (expected_resource_subscriptions != resource_subscriptions) {
+    return AssertionFailure() << fmt::format(
+               "newly subscribed resources {} do not match expected {} in {}",
+               fmt::join(resource_subscriptions.begin(), resource_subscriptions.end(), ","),
+               fmt::join(expected_resource_subscriptions.begin(),
+                         expected_resource_subscriptions.end(), ","),
+               request.DebugString());
+  }
+  const std::vector<std::string> resource_unsubscriptions(
+      request.resource_names_unsubscribe().cbegin(), request.resource_names_unsubscribe().cend());
+  if (expected_resource_unsubscriptions != resource_unsubscriptions) {
+    return AssertionFailure() << fmt::format(
+               "newly UNsubscribed resources {} do not match expected {} in {}",
+               fmt::join(resource_unsubscriptions.begin(), resource_unsubscriptions.end(), ","),
+               fmt::join(expected_resource_unsubscriptions.begin(),
+                         expected_resource_unsubscriptions.end(), ","),
+               request.DebugString());
+  }
+  return AssertionSuccess();
+}
+
+} // namespace Envoy

--- a/test/integration/delta_xds_integration_test_base.h
+++ b/test/integration/delta_xds_integration_test_base.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "envoy/api/v2/discovery.pb.h"
+#include "envoy/grpc/status.h"
+#include "envoy/stats/scope.h"
+
+#include "common/config/resources.h"
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+
+#include "test/integration/http_integration.h"
+#include "test/integration/utility.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+using testing::AssertionFailure;
+using testing::AssertionResult;
+using testing::AssertionSuccess;
+using testing::IsSubstring;
+
+namespace Envoy {
+
+class DeltaXdsIntegrationTestBase : public HttpIntegrationTest {
+public:
+  DeltaXdsIntegrationTestBase(Http::CodecClient::Type downstream_protocol,
+                              Network::Address::IpVersion version)
+      : HttpIntegrationTest(downstream_protocol, version, realTime()) {}
+  DeltaXdsIntegrationTestBase(Http::CodecClient::Type downstream_protocol,
+                              Network::Address::IpVersion version, const std::string& config)
+      : HttpIntegrationTest(downstream_protocol, version, realTime(), config) {}
+
+  void createXdsConnection(FakeUpstream& upstream);
+
+  void cleanUpXdsConnection();
+
+protected:
+  FakeUpstream* xds_upstream_{};
+  FakeHttpConnectionPtr xds_connection_;
+  FakeStreamPtr xds_stream_;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
+};
+
+} // namespace Envoy

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -25,7 +25,6 @@ namespace Envoy {
 namespace {
 
 // TODO(jmarantz): switch this to simulated-time after debugging flakes.
-
 class HdsIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                            public HttpIntegrationTest {
 public:

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -345,7 +345,7 @@ void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
 
 IntegrationStreamDecoderPtr
 HttpIntegrationTest::makeHeaderOnlyRequest(ConnectionCreationFunction* create_connection,
-                                           int upstream_index) {
+                                           int upstream_index, const std::string& path) {
   // This is called multiple times per test in ads_integration_test. Only call
   // initialize() the first time.
   if (!initialized()) {
@@ -354,7 +354,7 @@ HttpIntegrationTest::makeHeaderOnlyRequest(ConnectionCreationFunction* create_co
   codec_client_ = makeHttpConnection(
       create_connection ? ((*create_connection)()) : makeClientConnection((lookupPort("http"))));
   Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/test/long/url"},
+                                          {":path", path},
                                           {":scheme", "http"},
                                           {":authority", "host"},
                                           {"x-lyft-user-id", "123"}};
@@ -363,8 +363,8 @@ HttpIntegrationTest::makeHeaderOnlyRequest(ConnectionCreationFunction* create_co
 }
 
 void HttpIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
-    ConnectionCreationFunction* create_connection, int upstream_index) {
-  auto response = makeHeaderOnlyRequest(create_connection, upstream_index);
+    ConnectionCreationFunction* create_connection, int upstream_index, const std::string& path) {
+  auto response = makeHeaderOnlyRequest(create_connection, upstream_index, path);
   checkSimpleRequestSuccess(0U, 0U, response.get());
 }
 

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -139,7 +139,8 @@ protected:
   typedef std::function<Network::ClientConnectionPtr()> ConnectionCreationFunction;
   // Sends a simple header-only HTTP request, and waits for a response.
   IntegrationStreamDecoderPtr makeHeaderOnlyRequest(ConnectionCreationFunction* create_connection,
-                                                    int upstream_index);
+                                                    int upstream_index,
+                                                    const std::string& path = "/test/long/url");
   void testRouterNotFound();
   void testRouterNotFoundWithBody();
 
@@ -147,7 +148,8 @@ protected:
                                             bool big_header,
                                             ConnectionCreationFunction* creator = nullptr);
   void testRouterHeaderOnlyRequestAndResponse(ConnectionCreationFunction* creator = nullptr,
-                                              int upstream_index = 0);
+                                              int upstream_index = 0,
+                                              const std::string& path = "/test/long/url");
   void testRequestAndResponseShutdownWithActiveConnection();
 
   // Disconnect tests

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -525,4 +525,51 @@ AssertionResult BaseIntegrationTest::compareDiscoveryRequest(
   }
   return AssertionSuccess();
 }
+
+AssertionResult BaseIntegrationTest::compareDeltaDiscoveryRequest(
+    const std::string& expected_type_url,
+    const std::vector<std::string>& expected_resource_subscriptions,
+    const std::vector<std::string>& expected_resource_unsubscriptions,
+    const Protobuf::int32 expected_error_code, const std::string& expected_error_message) {
+  envoy::api::v2::DeltaDiscoveryRequest request;
+  VERIFY_ASSERTION(xds_stream_->waitForGrpcMessage(*dispatcher_, request));
+
+  EXPECT_TRUE(request.has_node());
+  EXPECT_FALSE(request.node().id().empty());
+  EXPECT_FALSE(request.node().cluster().empty());
+
+  // TODO(PiotrSikora): Remove this hack once fixed internally.
+  if (!(expected_type_url == request.type_url())) {
+    return AssertionFailure() << fmt::format("type_url {} does not match expected {}",
+                                             request.type_url(), expected_type_url);
+  }
+  if (!(expected_error_code == request.error_detail().code())) {
+    return AssertionFailure() << fmt::format("error_code {} does not match expected {}",
+                                             request.error_detail().code(), expected_error_code);
+  }
+  EXPECT_TRUE(IsSubstring("", "", expected_error_message, request.error_detail().message()));
+
+  const std::vector<std::string> resource_subscriptions(request.resource_names_subscribe().cbegin(),
+                                                        request.resource_names_subscribe().cend());
+  if (expected_resource_subscriptions != resource_subscriptions) {
+    return AssertionFailure() << fmt::format(
+               "newly subscribed resources {} do not match expected {} in {}",
+               fmt::join(resource_subscriptions.begin(), resource_subscriptions.end(), ","),
+               fmt::join(expected_resource_subscriptions.begin(),
+                         expected_resource_subscriptions.end(), ","),
+               request.DebugString());
+  }
+  const std::vector<std::string> resource_unsubscriptions(
+      request.resource_names_unsubscribe().cbegin(), request.resource_names_unsubscribe().cend());
+  if (expected_resource_unsubscriptions != resource_unsubscriptions) {
+    return AssertionFailure() << fmt::format(
+               "newly UNsubscribed resources {} do not match expected {} in {}",
+               fmt::join(resource_unsubscriptions.begin(), resource_unsubscriptions.end(), ","),
+               fmt::join(expected_resource_unsubscriptions.begin(),
+                         expected_resource_unsubscriptions.end(), ","),
+               request.DebugString());
+  }
+  return AssertionSuccess();
+}
+
 } // namespace Envoy

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -215,6 +215,29 @@ public:
     xds_stream_->sendGrpcMessage(discovery_response);
   }
 
+  AssertionResult compareDeltaDiscoveryRequest(
+      const std::string& expected_type_url,
+      const std::vector<std::string>& expected_resource_subscriptions,
+      const std::vector<std::string>& expected_resource_unsubscriptions,
+      const Protobuf::int32 expected_error_code = Grpc::Status::GrpcStatus::Ok,
+      const std::string& expected_error_message = "");
+  template <class T>
+  void sendDeltaDiscoveryResponse(const std::vector<T>& added_or_updated,
+                                  const std::vector<std::string>& removed,
+                                  const std::string& version) {
+    envoy::api::v2::DeltaDiscoveryResponse response;
+    response.set_system_version_info("system_version_info_this_is_a_test");
+    for (const auto& message : added_or_updated) {
+      auto* resource = response.add_resources();
+      resource->set_name(message.name());
+      resource->set_version(version);
+      resource->mutable_resource()->PackFrom(message);
+    }
+    *response.mutable_removed_resources() = {removed.begin(), removed.end()};
+    response.set_nonce("noncense");
+    xds_stream_->sendGrpcMessage(response);
+  }
+
 private:
   Event::GlobalTimeSystem time_system_;
 

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -26,9 +26,14 @@ public:
   }
   template <class T> static std::string resourceName_(const T& resource) { return resource.name(); }
 
+  // TODO(fredlas) deduplicate
   MOCK_METHOD2_T(onConfigUpdate,
                  void(const typename SubscriptionCallbacks<ResourceType>::ResourceVector& resources,
                       const std::string& version_info));
+  MOCK_METHOD3_T(onConfigUpdate,
+                 void(const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>& added_resources,
+                      const Protobuf::RepeatedPtrField<std::string>& removed_resources,
+                      const std::string& system_version_info));
   MOCK_METHOD1_T(onConfigUpdateFailed, void(const EnvoyException* e));
   MOCK_METHOD1_T(resourceName, std::string(const ProtobufWkt::Any& resource));
 };

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -183,6 +183,7 @@ RCU
 RDN
 RDS
 RDWR
+REIMPLEMENT
 REQ
 RFC
 RHS
@@ -258,6 +259,7 @@ WS
 Welford's
 Werror
 XDS
+xDSes
 XFCC
 XFF
 XM


### PR DESCRIPTION
Signed-off-by: Fred Douglas <fredlas@google.com>

Description: Code for Envoy to speak delta CDS with a management server. DELTA_GRPC added to config_source.proto's ApiTypes, to allow bootstrap configs to ask for incremental xDS.

Part of #4991. Was #5466; giving up on broken DCO craziness.

Risk Level: medium
Testing: new integration test