### PR TITLE
config: re-add logger.h.

### DIFF
--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -6,6 +6,8 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 
+#include "common/common/logger.h"
+
 namespace Envoy {
 namespace Config {
 


### PR DESCRIPTION
It was inadvertently removed in #6819.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>