### PR TITLE
Rollforward of api: Add total_issued_requests to Upstream Locality and Endpoint Stats. (#6692)

### DIFF
--- a/api/envoy/api/v2/endpoint/load_report.proto
+++ b/api/envoy/api/v2/endpoint/load_report.proto
@@ -25,15 +25,6 @@ message UpstreamLocalityStats {
   // collected from. Zone and region names could be empty if unknown.
   core.Locality locality = 1;
 
-  // The total number of requests sent by this Envoy since the last report. This
-  // information is aggregated over all the upstream Endpoints. total_requests
-  // can be inferred from:
-  //
-  // .. code-block:: none
-  //
-  //   total_requests = total_successful_requests + total_requests_in_progress +
-  //     total_error_requests
-  //
   // The total number of requests successfully completed by the endpoints in the
   // locality.
   uint64 total_successful_requests = 2;
@@ -44,6 +35,11 @@ message UpstreamLocalityStats {
   // The total number of requests that failed due to errors at the endpoint,
   // aggregated over all endpoints in the locality.
   uint64 total_error_requests = 4;
+
+  // The total number of requests that were issued by this Envoy since
+  // the last report. This information is aggregated over all the
+  // upstream endpoints in the locality.
+  uint64 total_issued_requests = 8;
 
   // Stats for multi-dimensional load balancing.
   repeated EndpointLoadMetricStats load_metric_stats = 5;
@@ -66,16 +62,6 @@ message UpstreamEndpointStats {
   // endpoint. Envoy will pass this directly to the management server.
   google.protobuf.Struct metadata = 6;
 
-  // The total number of requests successfully completed by the endpoint. A
-  // single HTTP or gRPC request or stream is counted as one request. A TCP
-  // connection is also treated as one request. There is no explicit
-  // total_requests field below for an endpoint, but it may be inferred from:
-  //
-  // .. code-block:: none
-  //
-  //   total_requests = total_successful_requests + total_requests_in_progress +
-  //     total_error_requests
-  //
   // The total number of requests successfully completed by the endpoints in the
   // locality. These include non-5xx responses for HTTP, where errors
   // originate at the client and the endpoint responded successfully. For gRPC,
@@ -96,6 +82,11 @@ message UpstreamEndpointStats {
   //   - Unknown
   //   - DataLoss
   uint64 total_error_requests = 4;
+
+  // The total number of requests that were issued to this endpoint
+  // since the last report. A single TCP connection, HTTP or gRPC
+  // request or stream is counted as one request.
+  uint64 total_issued_requests = 7;
 
   // Stats for multi-dimensional load balancing.
   repeated EndpointLoadMetricStats load_metric_stats = 5;
@@ -133,13 +124,7 @@ message ClusterStats {
 
   // Cluster-level stats such as total_successful_requests may be computed by
   // summing upstream_locality_stats. In addition, below there are additional
-  // cluster-wide stats. The following total_requests equality holds at the
-  // cluster-level:
-  //
-  // .. code-block:: none
-  //
-  //   sum_locality(total_successful_requests) + sum_locality(total_requests_in_progress) +
-  //     sum_locality(total_error_requests) + total_dropped_requests`
+  // cluster-wide stats.
   //
   // The total number of dropped requests. This covers requests
   // deliberately dropped by the drop_overload policy and circuit breaking.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.11.0 (Pending)
 ================
 * access log: added a new field for response code details in :ref:`file access logger<config_access_log_format_response_code_details>` and :ref:`gRPC access logger<envoy_api_field_data.accesslog.v2.HTTPResponseProperties.response_code_details>`.
+* api: track and report requests issued since last load report.
 * build: releases are built with Clang and linked with LLD.
 * dubbo_proxy: support the :ref:`Dubbo proxy filter <config_network_filters_dubbo_proxy>`.
 * eds: added support to specify max time for which endpoints can be used :ref:`gRPC filter <envoy_api_msg_ClusterLoadAssignment.Policy>`.

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -63,10 +63,12 @@ void LoadStatsReporter::sendLoadStatsRequest() {
         uint64_t rq_success = 0;
         uint64_t rq_error = 0;
         uint64_t rq_active = 0;
+        uint64_t rq_issued = 0;
         for (auto host : hosts) {
           rq_success += host->stats().rq_success_.latch();
           rq_error += host->stats().rq_error_.latch();
           rq_active += host->stats().rq_active_.value();
+          rq_issued += host->stats().rq_total_.latch();
         }
         if (rq_success + rq_error + rq_active != 0) {
           auto* locality_stats = cluster_stats->add_upstream_locality_stats();
@@ -75,6 +77,7 @@ void LoadStatsReporter::sendLoadStatsRequest() {
           locality_stats->set_total_successful_requests(rq_success);
           locality_stats->set_total_error_requests(rq_error);
           locality_stats->set_total_requests_in_progress(rq_active);
+          locality_stats->set_total_issued_requests(rq_issued);
         }
       }
     }
@@ -154,6 +157,7 @@ void LoadStatsReporter::startLoadReportPeriod() {
       for (auto host : host_set->hosts()) {
         host->stats().rq_success_.latch();
         host->stats().rq_error_.latch();
+        host->stats().rq_total_.latch();
       }
     }
     cluster.info()->loadReportStats().upstream_rq_dropped_.latch();


### PR DESCRIPTION
No new changes.

Signed-off-by: Karthik Reddy <rekarthik@google.com>
