### PR TITLE
test: update http ratelimit for v2

### DIFF
--- a/test/extensions/filters/http/ratelimit/BUILD
+++ b/test/extensions/filters/http/ratelimit/BUILD
@@ -18,7 +18,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/common:empty_string",
-        "//source/common/config:filter_json_lib",
         "//source/common/http:context_lib",
         "//source/common/http:headers_lib",
         "//source/extensions/filters/common/ratelimit:ratelimit_lib",

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -36,7 +36,7 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   )EOF";
 
   envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
-  MessageUtil::loadFromYaml(yaml, proto_config);
+  MessageUtil::loadFromYamlAndValidate(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
@@ -68,12 +68,12 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
 
 TEST(RateLimitFilterConfigTest, BadRateLimitFilterConfig) {
   const std::string yaml = R"EOF(
-  domain: test
-  timeout: 20
+  domain: foo
+  route_key: my_route
   )EOF";
 
   envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
-  EXPECT_THROW(MessageUtil::loadFromYaml(yaml, proto_config), EnvoyException);
+  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromYamlAndValidate(yaml, proto_config), EnvoyException, "INVALID_ARGUMENT:route_key: Cannot find field");
 }
 
 } // namespace

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -73,7 +73,8 @@ TEST(RateLimitFilterConfigTest, BadRateLimitFilterConfig) {
   )EOF";
 
   envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
-  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromYamlAndValidate(yaml, proto_config), EnvoyException, "INVALID_ARGUMENT:route_key: Cannot find field");
+  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromYamlAndValidate(yaml, proto_config), EnvoyException,
+                          "INVALID_ARGUMENT:route_key: Cannot find field");
 }
 
 } // namespace

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -4,7 +4,6 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/empty_string.h"
-#include "common/config/filter_json.h"
 #include "common/http/context_impl.h"
 #include "common/http/headers.h"
 
@@ -94,20 +93,6 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   Http::ContextImpl http_context_;
 };
-
-TEST_F(HttpRateLimitFilterTest, BadConfig) {
-  const std::string filter_config = R"EOF(
-  {
-    "domain": "foo",
-    "route_key" : "my_route"
-  }
-  )EOF";
-
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(filter_config);
-  envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
-  EXPECT_THROW(Config::FilterJson::translateHttpRateLimitFilter(*json_config, proto_config),
-               Json::Exception);
-}
 
 TEST_F(HttpRateLimitFilterTest, NoRoute) {
   SetUpTest(filter_config_);


### PR DESCRIPTION
Description: In this case there was only 1 test that needed updating, but its practically a duplicate of an existing test in config tests (the two are called `BadConfig` and `BadRateLimitFilterConfig`) so I removed it from the ratelimit filter tests and updated the config test. Previously, the config test was failing due to giving `20` to a duration type instead of `20s` so changed it to fail for an unknown key instead. For #6362.
Risk Level: none
Testing: included
Docs Changes: n/a
Release Notes: n/a
