### PR TITLE
WIP Add large response header tests

### DIFF
--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1009,6 +1009,22 @@ TEST_P(Http2CodecImplTest, TestLargeRequestHeadersAtMaxConfigurable) {
   request_encoder_->encodeHeaders(request_headers, true);
 }
 
+TEST_P(Http2CodecImplTest, TestLargeResponseHeaders) {
+  initialize();
+
+  TestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
+  request_encoder_->encodeHeaders(request_headers, true);
+
+  TestHeaderMapImpl response_headers{{":status", "200"}};
+  std::string long_string = std::string((1UL << 6) * 1024, 'q');
+
+  response_headers.addCopy("big", long_string);
+  EXPECT_CALL(response_decoder_, decodeHeaders_(_, true));
+  response_encoder_->encodeHeaders(response_headers, true);
+}
+
 // Note this is Http2CodecImplTestAll not Http2CodecImplTest, to test
 // compression with min and max HPACK table size.
 TEST_P(Http2CodecImplTestAll, TestCodecHeaderCompression) {


### PR DESCRIPTION
I'm trying to add tests and upper bounds around response header size. These tests add 2^15 kb tests (our internal requirement). The http1 codec tests are fine, but the http2 tests cause codec issues I need help (probably from @mattklein123) diagnosing.

From some tweaking, I found that 2^5 kb succeeds, while 2^6 kb causes a premature connection close. This actually causes a segfault because we don't null-check the output of getStream() at (I THINK; have to double-check) http2/codec_impl.cc:528. Aside from that error-catch, there is some sort of bug in the nghttp2 code here; does anyone have experience with the nghttp2 code at all?