### PR TITLE
add checks for openssl release testing

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -77,7 +77,9 @@ ConnectionImpl::~ConnectionImpl() {
   // run. This generally must be done so that callbacks run in the correct context (vs. deferred
   // deletion). Hence the assert above. However, call close() here just to be completely sure that
   // the fd is closed and make it more likely that we crash from a bad close callback.
-  close(ConnectionCloseType::NoFlush);
+  if (ioHandle().fd() == -1 && delayed_close_timer_ == nullptr) {
+    close(ConnectionCloseType::NoFlush);
+  }
 }
 
 void ConnectionImpl::addWriteFilter(WriteFilterSharedPtr filter) {
@@ -387,6 +389,9 @@ void ConnectionImpl::write(Buffer::Instance& data, bool end_stream) {
     // with a connection error if a call to write(2) occurs before the connection is completed.
     if (!connecting_) {
       ASSERT(file_event_ != nullptr, "ConnectionImpl file event was unexpectedly reset");
+      if (file_event_ == nullptr) {
+        throw EnvoyException("ConnectionImpl file event was unexpectedly reset");
+      }
       file_event_->activate(Event::FileReadyType::Write);
     }
   }


### PR DESCRIPTION
Signed-off-by: William DeCoste <bdecoste@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: Add checks corresponding to asserts to enable release config (i.e. NDEBUG) tests of openssl-enabled envoy/istio proxy. 
Risk Level: Low
Testing: Passes standard tests
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue]
[Optional Deprecated:]
