### PR TITLE
Support gRPC-JSON translate without the google.api.http option.

### DIFF
--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -92,4 +92,25 @@ message GrpcJsonTranscoder {
   // binding for ``foo`` is not defined. Adding ``foo`` to ``ignored_query_parameters`` will allow
   // the same request to be mapped to ``GetShelf``.
   repeated string ignored_query_parameters = 6;
+
+  // Whether to route methods without the ``google.api.http`` option.
+  //
+  // Example :
+  //
+  // .. code-block:: proto
+  //     package bookstore;
+  //
+  //     service Bookstore {
+  //       rpc GetShelf(GetShelfRequest) returns (Shelf) {}
+  //     }
+  //
+  //     message GetShelfRequest {
+  //       int64 shelf = 1;
+  //     }
+  //
+  //     message Shelf {}
+  //
+  // The client could ``post`` a json body ``{"shelf": 1234}`` with the path of
+  // ``/bookstore.Bookstore/GetShelfRequest`` to call ``GetShelfRequest``.
+  bool auto_mapping = 7;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -98,6 +98,7 @@ message GrpcJsonTranscoder {
   // Example :
   //
   // .. code-block:: proto
+  //
   //     package bookstore;
   //
   //     service Bookstore {

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -27,6 +27,8 @@ Version history
   it in a future update. This is a mechanism to work around a race condition in which an EDS
   implementation may remove a host before it has stopped passing active HC, thus causing the host
   to become stranded until a future update.
+* grpc-json: added support for :ref:`auto mapping
+  <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.auto_mapping>`.
 
 1.10.0 (Apr 5, 2019)
 ====================

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -127,9 +127,8 @@ JsonTranscoderConfig::JsonTranscoderConfig(
         http_rule.set_body("*");
       }
 
-      if (!PathMatcherUtility::RegisterByHttpRule(pmb,
-                                                  http_rule,
-                                                  ignored_query_parameters, method)) {
+      if (!PathMatcherUtility::RegisterByHttpRule(pmb, http_rule, ignored_query_parameters,
+                                                  method)) {
         throw EnvoyException("transcoding_filter: Cannot register '" + method->full_name() +
                              "' to path matcher");
       }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -121,7 +121,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
       auto method = service->method(i);
       auto http_rule = method->options().GetExtension(google::api::http);
 
-      if (!http_rule.pattern_case() && proto_config.auto_mapping()) {
+      if (!method->options().HasExtension(google::api::http) && proto_config.auto_mapping()) {
         auto post = "/" + service->full_name() + "/" + method->name();
         http_rule.set_post(post);
         http_rule.set_body("*");

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -122,7 +122,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
       auto http_rule = method->options().GetExtension(google::api::http);
 
       if (!http_rule.pattern_case() && proto_config.auto_mapping()) {
-        auto post = "/" + service->file()->package() + "." + service->name() + "/" + method->name();
+        auto post = "/" + service->full_name() + "/" + method->name();
         http_rule.set_post(post);
         http_rule.set_body("*");
       }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -28,6 +28,7 @@ using Envoy::Protobuf::FileDescriptorSet;
 using Envoy::Protobuf::io::ZeroCopyInputStream;
 using Envoy::ProtobufUtil::Status;
 using Envoy::ProtobufUtil::error::Code;
+using google::api::HttpRule;
 using google::grpc::transcoding::JsonRequestTranslator;
 using google::grpc::transcoding::PathMatcherBuilder;
 using google::grpc::transcoding::PathMatcherUtility;
@@ -119,9 +120,11 @@ JsonTranscoderConfig::JsonTranscoderConfig(
     }
     for (int i = 0; i < service->method_count(); ++i) {
       auto method = service->method(i);
-      auto http_rule = method->options().GetExtension(google::api::http);
 
-      if (!method->options().HasExtension(google::api::http) && proto_config.auto_mapping()) {
+      HttpRule(http_rule);
+      if (method->options().HasExtension(google::api::http)) {
+        http_rule = method->options().GetExtension(google::api::http);
+      } else if (proto_config.auto_mapping()) {
         auto post = "/" + service->full_name() + "/" + method->name();
         http_rule.set_post(post);
         http_rule.set_body("*");

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -121,7 +121,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
     for (int i = 0; i < service->method_count(); ++i) {
       auto method = service->method(i);
 
-      HttpRule(http_rule);
+      HttpRule http_rule;
       if (method->options().HasExtension(google::api::http)) {
         http_rule = method->options().GetExtension(google::api::http);
       } else if (proto_config.auto_mapping()) {

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -127,7 +127,9 @@ JsonTranscoderConfig::JsonTranscoderConfig(
         http_rule.set_body("*");
       }
 
-      if (!PathMatcherUtility::RegisterByHttpRule(pmb, http_rule, ignored_query_parameters, method)) {
+      if (!PathMatcherUtility::RegisterByHttpRule(pmb,
+                                                  http_rule,
+                                                  ignored_query_parameters, method)) {
         throw EnvoyException("transcoding_filter: Cannot register '" + method->full_name() +
                              "' to path matcher");
       }

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -208,6 +208,25 @@ TEST_F(GrpcJsonTranscoderConfigTest, CreateTranscoder) {
   EXPECT_EQ("bookstore.Bookstore.ListShelves", method_descriptor->full_name());
 }
 
+TEST_F(GrpcJsonTranscoderConfigTest, CreateTranscoderAutoMap) {
+  auto proto_config = getProtoConfig(TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"), "bookstore.Bookstore");
+  proto_config.set_auto_mapping(true);
+
+  JsonTranscoderConfig config(proto_config, *api_);
+
+  Http::TestHeaderMapImpl headers{{":method", "POST"}, {":path", "/bookstore.Bookstore/DeleteShelf"}};
+
+  TranscoderInputStreamImpl request_in, response_in;
+  std::unique_ptr<Transcoder> transcoder;
+  const MethodDescriptor* method_descriptor;
+  auto status =
+      config.createTranscoder(headers, request_in, response_in, transcoder, method_descriptor);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(transcoder);
+  EXPECT_EQ("bookstore.Bookstore.DeleteShelf", method_descriptor->full_name());
+}
+
 TEST_F(GrpcJsonTranscoderConfigTest, InvalidQueryParameter) {
   JsonTranscoderConfig config(
       getProtoConfig(TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"),

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -209,12 +209,14 @@ TEST_F(GrpcJsonTranscoderConfigTest, CreateTranscoder) {
 }
 
 TEST_F(GrpcJsonTranscoderConfigTest, CreateTranscoderAutoMap) {
-  auto proto_config = getProtoConfig(TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"), "bookstore.Bookstore");
+  auto proto_config = getProtoConfig(
+      TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"), "bookstore.Bookstore");
   proto_config.set_auto_mapping(true);
 
   JsonTranscoderConfig config(proto_config, *api_);
 
-  Http::TestHeaderMapImpl headers{{":method", "POST"}, {":path", "/bookstore.Bookstore/DeleteShelf"}};
+  Http::TestHeaderMapImpl headers{{":method", "POST"},
+                                  {":path", "/bookstore.Bookstore/DeleteShelf"}};
 
   TranscoderInputStreamImpl request_in, response_in;
   std::unique_ptr<Transcoder> transcoder;


### PR DESCRIPTION
Description: Support gRPC-JSON translate without the `google.api.http` option.
Risk Level: Low
Testing: Done
Docs Changes: Done
Release Notes: Done

fixes #3631