### PR TITLE
http: add ability to forward peer certificate chains

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -24,7 +24,7 @@ import "gogoproto/gogo.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-// [#comment:next free field: 30]
+// [#comment:next free field: 31]
 message HttpConnectionManager {
   enum CodecType {
     option (gogoproto.goproto_enum_prefix) = false;
@@ -268,28 +268,29 @@ message HttpConnectionManager {
   // is not desired it can be disabled.
   google.protobuf.BoolValue generate_request_id = 15;
 
-  // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
-  // header.
+  // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) and the
+  // :ref:`config_http_conn_man_headers_x-forwarded-client-cert-chain` (XFCC-chain) HTTP headers.
   enum ForwardClientCertDetails {
     option (gogoproto.goproto_enum_prefix) = false;
 
-    // Do not send the XFCC header to the next hop. This is the default value.
+    // Do not send the XFCC/XFCC-chain header to the next hop. This is the default value.
     SANITIZE = 0;
 
-    // When the client connection is mTLS (Mutual TLS), forward the XFCC header
-    // in the request.
+    // When the client connection is mTLS (Mutual TLS), forward the XFCC/XFCC-chain header in the
+    // request.
     FORWARD_ONLY = 1;
 
-    // When the client connection is mTLS, append the client certificate
-    // information to the request’s XFCC header and forward it.
+    // When the client connection is mTLS, append the client certificate information to the
+    // request’s XFCC header and forward it. Note that this option is not available while
+    // forwarding the XFCC-chain header.
     APPEND_FORWARD = 2;
 
-    // When the client connection is mTLS, reset the XFCC header with the client
-    // certificate information and send it to the next hop.
+    // When the client connection is mTLS, reset the XFCC/XFCC-chain header with the client
+    // certificate/client certificate chain information and send it to the next hop.
     SANITIZE_SET = 3;
 
-    // Always forward the XFCC header in the request, regardless of whether the
-    // client connection is mTLS.
+    // Always forward the XFCC/XFCC-chain header in the request, regardless of whether the client
+    // connection is mTLS.
     ALWAYS_FORWARD_ONLY = 4;
   };
 
@@ -326,6 +327,11 @@ message HttpConnectionManager {
   // *By* is always set when the client certificate presents the URI type Subject Alternative Name
   // value.
   SetCurrentClientCertDetails set_current_client_cert_details = 17;
+
+  // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert-chain`
+  // (XFCC-chain) HTTP header.
+  ForwardClientCertDetails forward_client_cert_chain_details = 30
+      [(validate.rules).enum.defined_only = true];
 
   // If proxy_100_continue is true, Envoy will proxy incoming "Expect:
   // 100-continue" headers upstream, and forward "100 Continue" responses

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -154,6 +154,25 @@ and the
 HTTP connection manager options. If *forward_client_cert_details* is unset, the XFCC header will be sanitized by
 default.
 
+.. _config_http_conn_man_headers_x-forwarded-client-cert-chain:
+
+x-forwarded-client-cert-chain
+-----------------------------
+
+*x-forwarded-client-cert-chain* (XFCC-chain) is a proxy header which indicates certificate chain
+information of clients that a request has flowed through on its way to the server. A proxy may
+choose to sanitize/forward the XFCC-chain header before proxying the request.
+
+The XFCC-chain header value is a concatenated set of URL encoded PEM encoded certificate strings.
+Each substring is either a leaf, intermediate, or a root certificate. If ",", ";" or "=" appear in a
+value, the value should be double-quoted. Double-quotes in the value should be replaced by
+backslash-double-quote (\").
+
+How Envoy processes XFCC-chain is specified by the
+:ref:`forward_client_cert_chain_details <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.forward_client_cert_chain_details>`
+HTTP connection manager option. If *forward_client_cert_chain_details* is unset, the XFCC-chain
+header will be sanitized by default.
+
 .. _config_http_conn_man_headers_x-forwarded-for:
 
 x-forwarded-for

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -38,6 +38,8 @@ Version history
 * http: added :ref:`max request headers size <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_kb>`. The default behaviour is unchanged.
 * http: added modifyDecodingBuffer/modifyEncodingBuffer to allow modifying the buffered request/response data.
 * http: added encodeComplete/decodeComplete. These are invoked at the end of the stream, after all data has been encoded/decoded respectively. Default implementation is a no-op.
+* http: added the ability to pass a URL encoded PEM encoded peer certificate chain in the
+  :ref:`config_http_conn_man_headers_x-forwarded-client-cert-chain` header.
 * redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
 * redis: added :ref:`success and error stats <config_network_filters_redis_proxy_per_command_stats>` for commands.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -292,6 +292,7 @@ private:
   HEADER_FUNC(Etag)                                                                                \
   HEADER_FUNC(Expect)                                                                              \
   HEADER_FUNC(ForwardedClientCert)                                                                 \
+  HEADER_FUNC(ForwardedClientCertChain)                                                            \
   HEADER_FUNC(ForwardedFor)                                                                        \
   HEADER_FUNC(ForwardedProto)                                                                      \
   HEADER_FUNC(GrpcAcceptEncoding)                                                                  \

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -303,6 +303,12 @@ public:
   virtual ForwardClientCertType forwardClientCert() PURE;
 
   /**
+   * @return ForwardClientCertType the configuration of how to forward the client cert chain
+   * information.
+   */
+  virtual ForwardClientCertType forwardClientCertChain() PURE;
+
+  /**
    * @return vector of ClientCertDetailsType the configuration of the current client cert's details
    * to be forwarded.
    */

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -68,6 +68,10 @@ private:
 
   static void mutateXfccRequestHeader(HeaderMap& request_headers, Network::Connection& connection,
                                       ConnectionManagerConfig& config);
+
+  static void mutateXfccChainRequestHeader(HeaderMap& request_headers,
+                                           Network::Connection& connection,
+                                           ConnectionManagerConfig& config);
 };
 
 } // namespace Http

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -67,6 +67,7 @@ public:
   const LowerCaseString Etag{"etag"};
   const LowerCaseString Expect{"expect"};
   const LowerCaseString ForwardedClientCert{"x-forwarded-client-cert"};
+  const LowerCaseString ForwardedClientCertChain{"x-forwarded-client-cert-chain"};
   const LowerCaseString ForwardedFor{"x-forwarded-for"};
   const LowerCaseString ForwardedHost{"x-forwarded-host"};
   const LowerCaseString ForwardedProto{"x-forwarded-proto"};

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -193,6 +193,30 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     set_current_client_cert_details_.push_back(Http::ClientCertDetailsType::DNS);
   }
 
+  switch (config.forward_client_cert_details()) {
+  case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::SANITIZE:
+    forward_client_cert_chain_ = Http::ForwardClientCertType::Sanitize;
+    break;
+  case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
+      FORWARD_ONLY:
+    forward_client_cert_chain_ = Http::ForwardClientCertType::ForwardOnly;
+    break;
+  case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
+      SANITIZE_SET:
+    forward_client_cert_chain_ = Http::ForwardClientCertType::SanitizeSet;
+    break;
+  case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
+      ALWAYS_FORWARD_ONLY:
+    forward_client_cert_chain_ = Http::ForwardClientCertType::AlwaysForwardOnly;
+    break;
+  case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
+      APPEND_FORWARD:
+    throw EnvoyException("Error: the APPEND_FORWARD mode is not available for the "
+                         "x-forwarded-client-cert-chain header");
+  default:
+    NOT_REACHED_GCOVR_EXCL_LINE;
+  }
+
   if (config.has_add_user_agent() && config.add_user_agent().value()) {
     user_agent_ = context_.localInfo().clusterName();
   }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -116,6 +116,9 @@ public:
   bool skipXffAppend() const override { return skip_xff_append_; }
   const std::string& via() const override { return via_; }
   Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
+  Http::ForwardClientCertType forwardClientCertChain() override {
+    return forward_client_cert_chain_;
+  }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }
@@ -148,6 +151,7 @@ private:
   const bool skip_xff_append_;
   const std::string via_;
   Http::ForwardClientCertType forward_client_cert_;
+  Http::ForwardClientCertType forward_client_cert_chain_;
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   Router::RouteConfigProviderManager& route_config_provider_manager_;
   CodecType codec_type_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -117,6 +117,9 @@ public:
   Http::ForwardClientCertType forwardClientCert() override {
     return Http::ForwardClientCertType::Sanitize;
   }
+  Http::ForwardClientCertType forwardClientCertChain() override {
+    return Http::ForwardClientCertType::Sanitize;
+  }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -107,6 +107,9 @@ public:
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
   Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
+  Http::ForwardClientCertType forwardClientCertChain() override {
+    return forward_client_cert_chain_;
+  }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }
@@ -138,6 +141,7 @@ public:
   std::chrono::milliseconds delayed_close_timeout_{};
   bool use_remote_address_{true};
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
+  Http::ForwardClientCertType forward_client_cert_chain_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   Network::Address::Ipv4Instance local_address_{"127.0.0.1"};
   absl::optional<std::string> user_agent_;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -248,6 +248,9 @@ public:
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
   Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
+  Http::ForwardClientCertType forwardClientCertChain() override {
+    return forward_client_cert_chain_;
+  }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }
@@ -279,6 +282,7 @@ public:
   bool use_remote_address_{true};
   Http::DefaultInternalAddressConfig internal_address_config_;
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
+  Http::ForwardClientCertType forward_client_cert_chain_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   absl::optional<std::string> user_agent_;
   uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -68,6 +68,7 @@ public:
   MOCK_CONST_METHOD0(skipXffAppend, bool());
   MOCK_CONST_METHOD0(via, const std::string&());
   MOCK_METHOD0(forwardClientCert, Http::ForwardClientCertType());
+  MOCK_METHOD0(forwardClientCertChain, Http::ForwardClientCertType());
   MOCK_CONST_METHOD0(setCurrentClientCertDetails,
                      const std::vector<Http::ClientCertDetailsType>&());
   MOCK_METHOD0(localAddress, const Network::Address::Instance&());


### PR DESCRIPTION
Description: This adds a new header named `x-forwarded-client-cert-chain` in the HCM in
order to forward peer certificate chains.
Risk Level: Low
Testing: Pending
Docs Changes: Added documentation about `x-forwarded-client-cert-chain`
Release Notes: Added a note about the feature
Fixes #6135

/cc @PiotrSikora @lizan

I'll add/update the tests once we're okay with the implementation.