### PR TITLE
Remove the dependency from TimeSystem to libevent by using the Event::Scheduler abstraction as a delegate.

### DIFF
--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -48,6 +48,5 @@ envoy_cc_library(
     hdrs = ["timer.h"],
     deps = [
         "//include/envoy/common:time_interface",
-        "//source/common/event:libevent_lib",
     ],
 )

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -63,7 +63,7 @@ public:
    * Creates a timer factory. This indirection enables thread-local timer-queue management,
    * so servers can have a separate timer-factory in each thread.
    */
-  virtual SchedulerPtr createScheduler(Libevent::BasePtr&) PURE;
+  virtual SchedulerPtr createScheduler(Scheduler& base_scheduler) PURE;
 };
 
 } // namespace Event

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -7,8 +7,6 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 
-#include "common/event/libevent.h"
-
 namespace Envoy {
 namespace Event {
 

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
     ],
     deps = [
         ":dispatcher_includes",
+        ":libevent_scheduler_lib",
         ":real_time_system_lib",
         "//include/envoy/common:time_interface",
         "//include/envoy/event:signal_interface",
@@ -35,18 +36,21 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "event_impl_base_lib",
+    srcs = ["event_impl_base.cc"],
+    hdrs = ["event_impl_base.h"],
+    external_deps = [
+        "event",
+    ],
+)
+
+envoy_cc_library(
     name = "real_time_system_lib",
-    srcs = [
-        "event_impl_base.cc",
-        "real_time_system.cc",
-        "timer_impl.cc",
-    ],
-    hdrs = [
-        "event_impl_base.h",
-        "real_time_system.h",
-        "timer_impl.h",
-    ],
+    srcs = ["real_time_system.cc"],
+    hdrs = ["real_time_system.h"],
     deps = [
+        ":event_impl_base_lib",
+        ":timer_lib",
         "//include/envoy/event:timer_interface",
         "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",
@@ -62,6 +66,7 @@ envoy_cc_library(
     ],
     deps = [
         ":libevent_lib",
+        ":libevent_scheduler_lib",
         "//include/envoy/api:api_interface",
         "//include/envoy/event:deferred_deletable",
         "//include/envoy/event:dispatcher_interface",
@@ -82,6 +87,31 @@ envoy_cc_library(
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:c_smart_ptr_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "libevent_scheduler_lib",
+    srcs = ["libevent_scheduler.cc"],
+    hdrs = ["libevent_scheduler.h"],
+    external_deps = ["event"],
+    deps = [
+        ":libevent_lib",
+        ":timer_lib",
+        "//include/envoy/event:timer_interface",
+        "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "timer_lib",
+    srcs = ["timer_impl.cc"],
+    hdrs = ["timer_impl.h"],
+    external_deps = ["event"],
+    deps = [
+        ":event_impl_base_lib",
+        ":libevent_lib",
+        "//include/envoy/event:timer_interface",
     ],
 )
 

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -47,7 +47,6 @@ envoy_cc_library(
         "timer_impl.h",
     ],
     deps = [
-        ":libevent_lib",
         "//include/envoy/event:timer_interface",
         "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -29,10 +29,7 @@ namespace Envoy {
 namespace Event {
 
 DispatcherImpl::DispatcherImpl(Api::Api& api, Event::TimeSystem& time_system)
-    : DispatcherImpl(std::make_unique<Buffer::WatermarkBufferFactory>(), api, time_system) {
-  // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
-  RELEASE_ASSERT(Libevent::Global::initialized(), "");
-}
+    : DispatcherImpl(std::make_unique<Buffer::WatermarkBufferFactory>(), api, time_system) {}
 
 DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory, Api::Api& api,
                                Event::TimeSystem& time_system)

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -74,6 +74,7 @@ private:
   Thread::ThreadIdPtr run_tid_;
   Buffer::WatermarkFactoryPtr buffer_factory_;
   Libevent::BasePtr base_;
+  SchedulerPtr base_scheduler_;
   SchedulerPtr scheduler_;
   TimerPtr deferred_delete_timer_;
   TimerPtr post_timer_;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -14,6 +14,7 @@
 #include "common/common/logger.h"
 #include "common/common/thread.h"
 #include "common/event/libevent.h"
+#include "common/event/libevent_scheduler.h"
 
 namespace Envoy {
 namespace Event {
@@ -31,7 +32,7 @@ public:
   /**
    * @return event_base& the libevent base.
    */
-  event_base& base() { return *base_; }
+  event_base& base() { return base_scheduler_.base(); }
 
   // Event::Dispatcher
   TimeSource& timeSource() override { return api_.timeSource(); }
@@ -73,8 +74,7 @@ private:
   Api::Api& api_;
   Thread::ThreadIdPtr run_tid_;
   Buffer::WatermarkFactoryPtr buffer_factory_;
-  Libevent::BasePtr base_;
-  SchedulerPtr base_scheduler_;
+  LibeventScheduler base_scheduler_;
   SchedulerPtr scheduler_;
   TimerPtr deferred_delete_timer_;
   TimerPtr post_timer_;

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -7,6 +7,7 @@ namespace Envoy {
 namespace Event {
 
 LibeventScheduler::LibeventScheduler() : libevent_(event_base_new()) {
+  // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
   RELEASE_ASSERT(Libevent::Global::initialized(), "");
 }
 

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -1,0 +1,24 @@
+#include "common/event/libevent_scheduler.h"
+
+#include "common/common/assert.h"
+#include "common/event/timer_impl.h"
+
+namespace Envoy {
+namespace Event {
+
+LibeventScheduler::LibeventScheduler() : libevent_(event_base_new()) {
+  RELEASE_ASSERT(Libevent::Global::initialized(), "");
+}
+
+TimerPtr LibeventScheduler::createTimer(const TimerCb& cb) {
+  return std::make_unique<TimerImpl>(libevent_, cb);
+};
+
+void LibeventScheduler::nonBlockingLoop() { event_base_loop(libevent_.get(), EVLOOP_NONBLOCK); }
+
+void LibeventScheduler::blockingLoop() { event_base_loop(libevent_.get(), 0); }
+
+void LibeventScheduler::loopExit() { event_base_loopexit(libevent_.get(), nullptr); }
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "envoy/event/timer.h"
+
+#include "common/event/libevent.h"
+
+#include "event2/event.h"
+
+namespace Envoy {
+namespace Event {
+
+// Implements Scheduler based on libevent.
+class LibeventScheduler : public Scheduler {
+public:
+  LibeventScheduler();
+  TimerPtr createTimer(const TimerCb& cb) override;
+  void nonBlockingLoop();
+  void blockingLoop();
+  void loopExit();
+  event_base& base() { return *libevent_; }
+
+private:
+  Libevent::BasePtr libevent_;
+};
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -35,7 +35,7 @@ public:
   /**
    * TODO(jmarantz): consider strengthening this abstraction and instead of
    * exposing the libevent base pointer, provide API abstractions for the calls
-   * into it. Among other beneits this might make it more tractable to someday
+   * into it. Among other benefits this might make it more tractable to someday
    * consider an alternative to libevent if the need arises.
    *
    * @return the underlying libevent structure.

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -13,10 +13,33 @@ namespace Event {
 class LibeventScheduler : public Scheduler {
 public:
   LibeventScheduler();
+
+  // Scheduler
   TimerPtr createTimer(const TimerCb& cb) override;
+
+  /**
+   * Runs the libevent loop once, without blocking.
+   */
   void nonBlockingLoop();
+
+  /**
+   * Runs the libevent loop once, with block.
+   */
   void blockingLoop();
+
+  /**
+   * Exits the libevent loop.
+   */
   void loopExit();
+
+  /**
+   * TODO(jmarantz): consider strengthening this abstraction and instead of
+   * exposing the libevent base pointer, provide API abstractions for the calls
+   * into it. Among other beneits this might make it more tractable to someday
+   * consider an alternative to libevent if the need arises.
+   *
+   * @return the underlying libevent structure.
+   */
   event_base& base() { return *libevent_; }
 
 private:

--- a/source/common/event/real_time_system.cc
+++ b/source/common/event/real_time_system.cc
@@ -3,10 +3,7 @@
 #include <chrono>
 
 #include "common/common/assert.h"
-#include "common/event/event_impl_base.h"
 #include "common/event/timer_impl.h"
-
-#include "event2/event.h"
 
 namespace Envoy {
 namespace Event {
@@ -14,19 +11,17 @@ namespace {
 
 class RealScheduler : public Scheduler {
 public:
-  RealScheduler(Libevent::BasePtr& libevent) : libevent_(libevent) {}
-  TimerPtr createTimer(const TimerCb& cb) override {
-    return std::make_unique<TimerImpl>(libevent_, cb);
-  };
+  RealScheduler(Scheduler& base_scheduler) : base_scheduler_(base_scheduler) {}
+  TimerPtr createTimer(const TimerCb& cb) override { return base_scheduler_.createTimer(cb); };
 
 private:
-  Libevent::BasePtr& libevent_;
+  Scheduler& base_scheduler_;
 };
 
 } // namespace
 
-SchedulerPtr RealTimeSystem::createScheduler(Libevent::BasePtr& libevent) {
-  return std::make_unique<RealScheduler>(libevent);
+SchedulerPtr RealTimeSystem::createScheduler(Scheduler& base_scheduler) {
+  return std::make_unique<RealScheduler>(base_scheduler);
 }
 
 } // namespace Event

--- a/source/common/event/real_time_system.h
+++ b/source/common/event/real_time_system.h
@@ -13,7 +13,7 @@ namespace Event {
 class RealTimeSystem : public TimeSystem {
 public:
   // TimeSystem
-  SchedulerPtr createScheduler(Libevent::BasePtr&) override;
+  SchedulerPtr createScheduler(Scheduler&) override;
 
   // TimeSource
   SystemTime systemTime() override { return time_source_.systemTime(); }

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -5,6 +5,7 @@
 #include "envoy/event/timer.h"
 
 #include "common/event/event_impl_base.h"
+#include "common/event/libevent.h"
 
 namespace Envoy {
 namespace Event {

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -49,8 +49,8 @@ public:
   // where timer callbacks are triggered by the advancement of time. This implementation
   // matches recent behavior, where real-time timers were created directly in libevent
   // by dispatcher_impl.cc.
-  Event::SchedulerPtr createScheduler(Event::Libevent::BasePtr& base) override {
-    return real_time_.createScheduler(base);
+  Event::SchedulerPtr createScheduler(Event::Scheduler& base_scheduler) override {
+    return real_time_.createScheduler(base_scheduler);
   }
   void sleep(const Duration& duration) override { real_time_.sleep(duration); }
   Thread::CondVar::WaitStatus

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -196,6 +196,7 @@ envoy_cc_test(
     deps = [
         ":simulated_time_system_lib",
         ":utility_lib",
+        "//source/common/event:libevent_scheduler_lib",
     ],
 )
 

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -22,7 +22,7 @@ public:
   ~SimulatedTimeSystemHelper() override;
 
   // TimeSystem
-  SchedulerPtr createScheduler(Libevent::BasePtr&) override;
+  SchedulerPtr createScheduler(Scheduler& base_scheduler) override;
 
   // TestTimeSystem
   void sleep(const Duration& duration) override;

--- a/test/test_common/simulated_time_system_test.cc
+++ b/test/test_common/simulated_time_system_test.cc
@@ -1,5 +1,6 @@
 #include "common/common/thread.h"
 #include "common/event/libevent.h"
+#include "common/event/libevent_scheduler.h"
 #include "common/event/timer_impl.h"
 
 #include "test/test_common/simulated_time_system.h"
@@ -12,27 +13,6 @@ namespace Envoy {
 namespace Event {
 namespace Test {
 namespace {
-
-// SimulatedTimeSystem relies on a base scheduler to execute alarms. In
-// production this is libevent, and to make integration tests as faithful
-// as possible, we want the execution to flow through libevent in tests too.
-class LibeventScheduler : public Scheduler {
-public:
-  LibeventScheduler() : libevent_(event_base_new()) {
-    RELEASE_ASSERT(Libevent::Global::initialized(), "");
-  }
-
-  TimerPtr createTimer(const TimerCb& cb) override {
-    return std::make_unique<TimerImpl>(libevent_, cb);
-  };
-
-  void nonBlockingLoop() { event_base_loop(libevent_.get(), EVLOOP_NONBLOCK); }
-
-  void blockingLoop() { event_base_loop(libevent_.get(), 0); }
-
-private:
-  Libevent::BasePtr libevent_;
-};
 
 class SimulatedTimeSystemTest : public testing::Test {
 protected:

--- a/test/test_common/test_time.h
+++ b/test/test_common/test_time.h
@@ -17,8 +17,8 @@ public:
           const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
 
   // Event::TimeSystem
-  Event::SchedulerPtr createScheduler(Event::Libevent::BasePtr& libevent) override {
-    return real_time_system_.createScheduler(libevent);
+  Event::SchedulerPtr createScheduler(Scheduler& base_scheduler) override {
+    return real_time_system_.createScheduler(base_scheduler);
   }
 
   // TimeSource

--- a/test/test_common/test_time_system.h
+++ b/test/test_common/test_time_system.h
@@ -89,8 +89,8 @@ public:
     return timeSystem().waitFor(mutex, condvar, duration);
   }
 
-  SchedulerPtr createScheduler(Libevent::BasePtr& base_ptr) override {
-    return timeSystem().createScheduler(base_ptr);
+  SchedulerPtr createScheduler(Scheduler& base_scheduler) override {
+    return timeSystem().createScheduler(base_scheduler);
   }
   SystemTime systemTime() override { return timeSystem().systemTime(); }
   MonotonicTime monotonicTime() override { return timeSystem().monotonicTime(); }


### PR DESCRIPTION
Description: SimulatedTimeSystem and TimeSystem should not directly depend on libevent; they just need to be able to schedule events. This PR adds an abstraction boundary using the existing Scheduler interface.
Risk Level: low -- just a refactor
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Fixes #Issue: https://github.com/envoyproxy/envoy/issues/5820

