### PR TITLE
Add support to report Locality proximity information as part of Load assignment

### DIFF
--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -136,7 +136,7 @@ message LocalityLbEndpoints {
   // Optional: Per locality proximity value which indicates how close this
   // locality is from the source locality. This value only provides ordering
   // information (lower the value, closer it is to the source locality).
-  // This will be consumed by Load balancing schemes that need proximity order
+  // This will be consumed by load balancing schemes that need proximity order
   // to determine where to route the requests.
   // [#not-implemented-hide:]
   google.protobuf.UInt32Value proximity = 6;

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -138,5 +138,6 @@ message LocalityLbEndpoints {
   // information (lower the value, closer it is to the source locality).
   // This will be consumed by Load balancing schemes that need proximity order
   // to determine where to route the requests.
+  // [#not-implemented-hide:]
   google.protobuf.UInt32Value proximity_weight = 6;
 }

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -139,5 +139,5 @@ message LocalityLbEndpoints {
   // This will be consumed by Load balancing schemes that need proximity order
   // to determine where to route the requests.
   // [#not-implemented-hide:]
-  google.protobuf.UInt32Value proximity_weight = 6;
+  google.protobuf.UInt32Value proximity = 6;
 }

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -132,4 +132,11 @@ message LocalityLbEndpoints {
   //
   // Priorities should range from 0 (highest) to N (lowest) without skipping.
   uint32 priority = 5 [(validate.rules).uint32 = {lte: 128}];
+
+  // Optional: Per locality proximity value which indicates how close this
+  // locality is from the source locality. This value only provides ordering
+  // information (lower the value, closer it is to the source locality).
+  // This will be consumed by Load balancing schemes that need proximity order
+  // to determine where to route the requests.
+  google.protobuf.UInt32Value proximity_weight = 6;
 }


### PR DESCRIPTION
Signed-off-by: Vishal Powar <vishalpowar@google.com>

Description: Adding API support to report Locality proximity information as part of Locality Assignment. This does not need to be documented yet, and should be documented as part of LB algorithm implementation which will use this information.

Risk Level: LOW
Testing: None
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue]
[Optional Deprecated:]
