### PR TITLE
tests: fix a compilation error.

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -344,7 +344,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderMutateEmbeddedCRLF) {
           absl::StrCat(example_input.substr(0, n), std::string(1, c), example_input.substr(n)));
       try {
         codec_->dispatch(buffer);
-      } catch (CodecProtocolException) {
+      } catch (CodecProtocolException&) {
       }
     }
   }


### PR DESCRIPTION
Description:

Catch `CodecProtocolException` by reference to fix the following error when building tests:
```
test/common/http/http1/codec_impl_test.cc: In member function 'virtual void Envoy::Http::Http1::Http1ServerConnectionImplTest_HeaderMutateEmbeddedCRLF_Test::TestBody()':
test/common/http/http1/codec_impl_test.cc:347:16: error: catching polymorphic type 'class Envoy::Http::CodecProtocolException' by value [-Werror=catch-value=]
       } catch (CodecProtocolException) {
                ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```
Risk Level: low
Testing: compiling
Docs Changes: N/A
Release Notes: N/A
