### PR TITLE
support hooks: ignore submodules for single file format check

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -57,7 +57,7 @@ do
     # `$CLANG_FORMAT` and `$BUILDIFY` are defined, or that the default values it
     # assumes for these variables correspond to real binaries on the system. If
     # either of these things aren't true, the check fails.
-    for i in $(git diff --name-only $RANGE --diff-filter=ACMR 2>&1); do
+    for i in $(git diff --name-only $RANGE --diff-filter=ACMR --ignore-submodules=all 2>&1); do
       echo -ne "  Checking format for $i - "
       "$SCRIPT_DIR"/check_format.py check $i
       if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Allows using the format checking hooks from an owning directory.
