### PR TITLE
OMSDPM-2570 add moved/ask redirection support for Redis proxy

### DIFF
--- a/source/extensions/filters/network/common/redis/codec.h
+++ b/source/extensions/filters/network/common/redis/codec.h
@@ -27,6 +27,10 @@ public:
   RespValue() : type_(RespType::Null) {}
   ~RespValue() { cleanup(); }
 
+  RespValue(const RespValue& other);     // copy constructor
+  RespValue& operator=(RespValue other); // copy assignment
+  RespValue(RespValue&& other) noexcept; // move constructor
+
   /**
    * Convert a RESP value to a string for debugging purposes.
    */

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -116,6 +116,73 @@ void RespValue::type(RespType type) {
   }
 }
 
+RespValue::RespValue(const RespValue& other) {
+  this->type(other.type());
+  switch (type_) {
+  case RespType::Array: {
+    this->asArray() = other.asArray();
+    break;
+  }
+  case RespType::SimpleString:
+  case RespType::BulkString:
+  case RespType::Error: {
+    this->asString() = other.asString();
+    break;
+  }
+  case RespType::Integer: {
+    this->asInteger() = other.asInteger();
+    break;
+  }
+  case RespType::Null:
+    break;
+  }
+}
+
+RespValue& RespValue::operator=(RespValue other) {
+  this->type(other.type());
+  switch (type_) {
+  case RespType::Array: {
+    this->asArray() = other.asArray();
+    break;
+  }
+  case RespType::SimpleString:
+  case RespType::BulkString:
+  case RespType::Error: {
+    this->asString() = other.asString();
+    break;
+  }
+  case RespType::Integer: {
+    this->asInteger() = other.asInteger();
+    break;
+  }
+  case RespType::Null:
+    break;
+  }
+  return *this;
+}
+
+RespValue::RespValue(RespValue&& other) noexcept {
+  this->type(other.type());
+  switch (type_) {
+  case RespType::Array: {
+    this->asArray().swap(other.asArray());
+    break;
+  }
+  case RespType::SimpleString:
+  case RespType::BulkString:
+  case RespType::Error: {
+    this->asString().swap(other.asString());
+    break;
+  }
+  case RespType::Integer: {
+    this->asInteger() = other.asInteger();
+    break;
+  }
+  case RespType::Null:
+    break;
+  }
+}
+
 void DecoderImpl::decode(Buffer::Instance& data) {
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
   STACK_ARRAY(slices, Buffer::RawSlice, num_slices);

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -57,6 +57,7 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
         "//source/common/network:filter_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/upstream:load_balancer_lib",

--- a/source/extensions/filters/network/redis_proxy/command_splitter.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter.h
@@ -59,6 +59,17 @@ public:
    */
   virtual SplitRequestPtr makeRequest(const Common::Redis::RespValue& request,
                                       SplitCallbacks& callbacks) PURE;
+
+  /**
+   * Make a split redis request.
+   * @param request supplies the split request to make (ownership transferred to call).
+   * @param callbacks supplies the split request completion callbacks.
+   * @return SplitRequestPtr a handle to the active request or nullptr if the request has already
+   *         been satisfied (via onResponse() being called). The splitter ALWAYS calls
+   *         onResponse() for a given request.
+   */
+  virtual SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request,
+                                      SplitCallbacks& callbacks) PURE;
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -44,6 +44,20 @@ public:
    * Called when a network/protocol error occurs and there is no response.
    */
   virtual void onFailure() PURE;
+
+  /**
+   * Called when a MOVED redirection error is received, and the request must be retried.
+   * @param value supplies the MOVED error response
+   * @return bool true if the request is successfully redirected, false otherwise
+   */
+  virtual bool onMovedRedirection(Common::Redis::RespValue& value) PURE;
+
+  /**
+   * Called when an ASK redirection error is received, and the request must be retried.
+   * @param value supplies the ASK error response
+   * @return bool true if the request is succesfully redirected, false otherwise
+   */
+  virtual bool onAskRedirection(Common::Redis::RespValue& value) PURE;
 };
 
 /**
@@ -140,6 +154,18 @@ public:
   virtual PoolRequest* makeRequest(const std::string& hash_key,
                                    const Common::Redis::RespValue& request,
                                    PoolCallbacks& callbacks) PURE;
+
+  /**
+   * Redirects a redis request (moved/ask cluster redirection).
+   * @param host_address the address of the host to receive the request
+   * @param request supplies the request to make.
+   * @param callbacks supplies the request completion callbacks.
+   * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
+   *         for some reason.
+   */
+  virtual PoolRequest* redirectRequest(const std::string& host_address,
+                                       const Common::Redis::RespValue& request,
+                                       PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -55,7 +55,7 @@ public:
   /**
    * Called when an ASK redirection error is received, and the request must be retried.
    * @param value supplies the ASK error response
-   * @return bool true if the request is succesfully redirected, false otherwise
+   * @return bool true if the request is successfully redirected, false otherwise
    */
   virtual bool onAskRedirection(Common::Redis::RespValue& value) PURE;
 };

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -53,7 +53,7 @@ void ProxyFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& ca
 void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {
   pending_requests_.emplace_back(*this);
   PendingRequest& request = pending_requests_.back();
-  CommandSplitter::SplitRequestPtr split = splitter_.makeRequest(*value, request);
+  CommandSplitter::SplitRequestPtr split = splitter_.makeRequest(std::move(value), request);
   if (split) {
     // The splitter can immediately respond and destroy the pending request. Only store the handle
     // if the request is still alive.

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -99,6 +99,16 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onFailure() {
   handleFailure(envoy::data::core::v2alpha::HealthCheckFailureType::NETWORK);
 }
 
+bool RedisHealthChecker::RedisActiveHealthCheckSession::onMovedRedirection(
+    NetworkFilters::Common::Redis::RespValue&) {
+  return false;
+}
+
+bool RedisHealthChecker::RedisActiveHealthCheckSession::onAskRedirection(
+    NetworkFilters::Common::Redis::RespValue&) {
+  return false;
+}
+
 void RedisHealthChecker::RedisActiveHealthCheckSession::onTimeout() {
   current_request_->cancel();
   current_request_ = nullptr;

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -62,6 +62,8 @@ private:
     // Extensions::NetworkFilters::RedisProxy::ConnPool::PoolCallbacks
     void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;
+    bool onMovedRedirection(NetworkFilters::Common::Redis::RespValue& value) override;
+    bool onAskRedirection(NetworkFilters::Common::Redis::RespValue& value) override;
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -35,6 +35,10 @@ class NullInstanceImpl : public ConnPool::Instance {
                                      ConnPool::PoolCallbacks&) override {
     return nullptr;
   }
+  ConnPool::PoolRequest* redirectRequest(const std::string&, const Common::Redis::RespValue&,
+                                         ConnPool::PoolCallbacks&) override {
+    return nullptr;
+  }
 };
 
 class CommandLookUpSpeedTest {

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -86,6 +86,8 @@ public:
 
   MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
   MOCK_METHOD0(onFailure, void());
+  MOCK_METHOD1(onMovedRedirection, bool(Common::Redis::RespValue& value));
+  MOCK_METHOD1(onAskRedirection, bool(Common::Redis::RespValue& value));
 };
 
 class MockInstance : public Instance {
@@ -96,6 +98,9 @@ public:
   MOCK_METHOD3(makeRequest,
                PoolRequest*(const std::string& hash_key, const Common::Redis::RespValue& request,
                             PoolCallbacks& callbacks));
+  MOCK_METHOD3(redirectRequest,
+               PoolRequest*(const std::string& host_address,
+                            const Common::Redis::RespValue& request, PoolCallbacks& callbacks));
 };
 
 } // namespace ConnPool
@@ -128,6 +133,11 @@ public:
   SplitRequestPtr makeRequest(const Common::Redis::RespValue& request,
                               SplitCallbacks& callbacks) override {
     return SplitRequestPtr{makeRequest_(request, callbacks)};
+  }
+
+  SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request,
+                              SplitCallbacks& callbacks) override {
+    return SplitRequestPtr{makeRequest_(*request, callbacks)};
   }
 
   MOCK_METHOD2(makeRequest_,


### PR DESCRIPTION
This PR is for inspection and feedback only. I'm still working on extending unit testing...

- initial refactoring to ensure the original request RespValue
is saved for request retrying

- additional initial changes to support new PoolCallbacks for moved
and ask redirection at the command splitter request level

-- added host_address_map to lookup cluster hosts by address, and
code to keep this map in sync with host changes and cluster changes,
and unit test modifications

-- added ConnPool redirectRequest() interface to create a new request
via the requested client connection

- SingleServerRequest::onMovedRedirection() and SingleServerRequest::onAskRedirection()

- fragmented requests-based redirection callback support

- RespValue copy constructor, copy assignment, and move constructor
methods (no move assignment defined as it led to ambiguous method
resolution error in compiling the code)

- added cluster statistics, upstream_internal_redirect_succeeded_total
and upstream_internal_redirect_failed_total in ClientImpl::onRespValue()
callback

Signed-off-by: Mitch Sukalski <mitch.sukalski@workday.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
