### PR TITLE
test: cds api test configs to v2

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -19,10 +19,12 @@ envoy_cc_test(
         "//source/common/config:utility_lib",
         "//source/common/http:message_lib",
         "//source/common/json:json_loader_lib",
+        "//source/common/protobuf:utility_lib",
         "//source/common/upstream:cds_api_lib",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/api/v2/core:config_source_cc",
     ],
 )
 

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -7,6 +7,9 @@
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
 #include "common/upstream/cds_api_impl.h"
+#include "common/protobuf/utility.h"
+
+#include "envoy/api/v2/core/config_source.pb.validate.h"
 
 #include "test/common/upstream/utility.h"
 #include "test/mocks/local_info/mocks.h"
@@ -36,19 +39,16 @@ protected:
   CdsApiImplTest() : request_(&cm_.async_client_), api_(Api::createApiForTest(store_)) {}
 
   void setup() {
-    const std::string config_json = R"EOF(
-    {
-      "cluster": {
-        "name": "foo_cluster"
-      }
-    }
+    const std::string config_yaml = R"EOF(
+api_config_source:
+  cluster_names:
+  - foo_cluster
+  refresh_delay: 1s
+  api_type: REST
     )EOF";
 
-    Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
     envoy::api::v2::core::ConfigSource cds_config;
-    Config::Utility::translateCdsConfig(*config, cds_config);
-    cds_config.mutable_api_config_source()->set_api_type(
-        envoy::api::v2::core::ApiConfigSource::REST);
+    MessageUtil::loadFromYamlAndValidate(config_yaml, cds_config);
     cluster_map_.emplace("foo_cluster", mock_cluster_);
     EXPECT_CALL(cm_, clusters()).WillRepeatedly(Return(cluster_map_));
     EXPECT_CALL(mock_cluster_, info()).Times(AnyNumber());
@@ -288,19 +288,17 @@ TEST_F(CdsApiImplTest, ConfigUpdateAddsSecondClusterEvenIfFirstThrows) {
 }
 
 TEST_F(CdsApiImplTest, InvalidOptions) {
-  const std::string config_json = R"EOF(
-  {
-    "cluster": {
-      "name": "foo_cluster"
-    }
-  }
+  const std::string config_yaml = R"EOF(
+api_config_source:
+  cluster_names:
+  - foo_cluster
+  refresh_delay: 1s
   )EOF";
 
-  Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
   local_info_.node_.set_cluster("");
   local_info_.node_.set_id("");
   envoy::api::v2::core::ConfigSource cds_config;
-  Config::Utility::translateCdsConfig(*config, cds_config);
+  MessageUtil::loadFromYamlAndValidate(config_yaml, cds_config);
   EXPECT_THROW(
       CdsApiImpl::create(cds_config, cm_, dispatcher_, random_, local_info_, store_, *api_),
       EnvoyException);

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -3,13 +3,13 @@
 #include <string>
 #include <vector>
 
+#include "envoy/api/v2/core/config_source.pb.validate.h"
+
 #include "common/config/utility.h"
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
-#include "common/upstream/cds_api_impl.h"
 #include "common/protobuf/utility.h"
-
-#include "envoy/api/v2/core/config_source.pb.validate.h"
+#include "common/upstream/cds_api_impl.h"
 
 #include "test/common/upstream/utility.h"
 #include "test/mocks/local_info/mocks.h"


### PR DESCRIPTION
Description: Convert v1 config stubs for CDS API tests to v2. For #6362.
Risk Level: none
Testing: included
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Derek Argueta <dereka@pinterest.com>