### PR TITLE
build: remove bazel-prebuilt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ BROWSE
 .classpath
 .clwb/
 /ci/bazel-*
-/ci/prebuilt/thirdparty
-/ci/prebuilt/thirdparty_build
 compile_commands.json
 cscope.*
 .deps

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -8,12 +8,7 @@ independently sourced, the following steps should be followed:
 
 1. Install the latest version of [Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
 2. Configure, build and/or install the [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/install/building.html#requirements).
-3. Configure a Bazel [WORKSPACE](https://bazel.build/versions/master/docs/be/workspace.html)
-   to point Bazel at the Envoy dependencies. An example is provided in the CI Docker image
-   [WORKSPACE](https://github.com/envoyproxy/envoy/blob/master/ci/WORKSPACE) and corresponding
-   [BUILD](https://github.com/envoyproxy/envoy/blob/master/ci/prebuilt/BUILD) files.
-4. `bazel build --package_path %workspace%:<path to Envoy source tree> //source/exe:envoy-static`
-   from the directory containing your WORKSPACE.
+3. `bazel build //source/exe:envoy-static` from the repository root.
 
 ## Quick start Bazel build for developers
 

--- a/ci/build_container/Dockerfile-centos
+++ b/ci/build_container/Dockerfile-centos
@@ -1,10 +1,6 @@
 FROM centos:7
 
 COPY ./build_container_common.sh /
-COPY WORKSPACE /bazel-prebuilt/
-COPY ./api /bazel-prebuilt/api
-COPY ./bazel /bazel-prebuilt/bazel
-
 COPY ./build_container_centos.sh /
 
 ENV PATH /opt/rh/rh-git218/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:/opt/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/ci/build_container/Dockerfile-ubuntu
+++ b/ci/build_container/Dockerfile-ubuntu
@@ -1,10 +1,6 @@
 FROM ubuntu:xenial
 
 COPY ./build_container_common.sh /
-COPY WORKSPACE /bazel-prebuilt/
-COPY ./api /bazel-prebuilt/api
-COPY ./bazel /bazel-prebuilt/bazel
-
 COPY ./build_container_ubuntu.sh /
 
 RUN ./build_container_ubuntu.sh

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -6,17 +6,3 @@ SHA256=6e6aea35b2ea2b4951163f686dfbfe47b49c840c56b873b3a7afe60939772fc1
 curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/"$VERSION"/buildifier \
   && echo "$SHA256" '/usr/local/bin/buildifier' | sha256sum --check \
   && chmod +x /usr/local/bin/buildifier
-
-# GCC for everything.
-export CC=gcc
-export CXX=g++
-
-echo "Building Bazel-managed deps (//bazel/external:all_external)"
-mkdir /bazel-prebuilt-root /bazel-prebuilt-output
-BAZEL_OPTIONS="--output_user_root=/bazel-prebuilt-root --output_base=/bazel-prebuilt-output"
-cd /bazel-prebuilt
-for BAZEL_MODE in opt dbg fastbuild; do
-  bazel ${BAZEL_OPTIONS} build -c "${BAZEL_MODE}" //bazel/external:all_external
-done
-# Allow access by non-root for building.
-chmod -R a+rX /bazel-prebuilt-root /bazel-prebuilt-output

--- a/ci/build_container/docker_build.sh
+++ b/ci/build_container/docker_build.sh
@@ -3,8 +3,4 @@
 [[ -z "${LINUX_DISTRO}" ]] && LINUX_DISTRO="ubuntu"
 [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=envoyproxy/envoy-build-"${LINUX_DISTRO}"
 
-# We need //bazel/... and WORKSPACE for the build, but it's not in ci/build_container. Using Docker
-# relative path workaround from https://github.com/docker/docker/issues/2745#issuecomment-253230025
-# to get this to work.
-tar cf - . -C ../../ bazel WORKSPACE api \
-  | docker build -f Dockerfile-${LINUX_DISTRO} -t ${IMAGE_NAME}:$CIRCLE_SHA1 -
+docker build -f Dockerfile-${LINUX_DISTRO} -t ${IMAGE_NAME}:$CIRCLE_SHA1 -

--- a/ci/build_container/docker_build.sh
+++ b/ci/build_container/docker_build.sh
@@ -3,4 +3,4 @@
 [[ -z "${LINUX_DISTRO}" ]] && LINUX_DISTRO="ubuntu"
 [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=envoyproxy/envoy-build-"${LINUX_DISTRO}"
 
-docker build -f Dockerfile-${LINUX_DISTRO} -t ${IMAGE_NAME}:$CIRCLE_SHA1 -
+docker build -f Dockerfile-${LINUX_DISTRO} -t ${IMAGE_NAME}:$CIRCLE_SHA1 .

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -76,14 +76,6 @@ export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYT
   --cache_test_results=no --test_output=all ${BAZEL_EXTRA_TEST_OPTIONS}"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge
 
-# Replace the existing Bazel output cache with a copy of the image's prebuilt deps.
-if [[ -d /bazel-prebuilt-output && ! -d "${TEST_TMPDIR}/_bazel_${USER}" ]]; then
-  BAZEL_OUTPUT_BASE="$(bazel info output_base)"
-  mkdir -p "${TEST_TMPDIR}/_bazel_${USER}/install"
-  rsync -a /bazel-prebuilt-root/install/* "${TEST_TMPDIR}/_bazel_${USER}/install/"
-  rsync -a /bazel-prebuilt-output "${BAZEL_OUTPUT_BASE}"
-fi
-
 if [ "$1" != "-nofetch" ]; then
   # Setup Envoy consuming project.
   if [[ ! -a "${ENVOY_FILTER_EXAMPLE_SRCDIR}" ]]


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Remove prebuilt as it doesn't speed up CI anymore, as we have different set of toolchains/options for build pipelines, we also have remote cache enabled.

side-effect: picks up Bazel 0.25.1

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A