### PR TITLE
docs: add aspell to mac dependencies to fix check format script

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -50,7 +50,7 @@ for how to update or override dependencies.
 
     On macOS, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):
     ```
-    brew install coreutils wget cmake libtool go bazel automake ninja llvm@7 autoconf
+    brew install coreutils wget cmake libtool go bazel automake ninja llvm@7 autoconf aspell
     ```
     _notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`; `llvm@7` is used for `clang-format`
 
@@ -366,7 +366,7 @@ The following optional features can be enabled on the Bazel build command-line:
   release builds so that the condition is not evaluated. This option has no effect in debug builds.
 * memory-debugging (scribbling over memory after allocation and before freeing) with
   `--define tcmalloc=debug`. Note this option cannot be used with FIPS-compliant mode BoringSSL.
-* Default [path normalization](https://github.com/envoyproxy/envoy/issues/6435) with 
+* Default [path normalization](https://github.com/envoyproxy/envoy/issues/6435) with
   `--define path_normalization_by_default=true`. Note this still could be disable by explicit xDS config.
 
 ## Disabling extensions


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

Description: add aspell to mac dependencies to fix [check spelling pedantic script](https://github.com/envoyproxy/envoy/blob/3abb7d051c55f190d19b531a2fd1360842b334a5/tools/check_spelling_pedantic.py#L100).
Risk Level: Low
Testing: Tested this locally on my mac
Docs Changes: Included
Release Notes: N/A