### PR TITLE
examples: updating docker-compose version

### DIFF
--- a/examples/front-proxy/docker-compose.yml
+++ b/examples/front-proxy/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 services:
 
   front-envoy:


### PR DESCRIPTION
Description:
Upgrading the version of docker-compose for the front proxy example to be up to date with the latest (3.7).  Not too many changes other than some feature adds, and removals of things that aren't being used in this docker-compose file.  [Docs for upgrading docker-compose from 2.x to 3.x](https://docs.docker.com/compose/compose-file/compose-versioning/#version-3) 
Risk Level: Low
Testing:
Manual testing, starting and hitting the example services after upgrading the version of docker-compose
Docs Changes:
N/A
Release Notes:
N/A
