### PR TITLE
build: avoid direct references on @bazel_tools conditionals.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -37,16 +37,6 @@ genrule(
 )
 
 config_setting(
-    name = "windows_x86_64",
-    values = {"cpu": "x64_windows"},
-)
-
-config_setting(
-    name = "linux_ppc",
-    values = {"cpu": "ppc"},
-)
-
-config_setting(
     name = "windows_opt_build",
     values = {
         "cpu": "x64_windows",
@@ -163,6 +153,26 @@ alias(
         "//bazel:boringssl_fips": "@boringssl_fips//:ssl",
         "//conditions:default": "@boringssl//:ssl",
     }),
+)
+
+config_setting(
+    name = "linux_x86_64",
+    values = {"cpu": "k8"},
+)
+
+config_setting(
+    name = "linux_aarch64",
+    values = {"cpu": "aarch64"},
+)
+
+config_setting(
+    name = "linux_ppc",
+    values = {"cpu": "ppc"},
+)
+
+config_setting(
+    name = "windows_x86_64",
+    values = {"cpu": "x64_windows"},
 )
 
 # Configuration settings to make doing selects for Apple vs non-Apple platforms

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -23,13 +23,13 @@ envoy_cc_library(
 envoy_cc_library(
     name = "os_sys_calls_lib",
     srcs = ["os_sys_calls_impl.cc"] + select({
-        "@bazel_tools//src/conditions:linux_x86_64": ["os_sys_calls_impl_linux.cc"],
-        "@bazel_tools//src/conditions:linux_aarch64": ["os_sys_calls_impl_linux.cc"],
+        "//bazel:linux_x86_64": ["os_sys_calls_impl_linux.cc"],
+        "//bazel:linux_aarch64": ["os_sys_calls_impl_linux.cc"],
         "//conditions:default": [],
     }),
     hdrs = ["os_sys_calls_impl.h"] + select({
-        "@bazel_tools//src/conditions:linux_x86_64": ["os_sys_calls_impl_linux.h"],
-        "@bazel_tools//src/conditions:linux_aarch64": ["os_sys_calls_impl_linux.h"],
+        "//bazel:linux_x86_64": ["os_sys_calls_impl_linux.h"],
+        "//bazel:linux_aarch64": ["os_sys_calls_impl_linux.h"],
         "//conditions:default": [],
     }),
     deps = [

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -152,16 +152,16 @@ envoy_cc_library(
 envoy_cc_library(
     name = "options_lib",
     srcs = ["options_impl.cc"] + select({
-        "@bazel_tools//src/conditions:linux_x86_64": ["options_impl_platform_linux.cc"],
-        "@bazel_tools//src/conditions:linux_aarch64": ["options_impl_platform_linux.cc"],
+        "//bazel:linux_x86_64": ["options_impl_platform_linux.cc"],
+        "//bazel:linux_aarch64": ["options_impl_platform_linux.cc"],
         "//conditions:default": ["options_impl_platform_default.cc"],
     }),
     hdrs = [
         "options_impl.h",
         "options_impl_platform.h",
     ] + select({
-        "@bazel_tools//src/conditions:linux_x86_64": ["options_impl_platform_linux.h"],
-        "@bazel_tools//src/conditions:linux_aarch64": ["options_impl_platform_linux.h"],
+        "//bazel:linux_x86_64": ["options_impl_platform_linux.h"],
+        "//bazel:linux_aarch64": ["options_impl_platform_linux.h"],
         "//conditions:default": [],
     }),
     external_deps = ["tclap"],

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -433,6 +433,8 @@ def checkSourceLine(line, file_path, reportError):
 
 
 def checkBuildLine(line, file_path, reportError):
+  if '@bazel_tools' in line and not (isSkylarkFile(file_path) or file_path.startswith('./bazel/')):
+    reportError('unexpected @bazel_tools reference, please indirect via a definition in //bazel')
   if not whitelistedForProtobufDeps(file_path) and '"protobuf"' in line:
     reportError("unexpected direct external dependency on protobuf, use "
                 "//source/common/protobuf instead.")

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -195,6 +195,7 @@ if __name__ == "__main__":
   errors += checkUnfixableError("std_get_time.cc", "std::get_time")
   errors += checkUnfixableError("no_namespace_envoy.cc",
                                 "Unable to find Envoy namespace or NOLINT(namespace-envoy)")
+  errors += checkUnfixableError("bazel_tools.BUILD", "unexpected @bazel_tools reference")
   errors += checkUnfixableError("proto.BUILD", "unexpected direct external dependency on protobuf")
   errors += checkUnfixableError("proto_deps.cc", "unexpected direct dependency on google.protobuf")
   errors += checkUnfixableError("attribute_packed.cc", "Don't use __attribute__((packed))")

--- a/tools/testdata/check_format/bazel_tools.BUILD
+++ b/tools/testdata/check_format/bazel_tools.BUILD
@@ -1,0 +1,7 @@
+licenses(["notice"])  # Apache 2
+
+envoy_cc_binary(
+    name = "envoy-static",
+    stamped = True,
+    deps = ["@bazel_tools//some:thing"],
+)


### PR DESCRIPTION
We need to indirect via //bazel:BUILD definitions to support the Google
import.

Risk level: Low
Testing: check_format test added as a regression.

Signed-off-by: Harvey Tuch <htuch@google.com>