### PR TITLE
test: Add EXPECT_THAT_THROWS_MESSAGE, allowing arbitrary string matchers

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -70,8 +70,8 @@ namespace Envoy {
 // Expect that the statement throws the specified type of exception with a message that does not
 // contain any substring matching the specified regular expression.
 #define EXPECT_THROW_WITHOUT_REGEX(statement, expected_exception, regex_str)                       \
-  EXPECT_THAT_THROWS_MESSAGE(                                                                      \
-      statement, expected_exception, ::testing::Not(::testing::ContainsRegex(regex_str)))
+  EXPECT_THAT_THROWS_MESSAGE(statement, expected_exception,                                        \
+                             ::testing::Not(::testing::ContainsRegex(regex_str)))
 
 #define VERBOSE_EXPECT_NO_THROW(statement)                                                         \
   try {                                                                                            \

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -37,29 +37,41 @@ using testing::AssertionSuccess;
 using testing::Invoke;
 
 namespace Envoy {
+
+/*
+  Macro to use for validating that a statement throws the specified type of exception, and that
+  the exception's what() method returns a string which is matched by the specified matcher.
+  This allows for expectations such as:
+
+  EXPECT_THAT_THROWS_MESSAGE(
+      bad_function_call(),
+      EnvoyException,
+      AllOf(StartsWith("expected prefix"), HasSubstr("some substring")));
+*/
+#define EXPECT_THAT_THROWS_MESSAGE(statement, expected_exception, matcher)                         \
+  try {                                                                                            \
+    statement;                                                                                     \
+    ADD_FAILURE() << "Exception should take place. It did not.";                                   \
+  } catch (expected_exception & e) {                                                               \
+    EXPECT_THAT(std::string(e.what()), matcher);                                                   \
+  }
+
+// Expect that the statement throws the specified type of exception with exactly the specified
+// message.
 #define EXPECT_THROW_WITH_MESSAGE(statement, expected_exception, message)                          \
-  try {                                                                                            \
-    statement;                                                                                     \
-    ADD_FAILURE() << "Exception should take place. It did not.";                                   \
-  } catch (expected_exception & e) {                                                               \
-    EXPECT_EQ(message, std::string(e.what()));                                                     \
-  }
+  EXPECT_THAT_THROWS_MESSAGE(statement, expected_exception, ::testing::Eq(message))
 
+// Expect that the statement throws the specified type of exception with a message containing a
+// substring matching the specified regular expression (i.e. the regex doesn't have to match
+// the entire message).
 #define EXPECT_THROW_WITH_REGEX(statement, expected_exception, regex_str)                          \
-  try {                                                                                            \
-    statement;                                                                                     \
-    ADD_FAILURE() << "Exception should take place. It did not.";                                   \
-  } catch (expected_exception & e) {                                                               \
-    EXPECT_THAT(e.what(), ::testing::ContainsRegex(regex_str));                                    \
-  }
+  EXPECT_THAT_THROWS_MESSAGE(statement, expected_exception, ::testing::ContainsRegex(regex_str))
 
+// Expect that the statement throws the specified type of exception with a message that does not
+// contain any substring matching the specified regular expression.
 #define EXPECT_THROW_WITHOUT_REGEX(statement, expected_exception, regex_str)                       \
-  try {                                                                                            \
-    statement;                                                                                     \
-    ADD_FAILURE() << "Exception should take place. It did not.";                                   \
-  } catch (expected_exception & e) {                                                               \
-    EXPECT_THAT(e.what(), ::testing::Not(::testing::ContainsRegex(regex_str)));                    \
-  }
+  EXPECT_THAT_THROWS_MESSAGE(                                                                      \
+      statement, expected_exception, ::testing::Not(::testing::ContainsRegex(regex_str)))
 
 #define VERBOSE_EXPECT_NO_THROW(statement)                                                         \
   try {                                                                                            \


### PR DESCRIPTION
This was inspired by the same problem that #6558 is fixing, namely
an overly strict string match. Elisha wanted a more focused fix, so
I'm offering this for the next such case, enabling a test in
test/common/router/config_impl_test.cc such as:

EXPECT_THAT_THROWS_MESSAGE(
    TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
    EnvoyException,
    AllOf(HasSubstr("Unable to parse"),
          HasSubstr("virtual_hosts[0].routes[0].route.cors.enabled.value"),
          HasSubstr("invalid value 0 for type TYPE_BOOL")));

I've modified the existing EXPECT_THROWS.* macros to use this macro,
and added documentation of each of those macros.

Signed-off-by: James Synge <jamessynge@google.com>

