### PR TITLE
load balancer: use the right scheduler when targeting degraded hosts

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -296,9 +296,10 @@ public:
   virtual LocalityWeightsConstSharedPtr localityWeights() const PURE;
 
   /**
-   * @return next locality index to route to if performing locality weighted balancing.
+   * @return next locality index to route to if performing locality weighted balancing
+   * against healthy hosts.
    */
-  virtual absl::optional<uint32_t> chooseLocality() PURE;
+  virtual absl::optional<uint32_t> chooseHealthyLocality() PURE;
 
   /**
    * @return next locality index to route to if performing locality weighted balancing

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -301,6 +301,12 @@ public:
   virtual absl::optional<uint32_t> chooseLocality() PURE;
 
   /**
+   * @return next locality index to route to if performing locality weighted balancing
+   * against degraded hosts.
+   */
+  virtual absl::optional<uint32_t> chooseDegradedLocality() PURE;
+
+  /**
    * @return uint32_t the priority of this host set.
    */
   virtual uint32_t priority() const PURE;

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -542,7 +542,7 @@ ZoneAwareLoadBalancerBase::hostSourceToUse(LoadBalancerContext* context) {
   if (host_availability == HostAvailability::Degraded) {
     locality = host_set.chooseDegradedLocality();
   } else {
-    locality = host_set.chooseLocality();
+    locality = host_set.chooseHealthyLocality();
   }
 
   if (locality.has_value()) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -538,7 +538,13 @@ ZoneAwareLoadBalancerBase::hostSourceToUse(LoadBalancerContext* context) {
   }
 
   // If we're doing locality weighted balancing, pick locality.
-  const absl::optional<uint32_t> locality = host_set.chooseLocality();
+  absl::optional<uint32_t> locality;
+  if (host_availability == HostAvailability::Degraded) {
+    locality = host_set.chooseDegradedLocality();
+  } else {
+    locality = host_set.chooseLocality();
+  }
+
   if (locality.has_value()) {
     hosts_source.source_type_ = localitySourceType(host_availability);
     hosts_source.locality_index_ = locality.value();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -357,7 +357,7 @@ void HostSetImpl::rebuildLocalityScheduler(
   }
 }
 
-absl::optional<uint32_t> HostSetImpl::chooseLocality() {
+absl::optional<uint32_t> HostSetImpl::chooseHealthyLocality() {
   return chooseLocality(locality_scheduler_);
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -357,18 +357,24 @@ void HostSetImpl::rebuildLocalityScheduler(
   }
 }
 
-absl::optional<uint32_t> HostSetImpl::chooseLocality() {
-  if (locality_scheduler_ == nullptr) {
+absl::optional<uint32_t> HostSetImpl::chooseLocality() { return chooseLocality(locality_scheduler_); }
+
+absl::optional<uint32_t> HostSetImpl::chooseDegradedLocality() { return chooseLocality(degraded_locality_scheduler_); }
+
+absl::optional<uint32_t> HostSetImpl::chooseLocality(
+    std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler) {
+  if (locality_scheduler == nullptr) {
     return {};
   }
-  const std::shared_ptr<LocalityEntry> locality = locality_scheduler_->pick();
+  const std::shared_ptr<LocalityEntry> locality = locality_scheduler->pick();
   // We don't build a schedule if there are no weighted localities, so we should always succeed.
   ASSERT(locality != nullptr);
   // If we picked it before, its weight must have been positive.
   ASSERT(locality->effective_weight_ > 0);
-  locality_scheduler_->add(locality->effective_weight_, locality);
+  locality_scheduler->add(locality->effective_weight_, locality);
   return locality->index_;
 }
+
 
 PrioritySet::UpdateHostsParams
 HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -305,7 +305,7 @@ void HostSetImpl::updateHosts(PrioritySet::UpdateHostsParams&& update_hosts_para
   degraded_hosts_per_locality_ = std::move(update_hosts_params.degraded_hosts_per_locality);
   locality_weights_ = std::move(locality_weights);
 
-  rebuildLocalityScheduler(locality_scheduler_, locality_entries_, *healthy_hosts_per_locality_,
+  rebuildLocalityScheduler(healthy_locality_scheduler_, healthy_locality_entries_, *healthy_hosts_per_locality_,
                            *healthy_hosts_, hosts_per_locality_, locality_weights_,
                            overprovisioning_factor_);
   rebuildLocalityScheduler(degraded_locality_scheduler_, degraded_locality_entries_,
@@ -358,15 +358,15 @@ void HostSetImpl::rebuildLocalityScheduler(
 }
 
 absl::optional<uint32_t> HostSetImpl::chooseHealthyLocality() {
-  return chooseLocality(locality_scheduler_);
+  return chooseLocality(healthy_locality_scheduler_.get());
 }
 
 absl::optional<uint32_t> HostSetImpl::chooseDegradedLocality() {
-  return chooseLocality(degraded_locality_scheduler_);
+  return chooseLocality(degraded_locality_scheduler_.get());
 }
 
 absl::optional<uint32_t>
-HostSetImpl::chooseLocality(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler) {
+HostSetImpl::chooseLocality(EdfScheduler<LocalityEntry>* locality_scheduler) {
   if (locality_scheduler == nullptr) {
     return {};
   }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -357,12 +357,16 @@ void HostSetImpl::rebuildLocalityScheduler(
   }
 }
 
-absl::optional<uint32_t> HostSetImpl::chooseLocality() { return chooseLocality(locality_scheduler_); }
+absl::optional<uint32_t> HostSetImpl::chooseLocality() {
+  return chooseLocality(locality_scheduler_);
+}
 
-absl::optional<uint32_t> HostSetImpl::chooseDegradedLocality() { return chooseLocality(degraded_locality_scheduler_); }
+absl::optional<uint32_t> HostSetImpl::chooseDegradedLocality() {
+  return chooseLocality(degraded_locality_scheduler_);
+}
 
-absl::optional<uint32_t> HostSetImpl::chooseLocality(
-    std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler) {
+absl::optional<uint32_t>
+HostSetImpl::chooseLocality(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler) {
   if (locality_scheduler == nullptr) {
     return {};
   }
@@ -374,7 +378,6 @@ absl::optional<uint32_t> HostSetImpl::chooseLocality(
   locality_scheduler->add(locality->effective_weight_, locality);
   return locality->index_;
 }
-
 
 PrioritySet::UpdateHostsParams
 HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -305,9 +305,9 @@ void HostSetImpl::updateHosts(PrioritySet::UpdateHostsParams&& update_hosts_para
   degraded_hosts_per_locality_ = std::move(update_hosts_params.degraded_hosts_per_locality);
   locality_weights_ = std::move(locality_weights);
 
-  rebuildLocalityScheduler(healthy_locality_scheduler_, healthy_locality_entries_, *healthy_hosts_per_locality_,
-                           *healthy_hosts_, hosts_per_locality_, locality_weights_,
-                           overprovisioning_factor_);
+  rebuildLocalityScheduler(healthy_locality_scheduler_, healthy_locality_entries_,
+                           *healthy_hosts_per_locality_, *healthy_hosts_, hosts_per_locality_,
+                           locality_weights_, overprovisioning_factor_);
   rebuildLocalityScheduler(degraded_locality_scheduler_, degraded_locality_entries_,
                            *degraded_hosts_per_locality_, *degraded_hosts_, hosts_per_locality_,
                            locality_weights_, overprovisioning_factor_);

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -304,7 +304,7 @@ public:
     return *degraded_hosts_per_locality_;
   }
   LocalityWeightsConstSharedPtr localityWeights() const override { return locality_weights_; }
-  absl::optional<uint32_t> chooseLocality() override;
+  absl::optional<uint32_t> chooseHealthyLocality() override;
   absl::optional<uint32_t> chooseDegradedLocality() override;
   uint32_t priority() const override { return priority_; }
   uint32_t overprovisioningFactor() const override { return overprovisioning_factor_; }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -388,7 +388,8 @@ private:
       HostsPerLocalityConstSharedPtr all_hosts_per_locality,
       LocalityWeightsConstSharedPtr locality_weights, uint32_t overprovisioning_factor);
 
-  static absl::optional<uint32_t> chooseLocality(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler);
+  static absl::optional<uint32_t>
+  chooseLocality(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler);
 
   std::vector<std::shared_ptr<LocalityEntry>> locality_entries_;
   std::unique_ptr<EdfScheduler<LocalityEntry>> locality_scheduler_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -388,8 +388,7 @@ private:
       HostsPerLocalityConstSharedPtr all_hosts_per_locality,
       LocalityWeightsConstSharedPtr locality_weights, uint32_t overprovisioning_factor);
 
-  static absl::optional<uint32_t>
-  chooseLocality(EdfScheduler<LocalityEntry>* locality_scheduler);
+  static absl::optional<uint32_t> chooseLocality(EdfScheduler<LocalityEntry>* locality_scheduler);
 
   std::vector<std::shared_ptr<LocalityEntry>> healthy_locality_entries_;
   std::unique_ptr<EdfScheduler<LocalityEntry>> healthy_locality_scheduler_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -305,6 +305,7 @@ public:
   }
   LocalityWeightsConstSharedPtr localityWeights() const override { return locality_weights_; }
   absl::optional<uint32_t> chooseLocality() override;
+  absl::optional<uint32_t> chooseDegradedLocality() override;
   uint32_t priority() const override { return priority_; }
   uint32_t overprovisioningFactor() const override { return overprovisioning_factor_; }
 
@@ -386,6 +387,8 @@ private:
       const HostsPerLocality& eligible_hosts_per_locality, const HostVector& eligible_hosts,
       HostsPerLocalityConstSharedPtr all_hosts_per_locality,
       LocalityWeightsConstSharedPtr locality_weights, uint32_t overprovisioning_factor);
+
+  static absl::optional<uint32_t> chooseLocality(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler);
 
   std::vector<std::shared_ptr<LocalityEntry>> locality_entries_;
   std::unique_ptr<EdfScheduler<LocalityEntry>> locality_scheduler_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -389,10 +389,10 @@ private:
       LocalityWeightsConstSharedPtr locality_weights, uint32_t overprovisioning_factor);
 
   static absl::optional<uint32_t>
-  chooseLocality(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler);
+  chooseLocality(EdfScheduler<LocalityEntry>* locality_scheduler);
 
-  std::vector<std::shared_ptr<LocalityEntry>> locality_entries_;
-  std::unique_ptr<EdfScheduler<LocalityEntry>> locality_scheduler_;
+  std::vector<std::shared_ptr<LocalityEntry>> healthy_locality_entries_;
+  std::unique_ptr<EdfScheduler<LocalityEntry>> healthy_locality_scheduler_;
   std::vector<std::shared_ptr<LocalityEntry>> degraded_locality_entries_;
   std::unique_ptr<EdfScheduler<LocalityEntry>> degraded_locality_scheduler_;
 };

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -640,8 +640,7 @@ TEST_P(RoundRobinLoadBalancerTest, DegradedLocality) {
   HostVectorSharedPtr degraded_hosts(new HostVector({(*hosts)[1], (*hosts)[2]}));
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{(*hosts)[0]}, {(*hosts)[1], (*hosts)[2]}});
-  HostsPerLocalitySharedPtr healthy_hosts_per_locality =
-      makeHostsPerLocality({{(*hosts)[0]}, {}});
+  HostsPerLocalitySharedPtr healthy_hosts_per_locality = makeHostsPerLocality({{(*hosts)[0]}, {}});
   HostsPerLocalitySharedPtr degraded_hosts_per_locality =
       makeHostsPerLocality({{}, {(*hosts)[1], (*hosts)[2]}});
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -653,8 +653,8 @@ TEST_P(RoundRobinLoadBalancerTest, DegradedLocality) {
   init(false);
 
   EXPECT_CALL(random_, random()).WillOnce(Return(50)).WillOnce(Return(0));
-  // Since we're split between healthy and degraded, the LB should call into both chooseHealthyLocality
-  // and chooseDegradedLocality.
+  // Since we're split between healthy and degraded, the LB should call into both
+  // chooseHealthyLocality and chooseDegradedLocality.
   EXPECT_CALL(hostSet(), chooseDegradedLocality()).WillOnce(Return(1));
   EXPECT_EQ(hostSet().degraded_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(0));

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -612,23 +612,23 @@ TEST_P(RoundRobinLoadBalancerTest, Locality) {
   hostSet().healthy_hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(false);
-  // chooseLocality() return value determines which locality we use.
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(0));
+  // chooseHealthyLocality() return value determines which locality we use.
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(0));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(1));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(1));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(0));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(0));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(1));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(1));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(0));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(0));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   // When there is no locality, we RR over all available hosts.
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(absl::optional<uint32_t>()));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(absl::optional<uint32_t>()));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(absl::optional<uint32_t>()));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(absl::optional<uint32_t>()));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(absl::optional<uint32_t>()));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(absl::optional<uint32_t>()));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
 }
 
@@ -653,11 +653,11 @@ TEST_P(RoundRobinLoadBalancerTest, DegradedLocality) {
   init(false);
 
   EXPECT_CALL(random_, random()).WillOnce(Return(50)).WillOnce(Return(0));
-  // Since we're split between healthy and degraded, the LB should call into both chooseLocality
+  // Since we're split between healthy and degraded, the LB should call into both chooseHealthyLocality
   // and chooseDegradedLocality.
   EXPECT_CALL(hostSet(), chooseDegradedLocality()).WillOnce(Return(1));
   EXPECT_EQ(hostSet().degraded_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_CALL(hostSet(), chooseLocality()).WillOnce(Return(0));
+  EXPECT_CALL(hostSet(), chooseHealthyLocality()).WillOnce(Return(0));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
 }
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -56,7 +56,7 @@ public:
   MOCK_CONST_METHOD0(healthyHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(degradedHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(localityWeights, LocalityWeightsConstSharedPtr());
-  MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
+  MOCK_METHOD0(chooseHealthyLocality, absl::optional<uint32_t>());
   MOCK_METHOD0(chooseDegradedLocality, absl::optional<uint32_t>());
   MOCK_CONST_METHOD0(priority, uint32_t());
   uint32_t overprovisioningFactor() const override { return overprovisioning_factor_; }

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -57,6 +57,7 @@ public:
   MOCK_CONST_METHOD0(degradedHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(localityWeights, LocalityWeightsConstSharedPtr());
   MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
+  MOCK_METHOD0(chooseDegradedLocality, absl::optional<uint32_t>());
   MOCK_CONST_METHOD0(priority, uint32_t());
   uint32_t overprovisioningFactor() const override { return overprovisioning_factor_; }
   void setOverprovisioningFactor(const uint32_t overprovisioning_factor) {


### PR DESCRIPTION

This fixes a bug where the wrong locality scheduler was used when
targeting degraded hosts. Instead of using the scheduler with weights
adjusted for the number of degraded hosts, the regular one adjusted for
the number of *healthy* hosts would be used instead. This would lead to
occasional UH failures because a degraded priority was selected, but a
locality with no degraded hosts got selected.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Medium
Testing: Added UT verifying we use the correct scheduler
Docs Changes: n/a
Release Notes: n/a
Fixes #6287 