### PR TITLE
api: make any serialization stable for go

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -30,6 +30,7 @@ import "validate/validate.proto";
 import "gogoproto/gogo.proto";
 
 option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
 
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {

--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -17,6 +17,7 @@ import "gogoproto/gogo.proto";
 import "envoy/type/percent.proto";
 
 option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common types]
 

--- a/api/envoy/api/v2/discovery.proto
+++ b/api/envoy/api/v2/discovery.proto
@@ -14,6 +14,7 @@ import "google/rpc/status.proto";
 import "gogoproto/gogo.proto";
 
 option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common discovery API components]
 

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -19,6 +19,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/wrappers.proto";
 
 option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: EDS]
 // Endpoint discovery :ref:`architecture overview <arch_overview_service_discovery_types_eds>`

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -21,6 +21,7 @@ import "validate/validate.proto";
 import "gogoproto/gogo.proto";
 
 option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: HTTP route]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`

--- a/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -14,6 +14,9 @@ import "envoy/api/v2/core/http_uri.proto";
 import "envoy/type/matcher/string.proto";
 
 import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: External Authorization]
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.

--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -16,6 +16,8 @@ import "envoy/type/percent.proto";
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";
 
+option (gogoproto.stable_marshaler_all) = true;
+
 // [#protodoc-title: Health check]
 // Health check :ref:`configuration overview <config_http_filters_health_check>`.
 

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -14,6 +14,9 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: JWT Authentication]
 // JWT Authentication :ref:`configuration overview <config_http_filters_jwt_authn>`.

--- a/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.proto
@@ -16,6 +16,8 @@ import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";
 
+option (gogoproto.stable_marshaler_all) = true;
+
 // [#protodoc-title: Dubbo route configuration]
 
 message RouteConfiguration {

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "validate/validate.proto";
+import "gogoproto/gogo.proto";
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/route/route.proto";
 import "envoy/type/matcher/metadata.proto";
@@ -12,6 +13,8 @@ option java_outer_classname = "RbacProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.config.rbac.v2alpha";
 option go_package = "v2alpha";
+
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Role Based Access Control (RBAC)]
 

--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -15,6 +15,8 @@ import "google/protobuf/wrappers.proto";
 import "gogoproto/gogo.proto";
 import "validate/validate.proto";
 
+option (gogoproto.stable_marshaler_all) = true;
+
 // [#protodoc-title: gRPC access logs]
 // Envoy access logs describe incoming interaction with Envoy over a fixed
 // period of time, and typically cover a single request/response exchange,

--- a/api/envoy/service/auth/v2/attribute_context.proto
+++ b/api/envoy/service/auth/v2/attribute_context.proto
@@ -9,6 +9,9 @@ option java_package = "io.envoyproxy.envoy.service.auth.v2";
 import "envoy/api/v2/core/address.proto";
 
 import "google/protobuf/timestamp.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Attribute Context ]
 


### PR DESCRIPTION
Description: Using proto.MarshalAny results in unstable output due to non-deterministic map ordering. This in turn causes Envoy's diff to reload a config since the hash of the structure changes.
Enable stable marshaler for gogoproto to avoid this problem. See https://github.com/envoyproxy/envoy/issues/6252
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a

