### PR TITLE
test: relax some test expectations about exception strings

### DIFF
--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4154,8 +4154,7 @@ virtual_hosts:
 
   EXPECT_THROW_WITH_REGEX(
       TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
-      EnvoyException,
-      "Unable to parse JSON as proto .*: invalid value 0 for type TYPE_BOOL");
+      EnvoyException, "Unable to parse JSON as proto .*: invalid value 0 for type TYPE_BOOL");
 }
 
 TEST_F(RouteMatcherTest, Decorator) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4152,13 +4152,10 @@ virtual_hosts:
         enabled: 0
 )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THROW_WITH_REGEX(
       TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
       EnvoyException,
-      "Unable to parse JSON as proto "
-      "(INVALID_ARGUMENT:(virtual_hosts[0].routes[0].route.cors.enabled.value): invalid value 0 "
-      "for type TYPE_BOOL): " +
-          Json::Factory::loadFromYamlString(yaml)->asJsonString());
+      "Unable to parse JSON as proto .*: invalid value 0 for type TYPE_BOOL");
 }
 
 TEST_F(RouteMatcherTest, Decorator) {

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -74,7 +74,7 @@ TEST(RateLimitFilterConfigTest, BadRateLimitFilterConfig) {
 
   envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
   EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromYamlAndValidate(yaml, proto_config), EnvoyException,
-                          "INVALID_ARGUMENT:route_key: Cannot find field");
+                          "route_key: Cannot find field");
 }
 
 } // namespace


### PR DESCRIPTION
Description: these unit tests were failing when importing to our (Google's) environment because the exception string was slightly different (the exception name was "generic::invalid_argument" instead of the excepted "INVALID_ARGUMENT"). 
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind eziskind@google.com