### PR TITLE
test: enabling deprecated-and-fatal features in the fuzz tests

### DIFF
--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -7,6 +7,7 @@
 #include "server/proto_descriptors.h"
 #include "server/server.h"
 
+#include "test/common/runtime/utility.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/integration/server.h"
 #include "test/mocks/server/mocks.h"
@@ -52,9 +53,15 @@ makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
   return output;
 }
 
+class AllFeaturesHooks : public DefaultListenerHooks {
+  void onRuntimeCreated() override {
+    Runtime::RuntimeFeaturesPeer::setAllFeaturesAllowed();
+  }
+};
+
 DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   testing::NiceMock<MockOptions> options;
-  DefaultListenerHooks hooks;
+  AllFeaturesHooks hooks;
   testing::NiceMock<MockHotRestart> restart;
   Stats::TestIsolatedStoreImpl stats_store;
   Thread::MutexBasicLockable fakelock;

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -54,9 +54,7 @@ makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
 }
 
 class AllFeaturesHooks : public DefaultListenerHooks {
-  void onRuntimeCreated() override {
-    Runtime::RuntimeFeaturesPeer::setAllFeaturesAllowed();
-  }
+  void onRuntimeCreated() override { Runtime::RuntimeFeaturesPeer::setAllFeaturesAllowed(); }
 };
 
 DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {


### PR DESCRIPTION
The current test has deprecated field warnings - figure might as well fix while I'm looking at them.

Risk Level: n/a (test only)
Testing: tweaked test passes
Docs Changes: n/a
Release Notes: n/a
