### PR TITLE
fix(tracing): allow 256 chars in path tag

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -30,7 +30,7 @@ static std::string buildUrl(const Http::HeaderMap& request_headers) {
   std::string path = request_headers.EnvoyOriginalPath()
                          ? request_headers.EnvoyOriginalPath()->value().c_str()
                          : request_headers.Path()->value().c_str();
-  static const size_t max_path_length = 128;
+  static const size_t max_path_length = 256;
   if (path.length() > max_path_length) {
     path = path.substr(0, max_path_length);
   }

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -114,7 +114,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   const std::string path(300, 'a');
   const std::string path_prefix = "http://";
-  const std::string expected_path(128, 'a');
+  const std::string expected_path(256, 'a');
   NiceMock<MockSpan> span;
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
@@ -142,7 +142,7 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
 TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
   const std::string path(300, 'a');
   const std::string path_prefix = "http://";
-  const std::string expected_path(128, 'a');
+  const std::string expected_path(256, 'a');
   NiceMock<MockSpan> span;
 
   Http::TestHeaderMapImpl request_headers{


### PR DESCRIPTION
Description:

Increases the `max_path_length` for the `:path` tag in tracing to 256. This returns the length to the capacity that was supported before #444 . The issue of truncating the path has been raised in a few places recently, most notably in: https://github.com/istio/istio/issues/12561.

I inquired as to the reasoning behind the switch to 128 from 256, but did not receive an answer. If there are valid reasons to keep 128, I would appreciate feedback there.

Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A

cc: @Stono @objectiser 

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>
