### PR TITLE
exe: drop unused deps on zlib compressor code

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -33,8 +33,6 @@ envoy_cc_binary(
 envoy_cc_library(
     name = "envoy_common_lib",
     deps = [
-        "//source/common/compressor:compressor_lib",
-        "//source/common/decompressor:decompressor_lib",
         "//source/common/event:libevent_lib",
         "//source/common/network:utility_lib",
         "//source/common/stats:stats_lib",


### PR DESCRIPTION
Description:
`//source/exe:envoy_common_lib` doesn't really depend on zlib compressor/decompressor directly.

Risk Level: Low
Testing: unit tests and manual testing
Docs Changes: N/A
Release Notes: N/A
