### PR TITLE
 types: fixing some type problems when compiling against other targets

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -38,6 +38,7 @@ def envoy_copts(repository, test = False):
         "-Woverloaded-virtual",
         "-Wold-style-cast",
         "-Wvla",
+        "-DHAVE_LONG_LONG",
         "-std=c++14",
     ]
 
@@ -77,10 +78,6 @@ def envoy_copts(repository, test = False):
                "//conditions:default": ["-DENVOY_HANDLE_SIGNALS"],
            }) + select({
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
-               "//conditions:default": [],
-           }) + select({
-               # TCLAP command line parser needs this to support int64_t/uint64_t
-               repository + "//bazel:apple": ["-DHAVE_LONG_LONG"],
                "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
            envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -38,7 +38,6 @@ def envoy_copts(repository, test = False):
         "-Woverloaded-virtual",
         "-Wold-style-cast",
         "-Wvla",
-        "-DHAVE_LONG_LONG",
         "-std=c++14",
     ]
 

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -100,10 +100,10 @@ public:
     if (available_size == 0) {
       return {nullptr, 0};
     }
-    size_t reservation_size = std::min(size, available_size);
+    uint64_t reservation_size = std::min(size, available_size);
     void* reservation = &(base_[reservable_]);
     reservation_outstanding_ = true;
-    return {reservation, reservation_size};
+    return {reservation, static_cast<size_t>(reservation_size)};
   }
 
   /**

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -100,7 +100,7 @@ public:
     if (available_size == 0) {
       return {nullptr, 0};
     }
-    uint64_t reservation_size = std::min(size, available_size);
+    size_t reservation_size = std::min(size, available_size);
     void* reservation = &(base_[reservable_]);
     reservation_outstanding_ = true;
     return {reservation, reservation_size};

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -57,16 +57,16 @@ bool ipFamilySupported(int domain) {
 
 Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, socklen_t ss_len,
                                                     bool v6only) {
-  RELEASE_ASSERT(ss_len == 0 || ss_len >= sizeof(sa_family_t), "");
+  RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >= sizeof(sa_family_t), "");
   switch (ss.ss_family) {
   case AF_INET: {
-    RELEASE_ASSERT(ss_len == 0 || ss_len == sizeof(sockaddr_in), "");
+    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in), "");
     const struct sockaddr_in* sin = reinterpret_cast<const struct sockaddr_in*>(&ss);
     ASSERT(AF_INET == sin->sin_family);
     return std::make_shared<Address::Ipv4Instance>(sin);
   }
   case AF_INET6: {
-    RELEASE_ASSERT(ss_len == 0 || ss_len == sizeof(sockaddr_in6), "");
+    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in6), "");
     const struct sockaddr_in6* sin6 = reinterpret_cast<const struct sockaddr_in6*>(&ss);
     ASSERT(AF_INET6 == sin6->sin6_family);
     if (!v6only && IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
@@ -84,7 +84,7 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
   case AF_UNIX: {
     const struct sockaddr_un* sun = reinterpret_cast<const struct sockaddr_un*>(&ss);
     ASSERT(AF_UNIX == sun->sun_family);
-    RELEASE_ASSERT(ss_len == 0 || ss_len >= offsetof(struct sockaddr_un, sun_path) + 1, "");
+    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1, "");
     return std::make_shared<Address::PipeInstance>(sun, ss_len);
   }
   default:
@@ -336,7 +336,7 @@ PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len)
 #if !defined(__linux__)
     throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
 #endif
-    RELEASE_ASSERT(ss_len >= offsetof(struct sockaddr_un, sun_path) + 1, "");
+    RELEASE_ASSERT(ss_len >= 0 && static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1, "");
     abstract_namespace_ = true;
     address_length_ = ss_len - offsetof(struct sockaddr_un, sun_path);
   }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -57,16 +57,20 @@ bool ipFamilySupported(int domain) {
 
 Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, socklen_t ss_len,
                                                     bool v6only) {
-  RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >= sizeof(sa_family_t), "");
+  RELEASE_ASSERT(
+      ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >= sizeof(sa_family_t), "");
   switch (ss.ss_family) {
   case AF_INET: {
-    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in), "");
+    RELEASE_ASSERT(
+        ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in), "");
     const struct sockaddr_in* sin = reinterpret_cast<const struct sockaddr_in*>(&ss);
     ASSERT(AF_INET == sin->sin_family);
     return std::make_shared<Address::Ipv4Instance>(sin);
   }
   case AF_INET6: {
-    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in6), "");
+    RELEASE_ASSERT(ss_len == 0 ||
+                       ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in6),
+                   "");
     const struct sockaddr_in6* sin6 = reinterpret_cast<const struct sockaddr_in6*>(&ss);
     ASSERT(AF_INET6 == sin6->sin6_family);
     if (!v6only && IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
@@ -84,7 +88,9 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
   case AF_UNIX: {
     const struct sockaddr_un* sun = reinterpret_cast<const struct sockaddr_un*>(&ss);
     ASSERT(AF_UNIX == sun->sun_family);
-    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1, "");
+    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >=
+                                                     offsetof(struct sockaddr_un, sun_path) + 1,
+                   "");
     return std::make_shared<Address::PipeInstance>(sun, ss_len);
   }
   default:
@@ -336,7 +342,9 @@ PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len)
 #if !defined(__linux__)
     throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
 #endif
-    RELEASE_ASSERT(ss_len >= 0 && static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1, "");
+    RELEASE_ASSERT(ss_len >= 0 && static_cast<unsigned int>(ss_len) >=
+                                      offsetof(struct sockaddr_un, sun_path) + 1,
+                   "");
     abstract_namespace_ = true;
     address_length_ = ss_len - offsetof(struct sockaddr_un, sun_path);
   }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -57,20 +57,16 @@ bool ipFamilySupported(int domain) {
 
 Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, socklen_t ss_len,
                                                     bool v6only) {
-  RELEASE_ASSERT(
-      ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >= sizeof(sa_family_t), "");
+  RELEASE_ASSERT(ss_len == 0 || static_cast<unsigned int>(ss_len) >= sizeof(sa_family_t), "");
   switch (ss.ss_family) {
   case AF_INET: {
-    RELEASE_ASSERT(
-        ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in), "");
+    RELEASE_ASSERT(ss_len == 0 || static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in), "");
     const struct sockaddr_in* sin = reinterpret_cast<const struct sockaddr_in*>(&ss);
     ASSERT(AF_INET == sin->sin_family);
     return std::make_shared<Address::Ipv4Instance>(sin);
   }
   case AF_INET6: {
-    RELEASE_ASSERT(ss_len == 0 ||
-                       ss_len >= 0 && static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in6),
-                   "");
+    RELEASE_ASSERT(ss_len == 0 || static_cast<unsigned int>(ss_len) == sizeof(sockaddr_in6), "");
     const struct sockaddr_in6* sin6 = reinterpret_cast<const struct sockaddr_in6*>(&ss);
     ASSERT(AF_INET6 == sin6->sin6_family);
     if (!v6only && IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
@@ -88,8 +84,8 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
   case AF_UNIX: {
     const struct sockaddr_un* sun = reinterpret_cast<const struct sockaddr_un*>(&ss);
     ASSERT(AF_UNIX == sun->sun_family);
-    RELEASE_ASSERT(ss_len == 0 || ss_len >= 0 && static_cast<unsigned int>(ss_len) >=
-                                                     offsetof(struct sockaddr_un, sun_path) + 1,
+    RELEASE_ASSERT(ss_len == 0 || static_cast<unsigned int>(ss_len) >=
+                                      offsetof(struct sockaddr_un, sun_path) + 1,
                    "");
     return std::make_shared<Address::PipeInstance>(sun, ss_len);
   }
@@ -342,8 +338,7 @@ PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len)
 #if !defined(__linux__)
     throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
 #endif
-    RELEASE_ASSERT(ss_len >= 0 && static_cast<unsigned int>(ss_len) >=
-                                      offsetof(struct sockaddr_un, sun_path) + 1,
+    RELEASE_ASSERT(static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1,
                    "");
     abstract_namespace_ = true;
     address_length_ = ss_len - offsetof(struct sockaddr_un, sun_path);

--- a/source/common/stats/fake_symbol_table_impl.h
+++ b/source/common/stats/fake_symbol_table_impl.h
@@ -127,7 +127,7 @@ public:
 
 private:
   absl::string_view toStringView(const StatName& stat_name) const {
-    return {reinterpret_cast<const char*>(stat_name.data()), stat_name.dataSize()};
+    return {reinterpret_cast<const char*>(stat_name.data()), static_cast<absl::string_view::size_type>(stat_name.dataSize())};
   }
 
   StoragePtr encodeHelper(absl::string_view name) const {

--- a/source/common/stats/fake_symbol_table_impl.h
+++ b/source/common/stats/fake_symbol_table_impl.h
@@ -127,7 +127,8 @@ public:
 
 private:
   absl::string_view toStringView(const StatName& stat_name) const {
-    return {reinterpret_cast<const char*>(stat_name.data()), static_cast<absl::string_view::size_type>(stat_name.dataSize())};
+    return {reinterpret_cast<const char*>(stat_name.data()),
+            static_cast<absl::string_view::size_type>(stat_name.dataSize())};
   }
 
   StoragePtr encodeHelper(absl::string_view name) const {

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -767,13 +767,13 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
     }
 
     if (!parsed_alpn_protocols_.empty()) {
-      SSL_CTX_set_alpn_select_cb(ctx.ssl_ctx_.get(),
-                                 [](SSL*, const unsigned char** out, unsigned char* outlen,
-                                    const unsigned char* in, unsigned int inlen, void* arg) -> int {
-                                   return static_cast<ServerContextImpl*>(arg)->alpnSelectCallback(
-                                       out, outlen, in, inlen);
-                                 },
-                                 this);
+      SSL_CTX_set_alpn_select_cb(
+          ctx.ssl_ctx_.get(),
+          [](SSL*, const unsigned char** out, unsigned char* outlen, const unsigned char* in,
+             unsigned int inlen, void* arg) -> int {
+            return static_cast<ServerContextImpl*>(arg)->alpnSelectCallback(out, outlen, in, inlen);
+          },
+          this);
     }
 
     if (!session_ticket_keys_.empty()) {

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -50,7 +50,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
     : scope_(scope), stats_(generateStats(scope)), time_source_(time_source),
       tls_max_version_(config.maxProtocolVersion()) {
   const auto tls_certificates = config.tlsCertificates();
-  tls_contexts_.resize(std::max(1UL, tls_certificates.size()));
+  tls_contexts_.resize(std::max(1U, tls_certificates.size()));
 
   for (auto& ctx : tls_contexts_) {
     ctx.ssl_ctx_.reset(SSL_CTX_new(TLS_method()));

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -50,7 +50,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
     : scope_(scope), stats_(generateStats(scope)), time_source_(time_source),
       tls_max_version_(config.maxProtocolVersion()) {
   const auto tls_certificates = config.tlsCertificates();
-  tls_contexts_.resize(std::max(1U, tls_certificates.size()));
+  tls_contexts_.resize(std::max(static_cast<size_t>(1), tls_certificates.size()));
 
   for (auto& ctx : tls_contexts_) {
     ctx.ssl_ctx_.reset(SSL_CTX_new(TLS_method()));
@@ -767,13 +767,13 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
     }
 
     if (!parsed_alpn_protocols_.empty()) {
-      SSL_CTX_set_alpn_select_cb(
-          ctx.ssl_ctx_.get(),
-          [](SSL*, const unsigned char** out, unsigned char* outlen, const unsigned char* in,
-             unsigned int inlen, void* arg) -> int {
-            return static_cast<ServerContextImpl*>(arg)->alpnSelectCallback(out, outlen, in, inlen);
-          },
-          this);
+      SSL_CTX_set_alpn_select_cb(ctx.ssl_ctx_.get(),
+                                 [](SSL*, const unsigned char** out, unsigned char* outlen,
+                                    const unsigned char* in, unsigned int inlen, void* arg) -> int {
+                                   return static_cast<ServerContextImpl*>(arg)->alpnSelectCallback(
+                                       out, outlen, in, inlen);
+                                 },
+                                 this);
     }
 
     if (!session_ticket_keys_.empty()) {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -196,6 +196,8 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     external_deps = ["tclap"],
+    # TCLAP command line parser needs this to support int64_t/uint64_t in several build environments.
+    copts = ["-DHAVE_LONG_LONG"],
     deps = [
         "//include/envoy/network:address_interface",
         "//include/envoy/server:options_interface",

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -195,9 +195,9 @@ envoy_cc_library(
         "//bazel:linux_aarch64": ["options_impl_platform_linux.h"],
         "//conditions:default": [],
     }),
-    external_deps = ["tclap"],
     # TCLAP command line parser needs this to support int64_t/uint64_t in several build environments.
     copts = ["-DHAVE_LONG_LONG"],
+    external_deps = ["tclap"],
     deps = [
         "//include/envoy/network:address_interface",
         "//include/envoy/server:options_interface",

--- a/test/tools/schema_validator/BUILD
+++ b/test/tools/schema_validator/BUILD
@@ -21,9 +21,9 @@ envoy_cc_test_library(
         "validator.cc",
         "validator.h",
     ],
-    external_deps = ["tclap"],
     # TCLAP command line parser needs this to support int64_t/uint64_t in several build environments.
     copts = ["-DHAVE_LONG_LONG"],
+    external_deps = ["tclap"],
     deps = [
         "//include/envoy/api:api_interface",
         "//source/common/protobuf:utility_lib",

--- a/test/tools/schema_validator/BUILD
+++ b/test/tools/schema_validator/BUILD
@@ -22,6 +22,8 @@ envoy_cc_test_library(
         "validator.h",
     ],
     external_deps = ["tclap"],
+    # TCLAP command line parser needs this to support int64_t/uint64_t in several build environments.
+    copts = ["-DHAVE_LONG_LONG"],
     deps = [
         "//include/envoy/api:api_interface",
         "//source/common/protobuf:utility_lib",


### PR DESCRIPTION
Description: there where some type problems when compiling Envoy with the default androidndk cpp toolchain version 19. This PR addresses those problems.
Risk Level: medium, some static typing to more concrete types takes place.
Testing: current test suite.
Docs Changes: n/a
Release Notes: n/a
