### PR TITLE
timer: fix oss-fuzz issue #11852

### DIFF
--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -29,7 +29,7 @@ void TimerImpl::enableTimer(const std::chrono::milliseconds& d) {
     // overflow is undefined behavior). If it would overflow, just use
     // the maximum duration which can be expressed in microseconds.
     std::chrono::microseconds us;
-    if (d > std::chrono::duration_values<std::chrono::microseconds>::max() / 1000) {
+    if (d.count() > std::chrono::microseconds::duration::max().count() / 1000) {
       us = std::chrono::duration_values<std::chrono::microseconds>::max();
     } else {
       us = std::chrono::duration_cast<std::chrono::microseconds>(d);

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -23,7 +23,17 @@ void TimerImpl::enableTimer(const std::chrono::milliseconds& d) {
     event_active(&raw_event_, EV_TIMEOUT, 0);
   } else {
     // TODO(#4332): use duration_cast more nicely to clean up this code.
-    std::chrono::microseconds us = std::chrono::duration_cast<std::chrono::microseconds>(d);
+
+    // Since d is milliseconds, we need to check that the conversion
+    // doesn't overflow std::chrono::microseconds (since signed integer
+    // overflow is undefined behavior). If it would overflow, just use
+    // the maximum duration which can be expressed in microseconds.
+    std::chrono::microseconds us;
+    if (d > std::chrono::duration_values<std::chrono::microseconds>::max() / 1000) {
+      us = std::chrono::duration_values<std::chrono::microseconds>::max();
+    } else {
+      us = std::chrono::duration_cast<std::chrono::microseconds>(d);
+    }
     timeval tv;
     tv.tv_sec = us.count() / 1000000;
     tv.tv_usec = us.count() % 1000000;

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -9,6 +9,14 @@
 namespace Envoy {
 namespace Event {
 
+void TimerUtils::millisecondsToTimeval(const std::chrono::milliseconds& d, timeval& tv) {
+  std::chrono::seconds secs = std::chrono::duration_cast<std::chrono::seconds>(d);
+  std::chrono::microseconds usecs = std::chrono::duration_cast<std::chrono::microseconds>(d - secs);
+
+  tv.tv_sec = secs.count();
+  tv.tv_usec = usecs.count();
+}
+
 TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb) : cb_(cb) {
   ASSERT(cb_);
   evtimer_assign(
@@ -18,21 +26,12 @@ TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb) : cb_(cb) {
 
 void TimerImpl::disableTimer() { event_del(&raw_event_); }
 
-void TimerImpl::millisecondsToTimeval(timeval* tv, const std::chrono::milliseconds& d) {
-  ASSERT(tv);
-  std::chrono::seconds secs = std::chrono::duration_cast<std::chrono::seconds>(d);
-  std::chrono::microseconds usecs = std::chrono::duration_cast<std::chrono::microseconds>(d - secs);
-
-  tv->tv_sec = secs.count();
-  tv->tv_usec = usecs.count();
-}
-
 void TimerImpl::enableTimer(const std::chrono::milliseconds& d) {
   if (d.count() == 0) {
     event_active(&raw_event_, EV_TIMEOUT, 0);
   } else {
     timeval tv;
-    millisecondsToTimeval(&tv, d);
+    TimerUtils::millisecondsToTimeval(d, tv);
     event_add(&raw_event_, &tv);
   }
 }

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -22,6 +22,9 @@ public:
   void enableTimer(const std::chrono::milliseconds& d) override;
   bool enabled() override;
 
+  // Public for testing.
+  void millisecondsToTimeval(timeval* tv, const std::chrono::milliseconds& d);
+
 private:
   TimerCb cb_;
 };

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -11,6 +11,14 @@ namespace Envoy {
 namespace Event {
 
 /**
+ * Utility helper functions for Timer implementation.
+ */
+class TimerUtils {
+public:
+  static void millisecondsToTimeval(const std::chrono::milliseconds& d, timeval& tv);
+};
+
+/**
  * libevent implementation of Timer.
  */
 class TimerImpl : public Timer, ImplBase {
@@ -21,9 +29,6 @@ public:
   void disableTimer() override;
   void enableTimer(const std::chrono::milliseconds& d) override;
   bool enabled() override;
-
-  // Public for testing.
-  void millisecondsToTimeval(timeval* tv, const std::chrono::milliseconds& d);
 
 private:
   TimerCb cb_;

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -199,28 +199,24 @@ TEST(TimerImplTest, TimerEnabledDisabled) {
 }
 
 TEST(TimerImplTest, TimerValueConversion) {
-  Api::ApiPtr api = Api::createApiForTest();
-  DispatcherPtr dispatcher(api->allocateDispatcher());
-  Event::TimerPtr timer = dispatcher->createTimer([] {});
-  Event::TimerImpl* t = static_cast<Event::TimerImpl*>(timer.get());
   timeval tv;
   std::chrono::milliseconds msecs;
 
   // Basic test with zero milliseconds.
   msecs = std::chrono::milliseconds(0);
-  t->millisecondsToTimeval(&tv, msecs);
+  TimerUtils::millisecondsToTimeval(msecs, tv);
   EXPECT_EQ(tv.tv_sec, 0);
   EXPECT_EQ(tv.tv_usec, 0);
 
   // 2050 milliseconds is 2 seconds and 50000 microseconds.
   msecs = std::chrono::milliseconds(2050);
-  t->millisecondsToTimeval(&tv, msecs);
+  TimerUtils::millisecondsToTimeval(msecs, tv);
   EXPECT_EQ(tv.tv_sec, 2);
   EXPECT_EQ(tv.tv_usec, 50000);
 
   // Check maximum value conversion.
   msecs = std::chrono::milliseconds::duration::max();
-  t->millisecondsToTimeval(&tv, msecs);
+  TimerUtils::millisecondsToTimeval(msecs, tv);
   EXPECT_EQ(tv.tv_sec, msecs.count() / 1000);
   EXPECT_EQ(tv.tv_usec, (msecs.count() % tv.tv_sec) * 1000);
 }

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -218,7 +218,7 @@ TEST(TimerImplTest, TimerValueConversion) {
   EXPECT_EQ(tv.tv_sec, 2);
   EXPECT_EQ(tv.tv_usec, 50000);
 
-  // Check maximium value conversion.
+  // Check maximum value conversion.
   msecs = std::chrono::milliseconds::duration::max();
   t->millisecondsToTimeval(&tv, msecs);
   EXPECT_EQ(tv.tv_sec, msecs.count() / 1000);

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5686444035670016
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5686444035670016
@@ -1,0 +1,2 @@
+static_resources {   clusters {     name: " "     connect_timeout {       nanos: 4     }     hosts {
+      pipe {       }     }     health_checks {       timeout {         nanos: 4       }       interval {         nanos: 4       }       unhealthy_threshold {       }       healthy_threshold {       }       tcp_health_check {       }       no_traffic_interval {         seconds: 2818048       }       interval_jitter_percent: 537791091     }   } } 


### PR DESCRIPTION
Description:

Fix a time conversion signed int overflow (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11852).

Risk Level: low
Testing: fuzz