### PR TITLE
Add upstream bazel CI configuration

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,8 @@
+---
+tasks:
+  ubuntu_1804:
+    platform: ubuntu1804
+    build_targets:
+      - "//source/..."
+    test_targets:
+      - "//test/..."


### PR DESCRIPTION
This will allow bazel CI changes to be tested against envoy so we can
catch incompatible change issues sooner.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>

Risk Level: None