### PR TITLE
docs: deprecated.md to sphinx docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ maximize the chances of your PR being merged.
   deprecation window. Within this window, a warning of deprecation should be carefully logged (some
   features might need rate limiting for logging this). We make no guarantees about code or deployments
   that rely on undocumented behavior.
-* All deprecations/breaking changes will be clearly listed in [deprecated log](docs/root/intro/deprecated.rst).
+* All deprecations/breaking changes will be clearly listed in the [deprecated log](docs/root/intro/deprecated.rst).
 * High risk deprecations//breaking changes may be announced to the
   [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce) email list but by default
   it is expected the multi-phase warn-by-default/fail-by-default is sufficient to warn users to move
@@ -132,7 +132,8 @@ maximize the chances of your PR being merged.
   changes for 7 days. Obviously PRs that are closed due to lack of activity can be reopened later.
   Closing stale PRs helps us to keep on top of all of the work currently in flight.
 * If a commit deprecates a feature, the commit message must mention what has been deprecated.
-  Additionally, [deprecated log](docs/root/intro/deprecated.rst) must be updated as part of the commit.
+  Additionally, the [deprecated log](docs/root/intro/deprecated.rst) must be updated with relevant
+  RST links for fields and messages as part of the commit.
 * Please consider joining the [envoy-dev](https://groups.google.com/forum/#!forum/envoy-dev)
   mailing list.
 * If your PR involves any changes to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ maximize the chances of your PR being merged.
   deprecation window. Within this window, a warning of deprecation should be carefully logged (some
   features might need rate limiting for logging this). We make no guarantees about code or deployments
   that rely on undocumented behavior.
-* All deprecations/breaking changes will be clearly listed in [DEPRECATED.md](DEPRECATED.md).
+* All deprecations/breaking changes will be clearly listed in [deprecated log](docs/root/intro/deprecated.rst).
 * High risk deprecations//breaking changes may be announced to the
   [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce) email list but by default
   it is expected the multi-phase warn-by-default/fail-by-default is sufficient to warn users to move
@@ -132,7 +132,7 @@ maximize the chances of your PR being merged.
   changes for 7 days. Obviously PRs that are closed due to lack of activity can be reopened later.
   Closing stale PRs helps us to keep on top of all of the work currently in flight.
 * If a commit deprecates a feature, the commit message must mention what has been deprecated.
-  Additionally, [DEPRECATED.md](DEPRECATED.md) must be updated as part of the commit.
+  Additionally, [deprecated log](docs/root/intro/deprecated.rst) must be updated as part of the commit.
 * Please consider joining the [envoy-dev](https://groups.google.com/forum/#!forum/envoy-dev)
   mailing list.
 * If your PR involves any changes to

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -84,7 +84,7 @@ or you can subscribe to the iCal feed [here](https://app.opsgenie.com/webcal/get
   corrections.
 * Switch the [VERSION](VERSION) from a "dev" variant to a final variant. E.g., "1.6.0-dev" to
   "1.6.0". Also remove the "Pending" tag from the top of the [release notes](docs/root/intro/version_history.rst)
-  and [DEPRECATED.md](DEPRECATED.md). Get a review and merge.
+  and [deprecated log](docs/root/intro/deprecated.rst). Get a review and merge.
 * **Wait for tests to pass on
   [master](https://circleci.com/gh/envoyproxy/envoy/tree/master).**
 * Create a [tagged release](https://github.com/envoyproxy/envoy/releases). The release should
@@ -99,7 +99,7 @@ or you can subscribe to the iCal feed [here](https://app.opsgenie.com/webcal/get
   Envoy account post).
 * Do a new PR to update [VERSION](VERSION) to the next development release. E.g., "1.7.0-dev". At
   the same time, also add a new empty "pending" section to the [release
-  notes](docs/root/intro/version_history.rst) and to [DEPRECATED.md](DEPRECATED.md) for the
+  notes](docs/root/intro/version_history.rst) and to [deprecated log](docs/root/intro/deprecated.rst) for the
   following version. E.g., "1.7.0 (pending)".
 * Run the deprecate_versions.py script (e.g. `sh tools/deprecate_version/deprecate_version.sh 1.8.0 1.10.0`)
   to file tracking issues for code which can be removed.

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -74,7 +74,7 @@ you may instead just tag the PR with the issue:
 ### <a name="deprecated"></a>Deprecated
 
 If this PR deprecates existing Envoy APIs or code, it should include
-an update to the [deprecated file](DEPRECATED.md) and a one line note in the PR
+an update to the [deprecated file](docs/root/intro/deprecated.rst) and a one line note in the PR
 description.
 
 If you mark existing APIs or code as deprecated, when the next release is cut, the

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -194,7 +194,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>` clusters.
   // This field supersedes :ref:`hosts<envoy_api_field_Cluster.hosts>` field.
-  // [#comment:TODO(dio): Deprecate the hosts field and add it to DEPRECATED.md
+  // [#comment:TODO(dio): Deprecate the hosts field and add it to :ref:`deprecated log<deprecated>`
   // once load_assignment is implemented.]
   //
   // .. attention::

--- a/docs/root/configuration/runtime.rst
+++ b/docs/root/configuration/runtime.rst
@@ -89,7 +89,7 @@ feature deprecation in Envoy is in 3 phases: warn-by-default, fail-by-default, a
 
 In the first phase, Envoy logs a warning to the warning log that the feature is deprecated and
 increments the :ref:`deprecated_feature_use <runtime_stats>` runtime stat.
-Users are encouraged to go to :repo:`DEPRECATED.md <DEPRECATED.md>` to see how to
+Users are encouraged to go to :ref:`deprecated <deprecated>` to see how to
 migrate to the new code path and make sure it is suitable for their use case.
 
 In the second phase the message and filename will be added to

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -8,15 +8,17 @@ As of release 1.3.0, Envoy will follow a
 
 The following features have been DEPRECATED and will be removed in the specified release cycle.
 A logged warning is expected for each deprecated item that is in deprecation window.
+Deprecated items below are listed in chronological order.
+
 
 Version 1.10.0 (pending)
 ========================
-* Use of `use_alpha` in `Ext-Authz Authorization Service <https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/auth/v2/external_auth.proto>`_ is deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
+* Use of `use_alpha` in :ref:`Ext-Authz Authorization Service <envoy_api_file_envoy/service/auth/v2/external_auth.proto>` is deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
 * Use of `enabled` in `CorsPolicy`, found in
-  `route.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto>`_.
+  :ref:`route.proto <envoy_api_file_envoy/api/v2/route/route.proto>`.
   Set the `filter_enabled` field instead.
 * Use of the `type` field in the `FaultDelay` message (found in
-  `fault.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/fault/v2/fault.proto>`_)
+  :ref:`fault.proto <envoy_api_file_envoy/config/filter/fault/v2/fault.proto>`)
   has been deprecated. It was never used and setting it has no effect. It will be removed in the
   following release.
 

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -10,9 +10,11 @@ The following features have been DEPRECATED and will be removed in the specified
 A logged warning is expected for each deprecated item that is in deprecation window.
 Deprecated items below are listed in chronological order.
 
-
-Version 1.10.0 (pending)
+Version 1.11.0 (Pending)
 ========================
+
+Version 1.10.0 (Apr 5, 2019)
+============================
 * Use of `use_alpha` in :ref:`Ext-Authz Authorization Service <envoy_api_file_envoy/service/auth/v2/external_auth.proto>` is deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
 * Use of `enabled` in `CorsPolicy`, found in
   :ref:`route.proto <envoy_api_file_envoy/api/v2/route/route.proto>`.

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -1,66 +1,68 @@
-# DEPRECATED
+.. _deprecated:
+
+Deprecated
+----------
 
 As of release 1.3.0, Envoy will follow a
-[Breaking Change Policy](https://github.com/envoyproxy/envoy/blob/master//CONTRIBUTING.md#breaking-change-policy).
+`Breaking Change Policy <https://github.com/envoyproxy/envoy/blob/master//CONTRIBUTING.md#breaking-change-policy>`_.
 
 The following features have been DEPRECATED and will be removed in the specified release cycle.
 A logged warning is expected for each deprecated item that is in deprecation window.
 
-## Version 1.11.0 (Pending)
-
-## Version 1.10.0 (Apr 5, 2019)
-* Use of `use_alpha` in [Ext-Authz Authorization Service](https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/auth/v2/external_auth.proto) is deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
+Version 1.10.0 (pending)
+========================
+* Use of `use_alpha` in `Ext-Authz Authorization Service <https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/auth/v2/external_auth.proto>`_ is deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
 * Use of `enabled` in `CorsPolicy`, found in
-  [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto).
+  `route.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto>`_.
   Set the `filter_enabled` field instead.
 * Use of the `type` field in the `FaultDelay` message (found in
-  [fault.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/fault/v2/fault.proto))
+  `fault.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/fault/v2/fault.proto>`_)
   has been deprecated. It was never used and setting it has no effect. It will be removed in the
   following release.
 
-## Version 1.9.0 (Dec 20, 2018)
-
-* Order of execution of the network write filter chain has been reversed. Prior to this release cycle it was incorrect, see [#4599](https://github.com/envoyproxy/envoy/issues/4599). In the 1.9.0 release cycle we introduced `bugfix_reverse_write_filter_order` in [lds.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/lds.proto) to temporarily support both old and new behaviors. Note this boolean field is deprecated.
-* Order of execution of the HTTP encoder filter chain has been reversed. Prior to this release cycle it was incorrect, see [#4599](https://github.com/envoyproxy/envoy/issues/4599). In the 1.9.0 release cycle we introduced `bugfix_reverse_encode_order` in [http_connection_manager.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto) to temporarily support both old and new behaviors. Note this boolean field is deprecated.
+Version 1.9.0 (Dec 20, 2018)
+============================
+* Order of execution of the network write filter chain has been reversed. Prior to this release cycle it was incorrect, see `#4599 <https://github.com/envoyproxy/envoy/issues/4599>`_. In the 1.9.0 release cycle we introduced `bugfix_reverse_write_filter_order` in `lds.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/lds.proto>`_ to temporarily support both old and new behaviors. Note this boolean field is deprecated.
+* Order of execution of the HTTP encoder filter chain has been reversed. Prior to this release cycle it was incorrect, see `#4599 <https://github.com/envoyproxy/envoy/issues/4599>`_. In the 1.9.0 release cycle we introduced `bugfix_reverse_encode_order` in `http_connection_manager.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_ to temporarily support both old and new behaviors. Note this boolean field is deprecated.
 * Use of the v1 REST_LEGACY ApiConfigSource is deprecated.
 * Use of std::hash in the ring hash load balancer is deprecated.
-* Use of `rate_limit_service` configuration in the [bootstrap configuration](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/bootstrap/v2/bootstrap.proto) is deprecated.
+* Use of `rate_limit_service` configuration in the `bootstrap configuration <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/bootstrap/v2/bootstrap.proto>`_ is deprecated.
 * Use of `runtime_key` in `RequestMirrorPolicy`, found in
-  [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto)
+  `route.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto>`_
   is deprecated. Set the `runtime_fraction` field instead.
-* Use of buffer filter `max_request_time` is deprecated in favor of the request timeout found in [HttpConnectionManager](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto)
+* Use of buffer filter `max_request_time` is deprecated in favor of the request timeout found in `HttpConnectionManager <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_
 
-## Version 1.8.0 (Oct 4, 2018)
-
+Version 1.8.0 (Oct 4, 2018)
+==============================
 * Use of the v1 API (including `*.deprecated_v1` fields in the v2 API) is deprecated.
-  See envoy-announce [email](https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U).
+  See envoy-announce `email <https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U>`_.
 * Use of the legacy
-  [ratelimit.proto](https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto)
+  `ratelimit.proto <https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto>`_
   is deprecated, in favor of the proto defined in
-  [date-plane-api](https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/ratelimit/v2/rls.proto)
+  `date-plane-api <https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/ratelimit/v2/rls.proto>`_
   Prior to 1.8.0, Envoy can use either proto to send client requests to a ratelimit server with the use of the
-  `use_data_plane_proto` boolean flag in the [ratelimit configuration](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/ratelimit/v2/rls.proto).
+  `use_data_plane_proto` boolean flag in the `ratelimit configuration <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/ratelimit/v2/rls.proto>`_.
   However, when using the deprecated client a warning is logged.
 * Use of the --v2-config-only flag.
 * Use of both `use_websocket` and `websocket_config` in
-  [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto)
+  `route.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto>`_
   is deprecated. Please use the new `upgrade_configs` in the
-  [HttpConnectionManager](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto)
+  `HttpConnectionManager <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_
   instead.
-* Use of the integer `percent` field in [FaultDelay](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/fault/v2/fault.proto)
-  and in [FaultAbort](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/http/fault/v2/fault.proto) is deprecated in favor
+* Use of the integer `percent` field in `FaultDelay <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/fault/v2/fault.proto>`_
+  and in `FaultAbort <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/http/fault/v2/fault.proto>`_ is deprecated in favor
   of the new `FractionalPercent` based `percentage` field.
 * Setting hosts via `hosts` field in `Cluster` is deprecated. Use `load_assignment` instead.
 * Use of `response_headers_to_*` and `request_headers_to_add` are deprecated at the `RouteAction`
   level. Please use the configuration options at the `Route` level.
 * Use of `runtime` in `RouteMatch`, found in
-  [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto).
+  `route.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto>`_.
   Set the `runtime_fraction` field instead.
-* Use of the string `user` field in `Authenticated` in [rbac.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/rbac/v2alpha/rbac.proto)
+* Use of the string `user` field in `Authenticated` in `rbac.proto <https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/rbac/v2alpha/rbac.proto>`_
   is deprecated in favor of the new `StringMatcher` based `principal_name` field.
 
-## Version 1.7.0 (Jun 21, 2018)
-
+Version 1.7.0 (Jun 21, 2018)
+===============================
 * Admin mutations should be sent as POSTs rather than GETs. HTTP GETs will result in an error
   status code and will not have their intended effect. Prior to 1.7, GETs can be used for
   admin mutations, but a warning is logged.
@@ -76,8 +78,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
   field where one can specify HeaderMatch objects to match on.
 * The `sni_domains` field in the filter chain match was deprecated/renamed to `server_names`.
 
-## Version 1.6.0 (March 20, 2018)
-
+Version 1.6.0 (March 20, 2018)
+=================================
 * DOWNSTREAM_ADDRESS log formatter is deprecated. Use DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT
   instead.
 * CLIENT_IP header formatter is deprecated. Use DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT instead.
@@ -86,8 +88,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
 * `value` and `regex` fields in the `HeaderMatcher` message is deprecated. Use the `exact_match`
   or `regex_match` oneof instead.
 
-## Version 1.5.0 (Dec 4, 2017)
-
+Version 1.5.0 (Dec 4, 2017)
+==============================
 * The outlier detection `ejections_total` stats counter has been deprecated and not replaced. Monitor
   the individual `ejections_detected_*` counters for the detectors of interest, or
   `ejections_enforced_total` for the total number of ejections that actually occurred.
@@ -96,8 +98,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
 * The outlier detection `ejections_success_rate` stats counter has been deprecated in favour of
   `ejections_detected_success_rate` and `ejections_enforced_success_rate`.
 
-## Version 1.4.0 (Aug 24, 2017)
-
+Version 1.4.0 (Aug 24, 2017)
+============================
 * Config option `statsd_local_udp_port` has been deprecated and has been replaced with
   `statsd_udp_ip_address`.
 * `HttpFilterConfigFactory` filter API has been deprecated in favor of `NamedHttpFilterConfigFactory`.
@@ -105,7 +107,7 @@ A logged warning is expected for each deprecated item that is in deprecation win
 * The following log macros have been deprecated: `log_trace`, `log_debug`, `conn_log`,
   `conn_log_info`, `conn_log_debug`, `conn_log_trace`, `stream_log`, `stream_log_info`,
   `stream_log_debug`, `stream_log_trace`. For replacements, please see
-  [logger.h](https://github.com/envoyproxy/envoy/blob/master/source/common/common/logger.h).
+  `logger.h <https://github.com/envoyproxy/envoy/blob/master/source/common/common/logger.h>`_.
 * The connectionId() and ssl() callbacks of StreamFilterCallbacks have been deprecated and
   replaced with a more general connection() callback, which, when not returning a nullptr, can be
   used to get the connection id and SSL connection from the returned Connection object pointer.

--- a/docs/root/intro/intro.rst
+++ b/docs/root/intro/intro.rst
@@ -12,3 +12,4 @@ Introduction
   comparison
   getting_help
   version_history
+  deprecated

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -591,7 +591,7 @@ Version history
 * mongo filter: added :ref:`fault injection <config_network_filters_mongo_proxy_fault_injection>`.
 * mongo filter: added :ref:`"drain close" <arch_overview_draining>` support.
 * outlier detection: added :ref:`HTTP gateway failure type <arch_overview_outlier_detection>`.
-  See `DEPRECATED.md <https://github.com/envoyproxy/envoy/blob/master/DEPRECATED.md#version-150>`_
+  See :ref:`deprecated log <deprecated>`
   for outlier detection stats deprecations in this release.
 * redis: the :ref:`redis proxy filter <config_network_filters_redis_proxy>` is now considered
   production ready.
@@ -668,7 +668,7 @@ Version history
 * UDP `statsd_ip_address` option added.
 * Per-cluster DNS resolvers added.
 * :ref:`Fault filter <config_http_filters_fault_injection>` enhancements and fixes.
-* Several features are :repo:`deprecated as of the 1.4.0 release </DEPRECATED.md#version-140>`. They
+* Several features are :ref:`deprecated as of the 1.4.0 release <deprecated>`. They
   will be removed at the beginning of the 1.5.0 release cycle. We explicitly call out that the
   `HttpFilterConfigFactory` filter API has been deprecated in favor of
   `NamedHttpFilterConfigFactory`.

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -166,7 +166,7 @@ void MessageUtil::checkForDeprecation(const Protobuf::Message& message, Runtime:
     if (field->options().deprecated()) {
       std::string err = fmt::format(
           "Using deprecated option '{}' from file {}. This configuration will be removed from "
-          "Envoy soon. Please see https://github.com/envoyproxy/envoy/blob/master/DEPRECATED.md "
+          "Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated "
           "for details.",
           field->full_name(), filename);
       if (warn_only) {

--- a/tools/deprecate_version/deprecate_version.py
+++ b/tools/deprecate_version/deprecate_version.py
@@ -49,7 +49,7 @@ class DeprecateVersionError(Exception):
 
 # Figure out map from version to set of commits.
 def GetHistory():
-  """Obtain mapping from release version to DEPRECATED.md PRs.
+  """Obtain mapping from release version to docs/root/intro/deprecated.rst PRs.
 
   Returns:
     A dictionary mapping from release version to a set of git commit objects.
@@ -57,7 +57,7 @@ def GetHistory():
   repo = Repo(os.getcwd())
   version = None
   history = defaultdict(set)
-  for commit, lines in repo.blame('HEAD', 'DEPRECATED.md'):
+  for commit, lines in repo.blame('HEAD', 'docs/root/intro/deprecated.rst'):
     for line in lines:
       sr = re.match('## Version (.*) \(.*\)', line)
       if sr:


### PR DESCRIPTION
Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Description: Moved DEPRECATED.md to sphinx docs.
Risk Level: Low - only documentation
Testing: Compiles with sphinx docs without warnings or errors
Docs Changes: deprecated.rst created in intro section of sphinx docs and added to toctree
Release Notes: N/A
Fixes: #6386 
