### PR TITLE
Fix bug where cluster removes don't update local CDS local version.

### DIFF
--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -118,6 +118,7 @@ void CdsApiImpl::onConfigUpdate(
   }
   for (auto resource_name : removed_resources) {
     if (cm_.removeCluster(resource_name)) {
+      any_applied = true;
       ENVOY_LOG(debug, "cds: remove cluster '{}'", resource_name);
     }
   }

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -118,7 +118,6 @@ void CdsApiImpl::onConfigUpdate(
   }
   for (auto resource_name : removed_resources) {
     if (cm_.removeCluster(resource_name)) {
-      any_applied = true;
       ENVOY_LOG(debug, "cds: remove cluster '{}'", resource_name);
     }
   }

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -38,17 +38,18 @@ void LdsApiImpl::onConfigUpdate(
   cm_.adsMux().pause(Config::TypeUrl::get().RouteConfiguration);
   Cleanup rds_resume([this] { cm_.adsMux().resume(Config::TypeUrl::get().RouteConfiguration); });
 
+  bool any_applied = false;
   // We do all listener removals before adding the new listeners. This allows adding a new listener
   // with the same address as a listener that is to be removed. Do not change the order.
   for (const auto& removed_listener : removed_resources) {
     if (listener_manager_.removeListener(removed_listener)) {
       ENVOY_LOG(info, "lds: remove listener '{}'", removed_listener);
+      any_applied = true;
     }
   }
 
   std::vector<std::string> exception_msgs;
   std::unordered_set<std::string> listener_names;
-  bool any_applied = false;
   for (const auto& resource : added_resources) {
     envoy::api::v2::Listener listener;
     try {

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -197,6 +197,8 @@ TEST_F(CdsApiImplTest, ValidateFail) {
   EXPECT_CALL(request_, cancel());
 }
 
+// Regression test against only updating versionInfo() if at least one cluster
+// is are added/updated even if one or more are removed.
 TEST_F(CdsApiImplTest, UpdateVersionOnClusterRemove) {
   interval_timer_ = new Event::MockTimer(&dispatcher_);
   InSequence s;

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -197,6 +197,51 @@ TEST_F(CdsApiImplTest, ValidateFail) {
   EXPECT_CALL(request_, cancel());
 }
 
+TEST_F(CdsApiImplTest, UpdateVersionOnClusterRemove) {
+  interval_timer_ = new Event::MockTimer(&dispatcher_);
+  InSequence s;
+
+  setup();
+
+  const std::string response1_yaml = R"EOF(
+version_info: '0'
+resources:
+- "@type": type.googleapis.com/envoy.api.v2.Cluster
+  name: cluster1
+  type: EDS
+  eds_cluster_config:
+    eds_config:
+      path: eds path
+)EOF";
+
+  EXPECT_CALL(cm_, clusters()).WillOnce(Return(ClusterManager::ClusterInfoMap{}));
+  cm_.expectAdd("cluster1", "0");
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_EQ("", cds_->versionInfo());
+  EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.version").value());
+
+  callbacks_->onSuccess(parseResponseMessageFromYaml(response1_yaml));
+  EXPECT_EQ("0", cds_->versionInfo());
+
+  expectRequest();
+  interval_timer_->callback_();
+
+  const std::string response2_yaml = R"EOF(
+version_info: '1'
+resources:
+)EOF";
+  EXPECT_CALL(cm_, clusters()).WillOnce(Return(makeClusterMap({"cluster1"})));
+
+  EXPECT_CALL(cm_, removeCluster("cluster1")).WillOnce(Return(true));
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(parseResponseMessageFromYaml(response2_yaml));
+
+  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_attempt").value());
+  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_success").value());
+  EXPECT_EQ("1", cds_->versionInfo());
+}
+
 // Validate onConfigUpdate throws EnvoyException with duplicate clusters.
 TEST_F(CdsApiImplTest, ValidateDuplicateClusters) {
   InSequence s;

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -386,6 +386,64 @@ TEST_F(LdsApiTest, Basic) {
   EXPECT_EQ(13237225503670494420U, store_.gauge("listener_manager.lds.version").value());
 }
 
+// Regression test against only updating versionInfo() if at least one listener
+// is added/updated even if one or more are removed.
+TEST_F(LdsApiTest, UpdateVersionOnListenerRemove) {
+  InSequence s;
+
+  setup();
+
+  const std::string response1_json = R"EOF(
+{
+  "version_info": "0",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "listener1",
+      "address": { "socket_address": { "address": "tcp://0.0.0.1", "port_value": 0 } },
+      "filter_chains": [ { "filters": null } ]
+    }
+  ]
+}
+)EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response1_json);
+
+  makeListenersAndExpectCall({});
+  expectAdd("listener1", "0", true);
+  EXPECT_CALL(init_watcher_, ready());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  EXPECT_EQ("0", lds_->versionInfo());
+  expectRequest();
+  interval_timer_->callback_();
+
+  const std::string response2_json = R"EOF(
+{
+  "version_info": "1",
+  "resources": []
+}
+  )EOF";
+
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response2_json);
+
+  makeListenersAndExpectCall({"listener1"});
+  EXPECT_CALL(listener_manager_, removeListener("listener1")).WillOnce(Return(true));
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+  EXPECT_EQ("1", lds_->versionInfo());
+
+  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
+  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_success").value());
+  EXPECT_EQ(13237225503670494420U, store_.gauge("listener_manager.lds.version").value());
+}
+
+
 // Regression test issue #2188 where an empty ca_cert_file field was created and caused the LDS
 // update to fail validation.
 TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -443,7 +443,6 @@ TEST_F(LdsApiTest, UpdateVersionOnListenerRemove) {
   EXPECT_EQ(13237225503670494420U, store_.gauge("listener_manager.lds.version").value());
 }
 
-
 // Regression test issue #2188 where an empty ca_cert_file field was created and caused the LDS
 // update to fail validation.
 TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {


### PR DESCRIPTION
Signed-off-by: Michael Puncel <mpuncel@squareup.com>

Description: Fix a minor bug in CDS where an operation that only removes clusters (and does not add or update any) would not update the local CDS version reported in /config_dump
Risk Level: low
Testing: unit test & verified against internal integration tests
Docs Changes: n/a
Release Notes: n/a
