### PR TITLE
stats: Include a full log of stats memory changes in the memory test, and employ exact comparisons

### DIFF
--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -195,8 +195,22 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithStats) {
 
   EXPECT_LT(start_mem, m1);
   EXPECT_LT(start_mem, m1001);
-  // As of 2019/04/12, m_per_cluster = 59576 (libstdc++)
-  EXPECT_LT(m_per_cluster, 59600);
+
+  // Note: if you are increasing this golden value because you are adding a
+  // stat, please confirm that this will be generally useful to most Envoy
+  // users. Otherwise you are adding to the per-cluster memory overhead, which
+  // will be significant for Envoy installations that are massively
+  // multi-tenant.
+  //
+  // History of golden values:
+  //
+  // Date        PR       Bytes Per Cluster   Notes
+  // ----------  -----    -----------------   -----
+  // 2019/03/20  6329     59015               Initial version
+  // 2019/04/12  6477     59576               Implementing Endpoint lease...
+  // 2019/04/23  6659     59512               Reintroduce dispatcher stats...
+
+  EXPECT_EQ(m_per_cluster, 59512);
 }
 
 } // namespace


### PR DESCRIPTION
Description: Per @ambuc's comment on #6161 I think it would be better to keep a log of the memory consumed by stats, and also use exact comparisons. That way we can get historical perspective into the relative impact of adding new stats or families of stats.
Risk Level: low, but could cause more changes to this one test.
Testing: just this one test.
Docs Changes: n/a
Release Notes: n/a

