### PR TITLE
reduce default per-connection buffering limit from 1MB to 16KB

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -550,7 +550,7 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       connect_timeout_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(config, connect_timeout))),
       per_connection_buffer_limit_bytes_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 16 * 1024)),
       transport_socket_factory_(std::move(socket_factory)), stats_scope_(std::move(stats_scope)),
       stats_(generateStats(*stats_scope_)),
       load_report_stats_(generateLoadReportStats(load_report_stats_store_)),


### PR DESCRIPTION
Description:
The debugging of #6617 highlighted that the SSL socket implementation can use a very large amount of memory with the default buffering settings because it reads up to 1MB in a fast loop. This change reduces the default buffering limit from 1MB to 16KB.

Risk Level: medium 
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Brian Pane <brianp+github@brianp.net>
