### PR TITLE
build: Add common/common/macros.h for the FALLTHRU macro.

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -14,6 +14,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/hash.h"
+#include "common/common/macros.h"
 
 #include "absl/strings/string_view.h"
 


### PR DESCRIPTION
Add common/common/macros.h for the FALLTHRU macro.
It was included through the common/common/assert.h and broke google internal build that uses different header for asserts.

Risk Level: low
Testing: All unit tests

Signed-off-by: Yan Avlasov <yavlasov@google.com>
