### PR TITLE
router: max retries header takes precedence over retry policies

### DIFF
--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -28,10 +28,10 @@ x-envoy-max-retries
 ^^^^^^^^^^^^^^^^^^^
 If a :ref:`route config retry policy <envoy_api_field_route.RouteAction.retry_policy>` or a
 :ref:`virtual host retry policy <envoy_api_field_route.VirtualHost.retry_policy>` is in place, Envoy will default to retrying
-one time unless explicitly specified. The number of retries can be explicitly set in either the virtual host retry config,
-or the route retry config, or by using this header. If a retry policy is not configured and
-:ref:`config_http_filters_router_x-envoy-retry-on` or :ref:`config_http_filters_router_x-envoy-retry-grpc-on` headers
-are not specified, Envoy will not retry a failed request.
+one time unless explicitly specified. The number of retries can be explicitly set in the virtual host retry config,
+the route retry config, or by using this header. If this header is used, its value takes precedence over the number of
+retries set in either retry policy. If a retry policy is not configured and :ref:`config_http_filters_router_x-envoy-retry-on`
+or :ref:`config_http_filters_router_x-envoy-retry-grpc-on` headers are not specified, Envoy will not retry a failed request.
 
 A few notes on how Envoy does retries:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -61,6 +61,7 @@ Version history
 * router: added reset reason to response body when upstream reset happens. After this change, the response body will be of the form `upstream connect error or disconnect/reset before headers. reset reason:`
 * router: added :ref:`rq_reset_after_downstream_response_started <config_http_filters_router_stats>` counter stat to router stats.
 * router: added per-route configuration of :ref:`internal redirects <envoy_api_field_route.RouteAction.internal_redirect_action>`.
+* router: x-envoy-max-retries header takes precedence over the number of retries in route and virtual host retry policies.
 * stats: added support for histograms in prometheus
 * stats: added usedonly flag to prometheus stats to only output metrics which have been
   updated at least once.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -61,7 +61,7 @@ Version history
 * router: added reset reason to response body when upstream reset happens. After this change, the response body will be of the form `upstream connect error or disconnect/reset before headers. reset reason:`
 * router: added :ref:`rq_reset_after_downstream_response_started <config_http_filters_router_stats>` counter stat to router stats.
 * router: added per-route configuration of :ref:`internal redirects <envoy_api_field_route.RouteAction.internal_redirect_action>`.
-* router: x-envoy-max-retries header takes precedence over the number of retries in route and virtual host retry policies.
+* router: made :ref: `max retries header <config_http_filters_router_x-envoy-max-retries>` take precedence over the number of retries in route and virtual host retry policies.
 * stats: added support for histograms in prometheus
 * stats: added usedonly flag to prometheus stats to only output metrics which have been
   updated at least once.

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -58,7 +58,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
       retriable_status_codes_(route_policy.retriableStatusCodes()) {
 
   retry_on_ = route_policy.retryOn();
-  retries_remaining_ = route_policy.numRetries();
+  retries_remaining_ = std::max(retries_remaining_, route_policy.numRetries());
   const uint32_t base = runtime_.snapshot().getInteger("upstream.base_retry_backoff_ms", 25);
   // Cap the max interval to 10 times the base interval to ensure reasonable backoff intervals.
   backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(base, base * 10, random_);

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -57,8 +57,16 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
       retry_priority_(route_policy.retryPriority()),
       retriable_status_codes_(route_policy.retriableStatusCodes()) {
 
+  retry_on_ = route_policy.retryOn();
+  retries_remaining_ = route_policy.numRetries();
+  const uint32_t base = runtime_.snapshot().getInteger("upstream.base_retry_backoff_ms", 25);
+  // Cap the max interval to 10 times the base interval to ensure reasonable backoff intervals.
+  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(base, base * 10, random_);
+  host_selection_max_attempts_ = route_policy.hostSelectionMaxAttempts();
+
+  // Merge in the headers.
   if (request_headers.EnvoyRetryOn()) {
-    retry_on_ = parseRetryOn(request_headers.EnvoyRetryOn()->value().c_str());
+    retry_on_ |= parseRetryOn(request_headers.EnvoyRetryOn()->value().c_str());
   }
   if (request_headers.EnvoyRetryGrpcOn()) {
     retry_on_ |= parseRetryGrpcOn(request_headers.EnvoyRetryGrpcOn()->value().c_str());
@@ -67,6 +75,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
     const char* max_retries = request_headers.EnvoyMaxRetries()->value().c_str();
     uint64_t temp;
     if (StringUtil::atoull(max_retries, temp)) {
+      // The max retries header takes precedence if set.
       retries_remaining_ = temp;
     }
   }
@@ -79,14 +88,6 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
       }
     }
   }
-
-  // Merge in the route policy.
-  retry_on_ |= route_policy.retryOn();
-  retries_remaining_ = std::max(retries_remaining_, route_policy.numRetries());
-  const uint32_t base = runtime_.snapshot().getInteger("upstream.base_retry_backoff_ms", 25);
-  // Cap the max interval to 10 times the base interval to ensure reasonable backoff intervals.
-  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(base, base * 10, random_);
-  host_selection_max_attempts_ = route_policy.hostSelectionMaxAttempts();
 }
 
 RetryStateImpl::~RetryStateImpl() { resetRetry(); }

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -93,7 +93,7 @@ public:
   }
 
   std::chrono::milliseconds per_try_timeout_{0};
-  uint32_t num_retries_{1};
+  uint32_t num_retries_{};
   uint32_t retry_on_{};
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -93,7 +93,7 @@ public:
   }
 
   std::chrono::milliseconds per_try_timeout_{0};
-  uint32_t num_retries_{};
+  uint32_t num_retries_{1};
   uint32_t retry_on_{};
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;


### PR DESCRIPTION
Description: This change makes the max retries header overrule the number of retries set in the virtual host retry config and the route retry config.
Risk Level: low
Testing: Added a unit test
Docs Changes: update router filter doc
Release Notes: added
Fixes #6407 

