### PR TITLE
tidy: Add HeaderMap.empty() method, consistent with other containers

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -512,6 +512,11 @@ public:
   virtual size_t size() const PURE;
 
   /**
+   * @return true if the map is empty, false otherwise.
+   */
+  virtual bool empty() const PURE;
+
+  /**
    * Allow easy pretty-printing of the key/value pairs in HeaderMap
    * @param os supplies the ostream to print to.
    * @param headers the headers to print.

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -80,6 +80,7 @@ public:
   void remove(const LowerCaseString& key) override;
   void removePrefix(const LowerCaseString& key) override;
   size_t size() const override { return headers_.size(); }
+  bool empty() const override { return headers_.empty(); }
 
 protected:
   // For tests only, unoptimized, they aren't intended for regular HeaderMapImpl users.
@@ -177,6 +178,7 @@ protected:
     std::list<HeaderEntryImpl>::const_reverse_iterator rbegin() const { return headers_.rbegin(); }
     std::list<HeaderEntryImpl>::const_reverse_iterator rend() const { return headers_.rend(); }
     size_t size() const { return headers_.size(); }
+    bool empty() const { return headers_.empty(); }
 
   private:
     std::list<HeaderEntryImpl> headers_;


### PR DESCRIPTION
Signed-off-by: James Synge <jamessynge@google.com>
