### PR TITLE
build/alts: fixes needed for .bzl and to bump gRPC to 1.20.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,6 +1,7 @@
 load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
 load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
@@ -380,8 +381,6 @@ def envoy_cc_binary(
         stamp = 1,
         deps = deps,
     )
-
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # Envoy C++ fuzz test targes. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -683,6 +683,10 @@ def envoy_select_google_grpc(xs, repository = ""):
         "//conditions:default": xs,
     })
 
+# Dependencies on Google grpc should be wrapped with this function.
+def envoy_google_grpc_external_deps():
+    return envoy_select_google_grpc([envoy_external_dep_path("grpc")])
+
 # Select the given values if exporting is enabled in the current build.
 def envoy_select_exported_symbols(xs):
     return select({

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -82,9 +82,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gperftools/gperftools/archive/fc00474ddc21fff618fc3f009b46590e241e425e.tar.gz"],
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "a5342629fe1b689eceb3be4d4f167b04c70a84b9d61cf8b555e968bc500bdb5a",
-        strip_prefix = "grpc-1.16.1",
-        urls = ["https://github.com/grpc/grpc/archive/v1.16.1.tar.gz"],
+        sha256 = "01c5e617d098a33672ddb640d0e50831fb7c613999435e5dcf115021abde6b9a",
+        strip_prefix = "grpc-1.20.0",
+        urls = ["https://github.com/grpc/grpc/archive/v1.20.0.tar.gz"],
     ),
     com_github_luajit_luajit = dict(
         sha256 = "409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8",
@@ -225,7 +225,7 @@ REPOSITORY_LOCATIONS = dict(
     rules_foreign_cc = dict(
         sha256 = "136470a38dcd00c7890230402b43004dc947bf1e3dd0289dd1bd2bfb1e0a3484",
         strip_prefix = "rules_foreign_cc-e3f4b5e0bc9dac9cf036616c13de25e6cd5051a2",
-        # 2019-02-14
+        # 2019-04-04
         urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/e3f4b5e0bc9dac9cf036616c13de25e6cd5051a2.tar.gz"],
     ),
     six_archive = dict(

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -7,6 +7,7 @@ load(
     "envoy_cc_platform_dep",
     "envoy_cc_posix_library",
     "envoy_cc_win32_library",
+    "envoy_google_grpc_external_deps",
     "envoy_package",
 )
 load(
@@ -81,7 +82,7 @@ envoy_cc_library(
             ":sigaction_lib",
             ":terminate_handler_lib",
         ],
-    }) + envoy_cc_platform_dep("platform_impl_lib"),
+    }) + envoy_cc_platform_dep("platform_impl_lib") + envoy_google_grpc_external_deps(),
 )
 
 envoy_cc_posix_library(

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -26,6 +26,9 @@
 #endif
 
 #include "ares.h"
+#ifdef ENVOY_GOOGLE_GRPC
+#include "grpc/grpc.h"
+#endif
 
 namespace Envoy {
 
@@ -50,6 +53,9 @@ MainCommonBase::MainCommonBase(const OptionsImpl& options, Event::TimeSystem& ti
                                Filesystem::Instance& file_system)
     : options_(options), component_factory_(component_factory), thread_factory_(thread_factory),
       file_system_(file_system), stats_allocator_(symbol_table_) {
+#ifdef ENVOY_GOOGLE_GRPC
+  grpc_init();
+#endif
   ares_library_init(ARES_LIB_INIT_ALL);
   Event::Libevent::Global::initialize();
   RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
@@ -97,7 +103,12 @@ MainCommonBase::MainCommonBase(const OptionsImpl& options, Event::TimeSystem& ti
   }
 }
 
-MainCommonBase::~MainCommonBase() { ares_library_cleanup(); }
+MainCommonBase::~MainCommonBase() {
+  ares_library_cleanup();
+#ifdef ENVOY_GOOGLE_GRPC
+  grpc_shutdown();
+#endif
+}
 
 void MainCommonBase::configureComponentLogLevels() {
   for (auto& component_log_level : options_.componentLogLevels()) {

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -59,8 +59,27 @@ createHandshakeValidator(const envoy::config::transport_socket::alts::v2alpha::A
   return validator;
 }
 
+// Manage ALTS singleton state via SingletonManager
+class AltsSharedState : public Singleton::Instance {
+public:
+  AltsSharedState() {
+    grpc_alts_shared_resource_dedicated_init();
+  }
+
+  ~AltsSharedState() {
+    grpc_alts_shared_resource_dedicated_shutdown();
+  }
+};
+
+SINGLETON_MANAGER_REGISTRATION(alts_shared_state);
+
 Network::TransportSocketFactoryPtr
-createTransportSocketFactoryHelper(const Protobuf::Message& message, bool is_upstream) {
+createTransportSocketFactoryHelper(const Protobuf::Message& message, bool is_upstream, Server::Configuration::TransportSocketFactoryContext& factory_ctxt) {
+  // A reference to this is held in the factory closure to keep the singleton
+  // instance alive.
+  auto alts_shared_state = factory_ctxt.singletonManager().getTyped<AltsSharedState>(
+                  SINGLETON_MANAGER_REGISTERED_NAME(alts_shared_state),
+                  [] { return std::make_shared<AltsSharedState>(); });
   auto config =
       MessageUtil::downcastAndValidate<const envoy::config::transport_socket::alts::v2alpha::Alts&>(
           message);
@@ -69,7 +88,7 @@ createTransportSocketFactoryHelper(const Protobuf::Message& message, bool is_ups
   const std::string handshaker_service = config.handshaker_service();
   HandshakerFactory factory =
       [handshaker_service,
-       is_upstream](Event::Dispatcher& dispatcher,
+       is_upstream, alts_shared_state](Event::Dispatcher& dispatcher,
                     const Network::Address::InstanceConstSharedPtr& local_address,
                     const Network::Address::InstanceConstSharedPtr&) -> TsiHandshakerPtr {
     ASSERT(local_address != nullptr);
@@ -84,8 +103,9 @@ createTransportSocketFactoryHelper(const Protobuf::Message& message, bool is_ups
     tsi_handshaker* handshaker = nullptr;
     // Specifying target name as empty since TSI won't take care of validating peer identity
     // in this use case. The validation will be performed by TsiSocket with the validator.
-    tsi_result status = alts_tsi_handshaker_create(
-        options.get(), target_name, handshaker_service.c_str(), is_upstream, &handshaker);
+    tsi_result status =
+        alts_tsi_handshaker_create(options.get(), target_name, handshaker_service.c_str(),
+                                   is_upstream, nullptr /* interested_parties */, &handshaker);
     CHandshakerPtr handshaker_ptr{handshaker};
 
     if (status != TSI_OK) {
@@ -108,15 +128,15 @@ ProtobufTypes::MessagePtr AltsTransportSocketConfigFactory::createEmptyConfigPro
 
 Network::TransportSocketFactoryPtr
 UpstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
-    const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext&) {
-  return createTransportSocketFactoryHelper(message, /* is_upstream */ true);
+    const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext& factory_ctxt) {
+  return createTransportSocketFactoryHelper(message, /* is_upstream */ true, factory_ctxt);
 }
 
 Network::TransportSocketFactoryPtr
 DownstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
-    const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext&,
+    const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext& factory_ctxt,
     const std::vector<std::string>&) {
-  return createTransportSocketFactoryHelper(message, /* is_upstream */ false);
+  return createTransportSocketFactoryHelper(message, /* is_upstream */ false, factory_ctxt);
 }
 
 REGISTER_FACTORY(UpstreamAltsTransportSocketConfigFactory,

--- a/source/extensions/transport_sockets/alts/grpc_tsi.h
+++ b/source/extensions/transport_sockets/alts/grpc_tsi.h
@@ -9,6 +9,7 @@
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 
 #include "grpc/grpc_security.h"
+#include "src/core/tsi/alts/handshaker/alts_shared_resource.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
 #include "src/core/tsi/transport_security_interface.h"
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
+    "envoy_google_grpc_external_deps",
     "envoy_package",
 )
 
@@ -38,5 +39,5 @@ envoy_cc_test_library(
     ] + select({
         "//bazel:disable_signal_trace": [],
         "//conditions:default": ["//source/exe:sigaction_lib"],
-    }),
+    }) + envoy_google_grpc_external_deps(),
 )

--- a/test/extensions/filters/http/common/BUILD
+++ b/test/extensions/filters/http/common/BUILD
@@ -4,10 +4,10 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_package",
+    "envoy_cc_test_library",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_cc_test_library",
     "envoy_extension_cc_test",
 )
 

--- a/test/extensions/filters/http/common/BUILD
+++ b/test/extensions/filters/http/common/BUILD
@@ -3,8 +3,8 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
     "envoy_cc_test_library",
+    "envoy_package",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",

--- a/test/extensions/resource_monitors/injected_resource/BUILD
+++ b/test/extensions/resource_monitors/injected_resource/BUILD
@@ -2,11 +2,11 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
     "envoy_package",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_cc_test",
     "envoy_extension_cc_test",
 )
 

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_google_grpc",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -70,9 +71,7 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "alts_integration_test",
-    srcs = [
-        "alts_integration_test.cc",
-    ],
+    srcs = envoy_select_google_grpc(["alts_integration_test.cc"]),
     extension_name = "envoy.transport_sockets.alts",
     external_deps = [
         "grpc_alts_fake_handshaker_server",

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -75,6 +75,8 @@ public:
     fake_handshaker_server_ci_.waitReady();
 
     NiceMock<Server::Configuration::MockTransportSocketFactoryContext> mock_factory_ctx;
+    // We fake the singleton manager for the client, since it doesn't need to manage ALTS global
+    // state, this is done by the test server instead.
     // TODO(htuch): Make this a proper mock.
     class FakeSingletonManager : public Singleton::Manager {
     public:

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -20,6 +20,8 @@
 #include "grpcpp/impl/codegen/service_type.h"
 #include "gtest/gtest.h"
 
+using ::testing::ReturnRef;
+
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
@@ -73,6 +75,15 @@ public:
     fake_handshaker_server_ci_.waitReady();
 
     NiceMock<Server::Configuration::MockTransportSocketFactoryContext> mock_factory_ctx;
+    // TODO(htuch): Make this a proper mock.
+    class FakeSingletonManager : public Singleton::Manager {
+    public:
+      Singleton::InstanceSharedPtr get(const std::string&, Singleton::SingletonFactoryCb) override {
+        return nullptr;
+      }
+    };
+    FakeSingletonManager fsm;
+    ON_CALL(mock_factory_ctx, singletonManager()).WillByDefault(ReturnRef(fsm));
     UpstreamAltsTransportSocketConfigFactory factory;
 
     envoy::config::transport_socket::alts::v2alpha::Alts alts_config;

--- a/test/extensions/transport_sockets/alts/config_test.cc
+++ b/test/extensions/transport_sockets/alts/config_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/config/transport_socket/alts/v2alpha/alts.pb.validate.h"
 
 #include "common/protobuf/protobuf.h"
+#include "common/singleton/manager_impl.h"
 
 #include "extensions/transport_sockets/alts/config.h"
 
@@ -12,6 +13,7 @@
 using Envoy::Server::Configuration::MockTransportSocketFactoryContext;
 using testing::_;
 using testing::Invoke;
+using testing::ReturnRef;
 using testing::StrictMock;
 
 namespace Envoy {
@@ -22,6 +24,8 @@ namespace {
 
 TEST(UpstreamAltsConfigTest, CreateSocketFactory) {
   MockTransportSocketFactoryContext factory_context;
+  Singleton::ManagerImpl singleton_manager{Thread::threadFactoryForTest().currentThreadId()};
+  EXPECT_CALL(factory_context, singletonManager()).WillRepeatedly(ReturnRef(singleton_manager));
   UpstreamAltsTransportSocketConfigFactory factory;
 
   ProtobufTypes::MessagePtr config = factory.createEmptyConfigProto();
@@ -40,6 +44,8 @@ TEST(UpstreamAltsConfigTest, CreateSocketFactory) {
 
 TEST(DownstreamAltsConfigTest, CreateSocketFactory) {
   MockTransportSocketFactoryContext factory_context;
+  Singleton::ManagerImpl singleton_manager{Thread::threadFactoryForTest().currentThreadId()};
+  EXPECT_CALL(factory_context, singletonManager()).WillRepeatedly(ReturnRef(singleton_manager));
   DownstreamAltsTransportSocketConfigFactory factory;
 
   ProtobufTypes::MessagePtr config = factory.createEmptyConfigProto();

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -14,6 +14,10 @@
 
 #include "gmock/gmock.h"
 
+#ifdef ENVOY_GOOGLE_GRPC
+#include "grpc/grpc.h"
+#endif
+
 namespace Envoy {
 namespace {
 
@@ -65,6 +69,9 @@ class TestRunner {
 public:
   static int RunTests(int argc, char** argv) {
     ::testing::InitGoogleMock(&argc, argv);
+#ifdef ENVOY_GOOGLE_GRPC
+    grpc_init();
+#endif
     Event::Libevent::Global::initialize();
     Http::Http2::initializeNghttp2Logging();
 


### PR DESCRIPTION
This continues https://github.com/envoyproxy/envoy/pull/6620.

See also https://github.com/envoyproxy/envoy/pull/6308 and
https://github.com/envoyproxy/envoy/issues/5461.

Risk level: Low
Testing: Existing tests

Signed-off-by: Harvey Tuch <htuch@google.com>