### PR TITLE
config: delta RDS: don't onConfigUpdate when no resources

### DIFF
--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -140,13 +140,10 @@ void RdsRouteConfigSubscription::onConfigUpdate(
         "Server sent a delta RDS update attempting to remove a resource (name: {}). Ignoring.",
         removed_resources[0]);
   }
-  Protobuf::RepeatedPtrField<ProtobufWkt::Any> unwrapped_resource;
   if (!added_resources.empty()) {
+    Protobuf::RepeatedPtrField<ProtobufWkt::Any> unwrapped_resource;
     *unwrapped_resource.Add() = added_resources[0].resource();
     onConfigUpdate(unwrapped_resource, added_resources[0].version());
-  } else {
-    onConfigUpdate({}, "");
-    return;
   }
 }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -131,8 +131,7 @@ void RdsRouteConfigSubscription::onConfigUpdate(
 
 void RdsRouteConfigSubscription::onConfigUpdate(
     const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>& added_resources,
-    const Protobuf::RepeatedPtrField<std::string>& removed_resources,
-    const std::string& system_version_info) {
+    const Protobuf::RepeatedPtrField<std::string>& removed_resources, const std::string&) {
   if (!removed_resources.empty()) {
     // TODO(#2500) when on-demand resource loading is supported, an RDS removal may make sense (see
     // discussion in #6879), and so we should do something other than ignoring here.
@@ -146,7 +145,7 @@ void RdsRouteConfigSubscription::onConfigUpdate(
     *unwrapped_resource.Add() = added_resources[0].resource();
     onConfigUpdate(unwrapped_resource, added_resources[0].version());
   } else {
-    onConfigUpdate({}, system_version_info);
+    onConfigUpdate({}, "");
     return;
   }
 }


### PR DESCRIPTION
Previously, an empty update was passed through to state-of-the-world onConfigUpdate, with system_version_info as the version.

Risk Level: low