### PR TITLE
Correct usage of iter to comply with general rule

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -125,9 +125,8 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
       // Cluster::initialize() method can modify the list of secondary_init_clusters_ to remove
       // the item currently being initialized, so we eschew range-based-for and do this complicated
       // dance to increment the iterator before calling initialize.
-      for (auto iter = secondary_init_clusters_.begin(); iter != secondary_init_clusters_.end();) {
+      for (auto iter = secondary_init_clusters_.begin(); iter != secondary_init_clusters_.end(); ++iter) {
         Cluster* cluster = *iter;
-        ++iter;
         ENVOY_LOG(debug, "initializing secondary cluster {}", cluster->info()->name());
         cluster->initialize([cluster, this] { onClusterInit(*cluster); });
       }


### PR DESCRIPTION
Signed-off-by: xhzhf <guoyongxhzhf@163.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:In general, if there is no special condition, iter shoule be added at same line with 'for'
Risk Level:Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
