### PR TITLE
[test] remove translateTcpRateLimitFilter

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -163,7 +163,6 @@ envoy_cc_library(
         "@envoy_api//envoy/config/filter/network/client_ssl_auth/v2:client_ssl_auth_cc",
         "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:http_connection_manager_cc",
         "@envoy_api//envoy/config/filter/network/mongo_proxy/v2:mongo_proxy_cc",
-        "@envoy_api//envoy/config/filter/network/rate_limit/v2:rate_limit_cc",
         "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
         "@envoy_api//envoy/config/filter/network/tcp_proxy/v2:tcp_proxy_cc",
     ],

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -397,26 +397,6 @@ void FilterJson::translateTcpProxy(
   }
 }
 
-void FilterJson::translateTcpRateLimitFilter(
-    const Json::Object& json_config,
-    envoy::config::filter::network::rate_limit::v2::RateLimit& proto_config) {
-  json_config.validateSchema(Json::Schema::RATELIMIT_NETWORK_FILTER_SCHEMA);
-
-  JSON_UTIL_SET_STRING(json_config, proto_config, stat_prefix);
-  JSON_UTIL_SET_STRING(json_config, proto_config, domain);
-  JSON_UTIL_SET_DURATION(json_config, proto_config, timeout);
-
-  auto* descriptors = proto_config.mutable_descriptors();
-  for (const auto& json_descriptor : json_config.getObjectArray("descriptors", false)) {
-    auto* entries = descriptors->Add()->mutable_entries();
-    for (const auto& json_entry : json_descriptor->asObjectArray()) {
-      auto* entry = entries->Add();
-      JSON_UTIL_SET_STRING(*json_entry, *entry, key);
-      JSON_UTIL_SET_STRING(*json_entry, *entry, value);
-    }
-  }
-}
-
 void FilterJson::translateHttpRateLimitFilter(
     const Json::Object& json_config,
     envoy::config::filter::http::rate_limit::v2::RateLimit& proto_config) {

--- a/source/common/config/filter_json.h
+++ b/source/common/config/filter_json.h
@@ -11,7 +11,6 @@
 #include "envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.pb.h"
 #include "envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.h"
 #include "envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.pb.h"
-#include "envoy/config/filter/network/rate_limit/v2/rate_limit.pb.h"
 #include "envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.h"
 #include "envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.pb.h"
 #include "envoy/json/json_object.h"
@@ -140,16 +139,6 @@ public:
   static void
   translateTcpProxy(const Json::Object& json_config,
                     envoy::config::filter::network::tcp_proxy::v2::TcpProxy& proto_config);
-
-  /**
-   * Translate a v1 JSON TCP Rate Limit filter object to v2
-   * envoy::config::filter::network::rate_limit::v2::RateLimit.
-   * @param json_config source v1 JSON Tcp Rate Limit Filter object.
-   * @param proto_config destination v2 envoy::config::filter::network::rate_limit::v2::RateLimit.
-   */
-  static void translateTcpRateLimitFilter(
-      const Json::Object& json_config,
-      envoy::config::filter::network::rate_limit::v2::RateLimit& proto_config);
 
   /**
    * Translate a v1 JSON HTTP Rate Limit filter object to v2

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -112,7 +112,6 @@ envoy_cc_test(
     srcs = ["filter_manager_impl_test.cc"],
     deps = [
         "//source/common/buffer:buffer_lib",
-        "//source/common/config:filter_json_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/network:filter_manager_lib",
         "//source/common/stats:stats_lib",
@@ -130,6 +129,7 @@ envoy_cc_test(
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:host_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/extensions/filters/network/ratelimit/BUILD
+++ b/test/extensions/filters/network/ratelimit/BUILD
@@ -17,7 +17,6 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.network.ratelimit",
     deps = [
         "//source/common/buffer:buffer_lib",
-        "//source/common/config:filter_json_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/stats:stats_lib",
         "//source/extensions/filters/network/ratelimit:ratelimit_lib",
@@ -36,5 +35,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/network/ratelimit:config",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -1,10 +1,10 @@
+#include "envoy/config/filter/network/rate_limit/v2/rate_limit.pb.h"
 #include "envoy/config/filter/network/rate_limit/v2/rate_limit.pb.validate.h"
-
-#include "common/config/filter_json.h"
 
 #include "extensions/filters/network/ratelimit/config.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -24,7 +24,7 @@ TEST(RateLimitFilterConfigTest, ValidateFail) {
                ProtoValidationException);
 }
 
-TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
+TEST(RateLimitFilterConfigTest, CorrectProto) {
   const std::string yaml = R"EOF(
   stat_prefix: my_stat_prefix
   domain: fake_domain
@@ -56,7 +56,7 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   cb(connection);
 }
 
-TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
+TEST(RateLimitFilterConfigTest, EmptyProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   NiceMock<Server::MockInstance> instance;
   RateLimitConfigFactory factory;
@@ -65,6 +65,22 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
       *dynamic_cast<envoy::config::filter::network::rate_limit::v2::RateLimit*>(
           factory.createEmptyConfigProto().get());
   EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, context), EnvoyException);
+}
+
+TEST(RateLimitFilterConfigTest, IncorrectProto) {
+  std::string yaml_string = R"EOF(
+stat_prefix: my_stat_prefix
+domain: fake_domain
+descriptors:
+- entries:
+  - key: my_key
+    value: my_value
+ip_white_list: '12'
+  )EOF";
+
+  envoy::config::filter::network::rate_limit::v2::RateLimit proto_config;
+  EXPECT_THROW_WITH_REGEX(TestUtility::loadFromYaml(yaml_string, proto_config), EnvoyException,
+                          "ip_white_list: Cannot find field");
 }
 
 } // namespace RateLimitFilter

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -5,8 +5,6 @@
 #include "envoy/stats/stats.h"
 
 #include "common/buffer/buffer_impl.h"
-#include "common/config/filter_json.h"
-#include "common/json/json_loader.h"
 
 #include "extensions/filters/network/ratelimit/ratelimit.h"
 
@@ -95,23 +93,6 @@ failure_mode_deny: true
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
   Filters::Common::RateLimit::RequestCallbacks* request_callbacks_{};
 };
-
-TEST_F(RateLimitFilterTest, BadRatelimitConfig) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "domain" : "fake_domain",
-    "descriptors": [[{ "key" : "my_key",  "value" : "my_value" }]],
-    "ip_white_list": "12"
-  }
-  )EOF";
-
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  envoy::config::filter::network::rate_limit::v2::RateLimit proto_config{};
-
-  EXPECT_THROW(Envoy::Config::FilterJson::translateTcpRateLimitFilter(*json_config, proto_config),
-               Json::Exception);
-}
 
 TEST_F(RateLimitFilterTest, OK) {
   InSequence s;


### PR DESCRIPTION
Description: Convert test configs to v2, remove v1 translation function. For #6362.
Risk Level: low
Testing: included
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>