### PR TITLE
test: making our integration tests permissive w.r.t. deprecated features

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -82,7 +82,7 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
 
     restarter_.initialize(*dispatcher_, *this);
     drain_manager_ = component_factory.createDrainManager(*this);
-    initialize(options, local_address, component_factory, hooks);
+    initialize(options, std::move(local_address), component_factory, hooks);
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
@@ -232,7 +232,7 @@ void InstanceImpl::initialize(const Options& options,
             Buffer::OwnedImpl().usesOldImpl() ? "old (libevent)" : "new");
 
   // Handle configuration that needs to take place prior to the main configuration load.
-  InstanceUtil::loadBootstrapConfig(bootstrap_, options, api());
+  InstanceUtil::loadBootstrapConfig(bootstrap_, options, *api_);
   bootstrap_config_update_time_ = time_source_.systemTime();
 
   // Needs to happen as early as possible in the instantiation to preempt the objects that require
@@ -251,7 +251,7 @@ void InstanceImpl::initialize(const Options& options,
   assert_action_registration_ = Assert::setDebugAssertionFailureRecordAction(
       [this]() { server_stats_->debug_assertion_failures_.inc(); });
 
-  failHealthcheck(false);
+  InstanceImpl::failHealthcheck(false);
 
   uint64_t version_int;
   if (!StringUtil::atoull(VersionInfo::revision().substr(0, 6).c_str(), version_int, 16)) {
@@ -262,8 +262,8 @@ void InstanceImpl::initialize(const Options& options,
   bootstrap_.mutable_node()->set_build_version(VersionInfo::version());
 
   local_info_ = std::make_unique<LocalInfo::LocalInfoImpl>(
-      bootstrap_.node(), local_address, options.serviceZone(), options.serviceClusterName(),
-      options.serviceNodeName());
+      bootstrap_.node(), std::move(local_address), options.serviceZone(),
+      options.serviceClusterName(), options.serviceNodeName());
 
   Configuration::InitialImpl initial_config(bootstrap_);
 
@@ -292,10 +292,11 @@ void InstanceImpl::initialize(const Options& options,
   loadServerFlags(initial_config.flagsPath());
 
   // Initialize the overload manager early so other modules can register for actions.
-  overload_manager_ = std::make_unique<OverloadManagerImpl>(dispatcher(), stats(), threadLocal(),
-                                                            bootstrap_.overload_manager(), api());
+  overload_manager_ = std::make_unique<OverloadManagerImpl>(
+      *dispatcher_, stats_store_, thread_local_, bootstrap_.overload_manager(), *api_);
 
-  heap_shrinker_ = std::make_unique<Memory::HeapShrinker>(dispatcher(), overloadManager(), stats());
+  heap_shrinker_ =
+      std::make_unique<Memory::HeapShrinker>(*dispatcher_, *overload_manager_, stats_store_);
 
   // Workers get created first so they register for thread local updates.
   listener_manager_ =
@@ -319,9 +320,9 @@ void InstanceImpl::initialize(const Options& options,
       std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_source_);
 
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
-      admin(), runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(),
-      dispatcher(), localInfo(), secretManager(), api(), http_context_, accessLogManager(),
-      singletonManager());
+      *admin_, Runtime::LoaderSingleton::get(), stats_store_, thread_local_, *random_generator_,
+      dns_resolver_, *ssl_context_manager_, *dispatcher_, *local_info_, *secret_manager_, *api_,
+      http_context_, access_log_manager_, *singleton_manager_);
 
   // Now the configuration gets parsed. The configuration may start setting
   // thread local data per above. See MainImpl::initialize() for why ConfigImpl
@@ -339,14 +340,15 @@ void InstanceImpl::initialize(const Options& options,
   if (bootstrap_.has_hds_config()) {
     const auto& hds_config = bootstrap_.hds_config();
     async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
-        clusterManager(), thread_local_, time_source_, api());
+        *config_.clusterManager(), thread_local_, time_source_, *api_);
     hds_delegate_ = std::make_unique<Upstream::HdsDelegate>(
-        stats(),
-        Config::Utility::factoryForGrpcApiConfigSource(*async_client_manager_, hds_config, stats())
+        stats_store_,
+        Config::Utility::factoryForGrpcApiConfigSource(*async_client_manager_, hds_config,
+                                                       stats_store_)
             ->create(),
-        dispatcher(), runtime(), stats(), sslContextManager(), random(), info_factory_,
-        access_log_manager_, clusterManager(), localInfo(), admin(), singletonManager(),
-        threadLocal(), api());
+        *dispatcher_, Runtime::LoaderSingleton::get(), stats_store_, *ssl_context_manager_,
+        *random_generator_, info_factory_, access_log_manager_, *config_.clusterManager(),
+        *local_info_, *admin_, *singleton_manager_, thread_local_, *api_);
   }
 
   for (Stats::SinkPtr& sink : config_.statsSinks()) {
@@ -360,7 +362,7 @@ void InstanceImpl::initialize(const Options& options,
 
   // GuardDog (deadlock detection) object and thread setup before workers are
   // started and before our own run() loop runs.
-  guard_dog_ = std::make_unique<Server::GuardDogImpl>(stats_store_, config_, api());
+  guard_dog_ = std::make_unique<Server::GuardDogImpl>(stats_store_, config_, *api_);
 }
 
 void InstanceImpl::startWorkers() {
@@ -400,7 +402,7 @@ void InstanceImpl::loadServerFlags(const absl::optional<std::string>& flags_path
   ENVOY_LOG(info, "server flags path: {}", flags_path.value());
   if (api_->fileSystem().fileExists(flags_path.value() + "/drain")) {
     ENVOY_LOG(info, "starting server in drain mode");
-    failHealthcheck(true);
+    InstanceImpl::failHealthcheck(true);
   }
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -82,7 +82,7 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
 
     restarter_.initialize(*dispatcher_, *this);
     drain_manager_ = component_factory.createDrainManager(*this);
-    initialize(options, local_address, component_factory);
+    initialize(options, local_address, component_factory, hooks);
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
@@ -198,7 +198,7 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
 
 void InstanceImpl::initialize(const Options& options,
                               Network::Address::InstanceConstSharedPtr local_address,
-                              ComponentFactory& component_factory) {
+                              ComponentFactory& component_factory, TestHooks& hooks) {
   ENVOY_LOG(info, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
             restarter_.version());
 
@@ -312,6 +312,7 @@ void InstanceImpl::initialize(const Options& options,
   // load things may grab a reference to the loader for later use.
   runtime_singleton_ = std::make_unique<Runtime::ScopedLoaderSingleton>(
       component_factory.createRuntime(*this, initial_config));
+  hooks.onRuntimeCreated();
 
   // Once we have runtime we can initialize the SSL context manager.
   ssl_context_manager_ =

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -200,7 +200,7 @@ private:
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
   void flushStats();
   void initialize(const Options& options, Network::Address::InstanceConstSharedPtr local_address,
-                  ComponentFactory& component_factory);
+                  ComponentFactory& component_factory, TestHooks& hooks);
   void loadServerFlags(const absl::optional<std::string>& flags_path);
   uint64_t numConnections();
   void startWorkers();

--- a/source/server/test_hooks.h
+++ b/source/server/test_hooks.h
@@ -21,6 +21,11 @@ public:
    * Called when a worker has removed a listener and it is no longer listening.
    */
   virtual void onWorkerListenerRemoved() PURE;
+
+  /**
+   * Called when the Runtime::ScopedLoaderSingleton is created by the server.
+   */
+  virtual void onRuntimeCreated() PURE;
 };
 
 /**
@@ -31,6 +36,7 @@ public:
   // TestHooks
   void onWorkerListenerAdded() override {}
   void onWorkerListenerRemoved() override {}
+  void onRuntimeCreated() override {}
 };
 
 } // namespace Envoy

--- a/test/common/runtime/utility.h
+++ b/test/common/runtime/utility.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/runtime/runtime_features.h"
+#include "common/runtime/runtime_impl.h"
 
 namespace Envoy {
 namespace Runtime {

--- a/test/common/runtime/utility.h
+++ b/test/common/runtime/utility.h
@@ -16,6 +16,11 @@ public:
     const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
         ->enabled_features_.erase(feature);
   }
+  static void setAllFeaturesAllowed() {
+    for (const std::string& feature : RuntimeFeaturesDefaults::get().disallowed_features_) {
+      Runtime::LoaderSingleton::getExisting()->mergeValues({{feature, "true"}});
+    }
+  }
 };
 
 } // namespace Runtime

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -371,6 +371,7 @@ envoy_cc_test_library(
         "//source/server:hot_restart_nop_lib",
         "//source/server:server_lib",
         "//source/server:test_hooks_lib",
+        "//test/common/runtime:utility_lib",
         "//test/common/upstream:utility_lib",
         "//test/config:utility_lib",
         "//test/mocks/buffer:buffer_mocks",

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -14,6 +14,7 @@
 #include "server/hot_restart_nop_impl.h"
 #include "server/options_impl.h"
 
+#include "test/common/runtime/utility.h"
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"
 #include "test/mocks/runtime/mocks.h"
@@ -151,6 +152,16 @@ void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion vers
   }
   createAndRunEnvoyServer(options, time_system_, Network::Utility::getLocalAddress(version), *this,
                           lock, *this, std::move(random_generator));
+}
+
+void IntegrationTestServer::onRuntimeCreated() {
+  // Override runtime values to by default allow all disallowed features.
+  //
+  // Per #6288 we explicitly want to allow end to end testing of disallowed features until the code
+  // is removed from Envoy.
+  //
+  // This will revert as the runtime is torn down with the test Envoy server.
+  Runtime::RuntimeFeaturesPeer::setAllFeaturesAllowed();
 }
 
 void IntegrationTestServerImpl::createAndRunEnvoyServer(

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -185,10 +185,10 @@ public:
 
   Server::TestDrainManager& drainManager() { return *drain_manager_; }
   void setOnWorkerListenerAddedCb(std::function<void()> on_worker_listener_added) {
-    on_worker_listener_added_cb_ = on_worker_listener_added;
+    on_worker_listener_added_cb_ = std::move(on_worker_listener_added);
   }
   void setOnWorkerListenerRemovedCb(std::function<void()> on_worker_listener_removed) {
-    on_worker_listener_removed_cb_ = on_worker_listener_removed;
+    on_worker_listener_removed_cb_ = std::move(on_worker_listener_removed);
   }
   void onRuntimeCreated() override;
 

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -190,6 +190,8 @@ public:
   void setOnWorkerListenerRemovedCb(std::function<void()> on_worker_listener_removed) {
     on_worker_listener_removed_cb_ = on_worker_listener_removed;
   }
+  void onRuntimeCreated() override;
+
   void start(const Network::Address::IpVersion version,
              std::function<void()> on_server_init_function, bool deterministic,
              bool defer_listener_finalization);


### PR DESCRIPTION
Risk Level: Medium (minor refactors to server.cc to make clang-tidy happy)
Testing: integration tests now pass after deprecation script runs
Docs Changes: n/a
Release Notes: n/a
Fixes #6288
