### PR TITLE
test/main: refactor process-wide setup/shutdown.

### DIFF
--- a/source/common/common/cleanup.h
+++ b/source/common/common/cleanup.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 
 namespace Envoy {
 
@@ -14,7 +13,5 @@ public:
 private:
   std::function<void()> f_;
 };
-
-typedef std::unique_ptr<Cleanup> CleanupPtr;
 
 } // namespace Envoy

--- a/source/common/common/cleanup.h
+++ b/source/common/common/cleanup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 
 namespace Envoy {
 
@@ -13,5 +14,7 @@ public:
 private:
   std::function<void()> f_;
 };
+
+typedef std::unique_ptr<Cleanup> CleanupPtr;
 
 } // namespace Envoy

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -43,6 +43,18 @@ envoy_cc_library(
     ],
 )
 
+# Separate library for some nghttp2 setup stuff to avoid having tests take a
+# dependency on everything in codec_lib.
+envoy_cc_library(
+    name = "nghttp2_lib",
+    srcs = ["nghttp2.cc"],
+    hdrs = ["nghttp2.h"],
+    external_deps = ["nghttp2"],
+    deps = [
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
 envoy_cc_library(
     name = "conn_pool_lib",
     srcs = ["conn_pool.cc"],

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -38,19 +38,6 @@ bool Utility::reconstituteCrumbledCookies(const HeaderString& key, const HeaderS
   return true;
 }
 
-void initializeNghttp2Logging() {
-  nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
-    char buf[2048];
-    const int n = ::vsnprintf(buf, sizeof(buf), format, args);
-    // nghttp2 inserts new lines, but we also insert a new line in the ENVOY_LOG
-    // below, so avoid double \n.
-    if (n >= 1 && static_cast<size_t>(n) < sizeof(buf) && buf[n - 1] == '\n') {
-      buf[n - 1] = '\0';
-    }
-    ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::http2), trace, "nghttp2: {}", buf);
-  });
-}
-
 ConnectionImpl::Http2Callbacks ConnectionImpl::http2_callbacks_;
 
 /**

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -69,11 +69,6 @@ public:
 };
 
 /**
- * Setup nghttp2 trace-level logging for when debugging.
- */
-void initializeNghttp2Logging();
-
-/**
  * Base class for HTTP/2 client and server codecs.
  */
 class ConnectionImpl : public virtual Connection, protected Logger::Loggable<Logger::Id::http2> {

--- a/source/common/http/http2/nghttp2.cc
+++ b/source/common/http/http2/nghttp2.cc
@@ -1,0 +1,26 @@
+#include "common/http/http2/nghttp2.h"
+
+#include "common/common/logger.h"
+
+#include "nghttp2/nghttp2.h"
+
+namespace Envoy {
+namespace Http {
+namespace Http2 {
+
+void initializeNghttp2Logging() {
+  nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
+    char buf[2048];
+    const int n = ::vsnprintf(buf, sizeof(buf), format, args);
+    // nghttp2 inserts new lines, but we also insert a new line in the ENVOY_LOG
+    // below, so avoid double \n.
+    if (n >= 1 && static_cast<size_t>(n) < sizeof(buf) && buf[n - 1] == '\n') {
+      buf[n - 1] = '\0';
+    }
+    ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::http2), trace, "nghttp2: {}", buf);
+  });
+}
+
+} // namespace Http2
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/http2/nghttp2.h
+++ b/source/common/http/http2/nghttp2.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace Envoy {
+namespace Http {
+namespace Http2 {
+
+/**
+ * Setup nghttp2 trace-level logging for when debugging.
+ */
+void initializeNghttp2Logging();
+
+} // namespace Http2
+} // namespace Http
+} // namespace Envoy

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -25,11 +25,6 @@ DnsResolverImpl::DnsResolverImpl(
     const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers)
     : dispatcher_(dispatcher),
       timer_(dispatcher.createTimer([this] { onEventCallback(ARES_SOCKET_BAD, 0); })) {
-  // This is also done in main(), to satisfy the requirement that c-ares is
-  // initialized prior to threading. The additional call to ares_library_init()
-  // here is a nop in normal execution, but exists for testing where we don't
-  // launch via main().
-  ares_library_init(ARES_LIB_INIT_ALL);
   ares_options options;
 
   initializeChannel(&options, 0);
@@ -63,7 +58,6 @@ DnsResolverImpl::DnsResolverImpl(
 DnsResolverImpl::~DnsResolverImpl() {
   timer_->disableTimer();
   ares_destroy(channel_);
-  ares_library_cleanup();
 }
 
 void DnsResolverImpl::initializeChannel(ares_options* options, int optmask) {

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -36,7 +36,6 @@ DnsResolverImpl::DnsResolverImpl(
       // This should be an IP address (i.e. not a pipe).
       if (resolver->ip() == nullptr) {
         ares_destroy(channel_);
-        ares_library_cleanup();
         throw EnvoyException(
             fmt::format("DNS resolver '{}' is not an IP address", resolver->asString()));
       }

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -91,7 +91,6 @@ envoy_cc_library(
     external_deps = ["ares"],
     deps = [
         "//source/common/common:assert_lib",
-        "//source/common/common:cleanup_lib",
         "//source/common/event:libevent_lib",
         "//source/common/http/http2:nghttp2_lib",
         "//source/server:proto_descriptors_lib",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -67,14 +67,13 @@ envoy_cc_library(
     hdrs = ["main_common.h"],
     deps = [
         ":envoy_common_lib",
+        ":process_wide_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:compiler_requirements_lib",
-        "//source/common/http/http2:codec_lib",
         "//source/common/common:perf_annotation_lib",
         "//source/common/stats:fake_symbol_table_lib",
         "//source/server:hot_restart_lib",
         "//source/server:hot_restart_nop_lib",
-        "//source/server:proto_descriptors_lib",
         "//source/server/config_validation:server_lib",
     ] + select({
         "//bazel:disable_signal_trace": [],
@@ -82,7 +81,21 @@ envoy_cc_library(
             ":sigaction_lib",
             ":terminate_handler_lib",
         ],
-    }) + envoy_cc_platform_dep("platform_impl_lib") + envoy_google_grpc_external_deps(),
+    }) + envoy_cc_platform_dep("platform_impl_lib"),
+)
+
+envoy_cc_library(
+    name = "process_wide_lib",
+    srcs = ["process_wide.cc"],
+    hdrs = ["process_wide.h"],
+    external_deps = ["ares"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/common:cleanup_lib",
+        "//source/common/event:libevent_lib",
+        "//source/common/http/http2:nghttp2_lib",
+        "//source/server:proto_descriptors_lib",
+    ] + envoy_google_grpc_external_deps(),
 )
 
 envoy_cc_posix_library(

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -6,8 +6,6 @@
 
 #include "common/common/compiler_requirements.h"
 #include "common/common/perf_annotation.h"
-#include "common/event/libevent.h"
-#include "common/http/http2/codec_impl.h"
 #include "common/network/utility.h"
 #include "common/stats/thread_local_store.h"
 
@@ -16,18 +14,12 @@
 #include "server/hot_restart_nop_impl.h"
 #include "server/listener_hooks.h"
 #include "server/options_impl.h"
-#include "server/proto_descriptors.h"
 #include "server/server.h"
 
 #include "absl/strings/str_split.h"
 
 #ifdef ENVOY_HOT_RESTART
 #include "server/hot_restart_impl.h"
-#endif
-
-#include "ares.h"
-#ifdef ENVOY_GOOGLE_GRPC
-#include "grpc/grpc.h"
 #endif
 
 namespace Envoy {
@@ -51,16 +43,9 @@ MainCommonBase::MainCommonBase(const OptionsImpl& options, Event::TimeSystem& ti
                                std::unique_ptr<Runtime::RandomGenerator>&& random_generator,
                                Thread::ThreadFactory& thread_factory,
                                Filesystem::Instance& file_system)
-    : options_(options), component_factory_(component_factory), thread_factory_(thread_factory),
+    : process_cleanup_(ProcessWide::setup()), options_(options),
+      component_factory_(component_factory), thread_factory_(thread_factory),
       file_system_(file_system), stats_allocator_(symbol_table_) {
-#ifdef ENVOY_GOOGLE_GRPC
-  grpc_init();
-#endif
-  ares_library_init(ARES_LIB_INIT_ALL);
-  Event::Libevent::Global::initialize();
-  RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
-  Http::Http2::initializeNghttp2Logging();
-
   switch (options_.mode()) {
   case Server::Mode::InitOnly:
   case Server::Mode::Serve: {
@@ -101,13 +86,6 @@ MainCommonBase::MainCommonBase(const OptionsImpl& options, Event::TimeSystem& ti
                                                          restarter_->logLock());
     break;
   }
-}
-
-MainCommonBase::~MainCommonBase() {
-  ares_library_cleanup();
-#ifdef ENVOY_GOOGLE_GRPC
-  grpc_shutdown();
-#endif
 }
 
 void MainCommonBase::configureComponentLogLevels() {

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -43,8 +43,7 @@ MainCommonBase::MainCommonBase(const OptionsImpl& options, Event::TimeSystem& ti
                                std::unique_ptr<Runtime::RandomGenerator>&& random_generator,
                                Thread::ThreadFactory& thread_factory,
                                Filesystem::Instance& file_system)
-    : process_cleanup_(ProcessWide::setup()), options_(options),
-      component_factory_(component_factory), thread_factory_(thread_factory),
+    : options_(options), component_factory_(component_factory), thread_factory_(thread_factory),
       file_system_(file_system), stats_allocator_(symbol_table_) {
   switch (options_.mode()) {
   case Server::Mode::InitOnly:

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -3,7 +3,6 @@
 #include "envoy/event/timer.h"
 #include "envoy/runtime/runtime.h"
 
-#include "common/common/cleanup.h"
 #include "common/common/thread.h"
 #include "common/event/real_time_system.h"
 #include "common/stats/fake_symbol_table_impl.h"
@@ -65,7 +64,7 @@ public:
                     const AdminRequestFn& handler);
 
 protected:
-  CleanupPtr process_cleanup_;
+  ProcessWide process_wide_; // Process-wide state setup/teardown.
   const Envoy::OptionsImpl& options_;
   Stats::FakeSymbolTableImpl symbol_table_;
   Server::ComponentFactory& component_factory_;

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -3,6 +3,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/runtime/runtime.h"
 
+#include "common/common/cleanup.h"
 #include "common/common/thread.h"
 #include "common/event/real_time_system.h"
 #include "common/stats/fake_symbol_table_impl.h"
@@ -10,6 +11,7 @@
 #include "common/thread_local/thread_local_impl.h"
 
 #include "exe/platform_impl.h"
+#include "exe/process_wide.h"
 
 #include "server/listener_hooks.h"
 #include "server/options_impl.h"
@@ -38,7 +40,6 @@ public:
                  ListenerHooks& listener_hooks, Server::ComponentFactory& component_factory,
                  std::unique_ptr<Runtime::RandomGenerator>&& random_generator,
                  Thread::ThreadFactory& thread_factory, Filesystem::Instance& file_system);
-  ~MainCommonBase();
 
   bool run();
 
@@ -64,6 +65,7 @@ public:
                     const AdminRequestFn& handler);
 
 protected:
+  CleanupPtr process_cleanup_;
   const Envoy::OptionsImpl& options_;
   Stats::FakeSymbolTableImpl symbol_table_;
   Server::ComponentFactory& component_factory_;

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -15,12 +15,12 @@
 namespace Envoy {
 namespace {
 // Static variable to sanity check init state.
-bool process_wide_iniitalized;
+bool process_wide_initalized;
 } // namespace
 
 ProcessWide::ProcessWide() {
-  ASSERT(!process_wide_iniitalized);
-  process_wide_iniitalized = true;
+  ASSERT(!process_wide_initalized);
+  process_wide_initalized = true;
 #ifdef ENVOY_GOOGLE_GRPC
   grpc_init();
 #endif
@@ -31,8 +31,8 @@ ProcessWide::ProcessWide() {
 }
 
 ProcessWide::~ProcessWide() {
-  ASSERT(process_wide_iniitalized);
-  process_wide_iniitalized = false;
+  ASSERT(process_wide_initalized);
+  process_wide_initalized = false;
   ares_library_cleanup();
 #ifdef ENVOY_GOOGLE_GRPC
   grpc_shutdown();

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -17,11 +17,11 @@ namespace {
 // Static variable to count initialization pairs. For tests like
 // main_common_test, we need to count to avoid double initialization or
 // shutdown.
-uint32_t process_wide_initalized;
+uint32_t process_wide_initialized;
 } // namespace
 
-ProcessWide::ProcessWide() : initialization_depth_(process_wide_initalized) {
-  if (process_wide_initalized++ == 0) {
+ProcessWide::ProcessWide() : initialization_depth_(process_wide_initialized) {
+  if (process_wide_initialized++ == 0) {
 #ifdef ENVOY_GOOGLE_GRPC
     grpc_init();
 #endif
@@ -33,15 +33,15 @@ ProcessWide::ProcessWide() : initialization_depth_(process_wide_initalized) {
 }
 
 ProcessWide::~ProcessWide() {
-  ASSERT(process_wide_initalized > 0);
-  if (--process_wide_initalized == 0) {
-    process_wide_initalized = false;
+  ASSERT(process_wide_initialized > 0);
+  if (--process_wide_initialized == 0) {
+    process_wide_initialized = false;
     ares_library_cleanup();
 #ifdef ENVOY_GOOGLE_GRPC
     grpc_shutdown();
 #endif
   }
-  ASSERT(process_wide_initalized == initialization_depth_);
+  ASSERT(process_wide_initialized == initialization_depth_);
 }
 
 } // namespace Envoy

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -14,7 +14,7 @@
 
 namespace Envoy {
 
-CleanupPtr ProcessWide::setup() {
+ProcessWide::ProcessWide() {
 #ifdef ENVOY_GOOGLE_GRPC
   grpc_init();
 #endif
@@ -22,12 +22,13 @@ CleanupPtr ProcessWide::setup() {
   Event::Libevent::Global::initialize();
   RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
   Http::Http2::initializeNghttp2Logging();
-  return std::make_unique<Cleanup>([] {
-    ares_library_cleanup();
+}
+
+ProcessWide::~ProcessWide() {
+  ares_library_cleanup();
 #ifdef ENVOY_GOOGLE_GRPC
-    grpc_shutdown();
+  grpc_shutdown();
 #endif
-  });
 }
 
 } // namespace Envoy

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -1,0 +1,33 @@
+#include "exe/process_wide.h"
+
+#include "common/common/assert.h"
+#include "common/event/libevent.h"
+#include "common/http/http2/nghttp2.h"
+
+#include "server/proto_descriptors.h"
+
+#include "ares.h"
+
+#ifdef ENVOY_GOOGLE_GRPC
+#include "grpc/grpc.h"
+#endif
+
+namespace Envoy {
+
+CleanupPtr ProcessWide::setup() {
+#ifdef ENVOY_GOOGLE_GRPC
+  grpc_init();
+#endif
+  ares_library_init(ARES_LIB_INIT_ALL);
+  Event::Libevent::Global::initialize();
+  RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
+  Http::Http2::initializeNghttp2Logging();
+  return std::make_unique<Cleanup>([] {
+    ares_library_cleanup();
+#ifdef ENVOY_GOOGLE_GRPC
+    grpc_shutdown();
+#endif
+  });
+}
+
+} // namespace Envoy

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -13,8 +13,14 @@
 #endif
 
 namespace Envoy {
+namespace {
+// Static variable to sanity check init state.
+bool process_wide_iniitalized;
+} // namespace
 
 ProcessWide::ProcessWide() {
+  ASSERT(!process_wide_iniitalized);
+  process_wide_iniitalized = true;
 #ifdef ENVOY_GOOGLE_GRPC
   grpc_init();
 #endif
@@ -25,6 +31,8 @@ ProcessWide::ProcessWide() {
 }
 
 ProcessWide::~ProcessWide() {
+  ASSERT(process_wide_iniitalized);
+  process_wide_iniitalized = false;
   ares_library_cleanup();
 #ifdef ENVOY_GOOGLE_GRPC
   grpc_shutdown();

--- a/source/exe/process_wide.h
+++ b/source/exe/process_wide.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Envoy {
 
 // Process-wide lifecycle events for global state in third-party dependencies,
@@ -8,6 +10,9 @@ class ProcessWide {
 public:
   ProcessWide();
   ~ProcessWide();
+
+private:
+  uint32_t initialization_depth_;
 };
 
 } // namespace Envoy

--- a/source/exe/process_wide.h
+++ b/source/exe/process_wide.h
@@ -1,16 +1,13 @@
 #pragma once
 
-#include "common/common/cleanup.h"
-
 namespace Envoy {
 
 // Process-wide lifecycle events for global state in third-party dependencies,
-// e.g. gRPC, c-ares.
+// e.g. gRPC, c-ares. There should only ever be a single instance of this.
 class ProcessWide {
 public:
-  // Process-wide setup. This returns a Cleanup object, which will perform
-  // process-wide shutdown when destroyed via the RAII pattern.
-  static CleanupPtr setup();
+  ProcessWide();
+  ~ProcessWide();
 };
 
 } // namespace Envoy

--- a/source/exe/process_wide.h
+++ b/source/exe/process_wide.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "common/common/cleanup.h"
+
+namespace Envoy {
+
+// Process-wide lifecycle events for global state in third-party dependencies,
+// e.g. gRPC, c-ares.
+class ProcessWide {
+public:
+  // Process-wide setup. This returns a Cleanup object, which will perform
+  // process-wide shutdown when destroyed via the RAII pattern.
+  static CleanupPtr setup();
+};
+
+} // namespace Envoy

--- a/source/extensions/access_loggers/http_grpc/config.cc
+++ b/source/extensions/access_loggers/http_grpc/config.cc
@@ -26,7 +26,6 @@ AccessLog::InstanceSharedPtr
 HttpGrpcAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
                                                   AccessLog::FilterPtr&& filter,
                                                   Server::Configuration::FactoryContext& context) {
-  RELEASE_ASSERT(validateProtoDescriptors(), "");
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::config::accesslog::v2::HttpGrpcAccessLogConfig&>(config);
   std::shared_ptr<GrpcAccessLogStreamer> grpc_access_log_streamer =

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -19,7 +19,6 @@ namespace MetricsService {
 
 Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
                                                           Server::Instance& server) {
-  RELEASE_ASSERT(validateProtoDescriptors(), "");
   const auto& sink_config =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::MetricsServiceConfig&>(
           config);

--- a/test/BUILD
+++ b/test/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
-    "envoy_google_grpc_external_deps",
     "envoy_package",
 )
 
@@ -31,6 +30,7 @@ envoy_cc_test_library(
         "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
         "//source/common/http/http2:codec_lib",
+        "//source/exe:process_wide_lib",
         "//test/common/runtime:utility_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/test_common:environment_lib",
@@ -39,5 +39,5 @@ envoy_cc_test_library(
     ] + select({
         "//bazel:disable_signal_trace": [],
         "//conditions:default": ["//source/exe:sigaction_lib"],
-    }) + envoy_google_grpc_external_deps(),
+    }),
 )

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -39,6 +39,7 @@ envoy_cc_test_library(
         "//source/common/common:utility_lib",
         "//source/common/event:libevent_lib",
         "//source/common/http/http2:codec_lib",
+        "//source/exe:process_wide_lib",
         "//test/test_common:environment_lib",
     ],
 )

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -26,9 +26,9 @@ PerTestEnvironment::PerTestEnvironment()
 PerTestEnvironment::~PerTestEnvironment() { TestEnvironment::removePath(test_tmpdir_); }
 
 void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum default_log_level) {
-  // We hold on to process_cleanup to provide RAII cleanup of process-wide
+  // We hold on to process_wide to provide RAII cleanup of process-wide
   // state.
-  auto process_cleanup = Envoy::ProcessWide::setup();
+  ProcessWide process_wide;
   TestEnvironment::initializeOptions(argc, argv);
 
   const auto environment_log_level = TestEnvironment::getOptions().logLevel();

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -5,6 +5,8 @@
 #include "common/event/libevent.h"
 #include "common/http/http2/codec_impl.h"
 
+#include "exe/process_wide.h"
+
 #include "test/test_common/environment.h"
 
 namespace Envoy {
@@ -24,9 +26,9 @@ PerTestEnvironment::PerTestEnvironment()
 PerTestEnvironment::~PerTestEnvironment() { TestEnvironment::removePath(test_tmpdir_); }
 
 void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum default_log_level) {
-  Event::Libevent::Global::initialize();
-  Http::Http2::initializeNghttp2Logging();
-
+  // We hold on to process_cleanup to provide RAII cleanup of process-wide
+  // state.
+  auto process_cleanup = Envoy::ProcessWide::setup();
   TestEnvironment::initializeOptions(argc, argv);
 
   const auto environment_log_level = TestEnvironment::getOptions().logLevel();

--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -22,8 +22,6 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   TestComponentFactory component_factory;
   Fuzz::PerTestEnvironment test_env;
 
-  RELEASE_ASSERT(validateProtoDescriptors(), "");
-
   const std::string bootstrap_path = test_env.temporaryPath("bootstrap.pb_text");
   std::ofstream bootstrap_file(bootstrap_path);
   bootstrap_file << input.DebugString();

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -22,8 +22,6 @@ namespace Envoy {
 class ConfigValidation : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   ConfigValidation() {
-    Event::Libevent::Global::initialize();
-
     validation_ = std::make_unique<Api::ValidationImpl>(Thread::threadFactoryForTest(),
                                                         stats_store_, test_time_.timeSystem(),
                                                         Filesystem::fileSystemForTest());

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -63,8 +63,6 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   DangerousDeprecatedTestTime test_time;
   Fuzz::PerTestEnvironment test_env;
 
-  RELEASE_ASSERT(validateProtoDescriptors(), "");
-
   {
     const std::string bootstrap_path = test_env.temporaryPath("bootstrap.pb_text");
     std::ofstream bootstrap_file(bootstrap_path);

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -67,9 +67,9 @@ class TestRunner {
 public:
   static int RunTests(int argc, char** argv) {
     ::testing::InitGoogleMock(&argc, argv);
-    // We hold on to process_cleanup to provide RAII cleanup of process-wide
+    // We hold on to process_wide to provide RAII cleanup of process-wide
     // state.
-    auto process_cleanup = ProcessWide::setup();
+    ProcessWide process_wide;
     // Add a test-listener so we can call a hook where we can do a quiescence
     // check after each method. See
     // https://github.com/google/googletest/blob/master/googletest/docs/advanced.md

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -7,16 +7,14 @@
 #include "common/http/http2/codec_impl.h"
 #include "common/runtime/runtime_features.h"
 
+#include "exe/process_wide.h"
+
 #include "test/common/runtime/utility.h"
 #include "test/mocks/access_log/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_listener.h"
 
 #include "gmock/gmock.h"
-
-#ifdef ENVOY_GOOGLE_GRPC
-#include "grpc/grpc.h"
-#endif
 
 namespace Envoy {
 namespace {
@@ -69,12 +67,9 @@ class TestRunner {
 public:
   static int RunTests(int argc, char** argv) {
     ::testing::InitGoogleMock(&argc, argv);
-#ifdef ENVOY_GOOGLE_GRPC
-    grpc_init();
-#endif
-    Event::Libevent::Global::initialize();
-    Http::Http2::initializeNghttp2Logging();
-
+    // We hold on to process_cleanup to provide RAII cleanup of process-wide
+    // state.
+    auto process_cleanup = ProcessWide::setup();
     // Add a test-listener so we can call a hook where we can do a quiescence
     // check after each method. See
     // https://github.com/google/googletest/blob/master/googletest/docs/advanced.md


### PR DESCRIPTION
We have quite a few third party libraries that need to have process wide
setup/shutdown (including nghttp2, c-ares, gRPC, libevent). Ideally we
have a single source of truth for this sequence.

This PR is motivated by a TSAN race in CI reported in #6839, where the
DnsResolverImpl was doing its own c-ares setup/shutdown, racing with
gRPC library.

While we're mucking around in this code, also fix #6689.

Risk level: Low
Testing: bazel test --config=clang-tsan -c dbg
  //test/server:server_fuzz_test --runs_per_test=5000

Fixes #6839
Fixes #6689

Signed-off-by: Harvey Tuch <htuch@google.com>