### PR TITLE
router: scoped rds (2a): scoped routing configuration protos

### DIFF
--- a/api/envoy/api/v2/BUILD
+++ b/api/envoy/api/v2/BUILD
@@ -144,3 +144,24 @@ api_go_grpc_library(
         "//envoy/api/v2/route:route_go_proto",
     ],
 )
+
+api_proto_library_internal(
+    name = "srds",
+    srcs = ["srds.proto"],
+    has_services = 1,
+    visibility = [":friends"],
+    deps = [
+        ":discovery",
+        "//envoy/api/v2/core:base",
+        "//envoy/api/v2/route",
+    ],
+)
+
+api_go_grpc_library(
+    name = "srds",
+    proto = ":srds",
+    deps = [
+        ":discovery_go_proto",
+        "//envoy/api/v2/core:base_go_proto",
+    ],
+)

--- a/api/envoy/api/v2/srds.proto
+++ b/api/envoy/api/v2/srds.proto
@@ -48,8 +48,9 @@ service ScopedRoutesDiscoveryService {
   }
 }
 
-// Specifies a routing scope, which associates a :ref:`envoy_api_msg_RouteConfiguration` (identified
-// by its resource name) to a :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>`.
+// Specifies a routing scope, which associates a
+// :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>` to a
+// :ref:`envoy_api_msg_RouteConfiguration` (identified by its resource name).
 //
 // The HTTP connection manager builds up a table consisting of these Key to RouteConfiguration
 // mappings, and looks up the RouteConfiguration to use per request according to the algorithm
@@ -64,14 +65,16 @@ service ScopedRoutesDiscoveryService {
 // .. code::
 //
 //   ...
-//   scope_key_builder:
-//     fragments:
-//       - header_element:
-//         name: X-Route-Selector
-//         element_separator: ,
-//         element:
-//           separator: =
-//           key: vip
+//   scoped_routes:
+//     name: foo-scoped-routes
+//     scope_key_builder:
+//       fragments:
+//         - header_value_extractor:
+//             name: X-Route-Selector
+//             element_separator: ,
+//             element:
+//               separator: =
+//               key: vip
 //
 // ScopedRouteConfiguration resources (specified statically via
 // :ref:`scoped_route_configurations_list<envoy_api_field_config.filter.network.http_connection_manager.v2.ScopedRoutes.scoped_route_configurations_list>`

--- a/api/envoy/api/v2/srds.proto
+++ b/api/envoy/api/v2/srds.proto
@@ -32,6 +32,7 @@ option (gogoproto.equal_all) = true;
 // ScopedRouteConfiguration resource represents a "routing scope" containing a mapping that allows
 // the HTTP connection manager to dynamically assign a routing table (specified via
 // a :ref:`RouteConfiguration<envoy_api_msg_RouteConfiguration>` message) to each HTTP request.
+// [#proto-status: experimental]
 service ScopedRoutesDiscoveryService {
   rpc StreamScopedRoutes(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
   }
@@ -100,10 +101,11 @@ service ScopedRoutesDiscoveryService {
 //     Host: foo.com
 //     X-Route-Selector: vip=172.10.10.20
 //
-// Would result in the routing table defined by the `route-config1` RouteConfiguration being
+// would result in the routing table defined by the `route-config1` RouteConfiguration being
 // assigned to the HTTP request/stream.
 //
 // [#comment:next free field: 4]
+// [#proto-status: experimental]
 message ScopedRouteConfiguration {
   // The name assigned to the routing scope.
   string name = 1 [(validate.rules).string.min_bytes = 1];
@@ -122,7 +124,9 @@ message ScopedRouteConfiguration {
       }
     }
 
-    // The ordered set of fragments to match against.
+    // The ordered set of fragments to match against. The order must match the fragments in the
+    // corresponding
+    // :ref:`scope_key_builder<envoy_api_field_config.filter.network.http_connection_manager.v2.ScopedRoutes.scope_key_builder>`.
     repeated Fragment fragments = 1 [(validate.rules).repeated .min_items = 1];
   }
 

--- a/api/envoy/api/v2/srds.proto
+++ b/api/envoy/api/v2/srds.proto
@@ -1,0 +1,135 @@
+syntax = "proto3";
+
+package envoy.api.v2;
+
+option java_outer_classname = "SrdsProto";
+option java_package = "io.envoyproxy.envoy.api.v2";
+option java_multiple_files = true;
+option java_generic_services = true;
+
+import "envoy/api/v2/discovery.proto";
+
+import "google/api/annotations.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: HTTP scoped routing configuration]
+// * Routing :ref:`architecture overview <arch_overview_http_routing>`
+//
+// .. attention::
+//
+//   The Scoped RDS API is not yet fully implemented and *should not* be enabled in
+//   :ref:`envoy_api_msg_config.filter.network.http_connection_manager.v2.HttpConnectionManager`.
+//
+// TODO(AndresGuedez): Update :ref:`arch_overview_http_routing` with scoped routing overview and
+// configuration details.
+
+// The Scoped Routes Discovery Service (SRDS) API distributes
+// :ref:`ScopedRouteConfiguration<envoy_api_msg.ScopedRouteConfiguration>` resources. Each
+// ScopedRouteConfiguration resource represents a "routing scope" containing a mapping that allows
+// the HTTP connection manager to dynamically assign a routing table (specified via
+// a :ref:`RouteConfiguration<envoy_api_msg_RouteConfiguration>` message) to each HTTP request.
+service ScopedRoutesDiscoveryService {
+  rpc StreamScopedRoutes(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaScopedRoutes(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchScopedRoutes(DiscoveryRequest) returns (DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:scoped-routes"
+      body: "*"
+    };
+  }
+}
+
+// Specifies a routing scope, which associates a :ref:`envoy_api_msg_RouteConfiguration` (identified
+// by its resource name) to a :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>`.
+//
+// The HTTP connection manager builds up a table consisting of these Key to RouteConfiguration
+// mappings, and looks up the RouteConfiguration to use per request according to the algorithm
+// specified in the
+// :ref:`scope_key_builder<envoy_api_field_config.filter.network.http_connection_manager.v2.ScopedRoutes.scope_key_builder>`
+// assigned to the HttpConnectionManager.
+//
+// For example, with the following configurations (in YAML):
+//
+// HttpConnectionManager config:
+//
+// .. code::
+//
+//   ...
+//   scope_key_builder:
+//     fragments:
+//       - header_element:
+//         name: X-Route-Selector
+//         element_separator: ,
+//         element:
+//           separator: =
+//           key: vip
+//
+// ScopedRouteConfiguration resources (specified statically via
+// :ref:`scoped_route_configurations_list<envoy_api_field_config.filter.network.http_connection_manager.v2.ScopedRoutes.scoped_route_configurations_list>`
+// or obtained dynamically via SRDS):
+//
+// .. code::
+//
+//  (1)
+//   name: route-scope1
+//   route_configuration_name: route-config1
+//   key:
+//      fragments:
+//        - string_key: 172.10.10.20
+//
+//  (2)
+//   name: route-scope2
+//   route_configuration_name: route-config2
+//   key:
+//     fragments:
+//       - string_key: 172.20.20.30
+//
+// A request from a client such as:
+//
+// .. code::
+//
+//     GET / HTTP/1.1
+//     Host: foo.com
+//     X-Route-Selector: vip=172.10.10.20
+//
+// Would result in the routing table defined by the `route-config1` RouteConfiguration being
+// assigned to the HTTP request/stream.
+//
+// [#comment:next free field: 4]
+message ScopedRouteConfiguration {
+  // The name assigned to the routing scope.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specifies a key which is matched against the output of the
+  // :ref:`scope_key_builder<envoy_api_field_config.filter.network.http_connection_manager.v2.ScopedRoutes.scope_key_builder>`
+  // specified in the HttpConnectionManager. The matching is done per HTTP request and is dependent
+  // on the order of the fragments contained in the Key.
+  message Key {
+    message Fragment {
+      oneof type {
+        option (validate.required) = true;
+
+        // A string to match against.
+        string string_key = 1;
+      }
+    }
+
+    // The ordered set of fragments to match against.
+    repeated Fragment fragments = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  // The resource name to use for a :ref:`envoy_api_msg_DiscoveryRequest` to an RDS server to
+  // fetch the :ref:`envoy_api_msg_RouteConfiguration` associated with this scope.
+  string route_configuration_name = 2 [(validate.rules).string.min_bytes = 1];
+
+  // The key to match against.
+  Key key = 3 [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -7,6 +7,7 @@ api_proto_library_internal(
     srcs = ["http_connection_manager.proto"],
     deps = [
         "//envoy/api/v2:rds",
+        "//envoy/api/v2:srds",
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/core:config_source",
         "//envoy/api/v2/core:protocol",
@@ -20,6 +21,7 @@ api_go_proto_library(
     proto = ":http_connection_manager",
     deps = [
         "//envoy/api/v2:rds_go_grpc",
+        "//envoy/api/v2:srds_go_grpc",
         "//envoy/api/v2/core:base_go_proto",
         "//envoy/api/v2/core:config_source_go_proto",
         "//envoy/api/v2/core:protocol_go_proto",

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -10,6 +10,7 @@ option go_package = "v2";
 import "envoy/api/v2/core/config_source.proto";
 import "envoy/api/v2/core/protocol.proto";
 import "envoy/api/v2/rds.proto";
+import "envoy/api/v2/srds.proto";
 import "envoy/config/filter/accesslog/v2/accesslog.proto";
 import "envoy/type/percent.proto";
 
@@ -24,7 +25,7 @@ import "gogoproto/gogo.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-// [#comment:next free field: 31]
+// [#comment:next free field: 32]
 message HttpConnectionManager {
   enum CodecType {
     option (gogoproto.goproto_enum_prefix) = false;
@@ -61,6 +62,11 @@ message HttpConnectionManager {
 
     // The route table for the connection manager is static and is specified in this property.
     envoy.api.v2.RouteConfiguration route_config = 4;
+
+    // A route table will be dynamically assigned to each request based on request attributes
+    // (e.g., the value of a header). The "routing scopes" (i.e., route tables) and "scope keys" are
+    // specified in this message.
+    ScopedRoutes scoped_routes = 31;
   }
 
   // A list of individual HTTP filters that make up the filter chain for
@@ -417,6 +423,115 @@ message Rds {
   // associated HTTP connection manager filters) to use different route
   // configurations.
   string route_config_name = 2 [(validate.rules).string.min_bytes = 1];
+}
+
+// This message is used to work around the limitations with 'oneof' and repeated fields.
+message ScopedRouteConfigurationsList {
+  repeated envoy.api.v2.ScopedRouteConfiguration scoped_route_configurations = 1
+      [(validate.rules).repeated .min_items = 1];
+}
+
+message ScopedRoutes {
+  // The name assigned to the scoped routing configuration.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specifies the mechanism for constructing "scope keys" based on HTTP request attributes. These
+  // keys are matched against a set of :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>`
+  // objects assembled from :ref:`ScopedRouteConfiguration<envoy_api_msg_ScopedRouteConfiguration>`
+  // messages distributed via SRDS (the Scoped Route Discovery Service) or assigned statically via
+  // :ref:`scoped_route_configurations_list<envoy_api_field_config.filter.network.http_connection_manager.v2.ScopedRoutes.scoped_route_configurations_list>`.
+  //
+  // Upon receiving a request's headers, the Router will build a key using the algorithm specified
+  // by this message. This key will be used to look up the routing table (i.e., the
+  // :ref:`RouteConfiguration<envoy_api_msg_RouteConfiguration>`) to use for the request.
+  message ScopeKeyBuilder {
+    // Specifies the mechanism for constructing key fragments which are composed into scope keys.
+    message FragmentBuilder {
+      // Specifies how the value of a header should be extracted.
+      // The following example maps the structure of a header to the fields in this message.
+      //
+      // .. code::
+      //
+      //    X-Header: a=b;c=d
+      //    |         || |
+      //    |         || \----> <element_separator>
+      //    |         ||
+      //    |         |\----> <element.separator>
+      //    |         |
+      //    |         \----> <element.key>
+      //    |
+      //    \----> <name>
+      //
+      //    Each 'a=b' key-value pair constitutes an 'element' of the header field.
+      message HeaderValueExtractor {
+        // The name of the header field to extract the value from.
+        string name = 1 [(validate.rules).string.min_bytes = 1];
+
+        // The element separator (e.g., ';' separates 'a;b;c;d').
+        string element_separator = 2;
+
+        // Specifies a header field's key value pair to match on.
+        message KvElement {
+          // The separator between key and value (e.g., '=' separates 'k=v;...').
+          string separator = 1;
+
+          // The key to match on.
+          string key = 2;
+        }
+
+        oneof extract_type {
+          // Specifies the index of the element to extract.
+          int32 index = 3;
+
+          // Specifies the key value pair to extract the value from.
+          KvElement element = 4;
+        }
+      }
+
+      oneof type {
+        option (validate.required) = true;
+
+        // Specifies how a header field's value should be extracted.
+        HeaderValueExtractor header_value_extractor = 1;
+      }
+    }
+
+    // The final scope key consists of the ordered union of these fragments.
+    repeated FragmentBuilder fragments = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  // The algorithm to use for constructing a scope key for each request.
+  ScopeKeyBuilder scope_key_builder = 2 [(validate.rules).message.required = true];
+
+  // Configuration source specifier for RDS.
+  // This config source is used to subscribe to RouteConfiguration resources specified in
+  // ScopedRouteConfiguration messages.
+  envoy.api.v2.core.ConfigSource rds_config_source = 3
+      [(validate.rules).message.required = true, (gogoproto.nullable) = false];
+
+  oneof config_specifier {
+    option (validate.required) = true;
+
+    // The set of routing scopes corresponding to the HCM. A scope is assigned to a request by
+    // matching a key constructed from the request's attributes according to the algorithm specified
+    // by the
+    // :ref:`ScopeKeyBuilder<envoy_api_msg_config.filter.network.http_connection_manager.v2.ScopedRoutes.ScopeKeyBuilder>`
+    // in this message.
+    ScopedRouteConfigurationsList scoped_route_configurations_list = 4;
+
+    // The set of routing scopes associated with the HCM will be dynamically loaded via the SRDS
+    // API. A scope is assigned to a request by matching a key constructed from the request's
+    // attributes according to the algorithm specified by the
+    // :ref:`ScopeKeyBuilder<envoy_api_msg_config.filter.network.http_connection_manager.v2.ScopedRoutes.ScopeKeyBuilder>`
+    // in this message.
+    ScopedRds scoped_rds = 5;
+  }
+}
+
+message ScopedRds {
+  // Configuration source specifier for scoped RDS.
+  envoy.api.v2.core.ConfigSource scoped_rds_config_source = 1
+      [(validate.rules).message.required = true, (gogoproto.nullable) = false];
 }
 
 message HttpFilter {

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -481,7 +481,7 @@ message ScopedRoutes {
 
         oneof extract_type {
           // Specifies the index of the element to extract.
-          int32 index = 3;
+          uint32 index = 3;
 
           // Specifies the key value pair to extract the value from.
           KvElement element = 4;

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -452,6 +452,7 @@ message ScopedRoutes {
       //
       // .. code::
       //
+      //              <0> <1>   <-- index
       //    X-Header: a=b;c=d
       //    |         || |
       //    |         || \----> <element_separator>
@@ -468,19 +469,22 @@ message ScopedRoutes {
         string name = 1 [(validate.rules).string.min_bytes = 1];
 
         // The element separator (e.g., ';' separates 'a;b;c;d').
+        // Default: empty string. This causes the entirety of the header field to be extracted.
+        // If this field is set to an empty string and 'index' is used in the oneof below, 'index'
+        // must be set to 0.
         string element_separator = 2;
 
         // Specifies a header field's key value pair to match on.
         message KvElement {
           // The separator between key and value (e.g., '=' separates 'k=v;...').
-          string separator = 1;
+          string separator = 1 [(validate.rules).string.min_bytes = 1];
 
           // The key to match on.
-          string key = 2;
+          string key = 2 [(validate.rules).string.min_bytes = 1];
         }
 
         oneof extract_type {
-          // Specifies the index of the element to extract.
+          // Specifies the zero based index of the element to extract.
           uint32 index = 3;
 
           // Specifies the key value pair to extract the value from.

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -76,6 +76,7 @@ PROTO_RST="
   /envoy/api/v2/cluster/circuit_breaker/envoy/api/v2/cluster/circuit_breaker.proto.rst
   /envoy/api/v2/rds/envoy/api/v2/rds.proto.rst
   /envoy/api/v2/route/route/envoy/api/v2/route/route.proto.rst
+  /envoy/api/v2/srds/envoy/api/v2/srds.proto.rst
   /envoy/api/v2/lds/envoy/api/v2/lds.proto.rst
   /envoy/api/v2/listener/listener/envoy/api/v2/listener/listener.proto.rst
   /envoy/api/v2/ratelimit/ratelimit/envoy/api/v2/ratelimit/ratelimit.proto.rst

--- a/docs/root/api-v2/http_routes/http_routes.rst
+++ b/docs/root/api-v2/http_routes/http_routes.rst
@@ -6,4 +6,5 @@ HTTP route management
   :maxdepth: 2
 
   ../api/v2/rds.proto
+  ../api/v2/srds.proto
   ../api/v2/route/route.proto

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -227,6 +227,7 @@ SPIFFE
 SPKI
 SQL
 SR
+SRDS
 SRV
 SS
 SSL
@@ -271,6 +272,7 @@ WS
 Welford's
 Werror
 XDS
+vip
 xDSes
 XFCC
 XFF


### PR DESCRIPTION
This PR introduces the configuration protos required for scoped routing support  (https://github.com/envoyproxy/envoy/issues/4704).

This is the second chain of PRs for SRDS support. This chain will be split up into multiple PRs in the following cadence:

1. Configuration protos
2. Configuration parsing
3. SRDS config subscription handling 

Risk Level: Low (the protos are not yet referenced by any code)
Testing: None (will be introduced in the next PR)