### PR TITLE
tap: use move semantics for submitTrace

### DIFF
--- a/source/extensions/common/tap/admin.h
+++ b/source/extensions/common/tap/admin.h
@@ -59,7 +59,7 @@ private:
     AdminPerTapSinkHandle(AdminHandler& parent) : parent_(parent) {}
 
     // Extensions::Common::Tap::PerTapSinkHandle
-    void submitTrace(const TraceWrapperSharedPtr& trace,
+    void submitTrace(TraceWrapperPtr&& trace,
                      envoy::service::tap::v2alpha::OutputSink::Format format) override;
 
     AdminHandler& parent_;

--- a/source/extensions/common/tap/tap.h
+++ b/source/extensions/common/tap/tap.h
@@ -14,7 +14,6 @@ namespace Extensions {
 namespace Common {
 namespace Tap {
 
-using TraceWrapper = envoy::data::tap::v2alpha::TraceWrapper;
 using TraceWrapperPtr = std::unique_ptr<envoy::data::tap::v2alpha::TraceWrapper>;
 inline TraceWrapperPtr makeTraceWrapper() {
   return std::make_unique<envoy::data::tap::v2alpha::TraceWrapper>();

--- a/source/extensions/common/tap/tap.h
+++ b/source/extensions/common/tap/tap.h
@@ -14,9 +14,10 @@ namespace Extensions {
 namespace Common {
 namespace Tap {
 
-using TraceWrapperSharedPtr = std::shared_ptr<envoy::data::tap::v2alpha::TraceWrapper>;
-inline TraceWrapperSharedPtr makeTraceWrapper() {
-  return std::make_shared<envoy::data::tap::v2alpha::TraceWrapper>();
+using TraceWrapper = envoy::data::tap::v2alpha::TraceWrapper;
+using TraceWrapperPtr = std::unique_ptr<envoy::data::tap::v2alpha::TraceWrapper>;
+inline TraceWrapperPtr makeTraceWrapper() {
+  return std::make_unique<envoy::data::tap::v2alpha::TraceWrapper>();
 }
 
 /**
@@ -33,7 +34,7 @@ public:
    * @param trace supplies the trace to send.
    * @param format supplies the output format to use.
    */
-  virtual void submitTrace(const TraceWrapperSharedPtr& trace,
+  virtual void submitTrace(TraceWrapperPtr&& trace,
                            envoy::service::tap::v2alpha::OutputSink::Format format) PURE;
 };
 
@@ -51,7 +52,7 @@ public:
   /**
    * Submit a buffered or streamed trace segment to all managed per-tap sink handles.
    */
-  virtual void submitTrace(const TraceWrapperSharedPtr& trace) PURE;
+  virtual void submitTrace(TraceWrapperPtr&& trace) PURE;
 };
 
 using PerTapSinkHandleManagerPtr = std::unique_ptr<PerTapSinkHandleManager>;

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -139,14 +139,13 @@ void Utility::bodyBytesToString(envoy::data::tap::v2alpha::TraceWrapper& trace,
   }
 }
 
-void TapConfigBaseImpl::PerTapSinkHandleManagerImpl::submitTrace(
-    const TraceWrapperSharedPtr& trace) {
+void TapConfigBaseImpl::PerTapSinkHandleManagerImpl::submitTrace(TraceWrapperPtr&& trace) {
   Utility::bodyBytesToString(*trace, parent_.sink_format_);
-  handle_->submitTrace(trace, parent_.sink_format_);
+  handle_->submitTrace(std::move(trace), parent_.sink_format_);
 }
 
 void FilePerTapSink::FilePerTapSinkHandle::submitTrace(
-    const TraceWrapperSharedPtr& trace, envoy::service::tap::v2alpha::OutputSink::Format format) {
+    TraceWrapperPtr&& trace, envoy::service::tap::v2alpha::OutputSink::Format format) {
   if (!output_file_.is_open()) {
     std::string path = fmt::format("{}_{}", parent_.config_.path_prefix(), trace_id_);
     switch (format) {

--- a/source/extensions/common/tap/tap_config_base.h
+++ b/source/extensions/common/tap/tap_config_base.h
@@ -74,7 +74,7 @@ public:
         : parent_(parent), handle_(parent.sink_to_use_->createPerTapSinkHandle(trace_id)) {}
 
     // PerTapSinkHandleManager
-    void submitTrace(const TraceWrapperSharedPtr& trace) override;
+    void submitTrace(TraceWrapperPtr&& trace) override;
 
   private:
     TapConfigBaseImpl& parent_;
@@ -129,7 +129,7 @@ private:
         : parent_(parent), trace_id_(trace_id) {}
 
     // PerTapSinkHandle
-    void submitTrace(const TraceWrapperSharedPtr& trace,
+    void submitTrace(TraceWrapperPtr&& trace,
                      envoy::service::tap::v2alpha::OutputSink::Format format) override;
 
     FilePerTapSink& parent_;

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -42,15 +42,24 @@ public:
   bool onDestroyLog() override;
 
 private:
+  typedef envoy::data::tap::v2alpha::Body* (
+      envoy::data::tap::v2alpha::HttpStreamedTraceSegment::*MutableBodyChunk)();
+  typedef envoy::data::tap::v2alpha::HttpBufferedTrace::Message* (
+      envoy::data::tap::v2alpha::HttpBufferedTrace::*MutableMessage)();
+
+  void onBody(const Buffer::Instance& data,
+              Extensions::Common::Tap::TraceWrapperPtr& buffered_streamed_body,
+              uint32_t maxBufferedBytes, MutableBodyChunk mutable_body_chunk,
+              MutableMessage mutable_message);
+
   void makeBufferedFullTraceIfNeeded() {
     if (buffered_full_trace_ == nullptr) {
       buffered_full_trace_ = Extensions::Common::Tap::makeTraceWrapper();
     }
   }
 
-  Extensions::Common::Tap::TraceWrapperSharedPtr makeTraceSegment() {
-    Extensions::Common::Tap::TraceWrapperSharedPtr segment =
-        Extensions::Common::Tap::makeTraceWrapper();
+  Extensions::Common::Tap::TraceWrapperPtr makeTraceSegment() {
+    Extensions::Common::Tap::TraceWrapperPtr segment = Extensions::Common::Tap::makeTraceWrapper();
     segment->mutable_http_streamed_trace_segment()->set_trace_id(stream_id_);
     return segment;
   }
@@ -71,9 +80,9 @@ private:
   const Http::HeaderMap* response_headers_{};
   const Http::HeaderMap* response_trailers_{};
   // Must be a shared_ptr because of submitTrace().
-  Extensions::Common::Tap::TraceWrapperSharedPtr buffered_streamed_request_body_;
-  Extensions::Common::Tap::TraceWrapperSharedPtr buffered_streamed_response_body_;
-  Extensions::Common::Tap::TraceWrapperSharedPtr buffered_full_trace_;
+  Extensions::Common::Tap::TraceWrapperPtr buffered_streamed_request_body_;
+  Extensions::Common::Tap::TraceWrapperPtr buffered_streamed_response_body_;
+  Extensions::Common::Tap::TraceWrapperPtr buffered_full_trace_;
 };
 
 } // namespace TapFilter

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -17,9 +17,9 @@ PerSocketTapperImpl::PerSocketTapperImpl(SocketTapConfigSharedPtr config,
       connection_(connection), statuses_(config_->createMatchStatusVector()) {
   config_->rootMatcher().onNewStream(statuses_);
   if (config_->streaming() && config_->rootMatcher().matchStatus(statuses_).matches_) {
-    TapCommon::TraceWrapperSharedPtr trace = makeTraceSegment();
+    TapCommon::TraceWrapperPtr trace = makeTraceSegment();
     fillConnectionInfo(*trace->mutable_socket_streamed_trace_segment()->mutable_connection());
-    sink_handle_->submitTrace(trace);
+    sink_handle_->submitTrace(std::move(trace));
   }
 }
 
@@ -36,15 +36,15 @@ void PerSocketTapperImpl::closeSocket(Network::ConnectionEvent) {
   }
 
   if (config_->streaming()) {
-    TapCommon::TraceWrapperSharedPtr trace = makeTraceSegment();
+    TapCommon::TraceWrapperPtr trace = makeTraceSegment();
     auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
     initEvent(event);
     event.mutable_closed();
-    sink_handle_->submitTrace(trace);
+    sink_handle_->submitTrace(std::move(trace));
   } else {
     makeBufferedTraceIfNeeded();
     fillConnectionInfo(*buffered_trace_->mutable_socket_buffered_trace()->mutable_connection());
-    sink_handle_->submitTrace(buffered_trace_);
+    sink_handle_->submitTrace(std::move(buffered_trace_));
   }
 
   // Here we explicitly reset the sink_handle_ to release any sink resources and force a flush
@@ -67,13 +67,13 @@ void PerSocketTapperImpl::onRead(const Buffer::Instance& data, uint32_t bytes_re
   }
 
   if (config_->streaming()) {
-    TapCommon::TraceWrapperSharedPtr trace = makeTraceSegment();
+    TapCommon::TraceWrapperPtr trace = makeTraceSegment();
     auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
     initEvent(event);
     TapCommon::Utility::addBufferToProtoBytes(*event.mutable_read()->mutable_data(),
                                               config_->maxBufferedRxBytes(), data,
                                               data.length() - bytes_read, bytes_read);
-    sink_handle_->submitTrace(trace);
+    sink_handle_->submitTrace(std::move(trace));
   } else {
     if (buffered_trace_ != nullptr && buffered_trace_->socket_buffered_trace().read_truncated()) {
       return;
@@ -99,14 +99,14 @@ void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_w
   }
 
   if (config_->streaming()) {
-    TapCommon::TraceWrapperSharedPtr trace = makeTraceSegment();
+    TapCommon::TraceWrapperPtr trace = makeTraceSegment();
     auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
     initEvent(event);
     TapCommon::Utility::addBufferToProtoBytes(*event.mutable_write()->mutable_data(),
                                               config_->maxBufferedTxBytes(), data, 0,
                                               bytes_written);
     event.mutable_write()->set_end_stream(end_stream);
-    sink_handle_->submitTrace(trace);
+    sink_handle_->submitTrace(std::move(trace));
   } else {
     if (buffered_trace_ != nullptr && buffered_trace_->socket_buffered_trace().write_truncated()) {
       return;

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -28,9 +28,8 @@ private:
       buffered_trace_->mutable_socket_buffered_trace()->set_trace_id(connection_.id());
     }
   }
-  Extensions::Common::Tap::TraceWrapperSharedPtr makeTraceSegment() {
-    Extensions::Common::Tap::TraceWrapperSharedPtr trace =
-        Extensions::Common::Tap::makeTraceWrapper();
+  Extensions::Common::Tap::TraceWrapperPtr makeTraceSegment() {
+    Extensions::Common::Tap::TraceWrapperPtr trace = Extensions::Common::Tap::makeTraceWrapper();
     trace->mutable_socket_streamed_trace_segment()->set_trace_id(connection_.id());
     return trace;
   }
@@ -40,7 +39,7 @@ private:
   const Network::Connection& connection_;
   Extensions::Common::Tap::Matcher::MatchStatusVector statuses_;
   // Must be a shared_ptr because of submitTrace().
-  Extensions::Common::Tap::TraceWrapperSharedPtr buffered_trace_;
+  Extensions::Common::Tap::TraceWrapperPtr buffered_trace_;
   uint32_t rx_bytes_buffered_{};
   uint32_t tx_bytes_buffered_{};
 };

--- a/test/extensions/common/tap/common.h
+++ b/test/extensions/common/tap/common.h
@@ -39,7 +39,7 @@ public:
   MockPerTapSinkHandleManager();
   ~MockPerTapSinkHandleManager();
 
-  void submitTrace(const TraceWrapperSharedPtr& trace) override { submitTrace_(*trace); }
+  void submitTrace(TraceWrapperPtr&& trace) override { submitTrace_(*trace); }
 
   MOCK_METHOD1(submitTrace_, void(const envoy::data::tap::v2alpha::TraceWrapper& trace));
 };


### PR DESCRIPTION
This PR makes submitTrace use move semantics. If I understand the current code correctly, the existing semantics were de-facto move semantics - this change makes it explicit so the contract is clear.
The goal of this change is to avoid copying the trace once grpc sink is implemented (so that the trace wrapper can be moved to the stream message), by being explicit on the semantics of submitTrace.

Additionally it merges the handling of trace request and response body in `tap_config_impl.cc` to reduce code duplication.

Next PR should be around introducing a grpc output sink.

Risk Level: Low - does not change functionality.
Testing: Existing tests
Docs Changes: N\A
Release Notes: N\A