### PR TITLE
Plumb BoolIndicator through stats sink and admin

### DIFF
--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -64,6 +64,13 @@ void UdpStatsdSink::flush(Stats::Source& source) {
                                buildTagStr(gauge->tags())));
     }
   }
+
+  for (const Stats::BoolIndicatorSharedPtr& boolIndicator : source.cachedBoolIndicators()) {
+    if (boolIndicator->used()) {
+      writer.write(fmt::format("{}.{}:{}|g{}", prefix_, getName(*boolIndicator), boolIndicator->value(),
+                               buildTagStr(boolIndicator->tags())));
+    }
+  }
 }
 
 void UdpStatsdSink::onHistogramComplete(const Stats::Histogram& histogram, uint64_t value) {
@@ -124,6 +131,13 @@ void TcpStatsdSink::flush(Stats::Source& source) {
       tls_sink.flushGauge(gauge->name(), gauge->value());
     }
   }
+
+  for (const Stats::BoolIndicatorSharedPtr& boolIndicator : source.cachedBoolIndicators()) {
+    if (boolIndicator->used()) {
+      tls_sink.flushGauge(boolIndicator->name(), static_cast<uint64_t>(boolIndicator->value()));
+    }
+  }
+
   tls_sink.endFlush(true);
 }
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -377,6 +377,7 @@ public:
   static uint64_t statsAsPrometheus(const std::vector<Stats::CounterSharedPtr>& counters,
                                     const std::vector<Stats::GaugeSharedPtr>& gauges,
                                     const std::vector<Stats::ParentHistogramSharedPtr>& histograms,
+                                    const std::vector<Stats::BoolIndicatorSharedPtr>& boolIndicators,
                                     Buffer::Instance& response, const bool used_only);
   /**
    * Format the given tags, returning a string as a comma-separated list

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1274,11 +1274,17 @@ protected:
     histograms_.push_back(histogram);
   }
 
+  void addBoolIndicator(const std::string& name, std::vector<Stats::Tag> cluster_tags) {
+    std::string tname = std::string(name);
+    bool_indicators_.push_back(alloc_.makeBoolIndicator(name, std::move(tname), std::move(cluster_tags)));
+  }
+
   Stats::StatsOptionsImpl stats_options_;
   Stats::HeapStatDataAllocator alloc_;
   std::vector<Stats::CounterSharedPtr> counters_;
   std::vector<Stats::GaugeSharedPtr> gauges_;
   std::vector<Stats::ParentHistogramSharedPtr> histograms_;
+  std::vector<Stats::BoolIndicatorSharedPtr> boolIndicators_;
 };
 
 TEST_F(PrometheusStatsFormatterTest, MetricName) {
@@ -1329,7 +1335,7 @@ TEST_F(PrometheusStatsFormatterTest, MetricNameCollison) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, false);
   EXPECT_EQ(2UL, size);
 }
 
@@ -1349,7 +1355,7 @@ TEST_F(PrometheusStatsFormatterTest, UniqueMetricName) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, false);
   EXPECT_EQ(4UL, size);
 }
 
@@ -1368,7 +1374,7 @@ TEST_F(PrometheusStatsFormatterTest, HistogramWithNoValuesAndNoTags) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_,response, false);
   EXPECT_EQ(1UL, size);
 
   const std::string expected_output = R"EOF(# TYPE envoy_histogram1 histogram
@@ -1420,7 +1426,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithAllMetricTypes) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, false);
   EXPECT_EQ(5UL, size);
 
   const std::string expected_output = R"EOF(# TYPE envoy_cluster_test_1_upstream_cx_total counter
@@ -1480,7 +1486,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithUsedOnly) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, response, true);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, true);
   EXPECT_EQ(1UL, size);
 
   const std::string expected_output = R"EOF(# TYPE envoy_cluster_test_1_upstream_rq_time histogram
@@ -1529,7 +1535,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithUsedOnlyHistogram) {
 
     Buffer::OwnedImpl response;
     auto size = PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_,
-                                                            response, used_only);
+                                                            bool_indicators_, response, used_only);
     EXPECT_EQ(0UL, size);
   }
 
@@ -1540,7 +1546,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithUsedOnlyHistogram) {
 
     Buffer::OwnedImpl response;
     auto size = PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_,
-                                                            response, used_only);
+                                                            bool_indicators_, response, used_only);
     EXPECT_EQ(1UL, size);
   }
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1276,7 +1276,7 @@ protected:
 
   void addBoolIndicator(const std::string& name, std::vector<Stats::Tag> cluster_tags) {
     std::string tname = std::string(name);
-    bool_indicators_.push_back(alloc_.makeBoolIndicator(name, std::move(tname), std::move(cluster_tags)));
+    boolIndicators_.push_back(alloc_.makeBoolIndicator(name, std::move(tname), std::move(cluster_tags)));
   }
 
   Stats::StatsOptionsImpl stats_options_;
@@ -1335,7 +1335,7 @@ TEST_F(PrometheusStatsFormatterTest, MetricNameCollison) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, boolIndicators_, response, false);
   EXPECT_EQ(2UL, size);
 }
 
@@ -1355,7 +1355,7 @@ TEST_F(PrometheusStatsFormatterTest, UniqueMetricName) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, boolIndicators_, response, false);
   EXPECT_EQ(4UL, size);
 }
 
@@ -1374,7 +1374,7 @@ TEST_F(PrometheusStatsFormatterTest, HistogramWithNoValuesAndNoTags) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_,response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, boolIndicators_,response, false);
   EXPECT_EQ(1UL, size);
 
   const std::string expected_output = R"EOF(# TYPE envoy_histogram1 histogram
@@ -1426,7 +1426,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithAllMetricTypes) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, false);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, boolIndicators_, response, false);
   EXPECT_EQ(5UL, size);
 
   const std::string expected_output = R"EOF(# TYPE envoy_cluster_test_1_upstream_cx_total counter
@@ -1486,7 +1486,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithUsedOnly) {
 
   Buffer::OwnedImpl response;
   auto size =
-      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, bool_indicators_, response, true);
+      PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_, boolIndicators_, response, true);
   EXPECT_EQ(1UL, size);
 
   const std::string expected_output = R"EOF(# TYPE envoy_cluster_test_1_upstream_rq_time histogram
@@ -1535,7 +1535,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithUsedOnlyHistogram) {
 
     Buffer::OwnedImpl response;
     auto size = PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_,
-                                                            bool_indicators_, response, used_only);
+                                                            boolIndicators_, response, used_only);
     EXPECT_EQ(0UL, size);
   }
 
@@ -1546,7 +1546,7 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithUsedOnlyHistogram) {
 
     Buffer::OwnedImpl response;
     auto size = PrometheusStatsFormatter::statsAsPrometheus(counters_, gauges_, histograms_,
-                                                            bool_indicators_, response, used_only);
+                                                            boolIndicators_, response, used_only);
     EXPECT_EQ(1UL, size);
   }
 }


### PR DESCRIPTION
WIP
Description: Plumb the boolIndicators through various stats sinks and handlers.  This also needs to cast from bool to int for collectors like statsd and prometheus.
Risk Level: Low
Testing: Manual testing

Fixes: #6277


Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>
