### PR TITLE
delete ci/prebuilt, which snuck back in

### DIFF
--- a/ci/prebuilt/thirdparty
+++ b/ci/prebuilt/thirdparty
@@ -1,1 +1,0 @@
-/thirdparty

--- a/ci/prebuilt/thirdparty_build
+++ b/ci/prebuilt/thirdparty_build
@@ -1,1 +1,0 @@
-/thirdparty_build


### PR DESCRIPTION
Risk Level: none