### PR TITLE
Fix typo in test_common/utility.h

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -445,7 +445,7 @@ public:
                                                 ProtobufMessage::getStrictValidationVisitor());
   }
 
-  static void jsonConvert(const ProtobufWkt::Message& source, Protobuf::Message& dest) {
+  static void jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest) {
     // Explicit round-tripping to support conversions inside tests between arbitrary messages as a
     // convenience.
     ProtobufWkt::Struct tmp;


### PR DESCRIPTION
Description: Fixes a typo from https://github.com/envoyproxy/envoy/pull/7072.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
