### PR TITLE
runtime: switching from unordered_map to absl::flat_hash_map

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -64,7 +64,7 @@ public:
     virtual ~OverrideLayer() {}
 
     /**
-     * @return const absl::flat_hash_ma<std::string, Entry>& the values in this layer.
+     * @return const absl::flat_hash_map<std::string, Entry>& the values in this layer.
      */
     virtual const EntryMap& values() const PURE;
 

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -12,6 +12,7 @@
 #include "common/common/assert.h"
 #include "common/singleton/threadsafe_singleton.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -52,7 +53,7 @@ public:
     absl::optional<bool> bool_value_;
   };
 
-  typedef std::unordered_map<std::string, Entry> EntryMap;
+  typedef absl::flat_hash_map<std::string, Entry> EntryMap;
 
   /**
    * A provider of runtime values. One or more of these compose the snapshot's source of values,
@@ -63,9 +64,9 @@ public:
     virtual ~OverrideLayer() {}
 
     /**
-     * @return const std::unordered_map<std::string, Entry>& the values in this layer.
+     * @return const absl::flat_hash_ma<std::string, Entry>& the values in this layer.
      */
-    virtual const std::unordered_map<std::string, Snapshot::Entry>& values() const PURE;
+    virtual const EntryMap& values() const PURE;
 
     /**
      * @return const std::string& a user-friendly alias for this layer, e.g. "admin" or "disk".
@@ -88,7 +89,7 @@ public:
   // Runtime features are used to easily allow switching between old and new code paths for high
   // risk changes. The intent is for the old code path to be short lived - the old code path is
   // deprecated as the feature is defaulted true, and removed with the following Envoy release.
-  virtual bool runtimeFeatureEnabled(const std::string& key) const PURE;
+  virtual bool runtimeFeatureEnabled(absl::string_view key) const PURE;
 
   /**
    * Test if a feature is enabled using the built in random generator. This is done by generating

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -9,7 +9,6 @@
 namespace Envoy {
 namespace Runtime {
 
-// TODO(alyssawilk) convert these to string view.
 class RuntimeFeatures {
 public:
   RuntimeFeatures();
@@ -17,13 +16,13 @@ public:
   // This tracks proto configured features, to determine if a given deprecated
   // feature is still allowed, or has been made fatal-by-default per the Envoy
   // deprecation process.
-  bool disallowedByDefault(const std::string& feature) const {
+  bool disallowedByDefault(absl::string_view feature) const {
     return disallowed_features_.find(feature) != disallowed_features_.end();
   }
 
   // This tracks config-guarded code paths, to determine if a given
   // runtime-guarded-code-path has the new code run by default or the old code.
-  bool enabledByDefault(const std::string& feature) const {
+  bool enabledByDefault(absl::string_view feature) const {
     return enabled_features_.find(feature) != enabled_features_.end();
   }
 

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -22,7 +22,7 @@
 namespace Envoy {
 namespace Runtime {
 
-bool runtimeFeatureEnabled(const std::string& feature) {
+bool runtimeFeatureEnabled(absl::string_view feature) {
   ASSERT(absl::StartsWith(feature, "envoy.reloadable_features"));
   if (Runtime::LoaderSingleton::getExisting()) {
     return Runtime::LoaderSingleton::getExisting()->snapshot().runtimeFeatureEnabled(feature);
@@ -174,7 +174,7 @@ bool SnapshotImpl::deprecatedFeatureEnabled(const std::string& key) const {
   return true;
 }
 
-bool SnapshotImpl::runtimeFeatureEnabled(const std::string& key) const {
+bool SnapshotImpl::runtimeFeatureEnabled(absl::string_view key) const {
   bool enabled = false;
   // If the value is not explicitly set as a runtime boolean, the default value is based on
   // disallowedByDefault.
@@ -257,7 +257,7 @@ uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value
   }
 }
 
-bool SnapshotImpl::getBoolean(const std::string& key, bool& value) const {
+bool SnapshotImpl::getBoolean(absl::string_view key, bool& value) const {
   auto entry = values_.find(key);
   if (entry != values_.end() && entry->second.bool_value_.has_value()) {
     value = entry->second.bool_value_.value();

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -24,7 +24,7 @@
 namespace Envoy {
 namespace Runtime {
 
-bool runtimeFeatureEnabled(const std::string& feature);
+bool runtimeFeatureEnabled(absl::string_view feature);
 
 using RuntimeSingleton = ThreadSafeSingleton<Loader>;
 
@@ -74,7 +74,7 @@ public:
 
   // Runtime::Snapshot
   bool deprecatedFeatureEnabled(const std::string& key) const override;
-  bool runtimeFeatureEnabled(const std::string& key) const override;
+  bool runtimeFeatureEnabled(absl::string_view key) const override;
   bool featureEnabled(const std::string& key, uint64_t default_value, uint64_t random_value,
                       uint64_t num_buckets) const override;
   bool featureEnabled(const std::string& key, uint64_t default_value) const override;
@@ -92,7 +92,7 @@ public:
 
   // Returns true and sets 'value' to the key if found.
   // Returns false if the key is not a boolean value.
-  bool getBoolean(const std::string& key, bool& value) const;
+  bool getBoolean(absl::string_view key, bool& value) const;
 
 private:
   static void resolveEntryType(Entry& entry) {

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -28,7 +28,7 @@ public:
   ~MockSnapshot() override;
 
   MOCK_CONST_METHOD1(deprecatedFeatureEnabled, bool(const std::string& key));
-  MOCK_CONST_METHOD1(runtimeFeatureEnabled, bool(const std::string& key));
+  MOCK_CONST_METHOD1(runtimeFeatureEnabled, bool(const absl::string_view key));
   MOCK_CONST_METHOD2(featureEnabled, bool(const std::string& key, uint64_t default_value));
   MOCK_CONST_METHOD3(featureEnabled,
                      bool(const std::string& key, uint64_t default_value, uint64_t random_value));
@@ -61,7 +61,7 @@ public:
   ~MockOverrideLayer();
 
   MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(values, const std::unordered_map<std::string, Snapshot::Entry>&());
+  MOCK_CONST_METHOD0(values, const Snapshot::EntryMap&());
 };
 
 } // namespace Runtime

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -28,7 +28,7 @@ public:
   ~MockSnapshot() override;
 
   MOCK_CONST_METHOD1(deprecatedFeatureEnabled, bool(const std::string& key));
-  MOCK_CONST_METHOD1(runtimeFeatureEnabled, bool(const absl::string_view key));
+  MOCK_CONST_METHOD1(runtimeFeatureEnabled, bool(absl::string_view key));
   MOCK_CONST_METHOD2(featureEnabled, bool(const std::string& key, uint64_t default_value));
   MOCK_CONST_METHOD3(featureEnabled,
                      bool(const std::string& key, uint64_t default_value, uint64_t random_value));

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -933,12 +933,11 @@ TEST_P(AdminInstanceTest, Runtime) {
   Runtime::MockLoader loader;
   auto layer1 = std::make_unique<NiceMock<Runtime::MockOverrideLayer>>();
   auto layer2 = std::make_unique<NiceMock<Runtime::MockOverrideLayer>>();
-  std::unordered_map<std::string, Runtime::Snapshot::Entry> entries2{
-      {"string_key", {"override", {}, {}, {}}}, {"extra_key", {"bar", {}, {}, {}}}};
-  std::unordered_map<std::string, Runtime::Snapshot::Entry> entries1{
-      {"string_key", {"foo", {}, {}, {}}},
-      {"int_key", {"1", 1, {}, {}}},
-      {"other_key", {"bar", {}, {}, {}}}};
+  Runtime::Snapshot::EntryMap entries2{{"string_key", {"override", {}, {}, {}}},
+                                       {"extra_key", {"bar", {}, {}, {}}}};
+  Runtime::Snapshot::EntryMap entries1{{"string_key", {"foo", {}, {}, {}}},
+                                       {"int_key", {"1", 1, {}, {}}},
+                                       {"other_key", {"bar", {}, {}, {}}}};
 
   ON_CALL(*layer1, name()).WillByDefault(testing::ReturnRefOfCopy(std::string{"layer1"}));
   ON_CALL(*layer1, values()).WillByDefault(testing::ReturnRef(entries1));


### PR DESCRIPTION
This allows us to move the new runtime APIs over to string_view without taking a string-serialization performance hit.

see https://abseil.io/docs/cpp/guides/container for flat_hash_map being a unordered_map replacement with heterogeneous lookup for string_view.

Risk Level: Medium (swapping the underlying internals of runtime)
Testing: existing tests pass
Docs Changes: no
Release Notes: no

