### PR TITLE
techdebt: eliminate absl::make_unique

### DIFF
--- a/source/common/network/addr_family_aware_socket_option_impl.h
+++ b/source/common/network/addr_family_aware_socket_option_impl.h
@@ -19,8 +19,8 @@ public:
   AddrFamilyAwareSocketOptionImpl(envoy::api::v2::core::SocketOption::SocketState in_state,
                                   SocketOptionName ipv4_optname, SocketOptionName ipv6_optname,
                                   int value)
-      : ipv4_option_(absl::make_unique<SocketOptionImpl>(in_state, ipv4_optname, value)),
-        ipv6_option_(absl::make_unique<SocketOptionImpl>(in_state, ipv6_optname, value)) {}
+      : ipv4_option_(std::make_unique<SocketOptionImpl>(in_state, ipv4_optname, value)),
+        ipv6_option_(std::make_unique<SocketOptionImpl>(in_state, ipv6_optname, value)) {}
 
   // Socket::Option
   bool setOption(Socket& socket,

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -216,7 +216,7 @@ RouteConfigProviderPtr RouteConfigProviderManagerImpl::createStaticRouteConfigPr
     const envoy::api::v2::RouteConfiguration& route_config,
     Server::Configuration::FactoryContext& factory_context) {
   auto provider =
-      absl::make_unique<StaticRouteConfigProviderImpl>(route_config, factory_context, *this);
+      std::make_unique<StaticRouteConfigProviderImpl>(route_config, factory_context, *this);
   static_route_config_providers_.insert(provider.get());
   return provider;
 }

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -197,7 +197,7 @@ ConfigProviderPtr ScopedRoutesConfigProviderManager::createStaticConfigProvider(
     Server::Configuration::FactoryContext& factory_context,
     const ConfigProviderManager::OptionalArg& optarg) {
   const auto& typed_optarg = static_cast<const ScopedRoutesConfigProviderManagerOptArg&>(optarg);
-  return absl::make_unique<InlineScopedRoutesConfigProvider>(
+  return std::make_unique<InlineScopedRoutesConfigProvider>(
       std::move(config_protos), typed_optarg.scoped_routes_name_, factory_context, *this,
       typed_optarg.rds_config_source_, typed_optarg.scope_key_builder_);
 }

--- a/source/extensions/quic_listeners/quiche/platform/quic_ptr_util_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_ptr_util_impl.h
@@ -14,7 +14,7 @@
 namespace quic {
 
 template <typename T, typename... Args> std::unique_ptr<T> QuicMakeUniqueImpl(Args&&... args) {
-  return absl::make_unique<T>(std::forward<Args>(args)...);
+  return std::make_unique<T>(std::forward<Args>(args)...);
 }
 
 template <typename T> std::unique_ptr<T> QuicWrapUniqueImpl(T* ptr) {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -593,7 +593,7 @@ void InstanceImpl::shutdownAdmin() {
 ServerLifecycleNotifier::HandlePtr InstanceImpl::registerCallback(Stage stage,
                                                                   StageCallback callback) {
   auto& callbacks = stage_callbacks_[stage];
-  return absl::make_unique<LifecycleCallbackHandle<LifecycleNotifierCallbacks>>(
+  return std::make_unique<LifecycleCallbackHandle<LifecycleNotifierCallbacks>>(
       callbacks, callbacks.insert(callbacks.end(), callback));
 }
 
@@ -601,7 +601,7 @@ ServerLifecycleNotifier::HandlePtr
 InstanceImpl::registerCallback(Stage stage, StageCallbackWithCompletion callback) {
   ASSERT(stage == Stage::ShutdownExit);
   auto& callbacks = stage_completable_callbacks_[stage];
-  return absl::make_unique<LifecycleCallbackHandle<LifecycleNotifierCompletionCallbacks>>(
+  return std::make_unique<LifecycleCallbackHandle<LifecycleNotifierCompletionCallbacks>>(
       callbacks, callbacks.insert(callbacks.end(), callback));
 }
 

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -355,23 +355,23 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
   const bool http2 = http_version == HttpVersion::Http2;
 
   if (http2) {
-    client = absl::make_unique<Http2::TestClientConnectionImpl>(client_connection, client_callbacks,
-                                                                stats_store, client_http2settings,
-                                                                max_request_headers_kb);
+    client = std::make_unique<Http2::TestClientConnectionImpl>(client_connection, client_callbacks,
+                                                               stats_store, client_http2settings,
+                                                               max_request_headers_kb);
   } else {
-    client = absl::make_unique<Http1::ClientConnectionImpl>(client_connection, client_callbacks);
+    client = std::make_unique<Http1::ClientConnectionImpl>(client_connection, client_callbacks);
   }
 
   NiceMock<Network::MockConnection> server_connection;
   NiceMock<MockServerConnectionCallbacks> server_callbacks;
   if (http2) {
     const Http2Settings server_http2settings{fromHttp2Settings(input.h2_settings().server())};
-    server = absl::make_unique<Http2::TestServerConnectionImpl>(server_connection, server_callbacks,
-                                                                stats_store, server_http2settings,
-                                                                max_request_headers_kb);
+    server = std::make_unique<Http2::TestServerConnectionImpl>(server_connection, server_callbacks,
+                                                               stats_store, server_http2settings,
+                                                               max_request_headers_kb);
   } else {
     const Http1Settings server_http1settings{fromHttp1Settings(input.h1_settings().server())};
-    server = absl::make_unique<Http1::ServerConnectionImpl>(
+    server = std::make_unique<Http1::ServerConnectionImpl>(
         server_connection, server_callbacks, server_http1settings, max_request_headers_kb);
   }
 


### PR DESCRIPTION
As we enforce c++14 which has `std::make_unique`, we should avoid use `absl::make_unique`

Signed-off-by: Yuchen Dai <silentdai@gmail.com>