### PR TITLE
envoy_build_system: remove unused build macro

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -603,11 +603,6 @@ def envoy_sh_test(
         **kargs
     )
 
-def _proto_header(proto_path):
-    if proto_path.endswith(".proto"):
-        return proto_path[:-5] + "pb.h"
-    return None
-
 # Envoy proto targets should be specified with this function.
 def envoy_proto_library(name, external_deps = [], **kwargs):
     external_proto_deps = []


### PR DESCRIPTION
Signed-off-by: Frank Fort <ffort@google.com>

Description: This build macro is private (`_`) and unused in `envoy_build_system.bzl`.
Risk Level: Low
Testing: Ran `bazel test //test/common/... //test/exe/...`
Docs Changes: N/A
Release Notes: N/A