### PR TITLE
Remove native from BUILD files

### DIFF
--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -154,7 +154,7 @@ envoy_directory_genrule(
 filegroup(
     name = "route_corpus",
     testonly = 1,
-    srcs = [":corpus_from_config_impl"] + native.glob(["route_corpus/**"]),
+    srcs = [":corpus_from_config_impl"] + glob(["route_corpus/**"]),
 )
 
 envoy_cc_fuzz_test(


### PR DESCRIPTION
Description: The "native" module will be removed from BUILD files, all the methods it contains are available as global symbols.
Risk Level: no (no-op change)
Testing: CI
