### PR TITLE
envoy_build_system: refactor main bzl file into separate smaller files

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -1,3 +1,4 @@
+# Envoy binary targets
 load(
     ":envoy_internal.bzl",
     "envoy_copts",

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -1,8 +1,10 @@
-load(":envoy_internal.bzl",
-	"envoy_copts",
-	"envoy_external_dep_path",
-	"envoy_static_link_libstdcpp_linkopts",
-	"tcmalloc_external_dep")
+load(
+    ":envoy_internal.bzl",
+    "envoy_copts",
+    "envoy_external_dep_path",
+    "envoy_static_link_libstdcpp_linkopts",
+    "tcmalloc_external_dep",
+)
 
 # Envoy C++ binary targets should be specified with this function.
 def envoy_cc_binary(

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -8,7 +8,6 @@ load(
     "tcmalloc_external_dep",
 )
 
-
 # Envoy C++ binary targets should be specified with this function.
 def envoy_cc_binary(
         name,
@@ -41,14 +40,12 @@ def envoy_cc_binary(
         deps = deps,
     )
 
-
 # Select the given values if exporting is enabled in the current build.
 def _envoy_select_exported_symbols(xs):
     return select({
         "@envoy//bazel:enable_exported_symbols": xs,
         "//conditions:default": [],
     })
-
 
 # Compute the final linkopts based on various options.
 def _envoy_linkopts():
@@ -73,7 +70,6 @@ def _envoy_linkopts():
            }) + envoy_static_link_libstdcpp_linkopts() + \
            _envoy_select_exported_symbols(["-Wl,-E"])
 
-
 def _envoy_stamped_deps():
     return select({
         "@envoy//bazel:apple": [
@@ -83,7 +79,6 @@ def _envoy_stamped_deps():
             "@envoy//bazel:gnu_build_id.ldscript",
         ],
     })
-
 
 def _envoy_stamped_linkopts():
     return select({

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -1,0 +1,98 @@
+load(":envoy_internal.bzl",
+	"envoy_copts",
+	"envoy_external_dep_path",
+	"envoy_static_link_libstdcpp_linkopts",
+	"tcmalloc_external_dep")
+
+# Envoy C++ binary targets should be specified with this function.
+def envoy_cc_binary(
+        name,
+        srcs = [],
+        data = [],
+        testonly = 0,
+        visibility = None,
+        external_deps = [],
+        repository = "",
+        stamped = False,
+        deps = [],
+        linkopts = []):
+    if not linkopts:
+        linkopts = _envoy_linkopts()
+    if stamped:
+        linkopts = linkopts + _envoy_stamped_linkopts()
+        deps = deps + _envoy_stamped_deps()
+    deps = deps + [envoy_external_dep_path(dep) for dep in external_deps]
+    native.cc_binary(
+        name = name,
+        srcs = srcs,
+        data = data,
+        copts = envoy_copts(repository),
+        linkopts = linkopts,
+        testonly = testonly,
+        linkstatic = 1,
+        visibility = visibility,
+        malloc = tcmalloc_external_dep(repository),
+        stamp = 1,
+        deps = deps,
+    )
+
+# Select the given values if exporting is enabled in the current build.
+def _envoy_select_exported_symbols(xs):
+    return select({
+        "@envoy//bazel:enable_exported_symbols": xs,
+        "//conditions:default": [],
+    })
+
+# Compute the final linkopts based on various options.
+def _envoy_linkopts():
+    return select({
+               # The macOS system library transitively links common libraries (e.g., pthread).
+               "@envoy//bazel:apple": [
+                   # See note here: https://luajit.org/install.html
+                   "-pagezero_size 10000",
+                   "-image_base 100000000",
+               ],
+               "@envoy//bazel:windows_x86_64": [
+                   "-DEFAULTLIB:advapi32.lib",
+                   "-DEFAULTLIB:ws2_32.lib",
+                   "-WX",
+               ],
+               "//conditions:default": [
+                   "-pthread",
+                   "-lrt",
+                   "-ldl",
+                   "-Wl,--hash-style=gnu",
+               ],
+           }) + envoy_static_link_libstdcpp_linkopts() + \
+           _envoy_select_exported_symbols(["-Wl,-E"])
+
+def _envoy_stamped_deps():
+    return select({
+        "@envoy//bazel:apple": [
+            "@envoy//bazel:raw_build_id.ldscript",
+        ],
+        "//conditions:default": [
+            "@envoy//bazel:gnu_build_id.ldscript",
+        ],
+    })
+
+def _envoy_stamped_linkopts():
+    return select({
+        # Coverage builds in CI are failing to link when setting a build ID.
+        #
+        # /usr/bin/ld.gold: internal error in write_build_id, at ../../gold/layout.cc:5419
+        "@envoy//bazel:coverage_build": [],
+        "@envoy//bazel:windows_x86_64": [],
+
+        # macOS doesn't have an official equivalent to the `.note.gnu.build-id`
+        # ELF section, so just stuff the raw ID into a new text section.
+        "@envoy//bazel:apple": [
+            "-sectcreate __TEXT __build_id",
+            "$(location @envoy//bazel:raw_build_id.ldscript)",
+        ],
+
+        # Note: assumes GNU GCC (or compatible) handling of `--build-id` flag.
+        "//conditions:default": [
+            "-Wl,@$(location @envoy//bazel:gnu_build_id.ldscript)",
+        ],
+    })

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -1,3 +1,4 @@
+# DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy binary targets
 load(
     ":envoy_internal.bzl",
@@ -6,6 +7,7 @@ load(
     "envoy_static_link_libstdcpp_linkopts",
     "tcmalloc_external_dep",
 )
+
 
 # Envoy C++ binary targets should be specified with this function.
 def envoy_cc_binary(
@@ -39,12 +41,14 @@ def envoy_cc_binary(
         deps = deps,
     )
 
+
 # Select the given values if exporting is enabled in the current build.
 def _envoy_select_exported_symbols(xs):
     return select({
         "@envoy//bazel:enable_exported_symbols": xs,
         "//conditions:default": [],
     })
+
 
 # Compute the final linkopts based on various options.
 def _envoy_linkopts():
@@ -69,6 +73,7 @@ def _envoy_linkopts():
            }) + envoy_static_link_libstdcpp_linkopts() + \
            _envoy_select_exported_symbols(["-Wl,-E"])
 
+
 def _envoy_stamped_deps():
     return select({
         "@envoy//bazel:apple": [
@@ -78,6 +83,7 @@ def _envoy_stamped_deps():
             "@envoy//bazel:gnu_build_id.ldscript",
         ],
     })
+
 
 def _envoy_stamped_linkopts():
     return select({

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,24 +1,30 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load(":envoy_binary.bzl", _envoy_cc_binary = "envoy_cc_binary")
 load(":envoy_internal.bzl", "envoy_external_dep_path")
-load(":envoy_library.bzl",
+load(
+    ":envoy_library.bzl",
     _envoy_basic_cc_library = "envoy_basic_cc_library",
     _envoy_cc_library = "envoy_cc_library",
     _envoy_cc_posix_library = "envoy_cc_posix_library",
     _envoy_cc_win32_library = "envoy_cc_win32_library",
     _envoy_include_prefix = "envoy_include_prefix",
-    _envoy_proto_library = "envoy_proto_library")
-load(":envoy_select.bzl", 
+    _envoy_proto_library = "envoy_proto_library",
+)
+load(
+    ":envoy_select.bzl",
+    _envoy_select_google_grpc = "envoy_select_google_grpc",
     _envoy_select_hot_restart = "envoy_select_hot_restart",
-    _envoy_select_google_grpc = "envoy_select_google_grpc")
-load(":envoy_test.bzl",
+)
+load(
+    ":envoy_test.bzl",
     _envoy_cc_fuzz_test = "envoy_cc_fuzz_test",
     _envoy_cc_mock = "envoy_cc_mock",
     _envoy_cc_test = "envoy_cc_test",
     _envoy_cc_test_binary = "envoy_cc_test_binary",
     _envoy_cc_test_library = "envoy_cc_test_library",
     _envoy_py_test_binary = "envoy_py_test_binary",
-    _envoy_sh_test = "envoy_sh_test")
+    _envoy_sh_test = "envoy_sh_test",
+)
 
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
@@ -153,7 +159,6 @@ def envoy_select_boringssl(if_fips, default = None):
         "@envoy//bazel:boringssl_fips": if_fips,
         "//conditions:default": default or [],
     })
-
 
 # Here we create wrappers for each of the public targets within the separate bazel
 # files loaded above. This is necessary so that consumers who had previously used

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,7 +1,24 @@
-load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load(":envoy_binary.bzl", _envoy_cc_binary = "envoy_cc_binary")
+load(":envoy_internal.bzl", "envoy_external_dep_path")
+load(":envoy_library.bzl",
+    _envoy_basic_cc_library = "envoy_basic_cc_library",
+    _envoy_cc_library = "envoy_cc_library",
+    _envoy_cc_posix_library = "envoy_cc_posix_library",
+    _envoy_cc_win32_library = "envoy_cc_win32_library",
+    _envoy_include_prefix = "envoy_include_prefix",
+    _envoy_proto_library = "envoy_proto_library")
+load(":envoy_select.bzl", 
+    _envoy_select_hot_restart = "envoy_select_hot_restart",
+    _envoy_select_google_grpc = "envoy_select_google_grpc")
+load(":envoy_test.bzl",
+    _envoy_cc_fuzz_test = "envoy_cc_fuzz_test",
+    _envoy_cc_mock = "envoy_cc_mock",
+    _envoy_cc_test = "envoy_cc_test",
+    _envoy_cc_test_binary = "envoy_cc_test_binary",
+    _envoy_cc_test_library = "envoy_cc_test_library",
+    _envoy_py_test_binary = "envoy_py_test_binary",
+    _envoy_sh_test = "envoy_sh_test")
 
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
@@ -27,180 +44,6 @@ envoy_directory_genrule = rule(
         "tools": attr.label_list(),
     },
 )
-
-# Compute the final copts based on various options.
-def _envoy_copts(repository, test = False):
-    posix_options = [
-        "-Wall",
-        "-Wextra",
-        "-Werror",
-        "-Wnon-virtual-dtor",
-        "-Woverloaded-virtual",
-        "-Wold-style-cast",
-        "-Wvla",
-        "-std=c++14",
-    ]
-
-    msvc_options = [
-        "-WX",
-        "-Zc:__cplusplus",
-        "-std:c++14",
-        "-DWIN32",
-        "-DWIN32_LEAN_AND_MEAN",
-        # need win8 for ntohll
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx
-        "-D_WIN32_WINNT=0x0602",
-        "-DNTDDI_VERSION=0x06020000",
-        "-DCARES_STATICLIB",
-        "-DNGHTTP2_STATICLIB",
-    ]
-
-    return select({
-               repository + "//bazel:windows_x86_64": msvc_options,
-               "//conditions:default": posix_options,
-           }) + select({
-               # Bazel adds an implicit -DNDEBUG for opt.
-               repository + "//bazel:opt_build": [] if test else ["-ggdb3"],
-               repository + "//bazel:fastbuild_build": [],
-               repository + "//bazel:dbg_build": ["-ggdb3"],
-               repository + "//bazel:windows_opt_build": [],
-               repository + "//bazel:windows_fastbuild_build": [],
-               repository + "//bazel:windows_dbg_build": [],
-           }) + select({
-               repository + "//bazel:disable_tcmalloc": ["-DABSL_MALLOC_HOOK_MMAP_DISABLE"],
-               "//conditions:default": ["-DTCMALLOC"],
-           }) + select({
-               repository + "//bazel:debug_tcmalloc": ["-DENVOY_MEMORY_DEBUG_ENABLED=1"],
-               "//conditions:default": [],
-           }) + select({
-               repository + "//bazel:disable_signal_trace": [],
-               "//conditions:default": ["-DENVOY_HANDLE_SIGNALS"],
-           }) + select({
-               repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
-               "//conditions:default": [],
-           }) + select({
-               # TCLAP command line parser needs this to support int64_t/uint64_t
-               repository + "//bazel:apple": ["-DHAVE_LONG_LONG"],
-               "//conditions:default": [],
-           }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
-           _envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
-           envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
-           _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
-
-def _envoy_linkstatic():
-    return select({
-        "@envoy//bazel:asan_build": 0,
-        "//conditions:default": 1,
-    })
-
-def _envoy_static_link_libstdcpp_linkopts():
-    return _envoy_select_force_libcpp(
-        # TODO(PiotrSikora): statically link libc++ once that's possible.
-        # See: https://reviews.llvm.org/D53238
-        ["-stdlib=libc++"],
-        ["-static-libstdc++", "-static-libgcc"],
-    )
-
-# Compute the final linkopts based on various options.
-def _envoy_linkopts():
-    return select({
-               # The macOS system library transitively links common libraries (e.g., pthread).
-               "@envoy//bazel:apple": [
-                   # See note here: https://luajit.org/install.html
-                   "-pagezero_size 10000",
-                   "-image_base 100000000",
-               ],
-               "@envoy//bazel:windows_x86_64": [
-                   "-DEFAULTLIB:advapi32.lib",
-                   "-DEFAULTLIB:ws2_32.lib",
-                   "-WX",
-               ],
-               "//conditions:default": [
-                   "-pthread",
-                   "-lrt",
-                   "-ldl",
-                   "-Wl,--hash-style=gnu",
-               ],
-           }) + _envoy_static_link_libstdcpp_linkopts() + \
-           _envoy_select_exported_symbols(["-Wl,-E"])
-
-def _envoy_stamped_linkopts():
-    return select({
-        # Coverage builds in CI are failing to link when setting a build ID.
-        #
-        # /usr/bin/ld.gold: internal error in write_build_id, at ../../gold/layout.cc:5419
-        "@envoy//bazel:coverage_build": [],
-        "@envoy//bazel:windows_x86_64": [],
-
-        # macOS doesn't have an official equivalent to the `.note.gnu.build-id`
-        # ELF section, so just stuff the raw ID into a new text section.
-        "@envoy//bazel:apple": [
-            "-sectcreate __TEXT __build_id",
-            "$(location @envoy//bazel:raw_build_id.ldscript)",
-        ],
-
-        # Note: assumes GNU GCC (or compatible) handling of `--build-id` flag.
-        "//conditions:default": [
-            "-Wl,@$(location @envoy//bazel:gnu_build_id.ldscript)",
-        ],
-    })
-
-def _envoy_stamped_deps():
-    return select({
-        "@envoy//bazel:apple": [
-            "@envoy//bazel:raw_build_id.ldscript",
-        ],
-        "//conditions:default": [
-            "@envoy//bazel:gnu_build_id.ldscript",
-        ],
-    })
-
-# Compute the test linkopts based on various options.
-def _envoy_test_linkopts():
-    return select({
-        "@envoy//bazel:apple": [
-            # See note here: https://luajit.org/install.html
-            "-pagezero_size 10000",
-            "-image_base 100000000",
-        ],
-        "@envoy//bazel:windows_x86_64": [
-            "-DEFAULTLIB:advapi32.lib",
-            "-DEFAULTLIB:ws2_32.lib",
-            "-WX",
-        ],
-
-        # TODO(mattklein123): It's not great that we universally link against the following libs.
-        # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
-        "//conditions:default": ["-pthread", "-lrt", "-ldl"],
-    }) + _envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
-
-# References to Envoy external dependencies should be wrapped with this function.
-def _envoy_external_dep_path(dep):
-    return "//external:%s" % dep
-
-# Dependencies on tcmalloc_and_profiler should be wrapped with this function.
-def _tcmalloc_external_dep(repository):
-    return select({
-        repository + "//bazel:disable_tcmalloc": None,
-        "//conditions:default": _envoy_external_dep_path("gperftools"),
-    })
-
-# As above, but wrapped in list form for adding to dep lists. This smell seems needed as
-# SelectorValue values have to match the attribute type. See
-# https://github.com/bazelbuild/bazel/issues/2273.
-def _tcmalloc_external_deps(repository):
-    return select({
-        repository + "//bazel:disable_tcmalloc": [],
-        "//conditions:default": [_envoy_external_dep_path("gperftools")],
-    })
-
-# Transform the package path (e.g. include/envoy/common) into a path for
-# exporting the package headers at (e.g. envoy/common). Source files can then
-# include using this path scheme (e.g. #include "envoy/common/time.h").
-def envoy_include_prefix(path):
-    if path.startswith("source/") or path.startswith("include/"):
-        return "/".join(path.split("/")[1:])
-    return None
 
 def _filter_windows_keys(cache_entries = {}):
     # On Windows, we don't want to explicitly set CMAKE_BUILD_TYPE,
@@ -261,13 +104,6 @@ def envoy_cmake_external(
         **kwargs
     )
 
-# Envoy C++ library targets that need no transformations or additional dependencies before being
-# passed to cc_library should be specified with this function. Note: this exists to ensure that
-# all envoy targets pass through an envoy-declared skylark function where they can be modified
-# before being passed to a native bazel function.
-def envoy_basic_cc_library(name, **kargs):
-    native.cc_library(name = name, **kargs)
-
 # Used to select a dependency that has different implementations on POSIX vs Windows.
 # The platform-specific implementations should be specified with envoy_cc_posix_library
 # and envoy_cc_win32_library respectively
@@ -276,359 +112,6 @@ def envoy_cc_platform_dep(name):
         "@envoy//bazel:windows_x86_64": [name + "_win32"],
         "//conditions:default": [name + "_posix"],
     })
-
-# Used to specify a library that only builds on POSIX
-def envoy_cc_posix_library(name, srcs = [], hdrs = [], **kargs):
-    envoy_cc_library(
-        name = name + "_posix",
-        srcs = select({
-            "@envoy//bazel:windows_x86_64": [],
-            "//conditions:default": srcs,
-        }),
-        hdrs = select({
-            "@envoy//bazel:windows_x86_64": [],
-            "//conditions:default": hdrs,
-        }),
-        **kargs
-    )
-
-# Used to specify a library that only builds on Windows
-def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
-    envoy_cc_library(
-        name = name + "_win32",
-        srcs = select({
-            "@envoy//bazel:windows_x86_64": srcs,
-            "//conditions:default": [],
-        }),
-        hdrs = select({
-            "@envoy//bazel:windows_x86_64": hdrs,
-            "//conditions:default": [],
-        }),
-        **kargs
-    )
-
-# Envoy C++ library targets should be specified with this function.
-def envoy_cc_library(
-        name,
-        srcs = [],
-        hdrs = [],
-        copts = [],
-        visibility = None,
-        external_deps = [],
-        tcmalloc_dep = None,
-        repository = "",
-        linkstamp = None,
-        tags = [],
-        deps = [],
-        strip_include_prefix = None):
-    if tcmalloc_dep:
-        deps += _tcmalloc_external_deps(repository)
-
-    native.cc_library(
-        name = name,
-        srcs = srcs,
-        hdrs = hdrs,
-        copts = _envoy_copts(repository) + copts,
-        visibility = visibility,
-        tags = tags,
-        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps] + [
-            repository + "//include/envoy/common:base_includes",
-            repository + "//source/common/common:fmt_lib",
-            _envoy_external_dep_path("abseil_flat_hash_map"),
-            _envoy_external_dep_path("abseil_flat_hash_set"),
-            _envoy_external_dep_path("abseil_strings"),
-            _envoy_external_dep_path("spdlog"),
-            _envoy_external_dep_path("fmtlib"),
-        ],
-        include_prefix = envoy_include_prefix(native.package_name()),
-        alwayslink = 1,
-        linkstatic = _envoy_linkstatic(),
-        linkstamp = select({
-            repository + "//bazel:windows_x86_64": None,
-            "//conditions:default": linkstamp,
-        }),
-        strip_include_prefix = strip_include_prefix,
-    )
-
-# Envoy C++ binary targets should be specified with this function.
-def envoy_cc_binary(
-        name,
-        srcs = [],
-        data = [],
-        testonly = 0,
-        visibility = None,
-        external_deps = [],
-        repository = "",
-        stamped = False,
-        deps = [],
-        linkopts = []):
-    if not linkopts:
-        linkopts = _envoy_linkopts()
-    if stamped:
-        linkopts = linkopts + _envoy_stamped_linkopts()
-        deps = deps + _envoy_stamped_deps()
-    deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps]
-    native.cc_binary(
-        name = name,
-        srcs = srcs,
-        data = data,
-        copts = _envoy_copts(repository),
-        linkopts = linkopts,
-        testonly = testonly,
-        linkstatic = 1,
-        visibility = visibility,
-        malloc = _tcmalloc_external_dep(repository),
-        stamp = 1,
-        deps = deps,
-    )
-
-# Envoy C++ fuzz test targes. These are not included in coverage runs.
-def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
-    if not (corpus.startswith("//") or corpus.startswith(":")):
-        corpus_name = name + "_corpus"
-        corpus = native.glob([corpus + "/**"])
-        native.filegroup(
-            name = corpus_name,
-            srcs = corpus,
-        )
-    else:
-        corpus_name = corpus
-    pkg_tar(
-        name = name + "_corpus_tar",
-        srcs = [corpus_name],
-        testonly = 1,
-    )
-    test_lib_name = name + "_lib"
-    envoy_cc_test_library(
-        name = test_lib_name,
-        deps = deps + ["//test/fuzz:fuzz_runner_lib"],
-        **kwargs
-    )
-    native.cc_test(
-        name = name,
-        copts = _envoy_copts("@envoy", test = True),
-        linkopts = _envoy_test_linkopts(),
-        linkstatic = 1,
-        args = ["$(locations %s)" % corpus_name],
-        data = [corpus_name],
-        # No fuzzing on macOS.
-        deps = select({
-            "@envoy//bazel:apple": ["//test:dummy_main"],
-            "//conditions:default": [
-                ":" + test_lib_name,
-                "//test/fuzz:main",
-            ],
-        }),
-        tags = tags,
-    )
-
-    # This target exists only for
-    # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield
-    # anything useful on its own, as it expects to be run in an environment where the linker options
-    # provide a path to FuzzingEngine.
-    native.cc_binary(
-        name = name + "_driverless",
-        copts = _envoy_copts("@envoy", test = True),
-        linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
-        linkstatic = 1,
-        testonly = 1,
-        deps = [":" + test_lib_name],
-        tags = ["manual"] + tags,
-    )
-
-# Envoy C++ test targets should be specified with this function.
-def envoy_cc_test(
-        name,
-        srcs = [],
-        data = [],
-        # List of pairs (Bazel shell script target, shell script args)
-        repository = "",
-        external_deps = [],
-        deps = [],
-        tags = [],
-        args = [],
-        copts = [],
-        shard_count = None,
-        coverage = True,
-        local = False,
-        size = "medium"):
-    test_lib_tags = []
-    if coverage:
-        test_lib_tags.append("coverage_test_lib")
-    _envoy_cc_test_infrastructure_library(
-        name = name + "_lib_internal_only",
-        srcs = srcs,
-        data = data,
-        external_deps = external_deps,
-        deps = deps + [repository + "//test/test_common:printers_includes"],
-        repository = repository,
-        tags = test_lib_tags,
-        copts = copts,
-        # Restrict only to the code coverage tools.
-        visibility = ["@envoy//test/coverage:__pkg__"],
-    )
-    native.cc_test(
-        name = name,
-        copts = _envoy_copts(repository, test = True) + copts,
-        linkopts = _envoy_test_linkopts(),
-        linkstatic = _envoy_linkstatic(),
-        malloc = _tcmalloc_external_dep(repository),
-        deps = [
-            ":" + name + "_lib_internal_only",
-            repository + "//test:main",
-        ],
-        # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51
-        # 2 - by default, mocks act as StrictMocks.
-        args = args + ["--gmock_default_mock_behavior=2"],
-        tags = tags + ["coverage_test"],
-        local = local,
-        shard_count = shard_count,
-        size = size,
-    )
-
-# Envoy C++ related test infrastructure (that want gtest, gmock, but may be
-# relied on by envoy_cc_test_library) should use this function.
-def _envoy_cc_test_infrastructure_library(
-        name,
-        srcs = [],
-        hdrs = [],
-        data = [],
-        external_deps = [],
-        deps = [],
-        repository = "",
-        tags = [],
-        include_prefix = None,
-        copts = [],
-        **kargs):
-    native.cc_library(
-        name = name,
-        srcs = srcs,
-        hdrs = hdrs,
-        data = data,
-        copts = _envoy_copts(repository, test = True) + copts,
-        testonly = 1,
-        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps] + [
-            _envoy_external_dep_path("googletest"),
-        ],
-        tags = tags,
-        include_prefix = include_prefix,
-        alwayslink = 1,
-        linkstatic = _envoy_linkstatic(),
-        **kargs
-    )
-
-# Envoy C++ test related libraries (that want gtest, gmock) should be specified
-# with this function.
-def envoy_cc_test_library(
-        name,
-        srcs = [],
-        hdrs = [],
-        data = [],
-        external_deps = [],
-        deps = [],
-        repository = "",
-        tags = [],
-        include_prefix = None,
-        copts = [],
-        **kargs):
-    deps = deps + [
-        repository + "//test/test_common:printers_includes",
-    ]
-    _envoy_cc_test_infrastructure_library(
-        name,
-        srcs,
-        hdrs,
-        data,
-        external_deps,
-        deps,
-        repository,
-        tags,
-        include_prefix,
-        copts,
-        visibility = ["//visibility:public"],
-        **kargs
-    )
-
-# Envoy test binaries should be specified with this function.
-def envoy_cc_test_binary(
-        name,
-        **kargs):
-    envoy_cc_binary(
-        name,
-        testonly = 1,
-        linkopts = _envoy_test_linkopts() + _envoy_static_link_libstdcpp_linkopts(),
-        **kargs
-    )
-
-# Envoy Python test binaries should be specified with this function.
-def envoy_py_test_binary(
-        name,
-        external_deps = [],
-        deps = [],
-        **kargs):
-    native.py_binary(
-        name = name,
-        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps],
-        **kargs
-    )
-
-# Envoy C++ mock targets should be specified with this function.
-def envoy_cc_mock(name, **kargs):
-    envoy_cc_test_library(name = name, **kargs)
-
-# Envoy shell tests that need to be included in coverage run should be specified with this function.
-def envoy_sh_test(
-        name,
-        srcs = [],
-        data = [],
-        coverage = True,
-        **kargs):
-    if coverage:
-        test_runner_cc = name + "_test_runner.cc"
-        native.genrule(
-            name = name + "_gen_test_runner",
-            srcs = srcs,
-            outs = [test_runner_cc],
-            cmd = "$(location //bazel:gen_sh_test_runner.sh) $(SRCS) >> $@",
-            tools = ["//bazel:gen_sh_test_runner.sh"],
-        )
-        envoy_cc_test_library(
-            name = name + "_lib",
-            srcs = [test_runner_cc],
-            data = srcs + data,
-            tags = ["coverage_test_lib"],
-            deps = ["//test/test_common:environment_lib"],
-        )
-    native.sh_test(
-        name = name,
-        srcs = ["//bazel:sh_test_wrapper.sh"],
-        data = srcs + data,
-        args = srcs,
-        **kargs
-    )
-
-def _proto_header(proto_path):
-    if proto_path.endswith(".proto"):
-        return proto_path[:-5] + "pb.h"
-    return None
-
-# Envoy proto targets should be specified with this function.
-def envoy_proto_library(name, external_deps = [], **kwargs):
-    external_proto_deps = []
-    external_cc_proto_deps = []
-    if "api_httpbody_protos" in external_deps:
-        external_cc_proto_deps.append("@googleapis//:api_httpbody_protos")
-        external_proto_deps.append("@googleapis//:api_httpbody_protos_proto")
-    api_proto_library(
-        name,
-        external_cc_proto_deps = external_cc_proto_deps,
-        external_proto_deps = external_proto_deps,
-        # Avoid generating .so, we don't need it, can interfere with builds
-        # such as OSS-Fuzz.
-        linkstatic = 1,
-        visibility = ["//visibility:public"],
-        **kwargs
-    )
 
 # Envoy proto descriptor targets should be specified with this function.
 # This is used for testing only.
@@ -661,55 +144,42 @@ def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
         tools = ["//external:protoc"],
     )
 
-# Selects the given values if hot restart is enabled in the current build.
-def envoy_select_hot_restart(xs, repository = ""):
-    return select({
-        repository + "//bazel:disable_hot_restart": [],
-        repository + "//bazel:apple": [],
-        "//conditions:default": xs,
-    })
-
-# Select the given values if default path normalization is on in the current build.
-def _envoy_select_path_normalization_by_default(xs, repository = ""):
-    return select({
-        repository + "//bazel:enable_path_normalization_by_default": xs,
-        "//conditions:default": [],
-    })
-
-def _envoy_select_perf_annotation(xs):
-    return select({
-        "@envoy//bazel:enable_perf_annotation": xs,
-        "//conditions:default": [],
-    })
-
-# Selects the given values if Google gRPC is enabled in the current build.
-def envoy_select_google_grpc(xs, repository = ""):
-    return select({
-        repository + "//bazel:disable_google_grpc": [],
-        "//conditions:default": xs,
-    })
-
 # Dependencies on Google grpc should be wrapped with this function.
 def envoy_google_grpc_external_deps():
-    return envoy_select_google_grpc([_envoy_external_dep_path("grpc")])
-
-# Select the given values if exporting is enabled in the current build.
-def _envoy_select_exported_symbols(xs):
-    return select({
-        "@envoy//bazel:enable_exported_symbols": xs,
-        "//conditions:default": [],
-    })
-
-def _envoy_select_force_libcpp(if_libcpp, default = None):
-    return select({
-        "@envoy//bazel:force_libcpp": if_libcpp,
-        "@envoy//bazel:apple": [],
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": default or [],
-    })
+    return envoy_select_google_grpc([envoy_external_dep_path("grpc")])
 
 def envoy_select_boringssl(if_fips, default = None):
     return select({
         "@envoy//bazel:boringssl_fips": if_fips,
         "//conditions:default": default or [],
     })
+
+
+# Here we create wrappers for each of the public targets within the separate bazel
+# files loaded above. This is necessary so that consumers who had previously used
+# macros imported from envoy_build_system.bzl don't have to change their BUILD
+# files to reference the new location.
+
+# Select wrappers (from envoy_build.bzl)
+envoy_select_hot_restart = _envoy_select_hot_restart
+envoy_select_google_grpc = _envoy_select_google_grpc
+
+# Binary wrappers (from envoy_binary.bzl)
+envoy_cc_binary = _envoy_cc_binary
+
+# Library wrappers (from envoy_library.bzl)
+envoy_basic_cc_library = _envoy_basic_cc_library
+envoy_cc_library = _envoy_cc_library
+envoy_cc_posix_library = _envoy_cc_posix_library
+envoy_cc_win32_library = _envoy_cc_win32_library
+envoy_include_prefix = _envoy_include_prefix
+envoy_proto_library = _envoy_proto_library
+
+# Test wrappers (from envoy_test.bzl)
+envoy_cc_fuzz_test = _envoy_cc_fuzz_test
+envoy_cc_mock = _envoy_cc_mock
+envoy_cc_test = _envoy_cc_test
+envoy_cc_test_binary = _envoy_cc_test_binary
+envoy_cc_test_library = _envoy_cc_test_library
+envoy_py_test_binary = _envoy_py_test_binary
+envoy_sh_test = _envoy_sh_test

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -29,7 +29,7 @@ envoy_directory_genrule = rule(
 )
 
 # Compute the final copts based on various options.
-def envoy_copts(repository, test = False):
+def _envoy_copts(repository, test = False):
     posix_options = [
         "-Wall",
         "-Wextra",
@@ -78,19 +78,23 @@ def envoy_copts(repository, test = False):
            }) + select({
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
                "//conditions:default": [],
+           }) + select({
+               # TCLAP command line parser needs this to support int64_t/uint64_t
+               repository + "//bazel:apple": ["-DHAVE_LONG_LONG"],
+               "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
-           envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
+           _envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
            envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
-           envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
+           _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
 
-def envoy_linkstatic():
+def _envoy_linkstatic():
     return select({
         "@envoy//bazel:asan_build": 0,
         "//conditions:default": 1,
     })
 
-def envoy_static_link_libstdcpp_linkopts():
-    return envoy_select_force_libcpp(
+def _envoy_static_link_libstdcpp_linkopts():
+    return _envoy_select_force_libcpp(
         # TODO(PiotrSikora): statically link libc++ once that's possible.
         # See: https://reviews.llvm.org/D53238
         ["-stdlib=libc++"],
@@ -98,7 +102,7 @@ def envoy_static_link_libstdcpp_linkopts():
     )
 
 # Compute the final linkopts based on various options.
-def envoy_linkopts():
+def _envoy_linkopts():
     return select({
                # The macOS system library transitively links common libraries (e.g., pthread).
                "@envoy//bazel:apple": [
@@ -117,8 +121,8 @@ def envoy_linkopts():
                    "-ldl",
                    "-Wl,--hash-style=gnu",
                ],
-           }) + envoy_static_link_libstdcpp_linkopts() + \
-           envoy_select_exported_symbols(["-Wl,-E"])
+           }) + _envoy_static_link_libstdcpp_linkopts() + \
+           _envoy_select_exported_symbols(["-Wl,-E"])
 
 def _envoy_stamped_linkopts():
     return select({
@@ -152,7 +156,7 @@ def _envoy_stamped_deps():
     })
 
 # Compute the test linkopts based on various options.
-def envoy_test_linkopts():
+def _envoy_test_linkopts():
     return select({
         "@envoy//bazel:apple": [
             # See note here: https://luajit.org/install.html
@@ -168,26 +172,26 @@ def envoy_test_linkopts():
         # TODO(mattklein123): It's not great that we universally link against the following libs.
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
-    }) + envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
+    }) + _envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
 
 # References to Envoy external dependencies should be wrapped with this function.
-def envoy_external_dep_path(dep):
+def _envoy_external_dep_path(dep):
     return "//external:%s" % dep
 
 # Dependencies on tcmalloc_and_profiler should be wrapped with this function.
-def tcmalloc_external_dep(repository):
+def _tcmalloc_external_dep(repository):
     return select({
         repository + "//bazel:disable_tcmalloc": None,
-        "//conditions:default": envoy_external_dep_path("gperftools"),
+        "//conditions:default": _envoy_external_dep_path("gperftools"),
     })
 
 # As above, but wrapped in list form for adding to dep lists. This smell seems needed as
 # SelectorValue values have to match the attribute type. See
 # https://github.com/bazelbuild/bazel/issues/2273.
-def tcmalloc_external_deps(repository):
+def _tcmalloc_external_deps(repository):
     return select({
         repository + "//bazel:disable_tcmalloc": [],
-        "//conditions:default": [envoy_external_dep_path("gperftools")],
+        "//conditions:default": [_envoy_external_dep_path("gperftools")],
     })
 
 # Transform the package path (e.g. include/envoy/common) into a path for
@@ -198,7 +202,7 @@ def envoy_include_prefix(path):
         return "/".join(path.split("/")[1:])
     return None
 
-def filter_windows_keys(cache_entries = {}):
+def _filter_windows_keys(cache_entries = {}):
     # On Windows, we don't want to explicitly set CMAKE_BUILD_TYPE,
     # rules_foreign_cc will figure it out for us
     return {key: cache_entries[key] for key in cache_entries.keys() if key != "CMAKE_BUILD_TYPE"}
@@ -240,8 +244,8 @@ def envoy_cmake_external(
     cmake_external(
         name = name,
         cache_entries = select({
-            "@envoy//bazel:windows_opt_build": filter_windows_keys(cache_entries),
-            "@envoy//bazel:windows_x86_64": filter_windows_keys(cache_entries_debug),
+            "@envoy//bazel:windows_opt_build": _filter_windows_keys(cache_entries),
+            "@envoy//bazel:windows_x86_64": _filter_windows_keys(cache_entries_debug),
             "@envoy//bazel:opt_build": cache_entries,
             "//conditions:default": cache_entries_debug,
         }),
@@ -318,27 +322,27 @@ def envoy_cc_library(
         deps = [],
         strip_include_prefix = None):
     if tcmalloc_dep:
-        deps += tcmalloc_external_deps(repository)
+        deps += _tcmalloc_external_deps(repository)
 
     native.cc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs,
-        copts = envoy_copts(repository) + copts,
+        copts = _envoy_copts(repository) + copts,
         visibility = visibility,
         tags = tags,
-        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
+        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//include/envoy/common:base_includes",
             repository + "//source/common/common:fmt_lib",
-            envoy_external_dep_path("abseil_flat_hash_map"),
-            envoy_external_dep_path("abseil_flat_hash_set"),
-            envoy_external_dep_path("abseil_strings"),
-            envoy_external_dep_path("spdlog"),
-            envoy_external_dep_path("fmtlib"),
+            _envoy_external_dep_path("abseil_flat_hash_map"),
+            _envoy_external_dep_path("abseil_flat_hash_set"),
+            _envoy_external_dep_path("abseil_strings"),
+            _envoy_external_dep_path("spdlog"),
+            _envoy_external_dep_path("fmtlib"),
         ],
         include_prefix = envoy_include_prefix(native.package_name()),
         alwayslink = 1,
-        linkstatic = envoy_linkstatic(),
+        linkstatic = _envoy_linkstatic(),
         linkstamp = select({
             repository + "//bazel:windows_x86_64": None,
             "//conditions:default": linkstamp,
@@ -359,21 +363,21 @@ def envoy_cc_binary(
         deps = [],
         linkopts = []):
     if not linkopts:
-        linkopts = envoy_linkopts()
+        linkopts = _envoy_linkopts()
     if stamped:
         linkopts = linkopts + _envoy_stamped_linkopts()
         deps = deps + _envoy_stamped_deps()
-    deps = deps + [envoy_external_dep_path(dep) for dep in external_deps]
+    deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps]
     native.cc_binary(
         name = name,
         srcs = srcs,
         data = data,
-        copts = envoy_copts(repository),
+        copts = _envoy_copts(repository),
         linkopts = linkopts,
         testonly = testonly,
         linkstatic = 1,
         visibility = visibility,
-        malloc = tcmalloc_external_dep(repository),
+        malloc = _tcmalloc_external_dep(repository),
         stamp = 1,
         deps = deps,
     )
@@ -402,8 +406,8 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     )
     native.cc_test(
         name = name,
-        copts = envoy_copts("@envoy", test = True),
-        linkopts = envoy_test_linkopts(),
+        copts = _envoy_copts("@envoy", test = True),
+        linkopts = _envoy_test_linkopts(),
         linkstatic = 1,
         args = ["$(locations %s)" % corpus_name],
         data = [corpus_name],
@@ -424,8 +428,8 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     # provide a path to FuzzingEngine.
     native.cc_binary(
         name = name + "_driverless",
-        copts = envoy_copts("@envoy", test = True),
-        linkopts = ["-lFuzzingEngine"] + envoy_test_linkopts(),
+        copts = _envoy_copts("@envoy", test = True),
+        linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
         linkstatic = 1,
         testonly = 1,
         deps = [":" + test_lib_name],
@@ -465,10 +469,10 @@ def envoy_cc_test(
     )
     native.cc_test(
         name = name,
-        copts = envoy_copts(repository, test = True) + copts,
-        linkopts = envoy_test_linkopts(),
-        linkstatic = envoy_linkstatic(),
-        malloc = tcmalloc_external_dep(repository),
+        copts = _envoy_copts(repository, test = True) + copts,
+        linkopts = _envoy_test_linkopts(),
+        linkstatic = _envoy_linkstatic(),
+        malloc = _tcmalloc_external_dep(repository),
         deps = [
             ":" + name + "_lib_internal_only",
             repository + "//test:main",
@@ -501,15 +505,15 @@ def _envoy_cc_test_infrastructure_library(
         srcs = srcs,
         hdrs = hdrs,
         data = data,
-        copts = envoy_copts(repository, test = True) + copts,
+        copts = _envoy_copts(repository, test = True) + copts,
         testonly = 1,
-        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
-            envoy_external_dep_path("googletest"),
+        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps] + [
+            _envoy_external_dep_path("googletest"),
         ],
         tags = tags,
         include_prefix = include_prefix,
         alwayslink = 1,
-        linkstatic = envoy_linkstatic(),
+        linkstatic = _envoy_linkstatic(),
         **kargs
     )
 
@@ -552,7 +556,7 @@ def envoy_cc_test_binary(
     envoy_cc_binary(
         name,
         testonly = 1,
-        linkopts = envoy_test_linkopts() + envoy_static_link_libstdcpp_linkopts(),
+        linkopts = _envoy_test_linkopts() + _envoy_static_link_libstdcpp_linkopts(),
         **kargs
     )
 
@@ -564,7 +568,7 @@ def envoy_py_test_binary(
         **kargs):
     native.py_binary(
         name = name,
-        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps],
+        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps],
         **kargs
     )
 
@@ -666,13 +670,13 @@ def envoy_select_hot_restart(xs, repository = ""):
     })
 
 # Select the given values if default path normalization is on in the current build.
-def envoy_select_path_normalization_by_default(xs, repository = ""):
+def _envoy_select_path_normalization_by_default(xs, repository = ""):
     return select({
         repository + "//bazel:enable_path_normalization_by_default": xs,
         "//conditions:default": [],
     })
 
-def envoy_select_perf_annotation(xs):
+def _envoy_select_perf_annotation(xs):
     return select({
         "@envoy//bazel:enable_perf_annotation": xs,
         "//conditions:default": [],
@@ -687,16 +691,16 @@ def envoy_select_google_grpc(xs, repository = ""):
 
 # Dependencies on Google grpc should be wrapped with this function.
 def envoy_google_grpc_external_deps():
-    return envoy_select_google_grpc([envoy_external_dep_path("grpc")])
+    return envoy_select_google_grpc([_envoy_external_dep_path("grpc")])
 
 # Select the given values if exporting is enabled in the current build.
-def envoy_select_exported_symbols(xs):
+def _envoy_select_exported_symbols(xs):
     return select({
         "@envoy//bazel:enable_exported_symbols": xs,
         "//conditions:default": [],
     })
 
-def envoy_select_force_libcpp(if_libcpp, default = None):
+def _envoy_select_force_libcpp(if_libcpp, default = None):
     return select({
         "@envoy//bazel:force_libcpp": if_libcpp,
         "@envoy//bazel:apple": [],

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -165,7 +165,7 @@ def envoy_select_boringssl(if_fips, default = None):
 # macros imported from envoy_build_system.bzl don't have to change their BUILD
 # files to reference the new location.
 
-# Select wrappers (from envoy_build.bzl)
+# Select wrappers (from envoy_select.bzl)
 envoy_select_hot_restart = _envoy_select_hot_restart
 envoy_select_google_grpc = _envoy_select_google_grpc
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,3 +1,5 @@
+# The main Envoy bazel file. Load this file for all Envoy-specific build macros
+# and rules that you'd like to use in your BUILD files.
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load(":envoy_binary.bzl", _envoy_cc_binary = "envoy_cc_binary")
 load(":envoy_internal.bzl", "envoy_external_dep_path")
@@ -12,6 +14,7 @@ load(
 )
 load(
     ":envoy_select.bzl",
+    _envoy_select_boringssl = "envoy_select_boringssl",
     _envoy_select_google_grpc = "envoy_select_google_grpc",
     _envoy_select_hot_restart = "envoy_select_hot_restart",
 )
@@ -26,8 +29,10 @@ load(
     _envoy_sh_test = "envoy_sh_test",
 )
 
+
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
+
 
 # A genrule variant that can output a directory. This is useful when doing things like
 # generating a fuzz corpus mechanically.
@@ -42,6 +47,7 @@ def _envoy_directory_genrule_impl(ctx):
     )
     return [DefaultInfo(files = depset([tree]))]
 
+
 envoy_directory_genrule = rule(
     implementation = _envoy_directory_genrule_impl,
     attrs = {
@@ -51,10 +57,12 @@ envoy_directory_genrule = rule(
     },
 )
 
+
 def _filter_windows_keys(cache_entries = {}):
     # On Windows, we don't want to explicitly set CMAKE_BUILD_TYPE,
     # rules_foreign_cc will figure it out for us
     return {key: cache_entries[key] for key in cache_entries.keys() if key != "CMAKE_BUILD_TYPE"}
+
 
 # External CMake C++ library targets should be specified with this function. This defaults
 # to building the dependencies with ninja
@@ -110,6 +118,7 @@ def envoy_cmake_external(
         **kwargs
     )
 
+
 # Used to select a dependency that has different implementations on POSIX vs Windows.
 # The platform-specific implementations should be specified with envoy_cc_posix_library
 # and envoy_cc_win32_library respectively
@@ -118,6 +127,7 @@ def envoy_cc_platform_dep(name):
         "@envoy//bazel:windows_x86_64": [name + "_win32"],
         "//conditions:default": [name + "_posix"],
     })
+
 
 # Envoy proto descriptor targets should be specified with this function.
 # This is used for testing only.
@@ -150,24 +160,21 @@ def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
         tools = ["//external:protoc"],
     )
 
+
 # Dependencies on Google grpc should be wrapped with this function.
 def envoy_google_grpc_external_deps():
     return envoy_select_google_grpc([envoy_external_dep_path("grpc")])
 
-def envoy_select_boringssl(if_fips, default = None):
-    return select({
-        "@envoy//bazel:boringssl_fips": if_fips,
-        "//conditions:default": default or [],
-    })
 
 # Here we create wrappers for each of the public targets within the separate bazel
-# files loaded above. This is necessary so that consumers who had previously used
-# macros imported from envoy_build_system.bzl don't have to change their BUILD
-# files to reference the new location.
+# files loaded above. This maintains envoy_build_system.bzl as the preferred import
+# for BUILD files that need these build macros. Do not use the imports directly
+# from the other bzl files (e.g. envoy_select.bzl, envoy_binary.bzl, etc.)
 
 # Select wrappers (from envoy_select.bzl)
-envoy_select_hot_restart = _envoy_select_hot_restart
+envoy_select_boringssl =  _envoy_select_boringssl
 envoy_select_google_grpc = _envoy_select_google_grpc
+envoy_select_hot_restart = _envoy_select_hot_restart
 
 # Binary wrappers (from envoy_binary.bzl)
 envoy_cc_binary = _envoy_cc_binary

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -29,10 +29,8 @@ load(
     _envoy_sh_test = "envoy_sh_test",
 )
 
-
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
-
 
 # A genrule variant that can output a directory. This is useful when doing things like
 # generating a fuzz corpus mechanically.
@@ -47,7 +45,6 @@ def _envoy_directory_genrule_impl(ctx):
     )
     return [DefaultInfo(files = depset([tree]))]
 
-
 envoy_directory_genrule = rule(
     implementation = _envoy_directory_genrule_impl,
     attrs = {
@@ -57,12 +54,10 @@ envoy_directory_genrule = rule(
     },
 )
 
-
 def _filter_windows_keys(cache_entries = {}):
     # On Windows, we don't want to explicitly set CMAKE_BUILD_TYPE,
     # rules_foreign_cc will figure it out for us
     return {key: cache_entries[key] for key in cache_entries.keys() if key != "CMAKE_BUILD_TYPE"}
-
 
 # External CMake C++ library targets should be specified with this function. This defaults
 # to building the dependencies with ninja
@@ -118,7 +113,6 @@ def envoy_cmake_external(
         **kwargs
     )
 
-
 # Used to select a dependency that has different implementations on POSIX vs Windows.
 # The platform-specific implementations should be specified with envoy_cc_posix_library
 # and envoy_cc_win32_library respectively
@@ -127,7 +121,6 @@ def envoy_cc_platform_dep(name):
         "@envoy//bazel:windows_x86_64": [name + "_win32"],
         "//conditions:default": [name + "_posix"],
     })
-
 
 # Envoy proto descriptor targets should be specified with this function.
 # This is used for testing only.
@@ -160,11 +153,9 @@ def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
         tools = ["//external:protoc"],
     )
 
-
 # Dependencies on Google grpc should be wrapped with this function.
 def envoy_google_grpc_external_deps():
     return envoy_select_google_grpc([envoy_external_dep_path("grpc")])
-
 
 # Here we create wrappers for each of the public targets within the separate bazel
 # files loaded above. This maintains envoy_build_system.bzl as the preferred import
@@ -172,7 +163,7 @@ def envoy_google_grpc_external_deps():
 # from the other bzl files (e.g. envoy_select.bzl, envoy_binary.bzl, etc.)
 
 # Select wrappers (from envoy_select.bzl)
-envoy_select_boringssl =  _envoy_select_boringssl
+envoy_select_boringssl = _envoy_select_boringssl
 envoy_select_google_grpc = _envoy_select_google_grpc
 envoy_select_hot_restart = _envoy_select_hot_restart
 

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -1,0 +1,108 @@
+# Targets from this file should be considered private and not used outside
+# of the @envoy//bazel package.
+load(":envoy_select.bzl", "envoy_select_google_grpc", "envoy_select_hot_restart")
+
+# Compute the final copts based on various options.
+def envoy_copts(repository, test = False):
+    posix_options = [
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wnon-virtual-dtor",
+        "-Woverloaded-virtual",
+        "-Wold-style-cast",
+        "-Wvla",
+        "-std=c++14",
+    ]
+
+    msvc_options = [
+        "-WX",
+        "-Zc:__cplusplus",
+        "-std:c++14",
+        "-DWIN32",
+        "-DWIN32_LEAN_AND_MEAN",
+        # need win8 for ntohll
+        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx
+        "-D_WIN32_WINNT=0x0602",
+        "-DNTDDI_VERSION=0x06020000",
+        "-DCARES_STATICLIB",
+        "-DNGHTTP2_STATICLIB",
+    ]
+
+    return select({
+               repository + "//bazel:windows_x86_64": msvc_options,
+               "//conditions:default": posix_options,
+           }) + select({
+               # Bazel adds an implicit -DNDEBUG for opt.
+               repository + "//bazel:opt_build": [] if test else ["-ggdb3"],
+               repository + "//bazel:fastbuild_build": [],
+               repository + "//bazel:dbg_build": ["-ggdb3"],
+               repository + "//bazel:windows_opt_build": [],
+               repository + "//bazel:windows_fastbuild_build": [],
+               repository + "//bazel:windows_dbg_build": [],
+           }) + select({
+               repository + "//bazel:disable_tcmalloc": ["-DABSL_MALLOC_HOOK_MMAP_DISABLE"],
+               "//conditions:default": ["-DTCMALLOC"],
+           }) + select({
+               repository + "//bazel:debug_tcmalloc": ["-DENVOY_MEMORY_DEBUG_ENABLED=1"],
+               "//conditions:default": [],
+           }) + select({
+               repository + "//bazel:disable_signal_trace": [],
+               "//conditions:default": ["-DENVOY_HANDLE_SIGNALS"],
+           }) + select({
+               repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
+               "//conditions:default": [],
+           }) + select({
+               # TCLAP command line parser needs this to support int64_t/uint64_t
+               repository + "//bazel:apple": ["-DHAVE_LONG_LONG"],
+               "//conditions:default": [],
+           }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
+           _envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
+           envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
+           _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
+
+# References to Envoy external dependencies should be wrapped with this function.
+def envoy_external_dep_path(dep):
+    return "//external:%s" % dep
+
+def envoy_linkstatic():
+    return select({
+        "@envoy//bazel:asan_build": 0,
+        "//conditions:default": 1,
+    })
+
+def envoy_select_force_libcpp(if_libcpp, default = None):
+    return select({
+        "@envoy//bazel:force_libcpp": if_libcpp,
+        "@envoy//bazel:apple": [],
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": default or [],
+    })
+
+def envoy_static_link_libstdcpp_linkopts():
+    return envoy_select_force_libcpp(
+        # TODO(PiotrSikora): statically link libc++ once that's possible.
+        # See: https://reviews.llvm.org/D53238
+        ["-stdlib=libc++"],
+        ["-static-libstdc++", "-static-libgcc"],
+    )
+
+# Dependencies on tcmalloc_and_profiler should be wrapped with this function.
+def tcmalloc_external_dep(repository):
+    return select({
+        repository + "//bazel:disable_tcmalloc": None,
+        "//conditions:default": envoy_external_dep_path("gperftools"),
+    })
+
+# Select the given values if default path normalization is on in the current build.
+def _envoy_select_path_normalization_by_default(xs, repository = ""):
+    return select({
+        repository + "//bazel:enable_path_normalization_by_default": xs,
+        "//conditions:default": [],
+    })
+
+def _envoy_select_perf_annotation(xs):
+    return select({
+        "@envoy//bazel:enable_perf_annotation": xs,
+        "//conditions:default": [],
+    })

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -1,7 +1,6 @@
-# DO NOT LOAD THIS FILE. Targets from this file should be considered private 
+# DO NOT LOAD THIS FILE. Targets from this file should be considered private
 # and not used outside of the @envoy//bazel package.
 load(":envoy_select.bzl", "envoy_select_google_grpc", "envoy_select_hot_restart")
-
 
 # Compute the final copts based on various options.
 def envoy_copts(repository, test = False):
@@ -58,18 +57,15 @@ def envoy_copts(repository, test = False):
            envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
            _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
 
-
 # References to Envoy external dependencies should be wrapped with this function.
 def envoy_external_dep_path(dep):
     return "//external:%s" % dep
-
 
 def envoy_linkstatic():
     return select({
         "@envoy//bazel:asan_build": 0,
         "//conditions:default": 1,
     })
-
 
 def envoy_select_force_libcpp(if_libcpp, default = None):
     return select({
@@ -79,7 +75,6 @@ def envoy_select_force_libcpp(if_libcpp, default = None):
         "//conditions:default": default or [],
     })
 
-
 def envoy_static_link_libstdcpp_linkopts():
     return envoy_select_force_libcpp(
         # TODO(PiotrSikora): statically link libc++ once that's possible.
@@ -88,7 +83,6 @@ def envoy_static_link_libstdcpp_linkopts():
         ["-static-libstdc++", "-static-libgcc"],
     )
 
-
 # Dependencies on tcmalloc_and_profiler should be wrapped with this function.
 def tcmalloc_external_dep(repository):
     return select({
@@ -96,14 +90,12 @@ def tcmalloc_external_dep(repository):
         "//conditions:default": envoy_external_dep_path("gperftools"),
     })
 
-
 # Select the given values if default path normalization is on in the current build.
 def _envoy_select_path_normalization_by_default(xs, repository = ""):
     return select({
         repository + "//bazel:enable_path_normalization_by_default": xs,
         "//conditions:default": [],
     })
-
 
 def _envoy_select_perf_annotation(xs):
     return select({

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -1,6 +1,7 @@
-# Targets from this file should be considered private and not used outside
-# of the @envoy//bazel package.
+# DO NOT LOAD THIS FILE. Targets from this file should be considered private 
+# and not used outside of the @envoy//bazel package.
 load(":envoy_select.bzl", "envoy_select_google_grpc", "envoy_select_hot_restart")
+
 
 # Compute the final copts based on various options.
 def envoy_copts(repository, test = False):
@@ -57,15 +58,18 @@ def envoy_copts(repository, test = False):
            envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
            _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
 
+
 # References to Envoy external dependencies should be wrapped with this function.
 def envoy_external_dep_path(dep):
     return "//external:%s" % dep
+
 
 def envoy_linkstatic():
     return select({
         "@envoy//bazel:asan_build": 0,
         "//conditions:default": 1,
     })
+
 
 def envoy_select_force_libcpp(if_libcpp, default = None):
     return select({
@@ -75,6 +79,7 @@ def envoy_select_force_libcpp(if_libcpp, default = None):
         "//conditions:default": default or [],
     })
 
+
 def envoy_static_link_libstdcpp_linkopts():
     return envoy_select_force_libcpp(
         # TODO(PiotrSikora): statically link libc++ once that's possible.
@@ -83,6 +88,7 @@ def envoy_static_link_libstdcpp_linkopts():
         ["-static-libstdc++", "-static-libgcc"],
     )
 
+
 # Dependencies on tcmalloc_and_profiler should be wrapped with this function.
 def tcmalloc_external_dep(repository):
     return select({
@@ -90,12 +96,14 @@ def tcmalloc_external_dep(repository):
         "//conditions:default": envoy_external_dep_path("gperftools"),
     })
 
+
 # Select the given values if default path normalization is on in the current build.
 def _envoy_select_path_normalization_by_default(xs, repository = ""):
     return select({
         repository + "//bazel:enable_path_normalization_by_default": xs,
         "//conditions:default": [],
     })
+
 
 def _envoy_select_perf_annotation(xs):
     return select({

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -1,0 +1,121 @@
+load(":envoy_internal.bzl", 
+	"envoy_copts",
+	"envoy_external_dep_path",
+	"envoy_linkstatic")
+load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+# As above, but wrapped in list form for adding to dep lists. This smell seems needed as
+# SelectorValue values have to match the attribute type. See
+# https://github.com/bazelbuild/bazel/issues/2273.
+def _tcmalloc_external_deps(repository):
+    return select({
+        repository + "//bazel:disable_tcmalloc": [],
+        "//conditions:default": [envoy_external_dep_path("gperftools")],
+    })
+
+# Envoy C++ library targets that need no transformations or additional dependencies before being
+# passed to cc_library should be specified with this function. Note: this exists to ensure that
+# all envoy targets pass through an envoy-declared skylark function where they can be modified
+# before being passed to a native bazel function.
+def envoy_basic_cc_library(name, **kargs):
+    native.cc_library(name = name, **kargs)
+
+# Envoy C++ library targets should be specified with this function.
+def envoy_cc_library(
+        name,
+        srcs = [],
+        hdrs = [],
+        copts = [],
+        visibility = None,
+        external_deps = [],
+        tcmalloc_dep = None,
+        repository = "",
+        linkstamp = None,
+        tags = [],
+        deps = [],
+        strip_include_prefix = None):
+    if tcmalloc_dep:
+        deps += _tcmalloc_external_deps(repository)
+
+    native.cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = hdrs,
+        copts = envoy_copts(repository) + copts,
+        visibility = visibility,
+        tags = tags,
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
+            repository + "//include/envoy/common:base_includes",
+            repository + "//source/common/common:fmt_lib",
+            envoy_external_dep_path("abseil_flat_hash_map"),
+            envoy_external_dep_path("abseil_flat_hash_set"),
+            envoy_external_dep_path("abseil_strings"),
+            envoy_external_dep_path("spdlog"),
+            envoy_external_dep_path("fmtlib"),
+        ],
+        include_prefix = envoy_include_prefix(native.package_name()),
+        alwayslink = 1,
+        linkstatic = envoy_linkstatic(),
+        linkstamp = select({
+            repository + "//bazel:windows_x86_64": None,
+            "//conditions:default": linkstamp,
+        }),
+        strip_include_prefix = strip_include_prefix,
+    )
+
+# Used to specify a library that only builds on POSIX
+def envoy_cc_posix_library(name, srcs = [], hdrs = [], **kargs):
+    envoy_cc_library(
+        name = name + "_posix",
+        srcs = select({
+            "@envoy//bazel:windows_x86_64": [],
+            "//conditions:default": srcs,
+        }),
+        hdrs = select({
+            "@envoy//bazel:windows_x86_64": [],
+            "//conditions:default": hdrs,
+        }),
+        **kargs
+    )
+
+# Used to specify a library that only builds on Windows
+def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
+    envoy_cc_library(
+        name = name + "_win32",
+        srcs = select({
+            "@envoy//bazel:windows_x86_64": srcs,
+            "//conditions:default": [],
+        }),
+        hdrs = select({
+            "@envoy//bazel:windows_x86_64": hdrs,
+            "//conditions:default": [],
+        }),
+        **kargs
+    )
+
+# Transform the package path (e.g. include/envoy/common) into a path for
+# exporting the package headers at (e.g. envoy/common). Source files can then
+# include using this path scheme (e.g. #include "envoy/common/time.h").
+def envoy_include_prefix(path):
+    if path.startswith("source/") or path.startswith("include/"):
+        return "/".join(path.split("/")[1:])
+    return None
+
+# Envoy proto targets should be specified with this function.
+def envoy_proto_library(name, external_deps = [], **kwargs):
+    external_proto_deps = []
+    external_cc_proto_deps = []
+    if "api_httpbody_protos" in external_deps:
+        external_cc_proto_deps.append("@googleapis//:api_httpbody_protos")
+        external_proto_deps.append("@googleapis//:api_httpbody_protos_proto")
+    api_proto_library(
+        name,
+        external_cc_proto_deps = external_cc_proto_deps,
+        external_proto_deps = external_proto_deps,
+        # Avoid generating .so, we don't need it, can interfere with builds
+        # such as OSS-Fuzz.
+        linkstatic = 1,
+        visibility = ["//visibility:public"],
+        **kwargs
+    )

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -1,3 +1,4 @@
+# DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy library targets
 load(
     ":envoy_internal.bzl",
@@ -8,6 +9,7 @@ load(
 load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
 load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 
+
 # As above, but wrapped in list form for adding to dep lists. This smell seems needed as
 # SelectorValue values have to match the attribute type. See
 # https://github.com/bazelbuild/bazel/issues/2273.
@@ -17,12 +19,14 @@ def _tcmalloc_external_deps(repository):
         "//conditions:default": [envoy_external_dep_path("gperftools")],
     })
 
+
 # Envoy C++ library targets that need no transformations or additional dependencies before being
 # passed to cc_library should be specified with this function. Note: this exists to ensure that
 # all envoy targets pass through an envoy-declared skylark function where they can be modified
 # before being passed to a native bazel function.
 def envoy_basic_cc_library(name, **kargs):
     native.cc_library(name = name, **kargs)
+
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(
@@ -67,6 +71,7 @@ def envoy_cc_library(
         strip_include_prefix = strip_include_prefix,
     )
 
+
 # Used to specify a library that only builds on POSIX
 def envoy_cc_posix_library(name, srcs = [], hdrs = [], **kargs):
     envoy_cc_library(
@@ -81,6 +86,7 @@ def envoy_cc_posix_library(name, srcs = [], hdrs = [], **kargs):
         }),
         **kargs
     )
+
 
 # Used to specify a library that only builds on Windows
 def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
@@ -97,6 +103,7 @@ def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
         **kargs
     )
 
+
 # Transform the package path (e.g. include/envoy/common) into a path for
 # exporting the package headers at (e.g. envoy/common). Source files can then
 # include using this path scheme (e.g. #include "envoy/common/time.h").
@@ -104,6 +111,7 @@ def envoy_include_prefix(path):
     if path.startswith("source/") or path.startswith("include/"):
         return "/".join(path.split("/")[1:])
     return None
+
 
 # Envoy proto targets should be specified with this function.
 def envoy_proto_library(name, external_deps = [], **kwargs):

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -1,7 +1,9 @@
-load(":envoy_internal.bzl", 
-	"envoy_copts",
-	"envoy_external_dep_path",
-	"envoy_linkstatic")
+load(
+    ":envoy_internal.bzl",
+    "envoy_copts",
+    "envoy_external_dep_path",
+    "envoy_linkstatic",
+)
 load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
 load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -1,3 +1,4 @@
+# Envoy library targets
 load(
     ":envoy_internal.bzl",
     "envoy_copts",

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -9,7 +9,6 @@ load(
 load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
 load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 
-
 # As above, but wrapped in list form for adding to dep lists. This smell seems needed as
 # SelectorValue values have to match the attribute type. See
 # https://github.com/bazelbuild/bazel/issues/2273.
@@ -19,14 +18,12 @@ def _tcmalloc_external_deps(repository):
         "//conditions:default": [envoy_external_dep_path("gperftools")],
     })
 
-
 # Envoy C++ library targets that need no transformations or additional dependencies before being
 # passed to cc_library should be specified with this function. Note: this exists to ensure that
 # all envoy targets pass through an envoy-declared skylark function where they can be modified
 # before being passed to a native bazel function.
 def envoy_basic_cc_library(name, **kargs):
     native.cc_library(name = name, **kargs)
-
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(
@@ -71,7 +68,6 @@ def envoy_cc_library(
         strip_include_prefix = strip_include_prefix,
     )
 
-
 # Used to specify a library that only builds on POSIX
 def envoy_cc_posix_library(name, srcs = [], hdrs = [], **kargs):
     envoy_cc_library(
@@ -86,7 +82,6 @@ def envoy_cc_posix_library(name, srcs = [], hdrs = [], **kargs):
         }),
         **kargs
     )
-
 
 # Used to specify a library that only builds on Windows
 def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
@@ -103,7 +98,6 @@ def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
         **kargs
     )
 
-
 # Transform the package path (e.g. include/envoy/common) into a path for
 # exporting the package headers at (e.g. envoy/common). Source files can then
 # include using this path scheme (e.g. #include "envoy/common/time.h").
@@ -111,7 +105,6 @@ def envoy_include_prefix(path):
     if path.startswith("source/") or path.startswith("include/"):
         return "/".join(path.split("/")[1:])
     return None
-
 
 # Envoy proto targets should be specified with this function.
 def envoy_proto_library(name, external_deps = [], **kwargs):

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -11,13 +11,11 @@ def envoy_cc_platform_dep(name):
         "//conditions:default": [name + "_posix"],
     })
 
-
 def envoy_select_boringssl(if_fips, default = None):
     return select({
         "@envoy//bazel:boringssl_fips": if_fips,
         "//conditions:default": default or [],
     })
-
 
 # Selects the given values if Google gRPC is enabled in the current build.
 def envoy_select_google_grpc(xs, repository = ""):
@@ -25,7 +23,6 @@ def envoy_select_google_grpc(xs, repository = ""):
         repository + "//bazel:disable_google_grpc": [],
         "//conditions:default": xs,
     })
-
 
 # Selects the given values if hot restart is enabled in the current build.
 def envoy_select_hot_restart(xs, repository = ""):

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -1,0 +1,14 @@
+# Selects the given values if hot restart is enabled in the current build.
+def envoy_select_hot_restart(xs, repository = ""):
+    return select({
+        repository + "//bazel:disable_hot_restart": [],
+        repository + "//bazel:apple": [],
+        "//conditions:default": xs,
+    })
+
+# Selects the given values if Google gRPC is enabled in the current build.
+def envoy_select_google_grpc(xs, repository = ""):
+    return select({
+        repository + "//bazel:disable_google_grpc": [],
+        "//conditions:default": xs,
+    })

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -1,4 +1,4 @@
-# Envoy select targets. This is in a separate file to avoid a circular 
+# Envoy select targets. This is in a separate file to avoid a circular
 # dependency with envoy_build_system.bzl.
 
 # Selects the given values if hot restart is enabled in the current build.

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -1,16 +1,35 @@
+# DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy select targets. This is in a separate file to avoid a circular
 # dependency with envoy_build_system.bzl.
 
-# Selects the given values if hot restart is enabled in the current build.
-def envoy_select_hot_restart(xs, repository = ""):
+# Used to select a dependency that has different implementations on POSIX vs Windows.
+# The platform-specific implementations should be specified with envoy_cc_posix_library
+# and envoy_cc_win32_library respectively
+def envoy_cc_platform_dep(name):
     return select({
-        repository + "//bazel:disable_hot_restart_or_apple": [],
-        "//conditions:default": xs,
+        "@envoy//bazel:windows_x86_64": [name + "_win32"],
+        "//conditions:default": [name + "_posix"],
     })
+
+
+def envoy_select_boringssl(if_fips, default = None):
+    return select({
+        "@envoy//bazel:boringssl_fips": if_fips,
+        "//conditions:default": default or [],
+    })
+
 
 # Selects the given values if Google gRPC is enabled in the current build.
 def envoy_select_google_grpc(xs, repository = ""):
     return select({
         repository + "//bazel:disable_google_grpc": [],
+        "//conditions:default": xs,
+    })
+
+
+# Selects the given values if hot restart is enabled in the current build.
+def envoy_select_hot_restart(xs, repository = ""):
+    return select({
+        repository + "//bazel:disable_hot_restart_or_apple": [],
         "//conditions:default": xs,
     })

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -1,3 +1,6 @@
+# Envoy select targets. This is in a separate file to avoid a circular 
+# dependency with envoy_build_system.bzl.
+
 # Selects the given values if hot restart is enabled in the current build.
 def envoy_select_hot_restart(xs, repository = ""):
     return select({

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,0 +1,253 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load(":envoy_binary.bzl", "envoy_cc_binary")
+load(":envoy_internal.bzl",
+    _envoy_copts = "envoy_copts",
+    _envoy_external_dep_path = "envoy_external_dep_path",
+    _envoy_linkstatic = "envoy_linkstatic",
+    _envoy_select_force_libcpp = "envoy_select_force_libcpp",
+    _envoy_static_link_libstdcpp_linkopts = "envoy_static_link_libstdcpp_linkopts",
+    _tcmalloc_external_dep = "tcmalloc_external_dep")
+
+# Envoy C++ related test infrastructure (that want gtest, gmock, but may be
+# relied on by envoy_cc_test_library) should use this function.
+def _envoy_cc_test_infrastructure_library(
+        name,
+        srcs = [],
+        hdrs = [],
+        data = [],
+        external_deps = [],
+        deps = [],
+        repository = "",
+        tags = [],
+        include_prefix = None,
+        copts = [],
+        **kargs):
+    native.cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = hdrs,
+        data = data,
+        copts = _envoy_copts(repository, test = True) + copts,
+        testonly = 1,
+        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps] + [
+            _envoy_external_dep_path("googletest"),
+        ],
+        tags = tags,
+        include_prefix = include_prefix,
+        alwayslink = 1,
+        linkstatic = _envoy_linkstatic(),
+        **kargs
+    )
+
+# Compute the test linkopts based on various options.
+def _envoy_test_linkopts():
+    return select({
+        "@envoy//bazel:apple": [
+            # See note here: https://luajit.org/install.html
+            "-pagezero_size 10000",
+            "-image_base 100000000",
+        ],
+        "@envoy//bazel:windows_x86_64": [
+            "-DEFAULTLIB:advapi32.lib",
+            "-DEFAULTLIB:ws2_32.lib",
+            "-WX",
+        ],
+
+        # TODO(mattklein123): It's not great that we universally link against the following libs.
+        # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
+        "//conditions:default": ["-pthread", "-lrt", "-ldl"],
+    }) + _envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
+
+# Envoy C++ fuzz test targets. These are not included in coverage runs.
+def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
+    if not (corpus.startswith("//") or corpus.startswith(":")):
+        corpus_name = name + "_corpus"
+        corpus = native.glob([corpus + "/**"])
+        native.filegroup(
+            name = corpus_name,
+            srcs = corpus,
+        )
+    else:
+        corpus_name = corpus
+    pkg_tar(
+        name = name + "_corpus_tar",
+        srcs = [corpus_name],
+        testonly = 1,
+    )
+    test_lib_name = name + "_lib"
+    envoy_cc_test_library(
+        name = test_lib_name,
+        deps = deps + ["//test/fuzz:fuzz_runner_lib"],
+        **kwargs
+    )
+    native.cc_test(
+        name = name,
+        copts = _envoy_copts("@envoy", test = True),
+        linkopts = _envoy_test_linkopts(),
+        linkstatic = 1,
+        args = ["$(locations %s)" % corpus_name],
+        data = [corpus_name],
+        # No fuzzing on macOS.
+        deps = select({
+            "@envoy//bazel:apple": ["//test:dummy_main"],
+            "//conditions:default": [
+                ":" + test_lib_name,
+                "//test/fuzz:main",
+            ],
+        }),
+        tags = tags,
+    )
+
+    # This target exists only for
+    # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield
+    # anything useful on its own, as it expects to be run in an environment where the linker options
+    # provide a path to FuzzingEngine.
+    native.cc_binary(
+        name = name + "_driverless",
+        copts = _envoy_copts("@envoy", test = True),
+        linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
+        linkstatic = 1,
+        testonly = 1,
+        deps = [":" + test_lib_name],
+        tags = ["manual"] + tags,
+    )
+
+# Envoy C++ test targets should be specified with this function.
+def envoy_cc_test(
+        name,
+        srcs = [],
+        data = [],
+        # List of pairs (Bazel shell script target, shell script args)
+        repository = "",
+        external_deps = [],
+        deps = [],
+        tags = [],
+        args = [],
+        copts = [],
+        shard_count = None,
+        coverage = True,
+        local = False,
+        size = "medium"):
+    test_lib_tags = []
+    if coverage:
+        test_lib_tags.append("coverage_test_lib")
+    _envoy_cc_test_infrastructure_library(
+        name = name + "_lib_internal_only",
+        srcs = srcs,
+        data = data,
+        external_deps = external_deps,
+        deps = deps + [repository + "//test/test_common:printers_includes"],
+        repository = repository,
+        tags = test_lib_tags,
+        copts = copts,
+        # Restrict only to the code coverage tools.
+        visibility = ["@envoy//test/coverage:__pkg__"],
+    )
+    native.cc_test(
+        name = name,
+        copts = _envoy_copts(repository, test = True) + copts,
+        linkopts = _envoy_test_linkopts(),
+        linkstatic = _envoy_linkstatic(),
+        malloc = _tcmalloc_external_dep(repository),
+        deps = [
+            ":" + name + "_lib_internal_only",
+            repository + "//test:main",
+        ],
+        # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51
+        # 2 - by default, mocks act as StrictMocks.
+        args = args + ["--gmock_default_mock_behavior=2"],
+        tags = tags + ["coverage_test"],
+        local = local,
+        shard_count = shard_count,
+        size = size,
+    )
+
+# Envoy C++ test related libraries (that want gtest, gmock) should be specified
+# with this function.
+def envoy_cc_test_library(
+        name,
+        srcs = [],
+        hdrs = [],
+        data = [],
+        external_deps = [],
+        deps = [],
+        repository = "",
+        tags = [],
+        include_prefix = None,
+        copts = [],
+        **kargs):
+    deps = deps + [
+        repository + "//test/test_common:printers_includes",
+    ]
+    _envoy_cc_test_infrastructure_library(
+        name,
+        srcs,
+        hdrs,
+        data,
+        external_deps,
+        deps,
+        repository,
+        tags,
+        include_prefix,
+        copts,
+        visibility = ["//visibility:public"],
+        **kargs
+    )
+
+# Envoy test binaries should be specified with this function.
+def envoy_cc_test_binary(
+        name,
+        **kargs):
+    envoy_cc_binary(
+        name,
+        testonly = 1,
+        linkopts = _envoy_test_linkopts() + _envoy_static_link_libstdcpp_linkopts(),
+        **kargs
+    )
+
+# Envoy Python test binaries should be specified with this function.
+def envoy_py_test_binary(
+        name,
+        external_deps = [],
+        deps = [],
+        **kargs):
+    native.py_binary(
+        name = name,
+        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps],
+        **kargs
+    )
+
+# Envoy C++ mock targets should be specified with this function.
+def envoy_cc_mock(name, **kargs):
+    envoy_cc_test_library(name = name, **kargs)
+
+# Envoy shell tests that need to be included in coverage run should be specified with this function.
+def envoy_sh_test(
+        name,
+        srcs = [],
+        data = [],
+        coverage = True,
+        **kargs):
+    if coverage:
+        test_runner_cc = name + "_test_runner.cc"
+        native.genrule(
+            name = name + "_gen_test_runner",
+            srcs = srcs,
+            outs = [test_runner_cc],
+            cmd = "$(location //bazel:gen_sh_test_runner.sh) $(SRCS) >> $@",
+            tools = ["//bazel:gen_sh_test_runner.sh"],
+        )
+        envoy_cc_test_library(
+            name = name + "_lib",
+            srcs = [test_runner_cc],
+            data = srcs + data,
+            tags = ["coverage_test_lib"],
+            deps = ["//test/test_common:environment_lib"],
+        )
+    native.sh_test(
+        name = name,
+        srcs = ["//bazel:sh_test_wrapper.sh"],
+        data = srcs + data,
+        args = srcs,
+        **kargs
+    )

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -13,7 +13,6 @@ load(
     _tcmalloc_external_dep = "tcmalloc_external_dep",
 )
 
-
 # Envoy C++ related test infrastructure (that want gtest, gmock, but may be
 # relied on by envoy_cc_test_library) should use this function.
 def _envoy_cc_test_infrastructure_library(
@@ -45,7 +44,6 @@ def _envoy_cc_test_infrastructure_library(
         **kargs
     )
 
-
 # Compute the test linkopts based on various options.
 def _envoy_test_linkopts():
     return select({
@@ -64,7 +62,6 @@ def _envoy_test_linkopts():
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
     }) + _envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
-
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
@@ -120,7 +117,6 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         tags = ["manual"] + tags,
     )
 
-
 # Envoy C++ test targets should be specified with this function.
 def envoy_cc_test(
         name,
@@ -171,7 +167,6 @@ def envoy_cc_test(
         size = size,
     )
 
-
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified
 # with this function.
 def envoy_cc_test_library(
@@ -204,7 +199,6 @@ def envoy_cc_test_library(
         **kargs
     )
 
-
 # Envoy test binaries should be specified with this function.
 def envoy_cc_test_binary(
         name,
@@ -215,7 +209,6 @@ def envoy_cc_test_binary(
         linkopts = _envoy_test_linkopts() + _envoy_static_link_libstdcpp_linkopts(),
         **kargs
     )
-
 
 # Envoy Python test binaries should be specified with this function.
 def envoy_py_test_binary(
@@ -229,11 +222,9 @@ def envoy_py_test_binary(
         **kargs
     )
 
-
 # Envoy C++ mock targets should be specified with this function.
 def envoy_cc_mock(name, **kargs):
     envoy_cc_test_library(name = name, **kargs)
-
 
 # Envoy shell tests that need to be included in coverage run should be specified with this function.
 def envoy_sh_test(

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,3 +1,5 @@
+# Envoy test targets. This includes both test library and test binary targets.
+
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,16 +1,15 @@
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
-
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(
     ":envoy_internal.bzl",
-    _envoy_copts = "envoy_copts",
-    _envoy_external_dep_path = "envoy_external_dep_path",
-    _envoy_linkstatic = "envoy_linkstatic",
-    _envoy_select_force_libcpp = "envoy_select_force_libcpp",
-    _envoy_static_link_libstdcpp_linkopts = "envoy_static_link_libstdcpp_linkopts",
-    _tcmalloc_external_dep = "tcmalloc_external_dep",
+    "envoy_copts",
+    "envoy_external_dep_path",
+    "envoy_linkstatic",
+    "envoy_select_force_libcpp",
+    "envoy_static_link_libstdcpp_linkopts",
+    "tcmalloc_external_dep",
 )
 
 # Envoy C++ related test infrastructure (that want gtest, gmock, but may be
@@ -32,15 +31,15 @@ def _envoy_cc_test_infrastructure_library(
         srcs = srcs,
         hdrs = hdrs,
         data = data,
-        copts = _envoy_copts(repository, test = True) + copts,
+        copts = envoy_copts(repository, test = True) + copts,
         testonly = 1,
-        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps] + [
-            _envoy_external_dep_path("googletest"),
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
+            envoy_external_dep_path("googletest"),
         ],
         tags = tags,
         include_prefix = include_prefix,
         alwayslink = 1,
-        linkstatic = _envoy_linkstatic(),
+        linkstatic = envoy_linkstatic(),
         **kargs
     )
 
@@ -61,7 +60,7 @@ def _envoy_test_linkopts():
         # TODO(mattklein123): It's not great that we universally link against the following libs.
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
-    }) + _envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
+    }) + envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
@@ -87,7 +86,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     )
     native.cc_test(
         name = name,
-        copts = _envoy_copts("@envoy", test = True),
+        copts = envoy_copts("@envoy", test = True),
         linkopts = _envoy_test_linkopts(),
         linkstatic = 1,
         args = ["$(locations %s)" % corpus_name],
@@ -109,7 +108,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     # provide a path to FuzzingEngine.
     native.cc_binary(
         name = name + "_driverless",
-        copts = _envoy_copts("@envoy", test = True),
+        copts = envoy_copts("@envoy", test = True),
         linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
         linkstatic = 1,
         testonly = 1,
@@ -150,10 +149,10 @@ def envoy_cc_test(
     )
     native.cc_test(
         name = name,
-        copts = _envoy_copts(repository, test = True) + copts,
+        copts = envoy_copts(repository, test = True) + copts,
         linkopts = _envoy_test_linkopts(),
-        linkstatic = _envoy_linkstatic(),
-        malloc = _tcmalloc_external_dep(repository),
+        linkstatic = envoy_linkstatic(),
+        malloc = tcmalloc_external_dep(repository),
         deps = [
             ":" + name + "_lib_internal_only",
             repository + "//test:main",
@@ -206,7 +205,7 @@ def envoy_cc_test_binary(
     envoy_cc_binary(
         name,
         testonly = 1,
-        linkopts = _envoy_test_linkopts() + _envoy_static_link_libstdcpp_linkopts(),
+        linkopts = _envoy_test_linkopts() + envoy_static_link_libstdcpp_linkopts(),
         **kargs
     )
 
@@ -218,7 +217,7 @@ def envoy_py_test_binary(
         **kargs):
     native.py_binary(
         name = name,
-        deps = deps + [_envoy_external_dep_path(dep) for dep in external_deps],
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps],
         **kargs
     )
 

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,12 +1,14 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load(":envoy_binary.bzl", "envoy_cc_binary")
-load(":envoy_internal.bzl",
+load(
+    ":envoy_internal.bzl",
     _envoy_copts = "envoy_copts",
     _envoy_external_dep_path = "envoy_external_dep_path",
     _envoy_linkstatic = "envoy_linkstatic",
     _envoy_select_force_libcpp = "envoy_select_force_libcpp",
     _envoy_static_link_libstdcpp_linkopts = "envoy_static_link_libstdcpp_linkopts",
-    _tcmalloc_external_dep = "tcmalloc_external_dep")
+    _tcmalloc_external_dep = "tcmalloc_external_dep",
+)
 
 # Envoy C++ related test infrastructure (that want gtest, gmock, but may be
 # relied on by envoy_cc_test_library) should use this function.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,3 +1,4 @@
+# DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
@@ -11,6 +12,7 @@ load(
     _envoy_static_link_libstdcpp_linkopts = "envoy_static_link_libstdcpp_linkopts",
     _tcmalloc_external_dep = "tcmalloc_external_dep",
 )
+
 
 # Envoy C++ related test infrastructure (that want gtest, gmock, but may be
 # relied on by envoy_cc_test_library) should use this function.
@@ -43,6 +45,7 @@ def _envoy_cc_test_infrastructure_library(
         **kargs
     )
 
+
 # Compute the test linkopts based on various options.
 def _envoy_test_linkopts():
     return select({
@@ -61,6 +64,7 @@ def _envoy_test_linkopts():
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
     }) + _envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
+
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
@@ -116,6 +120,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         tags = ["manual"] + tags,
     )
 
+
 # Envoy C++ test targets should be specified with this function.
 def envoy_cc_test(
         name,
@@ -166,6 +171,7 @@ def envoy_cc_test(
         size = size,
     )
 
+
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified
 # with this function.
 def envoy_cc_test_library(
@@ -198,6 +204,7 @@ def envoy_cc_test_library(
         **kargs
     )
 
+
 # Envoy test binaries should be specified with this function.
 def envoy_cc_test_binary(
         name,
@@ -208,6 +215,7 @@ def envoy_cc_test_binary(
         linkopts = _envoy_test_linkopts() + _envoy_static_link_libstdcpp_linkopts(),
         **kargs
     )
+
 
 # Envoy Python test binaries should be specified with this function.
 def envoy_py_test_binary(
@@ -221,9 +229,11 @@ def envoy_py_test_binary(
         **kargs
     )
 
+
 # Envoy C++ mock targets should be specified with this function.
 def envoy_cc_mock(name, **kargs):
     envoy_cc_test_library(name = name, **kargs)
+
 
 # Envoy shell tests that need to be included in coverage run should be specified with this function.
 def envoy_sh_test(


### PR DESCRIPTION
Description: This PR refactors `envoy_build_system.bzl` into 6 separate bzl files with the following dependencies:
![envoy_build_system_refactor](https://user-images.githubusercontent.com/435867/57860142-49fa1e00-77c2-11e9-8d56-2a3049ccede0.png)

No changes were made to the existing build macros themselves, only to their location.

The aim is to simplify this file and aid understanding and modification of the build system in the future.

Each of the separate files takes some of the build macros from `envoy_build_system.bzl`, e.g. `envoy_binary.bzl` has the macros for creating binaries, `envoy_test.bzl` has the macros for creating test targets and so on.

It was necessary to have `envoy_build_system.bzl` depend upon all other bzl files in order to not break backwards compatibility with `load()` statements from `BUILD` files that referred to `envoy_build_system.bzl`.

It was also necessary to move the public `envoy_select_*` macros from `envoy_build_system.bzl` into  `envoy_select.bzl` in order to avoid a circular dependency.

All macros in `envoy_internal.bzl` are meant to be private, but bazel has no concept of package private macros, so this was the best I could do. I could rename it `_envoy_internal` or move it to a sub-directory if we really want to hide it. I have taken to `load()`ing macros from this file using an underscore, e.g.  
  ```
  load(":envoy_internal.bzl", _foo = "foo")  
  ```

If going forward we wish to treat `envoy_build_system.bzl` as the only bzl file one should ever `load()` from, then this PR is sufficient to accomplish that. If we want developers to import the separate files (e.g. `envoy_binary.bzl`, `envoy_test.bzl`), I can work to migrate all existing uses within Envoy to the new files and mark the symbols referenced from `envoy_build_system.bzl` as deprecated (perhaps via `print` statement warnings).

Risk Level: Medium
Testing: Ran `bazel build //...`
Docs Changes: None necessary, this PR maintains backwards compatibility with existing `load()`s of `envoy_build_system.bzl`.
Release Notes: N/A