### PR TITLE
runtime: fixing a stat bug

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -157,8 +157,9 @@ void MessageUtil::checkForDeprecation(const Protobuf::Message& message, Runtime:
     // Allow runtime to be null both to not crash if this is called before server initialization,
     // and so proto validation works in context where runtime singleton is not set up (e.g.
     // standalone config validation utilities)
-    if (runtime && !runtime->snapshot().deprecatedFeatureEnabled(
-                       absl::StrCat("envoy.deprecated_features.", filename, ":", field->name()))) {
+    if (runtime && field->options().deprecated() &&
+        !runtime->snapshot().deprecatedFeatureEnabled(
+            absl::StrCat("envoy.deprecated_features.", filename, ":", field->name()))) {
       warn_only = false;
     }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -472,6 +472,7 @@ TEST_F(DeprecatedFieldsTest, NoErrorWhenDeprecatedFieldsUnused) {
   base.set_not_deprecated("foo");
   // Fatal checks for a non-deprecated field should cause no problem.
   MessageUtil::checkForDeprecation(base);
+  EXPECT_EQ(0, store_.gauge("runtime.deprecated_feature_use").value());
 }
 
 TEST_F(DeprecatedFieldsTest, IndividualFieldDeprecated) {
@@ -481,6 +482,7 @@ TEST_F(DeprecatedFieldsTest, IndividualFieldDeprecated) {
   EXPECT_LOG_CONTAINS("warning",
                       "Using deprecated option 'envoy.test.deprecation_test.Base.is_deprecated'",
                       MessageUtil::checkForDeprecation(base));
+  EXPECT_EQ(1, store_.gauge("runtime.deprecated_feature_use").value());
 }
 
 // Use of a deprecated and disallowed field should result in an exception.


### PR DESCRIPTION
Fixing a bug where we were over-enthusiastically treating all fields as deprecated for stats, not just deprecated fields.

Risk Level: low (stats bugfix)
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a
