### PR TITLE
/runtime_modify: add support for query params in body

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,7 @@ Version history
 * access log: added a new field for downstream TLS session ID to file and gRPC access logger.
 * access log: added a new field for response code details in :ref:`file access logger<config_access_log_format_response_code_details>` and :ref:`gRPC access logger<envoy_api_field_data.accesslog.v2.HTTPResponseProperties.response_code_details>`.
 * admin: the administration interface now includes a :ref:`/ready endpoint <operations_admin_interface>` for easier readiness checks.
+* admin: extend :ref:`/runtime_modify endpoint <operations_admin_interface_runtime_modify>` to support parameters within the request body.
 * api: track and report requests issued since last load report.
 * build: releases are built with Clang and linked with LLD.
 * dubbo_proxy: support the :ref:`Dubbo proxy filter <config_network_filters_dubbo_proxy>`.

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -130,6 +130,7 @@ public:
     const std::string GrpcWebText{"application/grpc-web-text"};
     const std::string GrpcWebTextProto{"application/grpc-web-text+proto"};
     const std::string Json{"application/json"};
+    const std::string FormUrlEncoded{"application/x-www-form-urlencoded"};
   } ContentTypeValues;
 
   struct {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -95,6 +95,7 @@ std::string Utility::createSslRedirectPath(const HeaderMap& headers) {
 Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
   size_t start = url.find('?');
   if (start == std::string::npos) {
+    QueryParams params;
     return params;
   }
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -93,13 +93,22 @@ std::string Utility::createSslRedirectPath(const HeaderMap& headers) {
 }
 
 Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
-  QueryParams params;
   size_t start = url.find('?');
   if (start == std::string::npos) {
     return params;
   }
 
   start++;
+  return parseParameters(url, start);
+}
+
+Utility::QueryParams Utility::parseFormBody(absl::string_view body) {
+  return parseParameters(body, 0);
+}
+
+Utility::QueryParams Utility::parseParameters(absl::string_view data, size_t start) {
+  QueryParams params;
+
   while (start < url.size()) {
     size_t end = url.find('&', start);
     if (end == std::string::npos) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -103,7 +103,7 @@ Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
   return parseParameters(url, start);
 }
 
-Utility::QueryParams Utility::parseFormBody(absl::string_view body) {
+Utility::QueryParams Utility::parseFromBody(absl::string_view body) {
   return parseParameters(body, 0);
 }
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -109,19 +109,19 @@ Utility::QueryParams Utility::parseFormBody(absl::string_view body) {
 Utility::QueryParams Utility::parseParameters(absl::string_view data, size_t start) {
   QueryParams params;
 
-  while (start < url.size()) {
-    size_t end = url.find('&', start);
+  while (start < data.size()) {
+    size_t end = data.find('&', start);
     if (end == std::string::npos) {
-      end = url.size();
+      end = data.size();
     }
-    absl::string_view param(url.data() + start, end - start);
+    absl::string_view param(data.data() + start, end - start);
 
     const size_t equal = param.find('=');
     if (equal != std::string::npos) {
-      params.emplace(StringUtil::subspan(url, start, start + equal),
-                     StringUtil::subspan(url, start + equal + 1, end));
+      params.emplace(StringUtil::subspan(data, start, start + equal),
+                     StringUtil::subspan(data, start + equal + 1, end));
     } else {
-      params.emplace(StringUtil::subspan(url, start, end), "");
+      params.emplace(StringUtil::subspan(data, start, end), "");
     }
 
     start = end + 1;

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -72,7 +72,7 @@ QueryParams parseQueryString(absl::string_view url);
  * @param body supplies the body to parse.
  * @return QueryParams the parsed parameters, if any.
  */
-QueryParams parseFormBody(absl::string_view body);
+QueryParams parseFromBody(absl::string_view body);
 
 /**
  * Parse query parameters from a URL or body.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -68,6 +68,21 @@ std::string createSslRedirectPath(const HeaderMap& headers);
 QueryParams parseQueryString(absl::string_view url);
 
 /**
+ * Parse a a request body into query parameters.
+ * @param body supplies the body to parse.
+ * @return QueryParams the parsed parameters, if any.
+ */
+QueryParams parseFormBody(absl::string_view body);
+
+/**
+ * Parse query parameters from a URL or body.
+ * @param data supplies the data to parse.
+ * @param start supplies the offset within the data.
+ * @return QueryParams the parsed parameters, if any.
+ */
+QueryParams parseParameters(absl::string_view data, size_t start);
+
+/**
  * Finds the start of the query string in a path
  * @param path supplies a HeaderString& to search for the query string
  * @return absl::string_view starting at the beginning of the query string,

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1081,7 +1081,7 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
     // Check if the params are in the request's body.
     // TODO(rgs1): check the content-type header in the request.
     if (admin_stream.getRequestBody() != nullptr) {
-      params = Http::Utility::parseFormBody(admin_stream.getRequestBody()->toString());
+      params = Http::Utility::parseFromBody(admin_stream.getRequestBody()->toString());
     }
 
     if (params.empty()) {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1087,7 +1087,6 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
   Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
   if (params.empty()) {
     // Check if the params are in the request's body.
-    // TODO(rgs1): check the content-type header in the request.
     if (admin_stream.getRequestBody() != nullptr &&
         isFormUrlEncoded(admin_stream.getRequestHeaders().ContentType())) {
       params = Http::Utility::parseFromBody(admin_stream.getRequestBody()->toString());

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1079,7 +1079,8 @@ bool AdminImpl::isFormUrlEncoded(const Http::HeaderEntry* content_type) const {
     return false;
   }
 
-  return content_type->value().getStringView() == "application/x-www-form-urlencoded";
+  return content_type->value().getStringView() ==
+         Http::Headers::get().ContentTypeValues.FormUrlEncoded;
 }
 
 Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMap&,

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1095,7 +1095,7 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
 
     if (params.empty()) {
       response.add("usage: /runtime_modify?key1=value1&key2=value2&keyN=valueN\n");
-      response.add("       or send the parameters within the request's body\n");
+      response.add("       or send the parameters as form values\n");
       response.add("use an empty value to remove a previously added override");
       return Http::Code::BadRequest;
     }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1078,9 +1078,8 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
                                            Buffer::Instance& response, AdminStream& admin_stream) {
   Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
   if (params.empty()) {
-    // Check if the params are in the request's body. Ideally, the content-type
-    // header would be `application/x-www-form-urlencoded`, but there's no way to
-    // check.
+    // Check if the params are in the request's body.
+    // TODO(rgs1): check the content-type header in the request.
     if (admin_stream.getRequestBody() != nullptr) {
       params = parseFormBody(admin_stream.getRequestBody()->toString());
     }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1086,6 +1086,7 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
 
     if (params.empty()) {
       response.add("usage: /runtime_modify?key1=value1&key2=value2&keyN=valueN\n");
+      response.add("       or send the parameters within the request's body\n");
       response.add("use an empty value to remove a previously added override");
       return Http::Code::BadRequest;
     }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1081,7 +1081,7 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
     // Check if the params are in the request's body.
     // TODO(rgs1): check the content-type header in the request.
     if (admin_stream.getRequestBody() != nullptr) {
-      params = parseFormBody(admin_stream.getRequestBody()->toString());
+      params = Http::Utility::parseFormBody(admin_stream.getRequestBody()->toString());
     }
 
     if (params.empty()) {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1082,8 +1082,7 @@ Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMa
     // header would be `application/x-www-form-urlencoded`, but there's no way to
     // check.
     if (admin_stream.getRequestBody() != nullptr) {
-      auto body = absl::string_view(admin_stream.getRequestBody()->toString());
-      params = parseFormBody(body);
+      params = parseFormBody(admin_stream.getRequestBody()->toString());
     }
 
     if (params.empty()) {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -253,6 +253,7 @@ private:
   Http::Code handlerRuntimeModify(absl::string_view path_and_query,
                                   Http::HeaderMap& response_headers, Buffer::Instance& response,
                                   AdminStream&);
+  bool isFormUrlEncoded(const Http::HeaderEntry* content_type) const;
 
   class AdminListener : public Network::ListenerConfig {
   public:

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -319,11 +319,24 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_EQ("application/json", ContentType(response));
 
+  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/runtime_modify",
+                                                "foo=bar&foo1=bar1", downstreamProtocol(), version_,
+                                                "host", "application/x-www-form-urlencoded");
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/runtime?format=json",
                                                 "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_EQ("application/json", ContentType(response));
+
+  Json::ObjectSharedPtr json = Json::Factory::loadFromString(response->body());
+  auto entries = json->getObject("entries");
+  auto foo_obj = entries->getObject("foo");
+  EXPECT_EQ("bar", foo_obj->getString("final_value"));
+  auto foo1_obj = entries->getObject("foo1");
+  EXPECT_EQ("bar1", foo1_obj->getString("final_value"));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/listeners", "",
                                                 downstreamProtocol(), version_);
@@ -331,7 +344,7 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_EQ("application/json", ContentType(response));
 
-  Json::ObjectSharedPtr json = Json::Factory::loadFromString(response->body());
+  json = Json::Factory::loadFromString(response->body());
   std::vector<Json::ObjectSharedPtr> listener_info = json->asObjectArray();
   auto listener_info_it = listener_info.cbegin();
   auto listeners = test_server_->server().listenerManager().listeners();

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -319,9 +319,9 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_EQ("application/json", ContentType(response));
 
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/runtime_modify",
-                                                "foo=bar&foo1=bar1", downstreamProtocol(), version_,
-                                                "host", "application/x-www-form-urlencoded");
+  response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "POST", "/runtime_modify", "foo=bar&foo1=bar1", downstreamProtocol(),
+      version_, "host", Http::Headers::get().ContentTypeValues.FormUrlEncoded);
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -595,12 +595,13 @@ public:
   Http::Code runCallback(absl::string_view path_and_query, Http::HeaderMap& response_headers,
                          Buffer::Instance& response, absl::string_view method,
                          absl::string_view body = absl::string_view()) {
-    request_headers_.insertMethod().value(method.data(), method.size());
-    admin_filter_.decodeHeaders(request_headers_, false);
-
     if (!body.empty()) {
+      request_headers_.insertContentType().value(std::string("application/x-www-form-urlencoded"));
       callbacks_.buffer_ = std::make_unique<Buffer::OwnedImpl>(body);
     }
+
+    request_headers_.insertMethod().value(method.data(), method.size());
+    admin_filter_.decodeHeaders(request_headers_, false);
 
     return admin_.runCallback(path_and_query, response_headers, response, admin_filter_);
   }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -596,7 +596,8 @@ public:
                          Buffer::Instance& response, absl::string_view method,
                          absl::string_view body = absl::string_view()) {
     if (!body.empty()) {
-      request_headers_.insertContentType().value(std::string("application/x-www-form-urlencoded"));
+      request_headers_.insertContentType().value(
+          Http::Headers::get().ContentTypeValues.FormUrlEncoded);
       callbacks_.buffer_ = std::make_unique<Buffer::OwnedImpl>(body);
     }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1006,16 +1006,15 @@ TEST_P(AdminInstanceTest, RuntimeModify) {
 }
 
 TEST_P(AdminInstanceTest, RuntimeModifyParamsInBody) {
-  const std::string key = "routing.traffic_shift.foo";
-  const std::string value = "numerator: 1\ndenominator: TEN_THOUSAND\n";
-  const std::string body = fmt::format("{}={}", key, value);
-
   Runtime::MockLoader loader;
   EXPECT_CALL(server_, runtime()).WillRepeatedly(testing::ReturnPointee(&loader));
 
+  const std::string key = "routing.traffic_shift.foo";
+  const std::string value = "numerator: 1\ndenominator: TEN_THOUSAND\n";
   const std::unordered_map<std::string, std::string> overrides = {{key, value}};
   EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
 
+  const std::string body = fmt::format("{}={}", key, value);
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, runCallback("/runtime_modify", header_map, response, "POST", body));

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1005,16 +1005,16 @@ TEST_P(AdminInstanceTest, RuntimeModify) {
 }
 
 TEST_P(AdminInstanceTest, RuntimeModifyParamsInBody) {
-  Http::HeaderMapImpl header_map;
-  Buffer::OwnedImpl response;
+  const std::string body = "numerator: 1\ndenominator: TEN_THOUSAND\n";
 
   Runtime::MockLoader loader;
   EXPECT_CALL(server_, runtime()).WillRepeatedly(testing::ReturnPointee(&loader));
 
-  const std::string body = "numerator: 1\ndenominator: TEN_THOUSAND\n";
-  std::unordered_map<std::string, std::string> overrides;
-  overrides["routing.traffic_shift.foo"] = body;
+  std::unordered_map<std::string, std::string> overrides = {{"routing.traffic_shift.foo", body}};
   EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
+
+  Http::HeaderMapImpl header_map;
+  Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, runCallback("/runtime_modify", header_map, response, "POST", body));
   EXPECT_EQ("OK\n", response.toString());
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -599,7 +599,7 @@ public:
     admin_filter_.decodeHeaders(request_headers_, false);
 
     if (!body.empty()) {
-      callbacks_.buffer_.reset(new Buffer::OwnedImpl(body));
+      callbacks_.buffer_ = std::make_unique<Buffer::OwnedImpl>(body);
     }
 
     return admin_.runCallback(path_and_query, response_headers, response, admin_filter_);

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -997,6 +997,21 @@ TEST_P(AdminInstanceTest, RuntimeModify) {
   EXPECT_EQ("OK\n", response.toString());
 }
 
+TEST_P(AdminInstanceTest, RuntimeModifyParamsInBody) {
+  Http::HeaderMapImpl header_map;
+  Buffer::OwnedImpl response;
+
+  Runtime::MockLoader loader;
+  EXPECT_CALL(server_, runtime()).WillRepeatedly(testing::ReturnPointee(&loader));
+
+  const std::string body = "numerator: 1\ndenominator: TEN_THOUSAND\n";
+  std::unordered_map<std::string, std::string> overrides;
+  overrides["routing.traffic_shift.foo"] = body;
+  EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
+  EXPECT_EQ(Http::Code::OK, admin_.request("/runtime_modify", "POST", header_map, body));
+  EXPECT_EQ("OK\n", response.toString());
+}
+
 TEST_P(AdminInstanceTest, RuntimeModifyNoArguments) {
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;


### PR DESCRIPTION
This adds support for setting RuntimeFractionalPercent values via
`/runtime_modify`, since it needs to be YAML and YAML cannot
be passed as query parameters (contains spaces & newlines).

Fixes: #6935

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
