### PR TITLE
build: Fix incompatible_bzl_disallow_load_after_statement

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,6 +1,7 @@
 load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
 load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
@@ -380,8 +381,6 @@ def envoy_cc_binary(
         stamp = 1,
         deps = deps,
     )
-
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # Envoy C++ fuzz test targes. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -82,9 +82,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gperftools/gperftools/archive/fc00474ddc21fff618fc3f009b46590e241e425e.tar.gz"],
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "a5342629fe1b689eceb3be4d4f167b04c70a84b9d61cf8b555e968bc500bdb5a",
-        strip_prefix = "grpc-1.16.1",
-        urls = ["https://github.com/grpc/grpc/archive/v1.16.1.tar.gz"],
+        sha256 = "01c5e617d098a33672ddb640d0e50831fb7c613999435e5dcf115021abde6b9a",
+        strip_prefix = "grpc-1.20.0",
+        urls = ["https://github.com/grpc/grpc/archive/v1.20.0.tar.gz"],
     ),
     com_github_luajit_luajit = dict(
         sha256 = "409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8",
@@ -225,7 +225,7 @@ REPOSITORY_LOCATIONS = dict(
     rules_foreign_cc = dict(
         sha256 = "136470a38dcd00c7890230402b43004dc947bf1e3dd0289dd1bd2bfb1e0a3484",
         strip_prefix = "rules_foreign_cc-e3f4b5e0bc9dac9cf036616c13de25e6cd5051a2",
-        # 2019-02-14
+        # 2019-04-04
         urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/e3f4b5e0bc9dac9cf036616c13de25e6cd5051a2.tar.gz"],
     ),
     six_archive = dict(

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -82,10 +82,17 @@ createTransportSocketFactoryHelper(const Protobuf::Message& message, bool is_ups
     }
     const char* target_name = is_upstream ? "" : nullptr;
     tsi_handshaker* handshaker = nullptr;
+    // TODO(cmluciano): Implement grpc_alts_shared_resource_dedicated_init(), and
+    // grpc_alts_shared_resource_dedicated_shutdown() to properly include interested parties
+    //
+    // grpc_pollset_set adds pollsets of interested parties & automatically adds their registered
+    // fd's hard-coding this to nullptr results in creation of a dedicated tsi_thread
+    grpc_pollset_set* interested_parties = nullptr;
     // Specifying target name as empty since TSI won't take care of validating peer identity
     // in this use case. The validation will be performed by TsiSocket with the validator.
-    tsi_result status = alts_tsi_handshaker_create(
-        options.get(), target_name, handshaker_service.c_str(), is_upstream, &handshaker);
+    tsi_result status =
+        alts_tsi_handshaker_create(options.get(), target_name, handshaker_service.c_str(),
+                                   is_upstream, interested_parties, &handshaker);
     CHandshakerPtr handshaker_ptr{handshaker};
 
     if (status != TSI_OK) {


### PR DESCRIPTION
Bazel 0.25.0 errors and requires a flag if load entries are not before custom
functions. The dependency bumps include the latest release of grpc and
rules_foreign_cc that have patches fixing the incompatibility in their own .bzl
files.

Example failure

``` bash
  'build' options: --verbose_failures --action_env=CXX=clang++-8 --action_env=CC=clang-8 --linkopt=-fuse-ld=lld-8 --experimental_strict_action_env=true  --announce_rc
ERROR: /home/cmluciano/go/src/github.com/envoyproxy/envoy/bazel/envoy_build_system.bzl:378:1: load() statements must be called before any other statement. First non-load() statement appears at /home/cmluciano/go/src/github.com/envoyproxy/envoy/bazel/envoy_build_system.bzl:5:1. Use --incompatible_bzl_disallow_load_after_statement=false to temporarily disable this check.
ERROR: Skipping '//source/exe:envoy-static': error loading package 'source/exe': Extension 'bazel/envoy_build_system.bzl' has errors
WARNING: Target pattern parsing failed.
ERROR: error loading package 'source/exe': Extension 'bazel/envoy_build_system.bzl' has errors
INFO: Elapsed time: 2.713s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
    currently loading: source/exe
    Fetching @envoy_build_config; Restarting.
```

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
