### PR TITLE
Kafka codec: avoid memcpy-ing data in serializers when the bytes to c…

### DIFF
--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -198,10 +198,11 @@ public:
 
     const size_t data_consumed = std::min<size_t>(required_, data.size());
     const size_t written = data_buf_.size() - required_;
-    memcpy(data_buf_.data() + written, data.data(), data_consumed);
-    required_ -= data_consumed;
-
-    data = {data.data() + data_consumed, data.size() - data_consumed};
+    if (data_consumed > 0) {
+      memcpy(data_buf_.data() + written, data.data(), data_consumed);
+      required_ -= data_consumed;
+      data = {data.data() + data_consumed, data.size() - data_consumed};
+    }
 
     if (required_ == 0) {
       ready_ = true;
@@ -269,10 +270,11 @@ public:
 
     const size_t data_consumed = std::min<size_t>(required_, data.size());
     const size_t written = data_buf_.size() - required_;
-    memcpy(data_buf_.data() + written, data.data(), data_consumed);
-    required_ -= data_consumed;
-
-    data = {data.data() + data_consumed, data.size() - data_consumed};
+    if (data_consumed > 0) {
+      memcpy(data_buf_.data() + written, data.data(), data_consumed);
+      required_ -= data_consumed;
+      data = {data.data() + data_consumed, data.size() - data_consumed};
+    }
 
     if (required_ == 0) {
       ready_ = true;
@@ -331,10 +333,11 @@ public:
 
     const size_t data_consumed = std::min<size_t>(required_, data.size());
     const size_t written = data_buf_.size() - required_;
-    memcpy(data_buf_.data() + written, data.data(), data_consumed);
-    required_ -= data_consumed;
-
-    data = {data.data() + data_consumed, data.size() - data_consumed};
+    if (data_consumed > 0) {
+      memcpy(data_buf_.data() + written, data.data(), data_consumed);
+      required_ -= data_consumed;
+      data = {data.data() + data_consumed, data.size() - data_consumed};
+    }
 
     if (required_ == 0) {
       ready_ = true;
@@ -400,10 +403,11 @@ public:
 
     const size_t data_consumed = std::min<size_t>(required_, data.size());
     const size_t written = data_buf_.size() - required_;
-    memcpy(data_buf_.data() + written, data.data(), data_consumed);
-    required_ -= data_consumed;
-
-    data = {data.data() + data_consumed, data.size() - data_consumed};
+    if (data_consumed > 0) {
+      memcpy(data_buf_.data() + written, data.data(), data_consumed);
+      required_ -= data_consumed;
+      data = {data.data() + data_consumed, data.size() - data_consumed};
+    }
 
     if (required_ == 0) {
       ready_ = true;


### PR DESCRIPTION
…opy are 0

Description:
As in title, avoids a situation when we invoke
```
memcpy(NULL, something, 0)
```
what causes asan to complain.
Testing on CI, because my mac build complains.

Risk Level: low (minor change to new code)
Testing: Will merge if ASAN CI is happy
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
