### PR TITLE
quiche: Implement some TODOs in quic_endian_impl.h

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -277,6 +277,7 @@ envoy_cc_test(
     name = "quic_platform_test",
     srcs = envoy_select_quiche(
         [
+            "quiche/quic/platform/api/quic_endian_test.cc",
             "quiche/quic/platform/api/quic_reference_counted_test.cc",
             "quiche/quic/platform/api/quic_string_utils_test.cc",
             "quiche/quic/platform/api/quic_text_utils_test.cc",

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -129,6 +129,7 @@ envoy_cc_library(
         ":quic_platform_logging_impl_lib",
         "//include/envoy/thread:thread_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:byte_order_lib",
         "//source/server:backtrace_lib",
     ]),
 )

--- a/source/extensions/quic_listeners/quiche/platform/quic_endian_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_endian_impl.h
@@ -1,31 +1,28 @@
 #pragma once
 
-#include <arpa/inet.h>
-
-#include <cstdint>
-
 // NOLINT(namespace-envoy)
 
 // This file is part of the QUICHE platform implementation, and is not to be
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
+#include <cstdint>
+
+#include "common/common/byte_order.h"
+
 namespace quic {
 
 class QuicEndianImpl {
 public:
-  static uint16_t HostToNet16(uint16_t x) { return htons(x); }
-  static uint32_t HostToNet32(uint32_t x) { return htonl(x); }
-  // TODO: implement
-  static uint64_t HostToNet64(uint64_t /*x*/) { return 0; }
+  static uint16_t HostToNet16(uint16_t x) { return toEndianness<ByteOrder::BigEndian>(x); }
+  static uint32_t HostToNet32(uint32_t x) { return toEndianness<ByteOrder::BigEndian>(x); }
+  static uint64_t HostToNet64(uint64_t x) { return toEndianness<ByteOrder::BigEndian>(x); }
 
-  static uint16_t NetToHost16(uint16_t x) { return ntohs(x); }
-  static uint32_t NetToHost32(uint32_t x) { return ntohl(x); }
-  // TODO: implement
-  static uint64_t NetToHost64(uint64_t /*x*/) { return 0; }
+  static uint16_t NetToHost16(uint16_t x) { return fromEndianness<ByteOrder::BigEndian>(x); }
+  static uint32_t NetToHost32(uint32_t x) { return fromEndianness<ByteOrder::BigEndian>(x); }
+  static uint64_t NetToHost64(uint64_t x) { return fromEndianness<ByteOrder::BigEndian>(x); }
 
-  // TODO: implement
-  static bool HostIsLittleEndian() { return false; }
+  static bool HostIsLittleEndian() { return NetToHost16(0x1234) != 0x1234; }
 };
 
 } // namespace quic


### PR DESCRIPTION
Description:

Implement QuicEndianImpl::HostToNet64, QuicEndianImpl::NetToHost64 and QuicEndianImpl::HostIsLittleEndian on top of common/common/byte_order.h. Remove corresponding TODOs.

Risk Level: minimum, code not used yet.
Testing:

Enabled QUICHE platform tests in quic_endian_test.cc.

Docs Changes: none
Release Notes: none
