### PR TITLE
http timeout integration test: wait for 10ms for upstream reset

### DIFF
--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -36,7 +36,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
 
   // Ensure we got a timeout downstream and canceled the upstream request.
   response->waitForHeaders();
-  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::milliseconds(10)));
+  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
   codec_client_->close();
 

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -36,7 +36,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
 
   // Ensure we got a timeout downstream and canceled the upstream request.
   response->waitForHeaders();
-  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::milliseconds(0)));
+  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::milliseconds(10)));
 
   codec_client_->close();
 


### PR DESCRIPTION
This test waits for the upstream to see a reset which confirms that the
router filter did the right thing when the global timeout is hit.
However since this involves the network, we would occasionally see the
reset after the wait call. Since we were waiting for 0ms we'd get
flakes. 10ms is hopefully high enough that the test will succeed
reliably.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>


Description: address an integration test flake by sleeping longer when waiting for a remote reset to occur.
Risk Level: low
Testing: integration test 
Docs Changes: n/a 
Release Notes: n/a
Fixes #6638 
[Optional Deprecated:]
