### PR TITLE
Make the new buffer impl's reserve/commit semantics match libevent

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -409,6 +409,9 @@ uint64_t OwnedImpl::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iove
     // Check whether there are any empty slices with reservable space at the end of the buffer.
     size_t first_reservable_slice = slices_.size();
     while (first_reservable_slice > 0) {
+      // Reclaim any space that was previously reserved but never committed.
+      slices_[first_reservable_slice - 1]->clearReservation();
+
       if (slices_[first_reservable_slice - 1]->reservableSize() == 0) {
         break;
       }

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -409,9 +409,6 @@ uint64_t OwnedImpl::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iove
     // Check whether there are any empty slices with reservable space at the end of the buffer.
     size_t first_reservable_slice = slices_.size();
     while (first_reservable_slice > 0) {
-      // Reclaim any space that was previously reserved but never committed.
-      slices_[first_reservable_slice - 1]->clearReservation();
-
       if (slices_[first_reservable_slice - 1]->reservableSize() == 0) {
         break;
       }

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -18,14 +18,14 @@ namespace Buffer {
 /**
  * A Slice manages a contiguous block of bytes.
  * The block is arranged like this:
- *                   |<- data_size() -->|<- reservable_size() ->|
- * +-----------------+------------------+-----------------------+
- * | Drained         | Data             | Reservable            |
- * | Unused space    | Usable content   | New content can be    |
- * | that formerly   |                  | added here with       |
- * | was in the Data |                  | reserve()/commit()    |
- * | section         |                  |                       |
- * +-----------------+------------------+-----------------------+
+ *                   |<- dataSize() ->|<- reservableSize() ->|
+ * +-----------------+----------------+----------------------+
+ * | Drained         | Data           | Reservable           |
+ * | Unused space    | Usable content | New content can be   |
+ * | that formerly   |                | added here with      |
+ * | was in the Data |                | reserve()/commit()   |
+ * | section         |                |                      |
+ * +-----------------+----------------+----------------------+
  *                   ^
  *                   |
  *                   data()
@@ -58,25 +58,19 @@ public:
   void drain(uint64_t size) {
     ASSERT(data_ + size <= reservable_);
     data_ += size;
-    if (data_ == reservable_ && !reservation_outstanding_) {
-      // There is no more content in the slice, and there is no outstanding reservation,
-      // so reset the Data section to the start of the slice to facilitate reuse.
-      data_ = reservable_ = 0;
+    if (data_ == reservable_) {
+      // All the data in the slice has been drained. Reset the offsets so all
+      // the data can be reused.
+      data_ = 0;
+      reservable_ = 0;
     }
   }
 
   /**
    * @return the number of bytes available to be reserve()d.
-   * @note If reserve() has been called without a corresponding commit(), this method
-   *       should return 0.
    * @note Read-only implementations of Slice should return zero from this method.
    */
-  uint64_t reservableSize() const {
-    if (reservation_outstanding_) {
-      return 0;
-    }
-    return capacity_ - reservable_;
-  }
+  uint64_t reservableSize() const { return capacity_ - reservable_; }
 
   /**
    * Reserve `size` bytes that the caller can populate with content. The caller SHOULD then
@@ -84,7 +78,7 @@ public:
    * section.
    * @note If there is already an outstanding reservation (i.e., a reservation obtained
    *       from reserve() that has not been released by calling commit()), this method will
-   *       return {nullptr, 0}.
+   *       return a new reservation that replaces it.
    * @param size the number of bytes to reserve. The Slice implementation MAY reserve
    *        fewer bytes than requested (for example, if it doesn't have enough room in the
    *        Reservable section to fulfill the whole request).
@@ -93,8 +87,16 @@ public:
    * @note Read-only implementations of Slice should return {nullptr, 0} from this method.
    */
   Reservation reserve(uint64_t size) {
-    if (reservation_outstanding_ || size == 0) {
+    if (size == 0) {
       return {nullptr, 0};
+    }
+    if (data_ != 0 && data_ == reservable_) {
+      // If the slice is empty but starts at an offset from its base, that means it
+      // used to contain some content but has since been fully drained. Resetting the
+      // offset to the start of the slice allows all the space in the slice to be
+      // reused.
+      data_ = 0;
+      reservable_ = 0;
     }
     uint64_t available_size = capacity_ - reservable_;
     if (available_size == 0) {
@@ -102,7 +104,6 @@ public:
     }
     uint64_t reservation_size = std::min(size, available_size);
     void* reservation = &(base_[reservable_]);
-    reservation_outstanding_ = true;
     return {reservation, static_cast<size_t>(reservation_size)};
   }
 
@@ -124,17 +125,9 @@ public:
       // The reservation is not from this OwnedSlice.
       return false;
     }
-    ASSERT(reservation_outstanding_);
     reservable_ += reservation.len_;
-    reservation_outstanding_ = false;
     return true;
   }
-
-  /**
-   * Clear any outstanding reservation on the Slice, allowing the memory
-   * to be re-reserve()d.
-   */
-  void clearReservation() { reservation_outstanding_ = false; }
 
   /**
    * Copy as much of the supplied data as possible to the end of the slice.
@@ -143,9 +136,6 @@ public:
    * @return number of bytes copied (may be a smaller than size, may even be zero).
    */
   uint64_t append(const void* data, uint64_t size) {
-    if (reservation_outstanding_) {
-      return 0;
-    }
     uint64_t copy_size = std::min(size, reservableSize());
     uint8_t* dest = base_ + reservable_;
     reservable_ += copy_size;
@@ -163,9 +153,6 @@ public:
    * @return number of bytes copied (may be a smaller than size, may even be zero).
    */
   uint64_t prepend(const void* data, uint64_t size) {
-    if (reservation_outstanding_) {
-      return 0;
-    }
     const uint8_t* src = static_cast<const uint8_t*>(data);
     uint64_t copy_size;
     if (dataSize() == 0) {
@@ -202,9 +189,6 @@ protected:
 
   /** Total number of bytes in the slice */
   uint64_t capacity_;
-
-  /** Whether reserve() has been called without a corresponding commit(). */
-  bool reservation_outstanding_{false};
 };
 
 using SlicePtr = std::unique_ptr<Slice>;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -131,6 +131,12 @@ public:
   }
 
   /**
+   * Clear any outstanding reservation on the Slice, allowing the memory
+   * to be re-reserve()d.
+   */
+  void clearReservation() { reservation_outstanding_ = false; }
+
+  /**
    * Copy as much of the supplied data as possible to the end of the slice.
    * @param data start of the data to copy.
    * @param size number of bytes to copy.

--- a/test/common/buffer/buffer_test.cc
+++ b/test/common/buffer/buffer_test.cc
@@ -37,7 +37,6 @@ protected:
     EXPECT_NE(nullptr, reservation.mem_);
     EXPECT_EQ(static_cast<const uint8_t*>(slice.data()) + slice.dataSize(), reservation.mem_);
     EXPECT_EQ(reservation_size, reservation.len_);
-    EXPECT_EQ(0, slice.reservableSize());
   }
 
   static void expectReservationFailure(const Slice::Reservation& reservation, const Slice& slice,
@@ -88,10 +87,10 @@ TEST_F(OwnedSliceTest, ReserveCommit) {
     expectReservationSuccess(reservation, *slice, 10);
 
     // Request a second reservation while the first reservation remains uncommitted.
-    // This should fail.
-    EXPECT_EQ(0, slice->reservableSize());
+    // This should succeed.
+    EXPECT_EQ(initial_capacity, slice->reservableSize());
     Slice::Reservation reservation2 = slice->reserve(1);
-    expectReservationFailure(reservation2, *slice, 0);
+    expectReservationSuccess(reservation2, *slice, 1);
 
     // Commit the entire reserved size.
     bool committed = slice->commit(reservation);

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -340,6 +340,69 @@ TEST_P(OwnedImplTest, ReserveCommit) {
   }
 }
 
+TEST_P(OwnedImplTest, ReserveCommitReuse) {
+  Buffer::OwnedImpl buffer;
+  verifyImplementation(buffer);
+
+  static constexpr uint64_t NumIovecs = 2;
+  Buffer::RawSlice iovecs[NumIovecs];
+
+  // Reserve 8KB and commit all but a few bytes of it, to ensure that
+  // the last slice of the buffer can hold part but not all of the
+  // next reservation. Note that the buffer implementation might
+  // allocate more than the requested 8KB. In case the implementation
+  // uses a power-of-two allocator, the subsequent reservations all
+  // request 16KB.
+  uint64_t num_reserved = buffer.reserve(8192, iovecs, NumIovecs);
+  EXPECT_EQ(1, num_reserved);
+  iovecs[0].len_ = 8000;
+  buffer.commit(iovecs, 1);
+  EXPECT_EQ(8000, buffer.length());
+
+  // Reserve 16KB. The resulting reservation should span 2 slices.
+  // Commit part of the first slice and none of the second slice.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  const void* first_slice = iovecs[0].mem_;
+  const void* second_slice = iovecs[1].mem_;
+  iovecs[0].len_ = 1;
+  buffer.commit(iovecs, 1);
+  EXPECT_EQ(8001, buffer.length());
+
+  // Reserve 16KB again, and check whether we get back the uncommitted
+  // second slice from the previous reservation.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(static_cast<const uint8_t*>(first_slice) + 1,
+            static_cast<const uint8_t*>(iovecs[0].mem_));
+  EXPECT_EQ(second_slice, iovecs[1].mem_);
+}
+
+TEST_P(OwnedImplTest, ReserveReuse) {
+  Buffer::OwnedImpl buffer;
+  verifyImplementation(buffer);
+
+  static constexpr uint64_t NumIovecs = 2;
+  Buffer::RawSlice iovecs[NumIovecs];
+
+  // Reserve some space and leave it uncommitted.
+  uint64_t num_reserved = buffer.reserve(8192, iovecs, NumIovecs);
+  EXPECT_EQ(1, num_reserved);
+  const void* first_slice = iovecs[0].mem_;
+
+  // Reserve more space and verify that it begins with the same slice from the last reservation.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  const void* second_slice = iovecs[1].mem_;
+
+  // Repeat the last reservation and verify that it yields the same slices.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  EXPECT_EQ(second_slice, iovecs[1].mem_);
+}
+
 TEST_P(OwnedImplTest, Search) {
   // Populate a buffer with a string split across many small slices, to
   // exercise edge cases in the search implementation.


### PR DESCRIPTION
Description:
* On OwnedImpl::reserve, if any slices at the end of the buffer
  have reservations, clear the reservations so the space can be
  used for the new reservation.
* Add tests for the two cases where this is important: calling
  reserve and never committing the buffers before the next reserve
  call; and calling reserve, getting back N slices, and only committing
  the first M of those slices (where M < N) before the next reserve
  call.

Risk Level: medium
Testing: new unit tests included
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Brian Pane <brianp+github@brianp.net>
