### PR TITLE
quiche: Implement spdy_test_helpers_impl.h

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -133,6 +133,13 @@ envoy_cc_library(
     deps = [":spdy_platform"],
 )
 
+envoy_cc_test_library(
+    name = "spdy_platform_test_helpers",
+    hdrs = ["quiche/spdy/platform/api/spdy_test_helpers.h"],
+    repository = "@envoy",
+    deps = ["@envoy//test/extensions/quic_listeners/quiche/platform:spdy_platform_test_helpers_impl_lib"],
+)
+
 envoy_cc_library(
     name = "spdy_platform_unsafe_arena_lib",
     hdrs = ["quiche/spdy/platform/api/spdy_unsafe_arena.h"],

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -26,6 +26,7 @@ cat <<EOF >sed_commands
 /^#include/ s!net/quic/platform/impl/quic_test_impl.h!test/extensions/quic_listeners/quiche/platform/quic_test_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_test_output_impl.h!test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_thread_impl.h!test/extensions/quic_listeners/quiche/platform/quic_thread_impl.h!
+/^#include/ s!net/spdy/platform/impl/spdy_test_helpers_impl.h!test/extensions/quic_listeners/quiche/platform/spdy_test_helpers_impl.h!
 
 # Rewrite include directives for platform impl files.
 /^#include/ s!net/(http2|spdy|quic)/platform/impl/!extensions/quic_listeners/quiche/platform/!

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -51,11 +51,35 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "spdy_platform_test",
-    srcs = envoy_select_quiche(["spdy_platform_test.cc"]),
+    srcs = ["spdy_platform_test.cc"],
     external_deps = ["quiche_spdy_platform"],
     deps = [
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
+        "@com_googlesource_quiche//:spdy_platform_test_helpers",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "epoll_server_platform_impl_lib",
+    hdrs = [
+        "epoll_address_test_utils_impl.h",
+        "epoll_bug_impl.h",
+        "epoll_expect_bug_impl.h",
+        "epoll_export_impl.h",
+        "epoll_logging_impl.h",
+        "epoll_ptr_util_impl.h",
+        "epoll_test_impl.h",
+        "epoll_thread_impl.h",
+        "epoll_time_impl.h",
+    ],
+    external_deps = ["abseil_time"],
+    deps = [
+        ":quic_platform_expect_bug_impl_lib",
+        ":quic_platform_thread_impl_lib",
+        "//include/envoy/network:address_interface",
+        "//source/extensions/quic_listeners/quiche/platform:quic_platform_base_impl_lib",
+        "//test/test_common:environment_lib",
     ],
 )
 
@@ -106,34 +130,19 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test_library(
-    name = "epoll_server_platform_impl_lib",
-    hdrs = [
-        "epoll_address_test_utils_impl.h",
-        "epoll_bug_impl.h",
-        "epoll_expect_bug_impl.h",
-        "epoll_export_impl.h",
-        "epoll_logging_impl.h",
-        "epoll_ptr_util_impl.h",
-        "epoll_test_impl.h",
-        "epoll_thread_impl.h",
-        "epoll_time_impl.h",
-    ],
-    external_deps = ["abseil_time"],
-    deps = [
-        ":quic_platform_expect_bug_impl_lib",
-        ":quic_platform_thread_impl_lib",
-        "//include/envoy/network:address_interface",
-        "//source/extensions/quic_listeners/quiche/platform:quic_platform_base_impl_lib",
-        "//test/test_common:environment_lib",
-    ],
-)
-
-envoy_cc_test_library(
     name = "quic_platform_test_output_impl_lib",
     srcs = ["quic_test_output_impl.cc"],
     hdrs = ["quic_test_output_impl.h"],
     deps = [
         "//source/common/filesystem:filesystem_lib",
         "@com_googlesource_quiche//:quic_platform_base",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "spdy_platform_test_helpers_impl_lib",
+    hdrs = ["spdy_test_helpers_impl.h"],
+    deps = [
+        ":quic_platform_expect_bug_impl_lib",
     ],
 )

--- a/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
@@ -12,6 +12,7 @@
 #include "quiche/spdy/platform/api/spdy_ptr_util.h"
 #include "quiche/spdy/platform/api/spdy_string.h"
 #include "quiche/spdy/platform/api/spdy_string_piece.h"
+#include "quiche/spdy/platform/api/spdy_test_helpers.h"
 
 // Basic tests to validate functioning of the QUICHE spdy platform
 // implementation. For platform APIs in which the implementation is a simple
@@ -103,6 +104,13 @@ TEST(SpdyPlatformTest, SpdyStringPiece) {
   spdy::SpdyString s = "bar";
   spdy::SpdyStringPiece sp(s);
   EXPECT_EQ('b', sp[0]);
+}
+
+TEST(SpdyPlatformTest, SpdyTestHelpers) {
+  auto bug = [](const char* error_message) { SPDY_BUG << error_message; };
+
+  EXPECT_SPDY_BUG(bug("bug one is expected"), "bug one");
+  EXPECT_SPDY_BUG(bug("bug two is expected"), "bug two");
 }
 
 } // namespace

--- a/test/extensions/quic_listeners/quiche/platform/spdy_test_helpers_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/spdy_test_helpers_impl.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+//
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "test/extensions/quic_listeners/quiche/platform/quic_expect_bug_impl.h"
+
+#define EXPECT_SPDY_BUG_IMPL EXPECT_QUIC_BUG_IMPL


### PR DESCRIPTION
Description:

Implement spdy_test_helpers_impl.h, by simply

#define EXPECT_SPDY_BUG_IMPL EXPECT_QUIC_BUG_IMPL

Risk Level: none, code not used yet.
Testing:

bazel test --test_output=all test/extensions/quic_listeners/quiche/platform:all @com_googlesource_quiche//:all

Docs Changes: none
Release Notes: none

