### PR TITLE
docs/configs/examples: use envoy-dev images

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -8,7 +8,7 @@ where `<hash>` is specified in [`envoy_build_sha.sh`](https://github.com/envoypr
 may work with `envoyproxy/envoy-build:latest` to provide a self-contained environment for building Envoy binaries and
 running tests that reflects the latest built Ubuntu Envoy image. Moreover, the Docker image
 at [`envoyproxy/envoy:<hash>`](https://hub.docker.com/r/envoyproxy/envoy/) is an image that has an Envoy binary at `/usr/local/bin/envoy`. The `<hash>`
-corresponds to the master commit at which the binary was compiled. Lastly, `envoyproxy/envoy:latest` contains an Envoy
+corresponds to the master commit at which the binary was compiled. Lastly, `envoyproxy/envoy-dev:latest` contains an Envoy
 binary built from the latest tip of master that passed tests.
 
 ## Alpine Envoy image

--- a/configs/Dockerfile
+++ b/configs/Dockerfile
@@ -1,7 +1,7 @@
 # This configuration will build a Docker container containing
 # an Envoy proxy that routes to Google.
 
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 RUN apt-get update
 COPY google_com_proxy.v2.yaml /etc/envoy.yaml
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml

--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -24,8 +24,8 @@ A very minimal Envoy configuration that can be used to validate basic plain HTTP
 proxying is available in :repo:`configs/google_com_proxy.v2.yaml`. This is not
 intended to represent a realistic Envoy deployment::
 
-  $ docker pull envoyproxy/envoy:latest
-  $ docker run --rm -d -p 10000:10000 envoyproxy/envoy:latest
+  $ docker pull envoyproxy/envoy-dev:latest
+  $ docker run --rm -d -p 10000:10000 envoyproxy/envoy-dev:latest
   $ curl -v localhost:10000
 
 The Docker image used will contain the latest version of Envoy
@@ -115,7 +115,7 @@ You can refer to the :ref:`Command line options <operations_cli>`.
 
 .. code-block:: none
 
-  FROM envoyproxy/envoy:latest
+  FROM envoyproxy/envoy-dev:latest
   COPY envoy.yaml /etc/envoy/envoy.yaml
 
 Build the Docker image that runs your configuration using::
@@ -138,7 +138,7 @@ by using a volume.
   version: '3'
   services:
     envoy:
-      image: envoyproxy/envoy:latest
+      image: envoyproxy/envoy-dev:latest
       ports:
         - "10000:10000"
       volumes:

--- a/examples/cors/backend/Dockerfile-frontenvoy
+++ b/examples/cors/backend/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get -q install -y \
     curl

--- a/examples/cors/frontend/Dockerfile-frontenvoy
+++ b/examples/cors/frontend/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get -q install -y \
     curl

--- a/examples/fault-injection/Dockerfile-envoy
+++ b/examples/fault-injection/Dockerfile-envoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get install -y curl tree
 COPY enable_delay_fault_injection.sh disable_delay_fault_injection.sh enable_abort_fault_injection.sh disable_abort_fault_injection.sh send_request.sh /

--- a/examples/front-proxy/Dockerfile-frontenvoy
+++ b/examples/front-proxy/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get -q install -y \
     curl

--- a/examples/grpc-bridge/Dockerfile-grpc
+++ b/examples/grpc-bridge/Dockerfile-grpc
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 RUN mkdir /var/log/envoy/
 COPY ./bin/service /usr/local/bin/srv

--- a/examples/grpc-bridge/Dockerfile-python
+++ b/examples/grpc-bridge/Dockerfile-python
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update
 RUN apt-get -q install -y python-dev \

--- a/examples/lua/Dockerfile-proxy
+++ b/examples/lua/Dockerfile-proxy
@@ -1,2 +1,2 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy

--- a/examples/mysql/Dockerfile-proxy
+++ b/examples/mysql/Dockerfile-proxy
@@ -1,3 +1,3 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug

--- a/examples/redis/Dockerfile-proxy
+++ b/examples/redis/Dockerfile-proxy
@@ -1,2 +1,2 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy


### PR DESCRIPTION
We need to think about whether we want to have all of these somehow
reference some type of environment variable that would point to the
right image in the context of the tree the user is looking at, but
given that the trunk documentation may require a master build, this
is more correct.