### PR TITLE
grpc_http1_reverse_bridge: Fix NULL pointer crashes, catch content length overflow

### DIFF
--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -98,7 +98,7 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& buffer, bool) {
 
 Http::FilterHeadersStatus Filter::encodeHeaders(Http::HeaderMap& headers, bool) {
   if (enabled_) {
-    if(headers.ContentType() == nullptr) {
+    if (headers.ContentType() == nullptr) {
       // If the content-type is empty return a useful error message in grpc-message.
       const auto grpc_message = fmt::format("envoy reverse bridge: upstream responded with "
                                             "no content-type, status code {}",


### PR DESCRIPTION
Description:
Fix 1: The grpc_http1_reverse_bridge filter assumes a client will send content type and status headers. If those headers are not included the daemon will crash with a NULL pointer dereference.
Fix 2: If a client sends a content-length header with a value less than GRPC_FRAME_HEADER_SIZE the lambdas passed to the adjustContentLength function will result in an integer overflow. I haven't found any security related consequences of this bug but a downstream consumer of these messages may not expect such a large value.

Risk Level: Low
Testing: Unit Test, Manual Testing
Docs Changes: n/a
Release Notes: n/a
