### PR TITLE
dispatcher: faster runOnAllThreads

### DIFF
--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -100,17 +100,13 @@ void InstanceImpl::runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_c
   cb();
 
   std::shared_ptr<Event::PostCb> shared_function(
-    new Event::PostCb(cb),
-    [this, all_threads_complete_cb](Event::PostCb* cb) {
-      main_thread_dispatcher_->post(all_threads_complete_cb);
-      delete cb;
-    }
-  );
+      new Event::PostCb(cb), [this, all_threads_complete_cb](Event::PostCb* cb) {
+        main_thread_dispatcher_->post(all_threads_complete_cb);
+        delete cb;
+      });
 
   for (Event::Dispatcher& dispatcher : registered_threads_) {
-    dispatcher.post([cb_guard = shared_function]() -> void {
-      cb_guard->operator()();
-    });
+    dispatcher.post([cb_guard = shared_function]() -> void { cb_guard->operator()(); });
   }
 }
 

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -98,14 +98,18 @@ void InstanceImpl::runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_c
   // all_threads_complete_cb method. Parallelism of main thread execution is being traded off
   // for programming simplicity here.
   cb();
-  std::shared_ptr<std::atomic<uint64_t>> worker_count =
-      std::make_shared<std::atomic<uint64_t>>(registered_threads_.size());
+
+  std::shared_ptr<Event::PostCb> shared_function(
+    new Event::PostCb(cb),
+    [this, all_threads_complete_cb](Event::PostCb* cb) {
+      main_thread_dispatcher_->post(all_threads_complete_cb);
+      delete cb;
+    }
+  );
+
   for (Event::Dispatcher& dispatcher : registered_threads_) {
-    dispatcher.post([this, worker_count, cb, all_threads_complete_cb]() -> void {
-      cb();
-      if (--*worker_count == 0) {
-        main_thread_dispatcher_->post(all_threads_complete_cb);
-      }
+    dispatcher.post([cb_guard = shared_function]() -> void {
+      cb_guard->operator()();
     });
   }
 }

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -99,14 +99,14 @@ void InstanceImpl::runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_c
   // for programming simplicity here.
   cb();
 
-  std::shared_ptr<Event::PostCb> shared_function(
-      new Event::PostCb(cb), [this, all_threads_complete_cb](Event::PostCb* cb) {
-        main_thread_dispatcher_->post(all_threads_complete_cb);
-        delete cb;
-      });
+  std::shared_ptr<Event::PostCb> cb_guard(new Event::PostCb(cb),
+                                          [this, all_threads_complete_cb](Event::PostCb* cb) {
+                                            main_thread_dispatcher_->post(all_threads_complete_cb);
+                                            delete cb;
+                                          });
 
   for (Event::Dispatcher& dispatcher : registered_threads_) {
-    dispatcher.post([cb_guard = shared_function]() -> void { cb_guard->operator()(); });
+    dispatcher.post([cb_guard]() -> void { (*cb_guard)(); });
   }
 }
 


### PR DESCRIPTION
Description:
The shared_ptr and the atomic<unit64_t> is duplicate in term of ref count.
Beside that this diff avoid `cb` and `all_threads_complete_cb` copy at O(number of worker) scale.

Theoretically the callback is passing by reference (was value copy) but I doubt anyone would rely on the previous behavior.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>


Risk Level: LOW
Testing: existing test
