### PR TITLE
health check: fix more fallout from inline deletion change

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -154,7 +154,6 @@ HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSessio
       local_address_(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1")) {}
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::~HttpActiveHealthCheckSession() {
-  onDeferredDelete();
   ASSERT(client_ == nullptr);
 }
 
@@ -356,7 +355,6 @@ TcpHealthCheckerImpl::TcpHealthCheckerImpl(const Cluster& cluster,
       receive_bytes_(TcpHealthCheckMatcher::loadProtoBytes(config.tcp_health_check().receive())) {}
 
 TcpHealthCheckerImpl::TcpActiveHealthCheckSession::~TcpActiveHealthCheckSession() {
-  onDeferredDelete();
   ASSERT(client_ == nullptr);
 }
 
@@ -464,7 +462,6 @@ GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::GrpcActiveHealthCheckSessio
     : ActiveHealthCheckSession(parent, host), parent_(parent) {}
 
 GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::~GrpcActiveHealthCheckSession() {
-  onDeferredDelete();
   ASSERT(client_ == nullptr);
 }
 

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -25,7 +25,6 @@ RedisHealthChecker::RedisActiveHealthCheckSession::RedisActiveHealthCheckSession
     : ActiveHealthCheckSession(parent, host), parent_(parent) {}
 
 RedisHealthChecker::RedisActiveHealthCheckSession::~RedisActiveHealthCheckSession() {
-  onDeferredDelete();
   ASSERT(current_request_ == nullptr);
   ASSERT(client_ == nullptr);
 }

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -217,7 +217,6 @@ TEST_F(HdsTest, TestProcessMessageHealthChecks) {
   // Check Correctness
   EXPECT_EQ(hds_delegate_->hdsClusters()[0]->healthCheckers().size(), 2);
   EXPECT_EQ(hds_delegate_->hdsClusters()[1]->healthCheckers().size(), 3);
-  EXPECT_CALL(dispatcher_, clearDeferredDeleteList()).Times(5);
 }
 
 // Tests OnReceiveMessage given a minimal HealthCheckSpecifier message
@@ -325,8 +324,6 @@ TEST_F(HdsTest, TestSendResponseOneEndpointTimeout) {
                 .socket_address()
                 .port_value(),
             1234);
-
-  EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
 }
 
 } // namespace Upstream

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -81,7 +81,6 @@ TEST(HealthCheckerFactoryTest, CreateGrpc) {
   Event::MockDispatcher dispatcher;
   AccessLog::MockAccessLogManager log_manager;
 
-  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
   EXPECT_NE(nullptr, dynamic_cast<GrpcHealthCheckerImpl*>(
                          HealthCheckerFactory::create(createGrpcHealthCheckConfig(), cluster,
                                                       runtime, random, dispatcher, log_manager)

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -189,7 +189,6 @@ public:
 private:
   const std::string cds_path_;
   uint32_t cds_version_{};
-  uint32_t update_successes_{};
 };
 
 // Common code for tests that deliver EDS update via the filesystem.

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -197,8 +197,10 @@ public:
   EdsHelper();
 
   // Set EDS contents on filesystem and wait for Envoy to pick this up.
-  void setEds(const std::vector<envoy::api::v2::ClusterLoadAssignment>& cluster_load_assignments,
-              IntegrationTestServerStats& server_stats, bool await_update = true);
+  void setEds(const std::vector<envoy::api::v2::ClusterLoadAssignment>& cluster_load_assignments);
+  void
+  setEdsAndWait(const std::vector<envoy::api::v2::ClusterLoadAssignment>& cluster_load_assignments,
+                IntegrationTestServerStats& server_stats);
   const std::string& eds_path() const { return eds_path_; }
 
 private:

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -178,6 +178,21 @@ private:
   bool finalized_{false};
 };
 
+class CdsHelper {
+public:
+  CdsHelper();
+
+  // Set CDS contents on filesystem and wait for Envoy to pick this up.
+  void setCds(const std::vector<envoy::api::v2::Cluster>& cluster,
+              IntegrationTestServerStats& server_stats);
+  const std::string& cds_path() const { return cds_path_; }
+
+private:
+  const std::string cds_path_;
+  uint32_t cds_version_{};
+  uint32_t update_successes_{};
+};
+
 // Common code for tests that deliver EDS update via the filesystem.
 class EdsHelper {
 public:

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -182,9 +182,8 @@ class CdsHelper {
 public:
   CdsHelper();
 
-  // Set CDS contents on filesystem and wait for Envoy to pick this up.
-  void setCds(const std::vector<envoy::api::v2::Cluster>& cluster,
-              IntegrationTestServerStats& server_stats);
+  // Set CDS contents on filesystem.
+  void setCds(const std::vector<envoy::api::v2::Cluster>& cluster);
   const std::string& cds_path() const { return cds_path_; }
 
 private:
@@ -200,7 +199,7 @@ public:
 
   // Set EDS contents on filesystem and wait for Envoy to pick this up.
   void setEds(const std::vector<envoy::api::v2::ClusterLoadAssignment>& cluster_load_assignments,
-              IntegrationTestServerStats& server_stats);
+              IntegrationTestServerStats& server_stats, bool await_update = true);
   const std::string& eds_path() const { return eds_path_; }
 
 private:

--- a/test/extensions/health_checkers/redis/config_test.cc
+++ b/test/extensions/health_checkers/redis/config_test.cc
@@ -107,7 +107,6 @@ TEST(HealthCheckerFactoryTest, CreateRedisViaUpstreamHealthCheckerFactory) {
   Event::MockDispatcher dispatcher;
   AccessLog::MockAccessLogManager log_manager;
 
-  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
   EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
                          Upstream::HealthCheckerFactory::create(
                              Upstream::parseHealthCheckFromV2Yaml(yaml), cluster, runtime, random,

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -46,7 +46,12 @@ public:
                                         : envoy::api::v2::core::HealthStatus::UNKNOWN);
       }
     }
-    eds_helper_.setEds({cluster_load_assignment}, *test_server_, await_update);
+
+    if (await_update) {
+      eds_helper_.setEdsAndWait({cluster_load_assignment}, *test_server_);
+    } else {
+      eds_helper_.setEds({cluster_load_assignment});
+    }
   }
 
   void initializeTest(bool http_active_hc) {
@@ -309,7 +314,7 @@ TEST_P(EdsIntegrationTest, BatchMemberUpdateCb) {
   auto* endpoint = locality_lb_endpoints->add_lb_endpoints();
   setUpstreamAddress(1, *endpoint);
 
-  eds_helper_.setEds({cluster_load_assignment}, *test_server_);
+  eds_helper_.setEdsAndWait({cluster_load_assignment}, *test_server_);
 
   EXPECT_EQ(1, member_update_count);
 }

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -98,8 +98,8 @@ public:
 INSTANTIATE_TEST_SUITE_P(IpVersions, EdsIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-// Verify that a host stabilized via active health checking which is first removed from EDS and
-// then fails health checking is removed.
+// Verifies that a new cluster can we warmed when using HTTP/2 health checking. Regression test
+// of the issue detailed in issue #6951.
 TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
   use_http2_hc_ = true;
   initializeTest(true);

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -135,7 +135,7 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
   RELEASE_ASSERT(result, result.message());
 
   // Respond with a health check. This will cause the previous cluster to be destroyed inline as
-  // part of handeling the response.
+  // part of processing the response.
   upstream_request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
   test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 0);
   EXPECT_EQ(0, test_server_->gauge("cluster_manager.warming_clusters")->value());

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -86,7 +86,7 @@ public:
       health_check->mutable_http_health_check()->set_use_http2(use_http2_hc_);
     }
     setEndpoints(0, 0, 0, true, absl::nullopt, false);
-    cds_helper_.setCds({cluster_}, *test_server_);
+    cds_helper_.setCds({cluster_});
     initialize();
     test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 0);
   }
@@ -119,7 +119,7 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
   // Trigger a CDS update. This should cause a new cluster to require warming, blocked on the host
   // being health checked.
   cluster_.mutable_circuit_breakers()->add_thresholds()->mutable_max_connections()->set_value(100);
-  cds_helper_.setCds({cluster_}, *test_server_);
+  cds_helper_.setCds({cluster_});
   test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 1);
   EXPECT_EQ(1, test_server_->gauge("cluster_manager.warming_clusters")->value());
 

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -121,8 +121,7 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
   test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 1);
   EXPECT_EQ(1, test_server_->gauge("cluster_manager.warming_clusters")->value());
 
-  // We need to do a bunch of work to get a hold of second hc connection. This is shamelessy stolen
-  // from waitForNextUpstreamRequest;
+  // We need to do a bunch of work to get a hold of second hc connection.
   FakeHttpConnectionPtr fake_upstream_connection;
   auto result = fake_upstreams_[0]->waitForHttpConnection(
       *dispatcher_, fake_upstream_connection, TestUtility::DefaultTimeout, max_request_headers_kb_);

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -135,7 +135,7 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
   RELEASE_ASSERT(result, result.message());
 
   // Respond with a health check. This will cause the previous cluster to be destroyed inline as
-  // part of handlig the response.
+  // part of handeling the response.
   upstream_request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
   test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 0);
   EXPECT_EQ(0, test_server_->gauge("cluster_manager.warming_clusters")->value());

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -93,7 +93,7 @@ public:
     for (uint32_t index : p1_dragon_upstreams.endpoints_) {
       addEndpoint(*dragon_p1, index, num_endpoints);
     }
-    eds_helper_.setEds({cluster_load_assignment}, *test_server_);
+    eds_helper_.setEdsAndWait({cluster_load_assignment}, *test_server_);
   }
 
   void createUpstreams() override {


### PR DESCRIPTION
Calling clearDeferredDeleteList() in the health check destructor
is very hard to reason about and can immediately delete items
in the list that need to stay deferred. This change reworks the
logic to no longer require doing that. This is much easier to
reason about.

Adds integration test coverage over the WIP PR https://github.com/envoyproxy/envoy/pull/6987

Risk Level: low
Testing: Added integration test
Docs Changes: n/a
Release Notes: n/a
Fixes #6951