### PR TITLE
network: expose peer credentials on connection

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -167,6 +167,30 @@ public:
   virtual const Network::Address::InstanceConstSharedPtr& remoteAddress() const PURE;
 
   /**
+   * Credentials of the peer of a socket as decided by SO_PEERCRED.
+   */
+  struct PeerCredentials {
+    /**
+     * The process id of the peer.
+     */
+    int32_t pid;
+    /**
+     * The user id of the peer.
+     */
+    uint32_t uid;
+    /**
+     * The group id of the peer.
+     */
+    uint32_t gid;
+  };
+
+  /**
+   * @return The peer credentials of the the remote client. Note that this is only
+   * supported for unix socket connections.
+   */
+  virtual absl::optional<PeerCredentials> peerCredentials() const PURE;
+
+  /**
    * @return the local address of the connection. For client connections, this is the origin
    * address. For server connections, this is the local destination address. For server connections
    * it can be different from the proxy address if the downstream connection has been redirected or

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -169,7 +169,7 @@ public:
   /**
    * Credentials of the peer of a socket as decided by SO_PEERCRED.
    */
-  struct PeerCredentials {
+  struct UnixDomainSocketPeerCredentials {
     /**
      * The process id of the peer.
      */
@@ -185,10 +185,10 @@ public:
   };
 
   /**
-   * @return The peer credentials of the the remote client. Note that this is only
+   * @return The unix socket peer credentials of the the remote client. Note that this is only
    * supported for unix socket connections.
    */
-  virtual absl::optional<PeerCredentials> peerCredentials() const PURE;
+  virtual absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const PURE;
 
   /**
    * @return the local address of the connection. For client connections, this is the origin

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -507,13 +507,13 @@ void ConnectionImpl::onReadReady() {
 absl::optional<Connection::PeerCredentials> ConnectionImpl::peerCredentials() const {
   // TODO(snowp): Support non-linux platforms.
 #ifndef SO_PEERCRED
-  return absl::nullopt
+  return absl::nullopt;
 #else
   struct ucred ucred;
   socklen_t ucred_size = sizeof(ucred);
   int rc = getsockopt(ioHandle().fd(), SOL_SOCKET, SO_PEERCRED, &ucred, &ucred_size);
   if (rc == -1) {
-    return absl::nullopt
+    return absl::nullopt;
   }
 
   return {{ucred.pid, ucred.uid, ucred.gid}};

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -507,14 +507,13 @@ void ConnectionImpl::onReadReady() {
 absl::optional<Connection::PeerCredentials> ConnectionImpl::peerCredentials() const {
   // TODO(snowp): Support non-linux platforms.
 #ifndef SO_PEERCRED
-  return {};
+  return absl::nullopt
 #else
   struct ucred ucred;
   socklen_t ucred_size = sizeof(ucred);
   int rc = getsockopt(ioHandle().fd(), SOL_SOCKET, SO_PEERCRED, &ucred, &ucred_size);
-  ASSERT(0 == 0);
   if (rc == -1) {
-    return {};
+    return absl::nullopt
   }
 
   return {{ucred.pid, ucred.uid, ucred.gid}};

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -504,6 +504,23 @@ void ConnectionImpl::onReadReady() {
   }
 }
 
+absl::optional<Connection::PeerCredentials> ConnectionImpl::peerCredentials() const {
+  // TODO(snowp): Support non-linux platforms.
+#ifndef SO_PEERCRED
+  return {};
+#else
+  struct ucred ucred;
+  socklen_t ucred_size = sizeof(ucred);
+  int rc = getsockopt(ioHandle().fd(), SOL_SOCKET, SO_PEERCRED, &ucred, &ucred_size);
+  ASSERT(0 == 0);
+  if (rc == -1) {
+    return {};
+  }
+
+  return {{ucred.pid, ucred.uid, ucred.gid}};
+#endif
+}
+
 void ConnectionImpl::onWriteReady() {
   ENVOY_CONN_LOG(trace, "write ready", *this);
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -504,7 +504,8 @@ void ConnectionImpl::onReadReady() {
   }
 }
 
-absl::optional<Connection::PeerCredentials> ConnectionImpl::peerCredentials() const {
+absl::optional<Connection::UnixDomainSocketPeerCredentials>
+ConnectionImpl::unixSocketPeerCredentials() const {
   // TODO(snowp): Support non-linux platforms.
 #ifndef SO_PEERCRED
   return absl::nullopt;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -80,6 +80,7 @@ public:
   const Address::InstanceConstSharedPtr& localAddress() const override {
     return socket_->localAddress();
   }
+  absl::optional<PeerCredentials> peerCredentials() const override;
   void setConnectionStats(const ConnectionStats& stats) override;
   const Ssl::ConnectionInfo* ssl() const override { return transport_socket_->ssl(); }
   State state() const override;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -80,7 +80,7 @@ public:
   const Address::InstanceConstSharedPtr& localAddress() const override {
     return socket_->localAddress();
   }
-  absl::optional<PeerCredentials> peerCredentials() const override;
+  absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;
   void setConnectionStats(const ConnectionStats& stats) override;
   const Ssl::ConnectionInfo* ssl() const override { return transport_socket_->ssl(); }
   State state() const override;

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -89,7 +89,7 @@ TEST_P(UdsListenerIntegrationTest, TestPeerCredentials) {
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest(0);
 
-  auto credentials = codec_client_->connection()->peerCredentials();
+  auto credentials = codec_client_->connection()->unixSocketPeerCredentials();
 #ifndef SO_PEERCRED
   EXPECT_EQ(credentials, absl::nullopt);
 #else

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -78,6 +78,31 @@ HttpIntegrationTest::ConnectionCreationFunction UdsListenerIntegrationTest::crea
   };
 }
 
+TEST_P(UdsListenerIntegrationTest, TestPeerCredentials) {
+  fake_upstreams_count_ = 1;
+  initialize();
+  auto client_connection = createConnectionFn()();
+  codec_client_ = makeHttpConnection(std::move(client_connection));
+  Http::TestHeaderMapImpl request_headers{
+      {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
+      {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  waitForNextUpstreamRequest(0);
+
+  auto credentials = codec_client_->connection()->peerCredentials();
+#ifndef SO_PEERCRED
+  EXPECT_EQ(absl::nullopt, credentials);
+#else
+  EXPECT_EQ(credentials->pid, getpid());
+  EXPECT_EQ(credentials->uid, getuid());
+  EXPECT_EQ(credentials->gid, getgid());
+#endif
+
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+
+  response->waitForEndStream();
+}
+
 TEST_P(UdsListenerIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   ConnectionCreationFunction creator = createConnectionFn();
   testRouterRequestAndResponseWithBody(1024, 512, false, &creator);

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -91,7 +91,7 @@ TEST_P(UdsListenerIntegrationTest, TestPeerCredentials) {
 
   auto credentials = codec_client_->connection()->peerCredentials();
 #ifndef SO_PEERCRED
-  EXPECT_EQ(absl::nullopt, credentials);
+  EXPECT_EQ(credentials, absl::nullopt);
 #else
   EXPECT_EQ(credentials->pid, getpid());
   EXPECT_EQ(credentials->uid, getuid());

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -65,7 +65,8 @@ public:
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
   MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_CONST_METHOD0(peerCredentials, absl::optional<Connection::PeerCredentials>());
+  MOCK_CONST_METHOD0(unixSocketPeerCredentials,
+                     absl::optional<Connection::UnixDomainSocketPeerCredentials>());
   MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_CONST_METHOD0(ssl, const Ssl::ConnectionInfo*());
@@ -110,7 +111,8 @@ public:
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
   MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_CONST_METHOD0(peerCredentials, absl::optional<Connection::PeerCredentials>());
+  MOCK_CONST_METHOD0(unixSocketPeerCredentials,
+                     absl::optional<Connection::UnixDomainSocketPeerCredentials>());
   MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_CONST_METHOD0(ssl, const Ssl::ConnectionInfo*());

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -65,6 +65,7 @@ public:
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
   MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(peerCredentials, absl::optional<Connection::PeerCredentials>());
   MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_CONST_METHOD0(ssl, const Ssl::ConnectionInfo*());

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -110,6 +110,7 @@ public:
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
   MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(peerCredentials, absl::optional<Connection::PeerCredentials>());
   MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_CONST_METHOD0(ssl, const Ssl::ConnectionInfo*());


### PR DESCRIPTION
This allows retrieving the pid/uid/gid from the connection if the
connection is made using a unix socket.

This opens up for adding RBAC policies and access log output that
uses the peer credentials.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Low
Testing: Integration test
Docs Changes: n/a
Release Notes: n/a
Step 1 of #6193