### PR TITLE
libc: add libc++ todo for TCMALLOC and use ifdef for LIBCPP_VERSION

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,6 +48,8 @@ build:clang-msan --define tcmalloc=disabled
 build:clang-msan --copt -fsanitize-memory-track-origins=2
 
 # Clang with libc++
+# TODO(cmluciano) fix and re-enable _LIBCPP_VERSION testing for TCMALLOC in Envoy::Stats::TestUtil::hasDeterministicMallocStats
+# and update stats_integration_test with appropriate m_per_cluster value
 build:libc++ --action_env=CC
 build:libc++ --action_env=CXX
 build:libc++ --action_env=CXXFLAGS=-stdlib=libc++

--- a/test/common/stats/stat_test_utility.cc
+++ b/test/common/stats/stat_test_utility.cc
@@ -13,7 +13,7 @@ bool hasDeterministicMallocStats() {
   // to a different malloc library than we'd have to re-evaluate all the
   // thresholds in the tests referencing hasDeterministicMallocStats().
   // TODO(cmluciano) Enable LIBCPP testing once stabilized
-#if _LIBCPP_VERSION
+#ifdef _LIBCPP_VERSION
   return false;
 #elif defined(TCMALLOC) && !defined(ENVOY_MEMORY_DEBUG_ENABLED)
   const size_t start_mem = Memory::Stats::totalCurrentlyAllocated();


### PR DESCRIPTION
Due to problems with libc++ environment setup, we can not accurately
measure the memory usage within hasDeterministicMallocStats.

The flip to ifdef should be more accurate for testing whether LIBCPP
is defined in pre-processing.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

Risk Level: Low - Mostly comments
Testing: `bazel test //test:integration:stats_integration_test`
Docs Changes: N/A
Release Notes: N/A
