### PR TITLE
Support google_default channel credentials

### DIFF
--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -25,6 +25,9 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::getChannelCredentials(
     case envoy::api::v2::core::GrpcService::GoogleGrpc::ChannelCredentials::kLocalCredentials: {
       return grpc::experimental::LocalCredentials(UDS);
     }
+    case envoy::api::v2::core::GrpcService::GoogleGrpc::ChannelCredentials::kGoogleDefault: {
+      return grpc::GoogleDefaultCredentials();
+    }
     default:
       return nullptr;
     }

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -78,6 +78,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "google_grpc_creds_test",
     srcs = envoy_select_google_grpc(["google_grpc_creds_test.cc"]),
+    data = [":service_key.json"],
     deps = [
         ":utility_lib",
         "//test/mocks/stats:stats_mocks",

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -1,7 +1,10 @@
+#include <stdlib.h>
+
 #include "common/grpc/google_grpc_creds_impl.h"
 
 #include "test/common/grpc/utility.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -31,6 +34,14 @@ TEST_F(CredsUtilityTest, GetChannelCredentials) {
   EXPECT_NE(nullptr, CredsUtility::getChannelCredentials(config, *api_));
   creds->mutable_local_credentials();
   EXPECT_NE(nullptr, CredsUtility::getChannelCredentials(config, *api_));
+
+  const char var_name[] = "GOOGLE_APPLICATION_CREDENTIALS";
+  EXPECT_EQ(nullptr, ::getenv(var_name));
+  const auto creds_path = TestEnvironment::runfilesPath("test/common/grpc/service_key.json");
+  ::setenv(var_name, creds_path.c_str(), 0);
+  creds->mutable_google_default();
+  EXPECT_NE(nullptr, CredsUtility::getChannelCredentials(config, *api_));
+  ::unsetenv(var_name);
 }
 
 TEST_F(CredsUtilityTest, DefaultSslChannelCredentials) {

--- a/test/common/grpc/service_key.json
+++ b/test/common/grpc/service_key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "teset-project",
+  "private_key_id": "xxx",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nspUMkfFsoTfa\n-----END PRIVATE KEY-----\n",
+  "client_email": "test@test.iam.gserviceaccount.com",
+  "client_id": "42",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%test-dev.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Support [google_default](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/grpc_service.proto.html#core-grpcservice-googlegrpc-channelcredentials) in channel credentials configuration. The documentation mentions this option and yet it's ignored. Confusing.

Risk Level: Low, the option was seemingly useless/unused. If anybody relies on it doing nothing, they can just unset it.

Testing: Tried running my own envoy, seemed to pick up the credentials pointed to be GOOGLE_APPLICATION_CREDENTIALS environment variable.