### PR TITLE
protobuf: add missing default case to enum

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -291,8 +291,9 @@ std::string MessageUtil::CodeEnumToString(ProtobufUtil::error::Code code) {
     return "UNAVAILABLE";
   case ProtobufUtil::error::DATA_LOSS:
     return "DATA_LOSS";
+  default:
+    return "";
   }
-  return "";
 }
 
 bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2) {


### PR DESCRIPTION
Signed-off-by: Frank Fort <ffort@google.com>

Description: Switch statements on enums should have a default case, see https://google.github.io/styleguide/cppguide.html#Loops_and_Switch_Statements.
Risk Level: Low
Testing: Ran bazel test source/common/protobuf/…
Docs Changes: N/A
Release Notes: N/A