### PR TITLE
build: add ppc llvm steps for ubuntu build container

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+ARCH="$(uname -m)"
+
 # Setup basic requirements and install them.
 apt-get update
 export DEBIAN_FRONTEND=noninteractive
@@ -9,10 +11,24 @@ apt-get install -y wget software-properties-common make cmake git python python-
   unzip bc libtool ninja-build automake zip time golang gdb strace wireshark tshark tcpdump lcov \
   apt-transport-https
 # clang 8.
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-apt-add-repository "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
-apt-get update
-apt-get install -y clang-8 clang-format-8 clang-tidy-8 lld-8 libc++-8-dev libc++abi-8-dev
+case $ARCH in
+    'ppc64le' )
+        LLVM_VERSION=8.0.0
+        LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-powerpc64le-unknown-unknown"
+        wget "https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz"
+        tar Jxf "${LLVM_RELEASE}.tar.xz"
+        mv "./${LLVM_RELEASE}" /opt/llvm
+        rm "./${LLVM_RELEASE}.tar.xz"
+        echo "/opt/llvm/lib" > /etc/ld.so.conf.d/llvm.conf
+        ldconfig
+        ;;
+    'x86_64' )
+	    wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+        apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+        apt-get update
+        apt-get install -y clang-8 clang-format-8 clang-tidy-8 lld-8 libc++-8-dev libc++abi-8-dev
+        ;;
+esac
 # gcc-7
 add-apt-repository -y ppa:ubuntu-toolchain-r/test
 apt update
@@ -25,10 +41,21 @@ update-alternatives --config g++
 update-alternatives --config gcov
 # Bazel and related dependencies.
 apt-get install -y openjdk-8-jdk curl
-echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-apt-get update
-apt-get install -y bazel
+case $ARCH in
+    'ppc64le' )
+        BAZEL_LATEST="$(curl https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_16.04/latest/ 2>&1 \
+          | sed -n 's/.*href="\([^"]*\).*/\1/p' | grep '^bazel' | head -n 1)"
+        curl -fSL https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_16.04/latest/${BAZEL_LATEST} \
+          -o /usr/local/bin/bazel
+        chmod +x /usr/local/bin/bazel
+        ;;
+    'x86_64' )
+        echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+        curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+        apt-get update
+        apt-get install -y bazel
+        ;;
+esac
 apt-get install -y aspell
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

Description: Add ppc64le build scripts for architecture specific docker builds. Previously I was building outside of a docker container & compiling the static binary. In lieu of a recent ppc test bug, I'd like to start building the docker container for ppc so that we can run the tests continually.
Risk Level: Medium - Could affect general CI but has been tested on both
Testing: Built container within ppc Jenkins CI
Docs Changes: N/A
Release Notes: N/A