### PR TITLE
stats: Cleanup rejects on throw

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -32,6 +32,10 @@ ThreadLocalStoreImpl::~ThreadLocalStoreImpl() {
   ASSERT(shutting_down_);
   default_scope_.reset();
   ASSERT(scopes_.empty());
+  for (StatNameStorageSet* rejected_stats : rejected_stats_purgatory_) {
+    rejected_stats->free(symbolTable());
+    delete rejected_stats;
+  }
 }
 
 void ThreadLocalStoreImpl::setStatsMatcher(StatsMatcherPtr&& stats_matcher) {
@@ -188,7 +192,7 @@ void ThreadLocalStoreImpl::mergeInternal(PostMergeCb merge_complete_cb) {
 }
 
 void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
-  Thread::LockGuard lock(lock_);
+  Thread::ReleasableLockGuard lock(lock_);
   ASSERT(scopes_.count(scope) == 1);
   scopes_.erase(scope);
 
@@ -200,20 +204,27 @@ void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
   // of all references.
   auto rejected_stats = new StatNameStorageSet;
   rejected_stats->swap(scope->central_cache_.rejected_stats_);
-  const uint64_t scope_id = scope->scope_id_;
-  auto clean_central_cache = [this, rejected_stats]() {
-    rejected_stats->free(symbolTable());
-    delete rejected_stats;
-  };
 
   // This can happen from any thread. We post() back to the main thread which will initiate the
   // cache flush operation.
   if (!shutting_down_ && main_thread_dispatcher_) {
+    const uint64_t scope_id = scope->scope_id_;
+    rejected_stats_purgatory_.insert(rejected_stats);
+    auto clean_central_cache = [this, rejected_stats]() {
+      {
+        Thread::LockGuard lock(lock_);
+        rejected_stats_purgatory_.erase(rejected_stats);
+      }
+      rejected_stats->free(symbolTable());
+      delete rejected_stats;
+    };
+    lock.release();
     main_thread_dispatcher_->post([this, clean_central_cache, scope_id]() {
       clearScopeFromCaches(scope_id, clean_central_cache);
     });
   } else {
-    clean_central_cache();
+    rejected_stats->free(symbolTable());
+    delete rejected_stats;
   }
 }
 

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -325,6 +325,8 @@ private:
   std::vector<CounterSharedPtr> deleted_counters_;
   std::vector<GaugeSharedPtr> deleted_gauges_;
   std::vector<HistogramSharedPtr> deleted_histograms_;
+
+  absl::flat_hash_set<StatNameStorageSet*> rejected_stats_purgatory_ GUARDED_BY(lock_);
 };
 
 } // namespace Stats

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -6,6 +6,7 @@
 #include "envoy/config/metrics/v2/stats.pb.h"
 
 #include "common/common/c_smart_ptr.h"
+#include "common/event/dispatcher_impl.h"
 #include "common/memory/stats.h"
 #include "common/stats/stats_matcher_impl.h"
 #include "common/stats/tag_producer_impl.h"
@@ -883,6 +884,19 @@ TEST_F(StatsThreadLocalStoreTest, MergeDuringShutDown) {
   EXPECT_TRUE(merge_called);
   store_->shutdownThreading();
   tls_.shutdownThread();
+}
+
+TEST(ThreadLocalStoreThreadTest, ConstructDestruct) {
+  Stats::FakeSymbolTableImpl symbol_table;
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  NiceMock<ThreadLocal::MockInstance> tls;
+  HeapStatDataAllocator alloc(symbol_table);
+  ThreadLocalStoreImpl store(alloc);
+
+  store.initializeThreading(*dispatcher, tls);
+  { ScopePtr scope1 = store.createScope("scope1."); }
+  store.shutdownThreading();
 }
 
 // Histogram tests


### PR DESCRIPTION
Description: Some negative tests external to this codebase exercise config errors resulting in thrown exceptions during server construction, which takes an altered path to shutdown. Notably, any cleanups in post() callbacks may not be called. This was causing memory-leaks in unit-tests. This PR fixes that by keeping a copy of the rejected-stats set in "purgatory" so they can be removed on destruction from ThreadLocalStore if they don't get cleaned up by the post().
Risk Level: medium
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a

