### PR TITLE
envoy_build_system: remove unnecessary return statement

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -613,7 +613,7 @@ def envoy_proto_library(name, external_deps = [], **kwargs):
     if "api_httpbody_protos" in external_deps:
         external_cc_proto_deps.append("@googleapis//:api_httpbody_protos")
         external_proto_deps.append("@googleapis//:api_httpbody_protos_proto")
-    return api_proto_library(
+    api_proto_library(
         name,
         external_cc_proto_deps = external_cc_proto_deps,
         external_proto_deps = external_proto_deps,


### PR DESCRIPTION
Signed-off-by: Frank Fort <ffort@google.com>

Description: Removes return statement in `envoy_proto_library` which isn't necessary since we are using this macro to declaring build targets rather than relying upon its return value.
Risk Level: Low
Testing: Ran `bazel test //test/common/...`
Docs Changes: N/A
Release Notes: N/A