### PR TITLE
Support NotModified (304) for REST responses

### DIFF
--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -32,6 +32,7 @@ void RestApiFetcher::onSuccess(Http::MessagePtr&& response) {
   uint64_t response_code = Http::Utility::getResponseStatus(response->headers());
   if (response_code == enumToInt(Http::Code::NotModified)) {
     requestComplete();
+    return;
   } else if (response_code != enumToInt(Http::Code::OK)) {
     onFailure(Http::AsyncClient::FailureReason::Reset);
     return;

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -30,7 +30,9 @@ void RestApiFetcher::initialize() { refresh(); }
 
 void RestApiFetcher::onSuccess(Http::MessagePtr&& response) {
   uint64_t response_code = Http::Utility::getResponseStatus(response->headers());
-  if (response_code != enumToInt(Http::Code::OK)) {
+  if (response_code == enumToInt(Http::Code::NotModified)) {
+    requestComplete();
+  } else if (response_code != enumToInt(Http::Code::OK)) {
     onFailure(Http::AsyncClient::FailureReason::Reset);
     return;
   }


### PR DESCRIPTION
There's currently no way to avoid sending a snapshot of configuration via a discovery response using REST, without Envoy considering it a failure.

For the situation where the configuration available on the control plane, and the configuration available on the envoy proxy are the same, a REST control plane must either:

1. Return a 200 OK with the full snapshot of configuration
2. Do something outside the norm, resulting in metrics being emitted that indicate an xDS update failure, in addition to warnings emitted to logs

I'd like to allow `HTTP 304 Not Modified` as a way of indicating that Envoy doesn't need to make any changes to configuration.

I don't really know C++ at all, so if this is completely wrong please let me know!
I hope that this change is okay.