### PR TITLE
server: add support for lifecycle notification completion callbacks

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -171,6 +171,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "lifecycle_notifier_interface",
     hdrs = ["lifecycle_notifier.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -18,7 +18,6 @@ public:
   enum class Stage {
     /**
      * The server instance main thread is about to enter the dispatcher loop.
-     * Note: the server will not wait for callback completion.
      */
     Startup,
 
@@ -38,8 +37,7 @@ public:
    * that callback to the main dispatcher when they have finished processing of
    * the new lifecycle state. This is useful when the main dispatcher needs to
    * wait for registered callbacks to finish their work before continuing, eg.
-   * during server shutdown. Note that whether or not the server will wait for
-   * callback completion depends on the specific stage (see comments above).
+   * during server shutdown.
    */
   using StageCallback = std::function<void()>;
   using StageCallbackWithCompletion = std::function<void(Event::PostCb)>;
@@ -47,6 +45,9 @@ public:
   /**
    * Register a callback function that will be invoked on the main thread when
    * the specified stage is reached.
+   *
+   * The second version which takes a completion back is currently only supported
+   * for the ShutdownExit stage.
    */
   virtual void registerCallback(Stage stage, StageCallback callback) PURE;
   virtual void registerCallback(Stage stage, StageCallbackWithCompletion callback) PURE;

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -18,12 +18,15 @@ public:
   enum class Stage {
     /**
      * The server instance main thread is about to enter the dispatcher loop.
+     * Note: the server will not wait for callback completion.
      */
     Startup,
 
     /**
      * The server instance is being shutdown and the dispatcher is about to exit.
      * This provides listeners a last chance to run a callback on the main dispatcher.
+     * Note: the server will wait for callbacks that registered to take a completion
+     * before exiting the dispatcher loop.
      */
     ShutdownExit
   };
@@ -35,7 +38,8 @@ public:
    * that callback to the main dispatcher when they have finished processing of
    * the new lifecycle state. This is useful when the main dispatcher needs to
    * wait for registered callbacks to finish their work before continuing, eg.
-   * during server shutdown.
+   * during server shutdown. Note that whether or not the server will wait for
+   * callback completion depends on the specific stage (see comments above).
    */
   using StageCallback = std::function<void()>;
   using StageCallbackWithCompletion = std::function<void(Event::PostCb)>;

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -29,14 +29,22 @@ public:
 
   /**
    * Callback invoked when the server reaches a certain lifecycle stage.
+   *
+   * Instances of the second type which take an Event::PostCb parameter must post
+   * that callback to the main dispatcher when they have finished processing of
+   * the new lifecycle state. This is useful when the main dispatcher needs to
+   * wait for registered callbacks to finish their work before continuing, eg.
+   * during server shutdown.
    */
   using StageCallback = std::function<void()>;
+  using StageCallbackWithCompletion = std::function<void(Event::PostCb)>;
 
   /**
    * Register a callback function that will be invoked on the main thread when
    * the specified stage is reached.
    */
   virtual void registerCallback(Stage stage, StageCallback callback) PURE;
+  virtual void registerCallback(Stage stage, StageCallbackWithCompletion callback) PURE;
 };
 
 } // namespace Server

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "envoy/common/pure.h"
+#include "envoy/event/dispatcher.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -554,6 +554,7 @@ void InstanceImpl::registerCallback(Stage stage, StageCallback callback) {
 }
 
 void InstanceImpl::registerCallback(Stage stage, StageCallbackWithCompletion callback) {
+  ASSERT(stage == Stage::ShutdownExit);
   stage_completable_callbacks_[stage].push_back(callback);
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -2,6 +2,7 @@
 
 #include <signal.h>
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -532,8 +533,13 @@ void InstanceImpl::shutdown() {
   ENVOY_LOG(info, "shutting down server instance");
   shutdown_ = true;
   restarter_.terminateParent();
-  notifyCallbacksForStage(Stage::ShutdownExit);
-  dispatcher_->exit();
+  auto completion_cb_count =
+      std::make_shared<std::atomic<int>>(stage_completable_callbacks_.size());
+  notifyCallbacksForStage(Stage::ShutdownExit, [this, completion_cb_count] {
+    if (--*completion_cb_count <= 0) {
+      dispatcher_->exit();
+    }
+  });
 }
 
 void InstanceImpl::shutdownAdmin() {
@@ -553,13 +559,26 @@ void InstanceImpl::registerCallback(Stage stage, StageCallback callback) {
   stage_callbacks_[stage].push_back(callback);
 }
 
-void InstanceImpl::notifyCallbacksForStage(Stage stage) {
+void InstanceImpl::registerCallback(Stage stage, StageCallbackWithCompletion callback) {
+  stage_completable_callbacks_[stage].push_back(callback);
+}
+
+void InstanceImpl::notifyCallbacksForStage(Stage stage, Event::PostCb completion_cb) {
   ASSERT(std::this_thread::get_id() == main_thread_id_);
   auto it = stage_callbacks_.find(stage);
   if (it != stage_callbacks_.end()) {
     for (const StageCallback& callback : it->second) {
       callback();
     }
+  }
+
+  auto it2 = stage_completable_callbacks_.find(stage);
+  if (it2 != stage_completable_callbacks_.end()) {
+    for (const StageCallbackWithCompletion& callback : it2->second) {
+      callback(completion_cb);
+    }
+  } else {
+    completion_cb();
   }
 }
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -194,6 +194,7 @@ public:
 
   // ServerLifecycleNotifier
   void registerCallback(Stage stage, StageCallback callback) override;
+  void registerCallback(Stage stage, StageCallbackWithCompletion callback) override;
 
 private:
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
@@ -204,7 +205,7 @@ private:
   uint64_t numConnections();
   void startWorkers();
   void terminate();
-  void notifyCallbacksForStage(Stage stage);
+  void notifyCallbacksForStage(Stage stage, Event::PostCb completion_cb = [] {});
 
   // init_manager_ must come before any member that participates in initialization, and destructed
   // only after referencing members are gone, since initialization continuation can potentially
@@ -260,6 +261,7 @@ private:
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
   const std::thread::id main_thread_id_;
   std::unordered_map<Stage, std::vector<StageCallback>> stage_callbacks_;
+  std::unordered_map<Stage, std::vector<StageCallbackWithCompletion>> stage_completable_callbacks_;
 };
 
 } // namespace Server

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -270,6 +270,7 @@ public:
   ~MockServerLifecycleNotifier();
 
   MOCK_METHOD2(registerCallback, void(Stage, StageCallback));
+  MOCK_METHOD2(registerCallback, void(Stage, StageCallbackWithCompletion));
 };
 
 class MockWorkerFactory : public WorkerFactory {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -14,6 +14,7 @@
 #include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
+#include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -126,11 +127,12 @@ protected:
       options_.config_path_ = TestEnvironment::temporaryFileSubstitute(
           bootstrap_path, {{"upstream_0", 0}, {"upstream_1", 0}}, version_);
     }
+    thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
     server_ = std::make_unique<InstanceImpl>(
         options_, test_time_.timeSystem(),
         Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
         hooks_, restart_, stats_store_, fakelock_, component_factory_,
-        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_,
+        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), *thread_local_,
         Thread::threadFactoryForTest(), Filesystem::fileSystemForTest());
 
     EXPECT_TRUE(server_->api().fileSystem().fileExists("/dev/null"));
@@ -143,11 +145,12 @@ protected:
         {{"health_check_timeout", fmt::format("{}", timeout).c_str()},
          {"health_check_interval", fmt::format("{}", interval).c_str()}},
         TestEnvironment::PortMap{}, version_);
+    thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
     server_ = std::make_unique<InstanceImpl>(
         options_, test_time_.timeSystem(),
         Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
         hooks_, restart_, stats_store_, fakelock_, component_factory_,
-        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_,
+        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), *thread_local_,
         Thread::threadFactoryForTest(), Filesystem::fileSystemForTest());
 
     EXPECT_TRUE(server_->api().fileSystem().fileExists("/dev/null"));
@@ -160,7 +163,7 @@ protected:
   testing::NiceMock<MockOptions> options_;
   DefaultTestHooks hooks_;
   testing::NiceMock<MockHotRestart> restart_;
-  ThreadLocal::InstanceImpl thread_local_;
+  std::unique_ptr<ThreadLocal::InstanceImpl> thread_local_;
   Stats::TestIsolatedStoreImpl stats_store_;
   Thread::MutexBasicLockable fakelock_;
   TestComponentFactory component_factory_;
@@ -173,24 +176,49 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ServerInstanceImplTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
-  initialize("test/server/node_bootstrap.yaml");
   bool startup = false, shutdown = false, shutdown_with_completion = false;
-  server_->registerCallback(ServerLifecycleNotifier::Stage::Startup, [&startup, this] {
-    startup = true;
-    server_->shutdown();
+  absl::Notification started, shutdown_begin, completion_block, completion_done;
+
+  // Run the server in a separate thread so we can test different lifecycle stages.
+  auto server_thread = Thread::threadFactoryForTest().createThread([&] {
+    initialize("test/server/node_bootstrap.yaml");
+    server_->registerCallback(ServerLifecycleNotifier::Stage::Startup, [&] {
+      startup = true;
+      started.Notify();
+    });
+    server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit, [&] {
+      shutdown = true;
+      shutdown_begin.Notify();
+    });
+    server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
+                              [&](Event::PostCb completion_cb) {
+                                // Block till we're told to complete
+                                completion_block.WaitForNotification();
+                                shutdown_with_completion = true;
+                                server_->dispatcher().post(completion_cb);
+                                completion_done.Notify();
+                              });
+    server_->run();
+    server_ = nullptr;
+    thread_local_ = nullptr;
   });
-  server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
-                            [&shutdown] { shutdown = true; });
-  Event::Dispatcher& dispatcher = server_->dispatcher();
-  server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
-                            [&shutdown_with_completion, &dispatcher](Event::PostCb completion_cb) {
-                              shutdown_with_completion = true;
-                              dispatcher.post(completion_cb);
-                            });
-  server_->run();
+
+  started.WaitForNotification();
   EXPECT_TRUE(startup);
+  EXPECT_FALSE(shutdown);
+
+  server_->dispatcher().post([&] { server_->shutdown(); });
+  shutdown_begin.WaitForNotification();
   EXPECT_TRUE(shutdown);
+
+  // Expect the server to block waiting for the completion callback to be invoked
+  EXPECT_FALSE(completion_done.WaitForNotificationWithTimeout(absl::Seconds(1)));
+
+  completion_block.Notify();
+  completion_done.WaitForNotification();
   EXPECT_TRUE(shutdown_with_completion);
+
+  server_thread->join();
 }
 
 TEST_P(ServerInstanceImplTest, V2ConfigOnly) {
@@ -357,12 +385,13 @@ TEST_P(ServerInstanceImplTest, LogToFileError) {
 // When there are no bootstrap CLI options, either for content or path, we can load the server with
 // an empty config.
 TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
+  thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
   EXPECT_THROW_WITH_MESSAGE(
       server_.reset(new InstanceImpl(
           options_, test_time_.timeSystem(),
           Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
           hooks_, restart_, stats_store_, fakelock_, component_factory_,
-          std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_,
+          std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), *thread_local_,
           Thread::threadFactoryForTest(), Filesystem::fileSystemForTest())),
       EnvoyException, "At least one of --config-path and --config-yaml should be non-empty");
 }


### PR DESCRIPTION
Description: Add support to the ServerLifecycleNotifier for registering callbacks which take a completion callback/continuation. This is useful for cases where we want the server to wait until registered callbacks have completed their work before continuing, eg. during shutdown.
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>

