### PR TITLE
mysql_filter: fix integration test flakes

### DIFF
--- a/test/extensions/filters/network/mysql_proxy/BUILD
+++ b/test/extensions/filters/network/mysql_proxy/BUILD
@@ -49,28 +49,24 @@ envoy_extension_cc_test(
     ],
 )
 
-# See https://github.com/envoyproxy/envoy/issues/6162.
-#
-# TODO(venilnoronha, #6162): uncomment this once this works on all platforms.
-#
-# envoy_extension_cc_test(
-#     name = "mysql_integration_test",
-#     srcs = [
-#         "mysql_integration_test.cc",
-#     ],
-#     data = [
-#         "mysql_test_config.yaml",
-#     ],
-#     extension_name = "envoy.filters.network.mysql_proxy",
-#     deps = [
-#         ":mysql_test_utils_lib",
-#         "//source/common/tcp_proxy",
-#         "//source/extensions/filters/network/mysql_proxy:config",
-#         "//source/extensions/filters/network/mysql_proxy:proxy_lib",
-#         "//source/extensions/filters/network/tcp_proxy:config",
-#         "//test/integration:integration_lib",
-#     ],
-# )
+envoy_extension_cc_test(
+    name = "mysql_integration_test",
+    srcs = [
+        "mysql_integration_test.cc",
+    ],
+    data = [
+        "mysql_test_config.yaml",
+    ],
+    extension_name = "envoy.filters.network.mysql_proxy",
+    deps = [
+        ":mysql_test_utils_lib",
+        "//source/common/tcp_proxy",
+        "//source/extensions/filters/network/mysql_proxy:config",
+        "//source/extensions/filters/network/mysql_proxy:proxy_lib",
+        "//source/extensions/filters/network/tcp_proxy:config",
+        "//test/integration:integration_lib",
+    ],
+)
 
 envoy_extension_cc_test(
     name = "mysql_command_tests",

--- a/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
@@ -78,7 +78,7 @@ TEST_P(MySQLIntegrationTest, MySQLStatsNewSessionTest) {
  * - no failures
  */
 TEST_P(MySQLIntegrationTest, MySQLLoginTest) {
-  std::string str = "";
+  std::string str;
   std::string rcvd_data;
   std::string user = "user1";
 
@@ -125,7 +125,7 @@ TEST_P(MySQLIntegrationTest, MySQLUnitTestMultiClientsLoop) {
   std::string rcvd_data;
 
   for (idx = 0; idx < CLIENT_NUM; idx++) {
-    std::string str = "";
+    std::string str;
     std::string user("user");
     user.append(std::to_string(idx));
 

--- a/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
@@ -74,8 +74,8 @@ TEST_P(MySQLIntegrationTest, MySQLStatsNewSessionTest) {
  * - correct number of attempts
  * - no failures
  */
-TEST_P(MySQLIntegrationTest, MysqLoginTest) {
-  std::string str;
+TEST_P(MySQLIntegrationTest, MySQLLoginTest) {
+  std::string str = "";
   std::string rcvd_data;
   std::string user = "user1";
 
@@ -86,7 +86,9 @@ TEST_P(MySQLIntegrationTest, MysqLoginTest) {
   // greeting
   std::string greeting = encodeServerGreeting(MYSQL_PROTOCOL_10);
   ASSERT_TRUE(fake_upstream_connection->write(greeting));
-  tcp_client->waitForData(str);
+
+  str.append(greeting);
+  tcp_client->waitForData(str, true);
 
   // Client username/password and capabilities
   std::string login = encodeClientLogin(MYSQL_CLIENT_CAPAB_41VS320, user, CHALLENGE_SEQ_NUM);
@@ -97,7 +99,9 @@ TEST_P(MySQLIntegrationTest, MysqLoginTest) {
   // Server response OK to username/password
   std::string loginok = encodeClientLoginResp(MYSQL_RESP_OK);
   ASSERT_TRUE(fake_upstream_connection->write(loginok));
-  tcp_client->waitForData(str);
+
+  str.append(loginok);
+  tcp_client->waitForData(str, true);
 
   tcp_client->close();
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
@@ -116,9 +120,9 @@ TEST_P(MySQLIntegrationTest, MysqLoginTest) {
 TEST_P(MySQLIntegrationTest, MySQLUnitTestMultiClientsLoop) {
   int idx;
   std::string rcvd_data;
-  std::string str;
 
   for (idx = 0; idx < CLIENT_NUM; idx++) {
+    std::string str = "";
     std::string user("user");
     user.append(std::to_string(idx));
 
@@ -129,7 +133,9 @@ TEST_P(MySQLIntegrationTest, MySQLUnitTestMultiClientsLoop) {
     // greeting
     std::string greeting = encodeServerGreeting(MYSQL_PROTOCOL_10);
     ASSERT_TRUE(fake_upstream_connection->write(greeting));
-    tcp_client->waitForData(str);
+
+    str.append(greeting);
+    tcp_client->waitForData(str, true);
 
     // Client username/password and capabilities
     std::string login = encodeClientLogin(MYSQL_CLIENT_CAPAB_41VS320, user, CHALLENGE_SEQ_NUM);
@@ -140,7 +146,9 @@ TEST_P(MySQLIntegrationTest, MySQLUnitTestMultiClientsLoop) {
     // Server response OK to username/password
     std::string loginok = encodeClientLoginResp(MYSQL_RESP_OK);
     ASSERT_TRUE(fake_upstream_connection->write(loginok));
-    tcp_client->waitForData(str);
+
+    str.append(loginok);
+    tcp_client->waitForData(str, true);
 
     tcp_client->close();
     ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());

--- a/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
@@ -30,8 +30,11 @@ class MySQLIntegrationTest : public testing::TestWithParam<Network::Address::IpV
                              public MySQLTestUtils,
                              public BaseIntegrationTest {
   std::string mysqlConfig() {
-    return TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
-        "test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml"));
+    return fmt::format(TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
+                           "test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml")),
+                       Network::Test::getLoopbackAddressString(GetParam()),
+                       Network::Test::getLoopbackAddressString(GetParam()),
+                       Network::Test::getAnyAddressString(GetParam()));
   }
 
 public:

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml
@@ -2,7 +2,7 @@ admin:
   access_log_path: /dev/null
   address:
     socket_address:
-      address: 127.0.0.1
+      address: "{}"
       port_value: 0
 static_resources:
   clusters:
@@ -15,13 +15,13 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: "{}"
                 port_value: 0
   listeners:
     name: listener_0
     address:
       socket_address:
-        address: 0.0.0.0
+        address: "{}"
         port_value: 0
     filter_chains:
       - filters:


### PR DESCRIPTION
Description: This fixes flakes in the MySQL integration tests by introducing an exact
match for server responses. A separate issue was found when running under IPv6 due to the presence of IPv4 addresses in the test configuration. This fixes that issue as well.
Risk Level: Low
Testing: Ran `mysql_integration_test` x5000
Docs Changes: N/A
Release Notes: N/A
Fixes #6162
Fixes #6131