### PR TITLE
Wire up panic mode subset to receive updates

### DIFF
--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -35,6 +35,25 @@ SubsetLoadBalancer::SubsetLoadBalancer(
       scale_locality_weight_(subsets.scaleLocalityWeight()) {
   ASSERT(subsets.isEnabled());
 
+  if (fallback_policy_ != envoy::api::v2::Cluster::LbSubsetConfig::NO_FALLBACK) {
+    HostPredicate predicate;
+    if (fallback_policy_ == envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT) {
+      predicate = [](const Host&) -> bool { return true; };
+
+      ENVOY_LOG(debug, "subset lb: creating any-endpoint fallback load balancer");
+    } else {
+      predicate = std::bind(&SubsetLoadBalancer::hostMatches, this, default_subset_metadata_,
+                            std::placeholders::_1);
+
+      ENVOY_LOG(debug, "subset lb: creating fallback load balancer for {}",
+                describeMetadata(default_subset_metadata_));
+    }
+
+    fallback_subset_ = std::make_unique<LbSubsetEntry>();
+    fallback_subset_->priority_subset_ = std::make_unique<PrioritySubsetImpl>(
+        *this, predicate, locality_weight_aware_, scale_locality_weight_);
+  }
+
   if (subsets.panicModeAny()) {
     HostPredicate predicate = [](const Host&) -> bool { return true; };
 
@@ -186,33 +205,12 @@ SubsetLoadBalancer::LbSubsetEntryPtr SubsetLoadBalancer::findSubset(
 
 void SubsetLoadBalancer::updateFallbackSubset(uint32_t priority, const HostVector& hosts_added,
                                               const HostVector& hosts_removed) {
-  if (fallback_policy_ == envoy::api::v2::Cluster::LbSubsetConfig::NO_FALLBACK) {
+  if (fallback_subset_ == nullptr) {
     ENVOY_LOG(debug, "subset lb: fallback load balancer disabled");
     return;
   }
 
-  if (fallback_subset_ == nullptr) {
-    // First update: create the default host subset.
-    HostPredicate predicate;
-    if (fallback_policy_ == envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT) {
-      predicate = [](const Host&) -> bool { return true; };
-
-      ENVOY_LOG(debug, "subset lb: creating any-endpoint fallback load balancer");
-    } else {
-      predicate = std::bind(&SubsetLoadBalancer::hostMatches, this, default_subset_metadata_,
-                            std::placeholders::_1);
-
-      ENVOY_LOG(debug, "subset lb: creating fallback load balancer for {}",
-                describeMetadata(default_subset_metadata_));
-    }
-
-    fallback_subset_.reset(new LbSubsetEntry());
-    fallback_subset_->priority_subset_.reset(
-        new PrioritySubsetImpl(*this, predicate, locality_weight_aware_, scale_locality_weight_));
-    return;
-  }
-
-  // Subsequent updates: add/remove hosts.
+  // Add/remove hosts.
   fallback_subset_->priority_subset_->update(priority, hosts_added, hosts_removed);
 
   // Same thing for the panic mode subset.

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -42,8 +42,8 @@ SubsetLoadBalancer::SubsetLoadBalancer(
 
       ENVOY_LOG(debug, "subset lb: creating any-endpoint fallback load balancer");
     } else {
-      predicate = [this](const Host&) -> bool {
-        return hostMaches(default_subset_metadata_, host);
+      predicate = [this](const Host& host) -> bool {
+        return hostMatches(default_subset_metadata_, host);
       };
 
       ENVOY_LOG(debug, "subset lb: creating fallback load balancer for {}",
@@ -253,7 +253,9 @@ void SubsetLoadBalancer::processSubsets(
           if (entry->initialized()) {
             update_cb(entry);
           } else {
-            HostPredicate predicate = [this](const Host&) -> bool { return hostMaches(kvs, host); };
+            HostPredicate predicate = [this](const Host& host) -> bool {
+              return hostMatches(kvs, host);
+            };
             new_cb(entry, predicate, kvs, adding_hosts);
           }
         }

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -253,7 +253,7 @@ void SubsetLoadBalancer::processSubsets(
           if (entry->initialized()) {
             update_cb(entry);
           } else {
-            HostPredicate predicate = [this](const Host& host) -> bool {
+            HostPredicate predicate = [this, kvs](const Host& host) -> bool {
               return hostMatches(kvs, host);
             };
             new_cb(entry, predicate, kvs, adding_hosts);

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -214,6 +214,11 @@ void SubsetLoadBalancer::updateFallbackSubset(uint32_t priority, const HostVecto
 
   // Subsequent updates: add/remove hosts.
   fallback_subset_->priority_subset_->update(priority, hosts_added, hosts_removed);
+
+  // Same thing for the panic mode subset.
+  if (panic_mode_subset_ != nullptr) {
+    panic_mode_subset_->priority_subset_->update(priority, hosts_added, hosts_removed);
+  }
 }
 
 // Iterates over the added and removed hosts, looking up an LbSubsetEntryPtr for each. For every

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -42,8 +42,9 @@ SubsetLoadBalancer::SubsetLoadBalancer(
 
       ENVOY_LOG(debug, "subset lb: creating any-endpoint fallback load balancer");
     } else {
-      predicate = std::bind(&SubsetLoadBalancer::hostMatches, this, default_subset_metadata_,
-                            std::placeholders::_1);
+      predicate = [this](const Host&) -> bool {
+        return hostMaches(default_subset_metadata_, host);
+      };
 
       ENVOY_LOG(debug, "subset lb: creating fallback load balancer for {}",
                 describeMetadata(default_subset_metadata_));
@@ -252,9 +253,7 @@ void SubsetLoadBalancer::processSubsets(
           if (entry->initialized()) {
             update_cb(entry);
           } else {
-            HostPredicate predicate =
-                std::bind(&SubsetLoadBalancer::hostMatches, this, kvs, std::placeholders::_1);
-
+            HostPredicate predicate = [this](const Host&) -> bool { return hostMaches(kvs, host); };
             new_cb(entry, predicate, kvs, adding_hosts);
           }
         }


### PR DESCRIPTION
The initial diff missed handling added/removed hosts, this
handles that.

While at this, lets move the fallback subset creation to the constructor
so that it's consistent with the panic mode subset.

Reported-by: @nezdolik
Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
