### PR TITLE
redis: outlier detection support for redirection wrong host for Redis…

### DIFF
--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -80,4 +80,14 @@ message OutlierDetection {
   // used to disable ejection or to ramp it up slowly. Defaults to 0.
   google.protobuf.UInt32Value enforcing_consecutive_gateway_failure = 11
       [(validate.rules).uint32.lte = 100];
+
+  // The number of consecutive wrong-host events from any given upstream host before the cluster
+  // is notified to possibly check its membership or load-balancer state. This value
+  // defaults to 1.
+  google.protobuf.UInt32Value consecutive_wrong_host = 12;
+
+  // The minimum time interval between notifying the cluster of any wrong-host events.
+  // Any cluster notification request generated within this time period after notifying
+  // a cluster of a wrong-host event will be ignored. This value defaults to 10s.
+  google.protobuf.Duration min_wrong_host_notify_time = 13 [(validate.rules).duration.gt = {}];
 }

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -139,6 +139,8 @@ statistics will be rooted at *cluster.<name>.outlier_detection.* and contain the
   ejections_detected_consecutive_gateway_failure, Counter, Number of detected consecutive gateway failure ejections (even if unenforced)
   ejections_total, Counter, Deprecated. Number of ejections due to any outlier type (even if unenforced)
   ejections_consecutive_5xx, Counter, Deprecated. Number of consecutive 5xx ejections (even if unenforced)
+  detected_consecutive_wrong_host, Counter, Number of detected consecutive wrong host events.
+  enforced_consecutive_wrong_host, Counter, Number of consecutive wrong host events that triggered a cluster update.
 
 .. _config_cluster_manager_cluster_stats_circuit_breakers:
 

--- a/docs/root/intro/arch_overview/outlier.rst
+++ b/docs/root/intro/arch_overview/outlier.rst
@@ -11,6 +11,12 @@ form of *passive* health checking. Envoy also supports :ref:`active health check
 <arch_overview_health_checking>`. *Passive* and *active* health checking can be enabled together or
 independently, and form the basis for an overall upstream health checking solution.
 
+Outlier detection actions extend beyond ejection. :ref:`Consecutive wrong host 
+<arch_overview_outlier_detection_consecutive_wrong_host>` outlier detection can trigger :ref:`Redis cluster 
+<arch_overview_redis_cluster_support>` topology rediscovery when :ref:`enable_redirection 
+<envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_redirection>` 
+is enabled and redirection errors are received from upstream Redis servers.
+
 Ejection algorithm
 ------------------
 
@@ -57,6 +63,21 @@ return one of these status codes on the upstream's behalf (reset, connection fai
 number of consecutive gateway failures required for ejection is controlled by
 the :ref:`outlier_detection.consecutive_gateway_failure
 <envoy_api_field_cluster.OutlierDetection.consecutive_gateway_failure>` value.
+
+.. _arch_overview_outlier_detection_consecutive_wrong_host:
+
+Consecutive Wrong Host
+^^^^^^^^^^^^^^^^^^^^^^
+If an upstream host that is part of a :ref:`Redis cluster <arch_overview_redis_cluster_support>`
+returns some number of `MOVED or ASK redirection errors 
+<https://redis.io/topics/cluster-spec#redirection-and-resharding>`_ (and :ref:`enable_redirection 
+<envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_redirection>` 
+is configured to be true), a cluster topology rediscovery session will be triggered. The number of
+consecutive redirection errors to trigger rediscovery is controlled by 
+:ref:`outlier_detection.consecutive_wrong_host <envoy_api_field_cluster.OutlierDetection.consecutive_wrong_host>`.
+The minimum amount of time that must pass after triggering before a cluster can be triggered again is
+controlled by :ref:`outlier_detection.OutlierDetection.min_wrong_host_notify_time 
+<envoy_api_field_cluster.OutlierDetection.min_wrong_host_notify_time>`.
 
 Success Rate
 ^^^^^^^^^^^^

--- a/docs/root/intro/arch_overview/redis.rst
+++ b/docs/root/intro/arch_overview/redis.rst
@@ -58,6 +58,8 @@ If passive healthchecking is desired, also configure
 For the purposes of passive healthchecking, connect timeouts, command timeouts, and connection
 close map to 5xx. All other responses from Redis are counted as a success.
 
+.. _arch_overview_redis_cluster_support:
+
 Redis Cluster Support (Experimental)
 ----------------------------------------
 

--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -35,6 +35,7 @@ enum class Result {
 
   REQUEST_FAILED, // Request was not completed successfully.
   SERVER_FAILURE, // The server indicated it cannot process a request.
+  WRONG_HOST,     // An upstream host has indicated that another host should process a request.
 };
 
 /**

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -906,6 +906,13 @@ public:
   virtual InitializePhase initializePhase() const PURE;
 
   /**
+   * Check the cluster's membership and load-balancer state, if appropriate. This is called by the
+   * outlier detector.
+   * @param host supplies a pointer to the "wrong" upstream host.
+   */
+  virtual void onWrongHost(HostSharedPtr host) PURE;
+
+  /**
    * @return the PrioritySet for the cluster.
    */
   virtual PrioritySet& prioritySet() PURE;

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -95,6 +95,8 @@ void CdsJson::translateOutlierDetection(
   JSON_UTIL_SET_INTEGER(json_outlier_detection, outlier_detection, success_rate_minimum_hosts);
   JSON_UTIL_SET_INTEGER(json_outlier_detection, outlier_detection, success_rate_request_volume);
   JSON_UTIL_SET_INTEGER(json_outlier_detection, outlier_detection, success_rate_stdev_factor);
+  JSON_UTIL_SET_INTEGER(json_outlier_detection, outlier_detection, consecutive_wrong_host);
+  JSON_UTIL_SET_DURATION(json_outlier_detection, outlier_detection, min_wrong_host_notify_time);
 }
 
 void CdsJson::translateCluster(const Json::Object& json_cluster,

--- a/source/common/upstream/cluster_factory_impl.cc
+++ b/source/common/upstream/cluster_factory_impl.cc
@@ -115,7 +115,7 @@ ClusterFactoryImplBase::create(const envoy::api::v2::Cluster& cluster,
   }
 
   new_cluster_pair.first->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
-      *new_cluster_pair.first, cluster, context.dispatcher(), context.runtime(),
+      new_cluster_pair.first, cluster, context.dispatcher(), context.runtime(),
       context.outlierEventLogger()));
   return new_cluster_pair;
 }

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -55,6 +55,7 @@ public:
   Outlier::Detector* outlierDetector() override { return outlier_detector_.get(); }
   const Outlier::Detector* outlierDetector() const override { return outlier_detector_.get(); }
   void initialize(std::function<void()> callback) override;
+  void onWrongHost(HostSharedPtr) override {}
 
   // Creates and starts healthcheckers to its endpoints
   void startHealthchecks(AccessLog::AccessLogManager& access_log_manager, Runtime::Loader& runtime,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -680,6 +680,7 @@ public:
   Outlier::Detector* outlierDetector() override { return outlier_detector_.get(); }
   const Outlier::Detector* outlierDetector() const override { return outlier_detector_.get(); }
   void initialize(std::function<void()> callback) override;
+  void onWrongHost(HostSharedPtr) override{};
 
 protected:
   ClusterImplBase(const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -51,6 +51,10 @@ RedisCluster::RedisCluster(
   }
 }
 
+void RedisCluster::onWrongHost(Upstream::HostSharedPtr) {
+  redis_discovery_session_.resolve_timer_->enableTimer(std::chrono::milliseconds(0));
+}
+
 void RedisCluster::startPreInit() {
   for (const DnsDiscoveryResolveTargetPtr& target : dns_discovery_resolve_targets_) {
     target->startResolve();

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -100,6 +100,9 @@ public:
                Server::Configuration::TransportSocketFactoryContext& factory_context,
                Stats::ScopePtr&& stats_scope, bool added_via_api);
 
+  // Upstream::Cluster
+  void onWrongHost(Upstream::HostSharedPtr host) override;
+
   struct ClusterSlotsRequest : public Extensions::NetworkFilters::Common::Redis::RespValue {
   public:
     ClusterSlotsRequest() : Extensions::NetworkFilters::Common::Redis::RespValue() {

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -591,7 +591,7 @@ TEST_F(RedisClientImplTest, AskRedirection) {
     response2->asString() = "ASK 2222 10.1.2.4:4321";
     EXPECT_CALL(callbacks2, onRedirection(Ref(*response2))).WillOnce(Return(true));
     EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
+    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::WRONG_HOST));
     callbacks_->onRespValue(std::move(response2));
 
     EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_internal_redirect_succeeded_total_.value());
@@ -651,7 +651,7 @@ TEST_F(RedisClientImplTest, MovedRedirection) {
     response2->asString() = "MOVED 2222 10.1.2.4:4321";
     EXPECT_CALL(callbacks2, onRedirection(Ref(*response2))).WillOnce(Return(true));
     EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SUCCESS));
+    EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::WRONG_HOST));
     callbacks_->onRespValue(std::move(response2));
 
     EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_internal_redirect_succeeded_total_.value());

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -168,6 +168,7 @@ public:
   MOCK_METHOD1(initialize, void(std::function<void()> callback));
   MOCK_CONST_METHOD0(initializePhase, InitializePhase());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_METHOD1(onWrongHost, void(HostSharedPtr host));
 
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   std::function<void()> initialize_callback_;


### PR DESCRIPTION
…Cluster

Signed-off-by: Mitch Sukalski <mitch.sukalski@workday.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:

Outlier detection has been extended to provide a configurable mechanism to control Redis cluster topology rediscovery when moved/ask redirection errors are received. A new outlier detection configuration setting, consecutive_wrong_host, controls how many consecutive redirection errors must be received from a host to trigger a consecutive_wrong_host event. Another setting, min_wrong_host_notify_time, controls how much time must pass after an event triggering before another one will be allowed for the same cluster. On triggering, the cluster's onWrongHost() method is called. Two new counters have been added to the outlier detector statistics at the cluster scope, detected_consecutive_wrong_host and enforced_consecutive_wrong_host.

Risk Level: low
Testing: unit tests
Docs Changes: changes to outlier detection architectural overview and statistics table
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
