### PR TITLE
source and test: fix comparisons of different signedness.

### DIFF
--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -646,8 +646,7 @@ bool ObjectHandler::Uint(unsigned value) {
 }
 bool ObjectHandler::Int64(int64_t value) { return handleValueEvent(Field::createValue(value)); }
 bool ObjectHandler::Uint64(uint64_t value) {
-  uint64_t max_int = std::numeric_limits<int64_t>::max();
-  if (value > max_int) {
+  if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
     throw Exception(fmt::format("JSON value from line {} is larger than int64_t (not supported)",
                                 stream_.getLineNumber()));
   }

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -646,7 +646,8 @@ bool ObjectHandler::Uint(unsigned value) {
 }
 bool ObjectHandler::Int64(int64_t value) { return handleValueEvent(Field::createValue(value)); }
 bool ObjectHandler::Uint64(uint64_t value) {
-  if (value > std::numeric_limits<int64_t>::max()) {
+  uint64_t max_int = std::numeric_limits<int64_t>::max();
+  if (value > max_int) {
     throw Exception(fmt::format("JSON value from line {} is larger than int64_t (not supported)",
                                 stream_.getLineNumber()));
   }

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -292,7 +292,8 @@ void BinaryProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) { UNREFERENCED_
 
 void BinaryProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                        FieldType value_type, uint32_t size) {
-  if (size > std::numeric_limits<int32_t>::max()) {
+  uint32_t max_int = std::numeric_limits<int32_t>::max();
+  if (size > max_int) {
     throw EnvoyException(fmt::format("illegal binary protocol map size {}", size));
   }
 
@@ -305,7 +306,8 @@ void BinaryProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PA
 
 void BinaryProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
                                         uint32_t size) {
-  if (size > std::numeric_limits<int32_t>::max()) {
+  uint32_t max_int = std::numeric_limits<int32_t>::max();
+  if (size > max_int) {
     throw EnvoyException(fmt::format("illegal binary protocol list/set size {}", size));
   }
 

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -292,8 +292,7 @@ void BinaryProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) { UNREFERENCED_
 
 void BinaryProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                        FieldType value_type, uint32_t size) {
-  uint32_t max_int = std::numeric_limits<int32_t>::max();
-  if (size > max_int) {
+  if (size > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
     throw EnvoyException(fmt::format("illegal binary protocol map size {}", size));
   }
 
@@ -306,8 +305,7 @@ void BinaryProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PA
 
 void BinaryProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
                                         uint32_t size) {
-  uint32_t max_int = std::numeric_limits<int32_t>::max();
-  if (size > max_int) {
+  if (size > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
     throw EnvoyException(fmt::format("illegal binary protocol list/set size {}", size));
   }
 

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -467,7 +467,8 @@ void CompactProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) {
 
 void CompactProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                         FieldType value_type, uint32_t size) {
-  if (size > std::numeric_limits<int32_t>::max()) {
+  uint32_t max_int = std::numeric_limits<int32_t>::max();
+  if (size > max_int) {
     throw EnvoyException(fmt::format("illegal compact protocol map size {}", size));
   }
 
@@ -486,7 +487,8 @@ void CompactProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_P
 
 void CompactProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
                                          uint32_t size) {
-  if (size > std::numeric_limits<int32_t>::max()) {
+  uint32_t max_int = std::numeric_limits<int32_t>::max();
+  if (size > max_int) {
     throw EnvoyException(fmt::format("illegal compact protocol list/set size {}", size));
   }
 

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -467,8 +467,7 @@ void CompactProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) {
 
 void CompactProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                         FieldType value_type, uint32_t size) {
-  uint32_t max_int = std::numeric_limits<int32_t>::max();
-  if (size > max_int) {
+  if (size > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
     throw EnvoyException(fmt::format("illegal compact protocol map size {}", size));
   }
 
@@ -487,8 +486,7 @@ void CompactProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_P
 
 void CompactProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
                                          uint32_t size) {
-  uint32_t max_int = std::numeric_limits<int32_t>::max();
-  if (size > max_int) {
+  if (size > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
     throw EnvoyException(fmt::format("illegal compact protocol list/set size {}", size));
   }
 

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -54,10 +54,9 @@ inline TestStreamInfo fromStreamInfo(const test::fuzz::StreamInfo& stream_info) 
   TestStreamInfo test_stream_info;
   test_stream_info.metadata_ = stream_info.dynamic_metadata();
   // libc++ clocks don't track at nanosecond on macOS.
+  uint64_t max_nanoseconds = std::numeric_limits<std::chrono::nanoseconds::rep>::max();
   const auto start_time =
-      std::numeric_limits<std::chrono::nanoseconds::rep>::max() < stream_info.start_time()
-          ? 0
-          : stream_info.start_time() / 1000;
+      max_nanoseconds < stream_info.start_time() ? 0 : stream_info.start_time() / 1000;
   test_stream_info.start_time_ = SystemTime(std::chrono::microseconds(start_time));
   if (stream_info.has_response_code()) {
     test_stream_info.response_code_ = stream_info.response_code().value();

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -54,9 +54,11 @@ inline TestStreamInfo fromStreamInfo(const test::fuzz::StreamInfo& stream_info) 
   TestStreamInfo test_stream_info;
   test_stream_info.metadata_ = stream_info.dynamic_metadata();
   // libc++ clocks don't track at nanosecond on macOS.
-  uint64_t max_nanoseconds = std::numeric_limits<std::chrono::nanoseconds::rep>::max();
   const auto start_time =
-      max_nanoseconds < stream_info.start_time() ? 0 : stream_info.start_time() / 1000;
+      static_cast<uint64_t>(std::numeric_limits<std::chrono::nanoseconds::rep>::max()) <
+              stream_info.start_time()
+          ? 0
+          : stream_info.start_time() / 1000;
   test_stream_info.start_time_ = SystemTime(std::chrono::microseconds(start_time));
   if (stream_info.has_response_code()) {
     test_stream_info.response_code_ = stream_info.response_code().value();

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -7,9 +7,8 @@ void HeaderToInt(const char header_name[], int32_t& return_int, Http::TestHeader
   const std::string header_value(headers.get_(header_name));
   if (!header_value.empty()) {
     uint64_t parsed_value;
-    RELEASE_ASSERT(absl::SimpleAtoi(header_value, &parsed_value) &&
-                       parsed_value < std::numeric_limits<int32_t>::max(),
-                   "");
+    uint32_t max_int = std::numeric_limits<int32_t>::max();
+    RELEASE_ASSERT(absl::SimpleAtoi(header_value, &parsed_value) && parsed_value < max_int, "");
     return_int = parsed_value;
   }
 }

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -7,8 +7,9 @@ void HeaderToInt(const char header_name[], int32_t& return_int, Http::TestHeader
   const std::string header_value(headers.get_(header_name));
   if (!header_value.empty()) {
     uint64_t parsed_value;
-    uint32_t max_int = std::numeric_limits<int32_t>::max();
-    RELEASE_ASSERT(absl::SimpleAtoi(header_value, &parsed_value) && parsed_value < max_int, "");
+    RELEASE_ASSERT(absl::SimpleAtoi(header_value, &parsed_value) &&
+                       parsed_value < static_cast<uint32_t>(std::numeric_limits<int32_t>::max()),
+                   "");
     return_int = parsed_value;
   }
 }


### PR DESCRIPTION
Description:

With `gcc version 9.1.1` I get the following warnings (upgraded to errors):

    source/common/json/json_loader.cc: In member function 'bool Envoy::Json::{anonymous}::ObjectHandler::Uint64(uint64_t)':
    source/common/json/json_loader.cc:649:13: warning: comparison of integer expressions of different signedness: 'uint64_t' {aka 'long unsigned int'} and 'long int' [-Wsign-compare]
      649 |   if (value > std::numeric_limits<int64_t>::max()) {
          |       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Instead of directly comparing signed and unsigned integers, first assign the signed integer maximum value into an unsigned integer variable.
Risk Level: low
Testing: ran unit tests
Docs Changes: N/A
Release Notes: N/A
