### PR TITLE
Redis: Fix remove prefix on keys

### DIFF
--- a/source/extensions/filters/network/redis_proxy/router.h
+++ b/source/extensions/filters/network/redis_proxy/router.h
@@ -41,6 +41,8 @@ typedef std::vector<MirrorPolicyConstSharedPtr> MirrorPolicies;
 
 /**
  * An resolved route that wraps an upstream connection pool and list of mirror policies
+ * Also provides a method to remove prefix from keys for this route, if remove_prefix is set on this
+ * route.
  */
 class Route {
 public:
@@ -49,6 +51,8 @@ public:
   virtual ConnPool::InstanceSharedPtr upstream() const PURE;
 
   virtual const MirrorPolicies& mirrorPolicies() const PURE;
+
+  virtual void removePrefix(std::string& key) const PURE;
 };
 
 typedef std::shared_ptr<Route> RouteSharedPtr;
@@ -62,11 +66,11 @@ public:
 
   /**
    * Returns a connection pool that matches a given route. When no match is found, the catch all
-   * pool is used. When remove prefix is set to true, the prefix will be removed from the key.
-   * @param key mutable reference to the key of the current command.
+   * pool is used.
+   * @param key key of the current command.
    * @return a handle to the connection pool.
    */
-  virtual RouteSharedPtr upstreamPool(std::string& key) PURE;
+  virtual RouteSharedPtr upstreamPool(const std::string& key) const PURE;
 };
 
 typedef std::unique_ptr<Router> RouterPtr;

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -42,6 +42,12 @@ Prefix::Prefix(
   }
 }
 
+void Prefix::removePrefix(std::string& key) const {
+  if (remove_prefix_) {
+    key.erase(0, prefix_.length());
+  }
+}
+
 PrefixRoutes::PrefixRoutes(
     const envoy::config::filter::network::redis_proxy::v2::RedisProxy::PrefixRoutes& config,
     Upstreams&& upstreams, Runtime::Loader& runtime)
@@ -65,7 +71,7 @@ PrefixRoutes::PrefixRoutes(
   }
 }
 
-RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
+RouteSharedPtr PrefixRoutes::upstreamPool(const std::string& key) const {
   PrefixSharedPtr value = nullptr;
   if (case_insensitive_) {
     std::string copy(key);
@@ -76,9 +82,6 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
   }
 
   if (value != nullptr) {
-    if (value->removePrefix()) {
-      key.erase(0, value->prefix().length());
-    }
     return value;
   }
 

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -52,7 +52,7 @@ public:
   ConnPool::InstanceSharedPtr upstream() const override { return upstream_; }
   const MirrorPolicies& mirrorPolicies() const override { return mirror_policies_; };
   const std::string& prefix() const { return prefix_; }
-  bool removePrefix() const { return remove_prefix_; }
+  void removePrefix(std::string& key) const override;
 
 private:
   const std::string prefix_;
@@ -69,7 +69,7 @@ public:
                    prefix_routes,
                Upstreams&& upstreams, Runtime::Loader& runtime);
 
-  RouteSharedPtr upstreamPool(std::string& key) override;
+  RouteSharedPtr upstreamPool(const std::string& key) const override;
 
 private:
   TrieLookupTable<PrefixSharedPtr> prefix_lookup_table_;

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -32,7 +32,7 @@ public:
 };
 
 class NullRouterImpl : public Router {
-  RouteSharedPtr upstreamPool(std::string&) override { return nullptr; }
+  RouteSharedPtr upstreamPool(const std::string&) const override { return nullptr; }
 };
 
 class CommandLookUpSpeedTest {

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -39,7 +39,7 @@ public:
   PassthruRouter(ConnPool::InstanceSharedPtr conn_pool)
       : route_(std::make_shared<testing::NiceMock<MockRoute>>(conn_pool)) {}
 
-  RouteSharedPtr upstreamPool(std::string&) override { return route_; }
+  RouteSharedPtr upstreamPool(const std::string&) const override { return route_; }
 
 private:
   RouteSharedPtr route_;

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -24,7 +24,7 @@ public:
   MockRouter();
   ~MockRouter();
 
-  MOCK_METHOD1(upstreamPool, RouteSharedPtr(std::string& key));
+  MOCK_CONST_METHOD1(upstreamPool, RouteSharedPtr(const std::string& key));
 };
 
 class MockRoute : public Route {
@@ -34,6 +34,7 @@ public:
 
   MOCK_CONST_METHOD0(upstream, ConnPool::InstanceSharedPtr());
   MOCK_CONST_METHOD0(mirrorPolicies, const MirrorPolicies&());
+  MOCK_CONST_METHOD1(removePrefix, void(std::string& key));
 
 private:
   ConnPool::InstanceSharedPtr conn_pool_;

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -838,7 +838,8 @@ TEST_P(RedisProxyWithRoutesIntegrationTest, SimpleRequestAndResponseRoutedByPref
                             "$3\r\nbar\r\n");
 
   // roundtrip to cluster_2 (prefix "baz:" route)
-  simpleRoundtripToUpstream(fake_upstreams_[4], makeBulkStringArray({"get", "baz:123"}),
+  simpleRoundtripToUpstream(fake_upstreams_[4],
+                            makeBulkStringArray({"eval", "script", "1", "baz:123", "baz:456"}),
                             "$3\r\nbar\r\n");
 }
 

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -127,7 +127,9 @@ TEST(PrefixRoutesTest, RemovePrefix) {
   PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_);
 
   std::string key("abc:bar");
-  EXPECT_EQ(upstream_a, router.upstreamPool(key)->upstream());
+  RouteSharedPtr route = router.upstreamPool(key);
+  EXPECT_EQ(upstream_a, route->upstream());
+  route->removePrefix(key);
   EXPECT_EQ(":bar", key);
 }
 


### PR DESCRIPTION
Description: 
- remove prefix only stripped the first key sent to envoy
- this worked for most commands because they are single key and the multi key commands
  were split and routed individually
- this did not work for eval style commands which sends multiple keys to the same upstream
- fix by overloading Router.upstreamPool() to also take a vector of keys
- this also changes the signature to use RespValue arguments instead of std::strings
  so that the command is forwarded correctly after stripping the inputRequest. I think
  it also makes it semantically clearer that the inputRequest is going to be modified.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A?
Release Notes: N/A?

Signed-off-by: Vivian Mathews <vivian.mathews@shopify.com>

