### PR TITLE
[tools] change schema validator to use --config-path instead of --json-path

### DIFF
--- a/docs/root/install/tools/schema_validator_check_tool.rst
+++ b/docs/root/install/tools/schema_validator_check_tool.rst
@@ -3,24 +3,26 @@
 Schema Validator check tool
 ===========================
 
-The schema validator tool validates that the passed in JSON conforms to a schema in
-the configuration. To validate the entire config, please refer to the
+The schema validator tool validates that the passed in configuration conforms to
+a given schema. The configuration may be JSON or YAML. To validate the entire
+config, please refer to the
 :ref:`config load check tool<install_tools_config_load_check_tool>`. Currently, only
 :ref:`route config<envoy_api_msg_RouteConfiguration>` schema validation is supported.
 
 Input
   The tool expects two inputs:
 
-  1. The schema type to check the passed in JSON against. The supported type is:
+  1. The schema type to check the passed in configuration against. The supported type is:
 
     * `route` - for :ref:`route configuration<envoy_api_msg_RouteConfiguration>` validation.
 
-  2. The path to the JSON.
+  2. The path to the configuration file.
 
 Output
-  If the JSON conforms to the schema, the tool will exit with status EXIT_SUCCESS. If the JSON does
-  not conform to the schema, an error message is outputted detailing what doesn't conform to the
-  schema. The tool will exit with status EXIT_FAILURE.
+  If the configuration conforms to the schema, the tool will exit with status
+  EXIT_SUCCESS. If the configuration does not conform to the schema, an error
+  message is outputted detailing what doesn't conform to the schema. The tool
+  will exit with status EXIT_FAILURE.
 
 Building
   The tool can be built locally using Bazel. ::
@@ -30,4 +32,4 @@ Building
 Running
   The tool takes a path as described above. ::
 
-    bazel-bin/test/tools/schema_validator/schema_validator_tool  --schema-type SCHEMA_TYPE  --json-path PATH
+    bazel-bin/test/tools/schema_validator/schema_validator_tool  --schema-type SCHEMA_TYPE  --config-path PATH

--- a/test/tools/schema_validator/schema_validator.cc
+++ b/test/tools/schema_validator/schema_validator.cc
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
   Envoy::Validator v;
 
   try {
-    v.validate(options.jsonPath(), options.schemaType());
+    v.validate(options.configPath(), options.schemaType());
   } catch (const Envoy::EnvoyException& ex) {
     std::cerr << ex.what() << std::endl;
     return EXIT_FAILURE;

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -22,11 +22,11 @@ const std::string& Schema::toString(Type type) {
 
 Options::Options(int argc, char** argv) {
   TCLAP::CmdLine cmd("schema_validator_tool", ' ', "none", false);
-  TCLAP::ValueArg<std::string> json_path("j", "json-path", "Path to JSON file.", true, "", "string",
+  TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file.", true, "", "string",
                                          cmd);
   TCLAP::ValueArg<std::string> schema_type(
       "t", "schema-type",
-      "Type of schema to validate the JSON against. Supported schema is: 'route'.", true, "",
+      "Type of schema to validate the configuration against. Supported schema is: 'route'.", true, "",
       "string", cmd);
 
   try {
@@ -43,17 +43,17 @@ Options::Options(int argc, char** argv) {
     exit(EXIT_FAILURE);
   }
 
-  json_path_ = json_path.getValue();
+  config_path_ = config_path.getValue();
 }
 
-void Validator::validate(const std::string& json_path, Schema::Type schema_type) {
+void Validator::validate(const std::string& config_path, Schema::Type schema_type) {
 
   switch (schema_type) {
   case Schema::Type::Route: {
     // Construct a envoy::api::v2::RouteConfiguration to validate the Route configuration and
     // ignore the output since nothing will consume it.
     envoy::api::v2::RouteConfiguration route_config;
-    MessageUtil::loadFromFile(json_path, route_config, *api_);
+    MessageUtil::loadFromFile(config_path, route_config, *api_);
     MessageUtil::validate(route_config);
     break;
   }

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -22,12 +22,12 @@ const std::string& Schema::toString(Type type) {
 
 Options::Options(int argc, char** argv) {
   TCLAP::CmdLine cmd("schema_validator_tool", ' ', "none", false);
-  TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file.", true, "", "string",
-                                         cmd);
+  TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file.", true,
+                                           "", "string", cmd);
   TCLAP::ValueArg<std::string> schema_type(
       "t", "schema-type",
-      "Type of schema to validate the configuration against. Supported schema is: 'route'.", true, "",
-      "string", cmd);
+      "Type of schema to validate the configuration against. Supported schema is: 'route'.", true,
+      "", "string", cmd);
 
   try {
     cmd.parse(argc, argv);

--- a/test/tools/schema_validator/validator.h
+++ b/test/tools/schema_validator/validator.h
@@ -44,9 +44,9 @@ public:
   Schema::Type schemaType() const { return schema_type_; }
 
   /**
-   * @return the path to JSON file.
+   * @return the path to configuration file.
    */
-  const std::string& jsonPath() const { return config_path_; }
+  const std::string& configPath() const { return config_path_; }
 
 private:
   Schema::Type schema_type_;
@@ -54,20 +54,20 @@ private:
 };
 
 /**
- * Validates the schema of a JSON.
+ * Validates the schema of a configuration.
  */
 class Validator {
 public:
   Validator() : api_(Api::createApiForTest(stats_)) {}
   /**
-   * Validates the JSON at config_path against schema_type.
+   * Validates the configuration at config_path against schema_type.
    * An EnvoyException is thrown in several cases:
-   *  - Cannot load the JSON from config_path(invalid path or malformed JSON).
-   *  - A schema error from validating the JSON.
-   * @param json_path specifies the path to the JSON file.
-   * @param schema_type specifies the schema to validate the JSON against.
+   *  - Cannot load the configuration from config_path(invalid path or malformed data).
+   *  - A schema error from validating the configuration.
+   * @param config_path specifies the path to the configuration file.
+   * @param schema_type specifies the schema to validate the configuration against.
    */
-  void validate(const std::string& json_path, Schema::Type schema_type);
+  void validate(const std::string& config_path, Schema::Type schema_type);
 
 private:
   Stats::IsolatedStoreImpl stats_;

--- a/test/tools/schema_validator/validator.h
+++ b/test/tools/schema_validator/validator.h
@@ -46,11 +46,11 @@ public:
   /**
    * @return the path to JSON file.
    */
-  const std::string& jsonPath() const { return json_path_; }
+  const std::string& jsonPath() const { return config_path_; }
 
 private:
   Schema::Type schema_type_;
-  std::string json_path_;
+  std::string config_path_;
 };
 
 /**


### PR DESCRIPTION
Description: In #6834, the schema validator was implicitly made format-agnostic. This PR updates
the arguments to better reflect that, switching to `--config-path` instead of `--json-path`. This is a
backwards-incompatible change to anyone who was using the schema validator tool, however given
that until today it was only supporting v1 API routes I don't find that to be a high probability.
Risk Level: Low (offline tool)
Testing: `bazel run` against a few different configs
Docs Changes: Updated schema validator docs
Release Notes: N/A (offline tool)