### PR TITLE
attribute_context: do not import unused base.proto

### DIFF
--- a/api/envoy/service/auth/v2/attribute_context.proto
+++ b/api/envoy/service/auth/v2/attribute_context.proto
@@ -6,7 +6,6 @@ option java_outer_classname = "AttributeContextProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.service.auth.v2";
 
-import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/address.proto";
 
 import "google/protobuf/timestamp.proto";


### PR DESCRIPTION
Description:

Fix a build warning by removing the unused `import`:

    INFO: From ProtoGenValidateCcGenerate external/envoy_api/envoy/service/auth/v2/attribute_context.pb.h:
    envoy/service/auth/v2/attribute_context.proto: warning: Import envoy/api/v2/core/base.proto but not used.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
