### PR TITLE
properly handle 'proxy-connection: close' header

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -692,7 +692,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
-  if (!state_.saw_connection_close_ && request_headers_->ProxyConnection() &&
+  if (protocol != Protocol::Http2 && !state_.saw_connection_close_ &&
+      request_headers_->ProxyConnection() &&
       absl::EqualsIgnoreCase(request_headers_->ProxyConnection()->value().getStringView(),
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -692,6 +692,11 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
+  if (!state_.saw_connection_close_ && request_headers_->ProxyConnection() &&
+      absl::EqualsIgnoreCase(request_headers_->ProxyConnection()->value().getStringView(),
+                             Http::Headers::get().ConnectionValues.Close)) {
+    state_.saw_connection_close_ = true;
+  }
 
   if (!state_.is_internally_created_) { // Only sanitize headers on first pass.
     // Modify the downstream remote address depending on configuration and headers.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -692,6 +692,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
+  // Note: Proxy-Connection is not a standard header, but is supported here
+  // since it is supported by http-parser the underlying parser for http
+  // requests.
   if (protocol != Protocol::Http2 && !state_.saw_connection_close_ &&
       request_headers_->ProxyConnection() &&
       absl::EqualsIgnoreCase(request_headers_->ProxyConnection()->value().getStringView(),

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -279,6 +279,12 @@ void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end
     saw_close_header_ = true;
     parent_.parent_.host_->cluster().stats().upstream_cx_close_notify_.inc();
   }
+  if (!saw_close_header_ && headers->ProxyConnection() &&
+      absl::EqualsIgnoreCase(headers->ProxyConnection()->value().getStringView(),
+                             Headers::get().ConnectionValues.Close)) {
+    saw_close_header_ = true;
+    parent_.parent_.host_->cluster().stats().upstream_cx_close_notify_.inc();
+  }
 
   StreamDecoderWrapper::decodeHeaders(std::move(headers), end_stream);
 }

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -264,10 +264,10 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
     break;
   }
 
-  if ((response_headers_->Connection() && protocol_ != Http::Protocol::Http2 &&
+  if ((response_headers_->Connection() &&
        absl::EqualsIgnoreCase(response_headers_->Connection()->value().getStringView(),
                               Http::Headers::get().ConnectionValues.Close)) ||
-      (response_headers_->ProxyConnection() &&
+      (response_headers_->ProxyConnection() && protocol_ != Http::Protocol::Http2 &&
        absl::EqualsIgnoreCase(response_headers_->ProxyConnection()->value().getStringView(),
                               Http::Headers::get().ConnectionValues.Close)) ||
       !parent_.reuse_connection_) {

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -267,6 +267,9 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
   if ((response_headers_->Connection() &&
        absl::EqualsIgnoreCase(response_headers_->Connection()->value().getStringView(),
                               Http::Headers::get().ConnectionValues.Close)) ||
+      (response_headers_->ProxyConnection() &&
+       absl::EqualsIgnoreCase(response_headers_->ProxyConnection()->value().getStringView(),
+                              Http::Headers::get().ConnectionValues.Close)) ||
       !parent_.reuse_connection_) {
     client_->close();
   }

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -264,7 +264,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
     break;
   }
 
-  if ((response_headers_->Connection() &&
+  if ((response_headers_->Connection() && protocol_ != Http::Protocol::Http2 &&
        absl::EqualsIgnoreCase(response_headers_->Connection()->value().getStringView(),
                               Http::Headers::get().ConnectionValues.Close)) ||
       (response_headers_->ProxyConnection() &&

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2166,6 +2166,7 @@ TEST_F(HttpConnectionManagerImplTest, DisconnectOnProxyConnectionDisconnect) {
       .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Connection());
         EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ(nullptr, headers.ProxyConnection());
       }));
   EXPECT_CALL(*decoder_filters_[0], onDestroy());
   EXPECT_CALL(filter_callbacks_.connection_,

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2143,6 +2143,38 @@ TEST_F(HttpConnectionManagerImplTest, ResponseBeforeRequestComplete) {
   decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true);
 }
 
+TEST_F(HttpConnectionManagerImplTest, DisconnectOnProxyConnectionDisconnect) {
+  InSequence s;
+  setup(false, "envoy-server-test");
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+    HeaderMapPtr headers{new TestHeaderMapImpl{
+        {":authority", "host"}, {":path", "/"}, {":method", "GET"}, {"proxy-connection", "close"}}};
+    decoder->decodeHeaders(std::move(headers), false);
+  }));
+
+  setupFilterChain(1, 0);
+
+  EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+
+  Buffer::OwnedImpl fake_input;
+  conn_manager_->onData(fake_input, false);
+
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
+      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+        EXPECT_NE(nullptr, headers.Connection());
+        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+      }));
+  EXPECT_CALL(*decoder_filters_[0], onDestroy());
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::FlushWriteAndDelay));
+
+  HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true);
+}
+
 TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
   setup(false, "");
 

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -579,6 +579,39 @@ TEST_F(Http1ConnPoolImplTest, ConnectionCloseHeader) {
 }
 
 /**
+ * Test when upstream sends us 'proxy-connection: close'
+ */
+TEST_F(Http1ConnPoolImplTest, ProxyConnectionCloseHeader) {
+  InSequence s;
+
+  // Request 1 should kick off a new connection.
+  NiceMock<Http::MockStreamDecoder> outer_decoder;
+  ConnPoolCallbacks callbacks;
+  conn_pool_.expectClientCreate();
+  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder, callbacks);
+
+  EXPECT_NE(nullptr, handle);
+
+  NiceMock<Http::MockStreamEncoder> request_encoder;
+  Http::StreamDecoder* inner_decoder;
+  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
+      .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
+  EXPECT_CALL(callbacks.pool_ready_, ready());
+
+  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
+
+  // Response with 'connection: close' which should cause the connection to go away.
+  EXPECT_CALL(conn_pool_, onClientDestroy());
+  Http::HeaderMapPtr response_headers(
+      new TestHeaderMapImpl{{":status", "200"}, {"Proxy-Connection", "Close"}});
+  inner_decoder->decodeHeaders(std::move(response_headers), true);
+  dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(0U, cluster_->stats_.upstream_cx_destroy_with_active_rq_.value());
+}
+
+/**
  * Test when we reach max requests per connection.
  */
 TEST_F(Http1ConnPoolImplTest, MaxRequestsPerConnection) {

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -601,7 +601,7 @@ TEST_F(Http1ConnPoolImplTest, ProxyConnectionCloseHeader) {
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
   callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
 
-  // Response with 'connection: close' which should cause the connection to go away.
+  // Response with 'proxy-connection: close' which should cause the connection to go away.
   EXPECT_CALL(conn_pool_, onClientDestroy());
   Http::HeaderMapPtr response_headers(
       new TestHeaderMapImpl{{":status", "200"}, {"Proxy-Connection", "Close"}});


### PR DESCRIPTION
Description:

currently envoy is only checking for the: `connection: close` header
and not the: `proxy-connection: close` header. this presents a problem
with HPE, because HPE marks a connection as closed when you specify
`proxy-connection: close`.

this can cause problems in a scenario where a load balancer is
forwarding traffic to envoy which does not support `proxy-connection`
header. in this case the load balancer will try to keep forwarding
data onto envoy regardless of the fact that HPE think it's closed.
thus causing a 400. this is a common scenario since `proxy-connection`
is not standard.

this commit fixes that by properly sending `connection: close` back
in a response whenever we receive a: `proxy-connection: close`. this
should properly get the proxy to close the connection as long as it
is spec compliant.

Risk Level: Medium

Testing:
ontop of the unit tests the most basic full test you can run is:

  1. Compile Envoy with this patch.
  2. Supply it with: https://gist.github.com/SecurityInsanity/bd0807d7b8a4a96101106e9aab3a8518
     (this is the most simple config I could think of).
  3. Start a netcat session with the local envoy:
  ```
  $ nc localhost 8443
  GET /health_check HTTP/1.1
  Host: localhost
  Proxy-Connection: close

  ```

You should get back a response with: `connection: close`.

Docs Changes: None
Release Notes: None

Signed-off-by: Eric <ecoan@rust-lang.life>
