### PR TITLE
fix to build kafka extension under python3

### DIFF
--- a/source/extensions/filters/network/kafka/protocol_code_generator/kafka_generator.py
+++ b/source/extensions/filters/network/kafka/protocol_code_generator/kafka_generator.py
@@ -235,7 +235,7 @@ class FieldList:
     return ', '.join(init_list)
 
   def field_count(self):
-    return len(self.used_fields())
+    return len(list(self.used_fields()))
 
   def example_value(self):
     return ', '.join(map(lambda x: x.example_value_for_test(self.version), self.used_fields()))


### PR DESCRIPTION
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

When trying to build kafka extension using python3 (python3.6 to be exact), I'm getting "TypeError: object of type 'filter' has no len()". This fixes the issue.

Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
