### PR TITLE
Kafka codec: precompute request size before serialization, so we do n…

### DIFF
--- a/source/extensions/filters/network/kafka/kafka_request.h
+++ b/source/extensions/filters/network/kafka/kafka_request.h
@@ -60,13 +60,13 @@ public:
    * Computes the size of this request, if it were to be serialized.
    * @return serialized size of request
    */
-  virtual size_t computeSize() const PURE;
+  virtual uint32_t computeSize() const PURE;
 
   /**
    * Encode the contents of this request into a given buffer.
    * @param dst buffer instance to keep serialized message
    */
-  virtual size_t encode(Buffer::Instance& dst) const PURE;
+  virtual uint32_t encode(Buffer::Instance& dst) const PURE;
 
   /**
    * Request's header.
@@ -89,11 +89,11 @@ public:
       : AbstractRequest{request_header}, data_{data} {};
 
   /**
-   * Compute the size of request, what includes both the request header and its real data.
+   * Compute the size of request, which includes both the request header and its real data.
    */
-  size_t computeSize() const override {
+  uint32_t computeSize() const override {
     const EncodingContext context{request_header_.api_version_};
-    size_t result = 0;
+    uint32_t result{0};
     // Compute size of header.
     result += context.computeSize(request_header_.api_key_);
     result += context.computeSize(request_header_.api_version_);
@@ -107,9 +107,9 @@ public:
   /**
    * Encodes given request into a buffer, with any extra configuration carried by the context.
    */
-  size_t encode(Buffer::Instance& dst) const override {
+  uint32_t encode(Buffer::Instance& dst) const override {
     EncodingContext context{request_header_.api_version_};
-    size_t written{0};
+    uint32_t written{0};
     // Encode request header.
     written += context.encode(request_header_.api_key_, dst);
     written += context.encode(request_header_.api_version_, dst);

--- a/source/extensions/filters/network/kafka/kafka_request_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.cc
@@ -45,7 +45,7 @@ RequestParseResponse RequestHeaderParser::parse(absl::string_view& data) {
 }
 
 RequestParseResponse SentinelParser::parse(absl::string_view& data) {
-  const size_t min = std::min<size_t>(context_->remaining_request_size_, data.size());
+  const uint32_t min = std::min<uint32_t>(context_->remaining_request_size_, data.size());
   data = {data.data() + min, data.size() - min};
   context_->remaining_request_size_ -= min;
   if (0 == context_->remaining_request_size_) {

--- a/source/extensions/filters/network/kafka/protocol_code_generator/complex_type_template.j2
+++ b/source/extensions/filters/network/kafka/protocol_code_generator/complex_type_template.j2
@@ -22,6 +22,23 @@ struct {{ complex_type.name }} {
   // constructor used in versions: {{ constructor['versions'] }}
   {{ constructor['full_declaration'] }}{% endfor %}
 
+  {# For every field that's used in version, just compute its size using an encoder. #}
+  {% if complex_type.fields|length > 0 %}
+  size_t computeSize(const EncodingContext& encoder) const {
+    const int16_t api_version = encoder.apiVersion();
+    size_t written{0};{% for field in complex_type.fields %}
+    if (api_version >= {{ field.version_usage[0] }}
+      && api_version < {{ field.version_usage[-1] + 1 }}) {
+      written += encoder.computeSize({{ field.name }}_);
+    }{% endfor %}
+    return written;
+  }
+  {% else %}
+  size_t computeSize(const EncodingContext&) const {
+    return 0;
+  }
+  {% endif %}
+
   {# For every field that's used in version, just serialize it. #}
   {% if complex_type.fields|length > 0 %}
   size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {

--- a/source/extensions/filters/network/kafka/protocol_code_generator/complex_type_template.j2
+++ b/source/extensions/filters/network/kafka/protocol_code_generator/complex_type_template.j2
@@ -24,9 +24,9 @@ struct {{ complex_type.name }} {
 
   {# For every field that's used in version, just compute its size using an encoder. #}
   {% if complex_type.fields|length > 0 %}
-  size_t computeSize(const EncodingContext& encoder) const {
+  uint32_t computeSize(const EncodingContext& encoder) const {
     const int16_t api_version = encoder.apiVersion();
-    size_t written{0};{% for field in complex_type.fields %}
+    uint32_t written{0};{% for field in complex_type.fields %}
     if (api_version >= {{ field.version_usage[0] }}
       && api_version < {{ field.version_usage[-1] + 1 }}) {
       written += encoder.computeSize({{ field.name }}_);
@@ -34,16 +34,16 @@ struct {{ complex_type.name }} {
     return written;
   }
   {% else %}
-  size_t computeSize(const EncodingContext&) const {
+  uint32_t computeSize(const EncodingContext&) const {
     return 0;
   }
   {% endif %}
 
   {# For every field that's used in version, just serialize it. #}
   {% if complex_type.fields|length > 0 %}
-  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+  uint32_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
     const int16_t api_version = encoder.apiVersion();
-    size_t written{0};{% for field in complex_type.fields %}
+    uint32_t written{0};{% for field in complex_type.fields %}
     if (api_version >= {{ field.version_usage[0] }}
       && api_version < {{ field.version_usage[-1] + 1 }}) {
       written += encoder.encode({{ field.name }}_, dst);
@@ -51,7 +51,7 @@ struct {{ complex_type.name }} {
     return written;
   }
   {% else %}
-  size_t encode(Buffer::Instance&, EncodingContext&) const {
+  uint32_t encode(Buffer::Instance&, EncodingContext&) const {
     return 0;
   }
   {% endif %}

--- a/source/extensions/filters/network/kafka/request_codec.cc
+++ b/source/extensions/filters/network/kafka/request_codec.cc
@@ -80,7 +80,7 @@ void RequestDecoder::doParse(const Buffer::RawSlice& slice) {
 }
 
 void RequestEncoder::encode(const AbstractRequest& message) {
-  const int32_t size = htobe32(message.computeSize());
+  const uint32_t size = htobe32(message.computeSize());
   output_.add(&size, sizeof(size)); // Encode data length.
   message.encode(output_);          // Encode data.
 }

--- a/source/extensions/filters/network/kafka/request_codec.cc
+++ b/source/extensions/filters/network/kafka/request_codec.cc
@@ -80,14 +80,9 @@ void RequestDecoder::doParse(const Buffer::RawSlice& slice) {
 }
 
 void RequestEncoder::encode(const AbstractRequest& message) {
-  Buffer::OwnedImpl data_buffer;
-  // TODO(adamkotwasinski) Precompute the size instead of using temporary buffer.
-  // When we have the 'computeSize' method, then we can push encoding request's size into
-  // Request::encode
-  int32_t data_len = message.encode(data_buffer); // Encode data and compute data length.
-  EncodingContext encoder{-1};
-  encoder.encode(data_len, output_); // Encode data length into result.
-  output_.add(data_buffer);          // Copy encoded data into result.
+  const int32_t size = htobe32(message.computeSize());
+  output_.add(&size, sizeof(size)); // Encode data length.
+  message.encode(output_);          // Encode data.
 }
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/serialization.cc
+++ b/source/extensions/filters/network/kafka/serialization.cc
@@ -24,12 +24,12 @@ constexpr static int32_t NULL_BYTES_LENGTH = -1;
  * @return number of bytes consumed.
  */
 template <typename DeserializerType, typename LengthType, typename ByteType>
-size_t feedBytesIntoBuffers(absl::string_view& data, DeserializerType& length_deserializer,
-                            bool& length_consumed_marker, LengthType& required,
-                            std::vector<ByteType>& data_buffer, bool& ready,
-                            const LengthType null_value_length, const bool allow_null_value) {
+uint32_t feedBytesIntoBuffers(absl::string_view& data, DeserializerType& length_deserializer,
+                              bool& length_consumed_marker, LengthType& required,
+                              std::vector<ByteType>& data_buffer, bool& ready,
+                              const LengthType null_value_length, const bool allow_null_value) {
 
-  const size_t length_consumed = length_deserializer.feed(data);
+  const uint32_t length_consumed = length_deserializer.feed(data);
   if (!length_deserializer.ready()) {
     // Break early: we still need to fill in length buffer.
     return length_consumed;
@@ -68,8 +68,8 @@ size_t feedBytesIntoBuffers(absl::string_view& data, DeserializerType& length_de
     return length_consumed;
   }
 
-  const size_t data_consumed = std::min<size_t>(required, data.size());
-  const size_t written = data_buffer.size() - required;
+  const uint32_t data_consumed = std::min<uint32_t>(required, data.size());
+  const uint32_t written = data_buffer.size() - required;
   if (data_consumed > 0) {
     memcpy(data_buffer.data() + written, data.data(), data_consumed);
     required -= data_consumed;
@@ -84,22 +84,22 @@ size_t feedBytesIntoBuffers(absl::string_view& data, DeserializerType& length_de
   return length_consumed + data_consumed;
 }
 
-size_t StringDeserializer::feed(absl::string_view& data) {
+uint32_t StringDeserializer::feed(absl::string_view& data) {
   return feedBytesIntoBuffers<Int16Deserializer, int16_t, char>(
       data, length_buf_, length_consumed_, required_, data_buf_, ready_, NULL_STRING_LENGTH, false);
 }
 
-size_t NullableStringDeserializer::feed(absl::string_view& data) {
+uint32_t NullableStringDeserializer::feed(absl::string_view& data) {
   return feedBytesIntoBuffers<Int16Deserializer, int16_t, char>(
       data, length_buf_, length_consumed_, required_, data_buf_, ready_, NULL_STRING_LENGTH, true);
 }
 
-size_t BytesDeserializer::feed(absl::string_view& data) {
+uint32_t BytesDeserializer::feed(absl::string_view& data) {
   return feedBytesIntoBuffers<Int32Deserializer, int32_t, unsigned char>(
       data, length_buf_, length_consumed_, required_, data_buf_, ready_, NULL_BYTES_LENGTH, false);
 }
 
-size_t NullableBytesDeserializer::feed(absl::string_view& data) {
+uint32_t NullableBytesDeserializer::feed(absl::string_view& data) {
   return feedBytesIntoBuffers<Int32Deserializer, int32_t, unsigned char>(
       data, length_buf_, length_consumed_, required_, data_buf_, ready_, NULL_BYTES_LENGTH, true);
 }

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -40,7 +40,7 @@ public:
    * @param data bytes to be processed, will be updated if any have been consumed.
    * @return number of bytes consumed (equal to change in 'data').
    */
-  virtual size_t feed(absl::string_view& data) PURE;
+  virtual uint32_t feed(absl::string_view& data) PURE;
 
   /**
    * Whether deserializer has consumed enough data to return result.
@@ -62,8 +62,8 @@ template <typename T> class IntDeserializer : public Deserializer<T> {
 public:
   IntDeserializer() : written_{0}, ready_(false){};
 
-  size_t feed(absl::string_view& data) override {
-    const size_t available = std::min<size_t>(sizeof(buf_) - written_, data.size());
+  uint32_t feed(absl::string_view& data) override {
+    const uint32_t available = std::min<uint32_t>(sizeof(buf_) - written_, data.size());
     memcpy(buf_ + written_, data.data(), available);
     written_ += available;
 
@@ -80,7 +80,7 @@ public:
 
 protected:
   char buf_[sizeof(T) / sizeof(char)];
-  size_t written_;
+  uint32_t written_;
   bool ready_{false};
 };
 
@@ -155,7 +155,7 @@ class BooleanDeserializer : public Deserializer<bool> {
 public:
   BooleanDeserializer(){};
 
-  size_t feed(absl::string_view& data) override { return buffer_.feed(data); }
+  uint32_t feed(absl::string_view& data) override { return buffer_.feed(data); }
 
   bool ready() const override { return buffer_.ready(); }
 
@@ -179,7 +179,7 @@ public:
   /**
    * Can throw EnvoyException if given string length is not valid.
    */
-  size_t feed(absl::string_view& data) override;
+  uint32_t feed(absl::string_view& data) override;
 
   bool ready() const override { return ready_; }
 
@@ -211,7 +211,7 @@ public:
   /**
    * Can throw EnvoyException if given string length is not valid.
    */
-  size_t feed(absl::string_view& data) override;
+  uint32_t feed(absl::string_view& data) override;
 
   bool ready() const override { return ready_; }
 
@@ -242,7 +242,7 @@ public:
   /**
    * Can throw EnvoyException if given bytes length is not valid.
    */
-  size_t feed(absl::string_view& data) override;
+  uint32_t feed(absl::string_view& data) override;
 
   bool ready() const override { return ready_; }
 
@@ -272,7 +272,7 @@ public:
   /**
    * Can throw EnvoyException if given bytes length is not valid.
    */
-  size_t feed(absl::string_view& data) override;
+  uint32_t feed(absl::string_view& data) override;
 
   bool ready() const override { return ready_; }
 
@@ -309,9 +309,9 @@ public:
   /**
    * Can throw EnvoyException if array length is invalid or if underlying deserializer can throw.
    */
-  size_t feed(absl::string_view& data) override {
+  uint32_t feed(absl::string_view& data) override {
 
-    const size_t length_consumed = length_buf_.feed(data);
+    const uint32_t length_consumed = length_buf_.feed(data);
     if (!length_buf_.ready()) {
       // Break early: we still need to fill in length buffer.
       return length_consumed;
@@ -331,7 +331,7 @@ public:
       return length_consumed;
     }
 
-    size_t child_consumed{0};
+    uint32_t child_consumed{0};
     for (DeserializerType& child : children_) {
       child_consumed += child.feed(data);
     }
@@ -386,9 +386,9 @@ public:
   /**
    * Can throw EnvoyException if array length is invalid or if underlying deserializer can throw.
    */
-  size_t feed(absl::string_view& data) override {
+  uint32_t feed(absl::string_view& data) override {
 
-    const size_t length_consumed = length_buf_.feed(data);
+    const uint32_t length_consumed = length_buf_.feed(data);
     if (!length_buf_.ready()) {
       // Break early: we still need to fill in length buffer.
       return length_consumed;
@@ -414,7 +414,7 @@ public:
       return length_consumed;
     }
 
-    size_t child_consumed{0};
+    uint32_t child_consumed{0};
     for (DeserializerType& child : children_) {
       child_consumed += child.feed(data);
     }
@@ -473,37 +473,37 @@ public:
    * Compute size of given reference, if it were to be encoded.
    * @return serialized size of argument.
    */
-  template <typename T> size_t computeSize(const T& arg) const;
+  template <typename T> uint32_t computeSize(const T& arg) const;
 
   /**
    * Compute size of given array, if it were to be encoded.
    * @return serialized size of argument.
    */
-  template <typename T> size_t computeSize(const std::vector<T>& arg) const;
+  template <typename T> uint32_t computeSize(const std::vector<T>& arg) const;
 
   /**
    * Compute size of given nullable array, if it were to be encoded.
    * @return serialized size of argument.
    */
-  template <typename T> size_t computeSize(const NullableArray<T>& arg) const;
+  template <typename T> uint32_t computeSize(const NullableArray<T>& arg) const;
 
   /**
    * Encode given reference in a buffer.
    * @return bytes written
    */
-  template <typename T> size_t encode(const T& arg, Buffer::Instance& dst);
+  template <typename T> uint32_t encode(const T& arg, Buffer::Instance& dst);
 
   /**
    * Encode given array in a buffer.
    * @return bytes written
    */
-  template <typename T> size_t encode(const std::vector<T>& arg, Buffer::Instance& dst);
+  template <typename T> uint32_t encode(const std::vector<T>& arg, Buffer::Instance& dst);
 
   /**
    * Encode given nullable array in a buffer.
    * @return bytes written
    */
-  template <typename T> size_t encode(const NullableArray<T>& arg, Buffer::Instance& dst);
+  template <typename T> uint32_t encode(const NullableArray<T>& arg, Buffer::Instance& dst);
 
   int16_t apiVersion() const { return api_version_; }
 
@@ -515,7 +515,7 @@ private:
  * For non-primitive types, call `computeSize` on them, to delegate the work to the entity itself.
  * The entity may use the information in context to decide which fields are included etc.
  */
-template <typename T> inline size_t EncodingContext::computeSize(const T& arg) const {
+template <typename T> inline uint32_t EncodingContext::computeSize(const T& arg) const {
   return arg.computeSize(*this);
 }
 
@@ -523,7 +523,7 @@ template <typename T> inline size_t EncodingContext::computeSize(const T& arg) c
  * For primitive types, Kafka size == sizeof(x).
  */
 #define COMPUTE_SIZE_OF_NUMERIC_TYPE(TYPE)                                                         \
-  template <> constexpr size_t EncodingContext::computeSize(const TYPE&) const {                   \
+  template <> constexpr uint32_t EncodingContext::computeSize(const TYPE&) const {                 \
     return sizeof(TYPE);                                                                           \
   }
 
@@ -538,7 +538,7 @@ COMPUTE_SIZE_OF_NUMERIC_TYPE(int64_t)
  * Template overload for string.
  * Kafka String's size is INT16 for header + N bytes.
  */
-template <> inline size_t EncodingContext::computeSize(const std::string& arg) const {
+template <> inline uint32_t EncodingContext::computeSize(const std::string& arg) const {
   return sizeof(int16_t) + arg.size();
 }
 
@@ -546,7 +546,7 @@ template <> inline size_t EncodingContext::computeSize(const std::string& arg) c
  * Template overload for nullable string.
  * Kafka NullableString's size is INT16 for header + N bytes (N >= 0).
  */
-template <> inline size_t EncodingContext::computeSize(const NullableString& arg) const {
+template <> inline uint32_t EncodingContext::computeSize(const NullableString& arg) const {
   return sizeof(int16_t) + (arg ? arg->size() : 0);
 }
 
@@ -554,7 +554,7 @@ template <> inline size_t EncodingContext::computeSize(const NullableString& arg
  * Template overload for byte array.
  * Kafka byte array size is INT32 for header + N bytes.
  */
-template <> inline size_t EncodingContext::computeSize(const Bytes& arg) const {
+template <> inline uint32_t EncodingContext::computeSize(const Bytes& arg) const {
   return sizeof(int32_t) + arg.size();
 }
 
@@ -562,7 +562,7 @@ template <> inline size_t EncodingContext::computeSize(const Bytes& arg) const {
  * Template overload for nullable byte array.
  * Kafka nullable byte array size is INT32 for header + N bytes (N >= 0).
  */
-template <> inline size_t EncodingContext::computeSize(const NullableBytes& arg) const {
+template <> inline uint32_t EncodingContext::computeSize(const NullableBytes& arg) const {
   return sizeof(int32_t) + (arg ? arg->size() : 0);
 }
 
@@ -570,8 +570,9 @@ template <> inline size_t EncodingContext::computeSize(const NullableBytes& arg)
  * Template overload for Array of T.
  * The size of array is size of header and all of its elements.
  */
-template <typename T> inline size_t EncodingContext::computeSize(const std::vector<T>& arg) const {
-  size_t result = sizeof(int32_t);
+template <typename T>
+inline uint32_t EncodingContext::computeSize(const std::vector<T>& arg) const {
+  uint32_t result = sizeof(int32_t);
   for (const T& el : arg) {
     result += computeSize(el);
   }
@@ -583,7 +584,7 @@ template <typename T> inline size_t EncodingContext::computeSize(const std::vect
  * The size of array is size of header and all of its elements.
  */
 template <typename T>
-inline size_t EncodingContext::computeSize(const NullableArray<T>& arg) const {
+inline uint32_t EncodingContext::computeSize(const NullableArray<T>& arg) const {
   return arg ? computeSize(*arg) : sizeof(int32_t);
 }
 
@@ -591,7 +592,7 @@ inline size_t EncodingContext::computeSize(const NullableArray<T>& arg) const {
  * For non-primitive types, call `encode` on them, to delegate the serialization to the entity
  * itself.
  */
-template <typename T> inline size_t EncodingContext::encode(const T& arg, Buffer::Instance& dst) {
+template <typename T> inline uint32_t EncodingContext::encode(const T& arg, Buffer::Instance& dst) {
   return arg.encode(dst, *this);
 }
 
@@ -599,7 +600,7 @@ template <typename T> inline size_t EncodingContext::encode(const T& arg, Buffer
  * Template overload for int8_t.
  * Encode a single byte.
  */
-template <> inline size_t EncodingContext::encode(const int8_t& arg, Buffer::Instance& dst) {
+template <> inline uint32_t EncodingContext::encode(const int8_t& arg, Buffer::Instance& dst) {
   dst.add(&arg, sizeof(int8_t));
   return sizeof(int8_t);
 }
@@ -609,7 +610,7 @@ template <> inline size_t EncodingContext::encode(const int8_t& arg, Buffer::Ins
  * Encode a N-byte integer, converting to network byte-order.
  */
 #define ENCODE_NUMERIC_TYPE(TYPE, CONVERTER)                                                       \
-  template <> inline size_t EncodingContext::encode(const TYPE& arg, Buffer::Instance& dst) {      \
+  template <> inline uint32_t EncodingContext::encode(const TYPE& arg, Buffer::Instance& dst) {    \
     const TYPE val = CONVERTER(arg);                                                               \
     dst.add(&val, sizeof(TYPE));                                                                   \
     return sizeof(TYPE);                                                                           \
@@ -624,7 +625,7 @@ ENCODE_NUMERIC_TYPE(int64_t, htobe64);
  * Template overload for bool.
  * Encode boolean as a single byte.
  */
-template <> inline size_t EncodingContext::encode(const bool& arg, Buffer::Instance& dst) {
+template <> inline uint32_t EncodingContext::encode(const bool& arg, Buffer::Instance& dst) {
   int8_t val = arg;
   dst.add(&val, sizeof(int8_t));
   return sizeof(int8_t);
@@ -634,9 +635,9 @@ template <> inline size_t EncodingContext::encode(const bool& arg, Buffer::Insta
  * Template overload for std::string.
  * Encode string as INT16 length + N bytes.
  */
-template <> inline size_t EncodingContext::encode(const std::string& arg, Buffer::Instance& dst) {
+template <> inline uint32_t EncodingContext::encode(const std::string& arg, Buffer::Instance& dst) {
   int16_t string_length = arg.length();
-  size_t header_length = encode(string_length, dst);
+  uint32_t header_length = encode(string_length, dst);
   dst.add(arg.c_str(), string_length);
   return header_length + string_length;
 }
@@ -646,7 +647,7 @@ template <> inline size_t EncodingContext::encode(const std::string& arg, Buffer
  * Encode nullable string as INT16 length + N bytes (length = -1 for null).
  */
 template <>
-inline size_t EncodingContext::encode(const NullableString& arg, Buffer::Instance& dst) {
+inline uint32_t EncodingContext::encode(const NullableString& arg, Buffer::Instance& dst) {
   if (arg.has_value()) {
     return encode(*arg, dst);
   } else {
@@ -659,9 +660,9 @@ inline size_t EncodingContext::encode(const NullableString& arg, Buffer::Instanc
  * Template overload for Bytes.
  * Encode byte array as INT32 length + N bytes.
  */
-template <> inline size_t EncodingContext::encode(const Bytes& arg, Buffer::Instance& dst) {
+template <> inline uint32_t EncodingContext::encode(const Bytes& arg, Buffer::Instance& dst) {
   const int32_t data_length = arg.size();
-  const size_t header_length = encode(data_length, dst);
+  const uint32_t header_length = encode(data_length, dst);
   dst.add(arg.data(), arg.size());
   return header_length + data_length;
 }
@@ -670,7 +671,8 @@ template <> inline size_t EncodingContext::encode(const Bytes& arg, Buffer::Inst
  * Template overload for NullableBytes.
  * Encode nullable byte array as INT32 length + N bytes (length = -1 for null value).
  */
-template <> inline size_t EncodingContext::encode(const NullableBytes& arg, Buffer::Instance& dst) {
+template <>
+inline uint32_t EncodingContext::encode(const NullableBytes& arg, Buffer::Instance& dst) {
   if (arg.has_value()) {
     return encode(*arg, dst);
   } else {
@@ -684,7 +686,7 @@ template <> inline size_t EncodingContext::encode(const NullableBytes& arg, Buff
  * Each element of type T then serializes itself on its own.
  */
 template <typename T>
-size_t EncodingContext::encode(const std::vector<T>& arg, Buffer::Instance& dst) {
+uint32_t EncodingContext::encode(const std::vector<T>& arg, Buffer::Instance& dst) {
   const NullableArray<T> wrapped = {arg};
   return encode(wrapped, dst);
 }
@@ -694,11 +696,11 @@ size_t EncodingContext::encode(const std::vector<T>& arg, Buffer::Instance& dst)
  * Each element of type T then serializes itself on its own.
  */
 template <typename T>
-size_t EncodingContext::encode(const NullableArray<T>& arg, Buffer::Instance& dst) {
+uint32_t EncodingContext::encode(const NullableArray<T>& arg, Buffer::Instance& dst) {
   if (arg.has_value()) {
     const int32_t len = arg->size();
-    const size_t header_length = encode(len, dst);
-    size_t written{0};
+    const uint32_t header_length = encode(len, dst);
+    uint32_t written{0};
     for (const T& el : *arg) {
       // For each of array elements, resolve the correct method again.
       // Elements could be primitives or complex types, so calling encode() on object won't work.

--- a/source/extensions/filters/network/kafka/serialization_code_generator/serialization_composite_h.j2
+++ b/source/extensions/filters/network/kafka/serialization_code_generator/serialization_composite_h.j2
@@ -46,7 +46,7 @@ template <typename ResponseType>
 class CompositeDeserializerWith0Delegates : public Deserializer<ResponseType> {
 public:
   CompositeDeserializerWith0Delegates(){};
-  size_t feed(absl::string_view&) override { return 0; }
+  uint32_t feed(absl::string_view&) override { return 0; }
   bool ready() const override { return true; }
   ResponseType get() const override { return {}; }
 };
@@ -71,8 +71,8 @@ class CompositeDeserializerWith{{ field_count }}Delegates : public Deserializer<
 public:
   CompositeDeserializerWith{{ field_count }}Delegates(){};
 
-  size_t feed(absl::string_view& data) override {
-    size_t consumed = 0;
+  uint32_t feed(absl::string_view& data) override {
+    uint32_t consumed = 0;
     {% for field in range(1, field_count + 1) %}
     consumed += delegate{{ field }}_.feed(data);
     {% endfor %}

--- a/source/extensions/filters/network/kafka/serialization_code_generator/serialization_composite_test_cc.j2
+++ b/source/extensions/filters/network/kafka/serialization_code_generator/serialization_composite_test_cc.j2
@@ -22,7 +22,7 @@ namespace Kafka {
 // Tests for composite deserializer with 0 fields (corner case).
 
 struct CompositeResultWith0Fields {
-  size_t encode(Buffer::Instance&, EncodingContext&) const { return 0; }
+  uint32_t encode(Buffer::Instance&, EncodingContext&) const { return 0; }
   bool operator==(const CompositeResultWith0Fields&) const { return true; }
 };
 
@@ -49,8 +49,8 @@ struct CompositeResultWith{{ field_count }}Fields {
   const std::string field{{ field }}_;
   {% endfor %}
 
-  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
-    size_t written{0};
+  uint32_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    uint32_t written{0};
     {% for field in range(1, field_count + 1) %}
     written += encoder.encode(field{{ field }}_, dst);
     {% endfor %}

--- a/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
@@ -25,12 +25,12 @@ public:
     return reinterpret_cast<const char*>((slices[0]).mem_);
   }
 
-  template <typename T> size_t putIntoBuffer(const T arg) {
+  template <typename T> uint32_t putIntoBuffer(const T arg) {
     EncodingContext encoder_{-1}; // Context's api_version is not used when serializing primitives.
     return encoder_.encode(arg, buffer_);
   }
 
-  absl::string_view putGarbageIntoBuffer(size_t size = 10000) {
+  absl::string_view putGarbageIntoBuffer(uint32_t size = 10000) {
     putIntoBuffer(Bytes(size));
     return {getBytes(), size};
   }
@@ -91,7 +91,7 @@ TEST_F(KafkaRequestParserTest, RequestHeaderParserShouldExtractHeaderAndResolveN
   const int16_t api_version{2};
   const int32_t correlation_id{10};
   const NullableString client_id{"aaa"};
-  size_t header_len = 0;
+  uint32_t header_len = 0;
   header_len += putIntoBuffer(api_key);
   header_len += putIntoBuffer(api_version);
   header_len += putIntoBuffer(correlation_id);
@@ -122,7 +122,7 @@ TEST_F(KafkaRequestParserTest, RequestHeaderParserShouldHandleExceptionsDuringFe
   // This deserializer throws during feeding.
   class ThrowingRequestHeaderDeserializer : public RequestHeaderDeserializer {
   public:
-    size_t feed(absl::string_view& data) override {
+    uint32_t feed(absl::string_view& data) override {
       // Move some pointers to simulate data consumption.
       data = {data.data() + FAILED_DESERIALIZER_STEP, data.size() - FAILED_DESERIALIZER_STEP};
       throw EnvoyException("feed");
@@ -166,7 +166,7 @@ TEST_F(KafkaRequestParserTest, RequestDataParserShouldHandleDeserializerExceptio
   // This deserializer throws during feeding.
   class ThrowingDeserializer : public Deserializer<int32_t> {
   public:
-    size_t feed(absl::string_view&) override {
+    uint32_t feed(absl::string_view&) override {
       // Move some pointers to simulate data consumption.
       throw EnvoyException("feed");
     };
@@ -196,7 +196,7 @@ TEST_F(KafkaRequestParserTest, RequestDataParserShouldHandleDeserializerExceptio
 // This deserializer consumes FAILED_DESERIALIZER_STEP bytes and returns 0
 class SomeBytesDeserializer : public Deserializer<int32_t> {
 public:
-  size_t feed(absl::string_view& data) override {
+  uint32_t feed(absl::string_view& data) override {
     data = {data.data() + FAILED_DESERIALIZER_STEP, data.size() - FAILED_DESERIALIZER_STEP};
     return FAILED_DESERIALIZER_STEP;
   };

--- a/test/extensions/filters/network/kafka/serialization_utilities.h
+++ b/test/extensions/filters/network/kafka/serialization_utilities.h
@@ -38,16 +38,16 @@ void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
 
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
-  const size_t written = encoder.encode(expected, buffer);
+  const uint32_t written = encoder.encode(expected, buffer);
   // Insert garbage after serialized payload.
-  const size_t garbage_size = encoder.encode(Bytes(10000), buffer);
+  const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
   // Tell parser that there is more data, it should never consume more than written.
   const absl::string_view orig_data = {getRawData(buffer), written + garbage_size};
   absl::string_view data = orig_data;
 
   // when
-  const size_t consumed = testee.feed(data);
+  const uint32_t consumed = testee.feed(data);
 
   // then
   ASSERT_EQ(consumed, written);
@@ -56,7 +56,7 @@ void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
   assertStringViewIncrement(data, orig_data, consumed);
 
   // when - 2
-  const size_t consumed2 = testee.feed(data);
+  const uint32_t consumed2 = testee.feed(data);
 
   // then - 2 (nothing changes)
   ASSERT_EQ(consumed2, 0);
@@ -73,18 +73,18 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
 
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
-  const size_t written = encoder.encode(expected, buffer);
+  const uint32_t written = encoder.encode(expected, buffer);
   // Insert garbage after serialized payload.
-  const size_t garbage_size = encoder.encode(Bytes(10000), buffer);
+  const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
   const absl::string_view orig_data = {getRawData(buffer), written + garbage_size};
 
   // when
   absl::string_view data = orig_data;
-  size_t consumed = 0;
-  for (size_t i = 0; i < written; ++i) {
+  uint32_t consumed = 0;
+  for (uint32_t i = 0; i < written; ++i) {
     data = {data.data(), 1}; // Consume data byte-by-byte.
-    size_t step = testee.feed(data);
+    uint32_t step = testee.feed(data);
     consumed += step;
     ASSERT_EQ(step, 1);
     ASSERT_EQ(data.size(), 0);
@@ -99,7 +99,7 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
 
   // when - 2
   absl::string_view more_data = {data.data(), garbage_size};
-  const size_t consumed2 = testee.feed(more_data);
+  const uint32_t consumed2 = testee.feed(more_data);
 
   // then - 2 (nothing changes)
   ASSERT_EQ(consumed2, 0);


### PR DESCRIPTION
…ot have buffer copying

Description:
Current request serialization code uses a temporary buffer to compute size of request (it's a non-trivial operation, driven by request's api version present in `EncodingContext`).
This PR finally adds `.computeSize` method to request and underlying structures, it's pretty similar to serialization after all (use template overload for primitive type/array/string OR just call `computeSize` on "rich object").

Identified in https://github.com/envoyproxy/envoy/pull/4950#discussion_r233280433

The alternative was to use `Buffer::Instance::prepend`, but then we require the user to provide empty buffer to codec.

Risk Level: Low (new Kafka codec that's not active anyways)
Testing: automated tests
Docs Changes: n/a
Release Notes: n/a