### PR TITLE
fix null pointer access when http 1.0 request is rejected

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -992,10 +992,15 @@ RouteMatcher::RouteMatcher(const envoy::api::v2::RouteConfiguration& route_confi
 RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& headers,
                                                          uint64_t random_value) const {
   // First check for ssl redirect.
-  if (ssl_requirements_ == SslRequirements::ALL && headers.ForwardedProto()->value() != "https") {
+  bool httpRequest = true;
+  if (headers.ForwardedProto() != nullptr) {
+    httpRequest = (headers.ForwardedProto()->value() != "https");
+  }
+
+  if (ssl_requirements_ == SslRequirements::ALL && httpRequest) {
     return SSL_REDIRECT_ROUTE;
-  } else if (ssl_requirements_ == SslRequirements::EXTERNAL_ONLY &&
-             headers.ForwardedProto()->value() != "https" && !headers.EnvoyInternalRequest()) {
+  } else if (ssl_requirements_ == SslRequirements::EXTERNAL_ONLY && httpRequest &&
+             !headers.EnvoyInternalRequest()) {
     return SSL_REDIRECT_ROUTE;
   }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -991,14 +991,14 @@ RouteMatcher::RouteMatcher(const envoy::api::v2::RouteConfiguration& route_confi
 
 RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& headers,
                                                          uint64_t random_value) const {
-  // No x-forwarded-proto header. This normally only happen when ActiveStream::decodeHeaders
+  // No x-forwarded-proto header. This normally only happens when ActiveStream::decodeHeaders
   // bails early (as it rejects a request), so there is no routing is going to happen anyway.
   if (headers.ForwardedProto() == nullptr) {
     return nullptr;
   }
 
   // Check if this is an http or https request. Defaults to assume that it is an http
-  // request undless ForwardedProto is explicitly set to https
+  // request unless ForwardedProto is explicitly set to https
   bool http_request = (headers.ForwardedProto()->value() != "https");
 
   // First check for ssl redirect.

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -82,7 +82,7 @@ Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::string& p
   return Http::TestHeaderMapImpl{{":authority", host},        {":path", path},
                                  {":method", method},         {"x-safe", "safe"},
                                  {"x-global-nope", "global"}, {"x-vhost-nope", "vhost"},
-                                 {"x-route-nope", "route"}};
+                                 {"x-route-nope", "route"},   {"x-forwarded-proto", "http"}};
 }
 
 envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
@@ -2663,7 +2663,7 @@ virtual_hosts:
 
   // route may be called early in some edge cases and "x-forwarded-proto" will not be set.
   Http::TestHeaderMapImpl headers{{":authority", "www.lyft.com"}, {":path", "/"}};
-  EXPECT_NO_THROW(config.route(headers, 0));
+  EXPECT_EQ(nullptr, config.route(headers, 0));
 }
 
 static Http::TestHeaderMapImpl genRedirectHeaders(const std::string& host, const std::string& path,

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -130,6 +130,11 @@ public:
     factory_context_.init_manager_.initialize(init_watcher_);
   }
 
+  RouteConstSharedPtr route(Http::TestHeaderMapImpl headers) {
+    headers.addCopy("x-forwarded-proto", "http");
+    return rds_->config()->route(headers, 0);
+  }
+
   NiceMock<Stats::MockStore> scope_;
   NiceMock<Server::MockInstance> server_;
   std::unique_ptr<RouteConfigProviderManagerImpl> route_config_provider_manager_;
@@ -221,7 +226,7 @@ TEST_F(RdsImplTest, Basic) {
   setup();
 
   // Make sure the initial empty route table works.
-  EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
+  EXPECT_EQ(nullptr, route(Http::TestHeaderMapImpl{{":authority", "foo"}}));
   EXPECT_EQ(0UL, factory_context_.scope_.gauge("foo.rds.foo_route_config.version").value());
 
   // Initial request.
@@ -245,7 +250,7 @@ TEST_F(RdsImplTest, Basic) {
   EXPECT_CALL(init_watcher_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
-  EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
+  EXPECT_EQ(nullptr, route(Http::TestHeaderMapImpl{{":authority", "foo"}}));
   EXPECT_EQ(13237225503670494420U,
             factory_context_.scope_.gauge("foo.rds.foo_route_config.version").value());
 
@@ -259,7 +264,7 @@ TEST_F(RdsImplTest, Basic) {
 
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
-  EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
+  EXPECT_EQ(nullptr, route(Http::TestHeaderMapImpl{{":authority", "foo"}}));
 
   EXPECT_EQ(13237225503670494420U,
             factory_context_.scope_.gauge("foo.rds.foo_route_config.version").value());
@@ -310,8 +315,7 @@ TEST_F(RdsImplTest, Basic) {
   EXPECT_CALL(factory_context_.cluster_manager_, get("bar")).Times(0);
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
-  EXPECT_EQ("foo", rds_->config()
-                       ->route(Http::TestHeaderMapImpl{{":authority", "foo"}, {":path", "/foo"}}, 0)
+  EXPECT_EQ("foo", route(Http::TestHeaderMapImpl{{":authority", "foo"}, {":path", "/foo"}})
                        ->routeEntry()
                        ->clusterName());
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -94,7 +94,8 @@ TEST(BadRateLimitConfiguration, ActionsMissingRequiredFields) {
 
 static Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::string& path,
                                           const std::string& method) {
-  return Http::TestHeaderMapImpl{{":authority", host}, {":path", path}, {":method", method}};
+  return Http::TestHeaderMapImpl{
+      {":authority", host}, {":path", path}, {":method", method}, {"x-forwarded-proto", "http"}};
 }
 
 class RateLimitConfiguration : public testing::Test {


### PR DESCRIPTION
When an HTTP 1.0 request makes it to envoy, envoy rejects it before adding the "x-forwarded-proto" to the request headers.
If there's an encoder filter that access the route() method, and ssl is required, this will cause invalid access to `headers.ForwardedProto()`. This PR fixes that by checking if `headers.ForwardedProto()` is valid prior access

Risk Level: Low
Testing: Unit Tests
Docs Changes: N\A
Release Notes: N\A
Fixes: https://github.com/solo-io/gloo/issues/635
