### PR TITLE
health check: fix additional regression from #6765

### DIFF
--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -111,7 +111,6 @@ private:
     ConnectionCallbackImpl connection_callback_impl_{*this};
     HttpHealthCheckerImpl& parent_;
     Http::CodecClientPtr client_;
-    Http::StreamEncoder* request_encoder_{};
     Http::HeaderMapPtr response_headers_;
     const std::string& hostname_;
     const Http::Protocol protocol_;

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -103,7 +103,8 @@ TEST_P(EdsIntegrationTest, RemoveAfterHcFail) {
 
   // Fail HC and verify the host is gone.
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
+  upstream_request_->encodeHeaders(
+      Http::TestHeaderMapImpl{{":status", "503"}, {"connection", "close"}}, true);
   test_server_->waitForGaugeEq("cluster.cluster_0.membership_healthy", 0);
   EXPECT_EQ(0, test_server_->gauge("cluster.cluster_0.membership_total")->value());
 }


### PR DESCRIPTION
If we inline delete a host during a failure callback we need to
account for the connection being cleaned up prior to handling
'connection: close' headers.

Risk Level: Low
Testing: New UT and modified integration test
Docs Changes: N/A
Release Notes: N/A
