### PR TITLE
build: use tmpdir to build luajit

### DIFF
--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -48,17 +48,20 @@ new file mode 100755
 index 0000000..9c71271
 --- /dev/null
 +++ b/build.py
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,28 @@
 +#!/usr/bin/env python
 +
 +import argparse
 +import os
++import shutil
 +
 +def main():
 +    parser = argparse.ArgumentParser()
 +    parser.add_argument("--prefix")
 +    args = parser.parse_args()
-+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
++    src_dir = os.path.dirname(os.path.realpath(__file__))
++    shutil.copytree(src_dir, os.path.basename(src_dir))
++    os.chdir(os.path.basename(src_dir))
 +
 +    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
 +    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Running make directly in LuaJIT source will break sandbox as the source directly is not writable. Copy it into current directly (which is tmpdir) to write into writable path.

Risk Level: Low
Testing: locally
Docs Changes:
Release Notes:
Fixes #6188.