### PR TITLE
tests: add test for invalid cors config on route

### DIFF
--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4137,6 +4137,26 @@ virtual_hosts:
   EXPECT_EQ(cors_policy->allowCredentials(), true);
 }
 
+TEST_F(RoutePropertyTest, TestBadCorsConfig) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: default
+  domains:
+  - "*"
+  routes:
+  - match:
+      prefix: "/api"
+    route:
+      cluster: ats
+      cors:
+        enabled: 0
+        allow_credentials: true
+)EOF";
+
+  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+               EnvoyException);
+}
+
 TEST_F(RouteMatcherTest, Decorator) {
   const std::string yaml = R"EOF(
 virtual_hosts:

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4157,9 +4157,8 @@ virtual_hosts:
       EnvoyException,
       "Unable to parse JSON as proto "
       "(INVALID_ARGUMENT:(virtual_hosts[0].routes[0].route.cors.enabled.value): invalid value 0 "
-      "for type TYPE_BOOL): "
-      "{\"virtual_hosts\":[{\"routes\":[{\"route\":{\"cors\":{\"enabled\":0},\"cluster\":\"ats\"},"
-      "\"match\":{\"prefix\":\"/api\"}}],\"domains\":[\"*\"],\"name\":\"default\"}]}");
+      "for type TYPE_BOOL): " +
+          Json::Factory::loadFromYamlString(yaml)->asJsonString());
 }
 
 TEST_F(RouteMatcherTest, Decorator) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4150,11 +4150,16 @@ virtual_hosts:
       cluster: ats
       cors:
         enabled: 0
-        allow_credentials: true
 )EOF";
 
-  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
-               EnvoyException);
+  EXPECT_THROW_WITH_MESSAGE(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "Unable to parse JSON as proto "
+      "(INVALID_ARGUMENT:(virtual_hosts[0].routes[0].route.cors.enabled.value): invalid value 0 "
+      "for type TYPE_BOOL): "
+      "{\"virtual_hosts\":[{\"routes\":[{\"route\":{\"cors\":{\"enabled\":0},\"cluster\":\"ats\"},"
+      "\"match\":{\"prefix\":\"/api\"}}],\"domains\":[\"*\"],\"name\":\"default\"}]}");
 }
 
 TEST_F(RouteMatcherTest, Decorator) {


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: Add a test for invalid CORS configurations
Risk Level: Low
Testing: Ran test locally
Docs Changes: N/A
Release Notes: N/A
