### PR TITLE
thread: Rename ThreadId::debugString to name

### DIFF
--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -14,7 +14,10 @@ class ThreadId {
 public:
   virtual ~ThreadId() {}
 
-  virtual std::string debugString() const PURE;
+  /**
+   * @return human-readable name for this thread id.
+   */
+  virtual std::string name() const PURE;
   virtual bool isCurrentThreadId() const PURE;
 };
 

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -26,7 +26,7 @@ int64_t getCurrentThreadId() {
 
 ThreadIdImplPosix::ThreadIdImplPosix(int64_t id) : id_(id) {}
 
-std::string ThreadIdImplPosix::debugString() const { return std::to_string(id_); }
+std::string ThreadIdImplPosix::name() const { return std::to_string(id_); }
 
 bool ThreadIdImplPosix::isCurrentThreadId() const { return id_ == getCurrentThreadId(); }
 

--- a/source/common/common/posix/thread_impl.h
+++ b/source/common/common/posix/thread_impl.h
@@ -14,7 +14,7 @@ public:
   ThreadIdImplPosix(int64_t id);
 
   // Thread::ThreadId
-  std::string debugString() const override;
+  std::string name() const override;
   bool isCurrentThreadId() const override;
 
 private:

--- a/source/common/common/win32/thread_impl.cc
+++ b/source/common/common/win32/thread_impl.cc
@@ -8,7 +8,7 @@ namespace Thread {
 
 ThreadIdImplWin32::ThreadIdImplWin32(DWORD id) : id_(id) {}
 
-std::string ThreadIdImplWin32::debugString() const { return std::to_string(id_); }
+std::string ThreadIdImplWin32::name() const { return std::to_string(id_); }
 
 bool ThreadIdImplWin32::isCurrentThreadId() const { return id_ == ::GetCurrentThreadId(); }
 

--- a/source/common/common/win32/thread_impl.h
+++ b/source/common/common/win32/thread_impl.h
@@ -18,7 +18,7 @@ public:
   ThreadIdImplWin32(DWORD id);
 
   // Thread::ThreadId
-  std::string debugString() const override;
+  std::string name() const override;
   bool isCurrentThreadId() const override;
 
 private:

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -79,14 +79,14 @@ void GuardDogImpl::step() {
       }
       if (killEnabled() && delta > kill_timeout_) {
         PANIC(fmt::format("GuardDog: one thread ({}) stuck for more than watchdog_kill_timeout",
-                          watched_dog.dog_->threadId().debugString()));
+                          watched_dog.dog_->threadId().name()));
       }
       if (multikillEnabled() && delta > multi_kill_timeout_) {
         if (seen_one_multi_timeout) {
 
           PANIC(fmt::format(
               "GuardDog: multiple threads ({},...) stuck for more than watchdog_multikill_timeout",
-              watched_dog.dog_->threadId().debugString()));
+              watched_dog.dog_->threadId().name()));
         } else {
           seen_one_multi_timeout = true;
         }

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -315,8 +315,7 @@ TEST_P(GuardDogTestBase, WatchDogThreadIdTest) {
   NiceMock<Configuration::MockMain> config(100, 90, 1000, 500);
   initGuardDog(stats, config);
   auto watched_dog = guard_dog_->createWatchDog(api_->threadFactory().currentThreadId());
-  EXPECT_EQ(watched_dog->threadId().debugString(),
-            api_->threadFactory().currentThreadId()->debugString());
+  EXPECT_TRUE(watched_dog->threadId().isCurrentThreadId());
   guard_dog_->stopWatching(watched_dog);
 }
 


### PR DESCRIPTION
Description: Rename ThreadId::debugString to name, to avoid the possible misperception that it should be treated as unstable. This is to support #6517, which exposes thread IDs in stats.
Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Dan Rosen <mergeconflict@google.com>
