### PR TITLE
docs/api: hide represent_ipv4_remote_address_as_ipv4_mapped_ipv6.

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -345,6 +345,7 @@ message HttpConnectionManager {
   // :ref:`http_connection_manager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6
   // <config_http_conn_man_runtime_represent_ipv4_remote_address_as_ipv4_mapped_ipv6>` for runtime
   // control.
+  // [#not-implemented-hide:]
   bool represent_ipv4_remote_address_as_ipv4_mapped_ipv6 = 20;
 
   // The configuration for HTTP upgrades.

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -325,12 +325,14 @@ A few very important notes about XFF:
      Envoy will not consider it internal. This is a known "bug" due to the simplification of how
      XFF is parsed to determine if a request is internal. In this scenario, do not forward XFF and
      allow Envoy to generate a new one with a single internal origin IP.
-3. Testing IPv6 in a large multi-hop system can be difficult from a change management perspective.
-   For testing IPv6 compatibility of upstream services which parse XFF header values,
-   :ref:`represent_ipv4_remote_address_as_ipv4_mapped_ipv6 <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6>`
-   can be enabled in the v2 API. Envoy will append an IPv4 address in mapped IPv6 format, e.g.
-   ::FFFF:50.0.0.1. This change will also apply to
-   :ref:`config_http_conn_man_headers_x-envoy-external-address`.
+
+.. The following feature is not implemented yet, preserving the RST for future use.
+   3. Testing IPv6 in a large multi-hop system can be difficult from a change management perspective.
+      For testing IPv6 compatibility of upstream services which parse XFF header values,
+      :ref:`represent_ipv4_remote_address_as_ipv4_mapped_ipv6 <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6>`
+      can be enabled in the v2 API. Envoy will append an IPv4 address in mapped IPv6 format, e.g.
+      ::FFFF:50.0.0.1. This change will also apply to
+      :ref:`config_http_conn_man_headers_x-envoy-external-address`.
 
 .. _config_http_conn_man_headers_x-forwarded-proto:
 

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -326,14 +326,6 @@ A few very important notes about XFF:
      XFF is parsed to determine if a request is internal. In this scenario, do not forward XFF and
      allow Envoy to generate a new one with a single internal origin IP.
 
-.. The following feature is not implemented yet, preserving the RST for future use.
-   3. Testing IPv6 in a large multi-hop system can be difficult from a change management perspective.
-      For testing IPv6 compatibility of upstream services which parse XFF header values,
-      :ref:`represent_ipv4_remote_address_as_ipv4_mapped_ipv6 <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6>`
-      can be enabled in the v2 API. Envoy will append an IPv4 address in mapped IPv6 format, e.g.
-      ::FFFF:50.0.0.1. This change will also apply to
-      :ref:`config_http_conn_man_headers_x-envoy-external-address`.
-
 .. _config_http_conn_man_headers_x-forwarded-proto:
 
 x-forwarded-proto

--- a/docs/root/configuration/http_conn_man/runtime.rst
+++ b/docs/root/configuration/http_conn_man/runtime.rst
@@ -5,16 +5,16 @@ Runtime
 
 The HTTP connection manager supports the following runtime settings:
 
-.. _config_http_conn_man_runtime_represent_ipv4_remote_address_as_ipv4_mapped_ipv6:
-
-http_connection_manager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6
-  % of requests with a remote address that will have their IPv4 address mapped to IPv6. Defaults to
-  0.
-  :ref:`use_remote_address <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.use_remote_address>`
-  must also be enabled. See
-  :ref:`represent_ipv4_remote_address_as_ipv4_mapped_ipv6
-  <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6>`
-  for more details.
+.. The following feature is not implemented yet, preserving the RST for future use.
+   .. _config_http_conn_man_runtime_represent_ipv4_remote_address_as_ipv4_mapped_ipv6:
+   http_connection_manager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6
+     % of requests with a remote address that will have their IPv4 address mapped to IPv6. Defaults to
+     0.
+     :ref:`use_remote_address <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.use_remote_address>`
+     must also be enabled. See
+     :ref:`represent_ipv4_remote_address_as_ipv4_mapped_ipv6
+     <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6>`
+     for more details.
 
 .. _config_http_conn_man_runtime_client_enabled:
 

--- a/docs/root/configuration/http_conn_man/runtime.rst
+++ b/docs/root/configuration/http_conn_man/runtime.rst
@@ -5,17 +5,6 @@ Runtime
 
 The HTTP connection manager supports the following runtime settings:
 
-.. The following feature is not implemented yet, preserving the RST for future use.
-   .. _config_http_conn_man_runtime_represent_ipv4_remote_address_as_ipv4_mapped_ipv6:
-   http_connection_manager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6
-     % of requests with a remote address that will have their IPv4 address mapped to IPv6. Defaults to
-     0.
-     :ref:`use_remote_address <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.use_remote_address>`
-     must also be enabled. See
-     :ref:`represent_ipv4_remote_address_as_ipv4_mapped_ipv6
-     <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6>`
-     for more details.
-
 .. _config_http_conn_man_runtime_client_enabled:
 
 tracing.client_enabled


### PR DESCRIPTION
This is not implemented yet.

Fixes #6405.

Signed-off-by: Harvey Tuch <htuch@google.com>