### PR TITLE
build: patch protobuf for UBSAN issue.

### DIFF
--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -1,0 +1,34 @@
+diff --git a/src/google/protobuf/stubs/strutil.cc b/src/google/protobuf/stubs/strutil.cc
+index 1d34870deb..3844fa6b8b 100644
+--- a/src/google/protobuf/stubs/strutil.cc
++++ b/src/google/protobuf/stubs/strutil.cc
+@@ -1116,10 +1116,12 @@ char* FastUInt64ToBufferLeft(uint64 u64, char* buffer) {
+ }
+ 
+ char* FastInt64ToBufferLeft(int64 i, char* buffer) {
+-  uint64 u = i;
++  uint64 u = 0;
+   if (i < 0) {
+     *buffer++ = '-';
+-    u = -i;
++    u -= i;
++  } else {
++    u = i;
+   }
+   return FastUInt64ToBufferLeft(u, buffer);
+ }
+diff --git a/src/google/protobuf/text_format.cc b/src/google/protobuf/text_format.cc
+index ba0c3028ee..801a8e3786 100644
+--- a/src/google/protobuf/text_format.cc
++++ b/src/google/protobuf/text_format.cc
+@@ -1315,7 +1315,9 @@ class TextFormat::Printer::TextGenerator
+     while (size > buffer_size_) {
+       // Data exceeds space in the buffer. Write what we can and request a new
+       // buffer.
+-      memset(buffer_, ' ', buffer_size_);
++      if (buffer_size_ > 0) {
++        memset(buffer_, ' ', buffer_size_);
++      }
+       size -= buffer_size_;
+       void* void_buffer;
+       failed_ = !output_->Next(&void_buffer, &buffer_size_);

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -486,7 +486,7 @@ def _com_google_protobuf():
         # TODO(htuch): remove this when > protobuf 3.7.1 is released.
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:protobuf.patch"],
-   )
+    )
 
     # Needed for cc_proto_library, Bazel doesn't support aliases today for repos,
     # see https://groups.google.com/forum/#!topic/bazel-discuss/859ybHQZnuI and

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -479,7 +479,14 @@ def _com_google_absl():
     )
 
 def _com_google_protobuf():
-    _repository_impl("com_google_protobuf")
+    _repository_impl(
+        "com_google_protobuf",
+        # The patch is only needed until
+        # https://github.com/protocolbuffers/protobuf/pull/5901 is available.
+        # TODO(htuch): remove this when > protobuf 3.7.1 is released.
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:protobuf.patch"],
+   )
 
     # Needed for cc_proto_library, Bazel doesn't support aliases today for repos,
     # see https://groups.google.com/forum/#!topic/bazel-discuss/859ybHQZnuI and
@@ -487,6 +494,11 @@ def _com_google_protobuf():
     _repository_impl(
         "com_google_protobuf_cc",
         repository_key = "com_google_protobuf",
+        # The patch is only needed until
+        # https://github.com/protocolbuffers/protobuf/pull/5901 is available.
+        # TODO(htuch): remove this when > protobuf 3.7.1 is released.
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:protobuf.patch"],
     )
     native.bind(
         name = "protobuf",


### PR DESCRIPTION
Since https://github.com/envoyproxy/envoy/pull/6610 the fuzzer build has
been broken. This is due to the interaction of rules_foreign_cc external
dependencies and the additional UBSAN blacklist maintained by the
oss-fuzz driver to workaround the fact we don't have
https://github.com/protocolbuffers/protobuf/pull/5901 yet.

Thir PR moves https://github.com/protocolbuffers/protobuf/pull/5901 into
Envoy proper and hence we don't need an UBSAN blacklist in the oss-fuzz
driver anymore.

Risk level: Low
Tesitng: oss-fuzz Docker build.

Signed-off-by: Harvey Tuch <htuch@google.com>