### PR TITLE
Loglevel debug in http codec_client on PrematureResponseException

### DIFF
--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -119,7 +119,7 @@ void CodecClient::onData(Buffer::Instance& data) {
     close();
     protocol_error = true;
   } catch (PrematureResponseException& e) {
-    ENVOY_CONN_LOG(info, "premature response", *connection_);
+    ENVOY_CONN_LOG(debug, "premature response", *connection_);
     close();
 
     // Don't count 408 responses where we have no active requests as protocol errors


### PR DESCRIPTION
Signed-off-by: Sumukh Shivaprakash <sumukhs@microsoft.com>
Description: change log level to debug on prematureresponseexception
Risk Level: Low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Fixes #6636 
