### PR TITLE
upstream: do not stabilize host when failed by EDS

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -22,6 +22,11 @@ Version history
   in full by the router. This ensures that the per try timeout does not account for slow
   downstreams and that will not start before the global timeout.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
+* upstream: an EDS management server can now force removal of a host that is still passing active
+  health checking by first marking the host as failed via EDS health check and subsequently removing
+  it in a future update. This is a mechanism to work around a race condition in which an EDS
+  implementation may remove a host before it has stopped passing active HC, thus causing the host
+  to become stranded until a future update.
 
 1.10.0 (Apr 5, 2019)
 ====================


### PR DESCRIPTION
Previously if an EDS cluster was using active health checking,
a host would only be removed if it was removed both from EDS as
well as failed active HC. This change allows a host to be removed
if it is first failed by EDS, and then removed by EDS. This provides
a management server a mechanism to force removal of a host even
when the host may still be passing active health checking.

Risk Level: Low
Testing: New UT
Docs Changes: N/A
Release Notes: Added