### PR TITLE
orca: add qps to load reports.

### DIFF
--- a/api/udpa/data/orca/v1/orca_load_report.proto
+++ b/api/udpa/data/orca/v1/orca_load_report.proto
@@ -22,10 +22,13 @@ message OrcaLoadReport {
   // during the request.
   double mem_utilization = 2 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
+  // Total QPS being served by an endpoint.
+  uint64 qps = 3;
+
   // Application specific requests costs. Each value may be an absolute cost (e.g.
   // 3487 bytes of storage) or utilization associated with the request,
   // expressed as a fraction of total resources available. Utilization
   // metrics should be derived from a sample or measurement taken
   // during the request.
-  map<string, double> request_cost_or_utilization = 3;
+  map<string, double> request_cost_or_utilization = 4;
 }

--- a/api/udpa/data/orca/v1/orca_load_report.proto
+++ b/api/udpa/data/orca/v1/orca_load_report.proto
@@ -22,8 +22,9 @@ message OrcaLoadReport {
   // during the request.
   double mem_utilization = 2 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
-  // Total QPS being served by an endpoint.
-  uint64 qps = 3;
+  // Total RPS being served by an endpoint. This should cover all services that an endpoint is
+  // responsible for.
+  uint64 rps = 3;
 
   // Application specific requests costs. Each value may be an absolute cost (e.g.
   // 3487 bytes of storage) or utilization associated with the request,


### PR DESCRIPTION
It's helpful to a client-side LB to know the total endpoint serving QPS when making LB decisions.
This could also be used as a signal for Envoy's least loaded LB.

Signed-off-by: Harvey Tuch <htuch@google.com>