### PR TITLE
http: fixing more absl::optional bugs in route cache

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -718,7 +718,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // TODO if there are no filters when starting a filter iteration, the connection manager
   // should return 404. The current returns no response if there is no router filter.
-  if (protocol == Protocol::Http11 && cached_route_.value()) {
+  if (protocol == Protocol::Http11 && hasCachedRoute()) {
     if (upgrade_rejected) {
       // Do not allow upgrades if the route does not support it.
       connection_manager_.stats_.named_.downstream_rq_ws_on_non_ws_route_.inc();
@@ -730,7 +730,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     // Allow non websocket requests to go through websocket enabled routes.
   }
 
-  if (cached_route_.value()) {
+  if (hasCachedRoute()) {
     const Router::RouteEntry* route_entry = cached_route_.value()->routeEntry();
     if (route_entry != nullptr && route_entry->idleTimeout()) {
       idle_timeout_ms_ = route_entry->idleTimeout().value();
@@ -778,7 +778,7 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
   // be broken in the case a filter changes the route.
 
   // If a decorator has been defined, apply it to the active span.
-  if (cached_route_.value() && cached_route_.value()->decorator()) {
+  if (hasCachedRoute() && cached_route_.value()->decorator()) {
     cached_route_.value()->decorator()->apply(*active_span_);
 
     // Cache decorated operation.
@@ -1607,7 +1607,7 @@ bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
 
     // We must check if the 'cached_route_' optional is populated since this function can be called
     // early via sendLocalReply(), before the cached route is populated.
-    if (cached_route_.has_value() && cached_route_.value() && cached_route_.value()->routeEntry()) {
+    if (hasCachedRoute() && cached_route_.value()->routeEntry()) {
       upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
     }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -487,6 +487,8 @@ private:
     // Per-stream request timeout callback
     void onRequestTimeout();
 
+    bool hasCachedRoute() { return cached_route_.has_value() && cached_route_.value(); }
+
     ConnectionManagerImpl& connection_manager_;
     Router::ConfigConstSharedPtr snapped_route_config_;
     Tracing::SpanPtr active_span_;

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -421,6 +421,7 @@ envoy_cc_test(
         "//source/extensions/filters/http/dynamo:config",
         "//source/extensions/filters/http/grpc_http1_bridge:config",
         "//source/extensions/filters/http/health_check:config",
+        "//test/integration/filters:clear_route_cache_filter_lib",
         "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",
     ],

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -23,6 +23,20 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test_library(
+    name = "clear_route_cache_filter_lib",
+    srcs = [
+        "clear_route_cache_filter.cc",
+    ],
+    deps = [
+        ":common_lib",
+        "//include/envoy/http:filter_interface",
+        "//include/envoy/registry",
+        "//include/envoy/server:filter_config_interface",
+        "//source/extensions/filters/http/common:empty_http_filter_config_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+envoy_cc_test_library(
     name = "modify_buffer_filter_config_lib",
     srcs = [
         "modify_buffer_filter.cc",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test_library(
         "//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )
+
 envoy_cc_test_library(
     name = "modify_buffer_filter_config_lib",
     srcs = [

--- a/test/integration/filters/clear_route_cache_filter.cc
+++ b/test/integration/filters/clear_route_cache_filter.cc
@@ -1,0 +1,37 @@
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "extensions/filters/http/common/empty_http_filter_config.h"
+#include "extensions/filters/http/common/pass_through_filter.h"
+
+namespace Envoy {
+
+// A test filter that clears the route cache on creation
+class ClearRouteCacheFilter : public Http::PassThroughFilter {
+public:
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
+    callbacks.clearRouteCache();
+    Http::PassThroughFilter::setDecoderFilterCallbacks(callbacks);
+  }
+};
+
+class ClearRouteCacheFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpFilterConfig {
+public:
+  ClearRouteCacheFilterConfig() : EmptyHttpFilterConfig("clear-route-cache") {}
+
+  Http::FilterFactoryCb createFilter(const std::string&, Server::Configuration::FactoryContext&) {
+    return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamFilter(std::make_shared<::Envoy::ClearRouteCacheFilter>());
+    };
+  }
+};
+
+// perform static registration
+static Registry::RegisterFactory<ClearRouteCacheFilterConfig,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+
+} // namespace Envoy

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -754,6 +754,14 @@ TEST_P(IntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
             1);
 }
 
+// Test that if the route cache is cleared, it doesn't cause problems.
+TEST_P(IntegrationTest, TestClearingRouteCacheFilter) {
+  config_helper_.addFilter("{ name: clear-route-cache, config: {} }");
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+}
+
 // Test that if no connection pools are free, Envoy fails to establish an upstream connection.
 TEST_P(IntegrationTest, NoConnectionPoolsFree) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {


### PR DESCRIPTION
belated follow-up to #5274, adding an integration test for cleared route cache and fixing various other bugs where the absl::optional was not correctly checked.  Hopefully between hasCachedRoute and the integration test this will be more future-proof.

Risk Level: Low 
Testing: new integration test
Docs Changes: n/a
Release Notes: n/a
