### PR TITLE
coverage: Increase timeout of the coverage test run to 3000 seconds

### DIFF
--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -53,7 +53,7 @@ BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} -c dbg --copt=-DNDEBUG"
 "${BAZEL_COVERAGE}" --batch test "${COVERAGE_TARGET}" ${BAZEL_TEST_OPTIONS} \
   --cache_test_results=no --cxxopt="--coverage" --cxxopt="-DENVOY_CONFIG_COVERAGE=1" \
   --linkopt="--coverage" --define ENVOY_CONFIG_COVERAGE=1 --test_output=streamed \
-  --strategy=Genrule=standalone --spawn_strategy=standalone --test_timeout=2000 \
+  --strategy=Genrule=standalone --spawn_strategy=standalone --test_timeout=3000 \
   --test_arg="--log-path /dev/null" --test_arg="-l trace"
 
 # The Bazel build has a lot of whack in it, in particular generated files, headers from external


### PR DESCRIPTION
Increase timeout of the coverage test run to 3000 seconds as it is now bumping in the current 2000s limit causing coverage run to abort sometimes.

Signed-off-by: Yan Avlasov <yavlasov@google.com>

Description: Increase timeout of the coverage test run to 3000 seconds as it is now bumping in the current 2000s limit causing coverage run to abort sometimes.
Risk Level: low
Testing: coverage test run
Docs Changes: N/A
Release Notes: N/A
