### PR TITLE
docs: move example configs to load_assignment

### DIFF
--- a/configs/envoy_double_proxy_v2.template.yaml
+++ b/configs/envoy_double_proxy_v2.template.yaml
@@ -91,20 +91,30 @@ static_resources:
     type: STATIC
     connect_timeout: 0.25s
     lb_policy: ROUND_ROBIN
-    hosts:
-      - socket_address:
-          protocol: TCP
-          address: 127.0.0.1
-          port_value: 8125
+    load_assignment:
+      cluster_name: statsd
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: 127.0.0.1
+                port_value: 8125
   - name: backhaul
     type: STRICT_DNS
     connect_timeout: 1s
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: front-proxy.yourcompany.net
-        port_value: 9400
+    load_assignment:
+      cluster_name: backhaul
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: front-proxy.yourcompany.net
+                port_value: 9400
     # There are so few connections going back
     # that we can get some imbalance. Until we come up
     # with a better solution just limit the requests
@@ -127,11 +137,16 @@ static_resources:
     type: LOGICAL_DNS
     connect_timeout: 1s
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: collector-grpc.lightstep.com
-        port_value: 443
+    load_assignment:
+      cluster_name: lightstep_saas
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: collector-grpc.lightstep.com
+                port_value: 443
     http2_protocol_options: {}
     tls_context:
       common_tls_context:
@@ -143,7 +158,7 @@ static_resources:
 flags_path: "/etc/envoy/flags"
 stats_sinks:
 - name: envoy.statsd
-  config: 
+  config:
     tcp_cluster_name: statsd
 tracing:
   http:

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -100,29 +100,44 @@ static_resources:
     type: STRICT_DNS
     connect_timeout: 0.25s
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-       protocol: TCP
-       address: disccovery.yourcompany.net
-       port_value: 80
+    load_assignment:
+      cluster_name: sds
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: disccovery.yourcompany.net
+                port_value: 80
   - name: statsd
     type: STATIC
     connect_timeout: 0.25s
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: 127.0.0.1
-        port_value: 8125
+    load_assignment:
+      cluster_name: statsd
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: 127.0.0.1
+                port_value: 8125
   - name: lightstep_saas
     type: LOGICAL_DNS
     connect_timeout: 1s
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: collector-grpc.lightstep.com
-        port_value: 443
+    load_assignment:
+      cluster_name: lightstep_saas
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: collector-grpc.lightstep.com
+                port_value: 443
     http2_protocol_options: {}
   {% for service, options in clusters.items() -%}
   - {{ helper.internal_cluster_definition(service, options)|indent(2) }}

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -108,7 +108,7 @@ static_resources:
             address:
               socket_address:
                 protocol: TCP
-                address: disccovery.yourcompany.net
+                address: discovery.yourcompany.net
                 port_value: 80
   - name: statsd
     type: STATIC

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -342,11 +342,16 @@ static_resources:
     {% endif %}
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        address: {{ host['remote_address'] }}
-        port_value: {{ host['port_value'] }}
-        protocol: {{ host['protocol'] }}
+    load_assignment:
+      cluster_name: egress_{{ host['name'] }}
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: {{ host['remote_address'] }}
+                port_value: {{ host['port_value'] }}
+                protocol: {{ host['protocol'] }}
   {% endfor -%}
   {% endfor -%}
   {% for key, value in mongos_servers.items() -%}
@@ -368,20 +373,30 @@ static_resources:
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        address: main_website.com
-        port_value: 443
+    load_assignment:
+      cluster_name: main_website
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: main_website.com
+                port_value: 443
     tls_context: { sni: www.main_website.com }
   - name: local_service
     connect_timeout: 0.25s
     type: STATIC
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: 127.0.0.1
-        port_value: 8080
+    load_assignment:
+      cluster_name: local_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: 127.0.0.1
+                port_value: 8080
     circuit_breakers:
       thresholds:
         max_pending_requests: 30
@@ -391,11 +406,16 @@ static_resources:
     type: STATIC
     lb_policy: ROUND_ROBIN
     http2_protocol_options: {}
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: 127.0.0.1
-        port_value: 8081
+    load_assignment:
+      cluster_name: local_service_grpc
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: 127.0.0.1
+                port_value: 8081
     circuit_breakers:
       thresholds:
         max_requests: 200
@@ -404,31 +424,46 @@ static_resources:
     connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: rds.yourcompany.net
-        port_value: 80
+    load_assignment:
+      cluster_name: rds
+      endpoints:
+      - lb_endpoints:
+        - endpoints:
+            address:
+              socket_address:
+                protocol: TCP
+                address: rds.yourcompany.net
+                port_value: 80
     dns_lookup_family: V4_ONLY
   - name: statsd
     connect_timeout: 0.25s
     type: STATIC
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: 127.0.0.1
-        port_value: 8125
+    load_assignment:
+      cluster_name: statsd
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                protocol: TCP
+                address: 127.0.0.1
+                port_value: 8125
     dns_lookup_family: V4_ONLY
   - name: lightstep_saas
     connect_timeout: 1s
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: collector-grpc.lightstep.com
-        port_value: 443
+    load_assignment:
+      cluster_name: lightstep_saas
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  protocol: TCP
+                  address: collector-grpc.lightstep.com
+                  port_value: 443
     http2_protocol_options:
       max_concurrent_streams: 100
     tls_context:
@@ -442,20 +477,30 @@ static_resources:
     connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: cds.yourcompany.net
-        port_value: 80
+    load_assignment:
+      cluster_name: lightstep_saas
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  protocol: TCP
+                  address: cds.yourcompany.net
+                  port_value: 80
   - name: sds
     connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        protocol: TCP
-        address: discovery.yourcompany.net
-        port_value: 80
+    load_assignment:
+      cluster_name: lightstep_saas
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  protocol: TCP
+                  address: discovery.yourcompany.net
+                  port_value: 80
 dynamic_resources:
   cds_config:
     api_config_source:


### PR DESCRIPTION
Move example CDS configs from `hosts` to `load_assignment`

Description: 
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>