### PR TITLE
proto: Add PATCH method to RequestMethod enum

### DIFF
--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -140,6 +140,7 @@ enum RequestMethod {
   CONNECT = 6;
   OPTIONS = 7;
   TRACE = 8;
+  PATCH = 9;
 }
 
 // Header name/value pair.

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -362,9 +362,10 @@ http_logs:
       upstream_transport_failure_reason: "TLS error"
     request:
       request_method: "METHOD_UNSPECIFIED"
+      request_headers_bytes: 16
     response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(&request_headers, nullptr, nullptr, stream_info);
   }
 
   {
@@ -417,9 +418,10 @@ http_logs:
         tls_session_id: D62A523A65695219D46FE1FFE285A4C371425ACE421B110B5B8D11D3EB4D5F0B
     request:
       request_method: "METHOD_UNSPECIFIED"
+      request_headers_bytes: 16
     response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(&request_headers, nullptr, nullptr, stream_info);
   }
 }
 

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -143,7 +143,7 @@ public:
     stream_info.host_ = nullptr;
 
     Http::TestHeaderMapImpl request_headers{
-      {":method", request_method},
+        {":method", request_method},
     };
 
     expectLog(fmt::format(R"EOF(
@@ -163,7 +163,8 @@ public:
           request_method: {}
           request_headers_bytes: {}
         response: {{}}
-    )EOF", request_method, request_method.length() + 7));
+    )EOF",
+                          request_method, request_method.length() + 7));
     access_log_->log(&request_headers, nullptr, nullptr, stream_info);
   }
 

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -307,6 +307,39 @@ http_logs:
   }
 
   {
+      NiceMock<StreamInfo::MockStreamInfo> stream_info;
+      stream_info.host_ = nullptr;
+      stream_info.start_time_ = SystemTime(1h);
+      stream_info.upstream_transport_failure_reason_ = "TLS error";
+
+      Http::TestHeaderMapImpl request_headers{
+          {":method", "PATCH"},
+      };
+
+      expectLog(R"EOF(
+  http_logs:
+    log_entry:
+      common_properties:
+        downstream_remote_address:
+          socket_address:
+            address: "127.0.0.1"
+            port_value: 0
+        downstream_local_address:
+          socket_address:
+            address: "127.0.0.2"
+            port_value: 0
+        start_time:
+          seconds: 3600
+        upstream_transport_failure_reason: "TLS error"
+      request:
+        request_method: "PATCH"
+        request_headers_bytes: 12
+      response: {}
+  )EOF");
+      access_log_->log(&request_headers, nullptr, nullptr, stream_info);
+  }
+
+  {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
     stream_info.host_ = nullptr;
     stream_info.start_time_ = SystemTime(1h);


### PR DESCRIPTION
Description: Add PATCH method to protobuf so that ALS can receive and log it properly
Risk Level: Low
Testing: None
Docs Changes: -
Release Notes: -
Fixes #6694