### PR TITLE
retry policy: check retry conditions before remaining retry count

### DIFF
--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -158,14 +158,15 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
 
   resetRetry();
 
+  if (!would_retry) {
+    return RetryStatus::No;
+  }
+
   if (retries_remaining_ == 0) {
     return RetryStatus::NoRetryLimitExceeded;
   }
 
   retries_remaining_--;
-  if (!would_retry) {
-    return RetryStatus::No;
-  }
 
   if (!cluster_.resourceManager(priority_).retries().canCreate()) {
     cluster_.stats().upstream_rq_retry_overflow_.inc();

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -284,6 +284,8 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
   EXPECT_TRUE(state_->enabled());
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_reset_, callback_));
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
 
@@ -496,7 +498,7 @@ TEST_F(RouterRetryStateImplTest, Backoff) {
   retry_timer_->callback_();
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
+  EXPECT_EQ(RetryStatus::No,
             state_->shouldRetryHeaders(response_headers, callback_));
 
   EXPECT_EQ(3UL, cluster_.stats().upstream_rq_retry_.value());
@@ -536,6 +538,23 @@ TEST_F(RouterRetryStateImplTest, ZeroMaxRetriesHeader) {
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryReset(connect_failure_, callback_));
+}
+
+// Check that if there are 0 remaining retries available but we get
+// non-retriable headers, we return No rather than NoRetryLimitExceeded.
+TEST_F(RouterRetryStateImplTest, NoPreferredOverLimitExceeded) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"},
+                                          {"x-envoy-max-retries", "1"}};
+  setup(request_headers);
+
+  Http::TestHeaderMapImpl bad_response_headers{{":status", "503"}};
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes,
+            state_->shouldRetryHeaders(bad_response_headers, callback_));
+
+  Http::TestHeaderMapImpl good_response_headers{{":status", "200"}};
+  EXPECT_EQ(RetryStatus::No,
+            state_->shouldRetryHeaders(good_response_headers, callback_));
 }
 
 } // namespace

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -498,8 +498,7 @@ TEST_F(RouterRetryStateImplTest, Backoff) {
   retry_timer_->callback_();
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(RetryStatus::No,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
 
   EXPECT_EQ(3UL, cluster_.stats().upstream_rq_retry_.value());
   EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_success_.value());
@@ -549,12 +548,10 @@ TEST_F(RouterRetryStateImplTest, NoPreferredOverLimitExceeded) {
 
   Http::TestHeaderMapImpl bad_response_headers{{":status", "503"}};
   expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes,
-            state_->shouldRetryHeaders(bad_response_headers, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(bad_response_headers, callback_));
 
   Http::TestHeaderMapImpl good_response_headers{{":status", "200"}};
-  EXPECT_EQ(RetryStatus::No,
-            state_->shouldRetryHeaders(good_response_headers, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(good_response_headers, callback_));
 }
 
 } // namespace


### PR DESCRIPTION
This commit reorders some of the checks in the HTTP retry state
implementation. Previously, it would check if there are remaining
retries before checking if a retry would be attempted based on the retry
policy and event that's occuring. This means that shouldRetry might
return NoRetryLimitExceeded for cases that should not be retried anyway.
This bubbles up to the router and causes a response flag that might be
confusing to end users. In particular this happens if the final retry
attempt succeeds.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: check retry conditions before remaining retries in HTTP retry state impl.
Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
