### PR TITLE
event: fix DispatcherImplTest::InitializeStats flake

### DIFF
--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -85,7 +85,7 @@ protected:
     dispatcher_thread_->join();
   }
 
-  NiceMock<Stats::MockStore> scope_;
+  NiceMock<Stats::MockStore> scope_; // Used in InitializeStats, needs to outlive dispatcher_.
   Api::ApiPtr api_;
   Thread::ThreadPtr dispatcher_thread_;
   DispatcherPtr dispatcher_;

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -85,7 +85,7 @@ protected:
     dispatcher_thread_->join();
   }
 
-  NiceMock<Stats::MockStore> scope_; // Used in InitializeStats, needs to outlive dispatcher_.
+  NiceMock<Stats::MockStore> scope_; // Used in InitializeStats, must outlive dispatcher_->exit().
   Api::ApiPtr api_;
   Thread::ThreadPtr dispatcher_thread_;
   DispatcherPtr dispatcher_;

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -85,6 +85,7 @@ protected:
     dispatcher_thread_->join();
   }
 
+  NiceMock<Stats::MockStore> scope_;
   Api::ApiPtr api_;
   Thread::ThreadPtr dispatcher_thread_;
   DispatcherPtr dispatcher_;
@@ -96,11 +97,9 @@ protected:
 };
 
 TEST_F(DispatcherImplTest, InitializeStats) {
-  // NiceMock because deliverHistogramToSinks may or may not be called, depending on timing.
-  NiceMock<Stats::MockStore> scope;
-  EXPECT_CALL(scope, histogram("test.dispatcher.loop_duration_us"));
-  EXPECT_CALL(scope, histogram("test.dispatcher.poll_delay_us"));
-  dispatcher_->initializeStats(scope, "test.");
+  EXPECT_CALL(scope_, histogram("test.dispatcher.loop_duration_us"));
+  EXPECT_CALL(scope_, histogram("test.dispatcher.poll_delay_us"));
+  dispatcher_->initializeStats(scope_, "test.");
 }
 
 TEST_F(DispatcherImplTest, Post) {


### PR DESCRIPTION
Description: Fix DispatcherImplTest::InitializeStats flake due to dispatcher lifetime exceeding mock stats scope lifetime.
Risk Level: low
Testing: bazel test //test/common/event:dispatcher_impl_test --runs_per_test=1000 (with ASAN enabled)
Docs Changes: n/a
Release Notes: n/a
Fixes #6611

Signed-off-by: Dan Rosen <mergeconflict@google.com>
