### PR TITLE
governance: noting CI is a maintainer responsibility, emailing failures to on-call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,8 @@ workflows:
               only: /^v.*/
       - mac
 
+# Instructions from https://docs.opsgenie.com/docs/circleci-integration
+# Configuration at https://app.opsgenie.com/integration#/edit/CircleCi/d9585dd7-b9c5-4723-abee-647a623639e4
 notify:
   webhooks:
      -url: https://api.opsgenie.com/v1/json/circleci?apiKey=f45d58a7-15a4-4800-8d2c-f460ec02cf71

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,7 @@ workflows:
 
 # Instructions from https://docs.opsgenie.com/docs/circleci-integration
 # Configuration at https://app.opsgenie.com/integration#/edit/CircleCi/d9585dd7-b9c5-4723-abee-647a623639e4
+# Deletion possible via https://app.opsgenie.com/integration#/configured-integrations
 notify:
   webhooks:
      -url: https://api.opsgenie.com/v1/json/circleci?apiKey=f45d58a7-15a4-4800-8d2c-f460ec02cf71

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,3 +196,7 @@ workflows:
             tags:
               only: /^v.*/
       - mac
+
+notify:
+  webhooks:
+     -url: https://api.opsgenie.com/v1/json/circleci?apiKey=f45d58a7-15a4-4800-8d2c-f460ec02cf71

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -37,6 +37,8 @@
 * Triage GitHub issues and perform pull request reviews for other maintainers and the community.
   The areas of specialization listed in [OWNERS.md](OWNERS.md) can be used to help with routing
   an issue/question to the right person.
+* Triage build issues - file issues for known flaky builds or bugs, and either fix or find someone
+  to fix any master build breakages.
 * During GitHub issue triage, apply all applicable [labels](https://github.com/envoyproxy/envoy/labels)
   to each new issue. Labels are extremely useful for future issue follow up. Which labels to apply
   is somewhat subjective so just use your best judgment. A few of the most important labels that are


### PR DESCRIPTION
I believe per https://docs.opsgenie.com/docs/circleci-integration and https://app.opsgenie.com/integration#/edit/CircleCi/d9585dd7-b9c5-4723-abee-647a623639e4 (logged in users only) this will result in CircleCI failures getting emailed to maintainer-on-call

I think emails are better than relying on slack or polling to notice build failures

Risk Level: n/a for Envoy.  Medium for annoying @jmarantz (or all of us!) if it ends up spammy :-P
Testing: Testing via submit / rollback.  Whee!
Docs Changes: yep
Release Notes: nope
Fixes our build breakages going into the void

