### PR TITLE
compat: explicitly convert absl::string_view to std::string 

### DIFF
--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -39,7 +39,7 @@ struct SuccessResponse {
           if (context->matchers_->matches(header.key().getStringView())) {
             context->response_->headers_to_add.emplace_back(
                 Http::LowerCaseString{std::string(header.key().getStringView())},
-                header.value().getStringView());
+                std::string(header.value().getStringView()));
           }
           return Http::HeaderMap::Iterate::Continue;
         },


### PR DESCRIPTION
Implicit direct initialization of a std::pair<std::string, ...> from an absl::string_view argument is not allowed in gcc-4.9.

This PR works around this issue by explicitly creating the std::string. 

Risk Level: Low.
Testing: All tests pass.

Signed-off-by: Andres Guedez <aguedez@google.com>