### PR TITLE
quiche: implement QuicSystemEventLoopImpl

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -193,6 +193,14 @@ cc_library(
 )
 
 cc_library(
+    name = "quic_platform_system_event_loop",
+    testonly = 1,
+    hdrs = ["quiche/quic/platform/api/quic_system_event_loop.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@envoy//test/extensions/quic_listeners/quiche/platform:quic_platform_system_event_loop_impl_lib"],
+)
+
+cc_library(
     name = "quic_platform_base",
     hdrs = [
         "quiche/quic/platform/api/quic_aligned.h",

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -22,6 +22,7 @@ cat <<EOF >sed_commands
 /^#include/ s!net/quic/platform/impl/quic_expect_bug_impl.h!test/extensions/quic_listeners/quiche/platform/quic_expect_bug_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_mock_log_impl.h!test/extensions/quic_listeners/quiche/platform/quic_mock_log_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_port_utils_impl.h!test/extensions/quic_listeners/quiche/platform/quic_port_utils_impl.h!
+/^#include/ s!net/quic/platform/impl/quic_system_event_loop_impl.h!test/extensions/quic_listeners/quiche/platform/quic_system_event_loop_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_test_impl.h!test/extensions/quic_listeners/quiche/platform/quic_test_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_test_output_impl.h!test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.h!
 

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -43,6 +43,7 @@ envoy_cc_test(
         "@com_googlesource_quiche//:quic_platform_mock_log",
         "@com_googlesource_quiche//:quic_platform_port_utils",
         "@com_googlesource_quiche//:quic_platform_sleep",
+        "@com_googlesource_quiche//:quic_platform_system_event_loop",
         "@com_googlesource_quiche//:quic_platform_test_output",
     ] + envoy_cc_platform_dep("//source/exe:platform_impl_lib"),
 )
@@ -80,6 +81,11 @@ envoy_cc_test_library(
         "//source/common/network:utility_lib",
         "//test/test_common:environment_lib",
     ],
+)
+
+envoy_cc_test_library(
+    name = "quic_platform_system_event_loop_impl_lib",
+    hdrs = ["quic_system_event_loop_impl.h"],
 )
 
 envoy_cc_test_library(

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -48,6 +48,7 @@
 #include "quiche/quic/platform/api/quic_stack_trace.h"
 #include "quiche/quic/platform/api/quic_stream_buffer_allocator.h"
 #include "quiche/quic/platform/api/quic_string_piece.h"
+#include "quiche/quic/platform/api/quic_system_event_loop.h"
 #include "quiche/quic/platform/api/quic_test_output.h"
 #include "quiche/quic/platform/api/quic_thread.h"
 #include "quiche/quic/platform/api/quic_uint128.h"
@@ -594,6 +595,13 @@ TEST_F(QuicPlatformTest, TestEnvoyQuicBufferAllocator) {
   if (deterministic_stats) {
     EXPECT_EQ(start_mem, Envoy::Memory::Stats::totalCurrentlyAllocated());
   }
+}
+
+TEST_F(QuicPlatformTest, TestSystemEventLoop) {
+  // These two interfaces are no-op in Envoy. The test just makes sure they
+  // build.
+  QuicRunSystemEventLoopIteration();
+  QuicSystemEventLoop("dummy");
 }
 
 } // namespace

--- a/test/extensions/quic_listeners/quiche/platform/quic_system_event_loop_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/quic_system_event_loop_impl.h
@@ -6,6 +6,8 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
+#include <string>
+
 inline void QuicRunSystemEventLoopIterationImpl() {
   // No-op.
 }

--- a/test/extensions/quic_listeners/quiche/platform/quic_system_event_loop_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/quic_system_event_loop_impl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+inline void QuicRunSystemEventLoopIterationImpl() {
+  // No-op.
+}
+
+class QuicSystemEventLoopImpl {
+public:
+  // Only used by quic_client_bin.cc which is not required in Envoy.
+  QuicSystemEventLoopImpl(std::string /*context_name*/) {}
+};


### PR DESCRIPTION
Add a dummy impl to QuicSystemEventLoop which is used to drive SimpleEpollServer to receive IO event in Chromium, but not needed in stand alone e2e tests.

Risk Level: low
Testing: added a test to make sure it compiles
Part of #2557