### PR TITLE
common: Make ThreadId (absl::hash)-able

### DIFF
--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -14,7 +14,7 @@ class ThreadId {
 public:
   virtual ~ThreadId() {}
 
-  virtual int64 tid() const PURE;
+  virtual int64_t tid() const PURE;
   virtual std::string debugString() const PURE;
   virtual bool isCurrentThreadId() const PURE;
 };

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -14,7 +14,7 @@ class ThreadId {
 public:
   virtual ~ThreadId() {}
 
-  virtual int tid() const PURE;
+  virtual int64 tid() const PURE;
   virtual std::string debugString() const PURE;
   virtual bool isCurrentThreadId() const PURE;
 };

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -14,6 +14,7 @@ class ThreadId {
 public:
   virtual ~ThreadId() {}
 
+  virtual int tid() const PURE;
   virtual std::string debugString() const PURE;
   virtual bool isCurrentThreadId() const PURE;
 };

--- a/source/common/common/posix/thread_impl.h
+++ b/source/common/common/posix/thread_impl.h
@@ -14,7 +14,7 @@ public:
   ThreadIdImplPosix(int64_t id);
 
   // Thread::ThreadId
-  int tid() const override { return id_; };
+  int64 tid() const override { return id_; };
   std::string debugString() const override;
   bool isCurrentThreadId() const override;
 

--- a/source/common/common/posix/thread_impl.h
+++ b/source/common/common/posix/thread_impl.h
@@ -14,6 +14,7 @@ public:
   ThreadIdImplPosix(int64_t id);
 
   // Thread::ThreadId
+  int tid() const override { return id_; };
   std::string debugString() const override;
   bool isCurrentThreadId() const override;
 

--- a/source/common/common/posix/thread_impl.h
+++ b/source/common/common/posix/thread_impl.h
@@ -14,7 +14,7 @@ public:
   ThreadIdImplPosix(int64_t id);
 
   // Thread::ThreadId
-  int64 tid() const override { return id_; };
+  int64_t tid() const override { return id_; };
   std::string debugString() const override;
   bool isCurrentThreadId() const override;
 

--- a/source/common/common/win32/thread_impl.h
+++ b/source/common/common/win32/thread_impl.h
@@ -18,7 +18,7 @@ public:
   ThreadIdImplWin32(DWORD id);
 
   // Thread::ThreadId
-  int tid() const override { return id_; };
+  int64 tid() const override { return id_; };
   std::string debugString() const override;
   bool isCurrentThreadId() const override;
 

--- a/source/common/common/win32/thread_impl.h
+++ b/source/common/common/win32/thread_impl.h
@@ -18,7 +18,7 @@ public:
   ThreadIdImplWin32(DWORD id);
 
   // Thread::ThreadId
-  int64 tid() const override { return id_; };
+  int64_t tid() const override { return id_; };
   std::string debugString() const override;
   bool isCurrentThreadId() const override;
 

--- a/source/common/common/win32/thread_impl.h
+++ b/source/common/common/win32/thread_impl.h
@@ -18,6 +18,7 @@ public:
   ThreadIdImplWin32(DWORD id);
 
   // Thread::ThreadId
+  int tid() const override { return id_; };
   std::string debugString() const override;
   bool isCurrentThreadId() const override;
 


### PR DESCRIPTION
Signed-off-by: Auni Ahsan <auni@google.com>

Description: I want to use ThreadIds as keys for a map for my use case.
Risk Level: Low I hope, but I have no idea how to build or test the ThreadIdImplWin32 class.
Testing: Added a test/common/common/thread_impl_test.cc that does a very basic hash/lookup test.