### PR TITLE
mysql_filter: add a warning about compatibility

### DIFF
--- a/docs/root/configuration/network_filters/mysql_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mysql_proxy_filter.rst
@@ -15,6 +15,11 @@ as operations performed on each table.
    development. Capabilities will be expanded over time and the
    configuration structures are likely to change.
 
+.. warning::
+
+   The mysql_proxy filter was tested with MySQL v5.5. The filter may not work
+   other versions of MySQL due to differences in the protocol implementation.
+
 .. _config_network_filters_mysql_proxy_config:
 
 Configuration

--- a/docs/root/configuration/network_filters/mysql_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mysql_proxy_filter.rst
@@ -18,7 +18,7 @@ as operations performed on each table.
 .. warning::
 
    The mysql_proxy filter was tested with MySQL v5.5. The filter may not work
-   other versions of MySQL due to differences in the protocol implementation.
+   with other versions of MySQL due to differences in the protocol implementation.
 
 .. _config_network_filters_mysql_proxy_config:
 


### PR DESCRIPTION
Description: This adds a warning to the MySQL filter docs regarding compatibility issues with the filter.
Risk Level: Low
Testing: N/A
Docs Changes: Updates the MySQL filter docs
Release Notes: N/A