### PR TITLE
[build] use HTTPS for debian artifacts when building Ubuntu container

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -6,10 +6,11 @@ set -e
 apt-get update
 export DEBIAN_FRONTEND=noninteractive
 apt-get install -y wget software-properties-common make cmake git python python-pip python3 python3-pip \
-  unzip bc libtool ninja-build automake zip time golang gdb strace wireshark tshark tcpdump lcov
+  unzip bc libtool ninja-build automake zip time golang gdb strace wireshark tshark tcpdump lcov \
+  apt-transport-https
 # clang 8.
-wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+apt-add-repository "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
 apt-get update
 apt-get install -y clang-8 clang-format-8 clang-tidy-8 lld-8 libc++-8-dev libc++abi-8-dev
 # gcc-7
@@ -24,7 +25,7 @@ update-alternatives --config g++
 update-alternatives --config gcov
 # Bazel and related dependencies.
 apt-get install -y openjdk-8-jdk curl
-echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 apt-get update
 apt-get install -y bazel


### PR DESCRIPTION
Description: Fetching build dependencies over plaintext HTTP should be avoided as it presents a security concern in the build process. Checked the other `build_container_*` scripts and they don't have the same issue.
Risk Level: N/A
Testing: rebuilt container locally
Docs Changes: N/A
Release Notes: N/A