### PR TITLE
Examples: Update gen script of grpc example service

### DIFF
--- a/examples/grpc-bridge/service/script/gen
+++ b/examples/grpc-bridge/service/script/gen
@@ -4,7 +4,7 @@ set -e
 
 cd $(dirname $0)/..
 
-rm -rf generated/*
+rm -rf gen/*
 
 # generate the protobufs
 protoc --go_out=plugins=grpc:./gen \


### PR DESCRIPTION
Description: Fix the outdated gen script of grpc-bridge examples
Risk Level: Low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
