### PR TITLE
[docs] minor fixes to clang-format docs

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -529,19 +529,20 @@ to run clang-format scripts on your workstation directly:
  * It's possible there is a speed advantage
  * Docker itself can sometimes go awry and you then have to deal with that
  * Type-ahead doesn't always work when waiting running a command through docker
+
 To run the tools directly, you must install the correct version of clang. This
-may change over time but as of January 2019,
-[clang+llvm-7.0.0](https://releases.llvm.org/download.html) works well. You must
+may change over time but as of June 2019,
+[clang+llvm-8.0.0](https://releases.llvm.org/download.html) works well. You must
 also have 'buildifier' installed from the bazel distribution.
 
 Edit the paths shown here to reflect the installation locations on your system:
 
 ```shell
-export CLANG_FORMAT="$HOME/ext/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang-format"
+export CLANG_FORMAT="$HOME/ext/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang-format"
 export BUILDIFIER_BIN="/usr/bin/buildifier"
 ```
 
-Once this is set up, you can run clang-tidy without docker:
+Once this is set up, you can run clang-format without docker:
 
 ```shell
 ./tools/check_format.py check


### PR DESCRIPTION
Description: Some fixes to [this documentation](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#running-clang-format-without-docker) - update references to clang-format 8, fix a reference from clang-tidy to clang-format, and fix paragraph formatting. 
Risk Level: None
Testing: N/A
Docs Changes: included
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>