### PR TITLE
[tools] update schema validator to use MessageUtil

### DIFF
--- a/test/tools/schema_validator/BUILD
+++ b/test/tools/schema_validator/BUILD
@@ -23,13 +23,10 @@ envoy_cc_test_library(
     ],
     external_deps = ["tclap"],
     deps = [
-        "//include/envoy/common:base_includes",
-        "//source/common/config:rds_json_lib",
-        "//source/common/json:json_loader_lib",
-        "//source/common/router:config_lib",
-        "//source/common/stats:stats_lib",
-        "//test/mocks/runtime:runtime_mocks",
-        "//test/mocks/upstream:upstream_mocks",
-        "//test/test_common:printers_lib",
+        "//include/envoy/api:api_interface",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/stats:isolated_store_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/api/v2:rds_cc",
     ],
 )

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -3,6 +3,8 @@
 #include "envoy/api/v2/rds.pb.h"
 #include "envoy/api/v2/rds.pb.validate.h"
 
+#include "common/protobuf/utility.h"
+
 #include "tclap/CmdLine.h"
 
 namespace Envoy {

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -1,8 +1,7 @@
 #include "test/tools/schema_validator/validator.h"
 
-#include "common/router/config_impl.h"
-
-#include "test/test_common/printers.h"
+#include "envoy/api/v2/rds.pb.h"
+#include "envoy/api/v2/rds.pb.validate.h"
 
 #include "tclap/CmdLine.h"
 
@@ -46,16 +45,14 @@ Options::Options(int argc, char** argv) {
 }
 
 void Validator::validate(const std::string& json_path, Schema::Type schema_type) {
-  Json::ObjectSharedPtr loader = Json::Factory::loadFromFile(json_path, *api_);
 
   switch (schema_type) {
   case Schema::Type::Route: {
-    Runtime::MockLoader runtime;
-    Upstream::MockClusterManager cm;
     // Construct a envoy::api::v2::RouteConfiguration to validate the Route configuration and
     // ignore the output since nothing will consume it.
     envoy::api::v2::RouteConfiguration route_config;
-    Config::RdsJson::translateRouteConfiguration(*loader, route_config);
+    MessageUtil::loadFromFile(json_path, route_config, *api_);
+    MessageUtil::validate(route_config);
     break;
   }
   default:

--- a/test/tools/schema_validator/validator.h
+++ b/test/tools/schema_validator/validator.h
@@ -8,8 +8,6 @@
 
 #include "test/test_common/utility.h"
 
-// #include "test/mocks/upstream/mocks.h"
-
 namespace Envoy {
 
 /**

--- a/test/tools/schema_validator/validator.h
+++ b/test/tools/schema_validator/validator.h
@@ -2,11 +2,13 @@
 
 #include <string>
 
-#include "common/json/json_loader.h"
+#include "envoy/api/api.h"
 
-#include "test/mocks/runtime/mocks.h"
-#include "test/mocks/upstream/mocks.h"
+#include "common/stats/isolated_store_impl.h"
+
 #include "test/test_common/utility.h"
+
+// #include "test/mocks/upstream/mocks.h"
 
 namespace Envoy {
 


### PR DESCRIPTION
Description: Switching to `MessageUtils` opens up some flexibility such as being able to load JSON or YAML (handled by `loadFromFile`), is v2-only, and lines up with the test-config conversion work I've been doing elsewhere to eliminate v1 API loading.
Risk Level: Low (offline tool)
Testing: I don't think this tool has any unit tests, verified manually with a config file.
Docs Changes: N/A - The docs actually link to v2 `RouteConfiguration`, so this technically fixes that...
Release Notes: I'm not sure if updating a tool warrants a release note, if so I'll be happy to include one.

I'm thinking of swapping `-j/--json-path` to `-c/--config-path` now that we can be format-agnostic.

This preludes some additional message types we would like to validate i.e. `DiscoveryResponse` and `Bootstrap`.

Signed-off-by: Derek Argueta <dereka@pinterest.com>