### PR TITLE
Disable pedantic spellcheck in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,6 @@ jobs:
        - run: ci/do_circle_ci.sh check_format
        - run: ci/do_circle_ci.sh check_repositories
        - run: ci/do_circle_ci.sh check_spelling
-       - run: ci/do_circle_ci.sh check_spelling_pedantic
    build_image:
      docker:
        - image: circleci/python:3.7


### PR DESCRIPTION
check_spelling is already catching common misspellings. check_spelling_pedantic is making us update a dictionary every time we write an unusual and/or technical word in a comment.