### PR TITLE
ci: add make_unique rule to check_format

### DIFF
--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -71,7 +71,7 @@ MockClusterInfo::MockClusterInfo()
       .WillByDefault(Invoke([this]() -> const Envoy::Config::TypedMetadata& {
         if (typed_metadata_ == nullptr) {
           typed_metadata_ =
-              absl::make_unique<Config::TypedMetadataImpl<ClusterTypedMetadataFactory>>(metadata_);
+              std::make_unique<Config::TypedMetadataImpl<ClusterTypedMetadataFactory>>(metadata_);
         }
         return *typed_metadata_;
       }));

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -75,7 +75,7 @@ PROTOBUF_TYPE_ERRORS = {
     "ProtobufWkt::MapPair":             "Protobuf::MapPair",
     "ProtobufUtil::MessageDifferencer": "Protobuf::util::MessageDifferencer"
 }
-CPP_STD_ERRORS = {
+LIBCXX_REPLACEMENTS = {
     "absl::make_unique<": "std::make_unique<",
 }
 # yapf: enable
@@ -345,7 +345,7 @@ def fixSourceLine(line):
     line = line.replace(invalid_construct, valid_construct)
 
   # Use recommended cpp stdlib
-  for invalid_construct, valid_construct in CPP_STD_ERRORS.items():
+  for invalid_construct, valid_construct in LIBCXX_REPLACEMENTS.items():
     line = line.replace(invalid_construct, valid_construct)
 
   return line
@@ -377,9 +377,9 @@ def checkSourceLine(line, file_path, reportError):
     if invalid_construct in line:
       reportError("incorrect protobuf type reference %s; "
                   "should be %s" % (invalid_construct, valid_construct))
-  for invalid_construct, valid_construct in CPP_STD_ERRORS.items():
+  for invalid_construct, valid_construct in LIBCXX_REPLACEMENTS.items():
     if invalid_construct in line:
-      reportError("cpp std: %s should be replaced by %s" % (invalid_construct, valid_construct))
+      reportError("term %s should be replaced with standard library term %s" % (invalid_construct, valid_construct))
 
   # Some errors cannot be fixed automatically, and actionable, consistent,
   # navigable messages should be emitted to make it easy to find and fix

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -75,6 +75,9 @@ PROTOBUF_TYPE_ERRORS = {
     "ProtobufWkt::MapPair":             "Protobuf::MapPair",
     "ProtobufUtil::MessageDifferencer": "Protobuf::util::MessageDifferencer"
 }
+CPP_STD_ERRORS = {
+    "absl::make_unique": "std::make_unique",
+}
 # yapf: enable
 
 
@@ -341,6 +344,10 @@ def fixSourceLine(line):
   for invalid_construct, valid_construct in PROTOBUF_TYPE_ERRORS.items():
     line = line.replace(invalid_construct, valid_construct)
 
+  # Use recommended cpp stdlib
+  for invalid_construct, valid_construct in CPP_STD_ERRORS.items():
+    line = line.replace(invalid_construct, valid_construct)
+
   return line
 
 
@@ -370,6 +377,9 @@ def checkSourceLine(line, file_path, reportError):
     if invalid_construct in line:
       reportError("incorrect protobuf type reference %s; "
                   "should be %s" % (invalid_construct, valid_construct))
+  for invalid_construct, valid_construct in CPP_STD_ERRORS.items():
+    if invalid_construct in line:
+      reportError("cpp std: %s should be replaced by %s" % (invalid_construct, valid_construct))
 
   # Some errors cannot be fixed automatically, and actionable, consistent,
   # navigable messages should be emitted to make it easy to find and fix

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -76,7 +76,7 @@ PROTOBUF_TYPE_ERRORS = {
     "ProtobufUtil::MessageDifferencer": "Protobuf::util::MessageDifferencer"
 }
 CPP_STD_ERRORS = {
-    "absl::make_unique": "std::make_unique",
+    "absl::make_unique<": "std::make_unique<",
 }
 # yapf: enable
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -379,7 +379,8 @@ def checkSourceLine(line, file_path, reportError):
                   "should be %s" % (invalid_construct, valid_construct))
   for invalid_construct, valid_construct in LIBCXX_REPLACEMENTS.items():
     if invalid_construct in line:
-      reportError("term %s should be replaced with standard library term %s" % (invalid_construct, valid_construct))
+      reportError("term %s should be replaced with standard library term %s" % (invalid_construct,
+                                                                                valid_construct))
 
   # Some errors cannot be fixed automatically, and actionable, consistent,
   # navigable messages should be emitted to make it easy to find and fix

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -229,7 +229,9 @@ if __name__ == "__main__":
   errors += checkAndFixError("bad_envoy_build_sys_ref.BUILD", "Superfluous '@envoy//' prefix")
   errors += checkAndFixError("proto_format.proto", "clang-format check failed")
   errors += checkAndFixError("api/java_options.proto", "Java proto option")
-  errors += checkAndFixError("cpp_std.cc", "term absl::make_unique< should be replaced with standard library term std::make_unique<")
+  errors += checkAndFixError(
+      "cpp_std.cc",
+      "term absl::make_unique< should be replaced with standard library term std::make_unique<")
 
   errors += checkFileExpectingOK("real_time_source_override.cc")
   errors += checkFileExpectingOK("time_system_wait_for.cc")

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -229,6 +229,7 @@ if __name__ == "__main__":
   errors += checkAndFixError("bad_envoy_build_sys_ref.BUILD", "Superfluous '@envoy//' prefix")
   errors += checkAndFixError("proto_format.proto", "clang-format check failed")
   errors += checkAndFixError("api/java_options.proto", "Java proto option")
+  errors += checkAndFixError("cpp_std.cc", "cpp std:")
 
   errors += checkFileExpectingOK("real_time_source_override.cc")
   errors += checkFileExpectingOK("time_system_wait_for.cc")

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
   errors += checkAndFixError("bad_envoy_build_sys_ref.BUILD", "Superfluous '@envoy//' prefix")
   errors += checkAndFixError("proto_format.proto", "clang-format check failed")
   errors += checkAndFixError("api/java_options.proto", "Java proto option")
-  errors += checkAndFixError("cpp_std.cc", "cpp std:")
+  errors += checkAndFixError("cpp_std.cc", "term absl::make_unique< should be replaced with standard library term std::make_unique<")
 
   errors += checkFileExpectingOK("real_time_source_override.cc")
   errors += checkFileExpectingOK("time_system_wait_for.cc")

--- a/tools/testdata/check_format/cpp_std.cc
+++ b/tools/testdata/check_format/cpp_std.cc
@@ -1,0 +1,12 @@
+#include <memory>
+
+#include "absl/memory/memory.h"
+
+namespace Envoy {
+
+std::unique_ptr<int> bad = absl::make_unique<int>(0);	
+std::unique_ptr<int> good = std::make_unique<int>(0);	
+
+// Awesome stuff goes here.
+
+} // namespace Envoy

--- a/tools/testdata/check_format/cpp_std.cc
+++ b/tools/testdata/check_format/cpp_std.cc
@@ -4,8 +4,7 @@
 
 namespace Envoy {
 
-std::unique_ptr<int> bad = absl::make_unique<int>(0);	
-std::unique_ptr<int> good = std::make_unique<int>(0);	
+std::unique_ptr<int> to_be_fix = absl::make_unique<int>(0);
 
 // Awesome stuff goes here.
 

--- a/tools/testdata/check_format/cpp_std.cc.gold
+++ b/tools/testdata/check_format/cpp_std.cc.gold
@@ -1,0 +1,11 @@
+#include <memory>
+
+#include "absl/memory/memory.h"
+
+namespace Envoy {
+
+std::unique_ptr<int> to_be_fix = std::make_unique<int>(0);
+
+// Awesome stuff goes here.
+
+} // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>


As a follow up of #7034 
```
$ ./tools/check_format.py  check tools/testdata/check_format/ |grep cpp_std |grep absl
ERROR: tools/testdata/check_format//cpp_std.cc:7: cpp std: absl::make_unique should be replaced by std::make_unique
```

tag #7053 