### PR TITLE
enable envoy to be tested as external dependency

### DIFF
--- a/test/main.cc
+++ b/test/main.cc
@@ -23,10 +23,19 @@ int main(int argc, char** argv) {
 #endif
   Envoy::Thread::ThreadFactorySingleton::set(&Envoy::Thread::threadFactoryForTest());
 
-  Envoy::TestEnvironment::setEnvVar("TEST_RUNDIR",
-                                    (Envoy::TestEnvironment::getCheckedEnvVar("TEST_SRCDIR") + "/" +
-                                     Envoy::TestEnvironment::getCheckedEnvVar("TEST_WORKSPACE")),
-                                    1);
+  if (std::getenv("EXTERNAL_TEST") != nullptr) {
+    Envoy::TestEnvironment::setEnvVar(
+        "TEST_RUNDIR",
+        (Envoy::TestEnvironment::getCheckedEnvVar("TEST_SRCDIR") + "/" +
+         Envoy::TestEnvironment::getCheckedEnvVar("TEST_WORKSPACE") + "/external/envoy/"),
+        1);
+  } else {
+    Envoy::TestEnvironment::setEnvVar("TEST_RUNDIR",
+                                      (Envoy::TestEnvironment::getCheckedEnvVar("TEST_SRCDIR") +
+                                       "/" +
+                                       Envoy::TestEnvironment::getCheckedEnvVar("TEST_WORKSPACE")),
+                                      1);
+  }
 
   // Select whether to test only for IPv4, IPv6, or both. The default is to
   // test for both. Options are {"v4only", "v6only", "all"}. Set


### PR DESCRIPTION
Signed-off-by: William DeCoste <bdecoste@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: This change will enable running tests containing paths to scripts, data files, etc. from projects that include Envoy as a dependency (e.g. Istio Proxy). Can now run bazel test with a target such as "@envoy//test/..." by adding --test_env=EXTERNAL_TEST=true to .bazelrc
Risk Level: Low
Testing: Passes all standard tests
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue]
[Optional Deprecated:]
