### PR TITLE
tcp: not calling watermark callbacks in delay close

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -438,6 +438,10 @@ void ConnectionImpl::onLowWatermark() {
   ENVOY_CONN_LOG(debug, "onBelowWriteBufferLowWatermark", *this);
   ASSERT(above_high_watermark_);
   above_high_watermark_ = false;
+
+  if (inDelayedClose()) {
+    return;
+  }
   for (ConnectionCallbacks* callback : callbacks_) {
     callback->onBelowWriteBufferLowWatermark();
   }
@@ -447,6 +451,10 @@ void ConnectionImpl::onHighWatermark() {
   ENVOY_CONN_LOG(debug, "onAboveWriteBufferHighWatermark", *this);
   ASSERT(!above_high_watermark_);
   above_high_watermark_ = true;
+
+  if (inDelayedClose()) {
+    return;
+  }
   for (ConnectionCallbacks* callback : callbacks_) {
     callback->onAboveWriteBufferHighWatermark();
   }


### PR DESCRIPTION
Risk Level: low
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a
Fixes #6872