### PR TITLE
Redis: Fix strip prefix

### DIFF
--- a/source/extensions/filters/network/redis_proxy/router.h
+++ b/source/extensions/filters/network/redis_proxy/router.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "envoy/common/pure.h"
 #include "envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.h"
@@ -26,7 +27,17 @@ public:
    * @param key mutable reference to the key of the current command.
    * @return a handle to the connection pool.
    */
-  virtual ConnPool::InstanceSharedPtr upstreamPool(std::string& key) PURE;
+  virtual ConnPool::InstanceSharedPtr upstreamPool(Common::Redis::RespValue& key) PURE;
+
+  /**
+   * Returns a connection pool that matches a given route from the first key in keys. When no match
+   * is found, the catch all pool is used. When remove prefix is set to true, the prefix will be
+   * removed from all the keys.
+   * @param keys mutable reference to the keys of the current command.
+   * @return a handle to the connection pool.
+   */
+  virtual ConnPool::InstanceSharedPtr
+  upstreamPool(std::vector<Common::Redis::RespValue>& keys) PURE;
 };
 
 typedef std::unique_ptr<Router> RouterPtr;

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.h"
 #include "envoy/thread_local/thread_local.h"
@@ -29,7 +30,8 @@ public:
                    prefix_routes,
                Upstreams&& upstreams);
 
-  ConnPool::InstanceSharedPtr upstreamPool(std::string& key) override;
+  ConnPool::InstanceSharedPtr upstreamPool(Common::Redis::RespValue& key) override;
+  ConnPool::InstanceSharedPtr upstreamPool(std::vector<Common::Redis::RespValue>& keys) override;
 
 private:
   struct Prefix {

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -33,7 +33,10 @@ public:
 };
 
 class NullRouterImpl : public Router {
-  ConnPool::InstanceSharedPtr upstreamPool(std::string&) override { return nullptr; }
+  ConnPool::InstanceSharedPtr upstreamPool(Common::Redis::RespValue&) override { return nullptr; }
+  ConnPool::InstanceSharedPtr upstreamPool(std::vector<Common::Redis::RespValue>&) override {
+    return nullptr;
+  }
 };
 
 class CommandLookUpSpeedTest {

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -42,7 +42,12 @@ class PassthruRouter : public Router {
 public:
   PassthruRouter(ConnPool::InstanceSharedPtr conn_pool) : conn_pool_(conn_pool) {}
 
-  ConnPool::InstanceSharedPtr upstreamPool(std::string&) override { return conn_pool_; }
+  ConnPool::InstanceSharedPtr upstreamPool(Common::Redis::RespValue&) override {
+    return conn_pool_;
+  }
+  ConnPool::InstanceSharedPtr upstreamPool(std::vector<Common::Redis::RespValue>&) override {
+    return conn_pool_;
+  }
 
 private:
   ConnPool::InstanceSharedPtr conn_pool_;

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -24,7 +24,9 @@ public:
   MockRouter();
   ~MockRouter();
 
-  MOCK_METHOD1(upstreamPool, ConnPool::InstanceSharedPtr(std::string& key));
+  MOCK_METHOD1(upstreamPool, ConnPool::InstanceSharedPtr(Common::Redis::RespValue& key));
+  MOCK_METHOD1(upstreamPool,
+               ConnPool::InstanceSharedPtr(std::vector<Common::Redis::RespValue>& key));
 };
 
 namespace ConnPool {


### PR DESCRIPTION
- strip prefix only stripped the first key sent to envoy
- this worked for most commands because they are single key and them multi key commands
  were split and routed individually
- this did not work for eval style commands which sends multiple keys to the same upstream
- fix by overloading upstreamPool to also take an vector of keys but this also changes the signature
  to use RespValue arguments instead of std::strings so that the command is forwarded correctly after stripping

Signed-off-by: Vivian Mathews <vivian.mathews@shopify.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
