### PR TITLE
config: add well-known tag for worker ids

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -109,6 +109,9 @@ TagNameValues::TagNameValues() {
 
   // http.[<stat_prefix>.]rds.(<route_config_name>.)<base_stat>
   addRegex(RDS_ROUTE_CONFIG, "^http(?=\\.).*?\\.rds\\.((.*?)\\.)\\w+?$", ".rds.");
+
+  // listener_manager.(worker_<id>.)*
+  addRegex(WORKER_ID, "^listener_manager\\.((worker_\\d+)\\.)", "listener_manager.worker_");
 }
 
 void TagNameValues::addRegex(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -147,6 +147,8 @@ public:
   const std::string RESPONSE_CODE_CLASS = "envoy.response_code_class";
   // Route config name for RDS updates
   const std::string RDS_ROUTE_CONFIG = "envoy.rds_route_config";
+  // Listener manager worker id
+  const std::string WORKER_ID = "envoy.worker_id";
 
   // Mapping from the names above to their respective regex strings.
   const std::vector<std::pair<std::string, std::string>> name_regex_pairs_;

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -338,6 +338,14 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
 
   regex_tester.testRegex("http.rds_connection_manager.rds.route_config.123.update_success",
                          "http.rds.update_success", {rds_hcm, rds_route_config});
+
+  // Listener manager worker id
+  Tag worker_id;
+  worker_id.name_ = tag_names.WORKER_ID;
+  worker_id.value_ = "worker_123";
+
+  regex_tester.testRegex("listener_manager.worker_123.dispatcher.loop_duration_us",
+                         "listener_manager.dispatcher.loop_duration_us", {worker_id});
 }
 
 TEST(TagExtractorTest, ExtractRegexPrefix) {


### PR DESCRIPTION
Description: Add a well-known tag to extract worker ids from listener manager dispatcher stats.
Risk Level: low
Testing: added unit test, observed changes to prometheus stats output with enable_dispatcher_stats=true.
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Dan Rosen <mergeconflict@google.com>
