### PR TITLE
 HCM: add compile option of path normalization

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -105,6 +105,11 @@ config_setting(
     values = {"define": "google_grpc=disabled"},
 )
 
+config_setting(
+    name = "enable_path_normalization_by_default",
+    values = {"define": "path_normalization_by_default=true"},
+)
+
 cc_proto_library(
     name = "grpc_health_proto",
     deps = ["@com_github_grpc_grpc//src/proto/grpc/health/v1:_health_proto_only"],

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -366,6 +366,8 @@ The following optional features can be enabled on the Bazel build command-line:
   release builds so that the condition is not evaluated. This option has no effect in debug builds.
 * memory-debugging (scribbling over memory after allocation and before freeing) with
   `--define tcmalloc=debug`. Note this option cannot be used with FIPS-compliant mode BoringSSL.
+* Default [path normalization](https://github.com/envoyproxy/envoy/issues/6435) with 
+  `--define path_normalization_by_default=true`. Note this still could be disable by explicit xDS config.
 
 ## Disabling extensions
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -83,7 +83,8 @@ def envoy_copts(repository, test = False):
                "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
            envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
-           envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository)
+           envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
+           envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
 
 def envoy_static_link_libstdcpp_linkopts():
     return envoy_select_force_libcpp(
@@ -646,6 +647,13 @@ def envoy_select_hot_restart(xs, repository = ""):
         repository + "//bazel:disable_hot_restart": [],
         repository + "//bazel:apple": [],
         "//conditions:default": xs,
+    })
+
+# Select the given values if default path normalization is on in the current build.
+def envoy_select_path_normalization_by_default(xs, repository = ""):
+    return select({
+        repository + "//bazel:enable_path_normalization_by_default": xs,
+        "//conditions:default": [],
     })
 
 def envoy_select_perf_annotation(xs):

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -176,6 +176,7 @@ elif [[ "$1" == "bazel.compile_time_options" ]]; then
     --define boringssl=fips \
     --define log_debug_assert_in_release=enabled \
     --define quiche=enabled \
+    --define path_normalization_by_default=true \
   "
   setup_clang_toolchain
   # This doesn't go into CI but is available for developer convenience.

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -151,18 +151,18 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
                                                                          context_.listenerScope())),
       proxy_100_continue_(config.proxy_100_continue()),
       delayed_close_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, delayed_close_timeout, 1000)),
-      normalize_path_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, normalize_path,
+      normalize_path_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          config, normalize_path,
+          // TODO(htuch): we should have a
+          // boolean variant of featureEnabled()
+          // here.
+          context.runtime().snapshot().featureEnabled("http_connection_manager.normalize_path",
 #ifdef ENVOY_NORMALIZE_PATH_BY_DEFAULT
-                                                      true
+                                                      100
 #else
-                                                      // TODO(htuch): we should have a
-                                                      // boolean variant of featureEnabled()
-                                                      // here.
-                                                      context.runtime().snapshot().featureEnabled(
-                                                          "http_connection_manager.normalize_path",
-                                                          0)
+                                                      0
 #endif
-                                                      )) {
+                                                      ))) {
 
   route_config_provider_ = Router::RouteConfigProviderUtil::create(config, context_, stats_prefix_,
                                                                    route_config_provider_manager_);

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -151,13 +151,18 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
                                                                          context_.listenerScope())),
       proxy_100_continue_(config.proxy_100_continue()),
       delayed_close_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, delayed_close_timeout, 1000)),
-      normalize_path_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, normalize_path,
-                                          // TODO(htuch): we should have a
-                                          // boolean variant of featureEnabled()
-                                          // here.
-                                          context.runtime().snapshot().featureEnabled(
-                                              "http_connection_manager.normalize_path", 0))) {
+      normalize_path_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, normalize_path,
+#ifdef ENVOY_NORMALIZE_PATH_BY_DEFAULT
+                                                      true
+#else
+                                                      // TODO(htuch): we should have a
+                                                      // boolean variant of featureEnabled()
+                                                      // here.
+                                                      context.runtime().snapshot().featureEnabled(
+                                                          "http_connection_manager.normalize_path",
+                                                          0)
+#endif
+                                                      )) {
 
   route_config_provider_ = Router::RouteConfigProviderUtil::create(config, context_, stats_prefix_,
                                                                    route_config_provider_manager_);

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -198,9 +198,11 @@ TEST_F(HttpConnectionManagerConfigTest, NormalizePathDefault) {
   - name: envoy.router
   )EOF";
 
+  EXPECT_CALL(context_.runtime_loader_.snapshot_, featureEnabled(_, An<uint64_t>()))
+      .WillOnce(Invoke(&context_.runtime_loader_.snapshot_,
+                       &Runtime::MockSnapshot::featureEnabledDefault));
   HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
                                      date_provider_, route_config_provider_manager_);
-
 #ifdef ENVOY_NORMALIZE_PATH_BY_DEFAULT
   EXPECT_TRUE(config.shouldNormalizePath());
 #else

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -186,6 +186,25 @@ TEST_F(HttpConnectionManagerConfigTest, DisabledStreamIdleTimeout) {
   EXPECT_EQ(0, config.streamIdleTimeout().count());
 }
 
+#ifdef ENVOY_NORMALIZE_PATH_BY_DEFAULT
+// Validated that we normalize paths compiled with enable-by-default
+TEST_F(HttpConnectionManagerConfigTest, NormalizePathCompileConfig) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  EXPECT_CALL(context_.runtime_loader_.snapshot_,
+              featureEnabled("http_connection_manager.normalize_path", 0))
+      .Times(0);
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_);
+  EXPECT_TRUE(config.shouldNormalizePath());
+}
+#else
 // Validated that by default we don't normalize paths
 TEST_F(HttpConnectionManagerConfigTest, NormalizePathDefault) {
   const std::string yaml_string = R"EOF(
@@ -218,6 +237,7 @@ TEST_F(HttpConnectionManagerConfigTest, NormalizePathRuntime) {
                                      date_provider_, route_config_provider_manager_);
   EXPECT_TRUE(config.shouldNormalizePath());
 }
+#endif
 
 // Validated that when configured, we normalize paths, ignoring runtime.
 TEST_F(HttpConnectionManagerConfigTest, NormalizePathTrue) {

--- a/test/mocks/runtime/mocks.cc
+++ b/test/mocks/runtime/mocks.cc
@@ -4,8 +4,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::An;
-using testing::Invoke;
 using testing::Return;
 using testing::ReturnArg;
 
@@ -16,11 +14,7 @@ MockRandomGenerator::MockRandomGenerator() { ON_CALL(*this, uuid()).WillByDefaul
 
 MockRandomGenerator::~MockRandomGenerator() {}
 
-MockSnapshot::MockSnapshot() {
-  ON_CALL(*this, getInteger(_, _)).WillByDefault(ReturnArg<1>());
-  ON_CALL(*this, featureEnabled(_, An<uint64_t>()))
-      .WillByDefault(Invoke(this, &MockSnapshot::featureEnabledDefault));
-}
+MockSnapshot::MockSnapshot() { ON_CALL(*this, getInteger(_, _)).WillByDefault(ReturnArg<1>()); }
 
 MockSnapshot::~MockSnapshot() {}
 

--- a/test/mocks/runtime/mocks.cc
+++ b/test/mocks/runtime/mocks.cc
@@ -19,7 +19,7 @@ MockRandomGenerator::~MockRandomGenerator() {}
 MockSnapshot::MockSnapshot() {
   ON_CALL(*this, getInteger(_, _)).WillByDefault(ReturnArg<1>());
   ON_CALL(*this, featureEnabled(_, An<uint64_t>()))
-      .WillByDefault(Invoke(this, &MockSnapshot::inheritedFeatureEnableStringUint64));
+      .WillByDefault(Invoke(this, &MockSnapshot::featureEnabledDefault));
 }
 
 MockSnapshot::~MockSnapshot() {}

--- a/test/mocks/runtime/mocks.cc
+++ b/test/mocks/runtime/mocks.cc
@@ -4,6 +4,8 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::An;
+using testing::Invoke;
 using testing::Return;
 using testing::ReturnArg;
 
@@ -14,7 +16,11 @@ MockRandomGenerator::MockRandomGenerator() { ON_CALL(*this, uuid()).WillByDefaul
 
 MockRandomGenerator::~MockRandomGenerator() {}
 
-MockSnapshot::MockSnapshot() { ON_CALL(*this, getInteger(_, _)).WillByDefault(ReturnArg<1>()); }
+MockSnapshot::MockSnapshot() {
+  ON_CALL(*this, getInteger(_, _)).WillByDefault(ReturnArg<1>());
+  ON_CALL(*this, featureEnabled(_, An<uint64_t>()))
+      .WillByDefault(Invoke(this, &MockSnapshot::inheritedFeatureEnableStringUint64));
+}
 
 MockSnapshot::~MockSnapshot() {}
 

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -27,6 +27,18 @@ public:
   MockSnapshot();
   ~MockSnapshot() override;
 
+  // Provide a default implementation of mocked featureEnabled/2.
+  bool inheritedFeatureEnableStringUint64(const std::string&, uint64_t default_value) {
+    if (default_value == 0) {
+      return false;
+    } else if (default_value == 100) {
+      return true;
+    } else {
+      throw std::invalid_argument("Not implemented yet. You may want to set expectation of mocked "
+                                  "featureEnabled() instead.");
+    }
+  }
+
   MOCK_CONST_METHOD1(deprecatedFeatureEnabled, bool(const std::string& key));
   MOCK_CONST_METHOD1(runtimeFeatureEnabled, bool(absl::string_view key));
   MOCK_CONST_METHOD2(featureEnabled, bool(const std::string& key, uint64_t default_value));

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -28,7 +28,7 @@ public:
   ~MockSnapshot() override;
 
   // Provide a default implementation of mocked featureEnabled/2.
-  bool inheritedFeatureEnableStringUint64(const std::string&, uint64_t default_value) {
+  bool featureEnabledDefault(const std::string&, uint64_t default_value) {
     if (default_value == 0) {
       return false;
     } else if (default_value == 100) {


### PR DESCRIPTION
Description:

Context 

As a follow up of initial fix of cve-2019-9901

This PR provides an alternative approach to enable path normalization for
mesh providers. 
Previously to enable the feature, mesh provider must either
use the runtime which requires subtle authentication
update the xDS service with the new API which requires xDS release

Approach

This PR adds config "--define path_normalization_by_default=true" to bazel
With this bazel config, the path normalization in HCM will
- ignore the runtime
- turn on the normalization if the xDS is not aware of this config

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Risk Level:
LOW
Testing:
bazel build {,--define path_normalization_by_default=true} source/exe:envoy-static
bazel test {,--define path_normalization_by_default=true} source/extensions/filters/network/http_connection_manager:all

Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
