### PR TITLE
Set case_insensitive_enum_parsing to true whenever parsing JSON.

### DIFF
--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -165,7 +165,7 @@ void FilterJson::translateHttpConnectionManager(
         "}";
 
     // JSON schema has already validated that this is a valid JSON object.
-    MessageUtil::loadFromJson(deprecated_config, filter->mutable_config());
+    MessageUtil::loadFromJson(deprecated_config, *filter->mutable_config());
   }
 
   JSON_UTIL_SET_BOOL(json_config, proto_config, add_user_agent);

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -164,8 +164,10 @@ void FilterJson::translateHttpConnectionManager(
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +
         "}";
 
+    Protobuf::util::JsonParseOptions options;
+    options.case_insensitive_enum_parsing = true;
     const auto status =
-        Protobuf::util::JsonStringToMessage(deprecated_config, filter->mutable_config());
+        Protobuf::util::JsonStringToMessage(deprecated_config, filter->mutable_config(), options);
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
   }

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -164,12 +164,8 @@ void FilterJson::translateHttpConnectionManager(
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +
         "}";
 
-    Protobuf::util::JsonParseOptions options;
-    options.case_insensitive_enum_parsing = true;
-    const auto status =
-        Protobuf::util::JsonStringToMessage(deprecated_config, filter->mutable_config(), options);
     // JSON schema has already validated that this is a valid JSON object.
-    ASSERT(status.ok());
+    MessageUtil::loadFromJson(deprecated_config, filter->mutable_config());
   }
 
   JSON_UTIL_SET_BOOL(json_config, proto_config, add_user_agent);

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -81,10 +81,10 @@ public:
     envoy::api::v2::DiscoveryResponse message;
     Protobuf::util::JsonParseOptions options;
     options.case_insensitive_enum_parsing = true;
-    const auto status =
-        Protobuf::util::JsonStringToMessage(response.bodyAsString(), &message, options);
-    if (!status.ok()) {
-      ENVOY_LOG(warn, "REST config JSON conversion error: {}", status.ToString());
+    try {
+      MessageUtil::loadFromJson(response.bodyAsString(), &message);
+    } catch (const EnvoyException& e) {
+      ENVOY_LOG(warn, "REST config JSON conversion error: {}", e,what());
       handleFailure(nullptr);
       return;
     }

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -84,7 +84,7 @@ public:
     try {
       MessageUtil::loadFromJson(response.bodyAsString(), &message);
     } catch (const EnvoyException& e) {
-      ENVOY_LOG(warn, "REST config JSON conversion error: {}", e,what());
+      ENVOY_LOG(warn, "REST config JSON conversion error: {}", e.what());
       handleFailure(nullptr);
       return;
     }

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -79,7 +79,10 @@ public:
 
   void parseResponse(const Http::Message& response) override {
     envoy::api::v2::DiscoveryResponse message;
-    const auto status = Protobuf::util::JsonStringToMessage(response.bodyAsString(), &message);
+    Protobuf::util::JsonParseOptions options;
+    options.case_insensitive_enum_parsing = true;
+    const auto status = Protobuf::util::JsonStringToMessage(
+        response.bodyAsString(), &message, options);
     if (!status.ok()) {
       ENVOY_LOG(warn, "REST config JSON conversion error: {}", status.ToString());
       handleFailure(nullptr);

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -79,10 +79,8 @@ public:
 
   void parseResponse(const Http::Message& response) override {
     envoy::api::v2::DiscoveryResponse message;
-    Protobuf::util::JsonParseOptions options;
-    options.case_insensitive_enum_parsing = true;
     try {
-      MessageUtil::loadFromJson(response.bodyAsString(), &message);
+      MessageUtil::loadFromJson(response.bodyAsString(), message);
     } catch (const EnvoyException& e) {
       ENVOY_LOG(warn, "REST config JSON conversion error: {}", e.what());
       handleFailure(nullptr);

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -81,8 +81,8 @@ public:
     envoy::api::v2::DiscoveryResponse message;
     Protobuf::util::JsonParseOptions options;
     options.case_insensitive_enum_parsing = true;
-    const auto status = Protobuf::util::JsonStringToMessage(
-        response.bodyAsString(), &message, options);
+    const auto status =
+        Protobuf::util::JsonStringToMessage(response.bodyAsString(), &message, options);
     if (!status.ok()) {
       ENVOY_LOG(warn, "REST config JSON conversion error: {}", status.ToString());
       handleFailure(nullptr);

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -43,8 +43,10 @@ void LdsJson::translateListener(const Json::Object& json_listener,
     const std::string json_config =
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +
         "}";
-
-    const auto status = Protobuf::util::JsonStringToMessage(json_config, filter->mutable_config());
+    Protobuf::util::JsonParseOptions options;
+    options.case_insensitive_enum_parsing = true;
+    const auto status = Protobuf::util::JsonStringToMessage(
+        json_config, filter->mutable_config(), options);
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
   }

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -45,8 +45,8 @@ void LdsJson::translateListener(const Json::Object& json_listener,
         "}";
     Protobuf::util::JsonParseOptions options;
     options.case_insensitive_enum_parsing = true;
-    const auto status = Protobuf::util::JsonStringToMessage(
-        json_config, filter->mutable_config(), options);
+    const auto status =
+        Protobuf::util::JsonStringToMessage(json_config, filter->mutable_config(), options);
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
   }

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -45,7 +45,7 @@ void LdsJson::translateListener(const Json::Object& json_listener,
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +
         "}";
     // JSON schema has already validated that this is a valid JSON object.
-    MessageUtil::loadFromJson(json_config, filter->mutable_config());
+    MessageUtil::loadFromJson(json_config, *filter->mutable_config());
   }
 
   const std::string drain_type = json_listener.getString("drain_type", "default");

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -9,6 +9,7 @@
 #include "common/config/utility.h"
 #include "common/json/config_schemas.h"
 #include "common/network/utility.h"
+#include "common/protobuf/utility.h"
 
 #include "extensions/filters/network/well_known_names.h"
 
@@ -43,12 +44,8 @@ void LdsJson::translateListener(const Json::Object& json_listener,
     const std::string json_config =
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +
         "}";
-    Protobuf::util::JsonParseOptions options;
-    options.case_insensitive_enum_parsing = true;
-    const auto status =
-        Protobuf::util::JsonStringToMessage(json_config, filter->mutable_config(), options);
     // JSON schema has already validated that this is a valid JSON object.
-    ASSERT(status.ok());
+    MessageUtil::loadFromJson(json_config, filter->mutable_config());
   }
 
   const std::string drain_type = json_listener.getString("drain_type", "default");

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -95,6 +95,7 @@ void MessageUtil::loadFromJsonEx(const std::string& json, Protobuf::Message& mes
   if (proto_unknown_fields == ProtoUnknownFieldsMode::Allow) {
     options.ignore_unknown_fields = true;
   }
+  options.case_insensitive_enum_parsing = true;
   const auto status = Protobuf::util::JsonStringToMessage(json, &message, options);
   if (!status.ok()) {
     throw EnvoyException("Unable to parse JSON as proto (" + status.ToString() + "): " + json);

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -72,7 +72,9 @@ public:
     file_json.pop_back();
     file_json += "]}";
     envoy::api::v2::DiscoveryResponse response_pb;
-    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(file_json, &response_pb).ok());
+    Protobuf::util::JsonParseOptions options;
+    options.case_insensitive_enum_parsing = true;
+    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(file_json, &response_pb).ok(), options);
     EXPECT_CALL(callbacks_,
                 onConfigUpdate(
                     RepeatedProtoEq(

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -73,7 +73,7 @@ public:
     file_json.pop_back();
     file_json += "]}";
     envoy::api::v2::DiscoveryResponse response_pb;
-    MessageUtil::loadFromJson(file_json, &response_pb);
+    MessageUtil::loadFromJson(file_json, response_pb);
     EXPECT_CALL(callbacks_,
                 onConfigUpdate(
                     RepeatedProtoEq(

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -74,7 +74,7 @@ public:
     envoy::api::v2::DiscoveryResponse response_pb;
     Protobuf::util::JsonParseOptions options;
     options.case_insensitive_enum_parsing = true;
-    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(file_json, &response_pb).ok(), options);
+    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(file_json, &response_pb, options).ok());
     EXPECT_CALL(callbacks_,
                 onConfigUpdate(
                     RepeatedProtoEq(

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -7,6 +7,7 @@
 #include "common/config/filesystem_subscription_impl.h"
 #include "common/config/utility.h"
 #include "common/event/dispatcher_impl.h"
+#include "common/protobuf/utility.h"
 
 #include "test/common/config/subscription_test_harness.h"
 #include "test/mocks/config/mocks.h"
@@ -72,9 +73,7 @@ public:
     file_json.pop_back();
     file_json += "]}";
     envoy::api::v2::DiscoveryResponse response_pb;
-    Protobuf::util::JsonParseOptions options;
-    options.case_insensitive_enum_parsing = true;
-    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(file_json, &response_pb, options).ok());
+    MessageUtil::loadFromJson(file_json, &response_pb);
     EXPECT_CALL(callbacks_,
                 onConfigUpdate(
                     RepeatedProtoEq(

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -10,6 +10,7 @@
 #include "common/config/utility.h"
 #include "common/http/message_impl.h"
 #include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
 
 #include "test/common/config/subscription_test_harness.h"
 #include "test/mocks/config/mocks.h"
@@ -112,9 +113,7 @@ public:
     response_json.pop_back();
     response_json += "]}";
     envoy::api::v2::DiscoveryResponse response_pb;
-    Protobuf::util::JsonParseOptions options;
-    options.case_insensitive_enum_parsing = true;
-    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(response_json, &response_pb, options).ok());
+    MessageUtil::loadFromJson(response_json, &response_pb);
     Http::HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
     Http::MessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
     message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -114,7 +114,7 @@ public:
     envoy::api::v2::DiscoveryResponse response_pb;
     Protobuf::util::JsonParseOptions options;
     options.case_insensitive_enum_parsing = true;
-    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(response_json, &response_pb).ok(), options);
+    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(response_json, &response_pb, options).ok());
     Http::HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
     Http::MessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
     message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -113,7 +113,7 @@ public:
     response_json.pop_back();
     response_json += "]}";
     envoy::api::v2::DiscoveryResponse response_pb;
-    MessageUtil::loadFromJson(response_json, &response_pb);
+    MessageUtil::loadFromJson(response_json, response_pb);
     Http::HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
     Http::MessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
     message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -112,7 +112,9 @@ public:
     response_json.pop_back();
     response_json += "]}";
     envoy::api::v2::DiscoveryResponse response_pb;
-    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(response_json, &response_pb).ok());
+    Protobuf::util::JsonParseOptions options;
+    options.case_insensitive_enum_parsing = true;
+    EXPECT_TRUE(Protobuf::util::JsonStringToMessage(response_json, &response_pb).ok(), options);
     Http::HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
     Http::MessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
     message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -1,5 +1,7 @@
 #include "test/integration/http_protocol_integration.h"
 
+#include "common/protobuf/utility.h"
+
 namespace Envoy {
 namespace {
 
@@ -56,9 +58,7 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
 
 ConfigHelper::HttpModifierFunction overrideConfig(const std::string& json_config) {
   ProtobufWkt::Struct pfc;
-  Protobuf::util::JsonParseOptions options;
-  options.case_insensitive_enum_parsing = true;
-  RELEASE_ASSERT(Protobuf::util::JsonStringToMessage(json_config, &pfc, options).ok(), "");
+  MessageUtil::loadFromJson(json_config, &pfc);
 
   return
       [pfc](

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -56,7 +56,9 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
 
 ConfigHelper::HttpModifierFunction overrideConfig(const std::string& json_config) {
   ProtobufWkt::Struct pfc;
-  RELEASE_ASSERT(Protobuf::util::JsonStringToMessage(json_config, &pfc).ok(), "");
+  Protobuf::util::JsonParseOptions options;
+  options.case_insensitive_enum_parsing = true;
+  RELEASE_ASSERT(Protobuf::util::JsonStringToMessage(json_config, &pfc).ok(), "", options);
 
   return
       [pfc](

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -58,7 +58,7 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
 
 ConfigHelper::HttpModifierFunction overrideConfig(const std::string& json_config) {
   ProtobufWkt::Struct pfc;
-  MessageUtil::loadFromJson(json_config, &pfc);
+  MessageUtil::loadFromJson(json_config, pfc);
 
   return
       [pfc](

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -58,7 +58,7 @@ ConfigHelper::HttpModifierFunction overrideConfig(const std::string& json_config
   ProtobufWkt::Struct pfc;
   Protobuf::util::JsonParseOptions options;
   options.case_insensitive_enum_parsing = true;
-  RELEASE_ASSERT(Protobuf::util::JsonStringToMessage(json_config, &pfc).ok(), "", options);
+  RELEASE_ASSERT(Protobuf::util::JsonStringToMessage(json_config, &pfc, options).ok(), "");
 
   return
       [pfc](

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -1,6 +1,6 @@
-#include "test/integration/http_protocol_integration.h"
-
 #include "common/protobuf/utility.h"
+
+#include "test/integration/http_protocol_integration.h"
 
 namespace Envoy {
 namespace {

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -95,7 +95,7 @@ TEST_P(RBACIntegrationTest, RouteOverride) {
   config_helper_.addConfigModifier(
       [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& cfg) {
         ProtobufWkt::Struct pfc;
-        MessageUtil::loadFromJson("{}", &pfc);
+        MessageUtil::loadFromJson("{}", pfc);
 
         auto* config = cfg.mutable_route_config()
                            ->mutable_virtual_hosts()

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/http/well_known_names.h"
 
+#include "common/protobuf/utility.h"
+
 #include "test/integration/http_protocol_integration.h"
 
 namespace Envoy {
@@ -93,9 +95,7 @@ TEST_P(RBACIntegrationTest, RouteOverride) {
   config_helper_.addConfigModifier(
       [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& cfg) {
         ProtobufWkt::Struct pfc;
-        Protobuf::util::JsonParseOptions options;
-        options.case_insensitive_enum_parsing = true;
-        ASSERT_TRUE(Protobuf::util::JsonStringToMessage("{}", &pfc, options).ok());
+        MessageUtil::loadFromJson("{}", &pfc);
 
         auto* config = cfg.mutable_route_config()
                            ->mutable_virtual_hosts()

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -93,7 +93,9 @@ TEST_P(RBACIntegrationTest, RouteOverride) {
   config_helper_.addConfigModifier(
       [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& cfg) {
         ProtobufWkt::Struct pfc;
-        ASSERT_TRUE(Protobuf::util::JsonStringToMessage("{}", &pfc).ok());
+        Protobuf::util::JsonParseOptions options;
+        options.case_insensitive_enum_parsing = true;
+        ASSERT_TRUE(Protobuf::util::JsonStringToMessage("{}", &pfc, options).ok());
 
         auto* config = cfg.mutable_route_config()
                            ->mutable_virtual_hosts()

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -1,6 +1,6 @@
-#include "extensions/filters/http/well_known_names.h"
-
 #include "common/protobuf/utility.h"
+
+#include "extensions/filters/http/well_known_names.h"
 
 #include "test/integration/http_protocol_integration.h"
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -440,9 +440,7 @@ def checkSourceLine(line, file_path, reportError):
   if not whitelistedForJsonStringToMessage(file_path) and 'JsonStringToMessage' in line:
     # Centralize all usage of JSON parsing so it is easier to make changes in JSON parsing
     # behavior.
-    reportError(
-        "Don't use Protobuf::util::JsonStringToMessage, use MessageUtil::loadFromJson."
-    )
+    reportError("Don't use Protobuf::util::JsonStringToMessage, use MessageUtil::loadFromJson.")
 
 
 def checkBuildLine(line, file_path, reportError):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -43,6 +43,9 @@ REAL_TIME_WHITELIST = ('./source/common/common/utility.h',
 SERIALIZE_AS_STRING_WHITELIST = ('./test/common/protobuf/utility_test.cc',
                                  './test/common/grpc/codec_test.cc')
 
+# Files in these paths can use Protobuf::util::JsonStringToMessage
+JSON_STRING_TO_MESSAGE_WHITELIST = ('./source/common/protobuf/utility.cc')
+
 CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-7")
 BUILDIFIER_PATH = os.getenv("BUILDIFIER_BIN", "$GOPATH/bin/buildifier")
 ENVOY_BUILD_FIXER_PATH = os.path.join(
@@ -222,6 +225,10 @@ def whitelistedForRealTime(file_path):
 
 def whitelistedForSerializeAsString(file_path):
   return file_path in SERIALIZE_AS_STRING_WHITELIST
+
+
+def whitelistedForJsonStringToMessage(file_path):
+  return file_path in JSON_STRING_TO_MESSAGE_WHITELIST
 
 
 def findSubstringAndReturnError(pattern, file_path, error_message):
@@ -429,6 +436,12 @@ def checkSourceLine(line, file_path, reportError):
     # use MessageUtil::hash instead.
     reportError(
         "Don't use MessageLite::SerializeAsString for generating deterministic serialization, use MessageUtil::hash instead."
+    )
+  if not whitelistedForJsonStringToMessage(file_path) and 'JsonStringToMessage' in line:
+    # Centralize all usage of JSON parsing so it is easier to make changes in JSON parsing
+    # behavior.
+    reportError(
+        "Don't use Protobuf::util::JsonStringToMessage, use MessageUtil::loadFromJson."
     )
 
 


### PR DESCRIPTION
Signed-off-by: Hao Nguyen <haon@google.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: Set case_insensitive_enum_parsing to true whenever parsing JSON. This is to retain existing behavior in Protobuf. We plan to set the default value of case_insensitive_enum_parsing to false in future Protobuf release to be consistent across all Protobuf supported languages. This change will ensure that the existing behavior in Envoy is kept even when the default value in Protobuf is changed in the future.
Risk Level: Low
Testing: No change in behavior
Docs Changes:
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
