### PR TITLE
docs: update load_balancing_weight behavior description

### DIFF
--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -43,9 +43,10 @@ service EndpointDiscoveryService {
 //
 // With EDS, each cluster is treated independently from a LB perspective, with
 // LB taking place between the Localities within a cluster and at a finer
-// granularity between the hosts within a locality. For a given cluster, the
-// effective weight of a host is its load_balancing_weight multiplied by the
-// load_balancing_weight of its Locality.
+// granularity between the hosts within a locality. The percentage of traffic
+// for each endpoint is determined by both its load_balancing_weight, and the
+// load_balancing_weight of its locality. First, a locality will be selected,
+// then an endpoint within that locality will be chose based on its weight.
 message ClusterLoadAssignment {
   // Name of the cluster. This will be the :ref:`service_name
   // <envoy_api_field_Cluster.EdsClusterConfig.service_name>` value if specified


### PR DESCRIPTION
Description: The documentation before was misleading; the weights are not actually multiplied together. This change brings the docs here in line with the actual behavior and the docs in other places
Risk Level: none
Testing: none
Docs Changes: this is only a docs change
Release Notes: n/a

Fixes #6458
