### PR TITLE
Add test for the SocketOptionFactory::buildLiteralOptions() method.

### DIFF
--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -235,6 +235,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "socket_option_factory_test",
     srcs = ["socket_option_factory_test.cc"],
+    external_deps = ["abseil_str_format"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:socket_option_factory_lib",


### PR DESCRIPTION
Signed-off-by: Yan Avlasov <yavlasov@google.com>

Description: Add test for the SocketOptionFactory::buildLiteralOptions() method to increase test coverage.
Risk Level: low
Testing: unit tests, coverage
Docs Changes: N/A
Release Notes: N/A
