### PR TITLE
tracing: Add trace sampling configuration to the route, to override the route level

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -233,7 +233,7 @@ message Route {
 
   // Presence of the object defines whether the connection manager's tracing configuration
   // is overridden by this route specific instance.
-  Tracing tracing = 14;
+  Tracing tracing = 15;
 }
 
 // Compared to the :ref:`cluster <envoy_api_field_route.RouteAction.cluster>` field that specifies a
@@ -1019,14 +1019,14 @@ message Tracing {
   // 'tracing.client_sampling' in the :ref:`HTTP Connection Manager
   // <config_http_conn_man_runtime>`.
   // Default: 100%
-  envoy.type.Percent client_sampling = 1;
+  envoy.type.FractionalPercent client_sampling = 1;
 
   // Target percentage of requests managed by this HTTP connection manager that will be randomly
   // selected for trace generation, if not requested by the client or not forced. This field is
   // a direct analog for the runtime variable 'tracing.random_sampling' in the
   // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
   // Default: 100%
-  envoy.type.Percent random_sampling = 2;
+  envoy.type.FractionalPercent random_sampling = 2;
 
   // Target percentage of requests managed by this HTTP connection manager that will be traced
   // after all other sampling checks have been applied (client-directed, force tracing, random
@@ -1036,7 +1036,7 @@ message Tracing {
   // analog for the runtime variable 'tracing.global_enabled' in the
   // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
   // Default: 100%
-  envoy.type.Percent overall_sampling = 3;
+  envoy.type.FractionalPercent overall_sampling = 3;
 }
 
 // A virtual cluster is a way of specifying a regex matching rule against

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -230,6 +230,10 @@ message Route {
   // Specifies a list of HTTP headers that should be removed from each response
   // to requests matching this route.
   repeated string response_headers_to_remove = 11;
+
+  // Presence of the object defines whether the connection manager's tracing configuration
+  // is overridden by this route specific instance.
+  Tracing tracing = 14;
 }
 
 // Compared to the :ref:`cluster <envoy_api_field_route.RouteAction.cluster>` field that specifies a
@@ -1005,6 +1009,34 @@ message Decorator {
   //   by the :ref:`x-envoy-decorator-operation
   //   <config_http_filters_router_x-envoy-decorator-operation>` header.
   string operation = 1 [(validate.rules).string.min_bytes = 1];
+}
+
+message Tracing {
+
+  // Target percentage of requests managed by this HTTP connection manager that will be force
+  // traced if the :ref:`x-client-trace-id <config_http_conn_man_headers_x-client-trace-id>`
+  // header is set. This field is a direct analog for the runtime variable
+  // 'tracing.client_sampling' in the :ref:`HTTP Connection Manager
+  // <config_http_conn_man_runtime>`.
+  // Default: 100%
+  envoy.type.Percent client_sampling = 1;
+
+  // Target percentage of requests managed by this HTTP connection manager that will be randomly
+  // selected for trace generation, if not requested by the client or not forced. This field is
+  // a direct analog for the runtime variable 'tracing.random_sampling' in the
+  // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+  // Default: 100%
+  envoy.type.Percent random_sampling = 2;
+
+  // Target percentage of requests managed by this HTTP connection manager that will be traced
+  // after all other sampling checks have been applied (client-directed, force tracing, random
+  // sampling). This field functions as an upper limit on the total configured sampling rate. For
+  // instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1%
+  // of client requests with the appropriate headers to be force traced. This field is a direct
+  // analog for the runtime variable 'tracing.global_enabled' in the
+  // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+  // Default: 100%
+  envoy.type.Percent overall_sampling = 3;
 }
 
 // A virtual cluster is a way of specifying a regex matching rule against

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -45,6 +45,7 @@ Version history
 * server: ``--define manual_stamp=manual_stamp`` was added to allow server stamping outside of binary rules.
   more info in the `bazel docs <https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#enabling-optional-features>`_.
 * tool: added :repo:`proto <test/tools/router_check/validation.proto>` support for :ref:`router check tool <install_tools_route_table_check_tool>` tests.
+* tracing: Add trace sampling configuration to the route, to override the route level
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
 * upstream: an EDS management server can now force removal of a host that is still passing active
   health checking by first marking the host as failed via EDS health check and subsequently removing

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -45,7 +45,7 @@ Version history
 * server: ``--define manual_stamp=manual_stamp`` was added to allow server stamping outside of binary rules.
   more info in the `bazel docs <https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#enabling-optional-features>`_.
 * tool: added :repo:`proto <test/tools/router_check/validation.proto>` support for :ref:`router check tool <install_tools_route_table_check_tool>` tests.
-* tracing: Add trace sampling configuration to the route, to override the route level
+* tracing: add trace sampling configuration to the route, to override the route level.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
 * upstream: an EDS management server can now force removal of a host that is still passing active
   health checking by first marking the host as failed via EDS health check and subsequently removing

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -779,19 +779,19 @@ public:
    * This method returns the client sampling percentage.
    * @return the client sampling percentage
    */
-  virtual uint64_t getClientSampling() const PURE;
+  virtual const envoy::type::FractionalPercent& getClientSampling() const PURE;
 
   /**
    * This method returns the random sampling percentage.
    * @return the random sampling percentage
    */
-  virtual uint64_t getRandomSampling() const PURE;
+  virtual const envoy::type::FractionalPercent& getRandomSampling() const PURE;
 
   /**
    * This method returns the overall sampling percentage.
    * @return the overall sampling percentage
    */
-  virtual uint64_t getOverallSampling() const PURE;
+  virtual const envoy::type::FractionalPercent& getOverallSampling() const PURE;
 };
 
 typedef std::unique_ptr<const RouteTracing> RouteTracingConstPtr;

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -769,6 +769,34 @@ public:
 typedef std::unique_ptr<const Decorator> DecoratorConstPtr;
 
 /**
+ * An interface representing the Tracing for the route configuration.
+ */
+class RouteTracing {
+public:
+  virtual ~RouteTracing() {}
+
+  /**
+   * This method returns the client sampling percentage.
+   * @return the client sampling percentage
+   */
+  virtual uint64_t getClientSampling() const PURE;
+
+  /**
+   * This method returns the random sampling percentage.
+   * @return the random sampling percentage
+   */
+  virtual uint64_t getRandomSampling() const PURE;
+
+  /**
+   * This method returns the overall sampling percentage.
+   * @return the overall sampling percentage
+   */
+  virtual uint64_t getOverallSampling() const PURE;
+};
+
+typedef std::unique_ptr<const RouteTracing> RouteTracingConstPtr;
+
+/**
  * An interface that holds a DirectResponseEntry or RouteEntry for a request.
  */
 class Route {
@@ -789,6 +817,11 @@ public:
    * @return the decorator or nullptr if not defined for the request.
    */
   virtual const Decorator* decorator() const PURE;
+
+  /**
+   * @return the tracing config or nullptr if not defined for the request.
+   */
+  virtual const RouteTracing* tracingConfig() const PURE;
 
   /**
    * @return const RouteSpecificFilterConfig* the per-filter config pre-processed object for

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -270,6 +270,7 @@ private:
     const Router::DirectResponseEntry* directResponseEntry() const override { return nullptr; }
     const Router::RouteEntry* routeEntry() const override { return &route_entry_; }
     const Router::Decorator* decorator() const override { return nullptr; }
+    const Router::RouteTracing* tracingConfig() const override { return nullptr; }
     const Router::RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override {
       return nullptr;
     }

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -106,9 +106,9 @@ struct ConnectionManagerTracingStats {
 struct TracingConnectionManagerConfig {
   Tracing::OperationName operation_name_;
   std::vector<Http::LowerCaseString> request_headers_for_tags_;
-  uint64_t client_sampling_;
-  uint64_t random_sampling_;
-  uint64_t overall_sampling_;
+  envoy::type::FractionalPercent client_sampling_;
+  envoy::type::FractionalPercent random_sampling_;
+  envoy::type::FractionalPercent overall_sampling_;
   bool verbose_;
 };
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -715,7 +715,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   ASSERT(!cached_route_);
   refreshCachedRoute();
 
-  if (!state_.is_internally_created_) {
+  if (!state_.is_internally_created_) { // Only mutate tracing headers on first pass.
     ConnectionManagerUtility::mutateTracingRequestHeader(
         *request_headers_, connection_manager_.runtime_, connection_manager_.config_,
         cached_route_.value().get());

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -708,12 +708,18 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     stream_info_.setDownstreamRemoteAddress(ConnectionManagerUtility::mutateRequestHeaders(
         *request_headers_, connection_manager_.read_callbacks_->connection(),
         connection_manager_.config_, *snapped_route_config_, connection_manager_.random_generator_,
-        connection_manager_.runtime_, connection_manager_.local_info_));
+        connection_manager_.local_info_));
   }
   ASSERT(stream_info_.downstreamRemoteAddress() != nullptr);
 
   ASSERT(!cached_route_);
   refreshCachedRoute();
+
+  if (!state_.is_internally_created_) {
+    ConnectionManagerUtility::mutateTracingRequestHeader(
+        *request_headers_, connection_manager_.runtime_, connection_manager_.config_, cached_route_.value().get());
+  }
+
   const bool upgrade_rejected = createFilterChain() == false;
 
   // TODO if there are no filters when starting a filter iteration, the connection manager

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -717,7 +717,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   if (!state_.is_internally_created_) {
     ConnectionManagerUtility::mutateTracingRequestHeader(
-        *request_headers_, connection_manager_.runtime_, connection_manager_.config_, cached_route_.value().get());
+        *request_headers_, connection_manager_.runtime_, connection_manager_.config_,
+        cached_route_.value().get());
   }
 
   const bool upgrade_rejected = createFilterChain() == false;

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -52,8 +52,7 @@ ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
 
 Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequestHeaders(
     HeaderMap& request_headers, Network::Connection& connection, ConnectionManagerConfig& config,
-    const Router::Config& route_config, Runtime::RandomGenerator& random, Runtime::Loader& runtime,
-    const LocalInfo::LocalInfo& local_info) {
+    const Router::Config& route_config, Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info) {
   // If this is a Upgrade request, do not remove the Connection and Upgrade headers,
   // as we forward them verbatim to the upstream hosts.
   if (Utility::isUpgrade(request_headers)) {
@@ -213,7 +212,6 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
     request_headers.insertRequestId().value(uuid);
   }
 
-  mutateTracingRequestHeader(request_headers, runtime, config);
   mutateXfccRequestHeader(request_headers, connection, config);
 
   return final_remote_address;
@@ -221,7 +219,8 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
 
 void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_headers,
                                                           Runtime::Loader& runtime,
-                                                          ConnectionManagerConfig& config) {
+                                                          ConnectionManagerConfig& config,
+                                                          const Router::Route* route) {
   if (!config.tracingConfig() || !request_headers.RequestId()) {
     return;
   }
@@ -234,23 +233,33 @@ void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_hea
     return;
   }
 
+  uint32_t client_sampling = config.tracingConfig()->client_sampling_;
+  uint32_t random_sampling = config.tracingConfig()->random_sampling_;
+  uint32_t overall_sampling = config.tracingConfig()->overall_sampling_;
+
+  if (route && route->tracingConfig()) {
+    client_sampling = route->tracingConfig()->getClientSampling();
+    random_sampling = route->tracingConfig()->getRandomSampling();
+    overall_sampling = route->tracingConfig()->getOverallSampling();
+  }
+
   // Do not apply tracing transformations if we are currently tracing.
   if (UuidTraceStatus::NoTrace == UuidUtils::isTraceableUuid(x_request_id)) {
     if (request_headers.ClientTraceId() &&
         runtime.snapshot().featureEnabled("tracing.client_enabled",
-                                          config.tracingConfig()->client_sampling_)) {
+                                          client_sampling)) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Client);
     } else if (request_headers.EnvoyForceTrace()) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Forced);
     } else if (runtime.snapshot().featureEnabled("tracing.random_sampling",
-                                                 config.tracingConfig()->random_sampling_, result,
+                                                 random_sampling, result,
                                                  10000)) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Sampled);
     }
   }
 
   if (!runtime.snapshot().featureEnabled("tracing.global_enabled",
-                                         config.tracingConfig()->overall_sampling_, result)) {
+                                         overall_sampling, result)) {
     UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::NoTrace);
   }
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -52,7 +52,8 @@ ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
 
 Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequestHeaders(
     HeaderMap& request_headers, Network::Connection& connection, ConnectionManagerConfig& config,
-    const Router::Config& route_config, Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info) {
+    const Router::Config& route_config, Runtime::RandomGenerator& random,
+    const LocalInfo::LocalInfo& local_info) {
   // If this is a Upgrade request, do not remove the Connection and Upgrade headers,
   // as we forward them verbatim to the upstream hosts.
   if (Utility::isUpgrade(request_headers)) {
@@ -246,20 +247,17 @@ void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_hea
   // Do not apply tracing transformations if we are currently tracing.
   if (UuidTraceStatus::NoTrace == UuidUtils::isTraceableUuid(x_request_id)) {
     if (request_headers.ClientTraceId() &&
-        runtime.snapshot().featureEnabled("tracing.client_enabled",
-                                          client_sampling)) {
+        runtime.snapshot().featureEnabled("tracing.client_enabled", client_sampling)) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Client);
     } else if (request_headers.EnvoyForceTrace()) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Forced);
-    } else if (runtime.snapshot().featureEnabled("tracing.random_sampling",
-                                                 random_sampling, result,
+    } else if (runtime.snapshot().featureEnabled("tracing.random_sampling", random_sampling, result,
                                                  10000)) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Sampled);
     }
   }
 
-  if (!runtime.snapshot().featureEnabled("tracing.global_enabled",
-                                         overall_sampling, result)) {
+  if (!runtime.snapshot().featureEnabled("tracing.global_enabled", overall_sampling, result)) {
     UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::NoTrace);
   }
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -234,9 +234,9 @@ void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_hea
     return;
   }
 
-  uint32_t client_sampling = config.tracingConfig()->client_sampling_;
-  uint32_t random_sampling = config.tracingConfig()->random_sampling_;
-  uint32_t overall_sampling = config.tracingConfig()->overall_sampling_;
+  envoy::type::FractionalPercent client_sampling = config.tracingConfig()->client_sampling_;
+  envoy::type::FractionalPercent random_sampling = config.tracingConfig()->random_sampling_;
+  envoy::type::FractionalPercent overall_sampling = config.tracingConfig()->overall_sampling_;
 
   if (route && route->tracingConfig()) {
     client_sampling = route->tracingConfig()->getClientSampling();
@@ -251,8 +251,8 @@ void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_hea
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Client);
     } else if (request_headers.EnvoyForceTrace()) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Forced);
-    } else if (runtime.snapshot().featureEnabled("tracing.random_sampling", random_sampling, result,
-                                                 10000)) {
+    } else if (runtime.snapshot().featureEnabled("tracing.random_sampling", random_sampling,
+                                                 result)) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Sampled);
     }
   }

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -67,7 +67,8 @@ public:
    * Mutate request headers if request needs to be traced.
    */
   static void mutateTracingRequestHeader(HeaderMap& request_headers, Runtime::Loader& runtime,
-                                         ConnectionManagerConfig& config, const Router::Route* route);
+                                         ConnectionManagerConfig& config,
+                                         const Router::Route* route);
 
 private:
   static void mutateXfccRequestHeader(HeaderMap& request_headers, Network::Connection& connection,

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -53,8 +53,7 @@ public:
   static Network::Address::InstanceConstSharedPtr
   mutateRequestHeaders(HeaderMap& request_headers, Network::Connection& connection,
                        ConnectionManagerConfig& config, const Router::Config& route_config,
-                       Runtime::RandomGenerator& random, Runtime::Loader& runtime,
-                       const LocalInfo::LocalInfo& local_info);
+                       Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info);
 
   static void mutateResponseHeaders(HeaderMap& response_headers, const HeaderMap* request_headers,
                                     const std::string& via);
@@ -64,13 +63,13 @@ public:
   // Return false if error happens during the sanitization.
   static bool maybeNormalizePath(HeaderMap& request_headers, const ConnectionManagerConfig& config);
 
-private:
   /**
    * Mutate request headers if request needs to be traced.
    */
   static void mutateTracingRequestHeader(HeaderMap& request_headers, Runtime::Loader& runtime,
-                                         ConnectionManagerConfig& config);
+                                         ConnectionManagerConfig& config, const Router::Route* route);
 
+private:
   static void mutateXfccRequestHeader(HeaderMap& request_headers, Network::Connection& connection,
                                       ConnectionManagerConfig& config);
 };

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -332,8 +332,8 @@ RouteTracingImpl::RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing
     client_sampling_ = tracing.client_sampling();
   }
   if (!tracing.has_random_sampling()) {
-    random_sampling_.set_numerator(10000);
-    random_sampling_.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+    random_sampling_.set_numerator(100);
+    random_sampling_.set_denominator(envoy::type::FractionalPercent::HUNDRED);
   } else {
     random_sampling_ = tracing.random_sampling();
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -324,9 +324,26 @@ void DecoratorImpl::apply(Tracing::Span& span) const {
 
 const std::string& DecoratorImpl::getOperation() const { return operation_; }
 
-RouteTracingImpl::RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing)
-    : client_sampling_(tracing.client_sampling()), random_sampling_(tracing.random_sampling()),
-      overall_sampling_(tracing.overall_sampling()) {}
+RouteTracingImpl::RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing) {
+  if (!tracing.has_client_sampling()) {
+    client_sampling_.set_numerator(100);
+    client_sampling_.set_denominator(envoy::type::FractionalPercent::HUNDRED);
+  } else {
+    client_sampling_ = tracing.client_sampling();
+  }
+  if (!tracing.has_random_sampling()) {
+    random_sampling_.set_numerator(10000);
+    random_sampling_.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+  } else {
+    random_sampling_ = tracing.random_sampling();
+  }
+  if (!tracing.has_overall_sampling()) {
+    overall_sampling_.set_numerator(100);
+    overall_sampling_.set_denominator(envoy::type::FractionalPercent::HUNDRED);
+  } else {
+    overall_sampling_ = tracing.overall_sampling();
+  }
+}
 
 const envoy::type::FractionalPercent& RouteTracingImpl::getClientSampling() const {
   return client_sampling_;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -325,18 +325,20 @@ void DecoratorImpl::apply(Tracing::Span& span) const {
 const std::string& DecoratorImpl::getOperation() const { return operation_; }
 
 RouteTracingImpl::RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing)
-    : client_sampling_(
-          PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, client_sampling, 100, 100)),
-      random_sampling_(
-          PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, random_sampling, 10000, 10000)),
-      overall_sampling_(
-          PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, overall_sampling, 100, 100)) {}
+    : client_sampling_(tracing.client_sampling()), random_sampling_(tracing.random_sampling()),
+      overall_sampling_(tracing.overall_sampling()) {}
 
-uint64_t RouteTracingImpl::getClientSampling() const { return client_sampling_; }
+const envoy::type::FractionalPercent& RouteTracingImpl::getClientSampling() const {
+  return client_sampling_;
+}
 
-uint64_t RouteTracingImpl::getRandomSampling() const { return random_sampling_; }
+const envoy::type::FractionalPercent& RouteTracingImpl::getRandomSampling() const {
+  return random_sampling_;
+}
 
-uint64_t RouteTracingImpl::getOverallSampling() const { return overall_sampling_; }
+const envoy::type::FractionalPercent& RouteTracingImpl::getOverallSampling() const {
+  return overall_sampling_;
+}
 
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                        const envoy::api::v2::route::Route& route,
@@ -374,7 +376,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                                        route.response_headers_to_remove())),
       metadata_(route.metadata()), typed_metadata_(route.metadata()),
       match_grpc_(route.match().has_grpc()), opaque_config_(parseOpaqueConfig(route)),
-      decorator_(parseDecorator(route)), routeTracing_(parseRouteTracing(route)),
+      decorator_(parseDecorator(route)), route_tracing_(parseRouteTracing(route)),
       direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
       direct_response_body_(ConfigUtility::parseDirectResponseBody(route, factory_context.api())),
       per_filter_configs_(route.typed_per_filter_config(), route.per_filter_config(),

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -325,9 +325,12 @@ void DecoratorImpl::apply(Tracing::Span& span) const {
 const std::string& DecoratorImpl::getOperation() const { return operation_; }
 
 RouteTracingImpl::RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing)
-    : client_sampling_(PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, client_sampling, 100, 100)),
-    random_sampling_(PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, random_sampling, 10000, 10000)),
-    overall_sampling_(PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, overall_sampling, 100, 100)) {}
+    : client_sampling_(
+          PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, client_sampling, 100, 100)),
+      random_sampling_(
+          PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, random_sampling, 10000, 10000)),
+      overall_sampling_(
+          PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing, overall_sampling, 100, 100)) {}
 
 uint64_t RouteTracingImpl::getClientSampling() const { return client_sampling_; }
 
@@ -371,8 +374,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                                        route.response_headers_to_remove())),
       metadata_(route.metadata()), typed_metadata_(route.metadata()),
       match_grpc_(route.match().has_grpc()), opaque_config_(parseOpaqueConfig(route)),
-      decorator_(parseDecorator(route)),
-      routeTracing_(parseRouteTracing(route)),
+      decorator_(parseDecorator(route)), routeTracing_(parseRouteTracing(route)),
       direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
       direct_response_body_(ConfigUtility::parseDirectResponseBody(route, factory_context.api())),
       per_filter_configs_(route.typed_per_filter_config(), route.per_filter_config(),
@@ -679,7 +681,8 @@ DecoratorConstPtr RouteEntryImplBase::parseDecorator(const envoy::api::v2::route
   return ret;
 }
 
-RouteTracingConstPtr RouteEntryImplBase::parseRouteTracing(const envoy::api::v2::route::Route& route) {
+RouteTracingConstPtr
+RouteEntryImplBase::parseRouteTracing(const envoy::api::v2::route::Route& route) {
   RouteTracingConstPtr ret;
   if (route.has_tracing()) {
     ret = RouteTracingConstPtr(new RouteTracingImpl(route.tracing()));

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -364,9 +364,9 @@ public:
   const envoy::type::FractionalPercent& getOverallSampling() const override;
 
 private:
-  const envoy::type::FractionalPercent client_sampling_;
-  const envoy::type::FractionalPercent random_sampling_;
-  const envoy::type::FractionalPercent overall_sampling_;
+  envoy::type::FractionalPercent client_sampling_;
+  envoy::type::FractionalPercent random_sampling_;
+  envoy::type::FractionalPercent overall_sampling_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -87,6 +87,7 @@ public:
   const DirectResponseEntry* directResponseEntry() const override { return &SSL_REDIRECTOR; }
   const RouteEntry* routeEntry() const override { return nullptr; }
   const Decorator* decorator() const override { return nullptr; }
+  const RouteTracing* tracingConfig() const override { return nullptr; }
   const RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override {
     return nullptr;
   }
@@ -347,6 +348,28 @@ private:
 };
 
 /**
+ * Implementation of RouteTracing that reads from the proto route tracing.
+ */
+class RouteTracingImpl : public RouteTracing {
+public:
+  RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing);
+
+  // Tracing::getClientSampling
+  uint64_t getClientSampling() const override;
+
+  // Tracing::getRandomSampling
+  uint64_t getRandomSampling() const override;
+
+  // Tracing::getOverallSampling
+  uint64_t getOverallSampling() const override;
+
+private:
+  const uint64_t client_sampling_;
+  const uint64_t random_sampling_;
+  const uint64_t overall_sampling_;
+};
+
+/**
  * Base implementation for all route entries.
  */
 class RouteEntryImplBase : public RouteEntry,
@@ -436,6 +459,7 @@ public:
   const DirectResponseEntry* directResponseEntry() const override;
   const RouteEntry* routeEntry() const override;
   const Decorator* decorator() const override { return decorator_.get(); }
+  const RouteTracing* tracingConfig() const override { return routeTracing_.get(); }
   const RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override;
 
 protected:
@@ -535,6 +559,7 @@ private:
     const DirectResponseEntry* directResponseEntry() const override { return nullptr; }
     const RouteEntry* routeEntry() const override { return this; }
     const Decorator* decorator() const override { return parent_->decorator(); }
+    const RouteTracing* tracingConfig() const override { return parent_->tracingConfig(); }
 
     const RouteSpecificFilterConfig* perFilterConfig(const std::string& name) const override {
       return parent_->perFilterConfig(name);
@@ -600,6 +625,8 @@ private:
 
   static DecoratorConstPtr parseDecorator(const envoy::api::v2::route::Route& route);
 
+  static RouteTracingConstPtr parseRouteTracing(const envoy::api::v2::route::Route& route);
+
   bool evaluateRuntimeMatch(const uint64_t random_value) const;
 
   HedgePolicyImpl
@@ -656,6 +683,7 @@ private:
   const std::multimap<std::string, std::string> opaque_config_;
 
   const DecoratorConstPtr decorator_;
+  const RouteTracingConstPtr routeTracing_;
   const absl::optional<Http::Code> direct_response_code_;
   std::string direct_response_body_;
   PerFilterConfigs per_filter_configs_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -355,18 +355,18 @@ public:
   RouteTracingImpl(const envoy::api::v2::route::Tracing& tracing);
 
   // Tracing::getClientSampling
-  uint64_t getClientSampling() const override;
+  const envoy::type::FractionalPercent& getClientSampling() const override;
 
   // Tracing::getRandomSampling
-  uint64_t getRandomSampling() const override;
+  const envoy::type::FractionalPercent& getRandomSampling() const override;
 
   // Tracing::getOverallSampling
-  uint64_t getOverallSampling() const override;
+  const envoy::type::FractionalPercent& getOverallSampling() const override;
 
 private:
-  const uint64_t client_sampling_;
-  const uint64_t random_sampling_;
-  const uint64_t overall_sampling_;
+  const envoy::type::FractionalPercent client_sampling_;
+  const envoy::type::FractionalPercent random_sampling_;
+  const envoy::type::FractionalPercent overall_sampling_;
 };
 
 /**
@@ -459,7 +459,7 @@ public:
   const DirectResponseEntry* directResponseEntry() const override;
   const RouteEntry* routeEntry() const override;
   const Decorator* decorator() const override { return decorator_.get(); }
-  const RouteTracing* tracingConfig() const override { return routeTracing_.get(); }
+  const RouteTracing* tracingConfig() const override { return route_tracing_.get(); }
   const RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override;
 
 protected:
@@ -683,7 +683,7 @@ private:
   const std::multimap<std::string, std::string> opaque_config_;
 
   const DecoratorConstPtr decorator_;
-  const RouteTracingConstPtr routeTracing_;
+  const RouteTracingConstPtr route_tracing_;
   const absl::optional<Http::Code> direct_response_code_;
   std::string direct_response_body_;
   PerFilterConfigs per_filter_configs_;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -235,6 +235,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     client_sampling.set_numerator(
         tracing_config.has_client_sampling() ? tracing_config.client_sampling().value() : 100);
     envoy::type::FractionalPercent random_sampling;
+    // TODO: Random sampling historically was an integer and default to out of 10,000. We should
+    // deprecate that and move to a straight fractional percent config.
     random_sampling.set_numerator(
         tracing_config.has_random_sampling() ? tracing_config.random_sampling().value() : 10000);
     random_sampling.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -231,12 +231,16 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       request_headers_for_tags.push_back(Http::LowerCaseString(header));
     }
 
-    uint64_t client_sampling{
-        PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, client_sampling, 100, 100)};
-    uint64_t random_sampling{PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(
-        tracing_config, random_sampling, 10000, 10000)};
-    uint64_t overall_sampling{
-        PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, overall_sampling, 100, 100)};
+    envoy::type::FractionalPercent client_sampling;
+    client_sampling.set_numerator(
+        PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, client_sampling, 100, 100));
+    envoy::type::FractionalPercent random_sampling;
+    random_sampling.set_numerator(PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(
+        tracing_config, random_sampling, 10000, 10000));
+    random_sampling.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+    envoy::type::FractionalPercent overall_sampling;
+    overall_sampling.set_numerator(
+        PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, overall_sampling, 100, 100));
 
     tracing_config_ =
         std::make_unique<Http::TracingConnectionManagerConfig>(Http::TracingConnectionManagerConfig{

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -233,14 +233,14 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
 
     envoy::type::FractionalPercent client_sampling;
     client_sampling.set_numerator(
-        PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, client_sampling, 100, 100));
+        tracing_config.has_client_sampling() ? tracing_config.client_sampling().value() : 100);
     envoy::type::FractionalPercent random_sampling;
-    random_sampling.set_numerator(PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(
-        tracing_config, random_sampling, 10000, 10000));
+    random_sampling.set_numerator(
+        tracing_config.has_random_sampling() ? tracing_config.random_sampling().value() : 10000);
     random_sampling.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
     envoy::type::FractionalPercent overall_sampling;
     overall_sampling.set_numerator(
-        PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, overall_sampling, 100, 100));
+        tracing_config.has_overall_sampling() ? tracing_config.overall_sampling().value() : 100);
 
     tracing_config_ =
         std::make_unique<Http::TracingConnectionManagerConfig>(Http::TracingConnectionManagerConfig{

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -919,6 +919,7 @@ public:
 // Test the extended fake route that AsyncClient uses.
 TEST_F(AsyncClientImplRouteTest, All) {
   EXPECT_EQ(nullptr, route_impl.decorator());
+  EXPECT_EQ(nullptr, route_impl.tracingConfig());
   EXPECT_EQ(nullptr, route_impl.perFilterConfig(""));
   EXPECT_EQ(Code::InternalServerError, route_impl.routeEntry()->clusterNotFoundResponseCode());
   EXPECT_EQ(nullptr, route_impl.routeEntry()->corsPolicy());

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -45,6 +45,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::An;
 using testing::AnyNumber;
 using testing::AtLeast;
 using testing::DoAll;
@@ -121,12 +122,17 @@ public:
     conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);
 
     if (tracing) {
+      envoy::type::FractionalPercent percent1;
+      percent1.set_numerator(100);
+      envoy::type::FractionalPercent percent2;
+      percent2.set_numerator(10000);
+      percent2.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
       tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(
           TracingConnectionManagerConfig{Tracing::OperationName::Ingress,
                                          {LowerCaseString(":method")},
-                                         100,
-                                         10000,
-                                         100,
+                                         percent1,
+                                         percent2,
+                                         percent1,
                                          false});
     }
   }
@@ -697,7 +703,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   EXPECT_CALL(*span, setTag(Eq(":method"), Eq("GET")));
   // Verify if the activeSpan interface returns reference to the current span.
   EXPECT_CALL(*span, setTag(Eq("service-cluster"), Eq("scoobydoo")));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
 
@@ -762,7 +769,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
           Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
 
@@ -824,7 +832,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
           Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(Eq("testOp")));
 
@@ -872,8 +881,18 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorator) {
   setup(false, "");
-  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(TracingConnectionManagerConfig{
-      Tracing::OperationName::Egress, {LowerCaseString(":method")}, 100, 10000, 100, false});
+  envoy::type::FractionalPercent percent1;
+  percent1.set_numerator(100);
+  envoy::type::FractionalPercent percent2;
+  percent2.set_numerator(10000);
+  percent2.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(
+      TracingConnectionManagerConfig{Tracing::OperationName::Egress,
+                                     {LowerCaseString(":method")},
+                                     percent1,
+                                     percent2,
+                                     percent1,
+                                     false});
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
@@ -891,7 +910,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
           Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
 
@@ -939,8 +959,18 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
 
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecoratorOverrideOp) {
   setup(false, "");
-  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(TracingConnectionManagerConfig{
-      Tracing::OperationName::Egress, {LowerCaseString(":method")}, 100, 10000, 100, false});
+  envoy::type::FractionalPercent percent1;
+  percent1.set_numerator(100);
+  envoy::type::FractionalPercent percent2;
+  percent2.set_numerator(10000);
+  percent2.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(
+      TracingConnectionManagerConfig{Tracing::OperationName::Egress,
+                                     {LowerCaseString(":method")},
+                                     percent1,
+                                     percent2,
+                                     percent1,
+                                     false});
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
@@ -958,7 +988,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
           Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   // Verify that span operation overridden by value supplied in response header.
   EXPECT_CALL(*span, setOperation(Eq("testOp")));
@@ -1001,10 +1032,21 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
 TEST_F(HttpConnectionManagerImplTest,
        StartAndFinishSpanNormalFlowEgressDecoratorOverrideOpNoActiveSpan) {
   setup(false, "");
-  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(TracingConnectionManagerConfig{
-      Tracing::OperationName::Egress, {LowerCaseString(":method")}, 100, 10000, 100, false});
+  envoy::type::FractionalPercent percent1;
+  percent1.set_numerator(100);
+  envoy::type::FractionalPercent percent2;
+  percent2.set_numerator(10000);
+  percent2.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(
+      TracingConnectionManagerConfig{Tracing::OperationName::Egress,
+                                     {LowerCaseString(":method")},
+                                     percent1,
+                                     percent2,
+                                     percent1,
+                                     false});
 
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(false));
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
@@ -1276,7 +1318,8 @@ TEST_F(HttpConnectionManagerImplTest, DoNotStartSpanIfTracingIsNotEnabled) {
   tracing_config_.reset();
 
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _)).Times(0);
-  ON_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  ON_CALL(runtime_.snapshot_,
+          featureEnabled("tracing.global_enabled", An<const envoy::type::FractionalPercent&>(), _))
       .WillByDefault(Return(true));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -19,6 +19,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::An;
 using testing::InSequence;
 using testing::Matcher;
 using testing::NiceMock;
@@ -87,7 +88,12 @@ public:
   ConnectionManagerUtilityTest() {
     ON_CALL(config_, userAgent()).WillByDefault(ReturnRef(user_agent_));
 
-    tracing_config_ = {Tracing::OperationName::Ingress, {}, 100, 10000, 100, false};
+    envoy::type::FractionalPercent percent1;
+    percent1.set_numerator(100);
+    envoy::type::FractionalPercent percent2;
+    percent2.set_numerator(10000);
+    percent2.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+    tracing_config_ = {Tracing::OperationName::Ingress, {}, percent1, percent2, percent1, false};
     ON_CALL(config_, tracingConfig()).WillByDefault(Return(&tracing_config_));
 
     ON_CALL(config_, via()).WillByDefault(ReturnRef(via_));
@@ -340,7 +346,8 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
     TestHeaderMapImpl headers{
         {"x-forwarded-for", "10.0.0.1"}, {"x-request-id", uuid}, {"x-envoy-force-trace", "true"}};
     EXPECT_CALL(random_, uuid()).Times(0);
-    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                   An<const envoy::type::FractionalPercent&>(), _))
         .WillOnce(Return(true));
 
     EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true}),
@@ -354,7 +361,11 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
     TestHeaderMapImpl headers{
         {"x-forwarded-for", "34.0.0.1"}, {"x-request-id", uuid}, {"x-envoy-force-trace", "true"}};
     EXPECT_CALL(random_, uuid()).Times(0);
-    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                   An<const envoy::type::FractionalPercent&>(), _))
+        .WillOnce(Return(false));
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                   An<const envoy::type::FractionalPercent&>(), _))
         .WillOnce(Return(true));
 
     EXPECT_EQ((MutateRequestRet{"34.0.0.1:0", false}),
@@ -368,7 +379,8 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
 TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownstream) {
   connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("34.0.0.1");
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
-  ON_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  ON_CALL(runtime_.snapshot_,
+          featureEnabled("tracing.global_enabled", An<const envoy::type::FractionalPercent&>(), _))
       .WillByDefault(Return(true));
 
   {
@@ -392,7 +404,8 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
                               {"x-request-id", "will_be_regenerated"},
                               {"x-client-trace-id", "trace-id"}};
     EXPECT_CALL(random_, uuid());
-    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", 100))
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled",
+                                                   An<const envoy::type::FractionalPercent&>()))
         .WillOnce(Return(false));
 
     EXPECT_EQ((MutateRequestRet{"34.0.0.1:0", false}),
@@ -407,7 +420,8 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
                               {"x-request-id", "will_be_regenerated"},
                               {"x-client-trace-id", "trace-id"}};
     EXPECT_CALL(random_, uuid());
-    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", 100))
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled",
+                                                   An<const envoy::type::FractionalPercent&>()))
         .WillOnce(Return(true));
 
     EXPECT_EQ((MutateRequestRet{"34.0.0.1:0", false}),
@@ -979,9 +993,11 @@ TEST_F(ConnectionManagerUtilityTest, NonTlsAlwaysForwardClientCert) {
 
 // Sampling, global on.
 TEST_F(ConnectionManagerUtilityTest, RandomSamplingWhenGlobalSet) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
@@ -992,9 +1008,11 @@ TEST_F(ConnectionManagerUtilityTest, RandomSamplingWhenGlobalSet) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, SamplingWithoutRouteOverride) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
@@ -1005,16 +1023,19 @@ TEST_F(ConnectionManagerUtilityTest, SamplingWithoutRouteOverride) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, SamplingWithRouteOverride) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling", 0, _, 10000))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(false));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 0, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(false));
 
   NiceMock<Router::MockRouteTracing> tracingConfig;
   EXPECT_CALL(route_, tracingConfig()).WillRepeatedly(Return(&tracingConfig));
-  EXPECT_CALL(tracingConfig, getClientSampling()).WillRepeatedly(Return(0));
-  EXPECT_CALL(tracingConfig, getRandomSampling()).WillRepeatedly(Return(0));
-  EXPECT_CALL(tracingConfig, getOverallSampling()).WillRepeatedly(Return(0));
+  const envoy::type::FractionalPercent percent;
+  EXPECT_CALL(tracingConfig, getClientSampling()).WillRepeatedly(ReturnRef(percent));
+  EXPECT_CALL(tracingConfig, getRandomSampling()).WillRepeatedly(ReturnRef(percent));
+  EXPECT_CALL(tracingConfig, getOverallSampling()).WillRepeatedly(ReturnRef(percent));
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
   callMutateRequestHeaders(request_headers, Protocol::Http2);
@@ -1025,9 +1046,11 @@ TEST_F(ConnectionManagerUtilityTest, SamplingWithRouteOverride) {
 
 // Sampling must not be done on client traced.
 TEST_F(ConnectionManagerUtilityTest, SamplingMustNotBeDoneOnClientTraced) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .Times(0);
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
 
   // The x_request_id has TRACE_FORCED(a) set in the TRACE_BYTE_POSITION(14) character.
@@ -1040,9 +1063,11 @@ TEST_F(ConnectionManagerUtilityTest, SamplingMustNotBeDoneOnClientTraced) {
 
 // Sampling, global off.
 TEST_F(ConnectionManagerUtilityTest, NoTraceWhenSamplingSetButGlobalNotSet) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(false));
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
@@ -1054,9 +1079,11 @@ TEST_F(ConnectionManagerUtilityTest, NoTraceWhenSamplingSetButGlobalNotSet) {
 
 // Client, client enabled, global on.
 TEST_F(ConnectionManagerUtilityTest, ClientSamplingWhenGlobalSet) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", 100))
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("tracing.client_enabled", An<const envoy::type::FractionalPercent&>()))
       .WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
 
   Http::TestHeaderMapImpl request_headers{
@@ -1070,9 +1097,14 @@ TEST_F(ConnectionManagerUtilityTest, ClientSamplingWhenGlobalSet) {
 
 // Client, client disabled, global on.
 TEST_F(ConnectionManagerUtilityTest, NoTraceWhenClientSamplingNotSetAndGlobalSet) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", 100))
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("tracing.client_enabled", An<const envoy::type::FractionalPercent&>()))
       .WillOnce(Return(false));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.random_sampling",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
+      .WillOnce(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
 
   Http::TestHeaderMapImpl request_headers{
@@ -1092,7 +1124,8 @@ TEST_F(ConnectionManagerUtilityTest, ForcedTracedWhenGlobalSet) {
                             {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"},
                             {"x-envoy-force-trace", "true"}};
   EXPECT_CALL(random_, uuid()).Times(0);
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(true));
 
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true}),
@@ -1108,7 +1141,8 @@ TEST_F(ConnectionManagerUtilityTest, NoTraceWhenForcedTracedButGlobalNotSet) {
                             {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"},
                             {"x-envoy-force-trace", "true"}};
   EXPECT_CALL(random_, uuid()).Times(0);
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
+                                                 An<const envoy::type::FractionalPercent&>(), _))
       .WillOnce(Return(false));
 
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true}),

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3472,6 +3472,13 @@ virtual_hosts:
         metadata: { filter_metadata: { com.bar.foo: { baz: test_value }, baz: {name: meh} } }
         decorator:
           operation: hello
+        tracing:
+          client_sampling:
+            value: 1
+          random_sampling:
+            value: 2
+          overall_sampling:
+            value: 3
         route:
           weighted_clusters:
             clusters:
@@ -3561,6 +3568,9 @@ virtual_hosts:
     EXPECT_EQ(nullptr, route_entry->typedMetadata().get<Foo>(baz_factory.name()));
     EXPECT_EQ("meh", route_entry->typedMetadata().get<Baz>(baz_factory.name())->name);
     EXPECT_EQ("hello", route->decorator()->getOperation());
+    EXPECT_EQ(1, route->tracingConfig()->getClientSampling());
+    EXPECT_EQ(2, route->tracingConfig()->getRandomSampling());
+    EXPECT_EQ(3, route->tracingConfig()->getOverallSampling());
 
     Http::TestHeaderMapImpl response_headers;
     StreamInfo::MockStreamInfo stream_info;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3569,7 +3569,7 @@ virtual_hosts:
     EXPECT_EQ("meh", route_entry->typedMetadata().get<Baz>(baz_factory.name())->name);
     EXPECT_EQ("hello", route->decorator()->getOperation());
     EXPECT_EQ(1, route->tracingConfig()->getClientSampling());
-    EXPECT_EQ(2, route->tracingConfig()->getRandomSampling());
+    EXPECT_EQ(200, route->tracingConfig()->getRandomSampling());
     EXPECT_EQ(3, route->tracingConfig()->getOverallSampling());
 
     Http::TestHeaderMapImpl response_headers;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3474,11 +3474,11 @@ virtual_hosts:
           operation: hello
         tracing:
           client_sampling:
-            value: 1
+            numerator: 1
           random_sampling:
-            value: 2
+            numerator: 2
           overall_sampling:
-            value: 3
+            numerator: 3
         route:
           weighted_clusters:
             clusters:
@@ -3568,9 +3568,9 @@ virtual_hosts:
     EXPECT_EQ(nullptr, route_entry->typedMetadata().get<Foo>(baz_factory.name()));
     EXPECT_EQ("meh", route_entry->typedMetadata().get<Baz>(baz_factory.name())->name);
     EXPECT_EQ("hello", route->decorator()->getOperation());
-    EXPECT_EQ(1, route->tracingConfig()->getClientSampling());
-    EXPECT_EQ(200, route->tracingConfig()->getRandomSampling());
-    EXPECT_EQ(3, route->tracingConfig()->getOverallSampling());
+    EXPECT_EQ(1, route->tracingConfig()->getClientSampling().numerator());
+    EXPECT_EQ(2, route->tracingConfig()->getRandomSampling().numerator());
+    EXPECT_EQ(3, route->tracingConfig()->getOverallSampling().numerator());
 
     Http::TestHeaderMapImpl response_headers;
     StreamInfo::MockStreamInfo stream_info;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4855,8 +4855,8 @@ virtual_hosts:
   const auto route3 = config.route(genHeaders("www.foo.com", "/third", "GET"), 0);
 
   // Check default values for random and overall sampling
-  EXPECT_EQ(10000, route1->tracingConfig()->getRandomSampling().numerator());
-  EXPECT_EQ(1, route1->tracingConfig()->getRandomSampling().denominator());
+  EXPECT_EQ(100, route1->tracingConfig()->getRandomSampling().numerator());
+  EXPECT_EQ(0, route1->tracingConfig()->getRandomSampling().denominator());
   EXPECT_EQ(100, route1->tracingConfig()->getOverallSampling().numerator());
   EXPECT_EQ(0, route1->tracingConfig()->getOverallSampling().denominator());
 

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -106,9 +106,13 @@ MockDecorator::MockDecorator() {
 }
 MockDecorator::~MockDecorator() {}
 
+MockRouteTracing::MockRouteTracing() {}
+MockRouteTracing::~MockRouteTracing() {}
+
 MockRoute::MockRoute() {
   ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_));
   ON_CALL(*this, decorator()).WillByDefault(Return(&decorator_));
+  ON_CALL(*this, tracingConfig()).WillByDefault(Return(nullptr));
 }
 MockRoute::~MockRoute() {}
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -341,9 +341,9 @@ public:
   ~MockRouteTracing();
 
   // Router::RouteTracing
-  MOCK_CONST_METHOD0(getClientSampling, uint64_t());
-  MOCK_CONST_METHOD0(getRandomSampling, uint64_t());
-  MOCK_CONST_METHOD0(getOverallSampling, uint64_t());
+  MOCK_CONST_METHOD0(getClientSampling, const envoy::type::FractionalPercent&());
+  MOCK_CONST_METHOD0(getRandomSampling, const envoy::type::FractionalPercent&());
+  MOCK_CONST_METHOD0(getOverallSampling, const envoy::type::FractionalPercent&());
 };
 
 class MockRoute : public Route {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -335,6 +335,17 @@ public:
   std::string operation_{"fake_operation"};
 };
 
+class MockRouteTracing : public RouteTracing {
+public:
+  MockRouteTracing();
+  ~MockRouteTracing();
+
+  // Router::RouteTracing
+  MOCK_CONST_METHOD0(getClientSampling, uint64_t());
+  MOCK_CONST_METHOD0(getRandomSampling, uint64_t());
+  MOCK_CONST_METHOD0(getOverallSampling, uint64_t());
+};
+
 class MockRoute : public Route {
 public:
   MockRoute();
@@ -344,10 +355,12 @@ public:
   MOCK_CONST_METHOD0(directResponseEntry, const DirectResponseEntry*());
   MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
   MOCK_CONST_METHOD0(decorator, const Decorator*());
+  MOCK_CONST_METHOD0(tracingConfig, const RouteTracing*());
   MOCK_CONST_METHOD1(perFilterConfig, const RouteSpecificFilterConfig*(const std::string&));
 
   testing::NiceMock<MockRouteEntry> route_entry_;
   testing::NiceMock<MockDecorator> decorator_;
+  testing::NiceMock<MockRouteTracing> route_tracing_;
 };
 
 class MockConfig : public Config {


### PR DESCRIPTION
Description: Enable trace sampling to be overridden at the route level.

Risk Level: low
Testing: added unit tests and manually updated examples/jaeger-tracing to try it out.
Docs Changes: Assume model docs are autogenerated. Not sure if any other docs need to be changed.
Release Notes:
Sampling associated with individual routes can now be overridden to define route specific values.

Fixes #6915 
