### PR TITLE
test: update redis config tests to v2

### DIFF
--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -83,6 +83,7 @@ envoy_extension_cc_test(
     srcs = ["config_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
     deps = [
+        "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/network/redis_proxy:config",
         "//test/mocks/server:server_mocks",
     ],

--- a/test/extensions/filters/network/redis_proxy/config_test.cc
+++ b/test/extensions/filters/network/redis_proxy/config_test.cc
@@ -1,8 +1,8 @@
 #include "envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.validate.h"
 
-#include "common/config/filter_json.h"
-
 #include "extensions/filters/network/redis_proxy/config.h"
+
+#include "common/protobuf/utility.h"
 
 #include "test/mocks/server/mocks.h"
 
@@ -23,40 +23,37 @@ TEST(RedisProxyFilterConfigFactoryTest, ValidateFail) {
                ProtoValidationException);
 }
 
-TEST(RedisProxyFilterConfigFactoryTest, RedisProxyCorrectJson) {
-  std::string json_string = R"EOF(
-  {
-    "cluster_name": "fake_cluster",
-    "stat_prefix": "foo",
-    "conn_pool": {
-      "op_timeout_ms": 20
-    }
-  }
+TEST(RedisProxyFilterConfigFactoryTest, RedisProxyNoSettings) {
+  const std::string yaml = R"EOF(
+cluster: fake_cluster
+stat_prefix: foo
   )EOF";
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-  RedisProxyFilterConfigFactory factory;
-  Network::FilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
-  Network::MockConnection connection;
-  EXPECT_CALL(connection, addReadFilter(_));
-  cb(connection);
+  envoy::config::filter::network::redis_proxy::v2::RedisProxy proto_config;
+  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromYamlAndValidate(yaml, proto_config), ProtoValidationException, "value is required");
+}
+
+TEST(RedisProxyFilterConfigFactoryTest, RedisProxyNoOpTimeout) {
+  const std::string yaml = R"EOF(
+cluster: fake_cluster
+stat_prefix: foo
+settings: {}
+  )EOF";
+
+  envoy::config::filter::network::redis_proxy::v2::RedisProxy proto_config;
+  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromYamlAndValidate(yaml, proto_config), ProtoValidationException, "embedded message failed validation");
 }
 
 TEST(RedisProxyFilterConfigFactoryTest, RedisProxyCorrectProto) {
-  std::string json_string = R"EOF(
-  {
-    "cluster_name": "fake_cluster",
-    "stat_prefix": "foo",
-    "conn_pool": {
-      "op_timeout_ms": 20
-    }
-  }
+  const std::string yaml = R"EOF(
+cluster: fake_cluster
+stat_prefix: foo
+settings:
+  op_timeout: 0.02s
   )EOF";
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   envoy::config::filter::network::redis_proxy::v2::RedisProxy proto_config{};
-  Config::FilterJson::translateRedisProxy(*json_config, proto_config);
+  MessageUtil::loadFromYamlAndValidate(yaml, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
@@ -66,24 +63,20 @@ TEST(RedisProxyFilterConfigFactoryTest, RedisProxyCorrectProto) {
 }
 
 TEST(RedisProxyFilterConfigFactoryTest, RedisProxyEmptyProto) {
-  std::string json_string = R"EOF(
-  {
-    "cluster_name": "fake_cluster",
-    "stat_prefix": "foo",
-    "conn_pool": {
-      "op_timeout_ms": 20
-    }
-  }
+  const std::string yaml = R"EOF(
+cluster: fake_cluster
+stat_prefix: foo
+settings:
+  op_timeout: 0.02s
   )EOF";
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
   envoy::config::filter::network::redis_proxy::v2::RedisProxy proto_config =
       *dynamic_cast<envoy::config::filter::network::redis_proxy::v2::RedisProxy*>(
           factory.createEmptyConfigProto().get());
 
-  Config::FilterJson::translateRedisProxy(*json_config, proto_config);
+  MessageUtil::loadFromYamlAndValidate(yaml, proto_config);
 
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
   Network::MockConnection connection;


### PR DESCRIPTION
Description: For #6362, this
1) removes a test that exercises the `createFilterFactory` method using JSON, which is deprecated as part of v2
2) updates the remainder of configs to v2
3) adds 2 tests for invalide protobuf configs

Risk Level: Low - no functional change
Testing: updated
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>