### PR TITLE
tools: force the use of the en_US dictionary

### DIFF
--- a/tools/check_spelling_pedantic.py
+++ b/tools/check_spelling_pedantic.py
@@ -97,7 +97,9 @@ class SpellChecker:
       f.writelines(words)
 
     # Start an aspell process.
-    aspell_args = ["aspell", "pipe", "--run-together", "--encoding=utf-8", "--personal=" + pws]
+    aspell_args = [
+        "aspell", "pipe", "--run-together", "--lang=en_US", "--encoding=utf-8", "--personal=" + pws
+    ]
     self.aspell = subprocess.Popen(
         aspell_args,
         bufsize=4096,


### PR DESCRIPTION
Description:
check_spelling_pedantic uses aspell, which uses the system dictionary
unless told otherwise. This causes problems for those who use non-US
dictionaries. Envoy's codebase has settled on using en_US as its
dictionary, so we should force aspell to use it as well.

Risk Level: Low
Testing: 
Ran `tools/check_spelling_pedantic.py check .` on my system with an en_CA dictionary. It fails without my change, and passes with it.
Docs Changes: None
Release Notes: None
