### PR TITLE
docs: adds information about the Envoy tracer from Instana

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -467,6 +467,24 @@ requests that spans are sampled and reported.
 
 .. _config_http_conn_man_headers_custom_request_headers:
 
+x-instana-t
+-----------
+
+The *x-instana-t* HTTP header is used by the Instana tracer in Envoy.
+The hex-encoded 64-bit value represents the ID of the overall distributed trace,
+and is used to correlate all spans which are part of the same distributed trace.
+
+.. _config_http_conn_man_headers_x-instana-t:
+
+x-instana-s
+-----------
+
+The *x-instana-s* HTTP header is used by the Instana tracer in Envoy.
+The hex-encoded 64-bit value represents the ID of parent Span ID of the calling context,
+and is used to create parent-child relationships between spans.
+
+.. _config_http_conn_man_headers_x-instana-s:
+
 Custom request/response headers
 -------------------------------
 

--- a/docs/root/intro/arch_overview/tracing.rst
+++ b/docs/root/intro/arch_overview/tracing.rst
@@ -78,6 +78,10 @@ Alternatively the trace context can be manually propagated by the service:
   :ref:`config_http_conn_man_headers_x-datadog-parent-id`,
   :ref:`config_http_conn_man_headers_x-datadog-sampling-priority`).
 
+* When using the Instana tracer, Envoy relies on the service to propagate then Instana-specific HTTP headers (
+  :ref:`config_http_conn_man_headers_x-instana-t`,
+  :ref:`config_http_conn_man_headers_x-instana-s`).
+
 What data each trace contains
 -----------------------------
 An end-to-end trace is comprised of one or more spans. A

--- a/docs/root/intro/arch_overview/tracing.rst
+++ b/docs/root/intro/arch_overview/tracing.rst
@@ -78,7 +78,7 @@ Alternatively the trace context can be manually propagated by the service:
   :ref:`config_http_conn_man_headers_x-datadog-parent-id`,
   :ref:`config_http_conn_man_headers_x-datadog-sampling-priority`).
 
-* When using the Instana tracer, Envoy relies on the service to propagate then Instana-specific HTTP headers (
+* When using the Instana tracer, Envoy relies on the service to propagate the Instana-specific HTTP headers (
   :ref:`config_http_conn_man_headers_x-instana-t`,
   :ref:`config_http_conn_man_headers_x-instana-s`).
 

--- a/docs/root/intro/arch_overview/tracing.rst
+++ b/docs/root/intro/arch_overview/tracing.rst
@@ -14,8 +14,8 @@ sources of latency. Envoy supports three features related to system wide tracing
   x-request-id header for unified logging as well as tracing.
 * **External trace service integration**: Envoy supports pluggable external trace visualization
   providers. Currently Envoy supports `LightStep <https://lightstep.com/>`_, `Zipkin <https://zipkin.io/>`_
-  or any Zipkin compatible backends (e.g. `Jaeger <https://github.com/jaegertracing/>`_), and
-  `Datadog <https://datadoghq.com>`_.
+  or any Zipkin compatible backends (e.g. `Jaeger <https://github.com/jaegertracing/>`_), 
+  `Datadog <https://datadoghq.com>`_, and `Instana <https://www.instana.com/blog/monitoring-envoy-proxy-microservices/>`_.
   However, support for other tracing providers would not be difficult to add.
 * **Client trace ID joining**: The :ref:`config_http_conn_man_headers_x-client-trace-id` header can
   be used to join untrusted request IDs to the trusted internal


### PR DESCRIPTION
Description: This PR adds the information for the Envoy tracer from Instana and also the HTTP headers being used to capture traces and spans. The information are written in the same way as for Zipkin, Datadog and others.
Risk Level: Low
Testing: n/a, doc change only
Docs Changes: See above, only doc change
Release Notes: no impact on users, no necessity to be mentioned in the release notes


PS: I hope this change is done according to the contributions best practices. If I missed anything, just let me know, happy to fix it.