### PR TITLE
upstream: consistent H1 and H2 rq_total stats

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -72,6 +72,7 @@ Version history
 * tracing: added :ref:`verbose <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` to support logging annotations on spans.
 * upstream: added support for host weighting and :ref:`locality weighting <arch_overview_load_balancing_locality_weighted_lb>` in the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`, and added a :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>` config parameter to strictly bound the ring size.
 * upstream: added configuration option to select any host when the fallback policy fails.
+* upstream: stopped incrementing upstream_rq_total for HTTP/1 conn pool when request is circuit broken.
 
 1.9.0 (Dec 20, 2018)
 ====================

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -90,9 +90,10 @@ void ConnPoolImpl::createNewConnection() {
 
 ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_decoder,
                                                      ConnectionPool::Callbacks& callbacks) {
-  host_->cluster().stats().upstream_rq_total_.inc();
-  host_->stats().rq_total_.inc();
   if (!ready_clients_.empty()) {
+    host_->cluster().stats().upstream_rq_total_.inc();
+    host_->stats().rq_total_.inc();
+
     ready_clients_.front()->moveBetweenLists(ready_clients_, busy_clients_);
     ENVOY_CONN_LOG(debug, "using existing connection", *busy_clients_.front()->codec_client_);
     attachRequestToClient(*busy_clients_.front(), response_decoder, callbacks);
@@ -105,6 +106,9 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_dec
     if (!can_create_connection) {
       host_->cluster().stats().upstream_cx_overflow_.inc();
     }
+
+    host_->cluster().stats().upstream_rq_total_.inc();
+    host_->stats().rq_total_.inc();
 
     // If we have no connections at all, make one no matter what so we don't starve.
     if ((ready_clients_.size() == 0 && busy_clients_.size() == 0) || can_create_connection) {

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -293,6 +293,7 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
   cluster_->resetResourceManager(1, 1, 1024, 1);
 
   EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.rq_pending_open_.value());
+  EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
 
   NiceMock<Http::MockStreamDecoder> outer_decoder;
   ConnPoolCallbacks callbacks;
@@ -307,6 +308,7 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
   EXPECT_EQ(nullptr, handle2);
 
   EXPECT_EQ(1U, cluster_->circuit_breakers_stats_.rq_pending_open_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
 
   handle->cancel();
 
@@ -315,6 +317,7 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
   dispatcher_.clearDeferredDeleteList();
 
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_pending_overflow_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
 }
 
 /**

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -169,7 +169,9 @@ struct ActiveTestRequest {
       parent.conn_pool_.test_clients_[client_index_].connection_->raiseEvent(
           Network::ConnectionEvent::Connected);
     }
-    EXPECT_EQ(current_rq_total + 1, parent_.cluster_->stats_.upstream_rq_total_.value());
+    if (type != Type::Pending) {
+      EXPECT_EQ(current_rq_total + 1, parent_.cluster_->stats_.upstream_rq_total_.value());
+    }
   }
 
   void completeResponse(bool with_body) {
@@ -293,7 +295,6 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
   cluster_->resetResourceManager(1, 1, 1024, 1);
 
   EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.rq_pending_open_.value());
-  EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
 
   NiceMock<Http::MockStreamDecoder> outer_decoder;
   ConnPoolCallbacks callbacks;
@@ -308,7 +309,6 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
   EXPECT_EQ(nullptr, handle2);
 
   EXPECT_EQ(1U, cluster_->circuit_breakers_stats_.rq_pending_open_.value());
-  EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
 
   handle->cancel();
 
@@ -317,7 +317,6 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
   dispatcher_.clearDeferredDeleteList();
 
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_pending_overflow_.value());
-  EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
 }
 
 /**
@@ -371,7 +370,7 @@ TEST_F(Http1ConnPoolImplTest, ConnectTimeout) {
   EXPECT_CALL(conn_pool_, onClientDestroy()).Times(2);
   dispatcher_.clearDeferredDeleteList();
 
-  EXPECT_EQ(2U, cluster_->stats_.upstream_rq_total_.value());
+  EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
   EXPECT_EQ(2U, cluster_->stats_.upstream_cx_connect_fail_.value());
   EXPECT_EQ(2U, cluster_->stats_.upstream_cx_connect_timeout_.value());
 }
@@ -633,6 +632,7 @@ TEST_F(Http1ConnPoolImplTest, ConcurrentConnections) {
   r1.completeResponse(false);
   conn_pool_.expectAndRunUpstreamReady();
   r3.startRequest();
+  EXPECT_EQ(3U, cluster_->stats_.upstream_rq_total_.value());
 
   r2.completeResponse(false);
   r3.completeResponse(false);
@@ -654,6 +654,7 @@ TEST_F(Http1ConnPoolImplTest, DrainCallback) {
   ActiveTestRequest r1(*this, 0, ActiveTestRequest::Type::CreateConnection);
   ActiveTestRequest r2(*this, 0, ActiveTestRequest::Type::Pending);
   r2.handle_->cancel();
+  EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
 
   EXPECT_CALL(drained, ready());
   r1.startRequest();
@@ -759,6 +760,7 @@ TEST_F(Http1ConnPoolImplTest, PendingRequestIsConsideredActive) {
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
   r1.handle_->cancel();
+  EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
   conn_pool_.drainConnections();
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();


### PR DESCRIPTION
Description: Previously, we incremented rq_total and upstream_rq_total for the HTTP/1
conn pool even if the request ended up being circuit broken. The stats
were not incremented for HTTP/2 requests. This change no longer
increments the stats for HTTP/1 circuit broken requests for consistency
between the two.
Risk Level: Low
Testing: Added checks to an existing unit test
Docs Changes: N/A
Release Notes: N/A
Fixes #6350 
