### PR TITLE
Update example ADS bootstrap config to specify TCP Keep-Alive options

### DIFF
--- a/api/XDS_PROTOCOL.md
+++ b/api/XDS_PROTOCOL.md
@@ -282,10 +282,10 @@ static_resources:
     lb_policy: ROUND_ROBIN
     http2_protocol_options: {}
     upstream_connection_options:
+      # configure a TCP keep-alive to detect and reconnect to the admin
+      # server in the event of a TCP socket disconnection
       tcp_keepalive:
-        keepalive_probes: 3
-        keepalive_time: 30
-        keepalive_interval: 10
+        ...
 admin:
   ...
 

--- a/api/XDS_PROTOCOL.md
+++ b/api/XDS_PROTOCOL.md
@@ -281,6 +281,11 @@ static_resources:
         port_value: <ADS management server port>
     lb_policy: ROUND_ROBIN
     http2_protocol_options: {}
+    upstream_connection_options:
+      tcp_keepalive:
+        keepalive_probes: 3
+        keepalive_time: 30
+        keepalive_interval: 10
 admin:
   ...
 

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -158,6 +158,11 @@ on 127.0.0.3:5678 is provided below:
       type: STATIC
       lb_policy: ROUND_ROBIN
       http2_protocol_options: {}
+      upstream_connection_options:
+        tcp_keepalive:
+          keepalive_probes: 3
+          keepalive_time: 30
+          keepalive_interval: 10
       load_assignment:
         cluster_name: xds_cluster
         endpoints:
@@ -230,6 +235,11 @@ below:
       type: STATIC
       lb_policy: ROUND_ROBIN
       http2_protocol_options: {}
+      upstream_connection_options:
+        tcp_keepalive:
+          keepalive_probes: 3
+          keepalive_time: 30
+          keepalive_interval: 10
       load_assignment:
         cluster_name: xds_cluster
         endpoints:
@@ -593,7 +603,7 @@ Management Server has a statistics tree rooted at *control_plane.* with the foll
    connected_state, BoolIndicator, Current connection state with management server
    rate_limit_enforced, Counter, Total number of times rate limit was enforced for management server requests
    pending_requests, Gauge, Total number of pending requests when the rate limit was enforced
-   
+
 .. _config_overview_v2_status:
 
 Status

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -159,10 +159,9 @@ on 127.0.0.3:5678 is provided below:
       lb_policy: ROUND_ROBIN
       http2_protocol_options: {}
       upstream_connection_options:
-        tcp_keepalive:
-          keepalive_probes: 3
-          keepalive_time: 30
-          keepalive_interval: 10
+        # configure a TCP keep-alive to detect and reconnect to the admin
+        # server in the event of a TCP socket half open connection
+        tcp_keepalive: {}
       load_assignment:
         cluster_name: xds_cluster
         endpoints:
@@ -176,6 +175,10 @@ on 127.0.0.3:5678 is provided below:
 Notice above that *xds_cluster* is defined to point Envoy at the management server. Even in
 an otherwise completely dynamic configurations, some static resources need to
 be defined to point Envoy at its xDS management server(s).
+
+It's important to set appropriate :ref:`TCP Keep-Alive options <envoy_api_msg_core.TcpKeepalive>`
+in the `tcp_keepalive` block. This will help detect TCP half open connections to the xDS management
+server and re-establish a full connection.
 
 In the above example, the EDS management server could then return a proto encoding of a
 :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`:
@@ -236,10 +239,9 @@ below:
       lb_policy: ROUND_ROBIN
       http2_protocol_options: {}
       upstream_connection_options:
-        tcp_keepalive:
-          keepalive_probes: 3
-          keepalive_time: 30
-          keepalive_interval: 10
+        # configure a TCP keep-alive to detect and reconnect to the admin
+        # server in the event of a TCP socket half open connection
+        tcp_keepalive: {}
       load_assignment:
         cluster_name: xds_cluster
         endpoints:


### PR DESCRIPTION
Description: Update ADS protocol docs to specify a Keep-Alive so others consider adding it in. If the Keep-Alive parameters are not specified, it's very easy to end up in a TCP Half Open state during a network glitch/force disconnect where the Envoy thinks it's connected to the ADS server when it's not.
Risk Level: Low
Testing: 
Docs Changes: N/A
Release Notes: N/A

Somewhat fixes: https://github.com/envoyproxy/envoy/issues/5173