### PR TITLE
router_check_tool: fix ASSERT in path_rewrite test

### DIFF
--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -91,6 +91,7 @@ bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_jso
 
   bool no_failures = true;
   for (const Json::ObjectSharedPtr& check_config : loader->asObjectArray()) {
+    perform_finalize_headers_ = false;
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
 
@@ -164,6 +165,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
   bool no_failures = true;
   for (const envoy::RouterCheckToolSchema::ValidationItem& check_config :
        validation_config.tests()) {
+    perform_finalize_headers_ = false;
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
 
@@ -265,8 +267,12 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
-                                                             true);
+    if (!perform_finalize_headers_) {
+      tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
+                                                               true);
+      perform_finalize_headers_ = true;
+    }
+
     actual = tool_config.headers_->get_(Http::Headers::get().Path);
   }
   return compareResults(actual, expected, "path_rewrite");
@@ -288,8 +294,12 @@ bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::str
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
-                                                             true);
+    if (!perform_finalize_headers_) {
+      tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
+                                                               true);
+      perform_finalize_headers_ = true;
+    }
+
     actual = tool_config.headers_->get_(Http::Headers::get().Host);
   }
   return compareResults(actual, expected, "host_rewrite");

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -91,7 +91,7 @@ bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_jso
 
   bool no_failures = true;
   for (const Json::ObjectSharedPtr& check_config : loader->asObjectArray()) {
-    perform_finalize_headers_ = false;
+    headers_finalized_ = false;
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
 
@@ -165,7 +165,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
   bool no_failures = true;
   for (const envoy::RouterCheckToolSchema::ValidationItem& check_config :
        validation_config.tests()) {
-    perform_finalize_headers_ = false;
+    headers_finalized_ = false;
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
 
@@ -267,10 +267,10 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
-    if (!perform_finalize_headers_) {
+    if (!headers_finalized_) {
       tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
                                                                true);
-      perform_finalize_headers_ = true;
+      headers_finalized_ = true;
     }
 
     actual = tool_config.headers_->get_(Http::Headers::get().Path);
@@ -294,10 +294,10 @@ bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::str
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
-    if (!perform_finalize_headers_) {
+    if (!headers_finalized_) {
       tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
                                                                true);
-      perform_finalize_headers_ = true;
+      headers_finalized_ = true;
     }
 
     actual = tool_config.headers_->get_(Http::Headers::get().Host);

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -130,7 +130,7 @@ private:
   bool compareResults(const std::string& actual, const std::string& expected,
                       const std::string& test_type);
 
-  bool perform_finalize_headers_{false};
+  bool headers_finalized_{false};
 
   bool details_{false};
 

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -130,6 +130,8 @@ private:
   bool compareResults(const std::string& actual, const std::string& expected,
                       const std::string& test_type);
 
+  bool perform_finalize_headers_{false};
+
   bool details_{false};
 
   // TODO(hennna): Switch away from mocks following work done by @rlazarus in github issue #499.

--- a/test/tools/router_check/test/config/Redirect.golden.json
+++ b/test/tools/router_check/test/config/Redirect.golden.json
@@ -74,5 +74,33 @@
       "internal": false
     },
     "validate": {"path_redirect": "https://new.lyft.com/new_baz"}
+  },
+  {
+    "test_name": "Test_9",
+    "input": {
+      ":authority": "api.lyft.com",
+      ":path": "/pretest",
+      "ssl": true
+    },
+    "validate": {
+      "host_rewrite": "api.lyft.com",
+      "virtual_host_name": "api",
+      "path_rewrite": "/pre/test",
+      "cluster_name": "www2"
+    }
+  },
+  {
+    "test_name": "Test_10",
+    "input": {
+      ":authority": "api.lyft.com",
+      ":path": "/secondtest",
+      "ssl": true
+    },
+    "validate": {
+      "host_rewrite": "api.lyft.com",
+      "virtual_host_name": "api",
+      "path_rewrite": "/second/test",
+      "cluster_name": "www2"
+    }
   }
 ]

--- a/test/tools/router_check/test/config/Redirect.golden.proto.json
+++ b/test/tools/router_check/test/config/Redirect.golden.proto.json
@@ -83,6 +83,36 @@
         "internal": false
       },
       "validate": {"path_redirect": "https://new.lyft.com/new_baz"}
+    },
+    {
+      "test_name": "Test_9",
+      "input": {
+        "authority": "api.lyft.com",
+        "path": "/pretest",
+        "method": "GET",
+        "ssl": true
+      },
+      "validate": {
+        "host_rewrite": "api.lyft.com",
+        "virtual_host_name": "api",
+        "path_rewrite": "/pre/test",
+        "cluster_name": "www2"
+      }
+    },
+    {
+      "test_name": "Test_9",
+      "input": {
+        "authority": "api.lyft.com",
+        "path": "/secondtest",
+        "method": "GET",
+        "ssl": true
+      },
+      "validate": {
+        "host_rewrite": "api.lyft.com",
+        "virtual_host_name": "api",
+        "path_rewrite": "/second/test",
+        "cluster_name": "www2"
+      }
     }
   ]
 }

--- a/test/tools/router_check/test/config/Redirect.yaml
+++ b/test/tools/router_check/test/config/Redirect.yaml
@@ -14,6 +14,16 @@ virtual_hosts:
   require_tls: EXTERNAL_ONLY
   routes:
     - match:
+        prefix: /pretest
+      route:
+        prefix_rewrite: /pre/test
+        cluster: www2
+    - match:
+        prefix: /secondtest
+      route:
+        prefix_rewrite: /second/test
+        cluster: www2
+    - match:
         prefix: /
       route:
         cluster: www2
@@ -25,7 +35,6 @@ virtual_hosts:
         prefix: /foo
       redirect:
         host_redirect: new.lyft.com
-
     - match:
         prefix: /bar
       redirect:


### PR DESCRIPTION
Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>

Description: When multiple test validations are mentioned in the `validation` section, 
eg: 
```
"validate": {
        "host_rewrite": "api.lyft.com",
        "virtual_host_name": "api",
        "path_rewrite": "/pre/test",
        "cluster_name": "www2"
      }
```
`finalizeRequestHeaders` is called multiple times causing ASSERT failures. None of the existing tests covered this scenario. Now few tests have been added to simulate the error.

Before the fix the failure looked like this
```
[2019-05-29 19:47:48.210][1405009][critical][assert] [source/common/router/config_impl.cc:557] assert failure: case_sensitive_ ? absl::StartsWith(path, matched_path) : absl::StartsWithIgnoreCase(path, matched_path).
```

Risk Level: Low
Testing: 
 - Added breaking tests and fixed them using the fix.
 - Tested the tool against lyft's routes
