### PR TITLE
grpc-json: fix string fallout.

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -483,7 +483,7 @@ void JsonTranscoderFilter::buildResponseFromHttpBodyOutput(Http::HeaderMap& resp
       http_body.ParseFromZeroCopyStream(&stream);
       const auto& body = http_body.data();
 
-      data.add(body);
+      data.add(std::string(body));
 
       response_headers.insertContentType().value(http_body.content_type());
       response_headers.insertContentLength().value(body.size());


### PR DESCRIPTION
Fixes Google import, since internally this is neither std::string
nor absl::string_view.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>