### PR TITLE
Remove redundant std::move() calls

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -109,7 +109,7 @@ ScopePtr ThreadLocalStoreImpl::createScope(const std::string& name) {
   auto new_scope = std::make_unique<ScopeImpl>(*this, name);
   Thread::LockGuard lock(lock_);
   scopes_.emplace(new_scope.get());
-  return std::move(new_scope);
+  return new_scope;
 }
 
 std::vector<GaugeSharedPtr> ThreadLocalStoreImpl::gauges() const {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -28,13 +28,13 @@ SlotPtr InstanceImpl::allocateSlot() {
     if (slots_[i] == nullptr) {
       std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, i));
       slots_[i] = slot.get();
-      return std::move(slot);
+      return slot;
     }
   }
 
   std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, slots_.size()));
   slots_.push_back(slot.get());
-  return std::move(slot);
+  return slot;
 }
 
 ThreadLocalObjectSharedPtr InstanceImpl::SlotImpl::get() {

--- a/source/common/upstream/cluster_factory_impl.cc
+++ b/source/common/upstream/cluster_factory_impl.cc
@@ -116,7 +116,7 @@ ClusterSharedPtr ClusterFactoryImplBase::create(const envoy::api::v2::Cluster& c
   new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
       *new_cluster, cluster, context.dispatcher(), context.runtime(),
       context.outlierEventLogger()));
-  return std::move(new_cluster);
+  return new_cluster;
 }
 
 ClusterImplBaseSharedPtr StaticClusterFactory::createClusterImpl(

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -69,7 +69,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       if (host) {
         ENVOY_LOG(debug, "Using existing host {}.", host->address()->asString());
         host->used(true); // Mark as used.
-        return std::move(host);
+        return host;
       }
       // Add a new host
       const Network::Address::Ip* dst_ip = dst_addr.ip();
@@ -100,7 +100,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
           });
         }
 
-        return std::move(host);
+        return host;
       } else {
         ENVOY_LOG(debug, "Failed to create host for {}.", dst_addr.asString());
       }

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -155,7 +155,7 @@ LoadBalancerPtr ThreadAwareLoadBalancerBase::LoadBalancerFactoryImpl::create() {
   lb->degraded_per_priority_load_ = degraded_per_priority_load_;
   lb->per_priority_state_ = per_priority_state_;
 
-  return std::move(lb);
+  return lb;
 }
 
 } // namespace Upstream

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -160,7 +160,7 @@ SplitRequestPtr SimpleRequest::create(Router& router,
   }
 
   request_ptr->incoming_request_ = std::move(incoming_request);
-  return std::move(request_ptr);
+  return request_ptr;
 }
 
 SplitRequestPtr EvalRequest::create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
@@ -191,7 +191,7 @@ SplitRequestPtr EvalRequest::create(Router& router, Common::Redis::RespValuePtr&
   }
 
   request_ptr->incoming_request_ = std::move(incoming_request);
-  return std::move(request_ptr);
+  return request_ptr;
 }
 
 FragmentedRequest::~FragmentedRequest() {
@@ -257,7 +257,7 @@ SplitRequestPtr MGETRequest::create(Router& router, Common::Redis::RespValuePtr&
 
   if (request_ptr->num_pending_responses_ > 0) {
     request_ptr->incoming_request_ = std::move(incoming_request);
-    return std::move(request_ptr);
+    return request_ptr;
   }
 
   return nullptr;
@@ -389,7 +389,7 @@ SplitRequestPtr MSETRequest::create(Router& router, Common::Redis::RespValuePtr&
 
   if (request_ptr->num_pending_responses_ > 0) {
     request_ptr->incoming_request_ = std::move(incoming_request);
-    return std::move(request_ptr);
+    return request_ptr;
   }
 
   return nullptr;
@@ -483,7 +483,7 @@ SplitRequestPtr SplitKeysSumResultRequest::create(Router& router,
 
   if (request_ptr->num_pending_responses_ > 0) {
     request_ptr->incoming_request_ = std::move(incoming_request);
-    return std::move(request_ptr);
+    return request_ptr;
   }
 
   return nullptr;

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -119,7 +119,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
   }
 
   ZipkinSpanPtr active_span(new ZipkinSpan(*new_zipkin_span, tracer));
-  return std::move(active_span);
+  return active_span;
 }
 
 ReporterImpl::ReporterImpl(Driver& driver, Event::Dispatcher& dispatcher,


### PR DESCRIPTION
Description:

There is a bunch of build warnings (elevated to errors) related to redundant `std::move()` calls in return statements. This warning is made by `gcc 9.0.1`, which is shipped with Fedora 30. All the errors look like this:

    source/extensions/filters/network/redis_proxy/command_splitter_impl.cc: In static member function 'static Envoy::Extensions::NetworkFilters::RedisProxy::CommandSplitter::SplitRequestPtr Envoy::Extensions::NetworkFilters::RedisProxy::CommandSplitter::SimpleRequest::create(Envoy::Extensions::NetworkFilters::RedisProxy::Router&, Envoy::Extensions::NetworkFilters::Common::Redis::RespValuePtr&&, Envoy::Extensions::NetworkFilters::RedisProxy::CommandSplitter::SplitCallbacks&, Envoy::Extensions::NetworkFilters::RedisProxy::CommandSplitter::CommandStats&, Envoy::TimeSource&, bool)':
    source/extensions/filters/network/redis_proxy/command_splitter_impl.cc:163:19: error: redundant move in return statement [-Werror=redundant-move]
      163 |   return std::move(request_ptr);
          |          ~~~~~~~~~^~~~~~~~~~~~~
    source/extensions/filters/network/redis_proxy/command_splitter_impl.cc:163:19: note: remove 'std::move' call

This PR removes `std::move()` calls from all return statements where the compiler thinks they are not needed. I didn't look deeply into the pointer semantics; I'm interested to see if CI can build this and if the tests pass. I'm setting the risk level to medium because of this.

/cc @lizan 

Risk Level: medium
Testing: N/A
Docs Changes: No
Release Notes: N/A
