### PR TITLE
Adding libcurl as a dependency.

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -67,6 +67,26 @@ envoy_cmake_external(
 )
 
 envoy_cmake_external(
+    name = "curl",
+    cache_entries = {
+        "BUILD_CURL_EXE": "off",
+        "BUILD_SHARED_LIBS": "off",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "HTTP_ONLY": "on",
+        "BUILD_TESTING": "off",
+        "CMAKE_USE_OPENSSL": "off",
+        "CURL_CA_PATH": "none",
+        "CURL_HIDDEN_SYMBOLS": "off",
+        "CMAKE_USE_LIBSSH2": "off",
+    },
+    lib_source = "@com_github_curl//:all",
+    static_libraries = select({
+        "//bazel:windows_x86_64": ["curl.lib"],
+        "//conditions:default": ["libcurl.a"],
+    }),
+)
+
+envoy_cmake_external(
     name = "event",
     cache_entries = {
         "EVENT__DISABLE_OPENSSL": "on",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -126,6 +126,7 @@ def envoy_dependencies(skip_targets = []):
     # dependencies and name conflicts.
     _com_github_c_ares_c_ares()
     _com_github_circonus_labs_libcircllhist()
+    _com_github_curl()
     _com_github_cyan4973_xxhash()
     _com_github_datadog_dd_opentracing_cpp()
     _com_github_eile_tclap()
@@ -194,6 +195,20 @@ def _com_github_c_ares_c_ares():
     native.bind(
         name = "ares",
         actual = "@envoy//bazel/foreign_cc:ares",
+    )
+
+def _com_github_curl():
+    location = REPOSITORY_LOCATIONS["com_github_curl"]
+    http_archive(
+        name = "com_github_curl",
+        build_file_content = BUILD_ALL_CONTENT + """
+cc_library(name = "curl", visibility = ["//visibility:public"], deps = ["@envoy//bazel/foreign_cc:curl"])
+""",
+        **location
+    )
+    native.bind(
+        name = "curl",
+        actual = "@envoy//bazel/foreign_cc:curl",
     )
 
 def _com_github_cyan4973_xxhash():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -37,6 +37,11 @@ REPOSITORY_LOCATIONS = dict(
         # 2019-02-11
         urls = ["https://github.com/circonus-labs/libcircllhist/archive/63a16dd6f2fc7bc841bb17ff92be8318df60e2e1.tar.gz"],
     ),
+    com_github_curl = dict(
+        sha256 = "d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41",
+        strip_prefix = "curl-7.63.0",
+        urls = ["https://github.com/curl/curl/releases/download/curl-7_63_0/curl-7.63.0.tar.gz"],
+    ),
     com_github_cyan4973_xxhash = dict(
         sha256 = "b34792646d5e19964bb7bba24f06cb13aecaac623ab91a54da08aa19d3686d7e",
         strip_prefix = "xxHash-0.7.0",

--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -12,7 +12,7 @@ fi
 
 # Check whether number of defined `url =` or `urls =` and `sha256 =` kwargs in
 # repository definitions is equal.
-urls_count=$(git grep -E "url(s)? =" -- '*.bzl' | wc -l)
+urls_count=$(git grep -E " url(s)? =" -- '*.bzl' | wc -l)
 sha256sums_count=$(git grep -E "sha256 =" -- '*.bzl' | wc -l)
 
 if [[ $urls_count != $sha256sums_count ]]; then


### PR DESCRIPTION
This is copied from #5387 and will be used by OpenCensus Zipkin
exporter and AWS credentials puller (#5215).

Signed-off-by: Ivan Vitjuk <ivanvit@amazon.com>

Description: Adding libcurl as a dependency.
Risk Level: Low
Testing: ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
Docs Changes: N/A
Release Notes: N/A
