### PR TITLE
jwt_authn: allow Jwt requirement to be specified by other filters via filterState

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -365,7 +365,7 @@ message MetadataRule {
   repeated string path = 2 [(validate.rules).repeated .min_items = 1];
 
   // A map of string keys to requirements. The string key is the value
-  // in the dynamic metadata specified by `filter` and `path` fields.
+  // in the dynamic metadata specified by above *filter* and *path* fields.
   map<string, JwtRequirement> requires = 3;
 }
 
@@ -465,7 +465,7 @@ message JwtAuthentication {
 
   // This message specifies Jwt requirements based on a metadata string value.
   // Other HTTP filters can use this message to specify Jwt requirements.
-  // The "rules" field above is checked first, if it could not find any matches,
+  // The *rules* field above is checked first, if it could not find any matches,
   // check this one.
   MetadataRule metadata_rules = 3;
 }

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -340,7 +340,7 @@ message RequirementRule {
 }
 
 // This message specifies Jwt requirements based on stream_info.filterState.
-// This FilterState should use Router::StringAccessor object to set a string value.
+// This FilterState should use `Router::StringAccessor` object to set a string value.
 // Other HTTP filters can use it to specify Jwt requirements dynamically.
 //
 // Example:
@@ -357,7 +357,7 @@ message RequirementRule {
 // If a filter set "jwt_selector" with "issuer_1" to FilterState for a request,
 // jwt_authn filter will use JwtRequirement{"provider_name": "issuer1"} to verify.
 message FilterStateRule {
-  // The filter state name to retrieve the Router::StringAccessor object.
+  // The filter state name to retrieve the `Router::StringAccessor` object.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // A map of string keys to requirements. The string key is the string value

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -339,6 +339,38 @@ message RequirementRule {
   JwtRequirement requires = 2;
 }
 
+// This message specifies Jwt requirements based on a Metadata string value
+// Another HTTP filter can use it to specify Jwt requirement dynamically.
+//
+// Example:
+//
+// .. code-block:: yaml
+//
+//    filter: foo
+//    path:
+//      - jwt_requirement
+//    requires:
+//      issuer_1:
+//        provider_name: issuer1
+//      issuer_2:
+//        provider_name: issuer2
+//
+// If filter "foo" sets {"jwt_requirement": "issuer_1"} to the dynamicMetadata for a request,
+// Jwt filter will use JwtRequirement({"provider_name": "issuer1"}) to verify. If the metadata
+// is not set, or metadata value is not found in the "requires" map, Jwt verification is not
+// required for the request.
+message MetadataRule {
+  // The filter name to retrieve the dynamic metadata Struct.
+  string filter = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The path to retrieve the Value from the dynamic metadata Struct.
+  // It mush point to a string value.
+  repeated string path = 2 [(validate.rules).repeated .min_items = 1];
+
+  // A map of the metadata string values to requirements.
+  map<string, JwtRequirement> requires = 3;
+}
+
 // This is the Envoy HTTP filter config for JWT authentication.
 //
 // For example:
@@ -432,4 +464,10 @@ message JwtAuthentication {
   //           - provider_name: provider2
   //
   repeated RequirementRule rules = 2;
+
+  // This message specifies Jwt requirements based on a Metadata string value
+  // Another HTTP filter can use it to specify JWT requirement dynamically.
+  // Above "rules" field is checked first, if it could not find any matches,
+  // check this one.
+  MetadataRule metadata_rules = 3;
 }

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -340,7 +340,7 @@ message RequirementRule {
 }
 
 // This message specifies Jwt requirements based on a Metadata string value
-// Another HTTP filter can use it to specify Jwt requirement dynamically.
+// Other HTTP filters can use this message to specify Jwt requirement.
 //
 // Example:
 //
@@ -348,26 +348,24 @@ message RequirementRule {
 //
 //    filter: foo
 //    path:
-//      - jwt_requirement
+//      - jwt_selector
 //    requires:
 //      issuer_1:
 //        provider_name: issuer1
 //      issuer_2:
 //        provider_name: issuer2
 //
-// If filter "foo" sets {"jwt_requirement": "issuer_1"} to the dynamicMetadata for a request,
-// Jwt filter will use JwtRequirement({"provider_name": "issuer1"}) to verify. If the metadata
-// is not set, or metadata value is not found in the "requires" map, Jwt verification is not
-// required for the request.
+// If the filter "foo" sets {"jwt_selector": "issuer_1"} to the dynamicMetadata for a request,
+// jwt_authn filter will use JwtRequirement{"provider_name": "issuer1"} to verify.
 message MetadataRule {
-  // The filter name to retrieve the dynamic metadata Struct.
+  // The filter name to retrieve the dynamic metadata.
   string filter = 1 [(validate.rules).string.min_bytes = 1];
 
-  // The path to retrieve the Value from the dynamic metadata Struct.
-  // It mush point to a string value.
+  // The path to retrieve a string value from the dynamic metadata.
   repeated string path = 2 [(validate.rules).repeated .min_items = 1];
 
-  // A map of the metadata string values to requirements.
+  // A map of string keys to requirements. The string key is the value
+  // in the dynamic metadata specified by `filter` and `path` fields.
   map<string, JwtRequirement> requires = 3;
 }
 
@@ -465,9 +463,9 @@ message JwtAuthentication {
   //
   repeated RequirementRule rules = 2;
 
-  // This message specifies Jwt requirements based on a Metadata string value
-  // Another HTTP filter can use it to specify JWT requirement dynamically.
-  // Above "rules" field is checked first, if it could not find any matches,
+  // This message specifies Jwt requirements based on a metadata string value.
+  // Other HTTP filters can use this message to specify Jwt requirements.
+  // The "rules" field above is checked first, if it could not find any matches,
   // check this one.
   MetadataRule metadata_rules = 3;
 }

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -340,7 +340,7 @@ message RequirementRule {
 }
 
 // This message specifies Jwt requirements based on stream_info.filterState.
-// This FilterState should use StringAccessor object to set a string value.
+// This FilterState should use Router::StringAccessor object to set a string value.
 // Other HTTP filters can use it to specify Jwt requirements dynamically.
 //
 // Example:
@@ -357,7 +357,7 @@ message RequirementRule {
 // If a filter set "jwt_selector" with "issuer_1" to FilterState for a request,
 // jwt_authn filter will use JwtRequirement{"provider_name": "issuer1"} to verify.
 message FilterStateRule {
-  // The filter state name to retrieve the StringAccessor object.
+  // The filter state name to retrieve the Router::StringAccessor object.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // A map of string keys to requirements. The string key is the string value

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -339,33 +339,29 @@ message RequirementRule {
   JwtRequirement requires = 2;
 }
 
-// This message specifies Jwt requirements based on a Metadata string value
-// Other HTTP filters can use this message to specify Jwt requirement.
+// This message specifies Jwt requirements based on stream_info.filterState.
+// This FilterState should use StringAccessor object to set a string value.
+// Other HTTP filters can use it to specify Jwt requirements dynamically.
 //
 // Example:
 //
 // .. code-block:: yaml
 //
-//    filter: foo
-//    path:
-//      - jwt_selector
+//    name: jwt_selector
 //    requires:
 //      issuer_1:
 //        provider_name: issuer1
 //      issuer_2:
 //        provider_name: issuer2
 //
-// If the filter "foo" sets {"jwt_selector": "issuer_1"} to the dynamicMetadata for a request,
+// If a filter set "jwt_selector" with "issuer_1" to FilterState for a request,
 // jwt_authn filter will use JwtRequirement{"provider_name": "issuer1"} to verify.
-message MetadataRule {
-  // The filter name to retrieve the dynamic metadata.
-  string filter = 1 [(validate.rules).string.min_bytes = 1];
+message FilterStateRule {
+  // The filter state name to retrieve the StringAccessor object.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
-  // The path to retrieve a string value from the dynamic metadata.
-  repeated string path = 2 [(validate.rules).repeated .min_items = 1];
-
-  // A map of string keys to requirements. The string key is the value
-  // in the dynamic metadata specified by above *filter* and *path* fields.
+  // A map of string keys to requirements. The string key is the string value
+  // in the FilterState with the name specified in the *name* field above.
   map<string, JwtRequirement> requires = 3;
 }
 
@@ -463,9 +459,9 @@ message JwtAuthentication {
   //
   repeated RequirementRule rules = 2;
 
-  // This message specifies Jwt requirements based on a metadata string value.
-  // Other HTTP filters can use this message to specify Jwt requirements.
+  // This message specifies Jwt requirements based on stream_info.filterState.
+  // Other HTTP filters can use it to specify Jwt requirements dynamically.
   // The *rules* field above is checked first, if it could not find any matches,
   // check this one.
-  MetadataRule metadata_rules = 3;
+  FilterStateRule filter_state_rules = 3;
 }

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -53,6 +53,8 @@ Version history
 * outlier_detection: added support for :ref:`outlier detection event protobuf-based logging <arch_overview_outlier_detection_logging>`.
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
 * performance: new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments when starting Envoy).
+* jwt_authn: added ref:`metadata_rules
+    <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.metadata_rules>` to specify jwt requirements from metadata by other filters.
 * ratelimit: removed deprecated rate limit configuration from bootstrap.
 * redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -54,7 +54,7 @@ Version history
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
 * performance: new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments when starting Envoy).
 * jwt_authn: added :ref:`metadata_rules
-    <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.metadata_rules>` to specify jwt requirements from metadata by other filters.
+    <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.metadata_rules>`.
 * ratelimit: removed deprecated rate limit configuration from bootstrap.
 * redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -53,8 +53,7 @@ Version history
 * outlier_detection: added support for :ref:`outlier detection event protobuf-based logging <arch_overview_outlier_detection_logging>`.
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
 * performance: new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments when starting Envoy).
-* jwt_authn: added :ref:`metadata_rules
-    <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.metadata_rules>`.
+* jwt_authn: added filter_state_rules to allow specifying requirements from filterState by other filters.
 * ratelimit: removed deprecated rate limit configuration from bootstrap.
 * redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -53,7 +53,7 @@ Version history
 * outlier_detection: added support for :ref:`outlier detection event protobuf-based logging <arch_overview_outlier_detection_logging>`.
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
 * performance: new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments when starting Envoy).
-* jwt_authn: added ref:`metadata_rules
+* jwt_authn: added :ref:`metadata_rules
     <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.metadata_rules>` to specify jwt requirements from metadata by other filters.
 * ratelimit: removed deprecated rate limit configuration from bootstrap.
 * redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -53,7 +53,7 @@ Version history
 * outlier_detection: added support for :ref:`outlier detection event protobuf-based logging <arch_overview_outlier_detection_logging>`.
 * mysql: added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy<config_network_filters_mysql_proxy>` for more details.
 * performance: new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments when starting Envoy).
-* jwt_authn: added filter_state_rules to allow specifying requirements from filterState by other filters.
+* jwt_authn: added :ref:`filter_state_rules <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.filter_state_rules>` to allow specifying requirements from filterState by other filters.
 * ratelimit: removed deprecated rate limit configuration from bootstrap.
 * redis: added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
 * redis: added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -100,9 +100,9 @@ envoy_cc_library(
     deps = [
         ":jwks_cache_lib",
         ":matchers_lib",
+        "//include/envoy/router:string_accessor_interface",
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/thread_local:thread_local_interface",
-        "//source/common/config:metadata_lib",
     ],
 )

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -103,5 +103,6 @@ envoy_cc_library(
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/thread_local:thread_local_interface",
+        "//source/common/config:metadata_lib",
     ],
 )

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -27,7 +27,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   stopped_ = false;
   // Verify the JWT token, onComplete() will be called when completed.
   const auto* verifier =
-      config_->findVerifier(headers, decoder_callbacks_->streamInfo().dynamicMetadata());
+      config_->findVerifier(headers, decoder_callbacks_->streamInfo().filterState());
   if (!verifier) {
     onComplete(Status::Ok);
   } else {

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -26,7 +26,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   state_ = Calling;
   stopped_ = false;
   // Verify the JWT token, onComplete() will be called when completed.
-  const auto* verifier = config_->findVerifier(headers);
+  const auto* verifier =
+      config_->findVerifier(headers, decoder_callbacks_->streamInfo().dynamicMetadata());
   if (!verifier) {
     onComplete(Status::Ok);
   } else {

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -116,7 +116,7 @@ public:
         return pair.verifier_.get();
       }
     }
-    if (filter_state_name_.size() > 0 && filter_state_verifiers_.size() > 0 &&
+    if (!filter_state_name_.empty() && !filter_state_verifiers_.empty() &&
         filter_state.hasData<Router::StringAccessor>(filter_state_name_)) {
       const auto& state = filter_state.getDataReadOnly<Router::StringAccessor>(filter_state_name_);
       ENVOY_LOG(debug, "use filter state value {} to find verifier.", state.asString());

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -164,10 +164,11 @@ private:
   ExtractorConstPtr extractor_;
   // The list of rule matchers.
   std::vector<MatcherVerifierPair> rule_pairs_;
-  // The metadata path filter name and path
+  // The metadata filter name.
   std::string metadata_filter_;
+  // The metadata path.
   std::vector<std::string> metadata_path_;
-  // The metadata verifier map
+  // The metadata verifier map.
   std::unordered_map<std::string, VerifierConstPtr> metadata_verifiers_;
   TimeSource& time_source_;
   Api::Api& api_;

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "common/config/metadata.h"
 #include "envoy/api/api.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/thread_local/thread_local.h"
+
+#include "common/config/metadata.h"
 
 #include "extensions/filters/http/jwt_authn/matcher.h"
 #include "extensions/filters/http/jwt_authn/verifier.h"

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -121,7 +121,8 @@ public:
       const auto& value =
           Envoy::Config::Metadata::metadataValue(metadata, metadata_filter_, metadata_path_);
       if (value.kind_case() == ProtobufWkt::Value::kStringValue) {
-        ENVOY_LOG(debug, "use metadata_rules key: {}", value.string_value());
+        ENVOY_LOG(debug, "use metadata value {} to find verifier from metadata_rules.",
+                  value.string_value());
         const auto& it = metadata_verifiers_.find(value.string_value());
         if (it != metadata_verifiers_.end()) {
           return it->second.get();

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -81,8 +81,8 @@ public:
 
     if (proto_config_.has_metadata_rules()) {
       metadata_filter_ = proto_config_.metadata_rules().filter();
-      for (const auto& key : proto_config_.metadata_rules().path()) {
-        metadata_path_.push_back(key);
+      for (const auto& path : proto_config_.metadata_rules().path()) {
+        metadata_path_.push_back(path);
       }
       for (const auto& it : proto_config_.metadata_rules().requires()) {
         metadata_verifiers_.emplace(it.first, Verifier::create(it.second, proto_config_.providers(),
@@ -117,9 +117,10 @@ public:
       }
     }
     if (metadata_path_.size() > 0 && metadata_verifiers_.size() > 0) {
-      const auto& value = Envoy::Config::Metadata::metadataValue(
-          metadata, metadata_filter_, metadata_path_);
+      const auto& value =
+          Envoy::Config::Metadata::metadataValue(metadata, metadata_filter_, metadata_path_);
       if (value.kind_case() == ProtobufWkt::Value::kStringValue) {
+        ENVOY_LOG(debug, "use metadata_rules key: {}", value.string_value());
         const auto& it = metadata_verifiers_.find(value.string_value());
         if (it != metadata_verifiers_.end()) {
           return it->second.get();

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -108,8 +108,8 @@ envoy_extension_cc_test(
     srcs = ["filter_integration_test.cc"],
     extension_name = "envoy.filters.http.jwt_authn",
     deps = [
-        "//source/extensions/filters/http/jwt_authn:config",
         "//source/extensions/filters/http/header_to_metadata:config",
+        "//source/extensions/filters/http/jwt_authn:config",
         "//test/config:utility_lib",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -51,6 +51,17 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "filter_config_test",
+    srcs = ["filter_config_test.cc"],
+    extension_name = "envoy.filters.http.jwt_authn",
+    deps = [
+        "//source/extensions/filters/http/jwt_authn:config",
+        "//test/extensions/filters/http/jwt_authn:test_common_lib",
+        "//test/mocks/server:server_mocks",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "filter_factory_test",
     srcs = ["filter_factory_test.cc"],
     extension_name = "envoy.filters.http.jwt_authn",
@@ -98,6 +109,7 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.http.jwt_authn",
     deps = [
         "//source/extensions/filters/http/jwt_authn:config",
+        "//source/extensions/filters/http/header_to_metadata:config",
         "//test/config:utility_lib",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -55,6 +55,8 @@ envoy_extension_cc_test(
     srcs = ["filter_config_test.cc"],
     extension_name = "envoy.filters.http.jwt_authn",
     deps = [
+        "//source/common/router:string_accessor_lib",
+        "//source/common/stream_info:filter_state_lib",
         "//source/extensions/filters/http/jwt_authn:config",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",
         "//test/mocks/server:server_mocks",
@@ -108,7 +110,9 @@ envoy_extension_cc_test(
     srcs = ["filter_integration_test.cc"],
     extension_name = "envoy.filters.http.jwt_authn",
     deps = [
-        "//source/extensions/filters/http/header_to_metadata:config",
+        "//source/common/router:string_accessor_lib",
+        "//source/extensions/filters/http/common:empty_http_filter_config_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//source/extensions/filters/http/jwt_authn:config",
         "//test/config:utility_lib",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -1,0 +1,112 @@
+#include "extensions/filters/http/jwt_authn/filter_config.h"
+
+#include "test/extensions/filters/http/jwt_authn/test_common.h"
+#include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::envoy::api::v2::core::Metadata;
+using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace JwtAuthn {
+namespace {
+
+TEST(HttpJwtAuthnFilterConfigTest, FindByMatch) {
+  const char config[] = R"(
+providers:
+  provider1:
+    issuer: issuer1
+    local_jwks:
+      inline_string: jwks
+rules:
+- match:
+    path: /path1
+  requires:
+    provider_name: provider1
+)";
+
+  JwtAuthentication proto_config;
+  MessageUtil::loadFromYaml(config, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  FilterConfig filter_conf(proto_config, "", context);
+
+  envoy::api::v2::core::Metadata metadata;
+  EXPECT_TRUE(filter_conf.findVerifier(
+                  Http::TestHeaderMapImpl{
+                      {":method", "GET"},
+                      {":path", "/path1"},
+                  },
+                  metadata) != nullptr);
+
+  EXPECT_TRUE(filter_conf.findVerifier(
+                  Http::TestHeaderMapImpl{
+                      {":method", "GET"},
+                      {":path", "/path2"},
+                  },
+                  metadata) == nullptr);
+}
+
+void setStringMetadata(Metadata& metadata, const std::string& filter, const std::string& key,
+                       const std::string& value) {
+  ProtobufWkt::Value proto_value;
+  proto_value.set_string_value(value);
+  ProtobufWkt::Struct md;
+  (*md.mutable_fields())[key] = proto_value;
+  (*metadata.mutable_filter_metadata())[filter].MergeFrom(md);
+}
+
+TEST(HttpJwtAuthnFilterConfigTest, FindByMetadata) {
+  const char config[] = R"(
+providers:
+  provider1:
+    issuer: issuer1
+    local_jwks:
+      inline_string: jwks
+  provider2:
+    issuer: issuer2
+    local_jwks:
+      inline_string: jwks
+metadata_rules:
+  filter: selector_filter
+  path:
+  - selector
+  requires:
+    selector1:
+      provider_name: provider1
+    selector2:
+      provider_name: provider2
+)";
+
+  JwtAuthentication proto_config;
+  MessageUtil::loadFromYaml(config, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  FilterConfig filter_conf(proto_config, "", context);
+
+  envoy::api::v2::core::Metadata metadata;
+  // Empty metadata
+  EXPECT_TRUE(filter_conf.findVerifier(Http::TestHeaderMapImpl(), metadata) == nullptr);
+
+  // Wrong selector
+  setStringMetadata(metadata, "selector_filter", "selector", "wrong_selector");
+  EXPECT_TRUE(filter_conf.findVerifier(Http::TestHeaderMapImpl(), metadata) == nullptr);
+
+  // correct selector
+  setStringMetadata(metadata, "selector_filter", "selector", "selector1");
+  EXPECT_TRUE(filter_conf.findVerifier(Http::TestHeaderMapImpl(), metadata) != nullptr);
+
+  // correct selector
+  setStringMetadata(metadata, "selector_filter", "selector", "selector2");
+  EXPECT_TRUE(filter_conf.findVerifier(Http::TestHeaderMapImpl(), metadata) != nullptr);
+}
+
+} // namespace
+} // namespace JwtAuthn
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -1,5 +1,6 @@
-#include "common/stream_info/filter_state_impl.h"
 #include "common/router/string_accessor_impl.h"
+#include "common/stream_info/filter_state_impl.h"
+
 #include "extensions/filters/http/jwt_authn/filter_config.h"
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -164,7 +164,7 @@ config:
         key: selector
 )";
 
-  // A config with local jwks with metadata rules.
+  // A config with metadata rules.
   const std::string auth_filter_conf = R"(
   providers:
     example_provider:
@@ -190,7 +190,7 @@ config:
     std::vector<std::pair<std::string, std::string>> extra_headers;
     std::string expected_status;
   };
-  // clang-format off
+
   const TestCase test_cases[] = {
       // Case1: not set metadata, so Jwt is not required, expect 200
       {
@@ -218,7 +218,6 @@ config:
           "200",
       },
   };
-  // clang-format on
 
   for (const auto& test : test_cases) {
     Http::TestHeaderMapImpl headers{

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -9,8 +9,6 @@
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
 #include "test/integration/http_protocol_integration.h"
 
-#include "fmt/printf.h"
-
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
 using ::envoy::config::filter::network::http_connection_manager::v2::HttpFilter;
 
@@ -58,9 +56,8 @@ public:
 };
 
 // perform static registration
-static Registry::RegisterFactory<HeaderToFilterStateFilterConfig,
-                                 Server::Configuration::NamedHttpFilterConfigFactory>
-    register_;
+REGISTER_FACTORY(HeaderToFilterStateFilterConfig,
+                 Server::Configuration::NamedHttpFilterConfigFactory);
 
 std::string getAuthFilterConfig(const std::string& config_str, bool use_local_jwks) {
   JwtAuthentication proto_config;
@@ -215,7 +212,7 @@ TEST_P(LocalJwksIntegrationTest, FilterStateRequirement) {
 )";
 
   config_helper_.addFilter(getAuthFilterConfig(auth_filter_conf, true));
-  config_helper_.addFilter(fmt::sprintf("name: %s", HeaderToFilterStateFilterName));
+  config_helper_.addFilter(absl::StrCat("name: ", HeaderToFilterStateFilterName));
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
 #include "test/integration/http_protocol_integration.h"
+
 #include "fmt/printf.h"
 
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
 #include "test/integration/http_protocol_integration.h"
+#include "fmt/printf.h"
 
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
 using ::envoy::config::filter::network::http_connection_manager::v2::HttpFilter;
@@ -14,9 +15,9 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
-std::string getFilterConfig(bool use_local_jwks) {
+std::string getAuthFilterConfig(const std::string& config_str, bool use_local_jwks) {
   JwtAuthentication proto_config;
-  MessageUtil::loadFromYaml(ExampleConfig, proto_config);
+  MessageUtil::loadFromYaml(config_str, proto_config);
 
   if (use_local_jwks) {
     auto& provider0 = (*proto_config.mutable_providers())[std::string(ProviderName)];
@@ -29,6 +30,10 @@ std::string getFilterConfig(bool use_local_jwks) {
   filter.set_name(HttpFilterNames::get().JwtAuthn);
   MessageUtil::jsonConvert(proto_config, *filter.mutable_config());
   return MessageUtil::getJsonStringFromMessage(filter);
+}
+
+std::string getFilterConfig(bool use_local_jwks) {
+  return getAuthFilterConfig(ExampleConfig, use_local_jwks);
 }
 
 typedef HttpProtocolIntegrationTest LocalJwksIntegrationTest;
@@ -85,6 +90,24 @@ TEST_P(LocalJwksIntegrationTest, ExpiredToken) {
   EXPECT_STREQ("401", response->headers().Status()->value().c_str());
 }
 
+TEST_P(LocalJwksIntegrationTest, MissingToken) {
+  config_helper_.addFilter(getFilterConfig(true));
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("401", response->headers().Status()->value().c_str());
+}
+
 TEST_P(LocalJwksIntegrationTest, ExpiredTokenHeadReply) {
   config_helper_.addFilter(getFilterConfig(true));
   initialize();
@@ -126,6 +149,97 @@ TEST_P(LocalJwksIntegrationTest, NoRequiresPath) {
   response->waitForEndStream();
   ASSERT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+}
+
+// This test verifies JwtRequirement specified from metadata
+TEST_P(LocalJwksIntegrationTest, MetadataRequirement) {
+  const std::string meta_filter_conf = R"(
+name: %s
+config:
+  request_rules:
+    - header: selector
+      on_header_present:
+        metadata_namespace: selector_filter
+        key: selector
+)";
+
+  // A config with local jwks with metadata rules.
+  const std::string auth_filter_conf = R"(
+  providers:
+    example_provider:
+      issuer: https://example.com
+      audiences:
+      - example_service
+  metadata_rules:
+    filter: selector_filter
+    path:
+    - selector
+    requires:
+      example_provider:
+        provider_name: example_provider
+)";
+
+  config_helper_.addFilter(getAuthFilterConfig(auth_filter_conf, true));
+  config_helper_.addFilter(fmt::sprintf(meta_filter_conf, HttpFilterNames::get().HeaderToMetadata));
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  struct TestCase {
+    std::vector<std::pair<std::string, std::string>> extra_headers;
+    std::string expected_status;
+  };
+  // clang-format off
+  const TestCase test_cases[] = {
+      // Case1: not set metadata, so Jwt is not required, expect 200
+      {
+          // Empty extra headers
+          {},
+          "200",
+      },
+
+      // Case2: requirement is set in the metadata, but missing token, expect 401
+      {
+          // selector header, but not token header
+          {
+              {"selector", "example_provider"},
+          },
+          "401",
+      },
+
+      // Case 3: requirement is set in the metadata, token is good, expect 200
+      {
+          // selector header, and token header
+          {
+              {"selector", "example_provider"},
+              {"Authorization", "Bearer " + std::string(GoodToken)},
+          },
+          "200",
+      },
+  };
+  // clang-format on
+
+  for (const auto& test : test_cases) {
+    Http::TestHeaderMapImpl headers{
+        {":method", "GET"},
+        {":path", "/foo"},
+        {":scheme", "http"},
+        {":authority", "host"},
+    };
+    for (const auto& h : test.extra_headers) {
+      headers.addCopy(h.first, h.second);
+    }
+    auto response = codec_client_->makeHeaderOnlyRequest(headers);
+
+    if (test.expected_status == "200") {
+      waitForNextUpstreamRequest();
+      upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+    }
+
+    response->waitForEndStream();
+    ASSERT_TRUE(response->complete());
+    EXPECT_EQ(test.expected_status, response->headers().Status()->value().c_str());
+  }
 }
 
 // The test case with a fake upstream for remote Jwks server.

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -20,8 +20,7 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
-const std::string HeaderToFilterStateFilterName =
-    "envoy.filters.http.header_to_filter_state_for_test";
+const char HeaderToFilterStateFilterName[] = "envoy.filters.http.header_to_filter_state_for_test";
 
 // This filter extracts a string header from "header" and
 // save it into FilterState as name "state" as read-only Router::StringAccessor.

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/config/filter/http/jwt_authn/v2alpha/config.pb.h"
 
 #include "common/router/string_accessor_impl.h"
+
 #include "extensions/filters/http/common/empty_http_filter_config.h"
 #include "extensions/filters/http/common/pass_through_filter.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -13,6 +13,7 @@ using ::google::jwt_verify::Status;
 
 using testing::_;
 using testing::Invoke;
+using testing::Return;
 
 namespace Envoy {
 namespace Extensions {
@@ -46,10 +47,7 @@ public:
   }
 
   void setupMockConfig() {
-    EXPECT_CALL(*mock_config_.get(), findVerifier(_, _))
-        .WillOnce(Invoke([&](const Http::HeaderMap&, const StreamInfo::FilterState&) {
-          return mock_verifier_.get();
-        }));
+    EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).WillOnce(Return(mock_verifier_.get()));
   }
 
   JwtAuthentication proto_config_;
@@ -177,9 +175,7 @@ TEST_F(FilterTest, OutBoundFailure) {
 
 // Test verifies that if no route matched requirement, then request is allowed.
 TEST_F(FilterTest, TestNoRouteMatched) {
-  EXPECT_CALL(*mock_config_.get(), findVerifier(_, _))
-      .WillOnce(
-          Invoke([&](const Http::HeaderMap&, const StreamInfo::FilterState&) { return nullptr; }));
+  EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).WillOnce(Return(nullptr));
 
   auto headers = Http::TestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -31,7 +31,8 @@ public:
       const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
       : FilterConfig(proto_config, stats_prefix, context) {}
-  MOCK_CONST_METHOD1(findVerifier, const Verifier*(const Http::HeaderMap& headers));
+  MOCK_CONST_METHOD2(findVerifier, const Verifier*(const Http::HeaderMap& headers,
+                                                   const envoy::api::v2::core::Metadata& metadata));
 };
 
 class FilterTest : public testing::Test {
@@ -45,9 +46,10 @@ public:
   }
 
   void setupMockConfig() {
-    EXPECT_CALL(*mock_config_.get(), findVerifier(_)).WillOnce(Invoke([&](const Http::HeaderMap&) {
-      return mock_verifier_.get();
-    }));
+    EXPECT_CALL(*mock_config_.get(), findVerifier(_, _))
+        .WillOnce(Invoke([&](const Http::HeaderMap&, const envoy::api::v2::core::Metadata&) {
+          return mock_verifier_.get();
+        }));
   }
 
   JwtAuthentication proto_config_;
@@ -175,9 +177,9 @@ TEST_F(FilterTest, OutBoundFailure) {
 
 // Test verifies that if no route matched requirement, then request is allowed.
 TEST_F(FilterTest, TestNoRouteMatched) {
-  EXPECT_CALL(*mock_config_.get(), findVerifier(_)).WillOnce(Invoke([&](const Http::HeaderMap&) {
-    return nullptr;
-  }));
+  EXPECT_CALL(*mock_config_.get(), findVerifier(_, _))
+      .WillOnce(Invoke(
+          [&](const Http::HeaderMap&, const envoy::api::v2::core::Metadata&) { return nullptr; }));
 
   auto headers = Http::TestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -32,7 +32,7 @@ public:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
       : FilterConfig(proto_config, stats_prefix, context) {}
   MOCK_CONST_METHOD2(findVerifier, const Verifier*(const Http::HeaderMap& headers,
-                                                   const envoy::api::v2::core::Metadata& metadata));
+                                                   const StreamInfo::FilterState& filter_state));
 };
 
 class FilterTest : public testing::Test {
@@ -47,7 +47,7 @@ public:
 
   void setupMockConfig() {
     EXPECT_CALL(*mock_config_.get(), findVerifier(_, _))
-        .WillOnce(Invoke([&](const Http::HeaderMap&, const envoy::api::v2::core::Metadata&) {
+        .WillOnce(Invoke([&](const Http::HeaderMap&, const StreamInfo::FilterState&) {
           return mock_verifier_.get();
         }));
   }
@@ -178,8 +178,8 @@ TEST_F(FilterTest, OutBoundFailure) {
 // Test verifies that if no route matched requirement, then request is allowed.
 TEST_F(FilterTest, TestNoRouteMatched) {
   EXPECT_CALL(*mock_config_.get(), findVerifier(_, _))
-      .WillOnce(Invoke(
-          [&](const Http::HeaderMap&, const envoy::api::v2::core::Metadata&) { return nullptr; }));
+      .WillOnce(
+          Invoke([&](const Http::HeaderMap&, const StreamInfo::FilterState&) { return nullptr; }));
 
   auto headers = Http::TestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Description:
Read a string value from stream_info.FilterState,  and use it to look up a JwtRequirement map in the filter config.

This is the PR to implement https://github.com/envoyproxy/envoy/issues/6399


Risk Level:  Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
