### PR TITLE
Add support to unregister from lifecycle notifications

### DIFF
--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -30,6 +30,15 @@ public:
     ShutdownExit
   };
 
+  // A handle to a registration that can be used to unregister.
+  class Handle {
+  public:
+    virtual ~Handle() = default;
+
+    virtual void unregister() PURE;
+  };
+  using HandlePtr = std::unique_ptr<Handle>;
+
   /**
    * Callback invoked when the server reaches a certain lifecycle stage.
    *
@@ -49,8 +58,8 @@ public:
    * The second version which takes a completion back is currently only supported
    * for the ShutdownExit stage.
    */
-  virtual void registerCallback(Stage stage, StageCallback callback) PURE;
-  virtual void registerCallback(Stage stage, StageCallbackWithCompletion callback) PURE;
+  virtual HandlePtr registerCallback(Stage stage, StageCallback callback) PURE;
+  virtual HandlePtr registerCallback(Stage stage, StageCallbackWithCompletion callback) PURE;
 };
 
 } // namespace Server

--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -30,12 +30,10 @@ public:
     ShutdownExit
   };
 
-  // A handle to a registration that can be used to unregister.
+  // A handle to a callback registration. Deleting this handle will unregister the callback.
   class Handle {
   public:
     virtual ~Handle() = default;
-
-    virtual void unregister() PURE;
   };
   using HandlePtr = std::unique_ptr<Handle>;
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -139,8 +139,12 @@ public:
   }
 
   // ServerLifecycleNotifier
-  ServerLifecycleNotifier::HandlePtr registerCallback(Stage, StageCallback) override { return nullptr; }
-  ServerLifecycleNotifier::HandlePtr registerCallback(Stage, StageCallbackWithCompletion) override { return nullptr; }
+  ServerLifecycleNotifier::HandlePtr registerCallback(Stage, StageCallback) override {
+    return nullptr;
+  }
+  ServerLifecycleNotifier::HandlePtr registerCallback(Stage, StageCallbackWithCompletion) override {
+    return nullptr;
+  }
 
 private:
   void initialize(const Options& options, Network::Address::InstanceConstSharedPtr local_address,

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -139,8 +139,8 @@ public:
   }
 
   // ServerLifecycleNotifier
-  void registerCallback(Stage, StageCallback) override {}
-  void registerCallback(Stage, StageCallbackWithCompletion) override {}
+  ServerLifecycleNotifier::HandlePtr registerCallback(Stage, StageCallback) override { return nullptr; }
+  ServerLifecycleNotifier::HandlePtr registerCallback(Stage, StageCallbackWithCompletion) override { return nullptr; }
 
 private:
   void initialize(const Options& options, Network::Address::InstanceConstSharedPtr local_address,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -194,8 +194,9 @@ public:
   }
 
   // ServerLifecycleNotifier
-  void registerCallback(Stage stage, StageCallback callback) override;
-  void registerCallback(Stage stage, StageCallbackWithCompletion callback) override;
+  ServerLifecycleNotifier::HandlePtr registerCallback(Stage stage, StageCallback callback) override;
+  ServerLifecycleNotifier::HandlePtr
+  registerCallback(Stage stage, StageCallbackWithCompletion callback) override;
 
 private:
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
@@ -260,8 +261,29 @@ private:
   Http::ContextImpl http_context_;
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
   const std::thread::id main_thread_id_;
-  absl::flat_hash_map<Stage, std::vector<StageCallback>> stage_callbacks_;
-  absl::flat_hash_map<Stage, std::vector<StageCallbackWithCompletion>> stage_completable_callbacks_;
+
+  using LifecycleNotifierCallbacks = std::list<StageCallback>;
+  using LifecycleNotifierCompletionCallbacks = std::list<StageCallbackWithCompletion>;
+
+  template <class T> class LifecycleCallbackHandle : public ServerLifecycleNotifier::Handle {
+  public:
+    LifecycleCallbackHandle(T& callbacks, typename T::iterator it)
+        : callbacks_(callbacks), it_(it) {}
+
+    void unregister() override {
+      ASSERT(!unregistered_);
+      unregistered_ = true;
+      callbacks_.erase(it_);
+    }
+
+  private:
+    bool unregistered_ = false;
+    T& callbacks_;
+    typename T::iterator it_;
+  };
+
+  absl::flat_hash_map<Stage, LifecycleNotifierCallbacks> stage_callbacks_;
+  absl::flat_hash_map<Stage, LifecycleNotifierCompletionCallbacks> stage_completable_callbacks_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -269,16 +269,9 @@ private:
   public:
     LifecycleCallbackHandle(T& callbacks, typename T::iterator it)
         : callbacks_(callbacks), it_(it) {}
-    ~LifecycleCallbackHandle() override { unregister(); }
+    ~LifecycleCallbackHandle() override { callbacks_.erase(it_); }
 
   private:
-    void unregister() {
-      ASSERT(!unregistered_);
-      unregistered_ = true;
-      callbacks_.erase(it_);
-    }
-
-    bool unregistered_ = false;
     T& callbacks_;
     typename T::iterator it_;
   };

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -269,14 +269,15 @@ private:
   public:
     LifecycleCallbackHandle(T& callbacks, typename T::iterator it)
         : callbacks_(callbacks), it_(it) {}
+    ~LifecycleCallbackHandle() override { unregister(); }
 
-    void unregister() override {
+  private:
+    void unregister() {
       ASSERT(!unregistered_);
       unregistered_ = true;
       callbacks_.erase(it_);
     }
 
-  private:
     bool unregistered_ = false;
     T& callbacks_;
     typename T::iterator it_;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -265,8 +265,9 @@ public:
   MockServerLifecycleNotifier();
   ~MockServerLifecycleNotifier();
 
-  MOCK_METHOD2(registerCallback, void(Stage, StageCallback));
-  MOCK_METHOD2(registerCallback, void(Stage, StageCallbackWithCompletion));
+  MOCK_METHOD2(registerCallback, ServerLifecycleNotifier::HandlePtr(Stage, StageCallback));
+  MOCK_METHOD2(registerCallback,
+               ServerLifecycleNotifier::HandlePtr(Stage, StageCallbackWithCompletion));
 };
 
 class MockWorkerFactory : public WorkerFactory {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -182,29 +182,32 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
   // Run the server in a separate thread so we can test different lifecycle stages.
   auto server_thread = Thread::threadFactoryForTest().createThread([&] {
     initialize("test/server/node_bootstrap.yaml");
-    server_->registerCallback(ServerLifecycleNotifier::Stage::Startup, [&] {
+    auto handle1 = server_->registerCallback(ServerLifecycleNotifier::Stage::Startup, [&] {
       startup = true;
       started.Notify();
     });
-    server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit, [&] {
+    auto handle2 = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit, [&] {
       shutdown = true;
       shutdown_begin.Notify();
     });
-    server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
-                              [&](Event::PostCb completion_cb) {
-                                // Block till we're told to complete
-                                completion_block.WaitForNotification();
-                                shutdown_with_completion = true;
-                                server_->dispatcher().post(completion_cb);
-                                completion_done.Notify();
-                              });
-    auto handle =
+    auto handle3 = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
+                                             [&](Event::PostCb completion_cb) {
+                                               // Block till we're told to complete
+                                               completion_block.WaitForNotification();
+                                               shutdown_with_completion = true;
+                                               server_->dispatcher().post(completion_cb);
+                                               completion_done.Notify();
+                                             });
+    auto handle4 =
         server_->registerCallback(ServerLifecycleNotifier::Stage::Startup, [&] { FAIL(); });
-    handle->unregister();
-    handle = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
-                                       [&](Event::PostCb) { FAIL(); });
-    handle->unregister();
+    handle4 = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
+                                        [&](Event::PostCb) { FAIL(); });
+    handle4 = nullptr;
+
     server_->run();
+    handle1 = nullptr;
+    handle2 = nullptr;
+    handle3 = nullptr;
     server_ = nullptr;
     thread_local_ = nullptr;
   });

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -198,6 +198,12 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
                                 server_->dispatcher().post(completion_cb);
                                 completion_done.Notify();
                               });
+    auto handle =
+        server_->registerCallback(ServerLifecycleNotifier::Stage::Startup, [&] { FAIL(); });
+    handle->unregister();
+    handle = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
+                                       [&](Event::PostCb) { FAIL(); });
+    handle->unregister();
     server_->run();
     server_ = nullptr;
     thread_local_ = nullptr;


### PR DESCRIPTION
Description: Return a handle from registration methods that can be used to unregister. This is needed for registrations made by objects that can have a shorter lifetime than the server (such as filters or access logs). When those objects are destroyed the callbacks will be invalidated so the registrations should be removed to avoid memory access violations.
Risk Level: low
Testing: unit tests
Signed-off-by: Elisha Ziskind eziskind@google.com