### PR TITLE
gzip: Handle encode trailers for gzip http filter

### DIFF
--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -150,8 +150,8 @@ Http::FilterTrailersStatus GzipFilter::encodeTrailers(Http::HeaderMap&) {
   if (!skip_compression_) {
     Buffer::OwnedImpl empty_buffer;
     compressor_.compress(empty_buffer, Compressor::State::Finish);
+    config_->stats().total_compressed_bytes_.add(empty_buffer.length());
     encoder_callbacks_->addEncodedData(empty_buffer, true);
-    return Http::FilterTrailersStatus::Continue;
   }
   return Http::FilterTrailersStatus::Continue;
 }

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -146,6 +146,16 @@ Http::FilterDataStatus GzipFilter::encodeData(Buffer::Instance& data, bool end_s
   return Http::FilterDataStatus::Continue;
 }
 
+Http::FilterTrailersStatus GzipFilter::encodeTrailers(Http::HeaderMap&) {
+  if (!skip_compression_) {
+    Buffer::OwnedImpl empty_buffer;
+    compressor_.compress(empty_buffer, Compressor::State::Finish);
+    encoder_callbacks_->addEncodedData(empty_buffer, true);
+    return Http::FilterTrailersStatus::Continue;
+  }
+  return Http::FilterTrailersStatus::Continue;
+}
+
 bool GzipFilter::hasCacheControlNoTransform(Http::HeaderMap& headers) const {
   const Http::HeaderEntry* cache_control = headers.CacheControl();
   if (cache_control) {

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -137,9 +137,7 @@ public:
   }
   Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap& headers, bool end_stream) override;
   Http::FilterDataStatus encodeData(Buffer::Instance& buffer, bool end_stream) override;
-  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap&) override {
-    return Http::FilterTrailersStatus::Continue;
-  }
+  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap&) override;
   Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap&) override {
     return Http::FilterMetadataStatus::Continue;
   }

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -71,7 +71,7 @@ protected:
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
   }
 
-  void verifyCompressedData(uint32_t content_length) {
+  void verifyCompressedData(const uint32_t content_length) {
     // This makes sure we have a finished buffer before sending it to the client.
     expectValidFinishedBuffer(content_length);
     decompressor_.decompress(data_, decompressed_data_);


### PR DESCRIPTION
Description: Compressor's compress needs to be called with Z_FINISH when end stream is true or at the encode trailers handler. 

Risk Level: Low
Testing: Unit test is provided
Docs Changes: N/A
Release Notes: N/A
Fixes #6894 

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>