### PR TITLE
docs: Revert api/envoy/service/auth/v2 CheckResponse.status change

### DIFF
--- a/api/envoy/service/auth/v2/external_auth.proto
+++ b/api/envoy/service/auth/v2/external_auth.proto
@@ -61,8 +61,7 @@ message OkHttpResponse {
 
 // Intended for gRPC and Network Authorization servers `only`.
 message CheckResponse {
-  // Status `OK` allows the request. Status `UNKNOWN` causes Envoy to abort. Any other status
-  // indicates the request should be denied.
+  // Status `OK` allows the request. Any other status indicates the request should be denied.
   google.rpc.Status status = 1;
 
   // An message that contains HTTP response attributes. This message is


### PR DESCRIPTION
Description: PR #6211 updated the documentation of `CheckResponse.status` to reflect Envoy's actual behavior at the time.  Later, PR #6505 changed that behavior to be in-line with the pre-6211 docs. So, revert that part of PR #6211.

Risk Level: Low
Testing: None
Docs Changes: Inline in API protos
Release Notes: None?
