### PR TITLE
cleanup: clang-tidy fixes

### DIFF
--- a/api/envoy/api/v2/rds.proto
+++ b/api/envoy/api/v2/rds.proto
@@ -46,7 +46,7 @@ service RouteDiscoveryService {
 }
 
 // Virtual Host Discovery Service (VHDS) is used to dynamically update the list of virtual hosts for
-// a given RouteConfiguration. If VHDS is configured a virtual host list update will be triggerred
+// a given RouteConfiguration. If VHDS is configured a virtual host list update will be triggered
 // during the processing of an HTTP request if a route for the request cannot be resolved. The
 // :ref:`resource_names_subscribe <envoy_api_msg_DeltaDiscoveryRequest.resource_names_subscribe>`
 // field contains a list of virtual host names or aliases to track. The contents of an alias would

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -45,10 +45,10 @@ bool PathUtil::canonicalPath(HeaderEntry& path_header) {
       query_pos == original_path.npos
           ? absl::string_view{}
           : absl::string_view{original_path.data() + query_pos, original_path.size() - query_pos};
-  if (query_suffix.size() > 0) {
+  if (!query_suffix.empty()) {
     normalized_path.insert(normalized_path.end(), query_suffix.begin(), query_suffix.end());
   }
-  path_header.value(std::move(normalized_path));
+  path_header.value(normalized_path);
   return true;
 }
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -25,16 +25,16 @@ InstanceImpl::InstanceImpl(
 }
 
 Common::Redis::Client::PoolRequest*
-InstanceImpl::makeRequest(const std::string& key, const Common::Redis::RespValue& value,
+InstanceImpl::makeRequest(const std::string& key, const Common::Redis::RespValue& request,
                           Common::Redis::Client::PoolCallbacks& callbacks) {
-  return tls_->getTyped<ThreadLocalPool>().makeRequest(key, value, callbacks);
+  return tls_->getTyped<ThreadLocalPool>().makeRequest(key, request, callbacks);
 }
 
 Common::Redis::Client::PoolRequest*
 InstanceImpl::makeRequestToHost(const std::string& host_address,
-                                const Common::Redis::RespValue& value,
+                                const Common::Redis::RespValue& request,
                                 Common::Redis::Client::PoolCallbacks& callbacks) {
-  return tls_->getTyped<ThreadLocalPool>().makeRequestToHost(host_address, value, callbacks);
+  return tls_->getTyped<ThreadLocalPool>().makeRequestToHost(host_address, request, callbacks);
 }
 
 InstanceImpl::ThreadLocalPool::ThreadLocalPool(InstanceImpl& parent, Event::Dispatcher& dispatcher,


### PR DESCRIPTION
Description: minor fixes to fix spelling and make clang-tidy happy
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>

