### PR TITLE
http conn man: send 'connection: close' header when draining.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1285,7 +1285,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     connection_manager_.stats_.named_.downstream_rq_response_before_rq_complete_.inc();
   }
 
-  if (connection_manager_.drain_state_ == DrainState::Closing &&
+  if (connection_manager_.drain_state_ != DrainState::NotDraining &&
       connection_manager_.codec_->protocol() != Protocol::Http2) {
     // If the connection manager is draining send "Connection: Close" on HTTP/1.1 connections.
     // Do not do this for H2 (which drains via GOAWAY) or Upgrade (as the upgrade


### PR DESCRIPTION
Description: This fixes a bug where the Http Connection Manager would only send a
connection close header when the drain state was Closing (for Http 1.1).
It will now send the connection close header while in the Draining state,
as well as the Closing state.

Risk Level: low (small bug fix)

Testing: added unit test

Release Notes: N/A

Fixes https://github.com/envoyproxy/envoy/issues/6802

Signed-off-by: Kyle Myerson <kmyerson@google.com>
