### PR TITLE
config: fix CDS gRPC not specifying StreamClusters gRPC method

### DIFF
--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -30,10 +30,10 @@ CdsApiImpl::CdsApiImpl(const envoy::api::v2::core::ConfigSource& cds_config, Clu
     : cm_(cm), scope_(scope.createScope("cluster_manager.cds.")) {
   Config::Utility::checkLocalInfo("cds", local_info);
 
-  bool is_delta = (cds_config.api_config_source().api_type() ==
-                   envoy::api::v2::core::ApiConfigSource::DELTA_GRPC);
-  std::string grpc_method = is_delta ? "envoy.api.v2.ClusterDiscoveryService.DeltaClusters"
-                                     : "envoy.api.v2.ClusterDiscoveryService.StreamClusters";
+  const bool is_delta = (cds_config.api_config_source().api_type() ==
+                         envoy::api::v2::core::ApiConfigSource::DELTA_GRPC);
+  const std::string grpc_method = is_delta ? "envoy.api.v2.ClusterDiscoveryService.DeltaClusters"
+                                           : "envoy.api.v2.ClusterDiscoveryService.StreamClusters";
   subscription_ =
       Config::SubscriptionFactory::subscriptionFromConfigSource<envoy::api::v2::Cluster>(
           cds_config, local_info, dispatcher, cm, random, *scope_,

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -30,11 +30,14 @@ CdsApiImpl::CdsApiImpl(const envoy::api::v2::core::ConfigSource& cds_config, Clu
     : cm_(cm), scope_(scope.createScope("cluster_manager.cds.")) {
   Config::Utility::checkLocalInfo("cds", local_info);
 
+  bool is_delta = (cds_config.api_config_source().api_type() ==
+                   envoy::api::v2::core::ApiConfigSource::DELTA_GRPC);
+  std::string grpc_method = is_delta ? "envoy.api.v2.ClusterDiscoveryService.DeltaClusters"
+                                     : "envoy.api.v2.ClusterDiscoveryService.StreamClusters";
   subscription_ =
       Config::SubscriptionFactory::subscriptionFromConfigSource<envoy::api::v2::Cluster>(
           cds_config, local_info, dispatcher, cm, random, *scope_,
-          "envoy.api.v2.ClusterDiscoveryService.FetchClusters",
-          "envoy.api.v2.ClusterDiscoveryService.DeltaClusters", api);
+          "envoy.api.v2.ClusterDiscoveryService.FetchClusters", grpc_method, api);
 }
 
 void CdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::string& version_info) {


### PR DESCRIPTION
Signed-off-by: Fred Douglas <fredlas@google.com>

Description: Choose gRPC method string to pass to SubscriptionFactory based on whether GRPC or DELTA_GRPC was specified. When the work-in-progress incremental CDS work had its incremental_cds_api_impl merged into cds_api_impl, the StreamClusters was changed (unconditionally) to DeltaClusters.

I wanted to add tests to prevent this particular breaking change from being made again, but found it surprisingly hard, and figured it's better to get it fixed right away.

Fixes #6237