### PR TITLE
Common: Fix a crash in metadata testing. 

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -150,7 +150,10 @@ void ConnectionImpl::StreamImpl::encodeTrailers(const HeaderMap& trailers) {
 void ConnectionImpl::StreamImpl::encodeMetadata(const MetadataMapVector& metadata_map_vector) {
   ASSERT(parent_.allow_metadata_);
 
-  getMetadataEncoder().createPayload(metadata_map_vector);
+  bool success = getMetadataEncoder().createPayload(metadata_map_vector);
+  if (!success) {
+    return;
+  }
 
   // Estimates the number of frames to generate, and breaks the while loop when the size is reached
   // in case submitting succeeds and packing fails, and we don't get error from packing.


### PR DESCRIPTION
Signed-off-by: Yang Song <yasong@google.com>

Description: Avoid calling sendPendingFrames() when metadata creation fails. 
Risk Level: Low. Fix a test crash.
Testing: Covered by existing unit and integration tests.
#5104
