### PR TITLE
test: null-initialize downstreamSslConnectionInfo in TestStreamInfo

### DIFF
--- a/test/common/router/header_parser_corpus/clusterfuzz-testcase-minimized-header_parser_fuzz_test-5702537941876736
+++ b/test/common/router/header_parser_corpus/clusterfuzz-testcase-minimized-header_parser_fuzz_test-5702537941876736
@@ -1,0 +1,7 @@
+headers_to_add {
+  header {
+    key: "m"
+    value: "%DOWNSTREAM_PEER_SUBJECT%"
+  }
+}
+

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -207,7 +207,7 @@ public:
   Network::Address::InstanceConstSharedPtr downstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_direct_remote_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
-  const Ssl::ConnectionInfo* downstream_connection_info_;
+  const Ssl::ConnectionInfo* downstream_connection_info_{};
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
   Envoy::StreamInfo::FilterStateImpl filter_state_{};


### PR DESCRIPTION
Description:
Fix uninitialized field in TestStreamInfo, discovered by https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15066

Risk Level: Low
Testing: corpus added
Docs Changes: N/A
Release Notes: N/A