### PR TITLE
common: use unscoped build target in generate_version_linkstamp

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -254,12 +254,12 @@ genrule(
 genrule(
     name = "generate_version_linkstamp",
     outs = ["lib/version_linkstamp.h"],
-    cmd = "$(location //source/common/common:generate_version_linkstamp.sh) >> $@",
+    cmd = "$(location :generate_version_linkstamp.sh) >> $@",
     # Undocumented attr to depend on workspace status files.
     # https://github.com/bazelbuild/bazel/issues/4942
     # Used here because generate_version_linkstamp.sh depends on the workspace status files.
     stamp = 1,
-    tools = ["//source/common/common:generate_version_linkstamp.sh"],
+    tools = [":generate_version_linkstamp.sh"],
 )
 
 genrule(


### PR DESCRIPTION
Signed-off-by: Frank Fort <ffort@google.com>

Description: Simplify `BUILD` file by using a locally scoped build target reference as opposed to a fully specified build target (e.g. from `//`).
Risk Level: Low
Testing: Ran `bazel build source/common/...`
Docs Changes: N/A
Release Notes: N/A