### PR TITLE
build: Change namespace of chromium_url.

### DIFF
--- a/source/common/chromium_url/README.md
+++ b/source/common/chromium_url/README.md
@@ -5,11 +5,14 @@ to support a security release fix for CVE-2019-9901. Long term we need this to
 be moved to absl or QUICHE for upgrades and long-term support.
 
 Some specific transforms of interest:
-* `url_parse.h` is minified to just `Component` and flattened back into the URL
-  directory. It does not contain any non-Chromium authored code any longer and
-  so does not have a separate LICENSE.
-* `envoy_shim.h` adapts various macros to the Envoy context.
-* Anything not reachable from `url::CanonicalizePath()` has been dropped.
-* Header include paths have changed as needed.
-* BUILD was manually written.
-* Various clang-tidy and format fixes.
+
+*   The namespace `url` was changed to `chromium_url`.
+*   `url_parse.h` is minified to just `Component` and flattened back into the
+    URL directory. It does not contain any non-Chromium authored code any longer
+    and so does not have a separate LICENSE.
+*   `envoy_shim.h` adapts various macros to the Envoy context.
+*   Anything not reachable from `url::CanonicalizePath()` has been dropped.
+*   Header include paths have changed as needed.
+*   BUILD was manually written.
+*   Various clang-tidy and format fixes.
+

--- a/source/common/chromium_url/README.md
+++ b/source/common/chromium_url/README.md
@@ -5,14 +5,12 @@ to support a security release fix for CVE-2019-9901. Long term we need this to
 be moved to absl or QUICHE for upgrades and long-term support.
 
 Some specific transforms of interest:
-
-*   The namespace `url` was changed to `chromium_url`.
-*   `url_parse.h` is minified to just `Component` and flattened back into the
-    URL directory. It does not contain any non-Chromium authored code any longer
-    and so does not have a separate LICENSE.
-*   `envoy_shim.h` adapts various macros to the Envoy context.
-*   Anything not reachable from `url::CanonicalizePath()` has been dropped.
-*   Header include paths have changed as needed.
-*   BUILD was manually written.
-*   Various clang-tidy and format fixes.
-
+* The namespace `url` was changed to `chromium_url`.
+* `url_parse.h` is minified to just `Component` and flattened back into the URL
+  directory. It does not contain any non-Chromium authored code any longer and
+  so does not have a separate LICENSE.
+* `envoy_shim.h` adapts various macros to the Envoy context.
+* Anything not reachable from `url::CanonicalizePath()` has been dropped.
+* Header include paths have changed as needed.
+* BUILD was manually written.
+* Various clang-tidy and format fixes.

--- a/source/common/chromium_url/url_canon.cc
+++ b/source/common/chromium_url/url_canon.cc
@@ -9,8 +9,8 @@
 
 #include "common/chromium_url/envoy_shim.h"
 
-namespace url {
+namespace chromium_url {
 
 template class EXPORT_TEMPLATE_DEFINE(COMPONENT_EXPORT(URL)) CanonOutputT<char>;
 
-} // namespace url
+} // namespace chromium_url

--- a/source/common/chromium_url/url_canon.h
+++ b/source/common/chromium_url/url_canon.h
@@ -14,7 +14,7 @@
 #include "common/chromium_url/envoy_shim.h"
 #include "common/chromium_url/url_parse.h"
 
-namespace url {
+namespace chromium_url {
 
 // Canonicalizer output -------------------------------------------------------
 
@@ -181,6 +181,6 @@ COMPONENT_EXPORT(URL)
 bool CanonicalizePath(const char* spec, const Component& path, CanonOutput* output,
                       Component* out_path);
 
-} // namespace url
+} // namespace chromium_url
 
 #endif // URL_URL_CANON_H_

--- a/source/common/chromium_url/url_canon_internal.cc
+++ b/source/common/chromium_url/url_canon_internal.cc
@@ -7,7 +7,7 @@
 
 #include "common/chromium_url/url_canon_internal.h"
 
-namespace url {
+namespace chromium_url {
 
 // See the header file for this array's declaration.
 const unsigned char kSharedCharTypeTable[0x100] = {
@@ -292,4 +292,4 @@ const char kCharToHexLookup[8] = {
     0,        // 0xE0 - 0xFF
 };
 
-} // namespace url
+} // namespace chromium_url

--- a/source/common/chromium_url/url_canon_internal.h
+++ b/source/common/chromium_url/url_canon_internal.h
@@ -19,7 +19,7 @@
 #include "common/chromium_url/envoy_shim.h"
 #include "common/chromium_url/url_canon.h"
 
-namespace url {
+namespace chromium_url {
 
 // Character type handling -----------------------------------------------------
 
@@ -241,6 +241,6 @@ inline bool DecodeEscaped(const CHAR* spec, int* begin, int end, unsigned char* 
   return true;
 }
 
-} // namespace url
+} // namespace chromium_url
 
 #endif // URL_URL_CANON_INTERNAL_H_

--- a/source/common/chromium_url/url_canon_path.cc
+++ b/source/common/chromium_url/url_canon_path.cc
@@ -11,7 +11,7 @@
 #include "common/chromium_url/url_canon_internal.h"
 #include "common/chromium_url/url_parse_internal.h"
 
-namespace url {
+namespace chromium_url {
 
 namespace {
 
@@ -414,4 +414,4 @@ bool CanonicalizePath(const char* spec, const Component& path, CanonOutput* outp
   return DoPath<char, unsigned char>(spec, path, output, out_path);
 }
 
-} // namespace url
+} // namespace chromium_url

--- a/source/common/chromium_url/url_canon_stdstring.cc
+++ b/source/common/chromium_url/url_canon_stdstring.cc
@@ -7,7 +7,7 @@
 
 #include "common/chromium_url/url_canon_stdstring.h"
 
-namespace url {
+namespace chromium_url {
 
 StdStringCanonOutput::StdStringCanonOutput(std::string* str) : CanonOutput(), str_(str) {
   cur_len_ = static_cast<int>(str_->size()); // Append to existing data.
@@ -30,4 +30,4 @@ void StdStringCanonOutput::Resize(int sz) {
   buffer_len_ = sz;
 }
 
-} // namespace url
+} // namespace chromium_url

--- a/source/common/chromium_url/url_canon_stdstring.h
+++ b/source/common/chromium_url/url_canon_stdstring.h
@@ -21,7 +21,7 @@
   TypeName(const TypeName&) = delete;                                                              \
   TypeName& operator=(const TypeName&) = delete
 
-namespace url {
+namespace chromium_url {
 
 // Write into a std::string given in the constructor. This object does not own
 // the string itself, and the user must ensure that the string stays alive
@@ -53,6 +53,6 @@ protected:
   DISALLOW_COPY_AND_ASSIGN(StdStringCanonOutput);
 };
 
-} // namespace url
+} // namespace chromium_url
 
 #endif // URL_URL_CANON_STDSTRING_H_

--- a/source/common/chromium_url/url_parse.h
+++ b/source/common/chromium_url/url_parse.h
@@ -8,7 +8,7 @@
 #ifndef URL_PARSE_H_
 #define URL_PARSE_H_
 
-namespace url {
+namespace chromium_url {
 
 // Component ------------------------------------------------------------------
 
@@ -44,6 +44,6 @@ struct Component {
 // points. The ending point is non-inclusive.
 inline Component MakeRange(int begin, int end) { return Component(begin, end - begin); }
 
-} // namespace url
+} // namespace chromium_url
 
 #endif // URL_PARSE_H_

--- a/source/common/chromium_url/url_parse_internal.h
+++ b/source/common/chromium_url/url_parse_internal.h
@@ -8,11 +8,11 @@
 #ifndef URL_URL_PARSE_INTERNAL_H_
 #define URL_URL_PARSE_INTERNAL_H_
 
-namespace url {
+namespace chromium_url {
 
 // We treat slashes and backslashes the same for IE compatibility.
 inline bool IsURLSlash(char ch) { return ch == '/' || ch == '\\'; }
 
-} // namespace url
+} // namespace chromium_url
 
 #endif // URL_URL_PARSE_INTERNAL_H_

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -13,10 +13,11 @@ namespace Http {
 namespace {
 absl::optional<std::string> canonicalizePath(absl::string_view original_path) {
   std::string canonical_path;
-  url::Component in_component(0, original_path.size());
-  url::Component out_component;
-  url::StdStringCanonOutput output(&canonical_path);
-  if (!url::CanonicalizePath(original_path.data(), in_component, &output, &out_component)) {
+  chromium_url::Component in_component(0, original_path.size());
+  chromium_url::Component out_component;
+  chromium_url::StdStringCanonOutput output(&canonical_path);
+  if (!chromium_url::CanonicalizePath(original_path.data(), in_component, &output,
+                                      &out_component)) {
     return absl::nullopt;
   } else {
     output.Complete();


### PR DESCRIPTION
Rename namespace `url` to `chromium_url`. Avoids link-time collisions
in binaries which link in Envoy and the original chromium URL
library.

Fix format of `chromium_url/README.md`.

Signed-off-by: James Synge <jamessynge@google.com>
