### PR TITLE
grpc: always check value of returned grpc::Status.

### DIFF
--- a/source/common/grpc/google_grpc_utils.cc
+++ b/source/common/grpc/google_grpc_utils.cc
@@ -78,7 +78,7 @@ Buffer::InstancePtr GoogleGrpcUtils::makeBufferInstance(const grpc::ByteBuffer& 
   // NB: ByteBuffer::Dump moves the data out of the ByteBuffer so we need to ensure that the
   // lifetime of the Slice(s) exceeds our Buffer::Instance.
   std::vector<grpc::Slice> slices;
-  byte_buffer.Dump(&slices);
+  RELEASE_ASSERT(byte_buffer.Dump(&slices) == grpc::Status::OK, "");
   auto* container = new ByteBufferContainer(static_cast<int>(slices.size()));
   std::function<void(const void*, size_t, const Buffer::BufferFragmentImpl*)> releaser =
       [container](const void*, size_t, const Buffer::BufferFragmentImpl*) {

--- a/test/common/grpc/google_grpc_utils_test.cc
+++ b/test/common/grpc/google_grpc_utils_test.cc
@@ -45,7 +45,7 @@ TEST(GoogleGrpcUtilsTest, MakeByteBuffer1) {
   buffer->add("test", 4);
   auto byte_buffer = GoogleGrpcUtils::makeByteBuffer(std::move(buffer));
   std::vector<grpc::Slice> slices;
-  byte_buffer.Dump(&slices);
+  RELEASE_ASSERT(byte_buffer.Dump(&slices) == grpc::Status::OK, "");
   std::string str;
   for (auto& s : slices) {
     str.append(std::string(reinterpret_cast<const char*>(s.begin()), s.size()));
@@ -64,7 +64,7 @@ TEST(GoogleGrpcUtilsTest, MakeByteBuffer3) {
   buffer->addBufferFragment(f3);
   auto byte_buffer = GoogleGrpcUtils::makeByteBuffer(std::move(buffer));
   std::vector<grpc::Slice> slices;
-  byte_buffer.Dump(&slices);
+  RELEASE_ASSERT(byte_buffer.Dump(&slices) == grpc::Status::OK, "");
   std::string str;
   for (auto& s : slices) {
     str.append(std::string(reinterpret_cast<const char*>(s.begin()), s.size()));


### PR DESCRIPTION
Fixes Google import, since grpc::Status is internally annotated
with warn_unused_result.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>