### PR TITLE
[WIP] adds zipkin span serializer interface and sets v1 as the default serializer.

### DIFF
--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -16,15 +16,15 @@ bool SpanBuffer::addSpan(const Span& span) {
   return true;
 }
 
-std::string SpanBuffer::toStringifiedJsonArray() {
+std::string SpanBuffer::toStringifiedJsonArray(SpanSerializer& span_serialier) {
   std::string stringified_json_array = "[";
 
   if (pendingSpans()) {
-    stringified_json_array += span_buffer_[0].toJson();
+    stringified_json_array += span_serialier.serialize(span_buffer_[0]);
     const uint64_t size = span_buffer_.size();
     for (uint64_t i = 1; i < size; i++) {
       stringified_json_array += ",";
-      stringified_json_array += span_buffer_[i].toJson();
+      stringified_json_array += span_serialier.serialize(span_buffer_[i]);
     }
   }
   stringified_json_array += "]";

--- a/source/extensions/tracers/zipkin/span_buffer.h
+++ b/source/extensions/tracers/zipkin/span_buffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "extensions/tracers/zipkin/span_serializer.h"
 #include "extensions/tracers/zipkin/zipkin_core_types.h"
 
 namespace Envoy {
@@ -57,7 +58,7 @@ public:
    * @return the contents of the buffer as a stringified array of JSONs, where
    * each JSON in the array corresponds to one Zipkin span.
    */
-  std::string toStringifiedJsonArray();
+  std::string toStringifiedJsonArray(SpanSerializer& span_serializer);
 
 private:
   // We use a pre-allocated vector to improve performance

--- a/source/extensions/tracers/zipkin/span_serializer.h
+++ b/source/extensions/tracers/zipkin/span_serializer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "extensions/tracers/zipkin/zipkin_core_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace Zipkin {
+class SpanSerializer {
+public:
+  /**
+   * Destructor.
+   */
+  virtual ~SpanSerializer() {}
+
+  /**
+   * Method that a concrete SpanSerializer class must implement to serialize spans.
+   *
+   * @param span The span that needs action.
+   */
+  virtual std::string serialize(const Span& span);
+};
+} // namespace Zipkin
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -208,6 +208,7 @@ private:
   Event::TimerPtr flush_timer_;
   SpanBuffer span_buffer_;
   const std::string collector_endpoint_;
+  SpanSerializer span_serializer_;
 };
 } // namespace Zipkin
 } // namespace Tracers


### PR DESCRIPTION
Description: This PR **will** add support for V2 format in zipkin.
Risk Level: low
Testing: we are not including changes yet
Docs Changes: will come when the change is done
Release Notes: Adds support for Zipkin V2 format

Question: Should we support both formats or just migrate to v2?

Ping @adriancole @Dudi119 @devinsba 

Fixes #4839