### PR TITLE
Implement http2 macros

### DIFF
--- a/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
@@ -19,7 +19,7 @@
 namespace http2 {
 
 template <typename T> T dieIfNull(T&& ptr) {
-  CHECK(ptr != nullptr);
+  CHECK((ptr) != nullptr);
   return std::forward<T>(ptr);
 }
 

--- a/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
@@ -18,7 +18,7 @@
 
 namespace http2 {
 
-template <typename T> T dieIfNull(T&& ptr) {
+template <typename T> inline T dieIfNull(T&& ptr) {
   CHECK((ptr) != nullptr);
   return std::forward<T>(ptr);
 }

--- a/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
@@ -1,15 +1,26 @@
 #pragma once
 
-#include "absl/base/macros.h"
-
 // NOLINT(namespace-envoy)
 
 // This file is part of the QUICHE platform implementation, and is not to be
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
-#define HTTP2_FALLTHROUGH_IMPL ABSL_FALLTHROUGH_INTENDED
-#define HTTP2_DIE_IF_NULL_IMPL(ptr) ABSL_DIE_IF_NULL(ptr)
+#include <utility>
 
-// TODO: implement
-#define HTTP2_UNREACHABLE_IMPL() 0
+#include "extensions/quic_listeners/quiche/platform/quic_logging_impl.h"
+
+#include "absl/base/macros.h"
+
+#define HTTP2_FALLTHROUGH_IMPL ABSL_FALLTHROUGH_INTENDED
+#define HTTP2_DIE_IF_NULL_IMPL(ptr) dieIfNull(ptr)
+#define HTTP2_UNREACHABLE_IMPL() DCHECK(false)
+
+namespace http2 {
+
+template <typename T> T dieIfNull(T&& ptr) {
+  CHECK(ptr != nullptr);
+  return std::forward<T>(ptr);
+}
+
+} // namespace http2

--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
@@ -1,3 +1,9 @@
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
 #include <memory>
 
 #include "test/test_common/logging.h"
@@ -8,6 +14,7 @@
 #include "quiche/http2/platform/api/http2_containers.h"
 #include "quiche/http2/platform/api/http2_estimate_memory_usage.h"
 #include "quiche/http2/platform/api/http2_logging.h"
+#include "quiche/http2/platform/api/http2_macros.h"
 #include "quiche/http2/platform/api/http2_optional.h"
 #include "quiche/http2/platform/api/http2_ptr_util.h"
 #include "quiche/http2/platform/api/http2_string.h"
@@ -19,10 +26,7 @@
 // minimal, and serve primarily to verify the APIs compile and link without
 // issue.
 
-namespace Envoy {
-namespace Extensions {
-namespace QuicListeners {
-namespace Quiche {
+namespace http2 {
 namespace {
 
 TEST(Http2PlatformTest, Http2Arraysize) {
@@ -96,8 +100,10 @@ TEST(Http2PlatformTest, Http2StringPiece) {
   EXPECT_EQ('b', sp[0]);
 }
 
+TEST(Http2PlatformTest, Http2Macro) {
+  EXPECT_DEBUG_DEATH(HTTP2_UNREACHABLE(), "");
+  EXPECT_DEATH(HTTP2_DIE_IF_NULL(nullptr), "");
+}
+
 } // namespace
-} // namespace Quiche
-} // namespace QuicListeners
-} // namespace Extensions
-} // namespace Envoy
+} // namespace http2


### PR DESCRIPTION
Implement HTTP2_DIE_IF_NULL and HTTP2_UNREACHABLE: https://quiche.googlesource.com/quiche/+/refs/heads/master/http2/platform/api/http2_macros.h
This two interfaces doesn't have clear documentation about their usage. But at a glance, HTTP2_DIE_IF_NULL(ptr) is used as a function to check if passed-in argument is a nullptr, if not return the pointer, see its usage in chromium code: https://cs.chromium.org/chromium/src/net/third_party/quiche/src/http2/hpack/decoder/hpack_whole_entry_buffer.cc?type=cs&g=0&l=22, and HTTP2_UNREACHABLE() is used as a function too: https://cs.chromium.org/chromium/src/net/third_party/quiche/src/http2/decoder/http2_frame_decoder.cc?rcl=9e84364c1893473f994688884920e9a32d7e02df&l=73

Risk Level: low
Testing: Added new test in test/extensions/quic_listeners/quiche/platform:http2_platform_test
Part of #2557