### PR TITLE
Disable libevent tests

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -67,6 +67,7 @@ envoy_cmake_external(
     cache_entries = {
         "EVENT__DISABLE_OPENSSL": "on",
         "EVENT__DISABLE_REGRESS": "on",
+        "EVENT__DISABLE_TESTS": "on",
         "EVENT__LIBRARY_TYPE": "STATIC",
         "CMAKE_BUILD_TYPE": "Release",
     },


### PR DESCRIPTION
By default libevent builds with tests enabled. In this configuration it
[links zlib](https://github.com/libevent/libevent/blob/8701d0d3d2519800f46ab031a0b0d887b6eb1359/CMakeLists.txt#L829-L839)

Because of issues with bazel toolchain's version of zlib not correctly
being propagated to rules_foreign_cc rules, this ends up failing android
ndk builds because it tries to link your host system's zlib. We
shouldn't need this behavior regardless, so we can disable it.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>

Risk Level: Low