### PR TITLE
header utility: support removing dot segment in the path header before matching

### DIFF
--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -195,6 +195,8 @@ message Principal {
 
     // A header (or pseudo-header such as :path or :method) on the incoming HTTP request. Only
     // available for HTTP request.
+    // Note: the dot segments in the :path header will be removed before used for matching. For
+    // example, the :path header "/a/./b/../c" will be converted to "/a/c" before used for matching.
     envoy.api.v2.route.HeaderMatcher header = 6;
 
     // Metadata that describes additional information about the principal.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -62,6 +62,7 @@ Version history
 * tracing: added :ref:`verbose <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` to support logging annotations on spans.
 * upstream: added support for host weighting and :ref:`locality weighting <arch_overview_load_balancing_locality_weighted_lb>` in the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`, and added a :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>` config parameter to strictly bound the ring size.
 * upstream: added configuration option to select any host when the fallback policy fails.
+* rbac: the dot segments in the path header will be removed before used for matching.
 
 1.9.0 (Dec 20, 2018)
 ====================

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -67,7 +67,7 @@ HeaderUtility::HeaderData::HeaderData(const Json::Object& config)
       }()) {}
 
 std::string removeDotSegments(absl::string_view input) {
-  std::vector<std::string> output;
+  std::vector<absl::string_view> output;
   while (!input.empty()) {
     // A. If the input buffer begins with a prefix of "../" or "./",
     // then remove that prefix from the input buffer;
@@ -124,7 +124,7 @@ std::string removeDotSegments(absl::string_view input) {
     // the next "/" character or the end of the input buffer.
     auto j = input.find("/", 1);
     auto seg = input.substr(0, j);
-    output.push_back(std::string(seg));
+    output.push_back(seg);
     input.remove_prefix(seg.length());
   }
   return absl::StrJoin(output, "");

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -67,6 +67,8 @@ HeaderUtility::HeaderData::HeaderData(const Json::Object& config)
       }()) {}
 
 std::string removeDotSegments(absl::string_view input) {
+  // This function implements the "Remove Dot Segments" algorithm specified in the rfc3986:
+  // https://tools.ietf.org/html/rfc3986#section-5.2.4
   std::vector<absl::string_view> output;
   while (!input.empty()) {
     // A. If the input buffer begins with a prefix of "../" or "./",

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -33,17 +33,30 @@ public:
     const bool invert_match_;
   };
 
+  // A MatchOption specifies how to match the header value.
+  struct MatchOption {
+    // If true, remove the dot segments in the ":path" header before matching.
+    // Single dot is removed directly from the path, double dots are removed
+    // together with the preceding path segment (if exist). For example,
+    // "/a/./c/../d" will be converted to "/a/d" before matching. See
+    // https://tools.ietf.org/html/rfc3986#section-5.2.4.
+    bool remove_dot_segments_in_path;
+  };
+
   /**
    * See if the headers specified in the config are present in a request.
    * @param request_headers supplies the headers from the request.
    * @param config_headers supplies the list of configured header conditions on which to match.
+   * @param MatchOption the match option that specifies how to match the header.
    * @return bool true if all the headers (and values) in the config_headers are found in the
    *         request_headers. If no config_headers are specified, returns true.
    */
   static bool matchHeaders(const Http::HeaderMap& request_headers,
-                           const std::vector<HeaderData>& config_headers);
+                           const std::vector<HeaderData>& config_headers,
+                           const MatchOption& match_option = MatchOption{});
 
-  static bool matchHeaders(const Http::HeaderMap& request_headers, const HeaderData& config_header);
+  static bool matchHeaders(const Http::HeaderMap& request_headers, const HeaderData& config_header,
+                           const MatchOption& match_option = MatchOption{});
 
   /**
    * Add headers from one HeaderMap to another

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -8,6 +8,9 @@ namespace Filters {
 namespace Common {
 namespace RBAC {
 
+static constexpr Envoy::Http::HeaderUtility::MatchOption headerMatchOption{
+    .remove_dot_segments_in_path = true};
+
 MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v2alpha::Permission& permission) {
   switch (permission.rule_case()) {
   case envoy::config::rbac::v2alpha::Permission::RuleCase::kAndRules:
@@ -114,7 +117,7 @@ bool NotMatcher::matches(const Network::Connection& connection,
 
 bool HeaderMatcher::matches(const Network::Connection&, const Envoy::Http::HeaderMap& headers,
                             const envoy::api::v2::core::Metadata&) const {
-  return Envoy::Http::HeaderUtility::matchHeaders(headers, header_);
+  return Envoy::Http::HeaderUtility::matchHeaders(headers, header_, headerMatchOption);
 }
 
 bool IPMatcher::matches(const Network::Connection& connection, const Envoy::Http::HeaderMap&,

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -151,6 +151,27 @@ TEST(HeaderMatcher, HeaderMatcher) {
   checkMatcher(matcher, false);
 }
 
+TEST(HeaderMatcher, HeaderMatcherForPath) {
+  envoy::api::v2::route::HeaderMatcher config;
+  config.set_name(":path");
+  config.set_prefix_match("/abc");
+
+  Envoy::Http::HeaderMapImpl headers;
+  Envoy::Http::LowerCaseString key(":path");
+  std::string value = "/abc/xyz";
+  headers.setReference(key, value);
+
+  RBAC::HeaderMatcher matcher(config);
+
+  checkMatcher(matcher, true, Envoy::Network::MockConnection(), headers);
+
+  value = "/abc/../data";
+  headers.setReference(key, value);
+
+  checkMatcher(matcher, false, Envoy::Network::MockConnection(), headers);
+  checkMatcher(matcher, false);
+}
+
 TEST(IPMatcher, IPMatcher) {
   Envoy::Network::MockConnection conn;
   Envoy::Network::Address::InstanceConstSharedPtr local =


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

**Description**: this PR adds a `MatchOption` to `HeaderUtility::matchHeaders()` to allow removing the dot segments in the path header before matching.
**Risk Level**: low
**Testing**: unit tests.
**Docs Changes**: updated the header matcher comment in rbac API
**Release Notes**: added for the behavior change in rbac filter
Fixes #6008
[Optional Deprecated:]

The only normalization we need for now is to remove the dots from the path.
/cc @lizan @htuch @liminw 