### PR TITLE
config: move logging of full response to trace logging

### DIFF
--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -56,8 +56,9 @@ public:
     stats_.update_success_.inc();
     stats_.update_attempt_.inc();
     stats_.version_.set(HashUtil::xxHash64(version_info));
-    ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
-              resources.size(), RepeatedPtrUtil::debugString(typed_resources));
+    ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources with version {}", type_url_,
+        resources.size(), version_info);
+    ENVOY_LOG(trace, "resources: {}", RepeatedPtrUtil::debugString(typed_resources));
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -57,7 +57,7 @@ public:
     stats_.update_attempt_.inc();
     stats_.version_.set(HashUtil::xxHash64(version_info));
     ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources with version {}", type_url_,
-        resources.size(), version_info);
+              resources.size(), version_info);
     ENVOY_LOG(trace, "resources: {}", RepeatedPtrUtil::debugString(typed_resources));
   }
 


### PR DESCRIPTION
With large response bodies, this tends to seize up the process due to
log volume, making debug logging not very useful. This drops logging the
entire update to trace.

Also includes the resource version in the debug log line.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
