### PR TITLE
admin: mutating without POST should fail with 405, not 400

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -79,6 +79,7 @@ Version history
   Refer to ::ref:`ZooKeeper proxy<config_network_filters_zookeeper_proxy>` for more details.
 * upstream: added configuration option to select any host when the fallback policy fails.
 * upstream: stopped incrementing upstream_rq_total for HTTP/1 conn pool when request is circuit broken.
+* admin: changed HTTP response status code from 400 to 405 when attempting to GET a POST-only route (such as /quitquitquit).
 
 1.9.0 (Dec 20, 2018)
 ====================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -10,6 +10,7 @@ Version history
   :ref:`gRPC access logger<envoy_api_field_data.accesslog.v2.AccessLogCommon.upstream_transport_failure_reason>` for HTTP access logs.
 * access log: added new fields for downstream x509 information (URI sans and subject) to file and gRPC access logger.
 * admin: the admin server can now be accessed via HTTP/2 (prior knowledge).
+* admin: changed HTTP response status code from 400 to 405 when attempting to GET a POST-only route (such as /quitquitquit).
 * buffer: fix vulnerabilities when allocation fails.
 * build: releases are built with GCC-7 and linked with LLD.
 * build: dev docker images :ref:`have been split <install_binaries>` from tagged images for easier
@@ -79,7 +80,6 @@ Version history
   Refer to ::ref:`ZooKeeper proxy<config_network_filters_zookeeper_proxy>` for more details.
 * upstream: added configuration option to select any host when the fallback policy fails.
 * upstream: stopped incrementing upstream_rq_total for HTTP/1 conn pool when request is circuit broken.
-* admin: changed HTTP response status code from 400 to 405 when attempting to GET a POST-only route (such as /quitquitquit).
 
 1.9.0 (Dec 20, 2018)
 ====================

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1197,8 +1197,8 @@ Http::Code AdminImpl::runCallback(absl::string_view path_and_query,
         if (method != Http::Headers::get().MethodValues.Post) {
           ENVOY_LOG(error, "admin path \"{}\" mutates state, method={} rather than POST",
                     handler.prefix_, method);
-          code = Http::Code::BadRequest;
-          response.add("Invalid request; POST required");
+          code = Http::Code::MethodNotAllowed;
+          response.add(fmt::format("Method {} not allowed, POST required.", method));
           break;
         }
       }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -698,7 +698,7 @@ TEST_P(AdminInstanceTest, MutatesErrorWithGet) {
   // just issue a warning, so that scripts using curl GET commands to mutate state can be fixed.
   EXPECT_LOG_CONTAINS("error",
                       "admin path \"" + path + "\" mutates state, method=GET rather than POST",
-                      EXPECT_EQ(Http::Code::BadRequest, getCallback(path, header_map, data)));
+                      EXPECT_EQ(Http::Code::MethodNotAllowed, getCallback(path, header_map, data)));
 }
 
 TEST_P(AdminInstanceTest, AdminBadProfiler) {


### PR DESCRIPTION
Description: Mutating admin operations (for example, /quitquitquit) are required to use POST. Currently we respond with a 400 (bad request) if called with a GET, but we should properly respond with 405 (method not allowed).
Risk Level: Low -- any programmatic usage of admin should be using POST.
Testing: Updated unit test.
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Dan Rosen <mergeconflict@google.com>
