### PR TITLE
add response code details to stream info

### DIFF
--- a/include/envoy/stream_info/BUILD
+++ b/include/envoy/stream_info/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         "//include/envoy/upstream:host_description_interface",
         "//source/common/common:assert_lib",
         "//source/common/protobuf",
+        "//source/common/singleton:const_singleton",
     ],
 )
 

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -74,7 +74,7 @@ enum ResponseFlag {
  * scoped to avoid collisions.
  */
 struct ResponseCodeDetailValues {
-  const std::string RC_SET_BY_UPSTREAM = "response_code_set_by_upstream";
+  const std::string SET_BY_UPSTREAM = "set_by_upstream";
 
   // TODO(#6542): add values for sendLocalReply use-cases
 };

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -65,6 +65,14 @@ enum ResponseFlag {
   LastFlag = StreamIdleTimeout
 };
 
+/**
+ * Constants for the response code details field of StreamInfo.
+ *
+ * These provide details about the stream state such as whether the
+ * response is from the upstream or from envoy (in case of a local reply).
+ * Custom extensions can define additional values provided they are appropriately
+ * scoped to avoid collisions.
+ */
 struct ResponseCodeDetailValues {
   const std::string RC_SET_BY_UPSTREAM = "response_code_set_by_upstream";
 };
@@ -125,8 +133,9 @@ public:
 
   /**
    * @param rc_details the response code details string to set for this request.
+   * See ResponseCodeDetailValues above for well-known constants.
    */
-  virtual void setResponseCodeDetails(const std::string& rc_details) PURE;
+  virtual void setResponseCodeDetails(absl::string_view rc_details) PURE;
 
   /**
    * @param response_flags the response_flags to intersect with.

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -74,7 +74,8 @@ enum ResponseFlag {
  * scoped to avoid collisions.
  */
 struct ResponseCodeDetailValues {
-  const std::string SET_BY_UPSTREAM = "set_by_upstream";
+  // Response code was set by the upstream.
+  const std::string ViaUpstream = "via_upstream";
 
   // TODO(#6542): add values for sendLocalReply use-cases
 };

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -14,6 +14,7 @@
 
 #include "common/common/assert.h"
 #include "common/protobuf/protobuf.h"
+#include "common/singleton/const_singleton.h"
 
 #include "absl/types/optional.h"
 
@@ -63,6 +64,12 @@ enum ResponseFlag {
   // ATTENTION: MAKE SURE THIS REMAINS EQUAL TO THE LAST FLAG.
   LastFlag = StreamIdleTimeout
 };
+
+struct ResponseCodeDetailValues {
+  const std::string RC_SET_BY_UPSTREAM = "response_code_set_by_upstream";
+};
+
+typedef ConstSingleton<ResponseCodeDetailValues> ResponseCodeDetails;
 
 struct UpstreamTiming {
   /**
@@ -117,6 +124,11 @@ public:
   virtual void setResponseFlag(ResponseFlag response_flag) PURE;
 
   /**
+   * @param rc_details the response code details string to set for this request.
+   */
+  virtual void setResponseCodeDetails(const std::string& rc_details) PURE;
+
+  /**
    * @param response_flags the response_flags to intersect with.
    * @return true if the intersection of the response_flags argument and the currently set response
    * flags is non-empty.
@@ -152,6 +164,11 @@ public:
    * @return the response code.
    */
   virtual absl::optional<uint32_t> responseCode() const PURE;
+
+  /**
+   * @return the response code details.
+   */
+  virtual const absl::optional<std::string>& responseCodeDetails() const PURE;
 
   /**
    * @return the time that the first byte of the request was received.

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -75,6 +75,8 @@ enum ResponseFlag {
  */
 struct ResponseCodeDetailValues {
   const std::string RC_SET_BY_UPSTREAM = "response_code_set_by_upstream";
+
+  // TODO(#6542): add values for sendLocalReply use-cases
 };
 
 typedef ConstSingleton<ResponseCodeDetailValues> ResponseCodeDetails;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -321,6 +321,8 @@ private:
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(HeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
+    // TODO(eziskind): add an extra parameter for setting rc details
+    stream_info_.setResponseCodeDetails("");
     Utility::sendLocalReply(
         is_grpc_request_,
         [this, modify_headers](HeaderMapPtr&& headers, bool end_stream) -> void {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -321,7 +321,7 @@ private:
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(HeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
-    // TODO(eziskind): add an extra parameter for setting rc details
+    // TODO(#6542): add an extra parameter for setting rc details
     stream_info_.setResponseCodeDetails("");
     Utility::sendLocalReply(
         is_grpc_request_,

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -222,6 +222,8 @@ private:
     void sendLocalReply(Code code, absl::string_view body,
                         std::function<void(HeaderMap& headers)> modify_headers,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
+      // TODO(eziskind): add an extra parameter for setting rc details
+      parent_.stream_info_.setResponseCodeDetails("");
       parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, parent_.is_head_request_,
                              grpc_status);
     }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -222,7 +222,7 @@ private:
     void sendLocalReply(Code code, absl::string_view body,
                         std::function<void(HeaderMap& headers)> modify_headers,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
-      // TODO(eziskind): add an extra parameter for setting rc details
+      // TODO(#6542): add an extra parameter for setting rc details
       parent_.stream_info_.setResponseCodeDetails("");
       parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, parent_.is_head_request_,
                              grpc_status);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -792,6 +792,8 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& head
     onUpstreamComplete();
   }
 
+  callbacks_->streamInfo().setResponseCodeDetails(
+      StreamInfo::ResponseCodeDetails::get().RC_SET_BY_UPSTREAM);
   callbacks_->encodeHeaders(std::move(headers), end_stream);
 }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -793,7 +793,7 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& head
   }
 
   callbacks_->streamInfo().setResponseCodeDetails(
-      StreamInfo::ResponseCodeDetails::get().SET_BY_UPSTREAM);
+      StreamInfo::ResponseCodeDetails::get().ViaUpstream);
   callbacks_->encodeHeaders(std::move(headers), end_stream);
 }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -793,7 +793,7 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& head
   }
 
   callbacks_->streamInfo().setResponseCodeDetails(
-      StreamInfo::ResponseCodeDetails::get().RC_SET_BY_UPSTREAM);
+      StreamInfo::ResponseCodeDetails::get().SET_BY_UPSTREAM);
   callbacks_->encodeHeaders(std::move(headers), end_stream);
 }
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -100,6 +100,14 @@ struct StreamInfoImpl : public StreamInfo {
 
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
 
+  const absl::optional<std::string>& responseCodeDetails() const override {
+    return response_code_details_;
+  }
+
+  void setResponseCodeDetails(const std::string& rc_details) override {
+    response_code_details_ = rc_details;
+  }
+
   void addBytesSent(uint64_t bytes_sent) override { bytes_sent_ += bytes_sent; }
 
   uint64_t bytesSent() const override { return bytes_sent_; }
@@ -205,6 +213,7 @@ struct StreamInfoImpl : public StreamInfo {
 
   absl::optional<Http::Protocol> protocol_;
   absl::optional<uint32_t> response_code_;
+  absl::optional<std::string> response_code_details_;
   uint64_t response_flags_{};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool health_check_request_{};

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -104,8 +104,8 @@ struct StreamInfoImpl : public StreamInfo {
     return response_code_details_;
   }
 
-  void setResponseCodeDetails(const std::string& rc_details) override {
-    response_code_details_ = rc_details;
+  void setResponseCodeDetails(absl::string_view rc_details) override {
+    response_code_details_.emplace(rc_details);
   }
 
   void addBytesSent(uint64_t bytes_sent) override { bytes_sent_ += bytes_sent; }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3119,6 +3119,9 @@ TEST_F(HttpConnectionManagerImplTest, HitRequestBufferLimits) {
   EXPECT_CALL(*encoder_filters_[1], encodeComplete());
   Buffer::OwnedImpl data("A longer string");
   decoder_filters_[0]->callbacks_->addDecodedData(data, false);
+  const auto rc_details = encoder_filters_[1]->callbacks_->streamInfo().responseCodeDetails();
+  EXPECT_TRUE(rc_details.has_value());
+  EXPECT_EQ("", rc_details.value());
 }
 
 // Return 413 from an intermediate filter and make sure we don't continue the filter chain.

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -755,8 +755,8 @@ TEST_F(RouterTest, ResponseCodeDetailsSetByUpstream) {
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
-  EXPECT_CALL(callbacks_.stream_info_,
-              setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().RC_SET_BY_UPSTREAM));
+  absl::string_view rc_details = StreamInfo::ResponseCodeDetails::get().RC_SET_BY_UPSTREAM;
+  EXPECT_CALL(callbacks_.stream_info_, setResponseCodeDetails(rc_details));
   response_decoder->decodeHeaders(std::move(response_headers), true);
   EXPECT_TRUE(verifyHostUpstreamStats(1, 0));
 }

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -755,7 +755,7 @@ TEST_F(RouterTest, ResponseCodeDetailsSetByUpstream) {
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
-  absl::string_view rc_details = StreamInfo::ResponseCodeDetails::get().RC_SET_BY_UPSTREAM;
+  absl::string_view rc_details = StreamInfo::ResponseCodeDetails::get().SET_BY_UPSTREAM;
   EXPECT_CALL(callbacks_.stream_info_, setResponseCodeDetails(rc_details));
   response_decoder->decodeHeaders(std::move(response_headers), true);
   EXPECT_TRUE(verifyHostUpstreamStats(1, 0));

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -755,7 +755,7 @@ TEST_F(RouterTest, ResponseCodeDetailsSetByUpstream) {
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
-  absl::string_view rc_details = StreamInfo::ResponseCodeDetails::get().SET_BY_UPSTREAM;
+  absl::string_view rc_details = StreamInfo::ResponseCodeDetails::get().ViaUpstream;
   EXPECT_CALL(callbacks_.stream_info_, setResponseCodeDetails(rc_details));
   response_decoder->decodeHeaders(std::move(response_headers), true);
   EXPECT_TRUE(verifyHostUpstreamStats(1, 0));

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -143,10 +143,9 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     EXPECT_EQ(200, stream_info.responseCode().value());
 
     EXPECT_FALSE(stream_info.responseCodeDetails().has_value());
-    stream_info.setResponseCodeDetails(ResponseCodeDetails::get().SET_BY_UPSTREAM);
+    stream_info.setResponseCodeDetails(ResponseCodeDetails::get().ViaUpstream);
     ASSERT_TRUE(stream_info.responseCodeDetails().has_value());
-    EXPECT_EQ(ResponseCodeDetails::get().SET_BY_UPSTREAM,
-              stream_info.responseCodeDetails().value());
+    EXPECT_EQ(ResponseCodeDetails::get().ViaUpstream, stream_info.responseCodeDetails().value());
 
     EXPECT_EQ(nullptr, stream_info.upstreamHost());
     Upstream::HostDescriptionConstSharedPtr host(new NiceMock<Upstream::MockHostDescription>());

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -143,9 +143,9 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     EXPECT_EQ(200, stream_info.responseCode().value());
 
     EXPECT_FALSE(stream_info.responseCodeDetails().has_value());
-    stream_info.setResponseCodeDetails(ResponseCodeDetails::get().RC_SET_BY_UPSTREAM);
+    stream_info.setResponseCodeDetails(ResponseCodeDetails::get().SET_BY_UPSTREAM);
     ASSERT_TRUE(stream_info.responseCodeDetails().has_value());
-    EXPECT_EQ(ResponseCodeDetails::get().RC_SET_BY_UPSTREAM,
+    EXPECT_EQ(ResponseCodeDetails::get().SET_BY_UPSTREAM,
               stream_info.responseCodeDetails().value());
 
     EXPECT_EQ(nullptr, stream_info.upstreamHost());

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -142,6 +142,12 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     ASSERT_TRUE(stream_info.responseCode());
     EXPECT_EQ(200, stream_info.responseCode().value());
 
+    EXPECT_FALSE(stream_info.responseCodeDetails().has_value());
+    stream_info.setResponseCodeDetails(ResponseCodeDetails::get().RC_SET_BY_UPSTREAM);
+    ASSERT_TRUE(stream_info.responseCodeDetails().has_value());
+    EXPECT_EQ(ResponseCodeDetails::get().RC_SET_BY_UPSTREAM,
+              stream_info.responseCodeDetails().value());
+
     EXPECT_EQ(nullptr, stream_info.upstreamHost());
     Upstream::HostDescriptionConstSharedPtr host(new NiceMock<Upstream::MockHostDescription>());
     stream_info.onUpstreamHostSelected(host);

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -31,6 +31,12 @@ public:
   absl::optional<Http::Protocol> protocol() const override { return protocol_; }
   void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
+  const absl::optional<std::string>& responseCodeDetails() const override {
+    return response_code_details_;
+  }
+  void setResponseCodeDetails(const std::string& rc_details) override {
+    response_code_details_ = rc_details;
+  }
   void addBytesSent(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesSent() const override { return 2; }
   bool intersectResponseFlags(uint64_t response_flags) const override {
@@ -188,6 +194,7 @@ public:
 
   absl::optional<Http::Protocol> protocol_{Http::Protocol::Http11};
   absl::optional<uint32_t> response_code_;
+  absl::optional<std::string> response_code_details_;
   uint64_t response_flags_{};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool health_check_request_{};

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -34,8 +34,8 @@ public:
   const absl::optional<std::string>& responseCodeDetails() const override {
     return response_code_details_;
   }
-  void setResponseCodeDetails(const std::string& rc_details) override {
-    response_code_details_ = rc_details;
+  void setResponseCodeDetails(absl::string_view rc_details) override {
+    response_code_details_.emplace(rc_details);
   }
   void addBytesSent(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesSent() const override { return 2; }

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -70,6 +70,7 @@ MockStreamInfo::MockStreamInfo()
   }));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));
   ON_CALL(*this, responseCode()).WillByDefault(ReturnPointee(&response_code_));
+  ON_CALL(*this, responseCodeDetails()).WillByDefault(ReturnPointee(&response_code_details_));
   ON_CALL(*this, addBytesReceived(_)).WillByDefault(Invoke([this](uint64_t bytes_received) {
     bytes_received_ += bytes_received;
   }));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -18,7 +18,7 @@ public:
 
   // StreamInfo::StreamInfo
   MOCK_METHOD1(setResponseFlag, void(ResponseFlag response_flag));
-  MOCK_METHOD1(setResponseCodeDetails, void(const std::string&));
+  MOCK_METHOD1(setResponseCodeDetails, void(absl::string_view));
   MOCK_CONST_METHOD1(intersectResponseFlags, bool(uint64_t));
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionConstSharedPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
@@ -92,6 +92,7 @@ public:
   absl::optional<std::chrono::nanoseconds> end_time_;
   absl::optional<Http::Protocol> protocol_;
   absl::optional<uint32_t> response_code_;
+  absl::optional<std::string> response_code_details_;
   envoy::api::v2::core::Metadata metadata_;
   FilterStateImpl filter_state_;
   uint64_t bytes_received_{};

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -18,6 +18,7 @@ public:
 
   // StreamInfo::StreamInfo
   MOCK_METHOD1(setResponseFlag, void(ResponseFlag response_flag));
+  MOCK_METHOD1(setResponseCodeDetails, void(const std::string&));
   MOCK_CONST_METHOD1(intersectResponseFlags, bool(uint64_t));
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionConstSharedPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
@@ -44,6 +45,7 @@ public:
   MOCK_CONST_METHOD0(protocol, absl::optional<Http::Protocol>());
   MOCK_METHOD1(protocol, void(Http::Protocol protocol));
   MOCK_CONST_METHOD0(responseCode, absl::optional<uint32_t>());
+  MOCK_CONST_METHOD0(responseCodeDetails, const absl::optional<std::string>&());
   MOCK_METHOD1(addBytesSent, void(uint64_t));
   MOCK_CONST_METHOD0(bytesSent, uint64_t());
   MOCK_CONST_METHOD1(hasResponseFlag, bool(ResponseFlag));


### PR DESCRIPTION
Description: add a response code field to the StreamInfo object with a helper class to hold well-known constants. For now this just has 1 value which lets access logs tell if the response is coming from the upstream vs from the envoy itself (in the case of a sendLocalReply), but many more values will added in future PRs. Making this a string rather than an enum so that 3rd parties can extend it.
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
