### PR TITLE
docs: correct a package of AggregatedDiscoveryService

### DIFF
--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -528,7 +528,7 @@ in :repo:`this
 <api/XDS_PROTOCOL.md#aggregated-discovery-services-ads>`
 document. The gRPC endpoint is:
 
-.. http:post:: /envoy.api.v2.AggregatedDiscoveryService/StreamAggregatedResources
+.. http:post:: /envoy.service.discovery.v2.AggregatedDiscoveryService/StreamAggregatedResources
 
 See :repo:`discovery.proto
 <api/envoy/api/v2/discovery.proto>`


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <y.skopets@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: Corrects an invalid example of xDS API call. ADS service belongs to `envoy.service.discovery.v2` package rather than to `envoy.api.v2`    
Risk Level: Low
Testing: N/A
Docs Changes: Corrected an invalid example of xDS API call in `docs/root/configuration/overview/v2_overview.rst`
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
