### PR TITLE
owners: add csrf extension to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,10 @@
 # By default, @envoyproxy/maintainers own everything.
 #*       @envoyproxy/maintainers
 
+# csrf extension
+/*/extensions/filters/http/csrf @dschaller @mattklein123
 # dubbo_proxy extension
-/*/extensions/filters/network/dubbo_proxy @zyfjeff @lizan 
+/*/extensions/filters/network/dubbo_proxy @zyfjeff @lizan
 # thrift_proxy extension
 /*/extensions/filters/network/thrift_proxy @zuercher @brian-pane
 # jwt_authn http filter extension


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: add csrf extension to codeowners as per the [extension policy](https://github.com/envoyproxy/envoy/blob/master/EXTENSION_POLICY.md#adding-new-extensions)
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
