### PR TITLE
dubbo_proxy: remove remains of TestBase

### DIFF
--- a/test/extensions/filters/network/dubbo_proxy/app_exception_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/app_exception_test.cc
@@ -7,7 +7,6 @@
 #include "extensions/filters/network/dubbo_proxy/metadata.h"
 
 #include "test/extensions/filters/network/dubbo_proxy/mocks.h"
-#include "test/test_common/test_base.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -20,7 +19,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace DubboProxy {
 
-class AppExceptionTest : public TestBase {
+class AppExceptionTest : public testing::Test {
 public:
   AppExceptionTest() : metadata_(std::make_shared<MessageMetadata>()) {}
 

--- a/test/extensions/filters/network/dubbo_proxy/router_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/router_test.cc
@@ -8,7 +8,6 @@
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/registry.h"
-#include "test/test_common/test_base.h"
 
 #include "gtest/gtest.h"
 
@@ -227,7 +226,7 @@ public:
   NiceMock<Network::MockClientConnection> upstream_connection_;
 };
 
-class DubboRouterTest : public DubboRouterTestBase, public TestBase {};
+class DubboRouterTest : public DubboRouterTestBase, public testing::Test {};
 
 TEST_F(DubboRouterTest, PoolRemoteConnectionFailure) {
   initializeRouter();


### PR DESCRIPTION
Description: remove remains of TestBase
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
