### PR TITLE
tracing: If parent span is propagated with empty string, it causes th…

### DIFF
--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -105,7 +105,7 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
     }
 
     auto b3_parent_id_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
-    if (b3_parent_id_entry) {
+    if (b3_parent_id_entry && b3_parent_id_entry->value().size() > 0) {
       const std::string pspid = b3_parent_id_entry->value().c_str();
       if (!StringUtil::atoull(pspid.c_str(), parent_id, 16)) {
         throw ExtractorException(fmt::format("Invalid parent span id {}", pspid.c_str()));

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -501,10 +501,8 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersEmptyParentSpanTest) {
 
   // Root span so have same trace and span id
   const std::string id = Hex::uint64ToHex(generateRandom64());
-  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_TRACE_ID,
-                                   id);
-  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_SPAN_ID,
-                                   id);
+  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_TRACE_ID, id);
+  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_SPAN_ID, id);
   request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_SAMPLED,
                                    ZipkinCoreConstants::get().SAMPLED);
 

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -496,6 +496,29 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersTest) {
   EXPECT_TRUE(zipkin_span->span().sampled());
 }
 
+TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersEmptyParentSpanTest) {
+  setupValidDriver();
+
+  // Root span so have same trace and span id
+  const std::string id = Hex::uint64ToHex(generateRandom64());
+  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_TRACE_ID,
+                                   id);
+  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_SPAN_ID,
+                                   id);
+  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_SAMPLED,
+                                   ZipkinCoreConstants::get().SAMPLED);
+
+  // Set parent span id to empty string, to ensure it is ignored
+  const std::string parent_span_id = "";
+  request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID, parent_span_id);
+
+  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+                                             start_time_, {Tracing::Reason::Sampling, true});
+
+  ZipkinSpanPtr zipkin_span(dynamic_cast<ZipkinSpan*>(span.release()));
+  EXPECT_TRUE(zipkin_span->span().sampled());
+}
+
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3Headers128TraceIdTest) {
   setupValidDriver();
 


### PR DESCRIPTION
…e next child span to not be created (i.e. returns null span)

Signed-off-by: Gary Brown <gary@brownuk.com>

Description:
Found an issue in Istio where if a service forwards an empty parent span id header, it results in the subsequent envoy proxy not creating a span for the outbound request, simply propagating the B3 headers to the next proxy handling the inbound request, which similarly has a problem creating a child span due to the same empty parent span id, etc.

See https://github.com/istio/istio/issues/11696 for more information.

Risk Level: Low
Testing: Unit test to confirm span created even with empty parent span id.
Docs Changes: no
Release Notes: no
[Optional Fixes #Issue]
[Optional Deprecated:]
