### PR TITLE
test: update network client_ssl_auth tests to v2

### DIFF
--- a/test/extensions/filters/network/client_ssl_auth/BUILD
+++ b/test/extensions/filters/network/client_ssl_auth/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
     srcs = ["config_test.cc"],
     extension_name = "envoy.filters.network.client_ssl_auth",
     deps = [
+        "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/network/client_ssl_auth:config",
         "//test/mocks/server:server_mocks",
     ],

--- a/test/extensions/filters/network/client_ssl_auth/config_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/config_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/registry/registry.h"
 
 #include "common/config/filter_json.h"
+#include "common/protobuf/utility.h"
 
 #include "extensions/filters/network/client_ssl_auth/config.h"
 #include "extensions/filters/network/well_known_names.h"
@@ -19,42 +20,45 @@ namespace ClientSslAuth {
 
 class IpWhiteListConfigTest : public testing::TestWithParam<std::string> {};
 
+const std::string ipv4_cidr_yaml = R"EOF(
+- address_prefix: "192.168.3.0"
+  prefix_len: 24
+)EOF";
+
+const std::string ipv6_cidr_yaml = R"EOF(
+- address_prefix: "2001:abcd::"
+  prefix_len: 64
+)EOF";
+
 INSTANTIATE_TEST_SUITE_P(IpList, IpWhiteListConfigTest,
-                         ::testing::Values(R"EOF(["192.168.3.0/24"])EOF",
-                                           R"EOF(["2001:abcd::/64"])EOF"));
+                         ::testing::Values(ipv4_cidr_yaml, ipv6_cidr_yaml));
 
 TEST_P(IpWhiteListConfigTest, ClientSslAuthCorrectJson) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "auth_api_cluster" : "fake_cluster",
-    "ip_white_list":)EOF" + GetParam() +
-                            R"EOF(
-  }
-  )EOF";
+  const std::string yaml = R"EOF(
+stat_prefix: my_stat_prefix
+auth_api_cluster: fake_cluster
+ip_white_list:
+)EOF" + GetParam();
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
+  envoy::config::filter::network::client_ssl_auth::v2::ClientSSLAuth proto_config;
+  MessageUtil::loadFromYamlAndValidate(yaml, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ClientSslAuthConfigFactory factory;
-  Network::FilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);
 }
 
 TEST_P(IpWhiteListConfigTest, ClientSslAuthCorrectProto) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "auth_api_cluster" : "fake_cluster",
-    "ip_white_list":)EOF" + GetParam() +
-                            R"EOF(
-  }
-  )EOF";
+  const std::string yaml = R"EOF(
+stat_prefix: my_stat_prefix
+auth_api_cluster: fake_cluster
+ip_white_list:
+)EOF" + GetParam();
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  envoy::config::filter::network::client_ssl_auth::v2::ClientSSLAuth proto_config{};
-  Envoy::Config::FilterJson::translateClientSslAuthFilter(*json_config, proto_config);
+  envoy::config::filter::network::client_ssl_auth::v2::ClientSSLAuth proto_config;
+  MessageUtil::loadFromYamlAndValidate(yaml, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ClientSslAuthConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
@@ -64,23 +68,19 @@ TEST_P(IpWhiteListConfigTest, ClientSslAuthCorrectProto) {
 }
 
 TEST_P(IpWhiteListConfigTest, ClientSslAuthEmptyProto) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "auth_api_cluster" : "fake_cluster",
-    "ip_white_list":)EOF" + GetParam() +
-                            R"EOF(
-  }
-  )EOF";
+  const std::string yaml = R"EOF(
+stat_prefix: my_stat_prefix
+auth_api_cluster: fake_cluster
+ip_white_list:
+)EOF" + GetParam();
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ClientSslAuthConfigFactory factory;
   envoy::config::filter::network::client_ssl_auth::v2::ClientSSLAuth proto_config =
       *dynamic_cast<envoy::config::filter::network::client_ssl_auth::v2::ClientSSLAuth*>(
           factory.createEmptyConfigProto().get());
 
-  Envoy::Config::FilterJson::translateClientSslAuthFilter(*json_config, proto_config);
+  MessageUtil::loadFromYamlAndValidate(yaml, proto_config);
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));


### PR DESCRIPTION
Description: For #6362, this
1) removes a test that exercises the createFilterFactory method using JSON, which is deprecated as part of v2
2) updates the remainder of configs to v2

Risk Level: Low - no functional change
Testing: updated
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>