### PR TITLE
config: logging LDS file on config failure

### DIFF
--- a/source/common/config/filesystem_subscription_impl.cc
+++ b/source/common/config/filesystem_subscription_impl.cc
@@ -42,8 +42,8 @@ void FilesystemSubscriptionImpl::refresh() {
   ENVOY_LOG(debug, "Filesystem config refresh for {}", path_);
   stats_.update_attempt_.inc();
   bool config_update_available = false;
+  envoy::api::v2::DiscoveryResponse message;
   try {
-    envoy::api::v2::DiscoveryResponse message;
     MessageUtil::loadFromFile(path_, message, api_);
     config_update_available = true;
     callbacks_->onConfigUpdate(message.resources(), message.version_info());
@@ -53,6 +53,7 @@ void FilesystemSubscriptionImpl::refresh() {
   } catch (const EnvoyException& e) {
     if (config_update_available) {
       ENVOY_LOG(warn, "Filesystem config update rejected: {}", e.what());
+      ENVOY_LOG(debug, "Failed configuration:\n{}", message.DebugString());
       stats_.update_rejected_.inc();
     } else {
       ENVOY_LOG(warn, "Filesystem config update failure: {}", e.what());


### PR DESCRIPTION
This mostly as a follow-on to #6933, it makes it less annoying to diagnose configuration issues when writing new integration tests by 
1) fast-failing if the LDS update is rejected
2) timing out if there's some other LDS failure
3) printing the LDS file if it was a valid proto but rejected for other reasons.

Risk Level: Low (log tweak + test changes)
Testing: existing tests pass (new tests are easier to write)
Docs Changes: n/a
Release Notes: n/a
