### PR TITLE
include required python and go dependencies for grpc-bridge example

### DIFF
--- a/examples/grpc-bridge/Dockerfile-python
+++ b/examples/grpc-bridge/Dockerfile-python
@@ -3,8 +3,8 @@ FROM envoyproxy/envoy-dev:latest
 RUN apt-get update
 RUN apt-get -q install -y python-dev \
     python-pip
-RUN pip install -q grpcio protobuf requests
 ADD ./client /client
+RUN pip install -r /client/requirements.txt
 RUN chmod a+x /client/client.py
 RUN mkdir /var/log/envoy/
 CMD /usr/local/bin/envoy -c /etc/s2s-python-envoy.yaml

--- a/examples/grpc-bridge/client/client.py
+++ b/examples/grpc-bridge/client/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import requests, sys
 import kv_pb2 as kv

--- a/examples/grpc-bridge/client/requirements.txt
+++ b/examples/grpc-bridge/client/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.20.0
 grpcio
+protobuf==3.7.0

--- a/examples/grpc-bridge/script/bootstrap
+++ b/examples/grpc-bridge/script/bootstrap
@@ -6,5 +6,6 @@ cd $(dirname $0)/..
 
 echo "fetching dependencies..."
 go get golang.org/x/net/context
+go get golang.org/x/sys/unix
 go get google.golang.org/grpc
 echo "done"


### PR DESCRIPTION
I followed the guide for the `grpc-bridge` example at https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/grpc_bridge and came into some problems with missing dependencies. The tweaks to the example are:

* Add `protobuf` python package so that `kv_pb2.py` works
* Add `golang.org/x/sys/unix` go package so that `script/build` works
* Use `/usr/bin/env python` instead of system default (so that virtual environments work)

Risk Level: Low

Testing: n/a
Docs Changes: n/a
Release Notes: n/a
