### PR TITLE
docs: Fix docs build

### DIFF
--- a/docs/root/configuration/best_practices/best_practices.rst
+++ b/docs/root/configuration/best_practices/best_practices.rst
@@ -1,0 +1,7 @@
+Configuration best practices
+============================
+
+.. toctree::
+  :maxdepth: 2
+
+  edge

--- a/docs/root/configuration/configuration.rst
+++ b/docs/root/configuration/configuration.rst
@@ -5,7 +5,6 @@ Configuration reference
 
 .. toctree::
   :maxdepth: 2
-  :includehidden:
 
   overview/v2_overview
   listeners/listeners
@@ -25,3 +24,4 @@ Configuration reference
   overload_manager/overload_manager
   secret
   well_known_dynamic_metadata
+  best_practices/best_practices


### PR DESCRIPTION
Description: Fixes docs build extracted from #7064.
Risk Level: Low
Testing: Manually run the build script locally
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>