### PR TITLE
Fix for an intermittently failing integration test

### DIFF
--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -187,6 +187,8 @@ public:
         compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
     sendDeltaDiscoveryResponse<envoy::api::v2::route::VirtualHost>({buildVirtualHost()}, {}, "1",
                                                                    vhds_stream_);
+    EXPECT_TRUE(
+        compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
 
     // Wait for our statically specified listener to become ready, and register its port in the
     // test framework's downstream listener port map.


### PR DESCRIPTION
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

This is  fix for intermittent failures in a vhds_integration_test: VhdsVirtualHostAddUpdateRemove.

Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
