### PR TITLE
Support to disable adding 'x-forwarded-proto'

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -25,7 +25,7 @@ import "gogoproto/gogo.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-// [#comment:next free field: 32]
+// [#comment:next free field: 33]
 message HttpConnectionManager {
   enum CodecType {
     option (gogoproto.goproto_enum_prefix) = false;
@@ -192,6 +192,17 @@ message HttpConnectionManager {
   // request is sent upstream (i.e. all decoding filters have processed the request), OR when the
   // response is initiated. If not specified or set to 0, this timeout is disabled.
   google.protobuf.Duration request_timeout = 28 [(gogoproto.stdduration) = true];
+
+  // Decides whether the :ref:`x-forwarded-proto' header should be excluded
+  // in the upstream request. Setting this option will prevent envoy from adding this header upstream.
+  // The default option of this boolean is false.
+  //
+  // In cases when the header is explicitly configured by client, this option has no effect in the behavior
+  // of envoy.
+  // This header is unaffected by the
+  // :ref:`suppress_envoy_headers
+  // <envoy_api_field_config.filter.http.router.v2.Router.suppress_envoy_headers>` flag.
+  bool exclude_request_forwarded_proto = 32;
 
   // The time that Envoy will wait between sending an HTTP/2 “shutdown
   // notification” (GOAWAY frame with max stream ID) and a final GOAWAY frame.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -337,6 +337,12 @@ public:
   virtual bool proxy100Continue() const PURE;
 
   /**
+   * @return bool supplies if the HttpConnectionManager should disable adding the x-forwarded-proto
+   *              header
+   */
+  virtual bool excludeRequestForwardedProto() const PURE;
+
+  /**
    * @return supplies the http1 settings.
    */
   virtual const Http::Http1Settings& http1Settings() const PURE;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -149,6 +149,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       listener_stats_(Http::ConnectionManagerImpl::generateListenerStats(stats_prefix_,
                                                                          context_.listenerScope())),
       proxy_100_continue_(config.proxy_100_continue()),
+      exclude_request_forwarded_proto_(config.exclude_request_forwarded_proto()),
       delayed_close_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, delayed_close_timeout, 1000)),
       normalize_path_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, normalize_path,

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -126,6 +126,7 @@ public:
   const absl::optional<std::string>& userAgent() override { return user_agent_; }
   Http::ConnectionManagerListenerStats& listenerStats() override { return listener_stats_; }
   bool proxy100Continue() const override { return proxy_100_continue_; }
+  bool excludeRequestForwardedProto() const override { return exclude_request_forwarded_proto_; }
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return normalize_path_; }
   std::chrono::milliseconds delayedCloseTimeout() const override { return delayed_close_timeout_; }
@@ -167,6 +168,7 @@ private:
   Http::DateProvider& date_provider_;
   Http::ConnectionManagerListenerStats listener_stats_;
   const bool proxy_100_continue_;
+  const bool exclude_request_forwarded_proto_;
   std::chrono::milliseconds delayed_close_timeout_;
   const bool normalize_path_;
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -125,6 +125,7 @@ public:
   const Http::TracingConnectionManagerConfig* tracingConfig() override { return nullptr; }
   Http::ConnectionManagerListenerStats& listenerStats() override { return listener_->stats_; }
   bool proxy100Continue() const override { return false; }
+  bool excludeRequestForwardedProto() const override { return false; }
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return true; }
   Http::Code request(absl::string_view path_and_query, absl::string_view method,

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -116,6 +116,7 @@ public:
   const TracingConnectionManagerConfig* tracingConfig() override { return tracing_config_.get(); }
   ConnectionManagerListenerStats& listenerStats() override { return listener_stats_; }
   bool proxy100Continue() const override { return proxy_100_continue_; }
+  bool excludeRequestForwardedProto() const override { return exclude_request_forwarded_proto_; }
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return false; }
 
@@ -145,6 +146,7 @@ public:
   absl::optional<std::string> user_agent_;
   TracingConnectionManagerConfigPtr tracing_config_;
   bool proxy_100_continue_{true};
+  bool exclude_request_forwarded_proto_{false};
   Http::Http1Settings http1_settings_;
   Http::DefaultInternalAddressConfig internal_address_config_;
   bool normalize_path_{true};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -330,6 +330,7 @@ public:
   Stats::IsolatedStoreImpl fake_listener_stats_;
   ConnectionManagerListenerStats listener_stats_;
   bool proxy_100_continue_ = false;
+  bool exclude_request_forwarded_proto_ = false;
   Http::Http1Settings http1_settings_;
   bool normalize_path_ = false;
   NiceMock<Network::MockClientConnection> upstream_conn_; // for websocket tests

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -283,6 +283,7 @@ public:
   const TracingConnectionManagerConfig* tracingConfig() override { return tracing_config_.get(); }
   ConnectionManagerListenerStats& listenerStats() override { return listener_stats_; }
   bool proxy100Continue() const override { return proxy_100_continue_; }
+  bool excludeRequestForwardedProto() const override { return exclude_request_forwarded_proto_; }
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return normalize_path_; }
 

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -63,6 +63,14 @@ TEST_P(Http2IntegrationTest, Retry) { testRetry(); }
 
 TEST_P(Http2IntegrationTest, RetryAttemptCount) { testRetryAttemptCountHeader(); }
 
+TEST_P(Http2IntegrationTest, ExcludeForwardedProto) { testExcludeForwardedProtoHeader(); }
+
+TEST_P(Http2IntegrationTest, SetForwardedProto) { testSetForwardedProtoHeader(); }
+
+TEST_P(Http2IntegrationTest, DefaultForwardedProto) { testDefaultForwardedProtoHeader(); }
+
+TEST_P(Http2IntegrationTest, IncludeForwardedProto) { testIncludeForwardedProtoHeader(); }
+
 static std::string response_metadata_filter = R"EOF(
 name: response-metadata-filter
 config: {}

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -647,9 +647,6 @@ void HttpIntegrationTest::testRetryAttemptCountHeader() {
 // Tests that the 'x-forwarded-proto' header is hidden on the upstream request
 // when exclude_request_forwarded_proto is set to true
 void HttpIntegrationTest::testExcludeForwardedProtoHeader() {
-  config_helper_.addRoute("host", "/test_retry", "cluster_0", false,
-                          envoy::api::v2::route::RouteAction::NOT_FOUND,
-                          envoy::api::v2::route::VirtualHost::NONE, {}, true);
   config_helper_.addConfigModifier(
       [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
           -> void { hcm.set_exclude_request_forwarded_proto(true);
@@ -680,9 +677,6 @@ void HttpIntegrationTest::testExcludeForwardedProtoHeader() {
 // Tests to check 'x-forwarded-proto' header is available on the upstream request despite setting
 // exclude_request_forwarded_proto to true when the header is explicitly configured by the client
 void HttpIntegrationTest::testSetForwardedProtoHeader() {
-  config_helper_.addRoute("host", "/test_retry", "cluster_0", false,
-                          envoy::api::v2::route::RouteAction::NOT_FOUND,
-                          envoy::api::v2::route::VirtualHost::NONE, {}, true);
   config_helper_.addConfigModifier(
       [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
           -> void { hcm.set_exclude_request_forwarded_proto(true);
@@ -717,10 +711,6 @@ void HttpIntegrationTest::testSetForwardedProtoHeader() {
 // Tests header preservation behavior of envoy when 'x-forwarded-proto' is
 // explicitly configured by the client.
 void HttpIntegrationTest::testDefaultForwardedProtoHeader() {
-  config_helper_.addRoute("host", "/test_retry", "cluster_0", false,
-                          envoy::api::v2::route::RouteAction::NOT_FOUND,
-                          envoy::api::v2::route::VirtualHost::NONE, {}, true);
-  initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response =
       codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
@@ -748,9 +738,6 @@ void HttpIntegrationTest::testDefaultForwardedProtoHeader() {
 // Tests that the 'x-forwarded-proto' header is available by on the upstream request
 // when exclude_request_forwarded_proto is set to false
 void HttpIntegrationTest::testIncludeForwardedProtoHeader() {
-  config_helper_.addRoute("host", "/test_retry", "cluster_0", false,
-                          envoy::api::v2::route::RouteAction::NOT_FOUND,
-                          envoy::api::v2::route::VirtualHost::NONE, {}, true);
   config_helper_.addConfigModifier(
       [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
           -> void { hcm.set_exclude_request_forwarded_proto(false);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -176,6 +176,10 @@ protected:
   void testRetry();
   void testRetryHittingBufferLimit();
   void testRetryAttemptCountHeader();
+  void testExcludeForwardedProtoHeader();
+  void testSetForwardedProtoHeader();
+  void testDefaultForwardedProtoHeader();
+  void testIncludeForwardedProtoHeader();
   void testGrpcRetry();
 
   void testEnvoyHandling100Continue(bool additional_continue_from_upstream = false,


### PR DESCRIPTION
  Description:
  * Envoy currently is adding the 'x-forwarded-proto' header to the requests from downstream
    clients to its upstream by default. This patch helps this operation be configuration driven, where in
    by setting the exclude_request_forwarded_proto variable to true, the header is not added to Envoy's
    upstream and the header is added all otherwise.
  * The boolean 'exclude_request_forwarded_proto' does not have any effect on upstream requests where the
    'x-forwarded-proto' header is explicitly configured by the client.

  Changes made:
  * Defined a new boolean in 'http_connection_manager.proto' file called 'exclude_request_forwarded_proto'
    that can be configured to disable adding the 'x-forwarded-proto' header during upstream request from Envoy
  * Included the 'excludeRequestForwardedProto()' to be extended by all inheriting classes in file
    'conn_manager_config.h'
  * Included the logic to exclude adding the header in file 'conn_manager_utility.cc'
  * Included support for populating variable 'exclude_request_forwarded_proto_' from config in file
    'config.cc'
  * Implemented mock tests in file 'conn_manager_utility_test.cc' checking default, true and false states for
    'exclude_request_forwarded_proto_' variable
  * Implemented integration tests in file 'http_integration.cc' and validated true and default states driven by config

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
