### PR TITLE
prevent internal fragmentation in SSL buffers

### DIFF
--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -88,7 +88,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       uint64_t offset = 0;
       while (offset < slices[i].len_) {
         int rc = SSL_read(ssl_.get(), static_cast<uint8_t*>(slices[i].mem_) + offset,
-          slices[i].len_ - offset);
+                          slices[i].len_ - offset);
         ENVOY_CONN_LOG(trace, "ssl read returns: {}", callbacks_->connection(), rc);
         if (rc > 0) {
           offset += rc;


### PR DESCRIPTION
Description:
Rewrite the read loop in `SslSocket::doRead` so it doesn't start reading into a
slice before it finishes filling the previous slice.

Risk Level: medium
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Fixes #6617 

Signed-off-by: Brian Pane <brianp+github@brianp.net>
