### PR TITLE
test: fixing a deadlock in simtime

### DIFF
--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -52,7 +52,8 @@ class SimulatedTimeSystemHelper::Alarm : public Timer {
 public:
   Alarm(SimulatedTimeSystemHelper& time_system, Scheduler& base_scheduler, TimerCb cb)
       : base_timer_(base_scheduler.createTimer([this, cb] { runAlarm(cb); })),
-        time_system_(time_system), index_(time_system.nextIndex()), armed_(false) {}
+        time_system_(time_system), index_(time_system.nextIndex()), armed_(false), pending_(false) {
+  }
 
   virtual ~Alarm();
 
@@ -77,6 +78,10 @@ public:
   void activateLockHeld() EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
     ASSERT(armed_);
     armed_ = false;
+    if (pending_) {
+      return;
+    }
+    pending_ = true;
     time_system_.incPending();
 
     // We don't want to activate the alarm under lock, as it will make a
@@ -101,6 +106,10 @@ private:
   friend SimulatedTimeSystemHelper::CompareAlarms;
 
   void runAlarm(TimerCb cb) {
+    {
+      Thread::LockGuard lock(time_system_.mutex_);
+      pending_ = false;
+    }
     // Capture time_system_ in a local in case the alarm gets deleted in the callback.
     SimulatedTimeSystemHelper& time_system = time_system_;
     cb();
@@ -112,6 +121,7 @@ private:
   MonotonicTime time_ GUARDED_BY(time_system_.mutex_);
   const uint64_t index_;
   bool armed_ GUARDED_BY(time_system_.mutex_);
+  bool pending_ GUARDED_BY(time_system_.mutex_);
 };
 
 // Compare two alarms, based on wakeup time and insertion order. Returns true if

--- a/test/test_common/simulated_time_system_test.cc
+++ b/test/test_common/simulated_time_system_test.cc
@@ -197,6 +197,7 @@ TEST_F(SimulatedTimeSystemTest, DeleteTime) {
   EXPECT_EQ("36", output_);
 }
 
+// Regression test for issues documented in https://github.com/envoyproxy/envoy/pull/6956
 TEST_F(SimulatedTimeSystemTest, DuplicateTimer) {
   // Set one alarm two times to test that pending does not get duplicated..
   std::chrono::milliseconds delay(0);

--- a/test/test_common/simulated_time_system_test.cc
+++ b/test/test_common/simulated_time_system_test.cc
@@ -201,7 +201,7 @@ TEST_F(SimulatedTimeSystemTest, DeleteTime) {
 TEST_F(SimulatedTimeSystemTest, DuplicateTimer) {
   // Set one alarm two times to test that pending does not get duplicated..
   std::chrono::milliseconds delay(0);
-  TimerPtr zero_timer = scheduler_->createTimer([this, delay]() { output_.append(1, '2'); });
+  TimerPtr zero_timer = scheduler_->createTimer([this]() { output_.append(1, '2'); });
   zero_timer->enableTimer(delay);
   zero_timer->enableTimer(delay);
   sleepMsAndLoop(1);

--- a/test/test_common/simulated_time_system_test.cc
+++ b/test/test_common/simulated_time_system_test.cc
@@ -197,6 +197,41 @@ TEST_F(SimulatedTimeSystemTest, DeleteTime) {
   EXPECT_EQ("36", output_);
 }
 
+TEST_F(SimulatedTimeSystemTest, DuplicateTimer) {
+  // Set one alarm two times to test that pending does not get duplicated..
+  std::chrono::milliseconds delay(0);
+  TimerPtr zero_timer = scheduler_->createTimer([this, delay]() { output_.append(1, '2'); });
+  zero_timer->enableTimer(delay);
+  zero_timer->enableTimer(delay);
+  sleepMsAndLoop(1);
+  EXPECT_EQ("2", output_);
+
+  // Now set an alarm which requires 10ms of progress and make sure waitFor works.
+  std::atomic<bool> done(false);
+  auto thread = Thread::threadFactoryForTest().createThread([this, &done]() {
+    while (!done) {
+      base_scheduler_.run(Dispatcher::RunType::Block);
+    }
+  });
+  Thread::CondVar condvar;
+  Thread::MutexBasicLockable mutex;
+  TimerPtr timer = scheduler_->createTimer([&condvar, &mutex, &done]() {
+    Thread::LockGuard lock(mutex);
+    done = true;
+    condvar.notifyOne();
+  });
+  timer->enableTimer(std::chrono::seconds(10));
+
+  {
+    Thread::LockGuard lock(mutex);
+    EXPECT_EQ(Thread::CondVar::WaitStatus::NoTimeout,
+              time_system_.waitFor(mutex, condvar, std::chrono::seconds(10)));
+  }
+  EXPECT_TRUE(done);
+
+  thread->join();
+}
+
 } // namespace
 } // namespace Test
 } // namespace Event


### PR DESCRIPTION
If in one event loop, two things tried to post to a dispatcher, the dispatcher would (multiple times) set a 0 ms timer.  For both instances, simtime would see the duration was 0, call activateLockHeld, increment pending alarms and set the base alarm to fire.
The base alarm would only fire once though, so the pending alarms would decrement once, pending would be true for ever and the whole system would "deadlock" waiting for pending to decrease to 0.

The symptom was the fault filter alarm being set to 200ms in #6933 but because of the extra dispatcher post triggering this deadlock the test would spin forever.

Risk Level: low (test only)
Testing: new unit test, verified fault filter test now works in the LDS PR
Docs Changes: n/a
Release Notes: n/a