### PR TITLE
fuzz: fix use of literal in default initialization.

### DIFF
--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -13,7 +13,7 @@ namespace Fuzz {
 // Convert from test proto Headers to TestHeaderMapImpl.
 inline Http::TestHeaderMapImpl fromHeaders(
     const test::fuzz::Headers& headers,
-    const std::unordered_set<std::string>& ignore_headers = std::unordered_set<std::string>({})) {
+    const std::unordered_set<std::string>& ignore_headers = std::unordered_set<std::string>()) {
   Http::TestHeaderMapImpl header_map;
   for (const auto& header : headers.headers()) {
     // HeaderMapImpl and places such as the route lookup should never see strings with embedded NULL

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -11,9 +11,9 @@ namespace Envoy {
 namespace Fuzz {
 
 // Convert from test proto Headers to TestHeaderMapImpl.
-inline Http::TestHeaderMapImpl
-fromHeaders(const test::fuzz::Headers& headers,
-            const std::unordered_set<std::string>& ignore_headers = {}) {
+inline Http::TestHeaderMapImpl fromHeaders(
+    const test::fuzz::Headers& headers,
+    const std::unordered_set<std::string>& ignore_headers = std::unordered_set<std::string>({})) {
   Http::TestHeaderMapImpl header_map;
   for (const auto& header : headers.headers()) {
     // HeaderMapImpl and places such as the route lookup should never see strings with embedded NULL


### PR DESCRIPTION
We hit
https://stackoverflow.com/questions/17264067/chosen-constructor-is-explicit-in-copy-initialization-error-with-clang-4-2
on Google import.

Signed-off-by: Harvey Tuch <htuch@google.com>