### PR TITLE
[tools] add DiscoveryResponse to schema_validator

### DIFF
--- a/docs/root/install/tools/schema_validator_check_tool.rst
+++ b/docs/root/install/tools/schema_validator_check_tool.rst
@@ -6,15 +6,15 @@ Schema Validator check tool
 The schema validator tool validates that the passed in configuration conforms to
 a given schema. The configuration may be JSON or YAML. To validate the entire
 config, please refer to the
-:ref:`config load check tool<install_tools_config_load_check_tool>`. Currently, only
-:ref:`route config<envoy_api_msg_RouteConfiguration>` schema validation is supported.
+:ref:`config load check tool<install_tools_config_load_check_tool>`.
 
 Input
   The tool expects two inputs:
 
-  1. The schema type to check the passed in configuration against. The supported type is:
+  1. The schema type to check the passed in configuration against. The supported types are:
 
     * `route` - for :ref:`route configuration<envoy_api_msg_RouteConfiguration>` validation.
+    * `discovery_response` for :ref:`discovery response<envoy_api_msg_DiscoveryRespons>` validation.
 
   2. The path to the configuration file.
 

--- a/docs/root/install/tools/schema_validator_check_tool.rst
+++ b/docs/root/install/tools/schema_validator_check_tool.rst
@@ -14,7 +14,7 @@ Input
   1. The schema type to check the passed in configuration against. The supported types are:
 
     * `route` - for :ref:`route configuration<envoy_api_msg_RouteConfiguration>` validation.
-    * `discovery_response` for :ref:`discovery response<envoy_api_msg_DiscoveryRespons>` validation.
+    * `discovery_response` for :ref:`discovery response<envoy_api_msg_DiscoveryResponse>` validation.
 
   2. The path to the configuration file.
 

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -1,5 +1,7 @@
 #include "test/tools/schema_validator/validator.h"
 
+#include "envoy/api/v2/discovery.pb.h"
+#include "envoy/api/v2/discovery.pb.validate.h"
 #include "envoy/api/v2/rds.pb.h"
 #include "envoy/api/v2/rds.pb.validate.h"
 
@@ -9,10 +11,13 @@
 
 namespace Envoy {
 
+const std::string Schema::DISCOVERY_RESPONSE = "discovery_response";
 const std::string Schema::ROUTE = "route";
 
 const std::string& Schema::toString(Type type) {
   switch (type) {
+  case Type::DiscoveryResponse:
+    return DISCOVERY_RESPONSE;
   case Type::Route:
     return ROUTE;
   }
@@ -38,6 +43,8 @@ Options::Options(int argc, char** argv) {
 
   if (schema_type.getValue() == Schema::toString(Schema::Type::Route)) {
     schema_type_ = Schema::Type::Route;
+  } else if (schema_type.getValue() == Schema::toString(Schema::Type::DiscoveryResponse)) {
+    schema_type_ = Schema::Type::DiscoveryResponse;
   } else {
     std::cerr << "error: unknown schema type '" << schema_type.getValue() << "'" << std::endl;
     exit(EXIT_FAILURE);
@@ -49,9 +56,13 @@ Options::Options(int argc, char** argv) {
 void Validator::validate(const std::string& config_path, Schema::Type schema_type) {
 
   switch (schema_type) {
+  case Schema::Type::DiscoveryResponse: {
+    envoy::api::v2::DiscoveryResponse discovery_response_config;
+    MessageUtil::loadFromFile(config_path, discovery_response_config, *api_);
+    MessageUtil::validate(discovery_response_config);
+    break;
+  }
   case Schema::Type::Route: {
-    // Construct a envoy::api::v2::RouteConfiguration to validate the Route configuration and
-    // ignore the output since nothing will consume it.
     envoy::api::v2::RouteConfiguration route_config;
     MessageUtil::loadFromFile(config_path, route_config, *api_);
     MessageUtil::validate(route_config);

--- a/test/tools/schema_validator/validator.h
+++ b/test/tools/schema_validator/validator.h
@@ -18,7 +18,7 @@ public:
   /**
    * List of supported schemas to validate.
    */
-  enum Type { Route };
+  enum Type { DiscoveryResponse, Route };
 
   /**
    * Get a string representation of the schema type.
@@ -28,6 +28,7 @@ public:
   static const std::string& toString(Type type);
 
 private:
+  static const std::string DISCOVERY_RESPONSE;
   static const std::string ROUTE;
 };
 


### PR DESCRIPTION
Description: This adds the `discovery_response` type to the schema validator. We keep some generated DiscoveryResponse configurations in git for infrequently changing xDS configs (i.e. edge listeners) and would like to run this tool on CI since they're template-generated as an assurance that bad configs never land.
Risk Level: Low, offline tool
Testing: Tested against some local configs
Docs Changes: updated
Release Notes: N/A(?)

Signed-off-by: Derek Argueta <dereka@pinterest.com>