### PR TITLE
fix explicit constructor in copy-initialization

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -720,8 +720,7 @@ ClusterImplBase::partitionHostList(const HostVector& hosts) {
     }
   }
 
-  return std::tuple<HealthyHostVectorConstSharedPtr, DegradedHostVectorConstSharedPtr,
-                    ExcludedHostVectorConstSharedPtr>{healthy_list, degraded_list, excluded_list};
+  return std::make_tuple(healthy_list, degraded_list, excluded_list);
 }
 
 std::tuple<HostsPerLocalityConstSharedPtr, HostsPerLocalityConstSharedPtr,
@@ -732,9 +731,8 @@ ClusterImplBase::partitionHostsPerLocality(const HostsPerLocality& hosts) {
        [](const Host& host) { return host.health() == Host::Health::Degraded; },
        [](const Host& host) { return host.healthFlagGet(Host::HealthFlag::PENDING_ACTIVE_HC); }});
 
-  return std::tuple<HostsPerLocalityConstSharedPtr, HostsPerLocalityConstSharedPtr,
-                    HostsPerLocalityConstSharedPtr>{
-      std::move(filtered_clones[0]), std::move(filtered_clones[1]), std::move(filtered_clones[2])};
+  return std::make_tuple(std::move(filtered_clones[0]), std::move(filtered_clones[1]),
+                         std::move(filtered_clones[2]));
 }
 
 bool ClusterInfoImpl::maintenanceMode() const {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -720,7 +720,8 @@ ClusterImplBase::partitionHostList(const HostVector& hosts) {
     }
   }
 
-  return {healthy_list, degraded_list, excluded_list};
+  return std::tuple<HealthyHostVectorConstSharedPtr, DegradedHostVectorConstSharedPtr,
+                    ExcludedHostVectorConstSharedPtr>{healthy_list, degraded_list, excluded_list};
 }
 
 std::tuple<HostsPerLocalityConstSharedPtr, HostsPerLocalityConstSharedPtr,
@@ -731,8 +732,9 @@ ClusterImplBase::partitionHostsPerLocality(const HostsPerLocality& hosts) {
        [](const Host& host) { return host.health() == Host::Health::Degraded; },
        [](const Host& host) { return host.healthFlagGet(Host::HealthFlag::PENDING_ACTIVE_HC); }});
 
-  return {std::move(filtered_clones[0]), std::move(filtered_clones[1]),
-          std::move(filtered_clones[2])};
+  return std::tuple<HostsPerLocalityConstSharedPtr, HostsPerLocalityConstSharedPtr,
+                    HostsPerLocalityConstSharedPtr>{
+      std::move(filtered_clones[0]), std::move(filtered_clones[1]), std::move(filtered_clones[2])};
 }
 
 bool ClusterInfoImpl::maintenanceMode() const {


### PR DESCRIPTION
Description:

commit: https://github.com/envoyproxy/envoy/commit/4c80194bf82193261aa52a4ca64c4e6a461881c0#diff-5d52e6425da0cdb53f84da8906c0a968R602
happened to break our builds because of the use of `return {}`'s
it introduced into upstream_impl.cc (we use a toolchain built around
clang-9, to more accurately map with the rest of our tools). this
fixes that build error.

Risk Level: Low
Testing:

Testing is hard in this one since as far as I can tell it doesn't happen with the toolchain inside of envoy-build-ubuntu. However, I scrapped together a quick public image you can use to validate:

1. Checkout master of envoy
2. Run the following:

```shell
docker pull gcr.io/ecoan-1280/ggg-bazel-image:latest
docker run \
       -e "CC=clang" \
       -e "CXX=clang++" \
       -it --rm \
 --net=host \
       --cap-add SYS_PTRACE \
       -v "$(pwd)":"/mnt/envoy" \
       -w "/mnt/envoy" \
       "gcr.io/ecoan-1280/ggg-bazel-image:latest" \
       /bin/bash
$ bazel build //source/exe:envoy-static
```
3. See build errors like:

```text
source/common/upstream/upstream_impl.cc:735:10: error: chosen constructor is explicit in copy-initialization
  return {std::move(filtered_clones[0]), std::move(filtered_clones[1]),
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

4. Checkout this commit into your branch.
5. Re-run the docker steps again.
6. Watch the build complete successfully.

Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Eric <ecoan@rust-lang.life>