### PR TITLE
test: fix use-of-uninitialized-value bug in unit test

### DIFF
--- a/test/extensions/filters/network/common/redis/codec_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/codec_impl_test.cc
@@ -65,6 +65,7 @@ TEST_F(RedisRespValueTest, EqualityTestingAndCopyingTest) {
   simplestring_value.type(RespType::SimpleString);
   error_value.type(RespType::Error);
   integer_value.type(RespType::Integer);
+  integer_value.asInteger() = 123;
 
   EXPECT_NE(bulkstring_value, simplestring_value);
   EXPECT_NE(bulkstring_value, error_value);


### PR DESCRIPTION
Description: fixes a use of uninitialized value bug in this unit test
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>


