### PR TITLE
Disable ranlib for cmake build dependencies

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -52,6 +52,10 @@ envoy_cmake_external(
         "CARES_SHARED": "no",
         "CARES_STATIC": "on",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        # Disable ranlib because it is not handled by bazel, and therefore
+        # doesn't respect custom toolchains such as the Android NDK,
+        # see https://github.com/bazelbuild/rules_foreign_cc/issues/252
+        "CMAKE_RANLIB": "",
     },
     copy_pdb = True,
     lib_source = "@com_github_c_ares_c_ares//:all",
@@ -70,6 +74,10 @@ envoy_cmake_external(
         "EVENT__DISABLE_TESTS": "on",
         "EVENT__LIBRARY_TYPE": "STATIC",
         "CMAKE_BUILD_TYPE": "Release",
+        # Disable ranlib because it is not handled by bazel, and therefore
+        # doesn't respect custom toolchains such as the Android NDK,
+        # see https://github.com/bazelbuild/rules_foreign_cc/issues/252
+        "CMAKE_RANLIB": "",
     },
     copy_pdb = True,
     lib_source = "@com_github_libevent_libevent//:all",
@@ -89,6 +97,10 @@ envoy_cmake_external(
         "ENABLE_LIB_ONLY": "on",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib",
+        # Disable ranlib because it is not handled by bazel, and therefore
+        # doesn't respect custom toolchains such as the Android NDK,
+        # see https://github.com/bazelbuild/rules_foreign_cc/issues/252
+        "CMAKE_RANLIB": "",
     },
     cmake_files_dir = "$BUILD_TMPDIR/lib/CMakeFiles",
     copy_pdb = True,
@@ -107,6 +119,10 @@ envoy_cmake_external(
         "YAML_CPP_BUILD_TESTS": "off",
         "YAML_CPP_BUILD_TOOLS": "off",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        # Disable ranlib because it is not handled by bazel, and therefore
+        # doesn't respect custom toolchains such as the Android NDK,
+        # see https://github.com/bazelbuild/rules_foreign_cc/issues/252
+        "CMAKE_RANLIB": "",
     },
     lib_source = "@com_github_jbeder_yaml_cpp//:all",
     static_libraries = select({
@@ -121,6 +137,10 @@ envoy_cmake_external(
     name = "zlib",
     cache_entries = {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        # Disable ranlib because it is not handled by bazel, and therefore
+        # doesn't respect custom toolchains such as the Android NDK,
+        # see https://github.com/bazelbuild/rules_foreign_cc/issues/252
+        "CMAKE_RANLIB": "",
     },
     copy_pdb = True,
     lib_source = "@net_zlib//:all",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -219,10 +219,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
     ),
     rules_foreign_cc = dict(
-        sha256 = "136470a38dcd00c7890230402b43004dc947bf1e3dd0289dd1bd2bfb1e0a3484",
-        strip_prefix = "rules_foreign_cc-e3f4b5e0bc9dac9cf036616c13de25e6cd5051a2",
-        # 2019-04-04
-        urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/e3f4b5e0bc9dac9cf036616c13de25e6cd5051a2.tar.gz"],
+        sha256 = "ccffb49fb24aee3f0a005fa59810dc596228fe86eacacbe0c004d59ed1881bd8",
+        strip_prefix = "rules_foreign_cc-bf99a0bf0080bcd50431aa7124ef23e5afd58325",
+        # 2019-05-17
+        urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/bf99a0bf0080bcd50431aa7124ef23e5afd58325.tar.gz"],
     ),
     six_archive = dict(
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",


### PR DESCRIPTION
`ranlib` is a tool to add a table of contents file to static archives.
On any modern system this is done automatically by creating the archive
with `ar` (unless you explicitly disable this behavior for performance
reasons). For backwards compatibility (I assume) cmake still calls
`ranlib` on archives to ensure this table of contents is created.
Unfortunately bazel knows nothing about ranlib, and never calls it for
any actions. Because of this rules_foreign_cc can not set the correct
path to `ranlib` based on the current `cc_toolchain`. Because of that
when you try to build envoy for the Android NDK, cmake auto-discovers a
version of ranlib, which on macOS happens to be `/usr/bin/ranlib`, which
then produces invalid ELF binaries.

Setting `CMAKE_RANLIB` to an empty string stops cmake from using it
ever, which avoids this issue.

Tracking upstream issue: https://github.com/bazelbuild/rules_foreign_cc/issues/252

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>

Risk Level: Low