### PR TITLE
ci docker: split dev images into "*-dev" docker hub repos

### DIFF
--- a/ci/docker_build.sh
+++ b/ci/docker_build.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-docker build -f ci/Dockerfile-envoy-image -t envoyproxy/envoy:latest .
-docker build -f ci/Dockerfile-envoy-alpine -t envoyproxy/envoy-alpine:latest .
-docker build -f ci/Dockerfile-envoy-alpine-debug -t envoyproxy/envoy-alpine-debug:latest .
+docker build -f ci/Dockerfile-envoy-image -t envoyproxy/envoy-dev:latest .
+docker build -f ci/Dockerfile-envoy-alpine -t envoyproxy/envoy-alpine-dev:latest .
+docker build -f ci/Dockerfile-envoy-alpine-debug -t envoyproxy/envoy-alpine-debug-dev:latest .

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -6,31 +6,25 @@ set -e
 
 if [ -n "$CIRCLE_PULL_REQUEST" ]
 then
-   echo 'Ignoring PR branch for docker push.'
-   exit 0
+    echo 'Ignoring PR branch for docker push.'
+    exit 0
 fi
 
 # push the envoy image on tags or merge to master
-if [ -n "$CIRCLE_TAG" ] || [ "$CIRCLE_BRANCH" == 'master' ]
+if [ -n "$CIRCLE_TAG" ] || [ "$CIRCLE_BRANCH" = 'master' ]
 then
-   docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-   docker push envoyproxy/envoy:latest
-   docker tag envoyproxy/envoy:latest envoyproxy/envoy:"$CIRCLE_SHA1"
-   docker push envoyproxy/envoy:"$CIRCLE_SHA1"
+    for BUILD_TYPE in "envoy" "envoy-alpine" "envoy-alpine-debug"; do
+        docker push envoyproxy/"$BUILD_TYPE"-dev:latest
+        docker tag envoyproxy/"$BUILD_TYPE"-dev:latest envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1"
+        docker push envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1"
+    done
 
-   docker tag envoyproxy/envoy-alpine:latest envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
-   docker push envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
-   docker push envoyproxy/envoy-alpine:latest
-
-   docker tag envoyproxy/envoy-alpine-debug:latest envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
-   docker push envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
-   docker push envoyproxy/envoy-alpine-debug:latest
-
-   # This script tests the docker examples.
-   # TODO(mattklein123): This almost always times out on CircleCI. Do not run for now until we
-   # have a better CI setup.
-   #./ci/verify_examples.sh
+    # This script tests the docker examples.
+    # TODO(mattklein123): This almost always times out on CircleCI. Do not run for now until we
+    # have a better CI setup.
+    #./ci/verify_examples.sh
 else
-   echo 'Ignoring non-master branch for docker push.'
+    echo 'Ignoring non-master branch for docker push.'
 fi

--- a/ci/docker_tag.sh
+++ b/ci/docker_tag.sh
@@ -11,9 +11,9 @@ then
     for BUILD_TYPE in "envoy" "envoy-alpine" "envoy-alpine-debug"; do
         docker pull envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1"
         docker tag envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1" envoyproxy/"$BUILD_TYPE":"$CIRCLE_TAG"
-        docker push envoyproxy/envoy:"$CIRCLE_TAG"
+        docker push envoyproxy/"$BUILD_TYPE":"$CIRCLE_TAG"
         docker tag envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1" envoyproxy/"$BUILD_TYPE":latest
-        docker push envoyproxy/envoy:latest
+        docker push envoyproxy/"$BUILD_TYPE":latest
     done
 else
     echo 'Ignoring non-tag event for docker tag.'

--- a/ci/docker_tag.sh
+++ b/ci/docker_tag.sh
@@ -6,19 +6,15 @@ set -e
 
 if [ -n "$CIRCLE_TAG" ]
 then
-   docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-   docker pull envoyproxy/envoy:"$CIRCLE_SHA1"
-   docker tag envoyproxy/envoy:"$CIRCLE_SHA1" envoyproxy/envoy:"$CIRCLE_TAG"
-   docker push envoyproxy/envoy:"$CIRCLE_TAG"
-
-   docker pull envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
-   docker tag envoyproxy/envoy-alpine:"$CIRCLE_SHA1" envoyproxy/envoy-alpine:"$CIRCLE_TAG"
-   docker push envoyproxy/envoy-alpine:"$CIRCLE_TAG"
-
-   docker pull envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
-   docker tag envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1" envoyproxy/envoy-alpine-debug:"$CIRCLE_TAG"
-   docker push envoyproxy/envoy-alpine-debug:"$CIRCLE_TAG"
+    for BUILD_TYPE in "envoy" "envoy-alpine" "envoy-alpine-debug"; do
+        docker pull envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1"
+        docker tag envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1" envoyproxy/"$BUILD_TYPE":"$CIRCLE_TAG"
+        docker push envoyproxy/envoy:"$CIRCLE_TAG"
+        docker tag envoyproxy/"$BUILD_TYPE"-dev:"$CIRCLE_SHA1" envoyproxy/"$BUILD_TYPE":latest
+        docker push envoyproxy/envoy:latest
+    done
 else
-   echo 'Ignoring non-tag event for docker tag.'
+    echo 'Ignoring non-tag event for docker tag.'
 fi


### PR DESCRIPTION
This will make tagged version images more easily discoverable.

Fixes https://github.com/envoyproxy/envoy/issues/4052

I will be doing a follow up PR for doc changes and announce emails once I verify this is
all actually working with some test tags.