### PR TITLE
Disable default/copy constructor

### DIFF
--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -76,6 +76,9 @@ public:
   Zipkin::Span& span() { return span_; }
 
 private:
+  ZipkinSpan();
+  ZipkinSpan(const ZipkinSpan& zipkin_span);
+  
   Zipkin::Span span_;
   Zipkin::Tracer& tracer_;
 };


### PR DESCRIPTION
Description: I notice the callsers of ZipkinSpan never use default/copy constructor to create ZipkinSpan object. I think it's good idea to disable default/copy constructor to avoid incorrect calling.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
