### PR TITLE
[docs] Remove outdated statements

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -192,7 +192,6 @@ public:
   /**
    * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The filter
    *         config, which arrives in an opaque message, will be parsed into this empty proto.
-   *         Optional today, will be compulsory when v1 is deprecated.
    */
   virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -312,8 +312,7 @@ public:
   /**
    * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The filter
    *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
-   *         JSON and then parsed into this empty proto. Optional today, will be compulsory when v1
-   *         is deprecated.
+   *         JSON and then parsed into this empty proto.
    */
   virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -251,8 +251,7 @@ public:
                                                        FactoryContext& context) PURE;
 
   /**
-   * v2 variant of createFilterFactory(..), where filter configs are specified as proto. This may be
-   * optionally implemented today, but will in the future become compulsory once v1 is deprecated.
+   * v2 variant of createFilterFactory(..), where filter configs are specified as proto.
    */
   virtual Network::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                                 FactoryContext& context) {
@@ -264,8 +263,7 @@ public:
   /**
    * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The filter
    *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
-   *         JSON and then parsed into this empty proto. Optional today, will be compulsory when v1
-   *         is deprecated.
+   *         JSON and then parsed into this empty proto.
    */
   virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
 
@@ -300,9 +298,7 @@ public:
                                                     FactoryContext& context) PURE;
 
   /**
-   * v2 API variant of createFilterFactory(..), where filter configs are specified as proto. This
-   * may be optionally implemented today, but will in the future become compulsory once v1 is
-   * deprecated.
+   * v2 API variant of createFilterFactory(..), where filter configs are specified as proto.
    */
   virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                              const std::string& stat_prefix,


### PR DESCRIPTION
Description: v1 has been deprecated, remove statements about API methods being "optional until v1 is deprecated". Somewhat related to #2832.
Risk Level: none
Testing: N/A
Docs Changes: included
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>