### PR TITLE
router: support secondary lookup without port if a port is in host/authority header

### DIFF
--- a/docs/root/configuration/http_conn_man/route_matching.rst
+++ b/docs/root/configuration/http_conn_man/route_matching.rst
@@ -11,4 +11,5 @@ When Envoy matches a route, it uses the following procedure:
    *in order*. If there is a match, the route is used and no further route checks are made.
 #. Independently, each :ref:`virtual cluster <envoy_api_msg_route.VirtualCluster>` in the
    virtual host is checked, *in order*. If there is a match, the virtual cluster is used and no
-   further virtual cluster checks are made.
+   further virtual cluster checks are made. If the *host* or *:authority* header contains a port, 
+   Envoy will first try to match with the full header value, and then it will try without the port.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -28,6 +28,7 @@ Version history
 * router: per try timeouts will no longer start before the downstream request has been received
   in full by the router. This ensures that the per try timeout does not account for slow
   downstreams and that will not start before the global timeout.
+* router: support secondary lookup without port if a port is in host/authority header
 * runtime: added support for statically :ref:`specifying the runtime in the bootstrap configuration
   <envoy_api_field_config.bootstrap.v2.Runtime.base>`.
 * server: ``--define manual_stamp=manual_stamp`` was added to allow server stamping outside of binary rules.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1059,6 +1059,16 @@ const VirtualHostImpl* RouteMatcher::findVirtualHost(const Http::HeaderMap& head
   if (iter != virtual_hosts_.end()) {
     return iter->second.get();
   }
+
+  // Try to match the host without the port appended
+  const std::string::size_type pos = host.find(":");
+  if (pos != std::string::npos) {
+    const auto& iter2 = virtual_hosts_.find(host.substr(0, pos));
+    if (iter2 != virtual_hosts_.end()) {
+      return iter2->second.get();
+    }
+  }
+
   if (!wildcard_virtual_host_suffixes_.empty()) {
     const VirtualHostImpl* vhost = findWildcardVirtualHost(
         host, wildcard_virtual_host_suffixes_,


### PR DESCRIPTION
**Description**: A naive attempt to add the behavior requested in #886. The router will try to match without the port suffix if it couldn't find a match with the original `host` or `:authority` header value. I'm inclined to put this behind configuration as it adds implicit behavior. 
**Risk Level**: High
**Testing**: Added 2 unit test cases.
**Docs Changes**: Added entry to [route_matching.rst](docs/root/configuration/http_conn_man/route_matching.rst)
**Release Notes**: Added entry to [version_history.rst](docs/root/intro/version_history.rst)
**Fixes**: #886 

_Disclaimer: Not familiar with C++_
Signed-off-by: Alexander Mays <amays@homeaway.com>

