### PR TITLE
reclaim all the reserved slices in a buffer upon commit

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -418,6 +418,7 @@ uint64_t OwnedImpl::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iove
     // Check whether there are any empty slices with reservable space at the end of the buffer.
     size_t first_reservable_slice = slices_.size();
     while (first_reservable_slice > 0) {
+      slices_[first_reservable_slice - 1]->clearReservation();
       if (slices_[first_reservable_slice - 1]->reservableSize() == 0) {
         break;
       }

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -147,6 +147,15 @@ void OwnedImpl::commit(RawSlice* iovecs, uint64_t num_iovecs) {
       }
     }
 
+    // If the slices just committed are not at the very end of the buffer,
+    // the caller probably used reserve() to get multiple iovecs but didn't
+    // read enough data to fill them all. In this case, we clear out the
+    // reservations for all the remaining slices at the end of the buffer
+    // so the next reserve() call can reuse them.
+    while (slice_index < static_cast<ssize_t>(slices_.size())) {
+      slices_[slice_index++]->clearReservation();
+    }
+
     ASSERT(num_slices_committed > 0);
   }
 }

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -131,6 +131,12 @@ public:
   }
 
   /**
+   * Clear any outstanding reservation on the Slice, allowing the memory
+   * to be re-reserve()d.
+   */
+  void clearReservation() { reservation_outstanding_ = false; }
+
+  /**
    * Copy as much of the supplied data as possible to the end of the slice.
    * @param data start of the data to copy.
    * @param size number of bytes to copy.

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -340,6 +340,68 @@ TEST_P(OwnedImplTest, ReserveCommit) {
   }
 }
 
+TEST_P(OwnedImplTest, ReserveCommitReuse) {
+  Buffer::OwnedImpl buffer;
+  verifyImplementation(buffer);
+
+  static constexpr uint64_t NumIovecs = 2;
+  Buffer::RawSlice iovecs[NumIovecs];
+
+  // Reserve 8KB and commit all but a few bytes of it, to ensure that
+  // the last slice of the buffer can hold part but not all of the
+  // next reservation. Note that the buffer implementation might
+  // allocate more than the requested 8KB. In case the implementation
+  // uses a power-of-two allocator, the subsequent reservations all
+  // request 16KB.
+  uint64_t num_reserved = buffer.reserve(8192, iovecs, NumIovecs);
+  EXPECT_EQ(1, num_reserved);
+  iovecs[0].len_ = 8000;
+  buffer.commit(iovecs, 1);
+  EXPECT_EQ(8000, buffer.length());
+
+  // Reserve 16KB. The resulting reservation should span 2 slices.
+  // Commit part of the first slice and none of the second slice.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  const void* first_slice = iovecs[0].mem_;
+  const void* second_slice = iovecs[1].mem_;
+  iovecs[0].len_ = 1;
+  buffer.commit(iovecs, 1);
+  EXPECT_EQ(8001, buffer.length());
+
+  // Reserve 16KB again, and check whether we get back the uncommitted
+  // second slice from the previous reservation.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(static_cast<const uint8_t*>(first_slice) + 1, static_cast<const uint8_t*>(iovecs[0].mem_));
+  EXPECT_EQ(second_slice, iovecs[1].mem_);
+}
+
+TEST_P(OwnedImplTest, ReserveReuse) {
+  Buffer::OwnedImpl buffer;
+  verifyImplementation(buffer);
+
+  static constexpr uint64_t NumIovecs = 2;
+  Buffer::RawSlice iovecs[NumIovecs];
+
+  // Reserve some space and leave it uncommitted.
+  uint64_t num_reserved = buffer.reserve(8192, iovecs, NumIovecs);
+  EXPECT_EQ(1, num_reserved);
+  const void* first_slice = iovecs[0].mem_;
+
+  // Reserve more space and verify that it begins with the same slice from the last reservation.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  const void* second_slice = iovecs[1].mem_;
+
+  // Repeat the last reservation and verify that it yields the same slices.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  EXPECT_EQ(second_slice, iovecs[1].mem_);
+}
+
 TEST_P(OwnedImplTest, Search) {
   // Populate a buffer with a string split across many small slices, to
   // exercise edge cases in the search implementation.

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -373,7 +373,8 @@ TEST_P(OwnedImplTest, ReserveCommitReuse) {
   // second slice from the previous reservation.
   num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
   EXPECT_EQ(2, num_reserved);
-  EXPECT_EQ(static_cast<const uint8_t*>(first_slice) + 1, static_cast<const uint8_t*>(iovecs[0].mem_));
+  EXPECT_EQ(static_cast<const uint8_t*>(first_slice) + 1,
+            static_cast<const uint8_t*>(iovecs[0].mem_));
   EXPECT_EQ(second_slice, iovecs[1].mem_);
 }
 


### PR DESCRIPTION
Description:
If the caller reserves N slices but only commits the first M of them, where M < N,
release the reservations for all N so they can be reused in the next reserve call.

Risk Level: medium
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Fixes #6617 

Signed-off-by: Brian Pane <brianp+github@brianp.net>
