### PR TITLE
Reclaim one byte from HeaderString

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -119,6 +119,8 @@ public:
   char* buffer() { return buffer_.dynamic_; }
 
   /**
+   * Get an absl::string_view. It will NOT be NUL terminated!
+   *
    * @return an absl::string_view.
    */
   absl::string_view getStringView() const {

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -23,6 +23,8 @@ namespace Http {
 // Used by ASSERTs to validate internal consistency. E.g. valid HTTP header keys/values should
 // never contain embedded NULLs.
 static inline bool validHeaderString(absl::string_view s) {
+  // If you modify this list of illegal embedded characters you will probably
+  // want to change header_map_fuzz_impl_test at the same time.
   for (const char c : {'\0', '\r', '\n'}) {
     if (s.find(c) != absl::string_view::npos) {
       return false;

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -25,9 +25,16 @@ namespace Http {
 static inline bool validHeaderString(absl::string_view s) {
   // If you modify this list of illegal embedded characters you will probably
   // want to change header_map_fuzz_impl_test at the same time.
-  for (const char c : {'\0', '\r', '\n'}) {
-    if (s.find(c) != absl::string_view::npos) {
+  for (const char c : s) {
+    switch (c) {
+    case '\0':
+      FALLTHRU;
+    case '\r':
+      FALLTHRU;
+    case '\n':
       return false;
+    default:
+      continue;
     }
   }
   return true;

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -113,7 +113,7 @@ void HeaderString::append(const char* data, uint32_t size) {
   }
 
   case Type::Inline: {
-    const uint64_t new_capacity = static_cast<uint64_t>(size) + 1 + string_length_;
+    const uint64_t new_capacity = static_cast<uint64_t>(size) + string_length_;
     if (new_capacity <= sizeof(inline_buffer_)) {
       // Already inline and the new value fits in inline storage.
       break;
@@ -148,7 +148,6 @@ void HeaderString::append(const char* data, uint32_t size) {
 
   memcpy(buffer_.dynamic_ + string_length_, data, size);
   string_length_ += size;
-  buffer_.dynamic_[string_length_] = 0;
   ASSERT(valid());
 }
 

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -75,7 +75,6 @@ HeaderString::HeaderString(HeaderString&& move_value) {
     buffer_.dynamic_ = inline_buffer_;
     memcpy(inline_buffer_, move_value.inline_buffer_, string_length_);
     move_value.string_length_ = 0;
-    move_value.inline_buffer_[0] = 0;
     break;
   }
   }
@@ -157,7 +156,6 @@ void HeaderString::clear() {
     break;
   }
   case Type::Inline: {
-    inline_buffer_[0] = 0;
     FALLTHRU;
   }
   case Type::Dynamic: {
@@ -207,7 +205,6 @@ void HeaderString::setCopy(const char* data, uint32_t size) {
   }
 
   memcpy(buffer_.dynamic_, data, size);
-  buffer_.dynamic_[size] = 0;
   string_length_ = size;
   ASSERT(valid());
 }

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -73,7 +73,7 @@ HeaderString::HeaderString(HeaderString&& move_value) {
   }
   case Type::Inline: {
     buffer_.dynamic_ = inline_buffer_;
-    memcpy(inline_buffer_, move_value.inline_buffer_, string_length_ + 1);
+    memcpy(inline_buffer_, move_value.inline_buffer_, string_length_);
     move_value.string_length_ = 0;
     move_value.inline_buffer_[0] = 0;
     break;
@@ -133,7 +133,7 @@ void HeaderString::append(const char* data, uint32_t size) {
       dynamic_capacity_ = new_capacity;
       type_ = Type::Dynamic;
     } else {
-      if (size + 1 + string_length_ > dynamic_capacity_) {
+      if (size + string_length_ > dynamic_capacity_) {
         const uint64_t new_capacity = newCapacity(string_length_, size);
         validateCapacity(new_capacity);
 
@@ -178,7 +178,7 @@ void HeaderString::setCopy(const char* data, uint32_t size) {
   }
 
   case Type::Inline: {
-    if (size + 1 <= sizeof(inline_buffer_)) {
+    if (size <= sizeof(inline_buffer_)) {
       // Already inline and the new value fits in inline storage.
       break;
     }
@@ -195,7 +195,7 @@ void HeaderString::setCopy(const char* data, uint32_t size) {
       RELEASE_ASSERT(buffer_.dynamic_ != nullptr, "");
       type_ = Type::Dynamic;
     } else {
-      if (size + 1 > dynamic_capacity_) {
+      if (size > dynamic_capacity_) {
         // Need to reallocate. Use free/malloc to avoid the copy since we are about to overwrite.
         dynamic_capacity_ = size * 2;
         validateCapacity(dynamic_capacity_);

--- a/test/common/http/header_map_impl_fuzz_test.cc
+++ b/test/common/http/header_map_impl_fuzz_test.cc
@@ -9,12 +9,31 @@
 
 namespace Envoy {
 
+namespace {
+// The HeaderMap code assumes that input does not contain certain characters, and
+// this is validated by the HTTP parser. The fuzzer will create strings with
+// these characters, however, and this creates not very interesting fuzz test
+// failures as an assertion is rapidly hit in the LowerCaseString constructor
+// before we get to anything interesting.
+//
+// This method will replace any of those characters found with spaces.
+std::string filterInvalidCharacters(const std::string& s) {
+  std::string filtered(s);
+  for (const char c : {'\0', '\r', '\n'}) {
+    std::replace(filtered.begin(), filtered.end(), c, ' ');
+  }
+  return filtered;
+}
+
+} // namespace
+
 // Fuzz the header map implementation.
 DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) {
   Http::HeaderMapImplPtr header_map = std::make_unique<Http::HeaderMapImpl>();
   const auto predefined_exists = [&header_map](const std::string& s) -> bool {
     const Http::HeaderEntry* entry;
-    return header_map->lookup(Http::LowerCaseString(s), &entry) == Http::HeaderMap::Lookup::Found;
+    return header_map->lookup(Http::LowerCaseString(filterInvalidCharacters(s)), &entry) ==
+           Http::HeaderMap::Lookup::Found;
   };
   std::vector<std::unique_ptr<Http::LowerCaseString>> lower_case_strings;
   std::vector<std::unique_ptr<std::string>> strings;
@@ -28,8 +47,10 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
       if (predefined_exists(add_reference.key())) {
         continue;
       }
-      lower_case_strings.emplace_back(std::make_unique<Http::LowerCaseString>(add_reference.key()));
-      strings.emplace_back(std::make_unique<std::string>(add_reference.value()));
+      lower_case_strings.emplace_back(
+          std::make_unique<Http::LowerCaseString>(filterInvalidCharacters(add_reference.key())));
+      strings.emplace_back(
+          std::make_unique<std::string>(filterInvalidCharacters(add_reference.value())));
       header_map->addReference(*lower_case_strings.back(), *strings.back());
       break;
     }
@@ -39,11 +60,12 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
       if (predefined_exists(add_reference_key.key())) {
         continue;
       }
-      lower_case_strings.emplace_back(
-          std::make_unique<Http::LowerCaseString>(add_reference_key.key()));
+      lower_case_strings.emplace_back(std::make_unique<Http::LowerCaseString>(
+          filterInvalidCharacters(add_reference_key.key())));
       switch (add_reference_key.value_selector_case()) {
       case test::common::http::AddReferenceKey::kStringValue:
-        header_map->addReferenceKey(*lower_case_strings.back(), add_reference_key.string_value());
+        header_map->addReferenceKey(*lower_case_strings.back(),
+                                    filterInvalidCharacters(add_reference_key.string_value()));
         break;
       case test::common::http::AddReferenceKey::kUint64Value:
         header_map->addReferenceKey(*lower_case_strings.back(), add_reference_key.uint64_value());
@@ -59,10 +81,10 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
       if (predefined_exists(add_copy.key())) {
         continue;
       }
-      const Http::LowerCaseString key{add_copy.key()};
+      const Http::LowerCaseString key{filterInvalidCharacters(add_copy.key())};
       switch (add_copy.value_selector_case()) {
       case test::common::http::AddCopy::kStringValue:
-        header_map->addCopy(key, add_copy.string_value());
+        header_map->addCopy(key, filterInvalidCharacters(add_copy.string_value()));
         break;
       case test::common::http::AddCopy::kUint64Value:
         header_map->addCopy(key, add_copy.uint64_value());
@@ -74,21 +96,25 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
     }
     case test::common::http::Action::kSetReference: {
       const auto& set_reference = action.set_reference();
-      lower_case_strings.emplace_back(std::make_unique<Http::LowerCaseString>(set_reference.key()));
-      strings.emplace_back(std::make_unique<std::string>(set_reference.value()));
+      lower_case_strings.emplace_back(
+          std::make_unique<Http::LowerCaseString>(filterInvalidCharacters(set_reference.key())));
+      strings.emplace_back(
+          std::make_unique<std::string>(filterInvalidCharacters(set_reference.value())));
       header_map->setReference(*lower_case_strings.back(), *strings.back());
       break;
     }
     case test::common::http::Action::kSetReferenceKey: {
       const auto& set_reference_key = action.set_reference_key();
-      lower_case_strings.emplace_back(
-          std::make_unique<Http::LowerCaseString>(set_reference_key.key()));
-      header_map->setReferenceKey(*lower_case_strings.back(), set_reference_key.value());
+      lower_case_strings.emplace_back(std::make_unique<Http::LowerCaseString>(
+          filterInvalidCharacters(set_reference_key.key())));
+      header_map->setReferenceKey(*lower_case_strings.back(),
+                                  filterInvalidCharacters(set_reference_key.value()));
       break;
     }
     case test::common::http::Action::kGetAndMutate: {
       const auto& get_and_mutate = action.get_and_mutate();
-      auto* header_entry = header_map->get(Http::LowerCaseString(get_and_mutate.key()));
+      auto* header_entry =
+          header_map->get(Http::LowerCaseString(filterInvalidCharacters(get_and_mutate.key())));
       if (header_entry != nullptr) {
         // Do some read-only stuff.
         (void)strlen(std::string(header_entry->key().getStringView()).c_str());
@@ -99,7 +125,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
         // Do some mutation or parameterized action.
         switch (get_and_mutate.mutate_selector_case()) {
         case test::common::http::GetAndMutate::kAppend:
-          header_entry->value().append(get_and_mutate.append().c_str(),
+          header_entry->value().append(filterInvalidCharacters(get_and_mutate.append()).c_str(),
                                        get_and_mutate.append().size());
           break;
         case test::common::http::GetAndMutate::kClear:
@@ -109,14 +135,15 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
           header_entry->value().getStringView().find(get_and_mutate.find());
           break;
         case test::common::http::GetAndMutate::kSetCopy:
-          header_entry->value().setCopy(get_and_mutate.set_copy().c_str(),
+          header_entry->value().setCopy(filterInvalidCharacters(get_and_mutate.set_copy()).c_str(),
                                         get_and_mutate.set_copy().size());
           break;
         case test::common::http::GetAndMutate::kSetInteger:
           header_entry->value().setInteger(get_and_mutate.set_integer());
           break;
         case test::common::http::GetAndMutate::kSetReference:
-          strings.emplace_back(std::make_unique<std::string>(get_and_mutate.set_reference()));
+          strings.emplace_back(std::make_unique<std::string>(
+              filterInvalidCharacters(get_and_mutate.set_reference())));
           header_entry->value().setReference(*strings.back());
           break;
         default:
@@ -132,15 +159,17 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
     }
     case test::common::http::Action::kLookup: {
       const Http::HeaderEntry* header_entry;
-      header_map->lookup(Http::LowerCaseString(action.lookup()), &header_entry);
+      header_map->lookup(Http::LowerCaseString(filterInvalidCharacters(action.lookup())),
+                         &header_entry);
       break;
     }
     case test::common::http::Action::kRemove: {
-      header_map->remove(Http::LowerCaseString(action.remove()));
+      header_map->remove(Http::LowerCaseString(filterInvalidCharacters(action.remove())));
       break;
     }
     case test::common::http::Action::kRemovePrefix: {
-      header_map->removePrefix(Http::LowerCaseString(action.remove_prefix()));
+      header_map->removePrefix(
+          Http::LowerCaseString(filterInvalidCharacters(action.remove_prefix())));
       break;
     }
     default:

--- a/test/common/http/header_map_impl_fuzz_test.cc
+++ b/test/common/http/header_map_impl_fuzz_test.cc
@@ -17,10 +17,21 @@ namespace {
 // before we get to anything interesting.
 //
 // This method will replace any of those characters found with spaces.
-std::string filterInvalidCharacters(const std::string& s) {
-  std::string filtered(s);
-  for (const char c : {'\0', '\r', '\n'}) {
-    std::replace(filtered.begin(), filtered.end(), c, ' ');
+std::string filterInvalidCharacters(absl::string_view string) {
+  std::string filtered;
+  filtered.reserve(string.length());
+  for (const char& c : string) {
+    switch (c) {
+    case '\0':
+      FALLTHRU;
+    case '\r':
+      FALLTHRU;
+    case '\n':
+      filtered.push_back(' ');
+      break;
+    default:
+      filtered.push_back(c);
+    }
   }
   return filtered;
 }

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -180,7 +180,7 @@ TEST(HeaderStringTest, All) {
   // Append, small buffer to dynamic
   {
     HeaderString string;
-    std::string test(127, 'a');
+    std::string test(128, 'a');
     string.append(test.c_str(), test.size());
     EXPECT_EQ(HeaderString::Type::Inline, string.type());
     string.append("a", 1);
@@ -208,20 +208,20 @@ TEST(HeaderStringTest, All) {
   // Append, realloc dynamic.
   {
     HeaderString string;
-    std::string large(128, 'a');
+    std::string large(129, 'a');
     string.append(large.c_str(), large.size());
     EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
     std::string large2 = large + large;
     string.append(large2.c_str(), large2.size());
     large += large2;
     EXPECT_EQ(large, string.getStringView());
-    EXPECT_EQ(384U, string.size());
+    EXPECT_EQ(387U, string.size());
   }
 
   // Append, realloc close to limit with small buffer.
   {
     HeaderString string;
-    std::string large(128, 'a');
+    std::string large(129, 'a');
     string.append(large.c_str(), large.size());
     EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
     std::string large2(120, 'b');
@@ -229,7 +229,7 @@ TEST(HeaderStringTest, All) {
     std::string large3(32, 'c');
     string.append(large3.c_str(), large3.size());
     EXPECT_EQ((large + large2 + large3), string.getStringView());
-    EXPECT_EQ(280U, string.size());
+    EXPECT_EQ(281U, string.size());
   }
 
   // Set integer, inline
@@ -243,7 +243,7 @@ TEST(HeaderStringTest, All) {
   // Set integer, dynamic
   {
     HeaderString string;
-    std::string large(128, 'a');
+    std::string large(129, 'a');
     string.append(large.c_str(), large.size());
     string.setInteger(123456789);
     EXPECT_EQ("123456789", string.getStringView());

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -260,7 +260,7 @@ TEST(HeaderStringTest, All) {
     EXPECT_EQ(11U, string.size());
     EXPECT_EQ(HeaderString::Type::Reference, string.type());
 
-    const std::string large(128, 'a');
+    const std::string large(129, 'a');
     string.setCopy(large.c_str(), large.size());
     EXPECT_NE(string.getStringView().data(), large.c_str());
     EXPECT_EQ(HeaderString::Type::Dynamic, string.type());


### PR DESCRIPTION
Description:

With conversion to `getStringView()` access there is no longer any need to reserve a NUL byte at the end of the HeaderString since all accesses will be through string_views which are not required to be NUL terminated.

Ran `bazel test -c opt //test/... --config=asan --runs_per_test=10` without issue. There is some risk that someone has or will abuse the data() accessor on a string_view assuming it is NUL terminated. A comment is added to emphasize that the `HeaderString::getStringView()` is not NUL terminated.

By eliminating this wasted byte it is more likely that a HeaderString will fit into the existing embedded space, hopefully giving a small performance gain and reduction in memory allocations.

The original version of this PR caused a fuzz test issue due to missing one of the NUL clobbers as a result of searching for `\0` and not `0`. This issue is resolved in this PR. Additional test coverage added in this PR manually looks for the clobber and verifies it does not happen.

Header map fuzz test improvements made as part of this PR:

It is invariant that the input into the headermap code should not contain certain reserved characters, and this is enforced by assertion. The fuzzer would frequently hang up on these and just fail the valid()
check, often just when constructing a LowerCaseString before doing anything interesting.

To get past this, filter the reserved characters to spaces. The fuzzer ran for 30 minutes with this change.

Additionally, in the valid() routine, instead of scanning a header string once for each of the invalid characters (three) scan the header string once and use a switch statement to find invalid characters.

This seems to have improved the fuzz test executions per second somewhat, and will likely improve performance of binaries with asserts turned on marginally since most headers are more than three characters.

Signed-off-by: Dan Noé dpn@google.com

Risk Level: High
Testing: `bazel test -c opt //test/... --config=asan --runs_per_test=10`, manual oss-fuzz runs, added additional unit tests
Docs Changes: None
Release Notes: None
Part of: Issue #6580