### PR TITLE
config: split SubscriptionFactory into .cc and .h

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -339,6 +339,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "subscription_factory_lib",
+    srcs = ["subscription_factory.cc"],
     hdrs = ["subscription_factory.h"],
     deps = [
         ":delta_subscription_lib",

--- a/source/common/config/subscription_factory.cc
+++ b/source/common/config/subscription_factory.cc
@@ -1,0 +1,85 @@
+#include "common/config/subscription_factory.h"
+
+#include "common/config/delta_subscription_impl.h"
+#include "common/config/filesystem_subscription_impl.h"
+#include "common/config/grpc_mux_subscription_impl.h"
+#include "common/config/grpc_subscription_impl.h"
+#include "common/config/http_subscription_impl.h"
+#include "common/config/utility.h"
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace Config {
+
+std::unique_ptr<Subscription> SubscriptionFactory::subscriptionFromConfigSource(
+    const envoy::api::v2::core::ConfigSource& config, const LocalInfo::LocalInfo& local_info,
+    Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm, Runtime::RandomGenerator& random,
+    Stats::Scope& scope, const std::string& rest_method, const std::string& grpc_method,
+    absl::string_view type_url, Api::Api& api) {
+  std::unique_ptr<Subscription> result;
+  SubscriptionStats stats = Utility::generateStats(scope);
+  switch (config.config_source_specifier_case()) {
+  case envoy::api::v2::core::ConfigSource::kPath: {
+    Utility::checkFilesystemSubscriptionBackingPath(config.path(), api);
+    result =
+        std::make_unique<Config::FilesystemSubscriptionImpl>(dispatcher, config.path(), stats, api);
+    break;
+  }
+  case envoy::api::v2::core::ConfigSource::kApiConfigSource: {
+    const envoy::api::v2::core::ApiConfigSource& api_config_source = config.api_config_source();
+    Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
+    switch (api_config_source.api_type()) {
+    case envoy::api::v2::core::ApiConfigSource::UNSUPPORTED_REST_LEGACY:
+      throw EnvoyException(
+          "REST_LEGACY no longer a supported ApiConfigSource. "
+          "Please specify an explicit supported api_type in the following config:\n" +
+          config.DebugString());
+    case envoy::api::v2::core::ApiConfigSource::REST:
+      result = std::make_unique<HttpSubscriptionImpl>(
+          local_info, cm, api_config_source.cluster_names()[0], dispatcher, random,
+          Utility::apiConfigSourceRefreshDelay(api_config_source),
+          Utility::apiConfigSourceRequestTimeout(api_config_source),
+          *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats,
+          Utility::configSourceInitialFetchTimeout(config));
+      break;
+    case envoy::api::v2::core::ApiConfigSource::GRPC:
+      result = std::make_unique<GrpcSubscriptionImpl>(
+          local_info,
+          Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
+                                                         api_config_source, scope)
+              ->create(),
+          dispatcher, random,
+          *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method), type_url,
+          stats, scope, Utility::parseRateLimitSettings(api_config_source),
+          Utility::configSourceInitialFetchTimeout(config));
+      break;
+    case envoy::api::v2::core::ApiConfigSource::DELTA_GRPC: {
+      Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
+      result = std::make_unique<DeltaSubscriptionImpl>(
+          local_info,
+          Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
+                                                         api_config_source, scope)
+              ->create(),
+          dispatcher, *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
+          type_url, random, scope, Utility::parseRateLimitSettings(api_config_source), stats,
+          Utility::configSourceInitialFetchTimeout(config));
+      break;
+    }
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+    }
+    break;
+  }
+  case envoy::api::v2::core::ConfigSource::kAds: {
+    result = std::make_unique<GrpcMuxSubscriptionImpl>(
+        cm.adsMux(), stats, type_url, dispatcher, Utility::configSourceInitialFetchTimeout(config));
+    break;
+  }
+  default:
+    throw EnvoyException("Missing config source specifier in envoy::api::v2::core::ConfigSource");
+  }
+  return result;
+}
+
+} // namespace Config
+} // namespace Envoy

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -1,20 +1,10 @@
 #pragma once
 
-#include <functional>
-
 #include "envoy/api/api.h"
 #include "envoy/api/v2/core/base.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/stats/scope.h"
 #include "envoy/upstream/cluster_manager.h"
-
-#include "common/config/delta_subscription_impl.h"
-#include "common/config/filesystem_subscription_impl.h"
-#include "common/config/grpc_mux_subscription_impl.h"
-#include "common/config/grpc_subscription_impl.h"
-#include "common/config/http_subscription_impl.h"
-#include "common/config/utility.h"
-#include "common/protobuf/protobuf.h"
 
 namespace Envoy {
 namespace Config {
@@ -41,72 +31,7 @@ public:
       const envoy::api::v2::core::ConfigSource& config, const LocalInfo::LocalInfo& local_info,
       Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm, Runtime::RandomGenerator& random,
       Stats::Scope& scope, const std::string& rest_method, const std::string& grpc_method,
-      absl::string_view type_url, Api::Api& api) {
-    std::unique_ptr<Subscription> result;
-    SubscriptionStats stats = Utility::generateStats(scope);
-    switch (config.config_source_specifier_case()) {
-    case envoy::api::v2::core::ConfigSource::kPath: {
-      Utility::checkFilesystemSubscriptionBackingPath(config.path(), api);
-      result = std::make_unique<Config::FilesystemSubscriptionImpl>(dispatcher, config.path(),
-                                                                    stats, api);
-      break;
-    }
-    case envoy::api::v2::core::ConfigSource::kApiConfigSource: {
-      const envoy::api::v2::core::ApiConfigSource& api_config_source = config.api_config_source();
-      Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
-      switch (api_config_source.api_type()) {
-      case envoy::api::v2::core::ApiConfigSource::UNSUPPORTED_REST_LEGACY:
-        throw EnvoyException(
-            "REST_LEGACY no longer a supported ApiConfigSource. "
-            "Please specify an explicit supported api_type in the following config:\n" +
-            config.DebugString());
-      case envoy::api::v2::core::ApiConfigSource::REST:
-        result = std::make_unique<HttpSubscriptionImpl>(
-            local_info, cm, api_config_source.cluster_names()[0], dispatcher, random,
-            Utility::apiConfigSourceRefreshDelay(api_config_source),
-            Utility::apiConfigSourceRequestTimeout(api_config_source),
-            *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats,
-            Utility::configSourceInitialFetchTimeout(config));
-        break;
-      case envoy::api::v2::core::ApiConfigSource::GRPC:
-        result = std::make_unique<GrpcSubscriptionImpl>(
-            local_info,
-            Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
-                                                           api_config_source, scope)
-                ->create(),
-            dispatcher, random,
-            *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method), type_url,
-            stats, scope, Utility::parseRateLimitSettings(api_config_source),
-            Utility::configSourceInitialFetchTimeout(config));
-        break;
-      case envoy::api::v2::core::ApiConfigSource::DELTA_GRPC: {
-        Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
-        result = std::make_unique<DeltaSubscriptionImpl>(
-            local_info,
-            Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
-                                                           api_config_source, scope)
-                ->create(),
-            dispatcher, *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
-            type_url, random, scope, Utility::parseRateLimitSettings(api_config_source), stats,
-            Utility::configSourceInitialFetchTimeout(config));
-        break;
-      }
-      default:
-        NOT_REACHED_GCOVR_EXCL_LINE;
-      }
-      break;
-    }
-    case envoy::api::v2::core::ConfigSource::kAds: {
-      result = std::make_unique<GrpcMuxSubscriptionImpl>(
-          cm.adsMux(), stats, type_url, dispatcher,
-          Utility::configSourceInitialFetchTimeout(config));
-      break;
-    }
-    default:
-      throw EnvoyException("Missing config source specifier in envoy::api::v2::core::ConfigSource");
-    }
-    return result;
-  }
+      absl::string_view type_url, Api::Api& api);
 };
 
 } // namespace Config

--- a/source/common/secret/BUILD
+++ b/source/common/secret/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
         "//source/common/common:cleanup_lib",
         "//source/common/config:resources_lib",
         "//source/common/config:subscription_factory_lib",
+        "//source/common/config:utility_lib",
         "//source/common/init:target_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/ssl:certificate_validation_context_config_impl_lib",

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -6,6 +6,7 @@
 
 #include "common/config/resources.h"
 #include "common/config/subscription_factory.h"
+#include "common/config/utility.h"
 #include "common/protobuf/utility.h"
 
 namespace Envoy {


### PR DESCRIPTION
Another .h split enabled by xDS detemplatization. (Followup to #6391)

Risk Level: none