### PR TITLE
security: templates for e-mails and CVE GH filing.

### DIFF
--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -38,9 +38,9 @@ Private Distributors List of some details on the pending Envoy $VERSION
 security release, following the process described at
 https://github.com/envoyproxy/envoy/blob/master/SECURITY_RELEASE_PROCESS.md.
 
-This release will be made available on the $ORDINALDATE of $MONTH $YEAR at
+This release will be made available on the $ORDINALDAY of $MONTH $YEAR at
 $PDTHOUR PDT ($GMTHOUR GMT). This release will fix $NUMDEFECTS security
-defects. The highest rated security defect is considered $SEVERITY severity.
+defect(s). The highest rated security defect is considered $SEVERITY severity.
 
 Below we provide details of these vulnerabilities under our embargo policy
 (https://github.com/envoyproxy/envoy/blob/master/SECURITY_RELEASE_PROCESS.md#embargo-policy).
@@ -83,13 +83,16 @@ Upgrading to $VERSION is encouraged to fix these issues.
 
 GitHub tag: https://github.com/envoyproxy/envoy/releases/tag/v$VERSION
 Docker images: https://hub.docker.com/r/envoyproxy/envoy/tags
-Release notes: https://www.envoyproxy.io/docs/envoy/latest/intro/version_history
+Release notes: https://www.envoyproxy.io/docs/envoy/v$VERSION/intro/version_history
 Docs: https://www.envoyproxy.io/docs/envoy/v$VERSION/
 
 **Am I vulnerable?**
 
 Run `envoy --version` and if it indicates a base version of $OLDVERSION or
 older you are running a vulnerable version.
+
+<!-- Provide details on features, extensions, configuration that make it likely that a system is
+vulnerable in practice. -->
 
 **How do I mitigate the vulnerability?**
 

--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -1,0 +1,128 @@
+# Envoy Security Process Email Templates
+
+This is a collection of email templates to handle various situations the security team encounters.
+
+## Upcoming security release to envoy-announce@googlegroups.com
+
+```
+Subject: Upcoming security release of Envoy $VERSION
+To: envoy-announce@googlegroups.com
+Cc: envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
+
+Hello Envoy Community,
+
+The Envoy maintainers would like to announce the forthcoming release of Envoy
+$VERSION.
+
+This release will be made available on the $ORDINALDAY of $MONTH $YEAR at
+$PDTHOUR PDT ($GMTHOUR GMT). This release will fix $NUMDEFECTS security
+defect(s). The highest rated security defect is considered $SEVERITY severity.
+
+No further details or patches will be made available in advance of the release.
+
+Thanks,
+$PERSON (on behalf of the Envoy maintainers)
+```
+
+## Upcoming security release to cncf-envoy-distributors-announce@lists.cncf.io
+
+```
+Subject: [CONFIDENTIAL] Further details on security release of Envoy $VERSION
+To: envoy-announce@googlegroups.com
+Cc: envoy-security@googlegroups.com
+
+Hello Envoy Distributors,
+
+The Envoy security team would like to provide advanced notice to the Envoy
+Private Distributors List of some details on the pending Envoy $VERSION
+security release, following the process described at
+https://github.com/envoyproxy/envoy/blob/master/SECURITY_RELEASE_PROCESS.md.
+
+This release will be made available on the $ORDINALDATE of $MONTH $YEAR at
+$PDTHOUR PDT ($GMTHOUR GMT). This release will fix $NUMDEFECTS security
+defects. The highest rated security defect is considered $SEVERITY severity.
+
+Below we provide details of these vulnerabilities under our embargo policy
+(https://github.com/envoyproxy/envoy/blob/master/SECURITY_RELEASE_PROCESS.md#embargo-policy).
+This information should be treated as confidential until public release by the
+Envoy maintainers on the Envoy GitHub.
+
+We will address the following CVE(s):
+
+* CVE-YEAR-ABCDEF (CVSS score $CVSS, $SEVERITY): $CVESUMMARY
+...
+
+We intend to make candidates release patches available under embargo on the
+$ORDINALDAY of $MONTH $YEAR, which you may use for testing and preparing your
+distributions.
+
+Please direct further communication amongst private distributors to this list
+or to envoy-security@googlegroups.com for direct communication with the Envoy
+security team.
+
+Thanks,
+$PERSON (on behalf of the Envoy security team)
+```
+
+## Security Fix Announcement
+
+```
+Subject: Security release of Envoy $VERSION is now available
+To: envoy-announce@googlegroups.com
+Cc: envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
+
+Hello Envoy Community,
+
+The Envoy maintainers would like to announce the availablity of Envoy $VERSION.
+This addresses the following CVE(s):
+
+* CVE-YEAR-ABCDEF (CVSS score $CVSS): $CVESUMMARY
+...
+
+Upgrading to $VERSION is encouraged to fix these issues.
+
+GitHub tag: https://github.com/envoyproxy/envoy/releases/tag/v$VERSION
+Docker images: https://hub.docker.com/r/envoyproxy/envoy/tags
+Release notes: https://www.envoyproxy.io/docs/envoy/latest/intro/version_history
+Docs: https://www.envoyproxy.io/docs/envoy/v$VERSION/
+
+**Am I vulnerable?**
+
+Run `envoy --version` and if it indicates a base version of $OLDVERSION or
+older you are running a vulnerable version.
+
+**How do I mitigate the vulnerability?**
+
+<!--
+[This is an optional section. Remove if there are no mitigations.]
+-->
+
+Avoid the use of feature XYZ in Envoy configuration.
+
+**How do I upgrade?**
+
+Update to $VERSION via your Envoy distribution or rebuild from the Envoy GitHub
+source at the $VERSION tag or HEAD @ master.
+
+**Vulnerability Details**
+
+<!--
+[For each CVE]
+-->
+
+***CVE-YEAR-ABCDEF***
+
+$CVESUMMARY
+
+This issue is filed as $CVE. We have rated it as [$CVSSSTRING]($CVSSURL)
+($CVSS, $SEVERITY) [See the GitHub issue for more details]($GITHUBISSUEURL)
+
+**Thank you**
+
+Thank you to $REPORTER, $DEVELOPERS, and the $RELEASEMANAGERS for the
+coordination in making this release.
+
+Thanks,
+
+$PERSON (on behalf of the Envoy maintainers)
+```

--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -73,7 +73,7 @@ Cc: envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
 
 Hello Envoy Community,
 
-The Envoy maintainers would like to announce the availablity of Envoy $VERSION.
+The Envoy maintainers would like to announce the availability of Envoy $VERSION.
 This addresses the following CVE(s):
 
 * CVE-YEAR-ABCDEF (CVSS score $CVSS): $CVESUMMARY

--- a/security/gh-cve-template.md
+++ b/security/gh-cve-template.md
@@ -1,0 +1,52 @@
+>This template is for public disclosure of CVE details on Envoy's GitHub. It should be filed
+with the public release of a security patch version, and will be linked to in the announcement sent
+to envoy-announce@googlegroups.com. The title of this issue should be the CVE identifier and it
+should have the `security` label applied.
+
+# CVE-YEAR-ABCDEF
+
+## Brief description
+
+>Brief description used when filing CVE.
+
+## CVSS
+
+>[$CVSSSTRING]($CVSSURL)($CVSSSCORE, $SEVERITY)
+
+## Affected version(s)
+
+>Envoy x.y.z and before.
+
+## Affected component(s)
+
+>List affected internal components and features.
+
+## Attack vector(s)
+
+>How would an attacker use this?
+
+## Discover(s)/Credits
+
+>Individual and optional organization.
+
+## Example exploit or proof-of-concept
+
+>If there is proof-of-concept or example, provide a concrete example.
+
+## Details
+
+>Deep dive into the defect. This should be detailed enough to maintain a record for posterity while
+being clear and concise.
+
+## Mitigations
+
+>Are there configuration or CLI options that can be used to mitigate?
+
+## Detection
+
+>How can exploitation of this bug be detected in existing and future Envoy versions? E.g. access logs.
+
+## References
+
+* CVE: $CVEURL
+>Any other public information.


### PR DESCRIPTION
These capture some of our existing patterns in CVE related e-mail announcements, as well as some
future planned e-mails and GH filing. They are based on OpenSSL security release announcement and
https://github.com/kubernetes/security/blob/master/email-templates.md#security-fix-announcement.

Signed-off-by: Harvey Tuch <htuch@google.com>
