### PR TITLE
Apply clang-tidy fixes for performance-move-const-arg.

### DIFF
--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -25,7 +25,7 @@ namespace Http1 {
 ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                            Upstream::ResourcePriority priority,
                            const Network::ConnectionSocket::OptionsSharedPtr& options)
-    : ConnPoolImplBase(std::move(host), std::move(priority)), dispatcher_(dispatcher),
+    : ConnPoolImplBase(std::move(host), priority), dispatcher_(dispatcher),
       socket_options_(options),
       upstream_ready_timer_(dispatcher_.createTimer([this]() { onUpstreamReady(); })) {}
 

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -18,7 +18,7 @@ namespace Http2 {
 ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                            Upstream::ResourcePriority priority,
                            const Network::ConnectionSocket::OptionsSharedPtr& options)
-    : ConnPoolImplBase(std::move(host), std::move(priority)), dispatcher_(dispatcher),
+    : ConnPoolImplBase(std::move(host), priority), dispatcher_(dispatcher),
       socket_options_(options) {}
 
 ConnPoolImpl::~ConnPoolImpl() {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -475,7 +475,7 @@ void Filter::onDownstreamEvent(Network::ConnectionEvent event) {
       if (upstream_conn_data_ != nullptr) {
         if (upstream_conn_data_->connection().state() != Network::Connection::State::Closed) {
           config_->drainManager().add(config_->sharedConfig(), std::move(upstream_conn_data_),
-                                      std::move(upstream_callbacks_), std::move(idle_timer_),
+                                      upstream_callbacks_, std::move(idle_timer_),
                                       read_callbacks_->upstreamHost());
         } else {
           upstream_conn_data_.reset();

--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -11,7 +11,7 @@ bool SpanBuffer::addSpan(const Span& span) {
     // Buffer full
     return false;
   }
-  span_buffer_.push_back(std::move(span));
+  span_buffer_.push_back(span);
 
   return true;
 }

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -20,7 +20,7 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 
   // Build the CS annotation
   Annotation cs;
-  cs.setEndpoint(std::move(ep));
+  cs.setEndpoint(ep);
   if (config.operationName() == Tracing::OperationName::Egress) {
     cs.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
   } else {
@@ -100,7 +100,7 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
   Endpoint ep(service_name_, address_);
 
   // Add the newly-created annotation to the span
-  annotation.setEndpoint(std::move(ep));
+  annotation.setEndpoint(ep);
   annotation.setTimestamp(timestamp_micro);
   span_ptr->addAnnotation(std::move(annotation));
 
@@ -125,7 +125,7 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 
 void Tracer::reportSpan(Span&& span) {
   if (reporter_ && span.sampled()) {
-    reporter_->reportSpan(std::move(span));
+    reporter_->reportSpan(span);
   }
 }
 

--- a/source/server/http/config_tracker_impl.cc
+++ b/source/server/http/config_tracker_impl.cc
@@ -5,9 +5,8 @@ namespace Server {
 
 ConfigTracker::EntryOwnerPtr ConfigTrackerImpl::add(const std::string& key, Cb cb) {
   auto insert_result = map_->emplace(key, std::move(cb));
-  return insert_result.second
-             ? std::make_unique<ConfigTrackerImpl::EntryOwnerImpl>(map_, std::move(key))
-             : nullptr;
+  return insert_result.second ? std::make_unique<ConfigTrackerImpl::EntryOwnerImpl>(map_, key)
+                              : nullptr;
 }
 
 const ConfigTracker::CbsMap& ConfigTrackerImpl::getCallbacksMap() const { return *map_; }

--- a/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
@@ -120,7 +120,7 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   // Test the move-semantics flavor of setEndpoint
   addr = Network::Utility::parseInternetAddressAndPort("192.168.1.1:5555");
   Endpoint ep2(std::string("my_service_2"), addr);
-  ann.setEndpoint(std::move(ep2));
+  ann.setEndpoint(ep2);
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service_2", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})",
@@ -241,7 +241,7 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   // Test the move-semantics flavor of setEndpoint
   addr = Network::Utility::parseInternetAddressAndPort("192.168.1.1:5555");
   Endpoint ep2(std::string("my_service_2"), addr);
-  ann.setEndpoint(std::move(ep2));
+  ann.setEndpoint(ep2);
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service_2", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})",


### PR DESCRIPTION
Note that a few of the proposed fixes were bad, resulting
in code that wouldn't compile, so I'm not adding this
check to WarningsAsErrors in .clang-tidy

Signed-off-by: James Synge <jamessynge@google.com>
