### PR TITLE
test: use ipv6_only IPv6 addresses in custom cluster integration tests.

### DIFF
--- a/test/integration/clusters/custom_static_cluster.cc
+++ b/test/integration/clusters/custom_static_cluster.cc
@@ -19,7 +19,7 @@ void CustomStaticCluster::startPreInit() {
 
 inline Upstream::HostSharedPtr CustomStaticCluster::makeHost() {
   Network::Address::InstanceConstSharedPtr address =
-      Network::Utility::parseInternetAddress(address_, port_, false);
+      Network::Utility::parseInternetAddress(address_, port_, true);
   return Upstream::HostSharedPtr{new Upstream::HostImpl(
       this->info(), "", address, this->info()->metadata(), 1,
       envoy::api::v2::core::Locality::default_instance(),


### PR DESCRIPTION
Needed for IPv6-only environments such as Google.

Risk level: Low
Testing: custom_cluster_integration_test in IPv6 only environment.

Signed-off-by: Harvey Tuch <htuch@google.com>