### PR TITLE
upstream: fix oss-fuzz issue #11329.

### DIFF
--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1429,8 +1429,11 @@ TEST_F(StaticClusterImplTest, MalformedHostIP) {
       "setting cluster type to 'STRICT_DNS' or 'LOGICAL_DNS'");
 }
 
+// Test for oss-fuzz issue #11329
+// (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11329). If no
+// hosts were specified in endpoints but a priority value > 0 there, a
+// crash would happen.
 TEST_F(StaticClusterImplTest, NoHostsTest) {
-
   const std::string yaml = R"EOF(
     name: staticcluster
     connect_timeout: 0.25s
@@ -1441,9 +1444,8 @@ TEST_F(StaticClusterImplTest, NoHostsTest) {
   )EOF";
 
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats_.createScope(fmt::format(
-      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
-                                                            : cluster_config.alt_stat_name()));
+  Envoy::Stats::ScopePtr scope =
+      stats_.createScope(fmt::format("cluster.{}.", cluster_config.name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, random_, stats_,
       singleton_manager_, tls_, *api_);

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1429,6 +1429,30 @@ TEST_F(StaticClusterImplTest, MalformedHostIP) {
       "setting cluster type to 'STRICT_DNS' or 'LOGICAL_DNS'");
 }
 
+TEST_F(StaticClusterImplTest, NoHostsTest) {
+
+  const std::string yaml = R"EOF(
+    name: staticcluster
+    connect_timeout: 0.25s
+    load_assignment:
+      cluster_name: foo
+      endpoints:
+      - priority: 1
+  )EOF";
+
+  envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
+  Envoy::Stats::ScopePtr scope = stats_.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
+  Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
+      admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, random_, stats_,
+      singleton_manager_, tls_, *api_);
+  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  cluster.initialize([] {});
+
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+}
+
 TEST(ClusterDefinitionTest, BadClusterConfig) {
   const std::string json = R"EOF(
   {

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5705296232579072
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5705296232579072
@@ -1,0 +1,1 @@
+static_resources {   clusters {     name: " "     connect_timeout {       nanos: 6     }     load_assignment {       cluster_name: " "       endpoints {         priority: 4       }     }   } } 


### PR DESCRIPTION
Description:

Fix oss-fuzz issue #11329. If no hosts were specified in `endpoints` but a `priority` value was there, a crash would happen when the `hosts` pointer was dereferenced. This is part of the effort started at https://github.com/envoyproxy/envoy/issues/4709.

Risk Level: low
Testing: local fuzzing
