### PR TITLE
load balancer: Add benchmark for round robin LB

### DIFF
--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -25,7 +25,7 @@ public:
     uint32_t max_host_weight = 1;
     for (uint64_t i = 0; i < num_hosts; i++) {
       const bool should_weight = i < num_hosts * (weighted_subset_percent / 100.0);
-      uint32_t host_weight = should_weight ? weight : 1;
+      const uint32_t host_weight = should_weight ? weight : 1;
       hosts.push_back(
           makeTestHost(info_, fmt::format("tcp://10.0.{}.{}:6379", i / 256, i % 256), host_weight));
       max_host_weight = std::max(host_weight, max_host_weight);


### PR DESCRIPTION
Add benchmark for round robin LB and fix existing load balancer benchmarks to exclude time spent in test framework and LoadBalancer destructors

Signed-off-by: Antonio Vicente <avd@google.com>

Description:

Add benchmarks for weighted and unweighted round robin LoadBalancer creation and calls to chooseHost.  Also, exclude benchmark setup/teardown overhead from benchmark timings in order to better capture the differences in create/chooseHost performance for RoundRobin, RingHash and Maglev load balancers.

Risk Level: Low
Testing: Manual run of load_balancer_benchmark in opt mode.  Existing tests pass.
Docs Changes: N/A
Release Notes: N/A
Part of: Issue #2874