### PR TITLE
stats: create non-trivial ParentHistogram for IsolatedStoreImpl

### DIFF
--- a/source/common/stats/heap_stat_data.h
+++ b/source/common/stats/heap_stat_data.h
@@ -18,7 +18,8 @@ namespace Stats {
 
 /**
  * This structure is an alternate backing store for both CounterImpl and GaugeImpl. It is designed
- * so that it can be allocated efficiently from the heap on demand.
+ * so that it can be allocated efficiently from the heap on demand. Note that this is not used for
+ * histograms, which are implemented with an external dependency and take non-constant heap space.
  */
 struct HeapStatData {
   /**

--- a/source/common/stats/histogram_impl.cc
+++ b/source/common/stats/histogram_impl.cc
@@ -79,5 +79,64 @@ void HistogramStatisticsImpl::refresh(const histogram_t* new_histogram_ptr) {
   }
 }
 
+ParentHistogramImpl::ParentHistogramImpl(const std::string& name, Store& parent,
+                                         std::string&& tag_extracted_name, std::vector<Tag>&& tags)
+    : MetricImpl(std::move(tag_extracted_name), std::move(tags)), parent_(parent),
+      interval_histogram_(hist_alloc()), cumulative_histogram_(hist_alloc()),
+      interval_statistics_(interval_histogram_), cumulative_statistics_(cumulative_histogram_),
+      used_(false), name_(name) {}
+
+ParentHistogramImpl::~ParentHistogramImpl() {
+  hist_free(interval_histogram_);
+  hist_free(cumulative_histogram_);
+}
+
+void ParentHistogramImpl::recordValue(uint64_t value) {
+  used_ = true;
+  hist_insert_intscale(interval_histogram_, value, 0, 1);
+  parent_.deliverHistogramToSinks(*this, value);
+}
+
+void ParentHistogramImpl::merge() {
+  hist_accumulate(cumulative_histogram_, &interval_histogram_, 1);
+  interval_statistics_.refresh(interval_histogram_);
+  cumulative_statistics_.refresh(cumulative_histogram_);
+  hist_clear(interval_histogram_);
+}
+
+// TODO(mergeconflict): figure out the best way to eliminate duplication between this and
+// bucketSummary below, and the implementations in ThreadLocalParentHistogramImpl.
+const std::string ParentHistogramImpl::quantileSummary() const {
+  if (used()) {
+    std::vector<std::string> summary;
+    const std::vector<double>& supported_quantiles_ref = interval_statistics_.supportedQuantiles();
+    summary.reserve(supported_quantiles_ref.size());
+    for (size_t i = 0; i < supported_quantiles_ref.size(); ++i) {
+      summary.push_back(fmt::format("P{}({},{})", 100 * supported_quantiles_ref[i],
+                                    interval_statistics_.computedQuantiles()[i],
+                                    cumulative_statistics_.computedQuantiles()[i]));
+    }
+    return absl::StrJoin(summary, " ");
+  } else {
+    return std::string("No recorded values");
+  }
+}
+
+const std::string ParentHistogramImpl::bucketSummary() const {
+  if (used()) {
+    std::vector<std::string> bucket_summary;
+    const std::vector<double>& supported_buckets = interval_statistics_.supportedBuckets();
+    bucket_summary.reserve(supported_buckets.size());
+    for (size_t i = 0; i < supported_buckets.size(); ++i) {
+      bucket_summary.push_back(fmt::format("B{}({},{})", supported_buckets[i],
+                                           interval_statistics_.computedBuckets()[i],
+                                           cumulative_statistics_.computedBuckets()[i]));
+    }
+    return absl::StrJoin(bucket_summary, " ");
+  } else {
+    return std::string("No recorded values");
+  }
+}
+
 } // namespace Stats
 } // namespace Envoy

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -34,8 +34,9 @@ IsolatedStoreImpl::IsolatedStoreImpl(SymbolTable& symbol_table)
         std::vector<Tag> tags;
         return alloc_.makeGauge(name, std::move(tag_extracted_name), std::move(tags));
       }),
-      histograms_([this](const std::string& name) -> HistogramSharedPtr {
-        return std::make_shared<HistogramImpl>(name, *this, std::string(name), std::vector<Tag>());
+      histograms_([this](const std::string& name) -> ParentHistogramSharedPtr {
+        return std::make_shared<ParentHistogramImpl>(name, *this, std::string(name),
+                                                     std::vector<Tag>());
       }) {}
 
 ScopePtr IsolatedStoreImpl::createScope(const std::string& name) {

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -74,7 +74,7 @@ public:
   std::vector<CounterSharedPtr> counters() const override { return counters_.toVector(); }
   std::vector<GaugeSharedPtr> gauges() const override { return gauges_.toVector(); }
   std::vector<ParentHistogramSharedPtr> histograms() const override {
-    return std::vector<ParentHistogramSharedPtr>{};
+    return histograms_.toVector();
   }
 
 private:
@@ -84,7 +84,7 @@ private:
   HeapStatDataAllocator alloc_;
   IsolatedStatsCache<Counter> counters_;
   IsolatedStatsCache<Gauge> gauges_;
-  IsolatedStatsCache<Histogram> histograms_;
+  IsolatedStatsCache<ParentHistogram> histograms_;
   const StatsOptionsImpl stats_options_;
   NullGaugeImpl null_gauge_;
 };

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -69,11 +69,11 @@ class TlsScope;
 /**
  * Log Linear Histogram implementation that is stored in the main thread.
  */
-class ParentHistogramImpl : public ParentHistogram, public MetricImpl {
+class ThreadLocalParentHistogramImpl : public ParentHistogram, public MetricImpl {
 public:
-  ParentHistogramImpl(const std::string& name, Store& parent, TlsScope& tlsScope,
-                      std::string&& tag_extracted_name, std::vector<Tag>&& tags);
-  ~ParentHistogramImpl();
+  ThreadLocalParentHistogramImpl(const std::string& name, Store& parent, TlsScope& tlsScope,
+                                 std::string&& tag_extracted_name, std::vector<Tag>&& tags);
+  ~ThreadLocalParentHistogramImpl();
 
   void addTlsHistogram(const TlsHistogramSharedPtr& hist_ptr);
   bool used() const override;
@@ -113,7 +113,7 @@ private:
   const std::string name_;
 };
 
-typedef std::shared_ptr<ParentHistogramImpl> ParentHistogramImplSharedPtr;
+typedef std::shared_ptr<ThreadLocalParentHistogramImpl> ThreadLocalParentHistogramImplSharedPtr;
 
 /**
  * Class used to create ThreadLocalHistogram in the scope.
@@ -127,7 +127,8 @@ public:
    * @return a ThreadLocalHistogram within the scope's namespace.
    * @param name name of the histogram with scope prefix attached.
    */
-  virtual Histogram& tlsHistogram(const std::string& name, ParentHistogramImpl& parent) PURE;
+  virtual Histogram& tlsHistogram(const std::string& name,
+                                  ThreadLocalParentHistogramImpl& parent) PURE;
 };
 
 /**
@@ -202,7 +203,7 @@ private:
   struct CentralCacheEntry {
     StatMap<CounterSharedPtr> counters_;
     StatMap<GaugeSharedPtr> gauges_;
-    StatMap<ParentHistogramImplSharedPtr> histograms_;
+    StatMap<ThreadLocalParentHistogramImplSharedPtr> histograms_;
     SharedStringSet rejected_stats_;
   };
 
@@ -223,7 +224,8 @@ private:
     Gauge& gauge(const std::string& name) override;
     NullGaugeImpl& nullGauge(const std::string&) override { return null_gauge_; }
     Histogram& histogram(const std::string& name) override;
-    Histogram& tlsHistogram(const std::string& name, ParentHistogramImpl& parent) override;
+    Histogram& tlsHistogram(const std::string& name,
+                            ThreadLocalParentHistogramImpl& parent) override;
     const Stats::StatsOptions& statsOptions() const override { return parent_.statsOptions(); }
 
     template <class StatType>

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -22,6 +22,15 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "histogram_impl_test",
+    srcs = ["histogram_impl_test.cc"],
+    deps = [
+        "//source/common/stats:histogram_lib",
+        "//test/mocks/stats:stats_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "isolated_store_impl_test",
     srcs = ["isolated_store_impl_test.cc"],
     deps = [

--- a/test/common/stats/histogram_impl_test.cc
+++ b/test/common/stats/histogram_impl_test.cc
@@ -1,0 +1,61 @@
+#include "test/mocks/stats/mocks.h"
+
+#include "gtest/gtest.h"
+
+using testing::_;
+
+namespace Envoy {
+namespace Stats {
+namespace {
+
+TEST(HistogramImplTest, Basic) {
+  MockStore store;
+  ParentHistogramImpl histogram("test", store, "test", std::vector<Tag>());
+  const HistogramStatistics &intervalStats = histogram.intervalStatistics(),
+                            &cumulativeStats = histogram.cumulativeStatistics();
+
+  // A histogram should retain the name it was given.
+  ASSERT_EQ("test", histogram.name());
+  EXPECT_STREQ("test", histogram.nameCStr());
+
+  // A histogram that hasn't been written to is not "used" and has no interesting statistics.
+  ASSERT_FALSE(histogram.used());
+  ASSERT_EQ(0, intervalStats.sampleCount());
+  ASSERT_EQ(0, cumulativeStats.sampleCount());
+
+  // Recording a value marks the histogram as "used" and delivers to sinks.
+  EXPECT_CALL(store, deliverHistogramToSinks(_, 123));
+  histogram.recordValue(123);
+  ASSERT_TRUE(histogram.used());
+
+  // Merging should populate statistics for the last interval, and cumulative statistics. Note that
+  // the sample sum loses precision; supposedly 125 is close enough to 123...
+  histogram.merge();
+  ASSERT_EQ(1, intervalStats.sampleCount());
+  ASSERT_EQ(125, intervalStats.sampleSum());
+  ASSERT_EQ(1, cumulativeStats.sampleCount());
+  ASSERT_EQ(125, cumulativeStats.sampleSum());
+
+  // Recording another value and merging again should yield fresh interval statistics, and add to
+  // cumulative statistics.
+  EXPECT_CALL(store, deliverHistogramToSinks(_, 456));
+  histogram.recordValue(456);
+  histogram.merge();
+  ASSERT_EQ(1, intervalStats.sampleCount());
+  ASSERT_EQ(455, intervalStats.sampleSum()); // 455 ~= 456
+  ASSERT_EQ(2, cumulativeStats.sampleCount());
+  ASSERT_EQ(580, cumulativeStats.sampleSum()); // 580 == 125 + 455.
+
+  // String quantile and bucket summaries should look sane.
+  EXPECT_EQ("P0(450,120) P25(452.5,125) P50(455,130) P75(457.5,455) P90(459,458) P95(459.5,459) "
+            "P99(459.9,459.8) P99.5(459.95,459.9) P99.9(459.99,459.98) P100(460,460)",
+            histogram.quantileSummary());
+  EXPECT_EQ("B0.5(0,0) B1(0,0) B5(0,0) B10(0,0) B25(0,0) B50(0,0) B100(0,0) B250(0,1) B500(1,2) "
+            "B1000(1,2) B2500(1,2) B5000(1,2) B10000(1,2) B30000(1,2) B60000(1,2) B300000(1,2) "
+            "B600000(1,2) B1.8e+06(1,2) B3.6e+06(1,2)",
+            histogram.bucketSummary());
+}
+
+} // namespace
+} // namespace Stats
+} // namespace Envoy

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -149,6 +149,11 @@ Stats::GaugeSharedPtr TestUtility::findGauge(Stats::Store& store, const std::str
   return findByName(store.gauges(), name);
 }
 
+Stats::ParentHistogramSharedPtr TestUtility::findHistogram(Stats::Store& store,
+                                                           const std::string& name) {
+  return findByName(store.histograms(), name);
+}
+
 std::list<Network::Address::InstanceConstSharedPtr>
 TestUtility::makeDnsResponse(const std::list<std::string>& addresses) {
   std::list<Network::Address::InstanceConstSharedPtr> ret;

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -181,6 +181,15 @@ public:
   static Stats::GaugeSharedPtr findGauge(Stats::Store& store, const std::string& name);
 
   /**
+   * Find a histogram in a stats store.
+   * @param store supplies the stats store.
+   * @param name supplies the name to search for.
+   * @return Stats::ParentHistogramSharedPtr the histogram or nullptr if there is none.
+   */
+  static Stats::ParentHistogramSharedPtr findHistogram(Stats::Store& store,
+                                                       const std::string& name);
+
+  /**
    * Convert a string list of IP addresses into a list of network addresses usable for DNS
    * response testing.
    */


### PR DESCRIPTION
Description: Create a non-trivial ParentHistogramImpl for IsolatedStoreImpl. This replaces HistogramImpl and allows tests to verify that histograms are being written as expected, in the same style as is currently done for counters and gauges.
Risk Level: low
Testing: added unit test; all existing tests pass.
Docs Changes: n/a
Release Notes: n/a
Fixes #6582

Signed-off-by: Dan Rosen <mergeconflict@google.com>
