### PR TITLE
docs: fix csrf filter source origin note

### DIFF
--- a/docs/root/configuration/http_filters/csrf_filter.rst
+++ b/docs/root/configuration/http_filters/csrf_filter.rst
@@ -30,7 +30,7 @@ the request is rejected.
 
   .. note::
     Due to differing functionality between browsers this filter will determine
-    a request's source origin from the Host header. If that is not present it will
+    a request's source origin from the Origin header. If that is not present it will
     fall back to the host and port value from the requests Referer header.
 
 


### PR DESCRIPTION
Signed-off-by: Derek <dschaller@users.noreply.github.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Fix CSRF filter note regarding how source origin is determined.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
