### PR TITLE
server: add no-op implementation of ServerLifecycleNotifier to ValidationInst…

### DIFF
--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -53,6 +53,7 @@ bool validateConfig(const Options& options, Network::Address::InstanceConstShare
 class ValidationInstance : Logger::Loggable<Logger::Id::main>,
                            public Instance,
                            public ListenerComponentFactory,
+                           public ServerLifecycleNotifier,
                            public WorkerFactory {
 public:
   ValidationInstance(const Options& options, Event::TimeSystem& time_system,
@@ -77,7 +78,7 @@ public:
   void getParentStats(HotRestart::GetParentStatsInfo&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   HotRestart& hotRestart() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Init::Manager& initManager() override { return init_manager_; }
-  ServerLifecycleNotifier& lifecycleNotifier() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ServerLifecycleNotifier& lifecycleNotifier() override { return *this; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
   Runtime::RandomGenerator& random() override { return random_generator_; }
@@ -137,6 +138,10 @@ public:
     // validation mock.
     return nullptr;
   }
+
+  // ServerLifecycleNotifier
+  void registerCallback(Stage, StageCallback) override {}
+  void registerCallback(Stage, StageCallbackWithCompletion) override {}
 
 private:
   void initialize(const Options& options, Network::Address::InstanceConstSharedPtr local_address,


### PR DESCRIPTION
…ance

Description: Make the ValidationInstance server implement the ServerLifecycleNotifier interface to avoid crashes when validating a config with listeners and other extensions that register for server lifecycle events. The ValidationInstance does not have a real lifecycle like the actual server so the registrations are no-ops.
Risk Level: low
Testing: built

Signed-off-by: Elisha Ziskind <eziskind@google.com>