### PR TITLE
test: remove v1 Redis HC tests

### DIFF
--- a/test/extensions/health_checkers/redis/config_test.cc
+++ b/test/extensions/health_checkers/redis/config_test.cc
@@ -112,57 +112,6 @@ TEST(HealthCheckerFactoryTest, createRedisViaUpstreamHealthCheckerFactory) {
                              dispatcher, log_manager)
                              .get()));
 }
-
-TEST(HealthCheckerFactoryTest, createRedisWithDeprecatedV1JsonConfig) {
-  const std::string json = R"EOF(
-    {
-      "type": "redis",
-      "timeout_ms": 1000,
-      "interval_ms": 1000,
-      "unhealthy_threshold": 1,
-      "healthy_threshold": 1
-    }
-    )EOF";
-
-  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
-  Runtime::MockLoader runtime;
-  Runtime::MockRandomGenerator random;
-  Event::MockDispatcher dispatcher;
-  AccessLog::MockAccessLogManager log_manager;
-  EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
-                         // Always use Upstream's HealthCheckerFactory when creating instance using
-                         // deprecated config.
-                         Upstream::HealthCheckerFactory::create(
-                             Upstream::parseHealthCheckFromV1Json(json), cluster, runtime, random,
-                             dispatcher, log_manager)
-                             .get()));
-}
-
-TEST(HealthCheckerFactoryTest, createRedisWithDeprecatedV1JsonConfigWithKey) {
-  const std::string json = R"EOF(
-    {
-      "type": "redis",
-      "timeout_ms": 1000,
-      "interval_ms": 1000,
-      "unhealthy_threshold": 1,
-      "healthy_threshold": 1,
-      "redis_key": "foo"
-    }
-    )EOF";
-
-  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
-  Runtime::MockLoader runtime;
-  Runtime::MockRandomGenerator random;
-  Event::MockDispatcher dispatcher;
-  AccessLog::MockAccessLogManager log_manager;
-  EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
-                         // Always use Upstream's HealthCheckerFactory when creating instance using
-                         // deprecated config.
-                         Upstream::HealthCheckerFactory::create(
-                             Upstream::parseHealthCheckFromV1Json(json), cluster, runtime, random,
-                             dispatcher, log_manager)
-                             .get()));
-}
 } // namespace
 } // namespace RedisHealthChecker
 } // namespace HealthCheckers


### PR DESCRIPTION
Description: This PR removes 2 tests that specifically exercise v1 API paths. This is under the observation that the cases being exercised are still tested through v2 API examples (`createRedis` and `createRedisWithoutKey`) so there is no need to conduct v1->v2 translation for these tests. These tests simply existed to verify v1 compatibility but that is no longer a concern.

The `parseHealthCheckFromV1Json` function used for the v1 API tests cannot yet be deleted because it is used by v1 tests in `test/common/upstream/health_checker_impl_test.cc`. It'll be removed when that code is updated.

Risk Level: Low (no functional change)
Testing:
Docs Changes: N/A
Release Notes: N/A
Resolves: a piece of https://github.com/envoyproxy/envoy/issues/6362

Signed-off-by: Derek Argueta <dereka@pinterest.com>