### PR TITLE
http: removing the old accessor for sendLocalReply

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -284,18 +284,6 @@ public:
   virtual HeaderMap& addDecodedTrailers() PURE;
 
   /**
-   * A wrapper for legacy sendLocalReply replies without the details parameter.
-   * See sendLocalReply below for usage
-   */
-  // TODO(alyssawilk) send an email to envoy-dev for API change, add for all other filters, and
-  // delete this placeholder.
-  void sendLocalReply(Code response_code, absl::string_view body_text,
-                      std::function<void(HeaderMap& headers)> modify_headers,
-                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status) {
-    sendLocalReply(response_code, body_text, modify_headers, grpc_status, "");
-  }
-
-  /**
    * Create a locally generated response using the provided response_code and body_text parameters.
    * If the request was a gRPC request the local reply will be encoded as a gRPC response with a 200
    * HTTP response code and grpc-status and grpc-message headers mapped from the provided

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3293,7 +3293,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterHeadReply) {
   EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
         decoder_filters_[0]->callbacks_->sendLocalReply(Code::BadRequest, "Bad request", nullptr,
-                                                        absl::nullopt);
+                                                        absl::nullopt, "");
         return FilterHeadersStatus::Continue;
       }));
 


### PR DESCRIPTION
This makes response code details (or at least an empty string) required.

This will require folks with downstream filters to alter their sendLocalReply if they have not already.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #6542
