### PR TITLE
cluster manager: destroy warming clusters during shutdown()

### DIFF
--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -203,9 +203,12 @@ public:
   Http::AsyncClient& httpAsyncClientForCluster(const std::string& cluster) override;
   bool removeCluster(const std::string& cluster) override;
   void shutdown() override {
+    // Make sure we destroy all potential outgoing connections before this returns.
     cds_api_.reset();
     ads_mux_.reset();
     active_clusters_.clear();
+    warming_clusters_.clear();
+    updateGauges();
   }
 
   const envoy::api::v2::core::BindConfig& bindConfig() const override { return bind_config_; }


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/6513.

This issue has existed for quite some time, so I'm unclear why we
just started seeing this. It's possible it's chance and it's also
possible it's in some way related to the init changes, but either
way, this is the correct fix.

Risk Level: Low
Testing: New UT
Docs Changes: N/A
Release Notes: N/A
