### PR TITLE
admin: fix syntax of gcov exclusion zone.

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -547,7 +547,7 @@ Http::Code AdminImpl::handlerHeapProfiler(absl::string_view url, Http::HeaderMap
       // TODO(silentdai) remove the GCOVR when startProfiler is better implemented
       response.add("Fail to start the heap profiler");
       res = Http::Code::InternalServerError;
-      // GCOVR_EXCL_END
+      // GCOVR_EXCL_STOP
     } else {
       response.add("Starting heap profiler");
       res = Http::Code::OK;


### PR DESCRIPTION
Description: When I run the coverage script manually on my workstation, I saw this warning:
```
(WARNING) The coverage exclusion region start flag GCOVR_EXCL_START
	on line 546 did not have corresponding GCOVR_EXCL_STOP flag
	 in file /export/obj2/jmarantz/bazel-cache/_bazel_jmarantz/e36ea2d96a6204d90eb044c224ebd630/execroot/envoy/source/server/http/admin.cc.
(WARNING) The coverage exclusion region start flag GCOVR_EXCL_START
	on line 546 did not have corresponding GCOVR_EXCL_STOP flag
	 in file /export/obj2/jmarantz/bazel-cache/_bazel_jmarantz/e36ea2d96a6204d90eb044c224ebd630/execroot/envoy/source/server/http/admin.cc.
```
This PR takes a shot at fixing that.
Risk Level: low -- just a comment change
Testing: just ran the format test.
Docs Changes: n/a
Release Notes: n/a

