### PR TITLE
Fix documentation referencing 127.0.0.3

### DIFF
--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -110,7 +110,7 @@ Mostly static with dynamic EDS
 A bootstrap config that continues from the above example with :ref:`dynamic endpoint
 discovery <arch_overview_dynamic_config_eds>` via an
 :ref:`EDS<envoy_api_file_envoy/api/v2/eds.proto>` gRPC management server listening
-on 127.0.0.3:5678 is provided below:
+on 127.0.0.1:5678 is provided below:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Docs Changes: Typo

I was looking through the docs and it looks like there was a typo here because the `xds_cluster` is listening at `127.0.0.1:5678`

