### PR TITLE
event: fix race condition in DispatcherImpl

### DIFF
--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -42,10 +42,14 @@ DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory, Api::Api& 
 DispatcherImpl::~DispatcherImpl() {}
 
 void DispatcherImpl::initializeStats(Stats::Scope& scope, const std::string& prefix) {
-  stats_prefix_ = prefix + "dispatcher";
-  stats_ = std::make_unique<DispatcherStats>(
-      DispatcherStats{ALL_DISPATCHER_STATS(POOL_HISTOGRAM_PREFIX(scope, stats_prefix_ + "."))});
-  base_scheduler_.initializeStats(stats_.get());
+  // this needs to be run in the dispatcher's thread, so that we have a thread id to log
+  post([this, &scope, prefix] {
+    stats_prefix_ = prefix + "dispatcher";
+    stats_ = std::make_unique<DispatcherStats>(
+        DispatcherStats{ALL_DISPATCHER_STATS(POOL_HISTOGRAM_PREFIX(scope, stats_prefix_ + "."))});
+    base_scheduler_.initializeStats(stats_.get());
+    ENVOY_LOG(debug, "running {} on thread {}", stats_prefix_, run_tid_->debugString());
+  });
 }
 
 void DispatcherImpl::clearDeferredDeleteList() {
@@ -165,9 +169,6 @@ void DispatcherImpl::post(std::function<void()> callback) {
 
 void DispatcherImpl::run(RunType type) {
   run_tid_ = api_.threadFactory().currentThreadId();
-  if (!stats_prefix_.empty()) {
-    ENVOY_LOG(debug, "running {} on thread {}", stats_prefix_, run_tid_->debugString());
-  }
 
   // Flush all post callbacks before we run the event loop. We do this because there are post
   // callbacks that have to get run before the initial event loop starts running. libevent does

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -42,7 +42,7 @@ DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory, Api::Api& 
 DispatcherImpl::~DispatcherImpl() {}
 
 void DispatcherImpl::initializeStats(Stats::Scope& scope, const std::string& prefix) {
-  // this needs to be run in the dispatcher's thread, so that we have a thread id to log
+  // This needs to be run in the dispatcher's thread, so that we have a thread id to log.
   post([this, &scope, prefix] {
     stats_prefix_ = prefix + "dispatcher";
     stats_ = std::make_unique<DispatcherStats>(


### PR DESCRIPTION
Description: Fix race between `initializeStats` and `run` in DispatcherImpl by consolidating these to the dispatcher's thread.
Risk Level: low
Testing: dispatcher_impl_test and worker_impl_test, with --runs_per_test=1000 (in Google's environment where the issue was found).
Docs Changes: n/a
Release Notes: n/a
Fixes: #6699

Signed-off-by: Dan Rosen <mergeconflict@google.com>
