### PR TITLE
docs: Rename localhost DNS name to host.docker.internal

### DIFF
--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -145,7 +145,7 @@ gRPC or RESTful JSON requests to localhost:51051.
               address:
                 socket_address:
                   # WARNING: "docker.for.mac.localhost" has been deprecated from Docker v18.03.0.
-                  # If you still use older version, please use "docker.for.mac.localhost" instead.
+                  # If you're running an older version of Docker, please use "docker.for.mac.localhost" instead.
                   # Reference: https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18030-ce-mac59-2018-03-26
                   address: host.docker.internal
                   port_value: 50051

--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -146,6 +146,7 @@ gRPC or RESTful JSON requests to localhost:51051.
                 socket_address:
                   # WARNING: "docker.for.mac.localhost" has been deprecated from Docker v18.03.0.
                   # If you still use older version, please use "docker.for.mac.localhost" instead.
+                  # Reference: https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18030-ce-mac59-2018-03-26
                   address: host.docker.internal
                   port_value: 50051
 

--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -144,6 +144,6 @@ gRPC or RESTful JSON requests to localhost:51051.
           - endpoint:
               address:
                 socket_address:
-                  address: docker.for.mac.localhost
+                  address: host.docker.internal
                   port_value: 50051
 

--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -144,6 +144,8 @@ gRPC or RESTful JSON requests to localhost:51051.
           - endpoint:
               address:
                 socket_address:
+                  # WARNING: "docker.for.mac.localhost" has been deprecated from Docker v18.03.0.
+                  # If you still use older version, please use "docker.for.mac.localhost" instead.
                   address: host.docker.internal
                   port_value: 50051
 


### PR DESCRIPTION
Description:
I found that `docker.for.mac.localhost` has been deprecated, which is used in envoy docs.
This PR renames them to `host.docker.internal` which is supported on Docker v18.03.0 above.
https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18030-ce-mac59-2018-03-26

Risk Level: Low
Testing: N/A
Docs Changes: fix sample code in grpc_json_transcoder_filter 
Release Notes: N/A
