### PR TITLE
stats: Remove the stat-merger regexes and clean up docs.

### DIFF
--- a/include/envoy/stats/scope.h
+++ b/include/envoy/stats/scope.h
@@ -58,6 +58,7 @@ public:
 
   /**
    * @param name The name of the stat, obtained from the SymbolTable.
+   * @param import_mode Whether hot-restart should accumulate this value.
    * @return a gauge within the scope's namespace.
    */
   virtual Gauge& gaugeFromStatName(StatName name, Gauge::ImportMode import_mode) PURE;
@@ -65,6 +66,7 @@ public:
   /**
    * TODO(#6667): this variant is deprecated: use gaugeFromStatName.
    * @param name The name, expressed as a string.
+   * @param import_mode Whether hot-restart should accumulate this value.
    * @return a gauge within the scope's namespace.
    */
   virtual Gauge& gauge(const std::string& name, Gauge::ImportMode import_mode) PURE;

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -143,7 +143,21 @@ public:
   virtual void set(uint64_t value) PURE;
   virtual void sub(uint64_t amount) PURE;
   virtual uint64_t value() const PURE;
+
+  /**
+   * @return the import mode, dictating behavior of the gauge across hot restarts.
+   */
   virtual ImportMode importMode() const PURE;
+
+  /**
+   * Gauges can be created as ImportMode::Uninitialized when during hot-restart
+   * merges, if they haven't been initialized by the child process yet. When
+   * they do get initialized, mergeImportMode should be called to establish the
+   * import mode. It is only valid to call mergeImportMode when the current
+   * current mode is Uninitialized.
+   *
+   * @param import_mode the new import mode.
+   */
   virtual void mergeImportMode(ImportMode import_mode) PURE;
 };
 

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -150,11 +150,11 @@ public:
   virtual ImportMode importMode() const PURE;
 
   /**
-   * Gauges can be created as ImportMode::Uninitialized when during hot-restart
-   * merges, if they haven't been initialized by the child process yet. When
-   * they do get initialized, mergeImportMode should be called to establish the
-   * import mode. It is only valid to call mergeImportMode when the current
-   * current mode is Uninitialized.
+   * Gauges can be created with ImportMode::Uninitialized during hot-restart
+   * merges, if they haven't yet been instantiated by the child process. When
+   * they finally get instantiated, mergeImportMode should be called to
+   * initialize the gauge's import mode. It is only valid to call
+   * mergeImportMode when the current mode is ImportMode::Uninitialized.
    *
    * @param import_mode the new import mode.
    */

--- a/source/common/stats/heap_stat_data.h
+++ b/source/common/stats/heap_stat_data.h
@@ -75,32 +75,8 @@ public:
 
   GaugeSharedPtr makeGauge(StatName name, absl::string_view tag_extracted_name,
                            const std::vector<Tag>& tags, Gauge::ImportMode import_mode) override {
-    GaugeSharedPtr gauge = std::make_shared<HeapStat<GaugeImpl<HeapStatData>>>(
+    return std::make_shared<HeapStat<GaugeImpl<HeapStatData>>>(
         alloc(name), *this, tag_extracted_name, tags, import_mode);
-
-    // TODO(jmarantz): Remove this double-checking ASAP. This is left in only
-    // for the transition while #7083 gets reviewed, while new code may be
-    // concurrently added that updates the regex library. Once #7083 is merged
-    // the regex table and this double-check can be deleted.
-    switch (gauge->importMode()) {
-    case Gauge::ImportMode::Accumulate:
-      if (!StatMerger::shouldImportBasedOnRegex(gauge->name())) {
-        std::cerr << "ImportMode conflict: regex says no, arg says yes: " << gauge->name()
-                  << std::endl;
-        new std::string; // Makes tests fail due to leak, but allows the process to keep running.
-      }
-      break;
-    case Gauge::ImportMode::NeverImport:
-      if (StatMerger::shouldImportBasedOnRegex(gauge->name())) {
-        std::cerr << "ImportMode conflict: regex says yes, arg says no: " << gauge->name()
-                  << std::endl;
-        new std::string; // Makes tests fail due to leak, but allows the process to keep running.
-      }
-      break;
-    case Gauge::ImportMode::Uninitialized:
-      break;
-    }
-    return gauge;
   }
 
 #ifndef ENVOY_CONFIG_COVERAGE

--- a/source/common/stats/stat_merger.h
+++ b/source/common/stats/stat_merger.h
@@ -21,12 +21,6 @@ public:
   void mergeStats(const Protobuf::Map<std::string, uint64_t>& counter_deltas,
                   const Protobuf::Map<std::string, uint64_t>& gauges);
 
-  /**
-   * @return true if the name is recognized as a gauge that should be accumulated across
-   *         hot restart.
-   */
-  static bool shouldImportBasedOnRegex(const std::string& gauge_name);
-
 private:
   void mergeCounters(const Protobuf::Map<std::string, uint64_t>& counter_deltas);
   void mergeGauges(const Protobuf::Map<std::string, uint64_t>& gauges);


### PR DESCRIPTION
Description: : Remove the regex used for determining the merge-mode for gauges; they are all specified when creating gauges now. Also cleans up some method docs.
Risk Level: low
Testing: //test/common/stats/... so far
Docs Changes: n/a
Release Notes: n/a
