### PR TITLE
remove use of std::tuple in gzip_filter_test to avoid compilation err…

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -594,15 +594,15 @@ void InstanceImpl::shutdownAdmin() {
 ServerLifecycleNotifier::HandlePtr InstanceImpl::registerCallback(Stage stage,
                                                                   StageCallback callback) {
   auto& callbacks = stage_callbacks_[stage];
-  return absl::make_unique<LifecycleCallbackHandle<StageCallback>>(callbacks, callback);
+  return std::make_unique<LifecycleCallbackHandle<StageCallback>>(callbacks, callback);
 }
 
 ServerLifecycleNotifier::HandlePtr
 InstanceImpl::registerCallback(Stage stage, StageCallbackWithCompletion callback) {
   ASSERT(stage == Stage::ShutdownExit);
   auto& callbacks = stage_completable_callbacks_[stage];
-  return absl::make_unique<LifecycleCallbackHandle<StageCallbackWithCompletion>>(callbacks,
-                                                                                 callback);
+  return std::make_unique<LifecycleCallbackHandle<StageCallbackWithCompletion>>(callbacks,
+                                                                                callback);
 }
 
 void InstanceImpl::notifyCallbacksForStage(Stage stage, Event::PostCb completion_cb) {

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -144,13 +144,12 @@ protected:
   }
 
   void expectValidCompressionStrategyAndLevel(
-      std::tuple<Compressor::ZlibCompressorImpl::CompressionStrategy, std::string,
-                 Compressor::ZlibCompressorImpl::CompressionLevel, std::string>
-          compression_settings) {
+      Compressor::ZlibCompressorImpl::CompressionStrategy strategy, absl::string_view strategy_name,
+      Compressor::ZlibCompressorImpl::CompressionLevel level, absl::string_view level_name) {
     setUpFilter(fmt::format(R"EOF({{"compression_strategy": "{}", "compression_level": "{}"}})EOF",
-                            std::get<1>(compression_settings), std::get<3>(compression_settings)));
-    EXPECT_EQ(std::get<0>(compression_settings), config_->compressionStrategy());
-    EXPECT_EQ(std::get<2>(compression_settings), config_->compressionLevel());
+                            strategy_name, level_name));
+    EXPECT_EQ(strategy, config_->compressionStrategy());
+    EXPECT_EQ(level, config_->compressionLevel());
     EXPECT_EQ(5, config_->memoryLevel());
     EXPECT_EQ(30, config_->minimumLength());
     EXPECT_EQ(28, config_->windowBits());
@@ -211,17 +210,17 @@ TEST_F(GzipFilterTest, DefaultConfigValues) {
 
 TEST_F(GzipFilterTest, AvailableCombinationCompressionStrategyAndLevelConfig) {
   expectValidCompressionStrategyAndLevel(
-      {Compressor::ZlibCompressorImpl::CompressionStrategy::Filtered, "FILTERED",
-       Compressor::ZlibCompressorImpl::CompressionLevel::Best, "BEST"});
+      Compressor::ZlibCompressorImpl::CompressionStrategy::Filtered, "FILTERED",
+      Compressor::ZlibCompressorImpl::CompressionLevel::Best, "BEST");
   expectValidCompressionStrategyAndLevel(
-      {Compressor::ZlibCompressorImpl::CompressionStrategy::Huffman, "HUFFMAN",
-       Compressor::ZlibCompressorImpl::CompressionLevel::Best, "BEST"});
+      Compressor::ZlibCompressorImpl::CompressionStrategy::Huffman, "HUFFMAN",
+      Compressor::ZlibCompressorImpl::CompressionLevel::Best, "BEST");
   expectValidCompressionStrategyAndLevel(
-      {Compressor::ZlibCompressorImpl::CompressionStrategy::Rle, "RLE",
-       Compressor::ZlibCompressorImpl::CompressionLevel::Speed, "SPEED"});
+      Compressor::ZlibCompressorImpl::CompressionStrategy::Rle, "RLE",
+      Compressor::ZlibCompressorImpl::CompressionLevel::Speed, "SPEED");
   expectValidCompressionStrategyAndLevel(
-      {Compressor::ZlibCompressorImpl::CompressionStrategy::Standard, "DEFAULT",
-       Compressor::ZlibCompressorImpl::CompressionLevel::Standard, "DEFAULT"});
+      Compressor::ZlibCompressorImpl::CompressionStrategy::Standard, "DEFAULT",
+      Compressor::ZlibCompressorImpl::CompressionLevel::Standard, "DEFAULT");
 }
 
 // Acceptance Testing with default configuration.


### PR DESCRIPTION
…or in libstdc+++

Signed-off-by: Xin Zhuang <stevenzzz@google.com>

Description: with libstdc++ the the std::tuple constructor picked by a {x,y,z} parameter is "explicit tuple(TP_&&...) ", which causes a compilation error, remove the usage of std::tuple to make the test code more compatible w/ libstdc++. 

Risk Level: LOW
Testing: Unit test.
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
