### PR TITLE
access log: add response code details to the access log formatter

### DIFF
--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -332,4 +332,7 @@ message HTTPResponseProperties {
 
   // Map of trailers configured to be logged.
   map<string, string> response_trailers = 5;
+
+  // The HTTP response code details
+  string response_code_details = 6;
 }

--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -333,6 +333,6 @@ message HTTPResponseProperties {
   // Map of trailers configured to be logged.
   map<string, string> response_trailers = 5;
 
-  // The HTTP response code details
+  // The HTTP response code details.
   string response_code_details = 6;
 }

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -162,6 +162,8 @@ The following command operators are supported:
   TCP
     Not implemented ("-").
 
+.. _config_access_log_format_response_code_details:
+
 %RESPONSE_CODE_DETAILS%
   HTTP
     HTTP response code details provides additional information about the response code, such as

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -162,6 +162,14 @@ The following command operators are supported:
   TCP
     Not implemented ("-").
 
+%RESPONSE_CODE_DETAILS%
+  HTTP
+    HTTP response code details provides additional information about the response code, such as
+    who set it (the upstream or envoy) and why.
+
+  TCP
+    Not implemented ("-")
+
 %BYTES_SENT%
   HTTP
     Body bytes sent. For WebSocket connection it will also include response header bytes.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,13 +3,13 @@ Version history
 
 1.11.0 (Pending)
 ================
+* access log: added RESPONSE_CODE_DETAILS.
 * dubbo_proxy: support the :ref:`Dubbo proxy filter <config_network_filters_dubbo_proxy>`.
 * event: added :ref:`loop duration and poll delay statistics <operations_performance>`.
 * http: mitigated a race condition with the :ref:`delayed_close_timeout<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` where it could trigger while actively flushing a pending write buffer for a downstream connection.
 * redis: added :ref:`prefix routing <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.prefix_routes>` to enable routing commands based on their key's prefix to different upstream.
 * redis: add support for zpopmax and zpopmin commands.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
-* access log: added RESPONSE_CODE_DETAILS.
 
 1.10.0 (Apr 5, 2019)
 ====================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,7 +3,7 @@ Version history
 
 1.11.0 (Pending)
 ================
-* access log: added RESPONSE_CODE_DETAILS.
+* access log: added a new field for response code details in :ref:`file access logger<config_access_log_format_response_code_details>` and :ref:`gRPC access logger<envoy_api_field_data.accesslog.v2.HTTPResponseProperties.response_code_details>`.
 * dubbo_proxy: support the :ref:`Dubbo proxy filter <config_network_filters_dubbo_proxy>`.
 * event: added :ref:`loop duration and poll delay statistics <operations_performance>`.
 * http: mitigated a race condition with the :ref:`delayed_close_timeout<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` where it could trigger while actively flushing a pending write buffer for a downstream connection.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,7 @@ Version history
 * redis: added :ref:`prefix routing <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.prefix_routes>` to enable routing commands based on their key's prefix to different upstream.
 * redis: add support for zpopmax and zpopmin commands.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
+* access log: added RESPONSE_CODE_DETAILS.
 
 1.10.0 (Apr 5, 2019)
 ====================

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -310,6 +310,11 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
       return stream_info.responseCode() ? fmt::format_int(stream_info.responseCode().value()).str()
                                         : "0";
     };
+  } else if (field_name == "RESPONSE_CODE_DETAILS") {
+    field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
+      return stream_info.responseCodeDetails() ? stream_info.responseCodeDetails().value()
+                                               : UnspecifiedValueString;
+    };
   } else if (field_name == "BYTES_SENT") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
       return fmt::format_int(stream_info.bytesSent()).str();

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
@@ -361,6 +361,9 @@ void HttpGrpcAccessLog::log(const Http::HeaderMap* request_headers,
   if (stream_info.responseCode()) {
     response_properties->mutable_response_code()->set_value(stream_info.responseCode().value());
   }
+  if (stream_info.responseCodeDetails()) {
+    response_properties->set_response_code_details(stream_info.responseCodeDetails().value());
+  }
   response_properties->set_response_headers_bytes(response_headers->byteSize());
   response_properties->set_response_body_bytes(stream_info.bytesSent());
   if (!response_headers_to_log_.empty()) {

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -126,6 +126,20 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
   }
 
   {
+    StreamInfoFormatter response_format("RESPONSE_CODE_DETAILS");
+    absl::optional<std::string> rc_details;
+    EXPECT_CALL(stream_info, responseCodeDetails()).WillRepeatedly(ReturnRef(rc_details));
+    EXPECT_EQ("-", response_format.format(header, header, header, stream_info));
+  }
+
+  {
+    StreamInfoFormatter response_code_format("RESPONSE_CODE_DETAILS");
+    absl::optional<std::string> rc_details{"via_upstream"};
+    EXPECT_CALL(stream_info, responseCodeDetails()).WillRepeatedly(ReturnRef(rc_details));
+    EXPECT_EQ("via_upstream", response_code_format.format(header, header, header, stream_info));
+  }
+
+  {
     StreamInfoFormatter bytes_sent_format("BYTES_SENT");
     EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(1));
     EXPECT_EQ("1", bytes_sent_format.format(header, header, header, stream_info));

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -227,6 +227,7 @@ http_logs:
     stream_info.addBytesReceived(10);
     stream_info.addBytesSent(20);
     stream_info.response_code_ = 200;
+    stream_info.response_code_details_ = "via_upstream";
     ON_CALL(stream_info, hasResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
         .WillByDefault(Return(true));
 
@@ -300,6 +301,7 @@ http_logs:
         value: 200
       response_headers_bytes: 10
       response_body_bytes: 20
+      response_code_details: "via_upstream"
 )EOF");
     access_log_->log(&request_headers, &response_headers, nullptr, stream_info);
   }


### PR DESCRIPTION
Description: add formatting for the "response code details" string recently added to the StreamInfo (#6530)
Risk Level: low
Testing: unit tests
Docs Changes: updated
Release Notes: updated

Signed-off-by: Elisha Ziskind <eziskind@google.com>
