### PR TITLE
dns: adjust DNS refresh rate respecting to record TTL

### DIFF
--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -161,6 +162,11 @@ public:
    * @return the type of address.
    */
   virtual Type type() const PURE;
+
+  /**
+   * @return address ttl.
+   */
+  virtual std::chrono::seconds ttl() const PURE;
 };
 
 typedef std::shared_ptr<const Instance> InstanceConstSharedPtr;

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -6,6 +6,7 @@
 #include <sys/un.h>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <string>
 
@@ -59,15 +60,18 @@ public:
   // Default logical name is the human-readable name.
   const std::string& logicalName() const override { return asString(); }
   Type type() const override { return type_; }
+  std::chrono::seconds ttl() const override { return addr_ttl_; }
+  void setAddrTtl(const std::chrono::seconds& ttl) { addr_ttl_ = ttl; }
 
 protected:
-  InstanceBase(Type type) : type_(type) {}
+  InstanceBase(Type type) : type_(type), addr_ttl_(std::chrono::seconds::max()) {}
   IoHandlePtr socketFromSocketType(SocketType type) const;
 
   std::string friendly_name_;
 
 private:
   const Type type_;
+  std::chrono::seconds addr_ttl_;
 };
 
 /**

--- a/source/common/upstream/strict_dns_cluster.cc
+++ b/source/common/upstream/strict_dns_cluster.cc
@@ -97,6 +97,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
 
         std::unordered_map<std::string, HostSharedPtr> updated_hosts;
         HostVector new_hosts;
+        std::chrono::seconds refresh_rate = std::chrono::seconds::max();
         for (const Network::Address::InstanceConstSharedPtr& address : address_list) {
           // TODO(mattklein123): Currently the DNS interface does not consider port. We need to
           // make a new address that has port in it. We need to both support IPv6 as well as
@@ -108,6 +109,8 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
               lb_endpoint_.metadata(), lb_endpoint_.load_balancing_weight().value(),
               locality_lb_endpoint_.locality(), lb_endpoint_.endpoint().health_check_config(),
               locality_lb_endpoint_.priority(), lb_endpoint_.health_status()));
+
+          refresh_rate = min(refresh_rate, address->ttl());
         }
 
         HostVector hosts_added;
@@ -130,7 +133,16 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         // completes. This is not perfect but is easier to code and unclear if the extra
         // complexity is needed so will start with this.
         parent_.onPreInitComplete();
-        resolve_timer_->enableTimer(parent_.dns_refresh_rate_ms_);
+
+        auto refresh_rate_ms = std::chrono::milliseconds(refresh_rate);
+        if (refresh_rate == std::chrono::seconds::max()) {
+          refresh_rate_ms = parent_.dns_refresh_rate_ms_;
+        }
+
+        ENVOY_LOG(debug, "DNS refresh rate reset for {}, refresh rate {} ms", dns_address_,
+                  refresh_rate_ms.count());
+
+        resolve_timer_->enableTimer(refresh_rate_ms);
       });
 }
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -372,6 +372,7 @@ public:
 
   const std::string& asString() const override { return physical_; }
   const std::string& logicalName() const override { return logical_; }
+  std::chrono::seconds ttl() const override { return std::chrono::seconds::max(); }
 
   const std::string logical_;
   const std::string physical_;

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -101,6 +101,7 @@ GLB
 GOAWAY
 GRPC
 GTEST
+GetHostbyName
 GiB
 HC
 HCM


### PR DESCRIPTION
Signed-off-by: Yan Xue <yxyan@google.com>

Description: Querying record TTL when resolving the host name and adjust DNS refresh rate respecting to record TTL.  
Risk Level: Medium
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Fixes #Issue: #6876
