### PR TITLE
fix NPE In refreshCachedRoute

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1061,7 +1061,10 @@ void ConnectionManagerImpl::startDrainSequence() {
 }
 
 void ConnectionManagerImpl::ActiveStream::refreshCachedRoute() {
-  Router::RouteConstSharedPtr route = snapped_route_config_->route(*request_headers_, stream_id_);
+  Router::RouteConstSharedPtr route;
+  if (request_headers_ != nullptr) {
+    route = snapped_route_config_->route(*request_headers_, stream_id_);
+  }
   stream_info_.route_entry_ = route ? route->routeEntry() : nullptr;
   cached_route_ = std::move(route);
   if (nullptr == stream_info_.route_entry_) {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1261,7 +1261,7 @@ TEST_F(HttpConnectionManagerImplTest, AccessEncoderRouteBeforeHeadersArriveOnIdl
     // encodeHeaders()/encodeData().
     EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
     EXPECT_CALL(*idle_timer, disableTimer());
-    // Simulate and idle timeout so that the filter chain gets created
+    // Simulate and idle timeout so that the filter chain gets created.
     idle_timer->callback_();
   }));
 
@@ -1272,18 +1272,17 @@ TEST_F(HttpConnectionManagerImplTest, AccessEncoderRouteBeforeHeadersArriveOnIdl
   EXPECT_CALL(*encoder_filters_[0], encodeComplete());
   EXPECT_CALL(*encoder_filters_[0], onDestroy());
 
-  // 408 direct response after timeout.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, _));
   EXPECT_CALL(response_encoder_, encodeData(_, _));
 
   Buffer::OwnedImpl fake_input;
   conn_manager_->onData(fake_input, false);
 
-  // This should not be called as we don't have request headers
+  // This should not be called as we don't have request headers.
   EXPECT_CALL(*route_config_provider_.route_config_, route(_, _)).Times(0);
 
   // Under heavy load it is possible that stream timeout will be reached before any headers were
-  // received. Envoy will creates a local reply that will go through the encoder filter chain. we
+  // received. Envoy will create a local reply that will go through the encoder filter chain. We
   // want to make sure that encoder filters get a null route object.
   auto route = encoder_filters_[0]->callbacks_->route();
   EXPECT_EQ(route.get(), nullptr);

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1248,6 +1248,47 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutGlobal) {
   EXPECT_EQ(1U, stats_.named_.downstream_rq_idle_timeout_.value());
 }
 
+TEST_F(HttpConnectionManagerImplTest, AccessEncoderRouteBeforeHeadersArriveOnIdleTimeout) {
+  stream_idle_timeout_ = std::chrono::milliseconds(10);
+  setup(false, "");
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    Event::MockTimer* idle_timer = setUpTimer();
+    EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(10)));
+    conn_manager_->newStream(response_encoder_);
+
+    // Expect resetIdleTimer() to be called for the response
+    // encodeHeaders()/encodeData().
+    EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
+    EXPECT_CALL(*idle_timer, disableTimer());
+    // Simulate and idle timeout so that the filter chain gets created
+    idle_timer->callback_();
+  }));
+
+  setupFilterChain(0, 1);
+
+  EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, _));
+  EXPECT_CALL(*encoder_filters_[0], encodeData(_, _));
+  EXPECT_CALL(*encoder_filters_[0], encodeComplete());
+  EXPECT_CALL(*encoder_filters_[0], onDestroy());
+
+  // 408 direct response after timeout.
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, _));
+  EXPECT_CALL(response_encoder_, encodeData(_, _));
+
+  Buffer::OwnedImpl fake_input;
+  conn_manager_->onData(fake_input, false);
+
+  // This should not be called as we dont have request headers
+  EXPECT_CALL(*route_config_provider_.route_config_, route(_, _)).Times(0);
+
+  // Under heavy load it is possible that stream timeout will be reached before any headers were
+  // received. Envoy will creates a local reply that will go through the encoder filter chain. we
+  // want to make sure that encoder filters get a null route object.
+  auto route = encoder_filters_[0]->callbacks_->route();
+  EXPECT_EQ(route.get(), nullptr);
+}
+
 TEST_F(HttpConnectionManagerImplTest, TestStreamIdleAccessLog) {
   stream_idle_timeout_ = std::chrono::milliseconds(10);
   setup(false, "");

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1279,7 +1279,7 @@ TEST_F(HttpConnectionManagerImplTest, AccessEncoderRouteBeforeHeadersArriveOnIdl
   Buffer::OwnedImpl fake_input;
   conn_manager_->onData(fake_input, false);
 
-  // This should not be called as we dont have request headers
+  // This should not be called as we don't have request headers
   EXPECT_CALL(*route_config_provider_.route_config_, route(_, _)).Times(0);
 
   // Under heavy load it is possible that stream timeout will be reached before any headers were


### PR DESCRIPTION
Fix refreshCachedRoute not check if request headers are null

Risk Level: Low
Testing: Added unit test
Docs Changes: N/A
Release Notes: N/A
Fixes #6348

