### PR TITLE
thrift_proxy: fix crash when remote closes the connection

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -87,8 +87,11 @@ void ConnectionManager::dispatch() {
 
 void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectResponse& response,
                                        bool end_stream) {
-  Buffer::OwnedImpl buffer;
+  if (read_callbacks_->connection().state() == Network::Connection::State::Closed) {
+    return;
+  }
 
+  Buffer::OwnedImpl buffer;
   const DirectResponse::ResponseType result = response.encode(metadata, *protocol_, buffer);
 
   Buffer::OwnedImpl response_buffer;
@@ -203,6 +206,11 @@ FilterStatus ConnectionManager::ResponseDecoder::transportEnd() {
   ASSERT(metadata_ != nullptr);
 
   ConnectionManager& cm = parent_.parent_;
+
+  if (cm.read_callbacks_->connection().state() == Network::Connection::State::Closed) {
+    complete_ = true;
+    throw EnvoyException("thrift downstream gone");
+  }
 
   Buffer::OwnedImpl buffer;
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -209,7 +209,7 @@ FilterStatus ConnectionManager::ResponseDecoder::transportEnd() {
 
   if (cm.read_callbacks_->connection().state() == Network::Connection::State::Closed) {
     complete_ = true;
-    throw EnvoyException("thrift downstream gone");
+    throw EnvoyException("downstream connection is closed");
   }
 
   Buffer::OwnedImpl buffer;

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -1239,9 +1239,6 @@ TEST_F(ThriftConnectionManagerTest, OnDataWithFilterSendLocalReplyRemoteClosedCo
   EXPECT_EQ(1U, store_.counter("test.request_call").value());
   EXPECT_EQ(0U, store_.gauge("test.request_active").value());
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
-
-  // This might not be true, if we haven't decoded a full request.
-  // EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
 }
 
 // Tests a decoder filter that modifies data.

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -1310,6 +1310,8 @@ TEST_F(ThriftConnectionManagerTest, transportEndWhenRemoteClose) {
   // Remote closes the connection.
   filter_callbacks_.connection_.state_ = Network::Connection::State::Closed;
   EXPECT_EQ(ThriftFilters::ResponseStatus::Reset, callbacks->upstreamData(write_buffer_));
+
+  filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 }
 
 } // namespace ThriftProxy

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -1238,6 +1238,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataWithFilterSendLocalReplyRemoteClosedCo
   EXPECT_EQ(1U, store_.counter("test.request").value());
   EXPECT_EQ(1U, store_.counter("test.request_call").value());
   EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
 }
 
@@ -1310,6 +1311,8 @@ TEST_F(ThriftConnectionManagerTest, transportEndWhenRemoteClose) {
   // Remote closes the connection.
   filter_callbacks_.connection_.state_ = Network::Connection::State::Closed;
   EXPECT_EQ(ThriftFilters::ResponseStatus::Reset, callbacks->upstreamData(write_buffer_));
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+  EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 }


### PR DESCRIPTION
There's a few paths within the Thrift Proxy where we should ensure
the connection is not closed, before trying to write. This change
ensures that sendLocalReply() will return early if the connection
is gone.

It also adds a check for transformEnd(), which gets called from
upstreamData().

Risk Level: *low*
Testing: unit tests added
Fixes: #6496

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
