### PR TITLE
Move from Xcode 9.3.0 to 9.3.1 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
            path: generated/docs
    mac:
      macos:
-       xcode: "9.3.0"
+       xcode: "9.3.1"
      environment:
        BAZEL_REMOTE_CACHE: https://storage.googleapis.com/envoy-circleci-bazel-cache/
      steps:


### PR DESCRIPTION
CircleCI will soon deprecate Xcode 9.3.0. More details [here](https://discuss.circleci.com/t/removing-support-for-xcode-versions-9-0-0-9-3-0-and-9-4-0/30084).

Moving the project from 9.3.0 to 9.3.1 should have no impact on the CircleCI jobs, and it will help avoid problems due to Xcode 9.3.0 image deprecation. Plus it will help the project to hit fewer Xcode bugs.

Risk Level: Low
Testing: Green macOS CI run is enough
Docs Changes: None
Release Notes: None
