### PR TITLE
docs: adds information about the Envoy tracer from Instana #6371

### DIFF
--- a/docs/root/intro/arch_overview/tracing.rst
+++ b/docs/root/intro/arch_overview/tracing.rst
@@ -12,14 +12,18 @@ sources of latency. Envoy supports three features related to system wide tracing
 * **Request ID generation**: Envoy will generate UUIDs when needed and populate the
   :ref:`config_http_conn_man_headers_x-request-id` HTTP header. Applications can forward the
   x-request-id header for unified logging as well as tracing.
-* **External trace service integration**: Envoy supports pluggable external trace visualization
-  providers. Currently Envoy supports `LightStep <https://lightstep.com/>`_, `Zipkin <https://zipkin.io/>`_
-  or any Zipkin compatible backends (e.g. `Jaeger <https://github.com/jaegertracing/>`_), and
-  `Datadog <https://datadoghq.com>`_.
-  However, support for other tracing providers would not be difficult to add.
 * **Client trace ID joining**: The :ref:`config_http_conn_man_headers_x-client-trace-id` header can
   be used to join untrusted request IDs to the trusted internal
   :ref:`config_http_conn_man_headers_x-request-id`.
+* **External trace service integration**: Envoy supports pluggable external trace visualization
+  providers, that are devided into two subgroups:
+
+  - External tracers which are part of the Envoy code base, like `LightStep <https://lightstep.com/>`_,
+    `Zipkin <https://zipkin.io/>`_  or any Zipkin compatible backends (e.g. `Jaeger <https://github.com/jaegertracing/>`_), and
+    `Datadog <https://datadoghq.com>`_.
+  - External tracers which come as a third party plugin, like `Instana <https://www.instana.com/blog/monitoring-envoy-proxy-microservices/>`_.
+
+Support for other tracing providers would not be difficult to add.
 
 How to initiate a trace
 -----------------------

--- a/docs/root/intro/arch_overview/tracing.rst
+++ b/docs/root/intro/arch_overview/tracing.rst
@@ -16,7 +16,7 @@ sources of latency. Envoy supports three features related to system wide tracing
   be used to join untrusted request IDs to the trusted internal
   :ref:`config_http_conn_man_headers_x-request-id`.
 * **External trace service integration**: Envoy supports pluggable external trace visualization
-  providers, that are devided into two subgroups:
+  providers, that are divided into two subgroups:
 
   - External tracers which are part of the Envoy code base, like `LightStep <https://lightstep.com/>`_,
     `Zipkin <https://zipkin.io/>`_  or any Zipkin compatible backends (e.g. `Jaeger <https://github.com/jaegertracing/>`_), and


### PR DESCRIPTION
Description: This PR adds the information for the Envoy tracer from Instana and also the HTTP headers being used to capture traces and spans. The information are written in the same way as for Zipkin, Datadog and others.
Risk Level: Low
Testing: n/a, doc change only
Docs Changes: See above, only doc change
Release Notes: no impact on users, no necessity to be mentioned in the release notes

PS:  @mattklein123 I messed up the force push and deleted the old branch (which automatically closed the old pull request #6371) :(