### PR TITLE
hcm: use optional<iter> instead of iter end

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -784,12 +784,12 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
 void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilter* filter,
                                                         HeaderMap& headers, bool end_stream) {
   std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
+  absl::optional<std::list<ActiveStreamDecoderFilterPtr>::iterator> continue_data_entry;
   if (!filter) {
     entry = decoder_filters_.begin();
   } else {
     entry = std::next(filter->entry());
   }
-  absl::optional<std::list<ActiveStreamDecoderFilterPtr>::iterator> continue_data_entry;
 
   for (; entry != decoder_filters_.end(); entry++) {
     ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeHeaders));
@@ -854,14 +854,14 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
   }
 
   std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
+  absl::optional<std::list<ActiveStreamDecoderFilterPtr>::iterator> continue_data_entry;
+  const bool trailers_exists_at_start = request_trailers_ != nullptr;
   if (!filter) {
     entry = decoder_filters_.begin();
   } else {
     entry = std::next(filter->entry());
   }
-  absl::optional<std::list<ActiveStreamDecoderFilterPtr>::iterator> continue_data_entry;
 
-  const bool trailers_exists_at_start = request_trailers_ != nullptr;
   for (; entry != decoder_filters_.end(); entry++) {
     // If end_stream_ is marked for a filter, the data is not for this filter and filters after.
     //

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -783,8 +783,12 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
 
 void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilter* filter,
                                                         HeaderMap& headers, bool end_stream) {
-  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
-      filter ? std::next(filter->entry()) : decoder_filters_.begin();
+  std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
+  if (!filter) {
+    entry = decoder_filters_.begin();
+  } else {
+    entry = std::next(filter->entry());
+  }
   absl::optional<std::list<ActiveStreamDecoderFilterPtr>::iterator> continue_data_entry;
 
   for (; entry != decoder_filters_.end(); entry++) {
@@ -849,8 +853,12 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
     return;
   }
 
-  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
-      filter ? std::next(filter->entry()) : decoder_filters_.begin();
+  std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
+  if (!filter) {
+    entry = decoder_filters_.begin();
+  } else {
+    entry = std::next(filter->entry());
+  }
   absl::optional<std::list<ActiveStreamDecoderFilterPtr>::iterator> continue_data_entry;
 
   const bool trailers_exists_at_start = request_trailers_ != nullptr;


### PR DESCRIPTION
Description: 
The pattern iterator::end() as pivot is less expressive than an
optional. Fix all the occurrences in HCM

Risk Level: LOW
Testing: existing test
