### PR TITLE
quiche: build spdy_core_alt_svc_wire_format_lib

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -139,6 +139,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "spdy_core_alt_svc_wire_format_lib",
+    srcs = ["quiche/spdy/core/spdy_alt_svc_wire_format.cc"],
+    hdrs = ["quiche/spdy/core/spdy_alt_svc_wire_format.h"],
+    copts = quiche_copt,
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [":spdy_platform"],
+)
+
+envoy_cc_library(
     name = "quic_platform",
     srcs = [
         "quiche/quic/platform/api/quic_clock.cc",

--- a/source/extensions/quic_listeners/quiche/platform/spdy_string_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/spdy_string_utils_impl.h
@@ -24,13 +24,13 @@ inline void SpdyStrAppendImpl(std::string* output, const Args&... args) {
   absl::StrAppend(output, std::forward<const Args&>(args)...);
 }
 
-char SpdyHexDigitToIntImpl(char c) { return quiche::HexDigitToInt(c); }
+inline char SpdyHexDigitToIntImpl(char c) { return quiche::HexDigitToInt(c); }
 
 inline std::string SpdyHexDecodeImpl(absl::string_view data) {
   return absl::HexStringToBytes(data);
 }
 
-bool SpdyHexDecodeToUInt32Impl(absl::string_view data, uint32_t* out) {
+inline bool SpdyHexDecodeToUInt32Impl(absl::string_view data, uint32_t* out) {
   return quiche::HexDecodeToUInt32(data, out);
 }
 
@@ -42,6 +42,6 @@ inline std::string SpdyHexEncodeUInt32AndTrimImpl(uint32_t data) {
   return absl::StrCat(absl::Hex(data));
 }
 
-std::string SpdyHexDumpImpl(absl::string_view data) { return quiche::HexDump(data); }
+inline std::string SpdyHexDumpImpl(absl::string_view data) { return quiche::HexDump(data); }
 
 } // namespace spdy


### PR DESCRIPTION
Add spdy_alt_svc_wire_format.(h|cc) into BUILD.bzl. Inline some helper functions in spdy_string_utils_impl.h as their API functions are also inlined.

Risk Level: low, not in use
Testing: clean up only, no new code in envoy tree.

Part of #2557
