### PR TITLE
Feature untrusted client cert routing

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -256,6 +256,16 @@ message CertificateValidationContext {
 
   // If specified, Envoy will not reject expired certificates.
   bool allow_expired_certificate = 8;
+
+  // If specified, Envoy will always request for clients to provide their
+  // certificate.
+  bool request_client_certificate = 9;
+
+  // If specified, Envoy will NOT reject connections using client certificates that have failed validation.
+  bool permit_untrusted_client_certificate = 10;
+
+  // If specified, Envoy will NOT require a client certificate if a validation context exists.
+  bool validation_permits_no_client_certificate = 11;
 }
 
 // TLS context shared by both client and server TLS contexts.

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -261,7 +261,8 @@ message CertificateValidationContext {
   // certificate.
   bool request_client_certificate = 9;
 
-  // If specified, Envoy will NOT reject connections using client certificates that have failed validation.
+  // If specified, Envoy will NOT reject connections using client certificates that have failed
+  // validation.
   bool permit_untrusted_client_certificate = 10;
 
   // If specified, Envoy will NOT require a client certificate if a validation context exists.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -298,6 +298,7 @@ private:
   HEADER_FUNC(Etag)                                                                                \
   HEADER_FUNC(Expect)                                                                              \
   HEADER_FUNC(ForwardedClientCert)                                                                 \
+  HEADER_FUNC(ForwardedUntrustedClientCert)                                                        \
   HEADER_FUNC(ForwardedFor)                                                                        \
   HEADER_FUNC(ForwardedProto)                                                                      \
   HEADER_FUNC(GrpcAcceptEncoding)                                                                  \

--- a/include/envoy/ssl/certificate_validation_context_config.h
+++ b/include/envoy/ssl/certificate_validation_context_config.h
@@ -66,7 +66,8 @@ public:
   virtual bool permitUntrustedClientCertificate() const PURE;
 
   /**
-   * @return True if client certificate is NOT required to be presented when a validation context exists.
+   * @return True if client certificate is NOT required to be presented when a validation context
+   * exists.
    */
   virtual bool validationPermitsNoClientCertificate() const PURE;
 };

--- a/include/envoy/ssl/certificate_validation_context_config.h
+++ b/include/envoy/ssl/certificate_validation_context_config.h
@@ -54,6 +54,21 @@ public:
    * @return whether to ignore expired certificates (both too new and too old).
    */
   virtual bool allowExpiredCertificate() const PURE;
+
+  /**
+   * @return True if client certificate is requested (without being required), false otherwise.
+   */
+  virtual bool requestClientCertificate() const PURE;
+
+  /**
+   * @return True if client certificate does not require validation, false otherwise.
+   */
+  virtual bool permitUntrustedClientCertificate() const PURE;
+
+  /**
+   * @return True if client certificate is NOT required to be presented when a validation context exists.
+   */
+  virtual bool validationPermitsNoClientCertificate() const PURE;
 };
 
 typedef std::unique_ptr<CertificateValidationContextConfig> CertificateValidationContextConfigPtr;

--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -24,6 +24,11 @@ public:
   virtual bool peerCertificatePresented() const PURE;
 
   /**
+   * @return bool whether the peer certificate was validated.
+   **/
+  virtual bool peerCertificateValidated() const PURE;
+
+  /**
    * @return std::string the URIs in the SAN field of the local certificate. Returns {} if there is
    *         no local certificate, or no SAN field, or no URI.
    **/

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -326,9 +326,11 @@ void ConnectionManagerUtility::mutateXfccRequestHeader(HeaderMap& request_header
 
   const std::string client_cert_details_str = absl::StrJoin(client_cert_details, ";");
   if (config.forwardClientCert() == ForwardClientCertType::AppendForward) {
-    HeaderMapImpl::appendToHeader(connection.ssl()->peerCertificateValidated() ? request_headers.insertForwardedClientCert().value() :
-                                                                                 request_headers.insertForwardedUntrustedClientCert().value(),
-                                  client_cert_details_str);
+    HeaderMapImpl::appendToHeader(
+        connection.ssl()->peerCertificateValidated()
+            ? request_headers.insertForwardedClientCert().value()
+            : request_headers.insertForwardedUntrustedClientCert().value(),
+        client_cert_details_str);
   } else if (config.forwardClientCert() == ForwardClientCertType::SanitizeSet) {
     if (connection.ssl()->peerCertificateValidated()) {
       request_headers.insertForwardedClientCert().value(client_cert_details_str);

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -67,6 +67,7 @@ public:
   const LowerCaseString Etag{"etag"};
   const LowerCaseString Expect{"expect"};
   const LowerCaseString ForwardedClientCert{"x-forwarded-client-cert"};
+  const LowerCaseString ForwardedUntrustedClientCert{"x-forwarded-untrusted-client-cert"};
   const LowerCaseString ForwardedFor{"x-forwarded-for"};
   const LowerCaseString ForwardedHost{"x-forwarded-host"};
   const LowerCaseString ForwardedProto{"x-forwarded-proto"};

--- a/source/common/ssl/certificate_validation_context_config_impl.cc
+++ b/source/common/ssl/certificate_validation_context_config_impl.cc
@@ -26,7 +26,10 @@ CertificateValidationContextConfigImpl::CertificateValidationContextConfigImpl(
                                     config.verify_certificate_hash().end()),
       verify_certificate_spki_list_(config.verify_certificate_spki().begin(),
                                     config.verify_certificate_spki().end()),
-      allow_expired_certificate_(config.allow_expired_certificate()) {
+      allow_expired_certificate_(config.allow_expired_certificate()),
+      request_client_certificate_(config.request_client_certificate()),
+      permit_untrusted_client_certificate_(config.permit_untrusted_client_certificate()),
+      validation_permits_no_client_certificate_(config.validation_permits_no_client_certificate()) {
   if (ca_cert_.empty()) {
     if (!certificate_revocation_list_.empty()) {
       throw EnvoyException(fmt::format("Failed to load CRL from {} without trusted CA",

--- a/source/common/ssl/certificate_validation_context_config_impl.h
+++ b/source/common/ssl/certificate_validation_context_config_impl.h
@@ -32,6 +32,9 @@ public:
     return verify_certificate_spki_list_;
   }
   bool allowExpiredCertificate() const override { return allow_expired_certificate_; }
+  bool requestClientCertificate() const override { return request_client_certificate_; }
+  bool permitUntrustedClientCertificate() const override { return permit_untrusted_client_certificate_; }
+  bool validationPermitsNoClientCertificate() const override { return validation_permits_no_client_certificate_; }
 
 private:
   const std::string ca_cert_;
@@ -42,6 +45,9 @@ private:
   const std::vector<std::string> verify_certificate_hash_list_;
   const std::vector<std::string> verify_certificate_spki_list_;
   const bool allow_expired_certificate_;
+  const bool request_client_certificate_;
+  const bool permit_untrusted_client_certificate_;
+  const bool validation_permits_no_client_certificate_;
 };
 
 } // namespace Ssl

--- a/source/common/ssl/certificate_validation_context_config_impl.h
+++ b/source/common/ssl/certificate_validation_context_config_impl.h
@@ -33,8 +33,12 @@ public:
   }
   bool allowExpiredCertificate() const override { return allow_expired_certificate_; }
   bool requestClientCertificate() const override { return request_client_certificate_; }
-  bool permitUntrustedClientCertificate() const override { return permit_untrusted_client_certificate_; }
-  bool validationPermitsNoClientCertificate() const override { return validation_permits_no_client_certificate_; }
+  bool permitUntrustedClientCertificate() const override {
+    return permit_untrusted_client_certificate_;
+  }
+  bool validationPermitsNoClientCertificate() const override {
+    return validation_permits_no_client_certificate_;
+  }
 
 private:
   const std::string ca_cert_;

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -45,6 +45,14 @@ bool cbsContainsU16(CBS& cbs, uint16_t n) {
 
 } // namespace
 
+int ContextImpl::sslCustomDataIndex() {
+  CONSTRUCT_ON_FIRST_USE(int, []() -> int {
+    int ssl_context_index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
+    RELEASE_ASSERT(ssl_context_index >= 0, "");
+    return ssl_context_index;
+  }());
+}
+
 ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& config,
                          TimeSource& time_source)
     : scope_(scope), stats_(generateStats(scope)), time_source_(time_source),
@@ -85,6 +93,16 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
   }
 
   int verify_mode = SSL_VERIFY_NONE;
+  if (config.certificateValidationContext() != nullptr &&
+      config.certificateValidationContext()->requestClientCertificate()) {
+    verify_mode = SSL_VERIFY_PEER;
+  }
+
+  const int verify_mode_validation_context =
+    config.certificateValidationContext() != nullptr &&
+    config.certificateValidationContext()->validationPermitsNoClientCertificate() ?
+      SSL_VERIFY_PEER : SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+
   if (config.certificateValidationContext() != nullptr &&
       !config.certificateValidationContext()->caCert().empty()) {
     ca_file_path_ = config.certificateValidationContext()->caCertPath();
@@ -169,7 +187,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
       !config.certificateValidationContext()->verifySubjectAltNameList().empty()) {
     verify_subject_alt_name_list_ =
         config.certificateValidationContext()->verifySubjectAltNameList();
-    verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+    verify_mode = verify_mode_validation_context;
   }
 
   if (config.certificateValidationContext() != nullptr &&
@@ -186,7 +204,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
       }
       verify_certificate_hash_list_.push_back(decoded);
     }
-    verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+    verify_mode = verify_mode_validation_context;
   }
 
   if (config.certificateValidationContext() != nullptr &&
@@ -198,7 +216,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
       }
       verify_certificate_spki_list_.emplace_back(decoded.begin(), decoded.end());
     }
-    verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+    verify_mode = verify_mode_validation_context;
   }
 
   for (auto& ctx : tls_contexts_) {
@@ -343,6 +361,10 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
     SSL_CTX_set_options(ctx.ssl_ctx_.get(), SSL_OP_CIPHER_SERVER_PREFERENCE);
   }
 
+  if (config.certificateValidationContext() != nullptr) {
+    permit_untrusted_certificate_ = config.certificateValidationContext()->permitUntrustedClientCertificate();
+  }
+
   parsed_alpn_protocols_ = parseAlpnProtocols(config.alpnProtocols());
 }
 
@@ -407,26 +429,49 @@ int ContextImpl::ignoreCertificateExpirationCallback(int ok, X509_STORE_CTX* ctx
 
 int ContextImpl::verifyCallback(X509_STORE_CTX* store_ctx, void* arg) {
   ContextImpl* impl = reinterpret_cast<ContextImpl*>(arg);
+  SSL* ssl = reinterpret_cast<SSL*>(
+      X509_STORE_CTX_get_ex_data(store_ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
+  ClientValidationStatus* clientValidationStatus =
+    reinterpret_cast<ClientValidationStatus*>(SSL_get_ex_data(ssl, ContextImpl::sslCustomDataIndex()));
 
   if (impl->verify_trusted_ca_) {
     int ret = X509_verify_cert(store_ctx);
+    if (clientValidationStatus) {
+      clientValidationStatus->status = ret == 1 ?
+                                  ClientValidationStatus::Status::Validated :
+                                  ClientValidationStatus::Status::Failed;
+    }
     if (ret <= 0) {
       impl->stats_.fail_verify_error_.inc();
-      return ret;
+      return impl->permit_untrusted_certificate_ ? 1 : ret;
     }
   }
 
-  SSL* ssl = reinterpret_cast<SSL*>(
-      X509_STORE_CTX_get_ex_data(store_ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl));
-  return impl->verifyCertificate(cert.get());
+
+  auto validated = impl->verifyCertificate(cert.get());
+  if (clientValidationStatus) {
+    if (clientValidationStatus->status == ClientValidationStatus::Status::NotValidated) {
+      clientValidationStatus->status = validated;
+    }
+    else if (validated != ClientValidationStatus::Status::NotValidated) {
+      clientValidationStatus->status = validated;
+    }
+  }
+
+  // permit connection through if 'permit_untrusted_certificate' configured
+  return impl->permit_untrusted_certificate_ ? 1 :
+    (validated != ClientValidationStatus::Status::Failed);
 }
 
-int ContextImpl::verifyCertificate(X509* cert) {
-  if (!verify_subject_alt_name_list_.empty() &&
-      !verifySubjectAltName(cert, verify_subject_alt_name_list_)) {
-    stats_.fail_verify_san_.inc();
-    return 0;
+ClientValidationStatus::Status ContextImpl::verifyCertificate(X509* cert) {
+  ClientValidationStatus::Status validated = ClientValidationStatus::Status::NotValidated;
+  if (!verify_subject_alt_name_list_.empty()) {
+    if (!verifySubjectAltName(cert, verify_subject_alt_name_list_)) {
+      stats_.fail_verify_san_.inc();
+      return ClientValidationStatus::Status::Failed;
+    }
+    validated = ClientValidationStatus::Status::Validated;
   }
 
   if (!verify_certificate_hash_list_.empty() || !verify_certificate_spki_list_.empty()) {
@@ -439,11 +484,13 @@ int ContextImpl::verifyCertificate(X509* cert) {
 
     if (!valid_certificate_hash && !valid_certificate_spki) {
       stats_.fail_verify_cert_hash_.inc();
-      return 0;
+      return ClientValidationStatus::Status::Failed;
     }
+
+    validated = ClientValidationStatus::Status::Validated;
   }
 
-  return 1;
+  return validated;
 }
 
 void ContextImpl::logHandshake(SSL* ssl) const {

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -44,19 +44,12 @@ struct SslStats {
   ALL_SSL_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
-struct ClientValidationStatus
-{
-    enum class Status
-    {
-        NotValidated,
-        NoClientCertificate,
-        Validated,
-        Failed
-    };
+struct ClientValidationStatus {
+  enum class Status { NotValidated, NoClientCertificate, Validated, Failed };
 
-    ClientValidationStatus() : status(Status::NotValidated) {}
+  ClientValidationStatus() : status(Status::NotValidated) {}
 
-    Status status;
+  Status status;
 };
 
 class ContextImpl : public virtual Envoy::Ssl::Context {

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -44,6 +44,21 @@ struct SslStats {
   ALL_SSL_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
+struct ClientValidationStatus
+{
+    enum class Status
+    {
+        NotValidated,
+        NoClientCertificate,
+        Validated,
+        Failed
+    };
+
+    ClientValidationStatus() : status(Status::NotValidated) {}
+
+    Status status;
+};
+
 class ContextImpl : public virtual Envoy::Ssl::Context {
 public:
   virtual bssl::UniquePtr<SSL> newSsl(absl::optional<std::string> override_server_name);
@@ -73,6 +88,12 @@ public:
 
   SslStats& stats() { return stats_; }
 
+  /**
+   * The global SSL-library index used for storing a pointer to the SslSocket
+   * class in the SSL instance, for retrieval in callbacks.
+   */
+  static int sslCustomDataIndex();
+
   // Ssl::Context
   size_t daysUntilFirstCertExpires() const override;
   Envoy::Ssl::CertificateDetailsPtr getCaCertInformation() const override;
@@ -94,7 +115,7 @@ protected:
   // A SSL_CTX_set_cert_verify_callback for custom cert validation.
   static int verifyCallback(X509_STORE_CTX* store_ctx, void* arg);
 
-  int verifyCertificate(X509* cert);
+  ClientValidationStatus::Status verifyCertificate(X509* cert);
 
   /**
    * Verifies certificate hash for pinning. The hash is a hex-encoded SHA-256 of the DER-encoded
@@ -150,6 +171,7 @@ protected:
   std::vector<std::string> verify_subject_alt_name_list_;
   std::vector<std::vector<uint8_t>> verify_certificate_hash_list_;
   std::vector<std::vector<uint8_t>> verify_certificate_spki_list_;
+  bool permit_untrusted_certificate_{false};
   Stats::Scope& scope_;
   SslStats stats_;
   std::vector<uint8_t> parsed_alpn_protocols_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -48,6 +48,10 @@ SslSocket::SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
       ssl_(ctx_->newSsl(transport_socket_options != nullptr
                             ? transport_socket_options->serverNameOverride()
                             : absl::nullopt)) {
+  if (!SSL_set_ex_data(ssl_.get(), ctx_->sslCustomDataIndex(), &(this->certificate_validation_status_))) {
+    ENVOY_LOG(error, "SslSocket::SslSocket SSL_set_ex_data failed");
+  }
+
   if (state == InitialState::Client) {
     SSL_set_connect_state(ssl_.get());
   } else {
@@ -250,6 +254,10 @@ void SslSocket::shutdownSsl() {
 bool SslSocket::peerCertificatePresented() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   return cert != nullptr;
+}
+
+bool SslSocket::peerCertificateValidated() const {
+  return certificate_validation_status_.status == ClientValidationStatus::Status::Validated;
 }
 
 std::vector<std::string> SslSocket::uriSanLocalCertificate() const {

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -48,7 +48,8 @@ SslSocket::SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
       ssl_(ctx_->newSsl(transport_socket_options != nullptr
                             ? transport_socket_options->serverNameOverride()
                             : absl::nullopt)) {
-  if (!SSL_set_ex_data(ssl_.get(), ctx_->sslCustomDataIndex(), &(this->certificate_validation_status_))) {
+  if (!SSL_set_ex_data(ssl_.get(), ctx_->sslCustomDataIndex(),
+                       &(this->certificate_validation_status_))) {
     ENVOY_LOG(error, "SslSocket::SslSocket SSL_set_ex_data failed");
   }
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -48,6 +48,7 @@ public:
 
   // Ssl::Connection
   bool peerCertificatePresented() const override;
+  bool peerCertificateValidated() const override;
   std::vector<std::string> uriSanLocalCertificate() const override;
   const std::string& sha256PeerCertificateDigest() const override;
   std::string serialNumberPeerCertificate() const override;
@@ -86,6 +87,7 @@ private:
   bool shutdown_sent_{};
   uint64_t bytes_to_retry_{};
   std::string failure_reason_;
+  ClientValidationStatus certificate_validation_status_{};
   mutable std::string cached_sha_256_peer_certificate_digest_;
   mutable std::string cached_url_encoded_pem_encoded_peer_certificate_;
   mutable std::string cached_url_encoded_pem_encoded_peer_cert_chain_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -707,6 +707,7 @@ TEST_F(ConnectionManagerUtilityTest, MutateResponseHeadersReturnXRequestId) {
 TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeClientCert) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   ON_CALL(connection_, ssl()).WillByDefault(Return(&ssl));
   ON_CALL(config_, forwardClientCert())
       .WillByDefault(Return(Http::ForwardClientCertType::Sanitize));
@@ -723,6 +724,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeClientCert) {
 TEST_F(ConnectionManagerUtilityTest, MtlsForwardOnlyClientCert) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   ON_CALL(connection_, ssl()).WillByDefault(Return(&ssl));
   ON_CALL(config_, forwardClientCert())
       .WillByDefault(Return(Http::ForwardClientCertType::ForwardOnly));
@@ -742,6 +744,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsForwardOnlyClientCert) {
 TEST_F(ConnectionManagerUtilityTest, MtlsSetForwardClientCert) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   const std::vector<std::string> local_uri_sans{"test://foo.com/be"};
   EXPECT_CALL(ssl, uriSanLocalCertificate()).WillOnce(Return(local_uri_sans));
   std::string expected_sha("abcdefg");
@@ -780,6 +783,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSetForwardClientCert) {
 TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCert) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   const std::vector<std::string> local_uri_sans{"test://foo.com/be"};
   EXPECT_CALL(ssl, uriSanLocalCertificate()).WillOnce(Return(local_uri_sans));
   std::string expected_sha("abcdefg");
@@ -818,6 +822,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCert) {
 TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCertLocalSanEmpty) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   EXPECT_CALL(ssl, uriSanLocalCertificate()).WillOnce(Return(std::vector<std::string>()));
   std::string expected_sha("abcdefg");
   EXPECT_CALL(ssl, sha256PeerCertificateDigest()).WillOnce(ReturnRef(expected_sha));
@@ -847,6 +852,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsAppendForwardClientCertLocalSanEmpty) {
 TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCert) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   const std::vector<std::string> local_uri_sans{"test://foo.com/be"};
   EXPECT_CALL(ssl, uriSanLocalCertificate()).WillOnce(Return(local_uri_sans));
   std::string expected_sha("abcdefg");
@@ -884,6 +890,7 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCert) {
 TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCertPeerSanEmpty) {
   NiceMock<Ssl::MockConnectionInfo> ssl;
   ON_CALL(ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  ON_CALL(ssl, peerCertificateValidated()).WillByDefault(Return(true));
   const std::vector<std::string> local_uri_sans{"test://foo.com/be"};
   EXPECT_CALL(ssl, uriSanLocalCertificate()).WillOnce(Return(local_uri_sans));
   std::string expected_sha("abcdefg");

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -36,6 +36,7 @@ public:
   ~MockConnectionInfo();
 
   MOCK_CONST_METHOD0(peerCertificatePresented, bool());
+  MOCK_CONST_METHOD0(peerCertificateValidated, bool());
   MOCK_CONST_METHOD0(uriSanLocalCertificate, std::vector<std::string>());
   MOCK_CONST_METHOD0(sha256PeerCertificateDigest, std::string&());
   MOCK_CONST_METHOD0(serialNumberPeerCertificate, std::string());


### PR DESCRIPTION
Description: Add the ability to pass through and route 'untrusted' clients.

By default the client validation rules are unchanged.

Additional validation context options:
- request_client_certificate : // If specified, Envoy will always request for clients to provide their certificate (without requiring it).
- permit_untrusted_client_certificate : // If specified, Envoy will NOT reject connections using client certificates that have failed validation.
- validation_permits_no_client_certificate : // If specified, Envoy will NOT require a client certificate if a validation context exists.

'untrusted' (either not validated, or failed validation) client certificate details added to 'x-forwarded-untrusted-client-cert'

Risk Level: Medium
Testing: Manual and unit tests
Docs Changes: API proto changes
Release Notes: N/A