### PR TITLE
Add OpenLab CI configuration

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,14 @@
+- project:
+    name: envoyproxy/envoy
+    check:
+      jobs:
+        - envoy-build-arm64
+
+- job:
+    name: envoy-build-arm64
+    parent: init-test
+    description: |
+      Envoy build in openlab cluster.
+    run: .zuul/playbooks/envoy-build/run.yaml
+    nodeset: ubuntu-xenial-arm64
+    voting: false

--- a/.zuul/playbooks/envoy-build/run.yaml
+++ b/.zuul/playbooks/envoy-build/run.yaml
@@ -1,0 +1,28 @@
+- hosts: all
+  become: yes
+  roles:
+    - role: config-gcc
+      gcc_version: 7
+  tasks:
+    - name: Build envoy
+      shell:
+        cmd: |
+          apt update
+          apt-get update
+          apt-get install -y \
+             libtool \
+             cmake \
+             automake \
+             autoconf \
+             make \
+             ninja-build \
+             curl \
+             unzip \
+             virtualenv
+
+          bazel build //source/exe:envoy-static | tee $LOGS_PATH//bazel.txt
+
+          cp -r ./bazel-bin $RESULTS_PATH
+        chdir: '{{ zuul.project.src_dir }}'
+        executable: /bin/bash
+      environment: '{{ global_env }}'


### PR DESCRIPTION
This patch adds the OpenLab CI configuration to enable the support for Envoy arm64 build in OpenLab.

After this, each pull request in envoy will trigger the `envoy-arm64-build` job which verified the arm build on OpenLab ARM cluster.

As the first version, we mark this job as non-voting job, that means the build job result is just a reference for developer and would not block the PR to be merged. Once we make sure the job can be executed stable, then we can mark it as normal "voting" job.

Related: #1861