### PR TITLE
router: defer per try timeout until downstream request is done

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -11,6 +11,9 @@ Version history
 * redis: added :ref:`prefix routing <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.prefix_routes>` to enable routing commands based on their key's prefix to different upstream.
 * redis: add support for zpopmax and zpopmin commands.
 * router: added ability to control retry back-off intervals via :ref:`retry policy <envoy_api_msg_route.RetryPolicy.RetryBackOff>`.
+* router: per try timeouts will no longer start before the downstream request has been received
+  in full by the router. This ensure that the per try timeout does not account for slow
+  downstreams and that will not not start before the global timeout.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
 
 1.10.0 (Apr 5, 2019)

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,8 +12,8 @@ Version history
 * redis: add support for zpopmax and zpopmin commands.
 * router: added ability to control retry back-off intervals via :ref:`retry policy <envoy_api_msg_route.RetryPolicy.RetryBackOff>`.
 * router: per try timeouts will no longer start before the downstream request has been received
-  in full by the router. This ensure that the per try timeout does not account for slow
-  downstreams and that will not not start before the global timeout.
+  in full by the router. This ensures that the per try timeout does not account for slow
+  downstreams and that will not start before the global timeout.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
 
 1.10.0 (Apr 5, 2019)

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -525,7 +525,7 @@ void Filter::onRequestComplete() {
     }
 
     for (auto& upstream_request : upstream_requests_) {
-      if (upstream_request->pending_per_try_timeout_) {
+      if (upstream_request->create_per_try_timeout_on_request_complete_) {
         upstream_request->setupPerTryTimeout();
       }
     }
@@ -992,7 +992,7 @@ Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::I
     : parent_(parent), conn_pool_(pool), grpc_rq_success_deferred_(false),
       stream_info_(pool.protocol(), parent_.callbacks_->dispatcher().timeSource()),
       calling_encode_headers_(false), upstream_canary_(false), encode_complete_(false),
-      encode_trailers_(false), pending_per_try_timeout_(false) {
+      encode_trailers_(false), create_per_try_timeout_on_request_complete_(false) {
 
   if (parent_.config_.start_child_span_) {
     span_ = parent_.callbacks_->activeSpan().spawnChild(
@@ -1195,7 +1195,7 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
   if (parent_.downstream_end_stream_) {
     setupPerTryTimeout();
   } else {
-    pending_per_try_timeout_ = true;
+    create_per_try_timeout_on_request_complete_ = true;
   }
 
   conn_pool_stream_handle_ = nullptr;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -152,7 +152,7 @@ public:
   Filter(FilterConfig& config)
       : config_(config), downstream_response_started_(false), downstream_end_stream_(false),
         do_shadowing_(false), is_retry_(false),
-        attempting_internal_redirect_with_complete_stream_(false) {}
+        attempting_internal_redirect_with_complete_stream_(false), pending_per_try_timeout_(false) {}
 
   ~Filter();
 
@@ -434,6 +434,9 @@ private:
   bool is_retry_ : 1;
   bool include_attempt_count_ : 1;
   bool attempting_internal_redirect_with_complete_stream_ : 1;
+  // Tracks whether we deferred a per try timeout because the downstream request
+  // had not been completed yet.
+  bool pending_per_try_timeout_ : 1;
   uint32_t attempt_count_{1};
 };
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -357,7 +357,7 @@ private:
     bool encode_trailers_ : 1;
     // Tracks whether we deferred a per try timeout because the downstream request
     // had not been completed yet.
-    bool pending_per_try_timeout_ : 1;
+    bool create_per_try_timeout_on_request_complete_ : 1;
   };
 
   typedef std::unique_ptr<UpstreamRequest> UpstreamRequestPtr;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -152,8 +152,7 @@ public:
   Filter(FilterConfig& config)
       : config_(config), downstream_response_started_(false), downstream_end_stream_(false),
         do_shadowing_(false), is_retry_(false),
-        attempting_internal_redirect_with_complete_stream_(false), pending_per_try_timeout_(false) {
-  }
+        attempting_internal_redirect_with_complete_stream_(false) {}
 
   ~Filter();
 
@@ -356,6 +355,9 @@ private:
     bool upstream_canary_ : 1;
     bool encode_complete_ : 1;
     bool encode_trailers_ : 1;
+    // Tracks whether we deferred a per try timeout because the downstream request
+    // had not been completed yet.
+    bool pending_per_try_timeout_ : 1;
   };
 
   typedef std::unique_ptr<UpstreamRequest> UpstreamRequestPtr;
@@ -435,9 +437,6 @@ private:
   bool is_retry_ : 1;
   bool include_attempt_count_ : 1;
   bool attempting_internal_redirect_with_complete_stream_ : 1;
-  // Tracks whether we deferred a per try timeout because the downstream request
-  // had not been completed yet.
-  bool pending_per_try_timeout_ : 1;
   uint32_t attempt_count_{1};
 };
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -152,7 +152,8 @@ public:
   Filter(FilterConfig& config)
       : config_(config), downstream_response_started_(false), downstream_end_stream_(false),
         do_shadowing_(false), is_retry_(false),
-        attempting_internal_redirect_with_complete_stream_(false), pending_per_try_timeout_(false) {}
+        attempting_internal_redirect_with_complete_stream_(false), pending_per_try_timeout_(false) {
+  }
 
   ~Filter();
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -163,8 +163,8 @@ public:
               callbacks.onPoolReady(encoder1, context_.cluster_manager_.conn_pool_.host_);
               return nullptr;
             }));
-    expectResponseTimerCreate();
     expectPerTryTimerCreate();
+    expectResponseTimerCreate();
 
     Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"},
                                     {"x-envoy-internal", "true"},


### PR DESCRIPTION
This defers starting the per try timeout timer until onRequestComplete
to ensure that it is not started before the global timeout. This ensures
that the per try timeout will not take into account the time spent
reading the downstream, which should be responsibility of the HCM level
timeouts.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Medium, changes to router logic
Testing: Added new UT, updated existing ones
Docs Changes: n/a
Release Notes: n/a
Fixes #6624 