### PR TITLE
ext_authz: Make sure initiateCall only called once

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -31,6 +31,10 @@ void FilterConfigPerRoute::merge(const FilterConfigPerRoute& other) {
 }
 
 void Filter::initiateCall(const Http::HeaderMap& headers) {
+  if (filter_return_ == FilterReturn::StopDecoding) {
+    return;
+  }
+
   Router::RouteConstSharedPtr route = callbacks_->route();
   if (route == nullptr || route->routeEntry() == nullptr) {
     return;
@@ -98,11 +102,9 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance&, bool end_stream) {
   if (buffer_data_) {
     const bool buffer_is_full = isBufferFull();
     if (end_stream || buffer_is_full) {
-      if (filter_return_ != FilterReturn::StopDecoding) {
-        ENVOY_STREAM_LOG(debug, "ext_authz filter finished buffering the request since {}",
-                         *callbacks_, buffer_is_full ? "buffer is full" : "stream is ended");
-        initiateCall(*request_headers_);
-      }
+      ENVOY_STREAM_LOG(debug, "ext_authz filter finished buffering the request since {}",
+                       *callbacks_, buffer_is_full ? "buffer is full" : "stream is ended");
+      initiateCall(*request_headers_);
       return filter_return_ == FilterReturn::StopDecoding
                  ? Http::FilterDataStatus::StopIterationAndWatermark
                  : Http::FilterDataStatus::Continue;

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -329,6 +329,10 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
 
   data_.add("barfoo");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+
+  data_.add("more data after watermark is set is possible");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_headers_));
 }
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -328,7 +328,7 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
 
   data_.add("barfoo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
 
   data_.add("more data after watermark is set is possible");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));


### PR DESCRIPTION
Description: 
After watermarked, it is possible that `decodeData` will be called
again. Hence, check if we have finished decoding and do `initiateCall`
only once.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Fixes #6787

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
