### PR TITLE
watcher: notify when watched files are modified

### DIFF
--- a/include/envoy/filesystem/watcher.h
+++ b/include/envoy/filesystem/watcher.h
@@ -20,6 +20,7 @@ public:
 
   struct Events {
     static const uint32_t MovedTo = 0x1;
+    static const uint32_t Modified = 0x2;
   };
 
   virtual ~Watcher() {}

--- a/source/common/filesystem/kqueue/watcher_impl.cc
+++ b/source/common/filesystem/kqueue/watcher_impl.cc
@@ -69,7 +69,7 @@ WatcherImpl::FileWatchPtr WatcherImpl::addWatch(const std::string& path, uint32_
   watch->callback_ = cb;
   watch->watching_dir_ = watching_dir;
 
-  int flags = NOTE_DELETE | NOTE_RENAME;
+  int flags = NOTE_DELETE | NOTE_RENAME | NOTE_WRITE;
   if (watching_dir) {
     flags = NOTE_DELETE | NOTE_WRITE;
   }
@@ -149,6 +149,9 @@ void WatcherImpl::onKqueueEvent() {
 
       if (event.fflags & NOTE_RENAME) {
         events |= Events::MovedTo;
+      }
+      if (event.fflags & NOTE_WRITE) {
+        events |= Events::Modified;
       }
     }
 

--- a/source/common/filesystem/kqueue/watcher_impl.cc
+++ b/source/common/filesystem/kqueue/watcher_impl.cc
@@ -69,7 +69,7 @@ WatcherImpl::FileWatchPtr WatcherImpl::addWatch(const std::string& path, uint32_
   watch->callback_ = cb;
   watch->watching_dir_ = watching_dir;
 
-  int flags = NOTE_DELETE | NOTE_RENAME | NOTE_WRITE;
+  u_int flags = NOTE_DELETE | NOTE_RENAME | NOTE_WRITE;
   if (watching_dir) {
     flags = NOTE_DELETE | NOTE_WRITE;
   }

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -91,6 +91,25 @@ TEST_F(WatcherImplTest, Create) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
+TEST_F(WatcherImplTest, Modify) {
+  Filesystem::WatcherPtr watcher = dispatcher_->createFilesystemWatcher();
+
+  TestUtility::createDirectory(TestEnvironment::temporaryPath("envoy_test"));
+  std::ofstream file(TestEnvironment::temporaryPath("envoy_test/watcher_target"));
+
+  WatchCallback callback;
+  EXPECT_CALL(callback, called(Watcher::Events::Modified));
+  watcher->addWatch(TestEnvironment::temporaryPath("envoy_test/watcher_target"),
+                    Watcher::Events::Modified, [&](uint32_t events) -> void {
+                      callback.called(events);
+                      dispatcher_->exit();
+                    });
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+
+  file << "text" << std::flush;
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+}
+
 TEST_F(WatcherImplTest, BadPath) {
   Filesystem::WatcherPtr watcher = dispatcher_->createFilesystemWatcher();
 

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -98,7 +98,6 @@ TEST_F(WatcherImplTest, Modify) {
   std::ofstream file(TestEnvironment::temporaryPath("envoy_test/watcher_target"));
 
   WatchCallback callback;
-  EXPECT_CALL(callback, called(Watcher::Events::Modified));
   watcher->addWatch(TestEnvironment::temporaryPath("envoy_test/watcher_target"),
                     Watcher::Events::Modified, [&](uint32_t events) -> void {
                       callback.called(events);
@@ -107,6 +106,7 @@ TEST_F(WatcherImplTest, Modify) {
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file << "text" << std::flush;
+  EXPECT_CALL(callback, called(Watcher::Events::Modified));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 }
 


### PR DESCRIPTION
The file system watcher previously only reported file movement events,
but it's also useful to track changes to watched files (to trigger a
reload, for example).

This change adds support for tracking file modification events reports
them using a new Watcher::Events::Modified. Both inotify (IN_MODIFY) and
kqueue (NOTE_WRITE) are supported.

This also reduces the set of watched inotify events to just the ones we
need: IN_MODIFY | IN_MOVED_TO.

Risk Level: Low (nothing is using this new event type yet)
Testing: New unit test (tested on macOS and Linux)

Signed-off-by: Jon Parise <jon@pinterest.com>