### PR TITLE
Change findTag to take a const& metric

### DIFF
--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -21,7 +21,7 @@ std::string Utility::sanitizeStatsName(absl::string_view name) {
   return stats_name;
 }
 
-absl::optional<StatName> Utility::findTag(Metric& metric, StatName find_tag_name) {
+absl::optional<StatName> Utility::findTag(const Metric& metric, StatName find_tag_name) {
   absl::optional<StatName> value;
   metric.iterateTagStatNames(
       [&value, &find_tag_name](Stats::StatName tag_name, Stats::StatName tag_value) -> bool {

--- a/source/common/stats/utility.h
+++ b/source/common/stats/utility.h
@@ -33,7 +33,7 @@ public:
    * @param find_tag_name The name of the tag to search for.
    * @return The value of the tag, if found.
    */
-  static absl::optional<StatName> findTag(Metric& metric, StatName find_tag_name);
+  static absl::optional<StatName> findTag(const Metric& metric, StatName find_tag_name);
 };
 
 } // namespace Stats


### PR DESCRIPTION
Description: change the metric parameter of the findTag utility to be a const reference.
Risk Level: low
Testing: unit tests
Signed-off-by: Elisha Ziskind <eziskind@google.com>
