### PR TITLE
Remove StringUtil::atoll, convert caller to absl::SimpleAtoi

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -240,21 +240,6 @@ bool StringUtil::atoull(const char* str, uint64_t& out, int base) {
   }
 }
 
-bool StringUtil::atoll(const char* str, int64_t& out, int base) {
-  if (strlen(str) == 0) {
-    return false;
-  }
-
-  char* end_ptr;
-  errno = 0;
-  out = std::strtoll(str, &end_ptr, base);
-  if (*end_ptr != '\0' || ((out == LLONG_MAX || out == LLONG_MIN) && errno == ERANGE)) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
 absl::string_view StringUtil::ltrim(absl::string_view source) {
   const absl::string_view::size_type pos = source.find_first_not_of(WhitespaceChars);
   if (pos != absl::string_view::npos) {

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -159,12 +159,6 @@ public:
   static bool atoull(const char* str, uint64_t& out, int base = 10);
 
   /**
-   * Convert a string to a long, checking for error.
-   * @param return true if successful, false otherwise.
-   */
-  static bool atoll(const char* str, int64_t& out, int base = 10);
-
-  /**
    * Convert an unsigned integer to a base 10 string as fast as possible.
    * @param out supplies the string to fill.
    * @param out_len supplies the length of the output buffer. Must be >= MIN_ITOA_OUT_LEN.

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -97,9 +97,7 @@ bool HeaderUtility::matchHeaders(const Http::HeaderMap& request_headers,
     break;
   case HeaderMatchType::Range: {
     int64_t header_value = 0;
-    // TODO(dnoe): Migrate to pure string_view to eliminate std:string instance (#6580)
-    const std::string header_string(header_view);
-    match = StringUtil::atoll(header_string.c_str(), header_value, 10) &&
+    match = absl::SimpleAtoi(header_view, &header_value) &&
             header_value >= header_data.range_.start() && header_value < header_data.range_.end();
     break;
   }

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
@@ -64,15 +64,15 @@ ParameterRouteEntryImpl::ParameterRouteEntryImpl(
 
 ParameterRouteEntryImpl::~ParameterRouteEntryImpl() {}
 
-bool ParameterRouteEntryImpl::matchParameter(const std::string& request_data,
+bool ParameterRouteEntryImpl::matchParameter(absl::string_view request_data,
                                              const ParameterData& config_data) const {
   switch (config_data.match_type_) {
   case Http::HeaderUtility::HeaderMatchType::Value:
     return config_data.value_.empty() || request_data == config_data.value_;
   case Http::HeaderUtility::HeaderMatchType::Range: {
     int64_t value = 0;
-    return StringUtil::atoll(request_data.c_str(), value, 10) &&
-           value >= config_data.range_.start() && value < config_data.range_.end();
+    return absl::SimpleAtoi(request_data, &value) && value >= config_data.range_.start() &&
+           value < config_data.range_.end();
   }
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.h
@@ -107,7 +107,7 @@ public:
                               uint64_t random_value) const override;
 
 private:
-  bool matchParameter(const std::string& request_data, const ParameterData& config_data) const;
+  bool matchParameter(absl::string_view request_data, const ParameterData& config_data) const;
 
   std::vector<ParameterData> parameter_data_list_;
 };

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -98,33 +98,6 @@ TEST(StringUtil, atoull) {
   EXPECT_EQ(18446744073709551615U, out);
 }
 
-TEST(StringUtil, atoll) {
-  int64_t out;
-  EXPECT_FALSE(StringUtil::atoll("-123b", out));
-  EXPECT_FALSE(StringUtil::atoll("", out));
-  EXPECT_FALSE(StringUtil::atoll("b123", out));
-
-  EXPECT_TRUE(StringUtil::atoll("123", out));
-  EXPECT_EQ(123, out);
-  EXPECT_TRUE(StringUtil::atoll("-123", out));
-  EXPECT_EQ(-123, out);
-  EXPECT_TRUE(StringUtil::atoll("+123", out));
-  EXPECT_EQ(123, out);
-
-  EXPECT_TRUE(StringUtil::atoll("  456", out));
-  EXPECT_EQ(456, out);
-
-  EXPECT_TRUE(StringUtil::atoll("00789", out));
-  EXPECT_EQ(789, out);
-
-  // INT64_MAX + 1
-  EXPECT_FALSE(StringUtil::atoll("9223372036854775808", out));
-
-  // INT64_MIN
-  EXPECT_TRUE(StringUtil::atoll("-9223372036854775808", out));
-  EXPECT_EQ(INT64_MIN, out);
-}
-
 TEST(DateUtil, All) {
   EXPECT_FALSE(DateUtil::timePointValid(SystemTime()));
   DangerousDeprecatedTestTime test_time;


### PR DESCRIPTION
Description: `absl::SimpleAtoi` takes `absl::string_view` argument and can replace all of the calls to `StringUtil::atoll` that are using Base 10 conversion, which turns out to be all of them. This PR removes `StringUtil::atoll` entirely and migrates all callers to `absl::SimpleAtoi`.

Risk Level: Low
Testing: `bazel test //test/...`
Docs Changes: N/A
Release Notes: N/A
Part of: Issue #6580

Signed-off-by: Dan Noé <dpn@google.com>
