### PR TITLE
owners: switch API to @envoyproxy/api-shepherds.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 #*       @envoyproxy/maintainers
 
 # api
-/api/ @htuch
+/api/ @envoyproxy/api-shepherds
 # csrf extension
 /*/extensions/filters/http/csrf @dschaller @mattklein123
 # original_src http filter extension


### PR DESCRIPTION
Followup to https://github.com/envoyproxy/envoy/pull/7114.

Signed-off-by: Harvey Tuch <htuch@google.com>