### PR TITLE
build: add missing conditions for linux/ppc

### DIFF
--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -25,11 +25,13 @@ envoy_cc_library(
     srcs = ["os_sys_calls_impl.cc"] + select({
         "//bazel:linux_x86_64": ["os_sys_calls_impl_linux.cc"],
         "//bazel:linux_aarch64": ["os_sys_calls_impl_linux.cc"],
+        "//bazel:linux_ppc": ["os_sys_calls_impl_linux.cc"],
         "//conditions:default": [],
     }) + envoy_select_hot_restart(["os_sys_calls_impl_hot_restart.cc"]),
     hdrs = ["os_sys_calls_impl.h"] + select({
         "//bazel:linux_x86_64": ["os_sys_calls_impl_linux.h"],
         "//bazel:linux_aarch64": ["os_sys_calls_impl_linux.h"],
+        "//bazel:linux_ppc": ["os_sys_calls_impl_linux.h"],
         "//conditions:default": [],
     }) + envoy_select_hot_restart(["os_sys_calls_impl_hot_restart.h"]),
     deps = [

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -185,6 +185,7 @@ envoy_cc_library(
     srcs = ["options_impl.cc"] + select({
         "//bazel:linux_x86_64": ["options_impl_platform_linux.cc"],
         "//bazel:linux_aarch64": ["options_impl_platform_linux.cc"],
+        "//bazel:linux_ppc": ["options_impl_platform_linux.cc"],
         "//conditions:default": ["options_impl_platform_default.cc"],
     }),
     hdrs = [
@@ -193,6 +194,7 @@ envoy_cc_library(
     ] + select({
         "//bazel:linux_x86_64": ["options_impl_platform_linux.h"],
         "//bazel:linux_aarch64": ["options_impl_platform_linux.h"],
+        "//bazel:linux_ppc": ["options_impl_platform_linux.h"],
         "//conditions:default": [],
     }),
     # TCLAP command line parser needs this to support int64_t/uint64_t in several build environments.


### PR DESCRIPTION
Use the Linux platform API implementations for PPC on Linux builds.

Risk Level: Low
Testing: ran tests for PPC with internal Bazel fork that supports them
Docs Changes: none
Release Notes: n/a