### PR TITLE
make bazel lld workaround support lld's named: `lld-<version_number>`

### DIFF
--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -73,8 +73,13 @@ def main():
 
   # Bazel will add -fuse-ld=gold in some cases, gcc/clang will take the last -fuse-ld argument,
   # so whenever we see lld once, add it to the end.
-  if "-fuse-ld=lld" in argv:
-    argv.append("-fuse-ld=lld")
+  lld_arg = ''
+  for arg_string in argv:
+    if "-fuse-ld=lld" in arg_string:
+      lld_arg = arg_string
+      break
+  if lld_arg != '':
+    argv.append(lld_arg)
 
   # Add compiler-specific options
   if "clang" in compiler:


### PR DESCRIPTION
Description:

for those installing lld with apt, the default lld's are named with
their version number as a suffix (e.g.: `lld-8`), as opposed to just
`lld`. this commit fixes the bazel workaround of bazel adding ld.gold
to support these versions of lld.

Risk Level: Low

Testing:

As far as I know there's no extra tests besides "it builds" for this bazel/cc_wrapper.py class. I did confirm this was valid python before pushing this up:

```text
Python 2.7.15 (default, May 29 2018, 09:27:15) 
[GCC 4.2.1 Compatible Clang 6.0.0 (tags/RELEASE_600/final)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> lld_arg = ''
>>> for arg_string in ["a", "b", "-fuse-ld=lld-8", "c"]:
...   print("checking: {}".format(arg_string))
...   if "-fuse-ld=lld" in arg_string:
...     lld_arg = arg_string
...     break
... 
checking: a
checking: b
checking: -fuse-ld=lld-8
>>> lld_arg
'-fuse-ld=lld-8'
```

Docs Changes: N/A
Release Notes: N/A
