### PR TITLE
stats: add tag extractor for RDS route config name

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -106,6 +106,9 @@ TagNameValues::TagNameValues() {
 
   // mongo.(<stat_prefix>.)*
   addRegex(MONGO_PREFIX, "^mongo\\.((.*?)\\.)");
+
+  // http.[<stat_prefix>.]rds.(<route_config_name>.)<base_stat>
+  addRegex(RDS_ROUTE_CONFIG, "^http(?=\\.).*?\\.rds\\.((.*?)\\.)\\w+?$", ".rds.");
 }
 
 void TagNameValues::addRegex(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -145,6 +145,8 @@ public:
   const std::string RESPONSE_CODE = "envoy.response_code";
   // Request response code class
   const std::string RESPONSE_CODE_CLASS = "envoy.response_code_class";
+  // Route config name for RDS updates
+  const std::string RDS_ROUTE_CONFIG = "envoy.rds_route_config";
 
   // Mapping from the names above to their respective regex strings.
   const std::vector<std::pair<std::string, std::string>> name_regex_pairs_;

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -327,6 +327,17 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   regex_tester.testRegex("http.fault_connection_manager.fault.fault_cluster.aborts_injected",
                          "http.fault.aborts_injected",
                          {fault_connection_manager, fault_downstream_cluster});
+
+  Tag rds_hcm;
+  rds_hcm.name_ = tag_names.HTTP_CONN_MANAGER_PREFIX;
+  rds_hcm.value_ = "rds_connection_manager";
+
+  Tag rds_route_config;
+  rds_route_config.name_ = tag_names.RDS_ROUTE_CONFIG;
+  rds_route_config.value_ = "route_config.123";
+
+  regex_tester.testRegex("http.rds_connection_manager.rds.route_config.123.update_success",
+                         "http.rds.update_success", {rds_hcm, rds_route_config});
 }
 
 TEST(TagExtractorTest, ExtractRegexPrefix) {


### PR DESCRIPTION
Description: add a tag extractor regex for the route config name for RDS stats (https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/rds.html)
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
