### PR TITLE
test: Re-enable guarddog tests which were accidentally disabled due to a parameterized test mishap.

### DIFF
--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -133,8 +133,8 @@ class GuardDogAlmostDeadTest : public GuardDogDeathTest {};
 
 INSTANTIATE_TEST_SUITE_P(
     TimeSystemType, GuardDogAlmostDeadTest,
-    testing::ValuesIn({ // TODO(#6464): TimeSystemType::Real -- fails in this suite 30/1000 times.
-        TimeSystemType::Simulated}));
+    testing::ValuesIn({// TODO(#6464): TimeSystemType::Real -- fails in this suite 30/1000 times.
+                       TimeSystemType::Simulated}));
 
 TEST_P(GuardDogDeathTest, KillDeathTest) {
   // Is it German for "The Function"? Almost...

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -133,8 +133,8 @@ class GuardDogAlmostDeadTest : public GuardDogDeathTest {};
 
 INSTANTIATE_TEST_SUITE_P(
     TimeSystemType, GuardDogAlmostDeadTest,
-    testing::ValuesIn({// TimeSystemType::Real -- fails in this suite 30/1000 times.
-                       TimeSystemType::Simulated}));
+    testing::ValuesIn({ // TODO(#6464): TimeSystemType::Real -- fails in this suite 30/1000 times.
+        TimeSystemType::Simulated}));
 
 TEST_P(GuardDogDeathTest, KillDeathTest) {
   // Is it German for "The Function"? Almost...
@@ -221,7 +221,7 @@ TEST_P(GuardDogMissTest, MissTest) {
 }
 
 TEST_P(GuardDogMissTest, MegaMissTest) {
-  // This test fails in real-time 1/1000 times, but passes in simulated time.
+  // TODO(#6464): This test fails in real-time 1/1000 times, but passes in simulated time.
   if (GetParam() == TimeSystemType::Real) {
     return;
   }
@@ -245,7 +245,7 @@ TEST_P(GuardDogMissTest, MegaMissTest) {
 }
 
 TEST_P(GuardDogMissTest, MissCountTest) {
-  // This test fails in real-time 9/1000 times, but passes in simulated time.
+  // TODO(#6464): This test fails in real-time 9/1000 times, but passes in simulated time.
   if (GetParam() == TimeSystemType::Real) {
     return;
   }

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -124,9 +124,17 @@ protected:
   WatchDogSharedPtr second_dog_;
 };
 
+INSTANTIATE_TEST_SUITE_P(TimeSystemType, GuardDogDeathTest,
+                         testing::ValuesIn({TimeSystemType::Real, TimeSystemType::Simulated}));
+
 // These tests use threads, and need to run after the real death tests, so we need to call them
 // a different name.
 class GuardDogAlmostDeadTest : public GuardDogDeathTest {};
+
+INSTANTIATE_TEST_SUITE_P(
+    TimeSystemType, GuardDogAlmostDeadTest,
+    testing::ValuesIn({// TimeSystemType::Real -- fails in this suite 30/1000 times.
+                       TimeSystemType::Simulated}));
 
 TEST_P(GuardDogDeathTest, KillDeathTest) {
   // Is it German for "The Function"? Almost...
@@ -190,6 +198,9 @@ protected:
   NiceMock<Configuration::MockMain> config_mega_;
 };
 
+INSTANTIATE_TEST_SUITE_P(TimeSystemType, GuardDogMissTest,
+                         testing::ValuesIn({TimeSystemType::Real, TimeSystemType::Simulated}));
+
 TEST_P(GuardDogMissTest, MissTest) {
   // This test checks the actual collected statistics after doing some timer
   // advances that should and shouldn't increment the counters.
@@ -210,6 +221,11 @@ TEST_P(GuardDogMissTest, MissTest) {
 }
 
 TEST_P(GuardDogMissTest, MegaMissTest) {
+  // This test fails in real-time 1/1000 times, but passes in simulated time.
+  if (GetParam() == TimeSystemType::Real) {
+    return;
+  }
+
   // This test checks the actual collected statistics after doing some timer
   // advances that should and shouldn't increment the counters.
   initGuardDog(stats_store_, config_mega_);
@@ -229,6 +245,11 @@ TEST_P(GuardDogMissTest, MegaMissTest) {
 }
 
 TEST_P(GuardDogMissTest, MissCountTest) {
+  // This test fails in real-time 9/1000 times, but passes in simulated time.
+  if (GetParam() == TimeSystemType::Real) {
+    return;
+  }
+
   // This tests a flake discovered in the MissTest where real timeout or
   // spurious condition_variable wakeup causes the counter to get incremented
   // more than it should be.


### PR DESCRIPTION
Description: Prior to final review in #6369 I made the test base-class parameterized to run it both with simulated time and real time. I was actually surprised to find that real-time tests worked in tsan 1000x. It was too good to be true. SimulatedTime is very robust but some of the real-time tests don't work.

I found when looking at coverage that some of the guarddog code wasn't being run in tests which surprised me, because I knew we should have coverage.

So this PR parametarizes all the test-classes, not just the base-class, getting the coverage back.
Risk Level: low
Testing: just this test, but with/without tsan and --runs_per_test=1000
Docs Changes: n/a
Release Notes: n/a
