### PR TITLE
quiche: Implement http2_reconstruct_object_impl.h.

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -29,6 +29,7 @@ load(":genrule_cmd.bzl", "genrule_cmd")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
+    "envoy_external_dep_path",
     "envoy_select_quiche",
 )
 
@@ -49,6 +50,26 @@ genrule(
 )
 
 cc_library(
+    name = "http2_platform_reconstruct_object",
+    testonly = 1,
+    hdrs = ["quiche/http2/platform/api/http2_reconstruct_object.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@envoy//test/extensions/quic_listeners/quiche/platform:http2_platform_reconstruct_object_impl_lib"],
+)
+
+cc_library(
+    name = "http2_test_tools_random",
+    testonly = 1,
+    srcs = ["quiche/http2/test_tools/http2_random.cc"],
+    hdrs = ["quiche/http2/test_tools/http2_random.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":http2_platform",
+        envoy_external_dep_path("ssl"),
+    ],
+)
+
+cc_library(
     name = "http2_platform",
     hdrs = [
         "quiche/http2/platform/api/http2_arraysize.h",
@@ -63,7 +84,6 @@ cc_library(
         "quiche/http2/platform/api/http2_string_piece.h",
         # TODO: uncomment the following files as implementations are added.
         # "quiche/http2/platform/api/http2_flags.h",
-        # "quiche/http2/platform/api/http2_reconstruct_object.h",
         # "quiche/http2/platform/api/http2_test_helpers.h",
     ] + envoy_select_quiche(
         [
@@ -277,12 +297,15 @@ cc_library(
 
 envoy_cc_test(
     name = "http2_platform_api_test",
-    srcs = envoy_select_quiche(
-        ["quiche/http2/platform/api/http2_string_utils_test.cc"],
-        "@envoy",
-    ),
+    srcs = [
+        "quiche/http2/platform/api/http2_string_utils_test.cc",
+        "quiche/http2/test_tools/http2_random_test.cc",
+    ],
     repository = "@envoy",
-    deps = [":http2_platform"],
+    deps = [
+        ":http2_platform",
+        ":http2_test_tools_random",
+    ],
 )
 
 envoy_cc_test(

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -31,7 +31,6 @@ load(
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_cc_test_library",
-    "envoy_external_dep_path",
     "envoy_select_quiche",
 )
 
@@ -64,11 +63,9 @@ envoy_cc_test_library(
     name = "http2_test_tools_random",
     srcs = ["quiche/http2/test_tools/http2_random.cc"],
     hdrs = ["quiche/http2/test_tools/http2_random.h"],
+    external_deps = ["ssl"],
     repository = "@envoy",
-    deps = [
-        ":http2_platform",
-        envoy_external_dep_path("ssl"),
-    ],
+    deps = [":http2_platform"],
 )
 
 envoy_cc_library(

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -19,6 +19,7 @@ src_base_dir=$$(dirname $$(dirname $$(dirname $(rootpath quic/core/quic_constant
 # sed commands to apply to each source file.
 cat <<EOF >sed_commands
 # Rewrite include directives for testonly platform impl files.
+/^#include/ s!net/http2/platform/impl/http2_reconstruct_object_impl.h!test/extensions/quic_listeners/quiche/platform/http2_reconstruct_object_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_expect_bug_impl.h!test/extensions/quic_listeners/quiche/platform/quic_expect_bug_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_mock_log_impl.h!test/extensions/quic_listeners/quiche/platform/quic_mock_log_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_port_utils_impl.h!test/extensions/quic_listeners/quiche/platform/quic_port_utils_impl.h!
@@ -31,7 +32,8 @@ cat <<EOF >sed_commands
 # Strip "net/third_party" from include directives to other QUICHE files.
 /^#include/ s!net/third_party/quiche/src/!quiche/!
 
-# Rewrite gtest includes.
+# Rewrite gmock & gtest includes.
+/^#include/ s!testing/gmock/include/gmock/!gmock/!
 /^#include/ s!testing/gtest/include/gtest/!gtest/!
 
 # Rewrite third_party includes.

--- a/source/extensions/quic_listeners/quiche/platform/http2_string_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/http2_string_utils_impl.h
@@ -36,7 +36,7 @@ inline std::string Http2HexDecodeImpl(absl::string_view data) {
   return absl::HexStringToBytes(data);
 }
 
-std::string Http2HexDumpImpl(absl::string_view data) { return quiche::HexDump(data); }
+inline std::string Http2HexDumpImpl(absl::string_view data) { return quiche::HexDump(data); }
 
 inline std::string Http2HexEscapeImpl(absl::string_view data) { return absl::CHexEscape(data); }
 

--- a/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
@@ -59,6 +59,13 @@
 #define CHECK(condition)                                                                           \
   QUIC_LOG_IF_IMPL(FATAL, ABSL_PREDICT_FALSE(!(condition))) << "CHECK failed: " #condition "."
 
+#define CHECK_GT(a, b) CHECK((a) > (b))
+#define CHECK_GE(a, b) CHECK((a) >= (b))
+#define CHECK_LT(a, b) CHECK((a) < (b))
+#define CHECK_LE(a, b) CHECK((a) <= (b))
+#define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_EQ(a, b) CHECK((a) == (b))
+
 #ifdef NDEBUG
 // Release build
 #define DCHECK(condition) QUIC_COMPILED_OUT_LOG()

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -16,17 +16,19 @@ envoy_package()
 
 envoy_cc_test(
     name = "http2_platform_test",
-    srcs = envoy_select_quiche(["http2_platform_test.cc"]),
+    srcs = ["http2_platform_test.cc"],
     external_deps = ["quiche_http2_platform"],
     deps = [
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
+        "@com_googlesource_quiche//:http2_platform_reconstruct_object",
+        "@com_googlesource_quiche//:http2_test_tools_random",
     ],
 )
 
 envoy_cc_test(
     name = "quic_platform_test",
-    srcs = envoy_select_quiche(["quic_platform_test.cc"]),
+    srcs = ["quic_platform_test.cc"],
     data = [
         "//test/extensions/transport_sockets/tls/test_data:certs",
     ],
@@ -55,6 +57,11 @@ envoy_cc_test(
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
     ],
+)
+
+envoy_cc_test_library(
+    name = "http2_platform_reconstruct_object_impl_lib",
+    hdrs = ["http2_reconstruct_object_impl.h"],
 )
 
 envoy_cc_test_library(

--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
@@ -17,8 +17,10 @@
 #include "quiche/http2/platform/api/http2_macros.h"
 #include "quiche/http2/platform/api/http2_optional.h"
 #include "quiche/http2/platform/api/http2_ptr_util.h"
+#include "quiche/http2/platform/api/http2_reconstruct_object.h"
 #include "quiche/http2/platform/api/http2_string.h"
 #include "quiche/http2/platform/api/http2_string_piece.h"
+#include "quiche/http2/test_tools/http2_random.h"
 
 // Basic tests to validate functioning of the QUICHE http2 platform
 // implementation. For platform APIs in which the implementation is a simple
@@ -77,6 +79,11 @@ TEST(Http2PlatformTest, Http2Log) {
   HTTP2_DLOG_EVERY_N(ERROR, 2) << "DLOG_EVERY_N(ERROR, 2)";
 }
 
+TEST(Http2PlatformTest, Http2MakeUnique) {
+  auto p = http2::Http2MakeUnique<int>(4);
+  EXPECT_EQ(4, *p);
+}
+
 TEST(Http2PlatformTest, Http2Optional) {
   http2::Http2Optional<int> opt;
   EXPECT_FALSE(opt.has_value());
@@ -84,9 +91,18 @@ TEST(Http2PlatformTest, Http2Optional) {
   EXPECT_TRUE(opt.has_value());
 }
 
-TEST(Http2PlatformTest, Http2MakeUnique) {
-  auto p = http2::Http2MakeUnique<int>(4);
-  EXPECT_EQ(4, *p);
+TEST(Http2PlatformTest, Http2ReconstructObject) {
+  http2::test::Http2Random rng;
+  std::string s;
+
+  http2::test::Http2ReconstructObject(&s, &rng, "123");
+  EXPECT_EQ("123", s);
+
+  http2::test::Http2ReconstructObject(&s, &rng, "456");
+  EXPECT_EQ("456", s);
+
+  http2::test::Http2DefaultReconstructObject(&s, &rng);
+  EXPECT_EQ("", s);
 }
 
 TEST(Http2PlatformTest, Http2String) {

--- a/test/extensions/quic_listeners/quiche/platform/http2_reconstruct_object_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/http2_reconstruct_object_impl.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include <utility>
+
+namespace http2 {
+namespace test {
+
+class Http2Random;
+
+// Reconstruct an object so that it is initialized as when it was first
+// constructed. Runs the destructor to handle objects that might own resources,
+// and runs the constructor with the provided arguments, if any.
+template <class T, class... Args>
+void Http2ReconstructObjectImpl(T* ptr, Http2Random* /*rng*/, Args&&... args) {
+  ptr->~T();
+  ::new (ptr) T(std::forward<Args>(args)...);
+}
+
+// This version applies default-initialization to the object.
+template <class T> void Http2DefaultReconstructObjectImpl(T* ptr, Http2Random* /*rng*/) {
+  ptr->~T();
+  ::new (ptr) T;
+}
+
+} // namespace test
+} // namespace http2


### PR DESCRIPTION
Description:

Implement http2_reconstruct_object_impl.h, which provides simple test-only apis to re-construct c++ objects in place.  Also added BUILD rule "http2_test_tools_random" since it's needed by http2_reconstruct_object_impl.h.

Risk Level: none, code not used yet.
Testing:

bazel test --test_output=all test/extensions/quic_listeners/quiche/platform:all @com_googlesource_quiche//:all

Docs Changes: none
Release Notes: none
