### PR TITLE
server: Replace unordere_map to absl::flat_hash_map

### DIFF
--- a/source/server/server.h
+++ b/source/server/server.h
@@ -36,6 +36,7 @@
 
 #include "extensions/transport_sockets/tls/context_manager_impl.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -260,8 +261,8 @@ private:
   Http::ContextImpl http_context_;
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
   const std::thread::id main_thread_id_;
-  std::unordered_map<Stage, std::vector<StageCallback>> stage_callbacks_;
-  std::unordered_map<Stage, std::vector<StageCallbackWithCompletion>> stage_completable_callbacks_;
+  absl::flat_hash_map<Stage, std::vector<StageCallback>> stage_callbacks_;
+  absl::flat_hash_map<Stage, std::vector<StageCallbackWithCompletion>> stage_completable_callbacks_;
 };
 
 } // namespace Server


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

Fix gcc55 compile error due to `Envoy::Server::ServerLifecycleNotifier::Stage` unhashable

```cpp
/usr/local/gcc54/lib/gcc/x86_64-unknown-linux-gnu/5.5.0/../../../../include/c++/5.5.0/bits/unordered_map.h:110:43: error: 'value' is not a member of 'std::__not_<std::__and_<std::__is_fast_hash<std::hash<Envoy::Server::ServerLifecycleNotifier::Stage> >, std::__detail::__is_noexcept_hash<Envoy::Server::ServerLifecycleNotifier::Stage, std::hash<Envoy::Server::ServerLifecycleNotifier::Stage> > > >'
```
Description:
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

