### PR TITLE
tls: drop unused headers from tls_inspector

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -16,7 +16,6 @@
 
 #include "extensions/transport_sockets/well_known_names.h"
 
-#include "openssl/bytestring.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -8,7 +8,6 @@
 
 #include "common/common/logger.h"
 
-#include "openssl/bytestring.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {


### PR DESCRIPTION
Description: the header file `openssl/bytestring.h` is not used neither by tls_inspector.h nor tls_inspector.cc hence can be safely unincluded.
Risk Level: low
Testing: manual testing
Docs Changes: N/A
Release Notes: N/A
