### PR TITLE
log: assign upstream logger id to UpstreamRequest

### DIFF
--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -293,10 +293,12 @@ protected:
   RetryStatePtr retry_state_;
 
 private:
-  struct UpstreamRequest : public Http::StreamDecoder,
-                           public Http::StreamCallbacks,
-                           public Http::ConnectionPool::Callbacks,
-                           public LinkedObject<UpstreamRequest> {
+  class UpstreamRequest : Logger::Loggable<Logger::Id::upstream>,
+                          public Http::StreamDecoder,
+                          public Http::StreamCallbacks,
+                          public Http::ConnectionPool::Callbacks,
+                          public LinkedObject<UpstreamRequest> {
+  public:
     UpstreamRequest(Filter& parent, Http::ConnectionPool::Instance& pool);
     ~UpstreamRequest();
 


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Description: The logger id fits the class name 
Risk Level: LOW
Testing: none
