### PR TITLE
upstream: Use valid enum value in subset lb docs

### DIFF
--- a/docs/root/intro/arch_overview/load_balancing/subsets.rst
+++ b/docs/root/intro/arch_overview/load_balancing/subsets.rst
@@ -15,7 +15,7 @@ condition described above.
 
 If subsets are :ref:`configured <envoy_api_field_Cluster.lb_subset_config>` and a route
 specifies no metadata or no subset matching the metadata exists, the subset load balancer initiates
-its fallback policy. The default policy is ``NO_ENDPOINT``, in which case the request fails as if
+its fallback policy. The default policy is ``NO_FALLBACK``, in which case the request fails as if
 the cluster had no hosts. Conversely, the ``ANY_ENDPOINT`` fallback policy load balances across all
 hosts in the cluster, without regard to host metadata. Finally, the ``DEFAULT_SUBSET`` causes
 fallback to load balance among hosts that match a specific set of metadata.

--- a/source/docs/subset_load_balancer.md
+++ b/source/docs/subset_load_balancer.md
@@ -15,7 +15,7 @@ balancer types except the Original DST load balancer may be used for subset load
 The SLB can be configured with one of three fallback policies. If no subset matching the
 `LoadBalancerContext` is found:
 
-1. `NO_ENDPOINT` specifies that `chooseHost` returns `nullptr` and load balancing fails.
+1. `NO_FALLBACK` specifies that `chooseHost` returns `nullptr` and load balancing fails.
 2. `ANY_ENDPOINT` specifies that load balancing occurs over the entire set of upstream hosts.
 3. `DEFAULT_SUBSET` specifies that load balancing occurs over a specific subset of upstream
    hosts. If the default subset is empty, `chooseHost` returns `nullptr` and load balancing fails.


### PR DESCRIPTION
Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: In docs for subset load balancing we use non existing enum value `NO_ENDPOINT`, switched to valid enum value `NO_FALLBACK` which has same semantics.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
