### PR TITLE
Fix conflicting hot restart select on macOS

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -105,6 +105,15 @@ config_setting(
     values = {"define": "hot_restart=disabled"},
 )
 
+# Used to avoid conflicting selects https://github.com/bazelbuild/bazel/issues/8323
+alias(
+    name = "disable_hot_restart_or_apple",
+    actual = select({
+        ":apple": ":apple",
+        "//conditions:default": ":disable_hot_restart",
+    }),
+)
+
 config_setting(
     name = "disable_google_grpc",
     values = {"define": "google_grpc=disabled"},

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -655,8 +655,7 @@ def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
 # Selects the given values if hot restart is enabled in the current build.
 def envoy_select_hot_restart(xs, repository = ""):
     return select({
-        repository + "//bazel:disable_hot_restart": [],
-        repository + "//bazel:apple": [],
+        repository + "//bazel:disable_hot_restart_or_apple": [],
         "//conditions:default": xs,
     })
 


### PR DESCRIPTION
Previously when targeting Apple platforms and also passing
`--define=hot_restart=disabled` bazel would error because multiple
conditions in the select statement matched. This introduces some
indirection to make sure that only 1 condition will match at a time.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>

Risk Level: Low