### PR TITLE
bazel: cc_wrapper.py fixes due to bazel flag defaults changing

### DIFF
--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -29,18 +29,18 @@ def sanitize_flagfile(in_path, out_fd):
 
 
 # Is the arg a flag indicating that we're building for C++ (rather than C)?
-def is_cpp_flag(arg):
+def old_is_cpp_flag(arg):
   return arg in ["-static-libstdc++", "-stdlib=libc++", "-lstdc++", "-lc++"
                 ] or arg.startswith("-std=c++") or arg.startswith("-std=gnu++")
 
+# Is the arg a flag indicating that we're building for C++ (rather than C)?
+def new_is_cpp_flag(arg):
+  return arg in ["-static-libstdc++\n", "-stdlib=libc++\n", "-lstdc++\n", "-lc++\n"
+                ] or arg.startswith("-std=c++") or arg.startswith("-std=gnu++")
 
-def main():
-  # Append CXXFLAGS to correctly detect include paths for either libstdc++ or libc++.
-  if sys.argv[1:5] == ["-E", "-xc++", "-", "-v"]:
-    os.execv(envoy_real_cxx, [envoy_real_cxx] + sys.argv[1:] + shlex.split(envoy_cxxflags))
-
+def old_modify_driver_command_line_and_execute(sys_argv):
   # Detect if we're building for C++ or vanilla C.
-  if any(map(is_cpp_flag, sys.argv[1:])):
+  if any(map(old_is_cpp_flag, sys_argv[1:])):
     compiler = envoy_real_cxx
     # Append CXXFLAGS to all C++ targets (this is mostly for dependencies).
     argv = shlex.split(envoy_cxxflags)
@@ -52,8 +52,8 @@ def main():
   # Either:
   # a) remove all occurrences of -lstdc++ (when statically linking against libstdc++),
   # b) replace all occurrences of -lstdc++ with -lc++ (when linking against libc++).
-  if "-static-libstdc++" in sys.argv[1:] or "-stdlib=libc++" in envoy_cxxflags:
-    for arg in sys.argv[1:]:
+  if "-static-libstdc++" in sys_argv[1:] or "-stdlib=libc++" in envoy_cxxflags:
+    for arg in sys_argv[1:]:
       if arg == "-lstdc++":
         if "-stdlib=libc++" in envoy_cxxflags:
           argv.append("-lc++")
@@ -69,7 +69,7 @@ def main():
       else:
         argv.append(arg)
   else:
-    argv += sys.argv[1:]
+    argv += sys_argv[1:]
 
   # Bazel will add -fuse-ld=gold in some cases, gcc/clang will take the last -fuse-ld argument,
   # so whenever we see lld once, add it to the end.
@@ -92,6 +92,71 @@ def main():
     argv.append("-Wno-maybe-uninitialized")
 
   os.execv(compiler, [compiler] + argv)
+
+def new_modify_driver_command_line_and_execute(flagfile_path, new_flagfile_path, new_flagfile_fd):
+  flagfile_contents = open(flagfile_path, "r").readlines()
+
+  # Detect if we're building for C++ or vanilla C.
+  if any(map(new_is_cpp_flag, flagfile_contents)):
+    compiler = envoy_real_cxx
+    # Append CXXFLAGS to all C++ targets (this is mostly for dependencies).
+    argv = shlex.split(envoy_cxxflags)
+  else:
+    compiler = envoy_real_cc
+    # Append CFLAGS to all C targets (this is mostly for dependencies).
+    argv = shlex.split(envoy_cflags)
+
+  # Either:
+  # a) remove all occurrences of -lstdc++ (when statically linking against libstdc++),
+  # b) replace all occurrences of -lstdc++ with -lc++ (when linking against libc++).
+  if "-static-libstdc++\n" in flagfile_contents or "-stdlib=libc++" in envoy_cxxflags:
+    for arg in flagfile_contents:
+      if arg == "-lstdc++\n":
+        if "-stdlib=libc++" in envoy_cxxflags:
+          argv.append("-lc++\n")
+      else:
+        argv.append(arg)
+  else:
+    argv += flagfile_contents
+
+  # Bazel will add -fuse-ld=gold in some cases, gcc/clang will take the last -fuse-ld argument,
+  # so whenever we see lld once, add it to the end.
+  if "-fuse-ld=lld\n" in argv:
+    argv.append("-fuse-ld=lld\n")
+
+  # Add compiler-specific options
+  if "clang" in compiler:
+    # This ensures that STL symbols are included.
+    # See https://github.com/envoyproxy/envoy/issues/1341
+    argv.append("-fno-limit-debug-info\n")
+    argv.append("-Wthread-safety\n")
+    argv.append("-Wgnu-conditional-omitted-operand\n")
+  elif "gcc" in compiler or "g++" in compiler:
+    # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
+    # to prevent build breakage. This option does not exist in clang, so setting
+    # it in clang builds causes a build error because of unknown command line
+    # flag.
+    # See https://github.com/envoyproxy/envoy/issues/2987
+    argv.append("-Wno-maybe-uninitialized\n")
+
+  for arg in argv:
+    os.write(new_flagfile_fd, arg)
+  os.execv(compiler, [compiler] + ["@" + new_flagfile_path])
+
+def main():
+  # Append CXXFLAGS to correctly detect include paths for either libstdc++ or libc++.
+  if sys.argv[1:5] == ["-E", "-xc++", "-", "-v"]:
+    os.execv(envoy_real_cxx, [envoy_real_cxx] + sys.argv[1:] + shlex.split(envoy_cxxflags))
+
+  if sys.argv[1].startswith("@"):
+    (new_flagfile_fd, new_flagfile_path) = tempfile.mkstemp(dir="./", suffix=".linker-params")
+    flagfile_path = sys.argv[1][1:]
+    with closing_fd(new_flagfile_fd):
+      new_modify_driver_command_line_and_execute(flagfile_path, new_flagfile_path, new_flagfile_fd)
+  else:
+    # TODO(https://github.com/bazelbuild/bazel/issues/7687): Remove this branch
+    # when Bazel 0.27 is released.
+    old_modify_driver_command_line_and_execute(sys.argv)
 
 
 if __name__ == "__main__":

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -33,10 +33,12 @@ def old_is_cpp_flag(arg):
   return arg in ["-static-libstdc++", "-stdlib=libc++", "-lstdc++", "-lc++"
                 ] or arg.startswith("-std=c++") or arg.startswith("-std=gnu++")
 
+
 # Is the arg a flag indicating that we're building for C++ (rather than C)?
 def new_is_cpp_flag(arg):
   return arg in ["-static-libstdc++\n", "-stdlib=libc++\n", "-lstdc++\n", "-lc++\n"
                 ] or arg.startswith("-std=c++") or arg.startswith("-std=gnu++")
+
 
 def old_modify_driver_command_line_and_execute(sys_argv):
   # Detect if we're building for C++ or vanilla C.
@@ -93,6 +95,7 @@ def old_modify_driver_command_line_and_execute(sys_argv):
 
   os.execv(compiler, [compiler] + argv)
 
+
 def new_modify_driver_command_line_and_execute(flagfile_path, new_flagfile_path, new_flagfile_fd):
   flagfile_contents = open(flagfile_path, "r").readlines()
 
@@ -142,6 +145,7 @@ def new_modify_driver_command_line_and_execute(flagfile_path, new_flagfile_path,
   for arg in argv:
     os.write(new_flagfile_fd, arg)
   os.execv(compiler, [compiler] + ["@" + new_flagfile_path])
+
 
 def main():
   # Append CXXFLAGS to correctly detect include paths for either libstdc++ or libc++.


### PR DESCRIPTION
Description: I copied @oquenchil's changes from https://github.com/envoyproxy/envoy/issues/6968#issuecomment-495184939 and fixed the python formatting errors. This let us link our exe w/ the new flag default (`--incompatible_do_not_split_linking_cmdline`) and with the old value. When Envoy upgrades to bazel 0.27 we should remove the `old` functions in this file.
Risk Level: Low
Testing: Ran `bazel test --incompatible_do_not_split_linking_cmdline //test/exe/...` and `bazel test //test/exe/...`
Docs Changes: N/A
Release Notes: N/A
Fixes #6968 