### PR TITLE
Use Swiss table with heterogenous lookup for CaseUnorderedSet

### DIFF
--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -345,7 +345,7 @@ public:
    * @return true if strings are semantically the same and false otherwise.
    */
   struct CaseInsensitiveCompare {
-    // Enable heterogenous lookup (https://abseil.io/tips/144)
+    // Enable heterogeneous lookup (https://abseil.io/tips/144)
     using is_transparent = void;
     bool operator()(absl::string_view lhs, absl::string_view rhs) const;
   };
@@ -356,7 +356,7 @@ public:
    * @return uint64_t hash representation of the supplied string view.
    */
   struct CaseInsensitiveHash {
-    // Enable heterogenous lookup (https://abseil.io/tips/144)
+    // Enable heterogeneous lookup (https://abseil.io/tips/144)
     using is_transparent = void;
     uint64_t operator()(absl::string_view key) const;
   };

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -345,6 +345,8 @@ public:
    * @return true if strings are semantically the same and false otherwise.
    */
   struct CaseInsensitiveCompare {
+    // Enable heterogenous lookup (https://abseil.io/tips/144)
+    using is_transparent = void;
     bool operator()(absl::string_view lhs, absl::string_view rhs) const;
   };
 
@@ -354,13 +356,15 @@ public:
    * @return uint64_t hash representation of the supplied string view.
    */
   struct CaseInsensitiveHash {
+    // Enable heterogenous lookup (https://abseil.io/tips/144)
+    using is_transparent = void;
     uint64_t operator()(absl::string_view key) const;
   };
 
   /**
    * Definition of unordered set of case-insensitive std::string.
    */
-  typedef std::unordered_set<std::string, CaseInsensitiveHash, CaseInsensitiveCompare>
+  typedef absl::flat_hash_set<std::string, CaseInsensitiveHash, CaseInsensitiveCompare>
       CaseUnorderedSet;
 
   /**

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -211,9 +211,8 @@ bool GzipFilter::isAcceptEncodingAllowed(Http::HeaderMap& headers) const {
 bool GzipFilter::isContentTypeAllowed(Http::HeaderMap& headers) const {
   const Http::HeaderEntry* content_type = headers.ContentType();
   if (content_type && !config_->contentTypeValues().empty()) {
-    // TODO(dnoe): Eliminate std:string construction with Swiss table (#6580)
-    const std::string value{
-        StringUtil::trim(StringUtil::cropRight(content_type->value().getStringView(), ";"))};
+    const absl::string_view value =
+        StringUtil::trim(StringUtil::cropRight(content_type->value().getStringView(), ";"));
     return config_->contentTypeValues().find(value) != config_->contentTypeValues().end();
   }
 


### PR DESCRIPTION
Description: By adding some "tags" to the functors used in `CaseUnorderedSet` and switching it to be an `absl::flat_hash_set` we can take advantage of heterogeneous lookup ( https://abseil.io/tips/144 ) which eliminates `std::string` construction when performing a lookup with a `string_view` argument (obviously, the key type stored must be a concrete `std::string` and not a `string_view`). Also convert the gzip filter to eliminate the explicit `std::string` construction previously required.
Risk Level: Low
Testing: `bazel test //test/...`
Docs Changes: N/A
Release Notes: N/A
Part of: Issue #6580

Signed-off-by: Dan Noé <dpn@google.com>