### PR TITLE
redis: fix asking output for ask redirection support

### DIFF
--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -27,6 +27,19 @@ Common::Redis::RespValuePtr Utility::makeError(const std::string& error) {
 
 namespace {
 
+// nullPoolCallbacks is used for requests that must be filtered and not redirected such as "asking".
+DoNothingPoolCallbacks nullPoolCallbacks;
+
+// Create an asking command request.
+Common::Redis::RespValue askingRequest() {
+  Common::Redis::RespValue asking_cmd, request;
+  asking_cmd.type(Common::Redis::RespType::BulkString);
+  asking_cmd.asString() = "asking";
+  request.type(Common::Redis::RespType::Array);
+  request.asArray().push_back(asking_cmd);
+  return request;
+}
+
 /**
  * Validate the received moved/ask redirection error and the original redis request.
  * @param[in] original_request supplies the incoming request associated with the command splitter
@@ -91,22 +104,6 @@ void SingleServerRequest::onFailure() {
   callbacks_.onResponse(Utility::makeError(Response::get().UpstreamFailure));
 }
 
-void SingleServerRequest::recreate(Common::Redis::RespValue& request, bool prepend_asking) {
-  if (!prepend_asking) {
-    request = *incoming_request_;
-    return;
-  }
-
-  Common::Redis::RespValue asking_cmd;
-  asking_cmd.type(Common::Redis::RespType::BulkString);
-  asking_cmd.asString() = "asking";
-
-  request.type(Common::Redis::RespType::Array);
-  request.asArray().push_back(asking_cmd);
-  request.asArray().insert(request.asArray().end(), incoming_request_->asArray().begin(),
-                           incoming_request_->asArray().end());
-}
-
 bool SingleServerRequest::onRedirection(const Common::Redis::RespValue& value) {
   std::vector<absl::string_view> err;
   bool ask_redirection = false;
@@ -114,11 +111,13 @@ bool SingleServerRequest::onRedirection(const Common::Redis::RespValue& value) {
     return false;
   }
 
-  Common::Redis::RespValue request;
-  recreate(request, ask_redirection);
-
   const std::string host_address = std::string(err[2]); // ip:port
-  handle_ = conn_pool_->makeRequestToHost(host_address, request, *this);
+  // Prepend request with asking command if redirected via ASK error.
+  if (ask_redirection &&
+      !conn_pool_->makeRequestToHost(host_address, askingRequest(), nullPoolCallbacks)) {
+    return false;
+  }
+  handle_ = conn_pool_->makeRequestToHost(host_address, *incoming_request_, *this);
   return (handle_ != nullptr);
 }
 
@@ -240,6 +239,35 @@ SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
   return nullptr;
 }
 
+bool FragmentedRequest::onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
+                                           ConnPool::Instance* conn_pool) {
+  std::vector<absl::string_view> err;
+  bool ask_redirection = false;
+  if (redirectionArgsInvalid(incoming_request_.get(), value, err, ask_redirection) || !conn_pool) {
+    return false;
+  }
+
+  // MOVED and ASK redirection errors have the following substrings: MOVED or ASK (err[0]), hash key
+  // slot (err[1]), and IP address and TCP port separated by a colon (err[2]).
+  std::string host_address = std::string(err[2]);
+  Common::Redis::RespValue request;
+  recreate(request, index);
+
+  // Prepend request with an asking command if redirected via an ASK error. The returned handle is
+  // not important since there is no point in being able to cancel the request. The use of
+  // nullPoolCallbacks ensures the transparent filtering of the Redis server's response to the
+  // "asking" command; this is fine since the server either responds with an OK or an error message
+  // if cluster support is not enabled (in which case, we should not get an ASK redirection error).
+  if (ask_redirection &&
+      !conn_pool->makeRequestToHost(host_address, askingRequest(), nullPoolCallbacks)) {
+    return false;
+  }
+
+  this->pending_requests_[index].handle_ =
+      conn_pool->makeRequestToHost(host_address, request, this->pending_requests_[index]);
+  return (this->pending_requests_[index].handle_ != nullptr);
+}
+
 void MGETRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) {
   pending_requests_[index].handle_ = nullptr;
 
@@ -273,9 +301,9 @@ void MGETRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t 
   }
 }
 
-void MGETRequest::recreate(Common::Redis::RespValue& request, uint32_t index, bool prepend_asking) {
+void MGETRequest::recreate(Common::Redis::RespValue& request, uint32_t index) {
   static const uint32_t GET_COMMAND_SUBSTRINGS = 2;
-  uint32_t num_values = prepend_asking ? (GET_COMMAND_SUBSTRINGS + 1) : GET_COMMAND_SUBSTRINGS;
+  uint32_t num_values = GET_COMMAND_SUBSTRINGS;
   std::vector<Common::Redis::RespValue> values(num_values);
 
   for (uint32_t i = 0; i < num_values; i++) {
@@ -283,28 +311,9 @@ void MGETRequest::recreate(Common::Redis::RespValue& request, uint32_t index, bo
   }
   values[--num_values].asString() = incoming_request_->asArray()[index + 1].asString();
   values[--num_values].asString() = "get";
-  if (prepend_asking) {
-    values[--num_values].asString() = "asking";
-  }
 
   request.type(Common::Redis::RespType::Array);
   request.asArray().swap(values);
-}
-
-bool MGETRequest::onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
-                                     ConnPool::Instance* conn_pool) {
-  std::vector<absl::string_view> err;
-  bool ask_redirection = false;
-  if (redirectionArgsInvalid(incoming_request_.get(), value, err, ask_redirection) || !conn_pool) {
-    return false;
-  }
-
-  Common::Redis::RespValue request;
-  recreate(request, index, ask_redirection);
-
-  this->pending_requests_[index].handle_ =
-      conn_pool->makeRequestToHost(std::string(err[2]), request, this->pending_requests_[index]);
-  return (this->pending_requests_[index].handle_ != nullptr);
 }
 
 SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
@@ -388,9 +397,9 @@ void MSETRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t 
   }
 }
 
-void MSETRequest::recreate(Common::Redis::RespValue& request, uint32_t index, bool prepend_asking) {
+void MSETRequest::recreate(Common::Redis::RespValue& request, uint32_t index) {
   static const uint32_t SET_COMMAND_SUBSTRINGS = 3;
-  uint32_t num_values = prepend_asking ? (SET_COMMAND_SUBSTRINGS + 1) : SET_COMMAND_SUBSTRINGS;
+  uint32_t num_values = SET_COMMAND_SUBSTRINGS;
   std::vector<Common::Redis::RespValue> values(num_values);
 
   for (uint32_t i = 0; i < num_values; i++) {
@@ -399,28 +408,9 @@ void MSETRequest::recreate(Common::Redis::RespValue& request, uint32_t index, bo
   values[--num_values].asString() = incoming_request_->asArray()[(index * 2) + 2].asString();
   values[--num_values].asString() = incoming_request_->asArray()[(index * 2) + 1].asString();
   values[--num_values].asString() = "set";
-  if (prepend_asking) {
-    values[--num_values].asString() = "asking";
-  }
 
   request.type(Common::Redis::RespType::Array);
   request.asArray().swap(values);
-}
-
-bool MSETRequest::onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
-                                     ConnPool::Instance* conn_pool) {
-  std::vector<absl::string_view> err;
-  bool ask_redirection = false;
-  if (redirectionArgsInvalid(incoming_request_.get(), value, err, ask_redirection) || !conn_pool) {
-    return false;
-  }
-
-  Common::Redis::RespValue request;
-  recreate(request, index, ask_redirection);
-
-  this->pending_requests_[index].handle_ =
-      conn_pool->makeRequestToHost(std::string(err[2]), request, this->pending_requests_[index]);
-  return (this->pending_requests_[index].handle_ != nullptr);
 }
 
 SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
@@ -496,10 +486,9 @@ void SplitKeysSumResultRequest::onChildResponse(Common::Redis::RespValuePtr&& va
   }
 }
 
-void SplitKeysSumResultRequest::recreate(Common::Redis::RespValue& request, uint32_t index,
-                                         bool prepend_asking) {
+void SplitKeysSumResultRequest::recreate(Common::Redis::RespValue& request, uint32_t index) {
   static const uint32_t BASE_COMMAND_SUBSTRINGS = 2;
-  uint32_t num_values = prepend_asking ? (BASE_COMMAND_SUBSTRINGS + 1) : BASE_COMMAND_SUBSTRINGS;
+  uint32_t num_values = BASE_COMMAND_SUBSTRINGS;
   std::vector<Common::Redis::RespValue> values(num_values);
 
   for (uint32_t i = 0; i < num_values; i++) {
@@ -507,28 +496,9 @@ void SplitKeysSumResultRequest::recreate(Common::Redis::RespValue& request, uint
   }
   values[--num_values].asString() = incoming_request_->asArray()[index + 1].asString();
   values[--num_values].asString() = incoming_request_->asArray()[0].asString();
-  if (prepend_asking) {
-    values[--num_values].asString() = "asking";
-  }
 
   request.type(Common::Redis::RespType::Array);
   request.asArray().swap(values);
-}
-
-bool SplitKeysSumResultRequest::onChildRedirection(const Common::Redis::RespValue& value,
-                                                   uint32_t index, ConnPool::Instance* conn_pool) {
-  std::vector<absl::string_view> err;
-  bool ask_redirection = false;
-  if (redirectionArgsInvalid(incoming_request_.get(), value, err, ask_redirection) || !conn_pool) {
-    return false;
-  }
-
-  Common::Redis::RespValue request;
-  recreate(request, index, ask_redirection);
-
-  this->pending_requests_[index].handle_ =
-      conn_pool->makeRequestToHost(std::string(err[2]), request, this->pending_requests_[index]);
-  return (this->pending_requests_[index].handle_ != nullptr);
 }
 
 InstanceImpl::InstanceImpl(ConnPool::InstancePtr&& conn_pool, Stats::Scope& scope,

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -343,9 +343,9 @@ private:
 class DoNothingPoolCallbacks : public Common::Redis::Client::PoolCallbacks {
 public:
   // Common::Redis::Client::PoolCallbacks
-  void onResponse(Common::Redis::RespValuePtr&&) override{};
-  void onFailure() override{};
-  bool onRedirection(const Common::Redis::RespValue&) override { return false; };
+  void onResponse(Common::Redis::RespValuePtr&&) override {}
+  void onFailure() override {}
+  bool onRedirection(const Common::Redis::RespValue&) override { return false; }
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -113,8 +113,6 @@ protected:
                       TimeSource& time_source, bool latency_in_micros)
       : SplitRequestBase(command_stats, time_source, latency_in_micros), callbacks_(callbacks) {}
 
-  void recreate(Common::Redis::RespValue& request, bool prepend_asking);
-
   SplitCallbacks& callbacks_;
   ConnPool::Instance* conn_pool_{};
   Common::Redis::Client::PoolRequest* handle_{};
@@ -191,8 +189,9 @@ protected:
 
   virtual void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) PURE;
   void onChildFailure(uint32_t index);
-  virtual bool onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
-                                  ConnPool::Instance* conn_pool) PURE;
+  bool onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
+                          ConnPool::Instance* conn_pool);
+  virtual void recreate(Common::Redis::RespValue& request, uint32_t index) PURE;
 
   SplitCallbacks& callbacks_;
 
@@ -221,9 +220,7 @@ private:
 
   // RedisProxy::CommandSplitter::FragmentedRequest
   void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
-  virtual bool onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
-                                  ConnPool::Instance* conn_pool) override;
-  void recreate(Common::Redis::RespValue& request, uint32_t index, bool prepend_asking);
+  void recreate(Common::Redis::RespValue& request, uint32_t index) override;
 };
 
 /**
@@ -246,9 +243,7 @@ private:
 
   // RedisProxy::CommandSplitter::FragmentedRequest
   void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
-  virtual bool onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
-                                  ConnPool::Instance* conn_pool) override;
-  void recreate(Common::Redis::RespValue& request, uint32_t index, bool prepend_asking);
+  void recreate(Common::Redis::RespValue& request, uint32_t index) override;
 
   int64_t total_{0};
 };
@@ -272,9 +267,7 @@ private:
 
   // RedisProxy::CommandSplitter::FragmentedRequest
   void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
-  virtual bool onChildRedirection(const Common::Redis::RespValue& value, uint32_t index,
-                                  ConnPool::Instance* conn_pool) override;
-  void recreate(Common::Redis::RespValue& request, uint32_t index, bool prepend_asking);
+  void recreate(Common::Redis::RespValue& request, uint32_t index) override;
 };
 
 /**
@@ -341,6 +334,18 @@ private:
   const ToLowerTable to_lower_table_;
   const bool latency_in_micros_;
   TimeSource& time_source_;
+};
+
+/**
+ * DoNothingPoolCallbacks is used for internally generated commands whose response is
+ * transparently filtered, and redirection never occurs (e.g., "asking", etc.).
+ */
+class DoNothingPoolCallbacks : public Common::Redis::Client::PoolCallbacks {
+public:
+  // Common::Redis::Client::PoolCallbacks
+  void onResponse(Common::Redis::RespValuePtr&&) override{};
+  void onFailure() override{};
+  bool onRedirection(const Common::Redis::RespValue&) override { return false; };
 };
 
 } // namespace CommandSplitter

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -446,5 +446,4 @@ TEST_P(RedisProxyWithRedirectionIntegrationTest, IgnoreRedirectionForAsking) {
 }
 
 } // namespace
-
 } // namespace Envoy

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -139,10 +139,13 @@ public:
    * @param target_server a handle to the second server that will respond to the request.
    * @param request supplies client data to transmit to the first upstream server.
    * @param redirection_response supplies the moved or ask redirection error from the first server.
+   * @param asking_response supplies the target_server's response to an "asking" command, if it is
+   * received.
    * @param response supplies data sent by the second server back to the fake Redis client.
    */
   void simpleRedirection(FakeUpstreamPtr& target_server, const std::string& request,
-                         const std::string& redirection_response, const std::string& response);
+                         const std::string& redirection_response, const std::string& response,
+                         const std::string& asking_response = "+OK\r\n");
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, RedisProxyIntegrationTest,
@@ -199,7 +202,8 @@ void RedisProxyIntegrationTest::simpleProxyResponse(const std::string& request,
 
 void RedisProxyWithRedirectionIntegrationTest::simpleRedirection(
     FakeUpstreamPtr& target_server, const std::string& request,
-    const std::string& redirection_response, const std::string& response) {
+    const std::string& redirection_response, const std::string& response,
+    const std::string& asking_response) {
 
   bool asking = (redirection_response.find("-ASK") != std::string::npos);
   std::string proxy_to_server;
@@ -227,8 +231,8 @@ void RedisProxyWithRedirectionIntegrationTest::simpleRedirection(
     EXPECT_TRUE(fake_upstream_connection_2->waitForData(asking_request.size() + request.size(),
                                                         &proxy_to_server));
     EXPECT_EQ(asking_request + request, proxy_to_server);
-    // Respond with an "OK" to the "asking" command.
-    EXPECT_TRUE(fake_upstream_connection_2->write("+OK\r\n"));
+    // Respond to the "asking" command.
+    EXPECT_TRUE(fake_upstream_connection_2->write(asking_response));
   } else {
     // The server, target_server, should receive request unchanged.
     EXPECT_TRUE(fake_upstream_connection_2->waitForData(request.size(), &proxy_to_server));
@@ -378,5 +382,69 @@ TEST_P(RedisProxyWithRedirectionIntegrationTest, BadRedirectStrings) {
   }
 }
 
+// This test verifies that an upstream connection failure during ask redirection processing is
+// handled correctly. In this case the "asking" command and original client request have been sent
+// to the target server, and then the connection is closed. The fake Redis client should receive an
+// upstream failure error in response to its request.
+
+TEST_P(RedisProxyWithRedirectionIntegrationTest, ConnectionFailureBeforeAskingResponse) {
+  initialize();
+
+  std::string request = makeBulkStringArray({"get", "foo"});
+  std::stringstream redirection_error;
+  redirection_error << "-ASK 1111 " << redisAddressAndPort(fake_upstreams_[1]) << "\r\n";
+
+  std::string proxy_to_server;
+  IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
+  redis_client->write(request);
+
+  FakeRawConnectionPtr fake_upstream_connection_1, fake_upstream_connection_2;
+
+  // Data from the client should always be routed to fake_upstreams_[0] by the load balancer.
+  EXPECT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection_1));
+  EXPECT_TRUE(fake_upstream_connection_1->waitForData(request.size(), &proxy_to_server));
+  // The data in request should be received by the first server, fake_upstreams_[0].
+  EXPECT_EQ(request, proxy_to_server);
+  proxy_to_server.clear();
+
+  // Send the redirection_response from the first fake Redis server back to the proxy.
+  EXPECT_TRUE(fake_upstream_connection_1->write(redirection_error.str()));
+  // The proxy should initiate a new connection to the fake redis server, target_server, in
+  // response.
+  EXPECT_TRUE(fake_upstreams_[1]->waitForRawConnection(fake_upstream_connection_2));
+
+  // The server, fake_upstreams_[1], should receive an "asking" command before the original request.
+  std::string asking_request = makeBulkStringArray({"asking"});
+  EXPECT_TRUE(fake_upstream_connection_2->waitForData(asking_request.size() + request.size(),
+                                                      &proxy_to_server));
+  EXPECT_EQ(asking_request + request, proxy_to_server);
+  // Close the upstream connection before responding to the "asking" command.
+  EXPECT_TRUE(fake_upstream_connection_2->close());
+
+  // The fake Redis client should receive an upstream failure error from the proxy.
+  std::stringstream error_response;
+  error_response << "-" << RedisCmdSplitter::Response::get().UpstreamFailure << "\r\n";
+  redis_client->waitForData(error_response.str());
+  EXPECT_EQ(error_response.str(), redis_client->data());
+
+  redis_client->close();
+  EXPECT_TRUE(fake_upstream_connection_1->close());
+}
+
+// This test verifies that a ASK redirection error as a response to an "asking" command is ignored.
+// This is a negative test scenario that should never happen since a Redis server will reply to an
+// "asking" command with either a "cluster support not enabled" error or "OK".
+
+TEST_P(RedisProxyWithRedirectionIntegrationTest, IgnoreRedirectionForAsking) {
+  initialize();
+  std::string request = makeBulkStringArray({"get", "foo"});
+  std::stringstream redirection_error, asking_response;
+  redirection_error << "-ASK 1111 " << redisAddressAndPort(fake_upstreams_[1]) << "\r\n";
+  asking_response << "-ASK 1111 " << redisAddressAndPort(fake_upstreams_[0]) << "\r\n";
+  simpleRedirection(fake_upstreams_[1], request, redirection_error.str(), "$3\r\nbar\r\n",
+                    asking_response.str());
+}
+
 } // namespace
+
 } // namespace Envoy

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -139,9 +139,9 @@ public:
    * @param target_server a handle to the second server that will respond to the request.
    * @param request supplies client data to transmit to the first upstream server.
    * @param redirection_response supplies the moved or ask redirection error from the first server.
-   * @param asking_response supplies the target_server's response to an "asking" command, if it is
-   * received.
    * @param response supplies data sent by the second server back to the fake Redis client.
+   * @param asking_response supplies the target_server's response to an "asking" command, if
+   * appropriate.
    */
   void simpleRedirection(FakeUpstreamPtr& target_server, const std::string& request,
                          const std::string& redirection_response, const std::string& response,


### PR DESCRIPTION
- issue separate, preceding "asking" command instead of prefixing
"asking" to the redirected command.

- combined all derived requests' onChildRedirection() methods into
a single method.

- fixed affected unit and integration tests.

Signed-off-by: Mitch Sukalski <mitch.sukalski@workday.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description:

For Redis ASK redirection support, the "asking" command is now a separate command issued before the redirected command, instead of being prepended to the redirected command itself ("asking" is now encoded at its own array of a single bulkstring, "asking" -- instead of being added as the first array element of the redirected command). The unit and integration tests have been updated to reflect this change, and additional optimization was done to remove redundant onChildRedirection() methods for command splitter request types derived from FragmentRequest.

Risk Level: low
Testing: unit and integration tests as well as direct verification via redis-cli to a Redis cluster
Docs Changes: none
Release Notes: none
[Optional Fixes #Issue]
[Optional Deprecated:]
