### PR TITLE
server: add an API for registering for notifications for server instance life…

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -90,6 +90,7 @@ envoy_cc_library(
         ":admin_interface",
         ":drain_manager_interface",
         ":hot_restart_interface",
+        ":lifecycle_notifier_interface",
         ":listener_manager_interface",
         ":options_interface",
         "//include/envoy/access_log:access_log_interface",
@@ -144,6 +145,7 @@ envoy_cc_library(
     hdrs = ["filter_config.h"],
     deps = [
         ":admin_interface",
+        ":lifecycle_notifier_interface",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/api:api_interface",
         "//include/envoy/http:codes_interface",
@@ -164,6 +166,11 @@ envoy_cc_library(
         "//source/common/protobuf",
         "@envoy_api//envoy/api/v2/core:base_cc",
     ],
+)
+
+envoy_cc_library(
+    name = "lifecycle_notifier_interface",
+    hdrs = ["lifecycle_notifier.h"],
 )
 
 envoy_cc_library(

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -13,6 +13,7 @@
 #include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/admin.h"
+#include "envoy/server/lifecycle_notifier.h"
 #include "envoy/server/overload_manager.h"
 #include "envoy/singleton/manager.h"
 #include "envoy/stats/scope.h"
@@ -78,6 +79,11 @@ public:
    *         will start listening.
    */
   virtual Init::Manager& initManager() PURE;
+
+  /**
+   * @return ServerLifecycleNotifier& the lifecycle notifier for the server.
+   */
+  virtual ServerLifecycleNotifier& lifecycleNotifier() PURE;
 
   /**
    * @return information about the local environment the server is running in.

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -17,6 +17,7 @@
 #include "envoy/server/admin.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/hot_restart.h"
+#include "envoy/server/lifecycle_notifier.h"
 #include "envoy/server/listener_manager.h"
 #include "envoy/server/options.h"
 #include "envoy/server/overload_manager.h"
@@ -146,6 +147,11 @@ public:
    * @return Runtime::Loader& the singleton runtime loader for the server.
    */
   virtual Runtime::Loader& runtime() PURE;
+
+  /**
+   * @return ServerLifecycleNotifier& the singleton lifecycle notifier for the server.
+   */
+  virtual ServerLifecycleNotifier& lifecycleNotifier() PURE;
 
   /**
    * Shutdown the server gracefully.

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -19,7 +19,7 @@ public:
     Startup,
 
     /**
-     * The server instance is being shutdown and the dispatcher is aboout the exit.
+     * The server instance is being shutdown and the dispatcher is about the exit.
      */
     ShutdownExit
   };

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -16,12 +16,13 @@ public:
    */
   enum class Stage {
     /**
-     * The server instance main thread has entered the dispatcher loop.
+     * The server instance main thread is about to enter the dispatcher loop.
      */
     Startup,
 
     /**
-     * The server instance is being shutdown and the dispatcher is about the exit.
+     * The server instance is being shutdown and the dispatcher is about to exit.
+     * This provides listeners a last chance to run a callback on the main dispatcher.
      */
     ShutdownExit
   };

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <functional>
+
+namespace Envoy {
+namespace Server {
+
+class ServerLifecycleNotifier {
+public:
+  virtual ~ServerLifecycleNotifier() {}
+
+  /**
+   * Stages of the envoy server instance lifecycle.
+   */
+  enum class Stage {
+    /**
+     * The server instance main thread has entered the dispatcher loop.
+     */
+    Startup,
+
+    /**
+     * The server instance is being shutdown and the dispatcher is aboout the exit.
+     */
+    ShutdownExit
+  };
+
+  /**
+   * Callback invoked when the server reaches a certain lifecycle stage.
+   */
+  using StageCallback = std::function<void()>;
+
+  /**
+   * Register a callback function that will be invoked on the main thread when
+   * the specified stage is reached.
+   */
+  virtual void registerCallback(Stage stage, StageCallback callback) PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -2,12 +2,14 @@
 
 #include <functional>
 
+#include "envoy/common/pure.h"
+
 namespace Envoy {
 namespace Server {
 
 class ServerLifecycleNotifier {
 public:
-  virtual ~ServerLifecycleNotifier() {}
+  virtual ~ServerLifecycleNotifier() = default;
 
   /**
    * Stages of the envoy server instance lifecycle.

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -75,6 +75,7 @@ public:
   void getParentStats(HotRestart::GetParentStatsInfo&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   HotRestart& hotRestart() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Init::Manager& initManager() override { return init_manager_; }
+  ServerLifecycleNotifier& lifecycleNotifier() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
   Runtime::RandomGenerator& random() override { return random_generator_; }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -297,6 +297,9 @@ public:
   }
   const Network::ListenerConfig& listenerConfig() const override { return *this; }
   Api::Api& api() override { return parent_.server_.api(); }
+  ServerLifecycleNotifier& lifecycleNotifier() override {
+    return parent_.server_.lifecycleNotifier();
+  }
 
   // Network::DrainDecision
   bool drainClose() const override;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -519,13 +519,11 @@ void InstanceImpl::terminate() {
 Runtime::Loader& InstanceImpl::runtime() { return Runtime::LoaderSingleton::get(); }
 
 void InstanceImpl::shutdown() {
-  dispatcher_->post([this] {
-    ENVOY_LOG(info, "shutting down server instance");
-    shutdown_ = true;
-    restarter_.terminateParent();
-    notifyCallbacksForStage(Stage::ShutdownExit);
-    dispatcher_->exit();
-  });
+  ENVOY_LOG(info, "shutting down server instance");
+  shutdown_ = true;
+  restarter_.terminateParent();
+  notifyCallbacksForStage(Stage::ShutdownExit);
+  dispatcher_->exit();
 }
 
 void InstanceImpl::shutdownAdmin() {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -66,7 +66,8 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
                           store),
       terminated_(false),
       mutex_tracer_(options.mutexTracingEnabled() ? &Envoy::MutexTracerImpl::getOrCreateTracer()
-                                                  : nullptr) {
+                                                  : nullptr),
+      main_thread_id_(std::this_thread::get_id()) {
   try {
     if (!options.logPath().empty()) {
       try {
@@ -469,6 +470,7 @@ void InstanceImpl::run() {
   ENVOY_LOG(info, "starting main dispatch loop");
   auto watchdog = guard_dog_->createWatchDog(api_->threadFactory().currentThreadId());
   watchdog->startWatchdog(*dispatcher_);
+  dispatcher_->post([this] { notifyCallbacksForStage(Stage::Startup); });
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   ENVOY_LOG(info, "main dispatch loop exited");
   guard_dog_->stopWatching(watchdog);
@@ -517,9 +519,13 @@ void InstanceImpl::terminate() {
 Runtime::Loader& InstanceImpl::runtime() { return Runtime::LoaderSingleton::get(); }
 
 void InstanceImpl::shutdown() {
-  shutdown_ = true;
-  restarter_.terminateParent();
-  dispatcher_->exit();
+  dispatcher_->post([this] {
+    ENVOY_LOG(info, "shutting down server instance");
+    shutdown_ = true;
+    restarter_.terminateParent();
+    notifyCallbacksForStage(Stage::ShutdownExit);
+    dispatcher_->exit();
+  });
 }
 
 void InstanceImpl::shutdownAdmin() {
@@ -533,6 +539,20 @@ void InstanceImpl::shutdownAdmin() {
 
   ENVOY_LOG(warn, "terminating parent process");
   restarter_.terminateParent();
+}
+
+void InstanceImpl::registerCallback(Stage stage, StageCallback callback) {
+  stage_callbacks_[stage].push_back(callback);
+}
+
+void InstanceImpl::notifyCallbacksForStage(Stage stage) {
+  ASSERT(std::this_thread::get_id() == main_thread_id_);
+  auto it = stage_callbacks_.find(stage);
+  if (it != stage_callbacks_.end()) {
+    for (const StageCallback& callback : it->second) {
+      callback();
+    }
+  }
 }
 
 ProtobufTypes::MessagePtr InstanceImpl::dumpBootstrapConfig() {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -136,7 +136,9 @@ private:
 /**
  * This is the actual full standalone server which stitches together various common components.
  */
-class InstanceImpl : Logger::Loggable<Logger::Id::main>, public Instance {
+class InstanceImpl : Logger::Loggable<Logger::Id::main>,
+                     public Instance,
+                     public ServerLifecycleNotifier {
 public:
   /**
    * @throw EnvoyException if initialization fails.
@@ -166,6 +168,7 @@ public:
   void getParentStats(HotRestart::GetParentStatsInfo& info) override;
   HotRestart& hotRestart() override { return restarter_; }
   Init::Manager& initManager() override { return init_manager_; }
+  ServerLifecycleNotifier& lifecycleNotifier() override { return *this; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
@@ -190,6 +193,9 @@ public:
     return config_.statsFlushInterval();
   }
 
+  // ServerLifecycleNotifier
+  void registerCallback(Stage stage, StageCallback callback) override;
+
 private:
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
   void flushStats();
@@ -199,6 +205,7 @@ private:
   uint64_t numConnections();
   void startWorkers();
   void terminate();
+  void notifyCallbacksForStage(Stage stage);
 
   // init_manager_ must come before any member that participates in initialization, and destructed
   // only after referencing members are gone, since initialization continuation can potentially
@@ -252,6 +259,8 @@ private:
   Envoy::MutexTracer* mutex_tracer_;
   Http::ContextImpl http_context_;
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
+  std::thread::id main_thread_id_;
+  std::unordered_map<Stage, std::vector<StageCallback>> stage_callbacks_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -259,7 +259,7 @@ private:
   Envoy::MutexTracer* mutex_tracer_;
   Http::ContextImpl http_context_;
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
-  std::thread::id main_thread_id_;
+  const std::thread::id main_thread_id_;
   std::unordered_map<Stage, std::vector<StageCallback>> stage_callbacks_;
 };
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -139,6 +139,7 @@ MockInstance::MockInstance()
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, hotRestart()).WillByDefault(ReturnRef(hot_restart_));
   ON_CALL(*this, random()).WillByDefault(ReturnRef(random_));
+  ON_CALL(*this, lifecycleNotifier()).WillByDefault(ReturnRef(lifecycle_notifier_));
   ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, drainManager()).WillByDefault(ReturnRef(drain_manager_));
@@ -171,6 +172,7 @@ MockFactoryContext::MockFactoryContext()
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
   ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
+  ON_CALL(*this, lifecycleNotifier()).WillByDefault(ReturnRef(lifecycle_notifier_));
   ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));
   ON_CALL(*this, random()).WillByDefault(ReturnRef(random_));
   ON_CALL(*this, runtime()).WillByDefault(ReturnRef(runtime_loader_));

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -99,6 +99,9 @@ MockListenerComponentFactory::MockListenerComponentFactory()
 }
 MockListenerComponentFactory::~MockListenerComponentFactory() = default;
 
+MockServerLifecycleNotifier::MockServerLifecycleNotifier() = default;
+MockServerLifecycleNotifier::~MockServerLifecycleNotifier() = default;
+
 MockListenerManager::MockListenerManager() = default;
 MockListenerManager::~MockListenerManager() = default;
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -261,6 +261,14 @@ public:
   MOCK_METHOD0(stopWorkers, void());
 };
 
+class MockServerLifecycleNotifier : public ServerLifecycleNotifier {
+public:
+  MockServerLifecycleNotifier() {}
+  ~MockServerLifecycleNotifier() {}
+
+  MOCK_METHOD2(registerCallback, void(Stage, StageCallback));
+};
+
 class MockWorkerFactory : public WorkerFactory {
 public:
   MockWorkerFactory();
@@ -339,6 +347,7 @@ public:
   MOCK_METHOD0(healthCheckFailed, bool());
   MOCK_METHOD0(hotRestart, HotRestart&());
   MOCK_METHOD0(initManager, Init::Manager&());
+  MOCK_METHOD0(lifecycleNotifier, ServerLifecycleNotifier&());
   MOCK_METHOD0(listenerManager, ListenerManager&());
   MOCK_METHOD0(mutexTracer, Envoy::MutexTracer*());
   MOCK_METHOD0(options, const Options&());
@@ -377,6 +386,7 @@ public:
   testing::NiceMock<MockHotRestart> hot_restart_;
   testing::NiceMock<MockOptions> options_;
   testing::NiceMock<Runtime::MockRandomGenerator> random_;
+  testing::NiceMock<MockServerLifecycleNotifier> lifecycle_notifier_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
   testing::NiceMock<Init::MockManager> init_manager_;
   testing::NiceMock<MockListenerManager> listener_manager_;
@@ -420,6 +430,7 @@ public:
   MOCK_METHOD0(healthCheckFailed, bool());
   MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
   MOCK_METHOD0(initManager, Init::Manager&());
+  MOCK_METHOD0(lifecycleNotifier, ServerLifecycleNotifier&());
   MOCK_METHOD0(random, Envoy::Runtime::RandomGenerator&());
   MOCK_METHOD0(runtime, Envoy::Runtime::Loader&());
   MOCK_METHOD0(scope, Stats::Scope&());
@@ -441,6 +452,7 @@ public:
   testing::NiceMock<MockDrainManager> drain_manager_;
   testing::NiceMock<Tracing::MockHttpTracer> http_tracer_;
   testing::NiceMock<Init::MockManager> init_manager_;
+  testing::NiceMock<MockServerLifecycleNotifier> lifecycle_notifier_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
   testing::NiceMock<Envoy::Runtime::MockRandomGenerator> random_;
   testing::NiceMock<Envoy::Runtime::MockLoader> runtime_loader_;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -263,8 +263,8 @@ public:
 
 class MockServerLifecycleNotifier : public ServerLifecycleNotifier {
 public:
-  MockServerLifecycleNotifier() {}
-  ~MockServerLifecycleNotifier() {}
+  MockServerLifecycleNotifier();
+  ~MockServerLifecycleNotifier();
 
   MOCK_METHOD2(registerCallback, void(Stage, StageCallback));
 };


### PR DESCRIPTION
…cycle events

Description: add an API to allow components and extensions to register for server instance lifecycle events (such as startup and shutdown).
Risk Level: low
Testing: unit tests
Docs Changes:
Release Notes:
Fixes #2802 

Signed-off-by: Elisha Ziskind <eziskind@google.com>

