### PR TITLE
quiche: Implement SpdyUnsafeArena using SpdySimpleArena

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -89,6 +89,7 @@ cc_library(
         "quiche/spdy/platform/api/spdy_ptr_util.h",
         "quiche/spdy/platform/api/spdy_string.h",
         "quiche/spdy/platform/api/spdy_string_piece.h",
+        "quiche/spdy/platform/api/spdy_unsafe_arena.h",
         # TODO: uncomment the following files as implementations are added.
         # "quiche/spdy/platform/api/spdy_flags.h",
     ] + envoy_select_quiche(
@@ -101,6 +102,21 @@ cc_library(
     ),
     visibility = ["//visibility:public"],
     deps = ["@envoy//source/extensions/quic_listeners/quiche/platform:spdy_platform_impl_lib"],
+)
+
+cc_library(
+    name = "spdy_simple_arena_lib",
+    srcs = ["quiche/spdy/core/spdy_simple_arena.cc"],
+    hdrs = ["quiche/spdy/core/spdy_simple_arena.h"],
+    visibility = ["//visibility:public"],
+    deps = [":spdy_platform"],
+)
+
+cc_library(
+    name = "spdy_platform_unsafe_arena_lib",
+    hdrs = ["quiche/spdy/platform/api/spdy_unsafe_arena.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@envoy//source/extensions/quic_listeners/quiche/platform:spdy_platform_unsafe_arena_impl_lib"],
 )
 
 cc_library(

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -89,7 +89,6 @@ cc_library(
         "quiche/spdy/platform/api/spdy_ptr_util.h",
         "quiche/spdy/platform/api/spdy_string.h",
         "quiche/spdy/platform/api/spdy_string_piece.h",
-        "quiche/spdy/platform/api/spdy_unsafe_arena.h",
         # TODO: uncomment the following files as implementations are added.
         # "quiche/spdy/platform/api/spdy_flags.h",
     ] + envoy_select_quiche(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -236,8 +236,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/subpar/archive/1.3.0.tar.gz"],
     ),
     com_googlesource_quiche = dict(
-        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/ba6354aa1b39f3d9788ead909ad3e678ac863938.tar.gz
-        sha256 = "4598537810c3d343c32333c5367fcb652638018118f7f4e844e080405d9e73bb",
-        urls = ["https://storage.googleapis.com/quiche-envoy-integration/ba6354aa1b39f3d9788ead909ad3e678ac863938.tar.gz"],
+        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/840edb6d672931ff936004fc35a82ecac6060844.tar.gz
+        sha256 = "1aba26cec596e9f3b52d93fe40e1640c854e3a4c8949e362647f67eb8e2382e3",
+        urls = ["https://storage.googleapis.com/quiche-envoy-integration/840edb6d672931ff936004fc35a82ecac6060844.tar.gz"],
     ),
 )

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -189,7 +189,6 @@ envoy_cc_library(
         "spdy_string_piece_impl.h",
         "spdy_test_helpers_impl.h",
         "spdy_test_utils_prod_impl.h",
-        "spdy_unsafe_arena_impl.h",
     ] + envoy_select_quiche([
         "spdy_bug_tracker_impl.h",
         "spdy_logging_impl.h",
@@ -207,5 +206,16 @@ envoy_cc_library(
         ":quic_platform_logging_impl_lib",
         ":string_utils_lib",
         "//source/common/common:assert_lib",
+    ]),
+)
+
+envoy_cc_library(
+    name = "spdy_platform_unsafe_arena_impl_lib",
+    hdrs = [
+        "spdy_unsafe_arena_impl.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = envoy_select_quiche([
+        "@com_googlesource_quiche//:spdy_simple_arena_lib",
     ]),
 )

--- a/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
@@ -82,6 +82,8 @@
 #define QUIC_NOTREACHED_IMPL() NOT_REACHED_GCOVR_EXCL_LINE
 #endif
 
+#define DCHECK_GE(a, b) DCHECK((a) >= (b))
+
 #define QUIC_PREDICT_FALSE_IMPL(x) ABSL_PREDICT_FALSE(x)
 
 namespace quic {

--- a/source/extensions/quic_listeners/quiche/platform/spdy_unsafe_arena_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/spdy_unsafe_arena_impl.h
@@ -6,9 +6,10 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
+#include "quiche/spdy/core/spdy_simple_arena.h"
+
 namespace spdy {
 
-// TODO: implement
-class SpdyUnsafeArenaImpl {};
+using SpdyUnsafeArenaImpl = SpdySimpleArena;
 
 } // namespace spdy


### PR DESCRIPTION
Using the provided SpdySimpleArena for the impl.
Update quiche tar ball. 
Add DCHEK_GE in quic_logging_impl.h as it's used in newly included spdy_simple_arena.cc.

Risk Level: low
Testing: The impl is a straight forward using statement. SpdySimpleArena has been tested in quiche via spdy_simple_arena_test.cc. 

Part of #2557
