### PR TITLE
config: removing deprecated use_std_hash

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -430,16 +430,7 @@ message Cluster {
     // :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>`.
     google.protobuf.UInt64Value minimum_ring_size = 1 [(validate.rules).uint64.lte = 8388608];
 
-    // [#not-implemented-hide:] Hide from docs.
-    message DeprecatedV1 {
-      // Defaults to false, meaning that `xxHash <https://github.com/Cyan4973/xxHash>`_
-      // is to hash hosts onto the ketama ring.
-      google.protobuf.BoolValue use_std_hash = 1;
-    }
-
-    // Deprecated settings from v1 config.
-    // [#not-implemented-hide:] Hide from docs.
-    DeprecatedV1 deprecated_v1 = 2 [deprecated = true];
+    reserved 2;
 
     // The hash function used to hash hosts onto the ketama ring.
     enum HashFunction {

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -15,6 +15,7 @@ Version history
 * config: logging warnings when deprecated fields are in use.
 * config: removed deprecated --v2-config-only from command line config.
 * config: removed deprecated_v1 sds_config from :ref:`Bootstrap config <config_overview_v2_bootstrap>`.
+* config: removed the deprecated_v1 config option from :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>`.
 * config: removed REST_LEGACY as a valid :ref:`ApiType <envoy_api_field_core.ApiConfigSource.api_type>`.
 * config: finish cluster warming only when a named response i.e. ClusterLoadAssignment associated to the cluster being warmed comes in the EDS response. This is a behavioural change from the current implementation where warming of cluster completes on missing load assignments also.
 * config: use Envoy cpuset size to set the default number or worker threads if :option:`--cpuset-threads` is enabled.

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -15,8 +15,6 @@ void CdsJson::translateRingHashLbConfig(
     const Json::Object& json_ring_hash_lb_config,
     envoy::api::v2::Cluster::RingHashLbConfig& ring_hash_lb_config) {
   JSON_UTIL_SET_INTEGER(json_ring_hash_lb_config, ring_hash_lb_config, minimum_ring_size);
-  JSON_UTIL_SET_BOOL(json_ring_hash_lb_config, *ring_hash_lb_config.mutable_deprecated_v1(),
-                     use_std_hash);
 }
 
 void CdsJson::translateHealthCheck(const Json::Object& json_health_check,

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1473,9 +1473,6 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
           "minimum_ring_size" : {
             "type" : "integer",
             "minimum" : 0
-          },
-          "use_std_hash" : {
-            "type" : "boolean"
           }
         }
       },

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -58,8 +58,8 @@ private:
 
   struct Ring : public HashingLoadBalancer {
     Ring(const NormalizedHostWeightVector& normalized_host_weights, double min_normalized_weight,
-         uint64_t min_ring_size, uint64_t max_ring_size, bool use_std_hash,
-         HashFunction hash_function, RingHashLoadBalancerStats& stats);
+         uint64_t min_ring_size, uint64_t max_ring_size, HashFunction hash_function,
+         RingHashLoadBalancerStats& stats);
 
     // ThreadAwareLoadBalancerBase::HashingLoadBalancer
     HostConstSharedPtr chooseHost(uint64_t hash) const override;
@@ -75,7 +75,7 @@ private:
   createLoadBalancer(const NormalizedHostWeightVector& normalized_host_weights,
                      double min_normalized_weight, double /* max_normalized_weight */) override {
     return std::make_shared<Ring>(normalized_host_weights, min_normalized_weight, min_ring_size_,
-                                  max_ring_size_, use_std_hash_, hash_function_, stats_);
+                                  max_ring_size_, hash_function_, stats_);
   }
 
   static RingHashLoadBalancerStats generateStats(Stats::Scope& scope);
@@ -87,7 +87,6 @@ private:
   static const uint64_t DefaultMaxRingSize = 1024 * 1024 * 8;
   const uint64_t min_ring_size_;
   const uint64_t max_ring_size_;
-  const bool use_std_hash_;
   const HashFunction hash_function_;
 };
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -608,8 +608,7 @@ TEST_F(ClusterManagerImplTest, RingHashLoadBalancerInitialization) {
       "name": "redis_cluster",
       "lb_type": "ring_hash",
       "ring_hash_lb_config": {
-        "minimum_ring_size": 125,
-        "use_std_hash": true
+        "minimum_ring_size": 125
       },
       "connect_timeout_ms": 250,
       "type": "static",
@@ -637,8 +636,6 @@ TEST_F(ClusterManagerImplTest, RingHashLoadBalancerV2Initialization) {
       dns_lookup_family: V4_ONLY
       ring_hash_lb_config:
         minimum_ring_size: 125
-        deprecated_v1:
-          use_std_hash: true
   )EOF";
   create(parseBootstrapFromV2Yaml(yaml));
 }

--- a/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-6287096397430784
+++ b/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-6287096397430784
@@ -94,11 +94,6 @@ static_resources {
       locality_weight_aware: true
     }
     ring_hash_lb_config {
-      deprecated_v1 {
-        use_std_hash {
-          value: true
-        }
-      }
     }
   }
   clusters {


### PR DESCRIPTION
Risk Level: Medium (ideally folks have moved over but you never know)
Testing: n/a
Docs Changes: n/a (I don't see any docs referencing the hash algorithm)
Release Notes: inline
Fixes #5379
