### PR TITLE
router: use new config_impl_test_lib instead of synthetic build target

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -455,15 +455,17 @@ def envoy_cc_test(
     test_lib_tags = []
     if coverage:
         test_lib_tags.append("coverage_test_lib")
-    envoy_cc_test_library(
-        name = name + "__lib",
+    _envoy_cc_test_infrastructure_library(
+        name = name + "_lib_INTERNAL_ONLY",
         srcs = srcs,
         data = data,
         external_deps = external_deps,
-        deps = deps,
+        deps = deps + [repository + "//test/test_common:printers_includes"],
         repository = repository,
         tags = test_lib_tags,
         copts = copts,
+        # Restrict only to the code coverage tools.
+        visibility = ["@envoy//test/coverage:__pkg__"],
     )
     native.cc_test(
         name = name,
@@ -472,7 +474,7 @@ def envoy_cc_test(
         linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
         deps = [
-            ":" + name + "__lib",
+            ":" + name + "_lib_INTERNAL_ONLY",
             repository + "//test:main",
         ],
         # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51
@@ -486,7 +488,7 @@ def envoy_cc_test(
 
 # Envoy C++ related test infrastructure (that want gtest, gmock, but may be
 # relied on by envoy_cc_test_library) should use this function.
-def envoy_cc_test_infrastructure_library(
+def _envoy_cc_test_infrastructure_library(
         name,
         srcs = [],
         hdrs = [],
@@ -496,7 +498,8 @@ def envoy_cc_test_infrastructure_library(
         repository = "",
         tags = [],
         include_prefix = None,
-        copts = []):
+        copts = [],
+        **kargs):
     native.cc_library(
         name = name,
         srcs = srcs,
@@ -511,7 +514,7 @@ def envoy_cc_test_infrastructure_library(
         include_prefix = include_prefix,
         alwayslink = 1,
         linkstatic = envoy_linkstatic(),
-        visibility = ["//visibility:public"],
+        **kargs
     )
 
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified
@@ -526,11 +529,12 @@ def envoy_cc_test_library(
         repository = "",
         tags = [],
         include_prefix = None,
-        copts = []):
+        copts = [],
+        **kargs):
     deps = deps + [
         repository + "//test/test_common:printers_includes",
     ]
-    envoy_cc_test_infrastructure_library(
+    _envoy_cc_test_infrastructure_library(
         name,
         srcs,
         hdrs,
@@ -541,6 +545,8 @@ def envoy_cc_test_library(
         tags,
         include_prefix,
         copts,
+        visibility = ["//visibility:public"],
+        **kargs
     )
 
 # Envoy test binaries should be specified with this function.

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -456,7 +456,7 @@ def envoy_cc_test(
     if coverage:
         test_lib_tags.append("coverage_test_lib")
     _envoy_cc_test_infrastructure_library(
-        name = name + "_lib_INTERNAL_ONLY",
+        name = name + "_lib_internal_only",
         srcs = srcs,
         data = data,
         external_deps = external_deps,
@@ -474,7 +474,7 @@ def envoy_cc_test(
         linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
         deps = [
-            ":" + name + "_lib_INTERNAL_ONLY",
+            ":" + name + "_lib_internal_only",
             repository + "//test:main",
         ],
         # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -456,7 +456,7 @@ def envoy_cc_test(
     if coverage:
         test_lib_tags.append("coverage_test_lib")
     envoy_cc_test_library(
-        name = name + "_lib",
+        name = name + "__lib",
         srcs = srcs,
         data = data,
         external_deps = external_deps,
@@ -472,7 +472,7 @@ def envoy_cc_test(
         linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
         deps = [
-            ":" + name + "_lib",
+            ":" + name + "__lib",
             repository + "//test:main",
         ],
         # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -5,6 +5,7 @@ load(
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_binary",
+    "envoy_cc_test_library",
     "envoy_directory_genrule",
     "envoy_package",
     "envoy_proto_library",
@@ -14,6 +15,11 @@ envoy_package()
 
 envoy_cc_test(
     name = "config_impl_test",
+    deps = [":config_impl_test_lib"],
+)
+
+envoy_cc_test_library(
+    name = "config_impl_test_lib",
     srcs = ["config_impl_test.cc"],
     deps = [
         ":route_fuzz_proto_cc",
@@ -99,7 +105,7 @@ envoy_proto_library(
 envoy_cc_test_binary(
     name = "config_impl_test_static",
     deps = [
-        "config_impl_test_lib",
+        ":config_impl_test_lib",
         "//test:main",
     ],
 )

--- a/test/coverage/gen_build.sh
+++ b/test/coverage/gen_build.sh
@@ -38,7 +38,7 @@ fi
 if [ "${NO_GCOV}" != 1 ]
 then
   # Here we use the synthetic library target created by envoy_build_system.bzl
-  TARGETS="${TARGETS} ${REPOSITORY}//test/coverage/gcc_only_test:gcc_only_test__lib"
+  TARGETS="${TARGETS} ${REPOSITORY}//test/coverage/gcc_only_test:gcc_only_test_lib_INTERNAL_ONLY"
 fi
 
 (

--- a/test/coverage/gen_build.sh
+++ b/test/coverage/gen_build.sh
@@ -38,7 +38,7 @@ fi
 if [ "${NO_GCOV}" != 1 ]
 then
   # Here we use the synthetic library target created by envoy_build_system.bzl
-  TARGETS="${TARGETS} ${REPOSITORY}//test/coverage/gcc_only_test:gcc_only_test_lib_INTERNAL_ONLY"
+  TARGETS="${TARGETS} ${REPOSITORY}//test/coverage/gcc_only_test:gcc_only_test_lib_internal_only"
 fi
 
 (

--- a/test/coverage/gen_build.sh
+++ b/test/coverage/gen_build.sh
@@ -37,7 +37,8 @@ fi
 # gcov requires gcc
 if [ "${NO_GCOV}" != 1 ]
 then
-  TARGETS="${TARGETS} ${REPOSITORY}//test/coverage/gcc_only_test:gcc_only_test_lib"
+  # Here we use the synthetic library target created by envoy_build_system.bzl
+  TARGETS="${TARGETS} ${REPOSITORY}//test/coverage/gcc_only_test:gcc_only_test__lib"
 fi
 
 (

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -5,7 +5,6 @@ load(
     "envoy_basic_cc_library",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_cc_test_infrastructure_library",
     "envoy_cc_test_library",
     "envoy_package",
 )


### PR DESCRIPTION
Signed-off-by: Frank Fort <ffort@google.com>

Description: The build target `//test/common/router:config_impl_test_static` was relying upon the `_lib` target that is created by the `envoy_cc_test` in envoy_build_system.bzl. This target should not be relied upon since it is an implementation detail of the Envoy build system rather than a public build target that we want to allow dependencies upon.

This PR restricts the visibility of these synthetic targets to only the code coverage tools and renames them to end with `_lib_INTERNAL_ONLY` instead. See #6725 for where we started using these synthetic targets in our `BUILD` files.

This PR also hides the `envoy_cc_test_infrastructure_library` build macro by renaming it to `_envoy_cc_test_infrastructure_library` as per https://docs.bazel.build/versions/master/build-ref.html#load. This macro was not being used outside of envoy_build_system.bzl.

Note this does not break coverage builds since coverage pulls in the synthetic targets via the `coverage_test_lib` tag, see [generated_coverage_BUILD.txt](https://github.com/envoyproxy/envoy/files/3163463/generated_coverage_BUILD.txt) for the generated coverage `BUILD` file.

Risk Level: Low
Testing: Ran `bazel test //test/common/...`. and ran `test/run_envoy_bazel_coverage.sh`. 
Docs Changes: N/A
Release Notes: N/A