### PR TITLE
docs: make deprecated.md point to deprecated log

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,3 @@
+# DEPRECATED
+
+The [deprecated log](https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated) can be found in the official Envoy developer documentation.


### PR DESCRIPTION
Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

Description: Because previous releases of Envoy point to DEPRECATED.md in error messages, it is necessary to link from it to the new location of the [deprecated log](https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated) in the Envoy developer docs
Risk Level: Low
Testing: N/A
Docs Changes: DEPRECATED.md added with pointer to Deprecated Log in Envoy docs

Note: This PR is in response to concerns raised by @lizan in #6454