### PR TITLE
tracing: rename const strings

### DIFF
--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -212,8 +212,8 @@ AsyncRequestImpl::AsyncRequestImpl(AsyncClientImpl& parent,
   current_span_ = parent_span.spawnChild(Tracing::EgressConfig::get(),
                                          "async " + parent.remote_cluster_name_ + " egress",
                                          parent.time_source_.systemTime());
-  current_span_->setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, parent.remote_cluster_name_);
-  current_span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
+  current_span_->setTag(Tracing::Tags::get().UpstreamCluster, parent.remote_cluster_name_);
+  current_span_->setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
 }
 
 void AsyncRequestImpl::initialize(bool buffer_body_for_retry) {
@@ -225,7 +225,7 @@ void AsyncRequestImpl::initialize(bool buffer_body_for_retry) {
 }
 
 void AsyncRequestImpl::cancel() {
-  current_span_->setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED);
+  current_span_->setTag(Tracing::Tags::get().Status, Tracing::Tags::get().Canceled);
   current_span_->finishSpan();
   this->resetStream();
 }
@@ -248,13 +248,13 @@ void AsyncRequestImpl::onReceiveMessageUntyped(ProtobufTypes::MessagePtr&& messa
 void AsyncRequestImpl::onReceiveTrailingMetadata(Http::HeaderMapPtr&&) {}
 
 void AsyncRequestImpl::onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) {
-  current_span_->setTag(Tracing::Tags::get().GRPC_STATUS_CODE, std::to_string(status));
+  current_span_->setTag(Tracing::Tags::get().GrpcStatusCode, std::to_string(status));
 
   if (status != Grpc::Status::GrpcStatus::Ok) {
-    current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    current_span_->setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
     callbacks_.onFailure(status, message, *current_span_);
   } else if (response_ == nullptr) {
-    current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    current_span_->setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
     callbacks_.onFailure(Status::Internal, EMPTY_STRING, *current_span_);
   } else {
     callbacks_.onSuccessUntyped(std::move(response_), *current_span_);

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -392,8 +392,8 @@ GoogleAsyncRequestImpl::GoogleAsyncRequestImpl(
   current_span_ = parent_span.spawnChild(Tracing::EgressConfig::get(),
                                          "async " + parent.stat_prefix_ + " egress",
                                          parent.timeSource().systemTime());
-  current_span_->setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, parent.stat_prefix_);
-  current_span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
+  current_span_->setTag(Tracing::Tags::get().UpstreamCluster, parent.stat_prefix_);
+  current_span_->setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
 }
 
 void GoogleAsyncRequestImpl::initialize(bool buffer_body_for_retry) {
@@ -405,7 +405,7 @@ void GoogleAsyncRequestImpl::initialize(bool buffer_body_for_retry) {
 }
 
 void GoogleAsyncRequestImpl::cancel() {
-  current_span_->setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED);
+  current_span_->setTag(Tracing::Tags::get().Status, Tracing::Tags::get().Canceled);
   current_span_->finishSpan();
   this->resetStream();
 }
@@ -429,13 +429,13 @@ ProtobufTypes::MessagePtr GoogleAsyncRequestImpl::createEmptyResponse() {
 
 void GoogleAsyncRequestImpl::onRemoteClose(Grpc::Status::GrpcStatus status,
                                            const std::string& message) {
-  current_span_->setTag(Tracing::Tags::get().GRPC_STATUS_CODE, std::to_string(status));
+  current_span_->setTag(Tracing::Tags::get().GrpcStatusCode, std::to_string(status));
 
   if (status != Grpc::Status::GrpcStatus::Ok) {
-    current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    current_span_->setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
     callbacks_.onFailure(status, message, *current_span_);
   } else if (response_ == nullptr) {
-    current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    current_span_->setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
     callbacks_.onFailure(Status::Internal, EMPTY_STRING, *current_span_);
   } else {
     callbacks_.onSuccessUntyped(std::move(response_), *current_span_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -974,7 +974,7 @@ Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::I
     span_ = parent_.callbacks_->activeSpan().spawnChild(
         parent_.callbacks_->tracingConfig(), "router " + parent.cluster_->name() + " egress",
         parent.timeSource().systemTime());
-    span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
+    span_->setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
   }
 
   stream_info_.healthCheck(parent_.callbacks_->streamInfo().healthCheck());

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -154,8 +154,7 @@ void HttpTracerUtility::finalizeSpan(Span& span, const Http::HeaderMap* request_
   span.setTag(Tracing::Tags::get().RequestSize, std::to_string(stream_info.bytesReceived()));
 
   if (nullptr != stream_info.upstreamHost()) {
-    span.setTag(Tracing::Tags::get().UpstreamCluster,
-                stream_info.upstreamHost()->cluster().name());
+    span.setTag(Tracing::Tags::get().UpstreamCluster, stream_info.upstreamHost()->cluster().name());
   }
 
   // Post response data.

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -39,15 +39,15 @@ static std::string buildUrl(const Http::HeaderMap& request_headers) {
                      valueOrDefault(request_headers.Host(), ""), path);
 }
 
-const std::string HttpTracerUtility::INGRESS_OPERATION = "ingress";
-const std::string HttpTracerUtility::EGRESS_OPERATION = "egress";
+const std::string HttpTracerUtility::IngressOperation = "ingress";
+const std::string HttpTracerUtility::EgressOperation = "egress";
 
 const std::string& HttpTracerUtility::toString(OperationName operation_name) {
   switch (operation_name) {
   case OperationName::Ingress:
-    return INGRESS_OPERATION;
+    return IngressOperation;
   case OperationName::Egress:
-    return EGRESS_OPERATION;
+    return EgressOperation;
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;
@@ -87,37 +87,37 @@ static void annotateVerbose(Span& span, const StreamInfo::StreamInfo& stream_inf
   if (stream_info.lastDownstreamRxByteReceived()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.lastDownstreamRxByteReceived()),
-             Tracing::Logs::get().LAST_DOWNSTREAM_RX_BYTE_RECEIVED);
+             Tracing::Logs::get().LastDownstreamRxByteReceived);
   }
   if (stream_info.firstUpstreamTxByteSent()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.firstUpstreamTxByteSent()),
-             Tracing::Logs::get().FIRST_UPSTREAM_TX_BYTE_SENT);
+             Tracing::Logs::get().FirstUpstreamTxByteSent);
   }
   if (stream_info.lastUpstreamTxByteSent()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.lastUpstreamTxByteSent()),
-             Tracing::Logs::get().LAST_UPSTREAM_TX_BYTE_SENT);
+             Tracing::Logs::get().LastUpstreamTxByteSent);
   }
   if (stream_info.firstUpstreamRxByteReceived()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.firstUpstreamRxByteReceived()),
-             Tracing::Logs::get().FIRST_UPSTREAM_RX_BYTE_RECEIVED);
+             Tracing::Logs::get().FirstUpstreamRxByteReceived);
   }
   if (stream_info.lastUpstreamRxByteReceived()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.lastUpstreamRxByteReceived()),
-             Tracing::Logs::get().LAST_UPSTREAM_RX_BYTE_RECEIVED);
+             Tracing::Logs::get().LastUpstreamRxByteReceived);
   }
   if (stream_info.firstDownstreamTxByteSent()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.firstDownstreamTxByteSent()),
-             Tracing::Logs::get().FIRST_DOWNSTREAM_TX_BYTE_SENT);
+             Tracing::Logs::get().FirstDownstreamTxByteSent);
   }
   if (stream_info.lastDownstreamTxByteSent()) {
     span.log(start_time + std::chrono::duration_cast<SystemTime::duration>(
                               *stream_info.lastDownstreamTxByteSent()),
-             Tracing::Logs::get().LAST_DOWNSTREAM_TX_BYTE_SENT);
+             Tracing::Logs::get().LastDownstreamTxByteSent);
   }
 }
 
@@ -127,19 +127,19 @@ void HttpTracerUtility::finalizeSpan(Span& span, const Http::HeaderMap* request_
   // Pre response data.
   if (request_headers) {
     if (request_headers->RequestId()) {
-      span.setTag(Tracing::Tags::get().GUID_X_REQUEST_ID,
+      span.setTag(Tracing::Tags::get().GuidXRequestId,
                   std::string(request_headers->RequestId()->value().c_str()));
     }
-    span.setTag(Tracing::Tags::get().HTTP_URL, buildUrl(*request_headers));
-    span.setTag(Tracing::Tags::get().HTTP_METHOD, request_headers->Method()->value().c_str());
-    span.setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER,
+    span.setTag(Tracing::Tags::get().HttpUrl, buildUrl(*request_headers));
+    span.setTag(Tracing::Tags::get().HttpMethod, request_headers->Method()->value().c_str());
+    span.setTag(Tracing::Tags::get().DownstreamCluster,
                 valueOrDefault(request_headers->EnvoyDownstreamServiceCluster(), "-"));
-    span.setTag(Tracing::Tags::get().USER_AGENT, valueOrDefault(request_headers->UserAgent(), "-"));
-    span.setTag(Tracing::Tags::get().HTTP_PROTOCOL,
+    span.setTag(Tracing::Tags::get().UserAgent, valueOrDefault(request_headers->UserAgent(), "-"));
+    span.setTag(Tracing::Tags::get().HttpProtocol,
                 AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocol()));
 
     if (request_headers->ClientTraceId()) {
-      span.setTag(Tracing::Tags::get().GUID_X_CLIENT_TRACE_ID,
+      span.setTag(Tracing::Tags::get().GuidXClientTraceId,
                   std::string(request_headers->ClientTraceId()->value().c_str()));
     }
 
@@ -151,17 +151,17 @@ void HttpTracerUtility::finalizeSpan(Span& span, const Http::HeaderMap* request_
       }
     }
   }
-  span.setTag(Tracing::Tags::get().REQUEST_SIZE, std::to_string(stream_info.bytesReceived()));
+  span.setTag(Tracing::Tags::get().RequestSize, std::to_string(stream_info.bytesReceived()));
 
   if (nullptr != stream_info.upstreamHost()) {
-    span.setTag(Tracing::Tags::get().UPSTREAM_CLUSTER,
+    span.setTag(Tracing::Tags::get().UpstreamCluster,
                 stream_info.upstreamHost()->cluster().name());
   }
 
   // Post response data.
-  span.setTag(Tracing::Tags::get().HTTP_STATUS_CODE, buildResponseCode(stream_info));
-  span.setTag(Tracing::Tags::get().RESPONSE_SIZE, std::to_string(stream_info.bytesSent()));
-  span.setTag(Tracing::Tags::get().RESPONSE_FLAGS,
+  span.setTag(Tracing::Tags::get().HttpStatusCode, buildResponseCode(stream_info));
+  span.setTag(Tracing::Tags::get().ResponseSize, std::to_string(stream_info.bytesSent()));
+  span.setTag(Tracing::Tags::get().ResponseFlags,
               StreamInfo::ResponseFlagUtils::toShortString(stream_info));
 
   if (tracing_config.verbose()) {
@@ -169,7 +169,7 @@ void HttpTracerUtility::finalizeSpan(Span& span, const Http::HeaderMap* request_
   }
 
   if (!stream_info.responseCode() || Http::CodeUtility::is5xx(stream_info.responseCode().value())) {
-    span.setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    span.setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
   }
 
   span.finishSpan();
@@ -191,9 +191,9 @@ SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request
   SpanPtr active_span = driver_->startSpan(config, request_headers, span_name,
                                            stream_info.startTime(), tracing_decision);
   if (active_span) {
-    active_span->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
-    active_span->setTag(Tracing::Tags::get().NODE_ID, local_info_.nodeName());
-    active_span->setTag(Tracing::Tags::get().ZONE, local_info_.zoneName());
+    active_span->setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
+    active_span->setTag(Tracing::Tags::get().NodeId, local_info_.nodeName());
+    active_span->setTag(Tracing::Tags::get().Zone, local_info_.zoneName());
   }
 
   return active_span;

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -20,43 +20,43 @@ namespace Tracing {
 class TracingTagValues {
 public:
   // OpenTracing standard tag names.
-  const std::string COMPONENT = "component";
-  const std::string DB_INSTANCE = "db.instance";
-  const std::string DB_STATEMENT = "db.statement";
-  const std::string DB_USER = "db.user";
-  const std::string DB_TYPE = "db.type";
-  const std::string ERROR = "error";
-  const std::string HTTP_METHOD = "http.method";
-  const std::string HTTP_STATUS_CODE = "http.status_code";
-  const std::string HTTP_URL = "http.url";
-  const std::string MESSAGE_BUS_DESTINATION = "message_bus.destination";
-  const std::string PEER_ADDRESS = "peer.address";
-  const std::string PEER_HOSTNAME = "peer.hostname";
-  const std::string PEER_IPV4 = "peer.ipv4";
-  const std::string PEER_IPV6 = "peer.ipv6";
-  const std::string PEER_PORT = "peer.port";
-  const std::string PEER_SERVICE = "peer.service";
-  const std::string SPAN_KIND = "span.kind";
+  const std::string Component = "component";
+  const std::string DbInstance = "db.instance";
+  const std::string DbStatement = "db.statement";
+  const std::string DbUser = "db.user";
+  const std::string DbType = "db.type";
+  const std::string Error = "error";
+  const std::string HttpMethod = "http.method";
+  const std::string HttpStatusCode = "http.status_code";
+  const std::string HttpUrl = "http.url";
+  const std::string MessageBusDestination = "message_bus.destination";
+  const std::string PeerAddress = "peer.address";
+  const std::string PeerHostname = "peer.hostname";
+  const std::string PeerIpv4 = "peer.ipv4";
+  const std::string PeerIpv6 = "peer.ipv6";
+  const std::string PeerPort = "peer.port";
+  const std::string PeerService = "peer.service";
+  const std::string SpanKind = "span.kind";
 
   // Non-standard tag names.
-  const std::string DOWNSTREAM_CLUSTER = "downstream_cluster";
-  const std::string GRPC_STATUS_CODE = "grpc.status_code";
-  const std::string GUID_X_CLIENT_TRACE_ID = "guid:x-client-trace-id";
-  const std::string GUID_X_REQUEST_ID = "guid:x-request-id";
-  const std::string HTTP_PROTOCOL = "http.protocol";
-  const std::string NODE_ID = "node_id";
-  const std::string REQUEST_SIZE = "request_size";
-  const std::string RESPONSE_FLAGS = "response_flags";
-  const std::string RESPONSE_SIZE = "response_size";
-  const std::string STATUS = "status";
-  const std::string UPSTREAM_CLUSTER = "upstream_cluster";
-  const std::string USER_AGENT = "user_agent";
-  const std::string ZONE = "zone";
+  const std::string DownstreamCluster = "downstream_cluster";
+  const std::string GrpcStatusCode = "grpc.status_code";
+  const std::string GuidXClientTraceId = "guid:x-client-trace-id";
+  const std::string GuidXRequestId = "guid:x-request-id";
+  const std::string HttpProtocol = "http.protocol";
+  const std::string NodeId = "node_id";
+  const std::string RequestSize = "request_size";
+  const std::string ResponseFlags = "response_flags";
+  const std::string ResponseSize = "response_size";
+  const std::string Status = "status";
+  const std::string UpstreamCluster = "upstream_cluster";
+  const std::string UserAgent = "user_agent";
+  const std::string Zone = "zone";
 
   // Tag values.
-  const std::string CANCELED = "canceled";
-  const std::string PROXY = "proxy";
-  const std::string TRUE = "true";
+  const std::string Canceled = "canceled";
+  const std::string Proxy = "proxy";
+  const std::string True = "true";
 };
 
 typedef ConstSingleton<TracingTagValues> Tags;
@@ -64,16 +64,16 @@ typedef ConstSingleton<TracingTagValues> Tags;
 class TracingLogValues {
 public:
   // OpenTracing standard key names.
-  const std::string EVENT_KEY = "event";
+  const std::string EventKey = "event";
 
   // Event names
-  const std::string LAST_DOWNSTREAM_RX_BYTE_RECEIVED = "last_downstream_rx_byte_received";
-  const std::string FIRST_UPSTREAM_TX_BYTE_SENT = "first_upstream_tx_byte_sent";
-  const std::string LAST_UPSTREAM_TX_BYTE_SENT = "last_upstream_tx_byte_sent";
-  const std::string FIRST_UPSTREAM_RX_BYTE_RECEIVED = "first_upstream_rx_byte_received";
-  const std::string LAST_UPSTREAM_RX_BYTE_RECEIVED = "last_upstream_rx_byte_received";
-  const std::string FIRST_DOWNSTREAM_TX_BYTE_SENT = "first_downstream_tx_byte_sent";
-  const std::string LAST_DOWNSTREAM_TX_BYTE_SENT = "last_downstream_tx_byte_sent";
+  const std::string LastDownstreamRxByteReceived = "last_downstream_rx_byte_received";
+  const std::string FirstUpstreamTxByteSent = "first_upstream_tx_byte_sent";
+  const std::string LastUpstreamTxByteSent = "last_upstream_tx_byte_sent";
+  const std::string FirstUpstreamRxByteReceived = "first_upstream_rx_byte_received";
+  const std::string LastUpstreamRxByteReceived = "last_upstream_rx_byte_received";
+  const std::string FirstDownstreamTxByteSent = "first_downstream_tx_byte_sent";
+  const std::string LastDownstreamTxByteSent = "last_downstream_tx_byte_sent";
 };
 
 typedef ConstSingleton<TracingLogValues> Logs;
@@ -103,8 +103,8 @@ public:
   static void finalizeSpan(Span& span, const Http::HeaderMap* request_headers,
                            const StreamInfo::StreamInfo& stream_info, const Config& tracing_config);
 
-  static const std::string INGRESS_OPERATION;
-  static const std::string EGRESS_OPERATION;
+  static const std::string IngressOperation;
+  static const std::string EgressOperation;
 };
 
 class EgressConfigImpl : public Config {

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -97,7 +97,7 @@ void OpenTracingSpan::setTag(const std::string& name, const std::string& value) 
 }
 
 void OpenTracingSpan::log(SystemTime timestamp, const std::string& event) {
-  opentracing::LogRecord record{timestamp, {{Tracing::Logs::get().EVENT_KEY, event}}};
+  opentracing::LogRecord record{timestamp, {{Tracing::Logs::get().EventKey, event}}};
   finish_options_.log_records.emplace_back(std::move(record));
 }
 

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -58,10 +58,10 @@ TEST_F(EnvoyAsyncClientImplTest, RequestHttpStartFail) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
       .WillOnce(Return(child_span));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "test_cluster"));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "14"));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UpstreamCluster, "test_cluster"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GrpcStatusCode, "14"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
   EXPECT_CALL(*child_span, finishSpan());
   EXPECT_CALL(*child_span, injectContext(_)).Times(0);
 
@@ -123,11 +123,11 @@ TEST_F(EnvoyAsyncClientImplTest, RequestHttpSendHeadersFail) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
       .WillOnce(Return(child_span));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "test_cluster"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UpstreamCluster, "test_cluster"));
   EXPECT_CALL(*child_span, injectContext(_));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "13"));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GrpcStatusCode, "13"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
   EXPECT_CALL(*child_span, finishSpan());
 
   auto* grpc_request = grpc_client_->send(*method_descriptor_, request_msg, grpc_callbacks,

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -95,10 +95,10 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, RequestHttpStartFail) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
       .WillOnce(Return(child_span));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "test_cluster"));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "14"));
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UpstreamCluster, "test_cluster"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GrpcStatusCode, "14"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
   EXPECT_CALL(*child_span, finishSpan());
   EXPECT_CALL(*child_span, injectContext(_));
 

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -272,8 +272,8 @@ TEST_P(GrpcClientIntegrationTest, RequestTrailersOnly) {
   initialize();
   auto request = createRequest(empty_metadata_);
   const Http::TestHeaderMapImpl reply_headers{{":status", "200"}, {"grpc-status", "0"}};
-  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
-  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().GrpcStatusCode, "0"));
+  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
   EXPECT_CALL(*request, onFailure(Status::Internal, "", _)).WillExitIfNeeded();
   dispatcher_helper_.setStreamEventPending();
   EXPECT_CALL(*request->child_span_, finishSpan());
@@ -340,7 +340,7 @@ TEST_P(GrpcClientIntegrationTest, CancelRequest) {
   initialize();
   auto request = createRequest(empty_metadata_);
   EXPECT_CALL(*request->child_span_,
-              setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED));
+              setTag(Tracing::Tags::get().Status, Tracing::Tags::get().Canceled));
   EXPECT_CALL(*request->child_span_, finishSpan());
   request->grpc_request_->cancel();
   dispatcher_helper_.dispatcher_.run(Event::Dispatcher::RunType::NonBlock);

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -200,7 +200,7 @@ public:
     fake_stream_->startGrpcStream();
     helloworld::HelloReply reply;
     reply.set_message(HELLO_REPLY);
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().GrpcStatusCode, "0"));
     EXPECT_CALL(*this, onSuccess_(HelloworldReplyEq(HELLO_REPLY), _)).WillExitIfNeeded();
     EXPECT_CALL(*child_span_, finishSpan());
     dispatcher_helper_.setStreamEventPending();
@@ -347,9 +347,9 @@ public:
     EXPECT_CALL(active_span, spawnChild_(_, "async fake_cluster egress", _))
         .WillOnce(Return(request->child_span_));
     EXPECT_CALL(*request->child_span_,
-                setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, fake_cluster_name_));
+                setTag(Tracing::Tags::get().UpstreamCluster, fake_cluster_name_));
     EXPECT_CALL(*request->child_span_,
-                setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
+                setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy));
     EXPECT_CALL(*request->child_span_, injectContext(_));
 
     request->grpc_request_ =

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -3039,7 +3039,7 @@ TEST_F(RouterTestChildSpan, BasicFlow) {
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
   EXPECT_CALL(callbacks_, tracingConfig());
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy));
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -3070,7 +3070,7 @@ TEST_F(RouterTestChildSpan, ResetFlow) {
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
   EXPECT_CALL(callbacks_, tracingConfig());
-  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy));
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -131,9 +131,9 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
   EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpUrl, path_prefix + expected_path));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpMethod, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpProtocol, "HTTP/2"));
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
@@ -157,9 +157,9 @@ TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
   EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpUrl, path_prefix + expected_path));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpMethod, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpProtocol, "HTTP/2"));
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
@@ -175,12 +175,12 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpStatusCode, "0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseSize, "11"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RequestSize, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UpstreamCluster, _)).Times(0);
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
@@ -211,13 +211,13 @@ TEST(HttpConnManFinalizerImpl, StreamInfoLogs) {
 
   const auto log_timestamp =
       start_timestamp + std::chrono::duration_cast<SystemTime::duration>(*nanoseconds);
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LAST_DOWNSTREAM_RX_BYTE_RECEIVED));
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().FIRST_UPSTREAM_TX_BYTE_SENT));
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LAST_UPSTREAM_TX_BYTE_SENT));
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().FIRST_UPSTREAM_RX_BYTE_RECEIVED));
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LAST_UPSTREAM_RX_BYTE_RECEIVED));
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().FIRST_DOWNSTREAM_TX_BYTE_SENT));
-  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LAST_DOWNSTREAM_TX_BYTE_SENT));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastDownstreamRxByteReceived));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().FirstUpstreamTxByteSent));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastUpstreamTxByteSent));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().FirstUpstreamRxByteReceived));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastUpstreamRxByteReceived));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().FirstDownstreamTxByteSent));
+  EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastDownstreamTxByteSent));
 
   NiceMock<MockConfig> config;
   EXPECT_CALL(config, verbose).WillOnce(Return(true));
@@ -235,12 +235,12 @@ TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, upstreamHost()).Times(2);
 
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "my_upstream_cluster"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UpstreamCluster, "my_upstream_cluster"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpStatusCode, "0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseSize, "11"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RequestSize, "10"));
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
@@ -261,24 +261,24 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, "https:///test"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().USER_AGENT, "-"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "-"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().GuidXRequestId, "id"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpUrl, "https:///test"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpMethod, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UserAgent, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpProtocol, "HTTP/1.0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().DownstreamCluster, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RequestSize, "10"));
 
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(100));
   EXPECT_CALL(stream_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpStatusCode, "0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseSize, "100"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UpstreamCluster, _)).Times(0);
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
@@ -303,14 +303,14 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, "http://api/test"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().USER_AGENT, "agent"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "downstream_cluster"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().GUID_X_CLIENT_TRACE_ID, "client_trace_id"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().GuidXRequestId, "id"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpUrl, "http://api/test"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpMethod, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UserAgent, "agent"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpProtocol, "HTTP/1.0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().DownstreamCluster, "downstream_cluster"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RequestSize, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().GuidXClientTraceId, "client_trace_id"));
 
   // Check that span has tags from custom headers.
   request_headers.addCopy(Http::LowerCaseString("aa"), "a");
@@ -332,11 +332,11 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
       .WillByDefault(Return(true));
   EXPECT_CALL(stream_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "503"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "UT"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HttpStatusCode, "503"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseSize, "100"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ResponseFlags, "UT"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UpstreamCluster, _)).Times(0);
 
   HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
 }
@@ -399,7 +399,7 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
   EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, stream_info_.start_time_, _))
       .WillOnce(Return(span));
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().NODE_ID, "node_name"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().NodeId, "node_name"));
 
   tracer_->startSpan(config_, request_headers_, stream_info_, {Reason::Sampling, true});
 }


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: Renames const std:string variables pertaining to tracing from CAPITAL_CASE to MixedCase. Motivation is that this aligns with the predominant (though still split) style present in the project (see, e.g. HTTP header names), and addresses a particularly problematic variable named TRUE (which conflicts with Apple's #define TRUE directive).

This also aligns with the Envoy style guide:
"If you pick CONSTANT_VAR, please be certain the name is globally significant to avoid potential conflicts with #defines, which ... may appear in externally controlled header files."

Risk Level: Low
Testing: Compiled and ran full test suite.
Docs Changes: N/A
Release Notes: N/A
