### PR TITLE
router: implement path rewrite with regex

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -460,7 +460,7 @@ message CorsPolicy {
   core.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#comment:next free field: 27]
+// [#comment:next free field: 30]
 message RouteAction {
   oneof cluster_specifier {
     option (validate.required) = true;
@@ -508,34 +508,47 @@ message RouteAction {
   // provided there taking precedence. The filter name should be specified as *envoy.lb*.
   core.Metadata metadata_match = 4;
 
-  // Indicates that during forwarding, the matched prefix (or path) should be
-  // swapped with this value. This option allows application URLs to be rooted
-  // at a different path from those exposed at the reverse proxy layer. The router filter will
-  // place the original path before rewrite into the :ref:`x-envoy-original-path
-  // <config_http_filters_router_x-envoy-original-path>` header.
-  //
-  // .. attention::
-  //
-  //   Pay careful attention to the use of trailing slashes in the
-  //   :ref:`route's match <envoy_api_field_route.Route.match>` prefix value.
-  //   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
-  //   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
-  //   :ref:`Route <envoy_api_msg_route.Route>`, as shown by the below config entries:
-  //
-  //   .. code-block:: yaml
-  //
-  //     - match:
-  //         prefix: "/prefix/"
-  //       route:
-  //         prefix_rewrite: "/"
-  //     - match:
-  //         prefix: "/prefix"
-  //       route:
-  //         prefix_rewrite: "/"
-  //
-  //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
-  //   requests to */prefix/etc* will be stripped to */etc*.
-  string prefix_rewrite = 5;
+  oneof path_rewrite_specifier {
+    // Indicates that during forwarding, the matched prefix (or path) should be
+    // swapped with this value. This option allows application URLs to be rooted
+    // at a different path from those exposed at the reverse proxy layer. The router filter will
+    // place the original path before rewrite into the :ref:`x-envoy-original-path
+    // <config_http_filters_router_x-envoy-original-path>` header.
+    //
+    // .. attention::
+    //
+    //   Pay careful attention to the use of trailing slashes in the
+    //   :ref:`route's match <envoy_api_field_route.Route.match>` prefix value.
+    //   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
+    //   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
+    //   :ref:`Route <envoy_api_msg_route.Route>`, as shown by the below config entries:
+    //
+    //   .. code-block:: yaml
+    //
+    //     - match:
+    //         prefix: "/prefix/"
+    //       route:
+    //         prefix_rewrite: "/"
+    //     - match:
+    //         prefix: "/prefix"
+    //       route:
+    //         prefix_rewrite: "/"
+    //
+    //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
+    //   requests to */prefix/etc* will be stripped to */etc*.
+    string prefix_rewrite = 5;
+
+    // Indicates that during forwarding, paths that match the pattern should be
+    // rewritten, interpolating capture groups from the path pattern into the new path as specified
+    // by the rewrite pattern. This option allows application URLs to be rewritten at the reverse
+    // proxy layer in a way that is aware of segments with variable contents like IDs. The router
+    // filter will place the original path before rewrite into the :ref:`x-envoy-original-path //
+    // <config_http_filters_router_x-envoy-original-path>` header. Examples:
+    //
+    // * The path pattern *^/foo/(bar)/(.*)$ paired with rewrite pattern */$1/$2* would transform
+    // */foo/bar/baz/bang* into */bar/baz/bang*.
+    RegexRewrite regex_rewrite = 29;
+  }
 
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
@@ -581,6 +594,19 @@ message RouteAction {
   // upstream response header has been received, otherwise a stream reset
   // occurs.
   google.protobuf.Duration idle_timeout = 24 [(gogoproto.stdduration) = true];
+
+  message RegexRewrite {
+    // Represents a regular expression that the path must match in order for the substitution
+    // to be applied. The regular expression may include capture groups to be interpolated into the
+    // substitution.
+    string pattern = 1;
+
+    // Represents the substitution used to build the final path of the request if the initial path
+    // matches
+    // the pattern. The substitution may include references to capture groups defined in the
+    // pattern which will be interpolated into the final path.
+    string substitution = 2;
+  }
 
   // Indicates that the route has a retry policy. Note that if this is set,
   // it'll take precedence over the virtual host level retry policy entirely

--- a/docs/root/configuration/tools/router_check.rst
+++ b/docs/root/configuration/tools/router_check.rst
@@ -76,6 +76,7 @@ expects a cluster name match of "instant-server".::
         "virtual_host_name": "...",
         "host_rewrite": "...",
         "path_rewrite": "...",
+        "regex_rewrite": "...",
         "path_redirect": "...",
         "header_fields" : [
           {

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -669,6 +669,13 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
       "host_redirect" : {"type" : "string"},
       "path_redirect" : {"type" : "string"},
       "prefix_rewrite" : {"type" : "string"},
+      "regex_rewrite" : {
+        "type" : "object",
+        "properties" : {
+          "pattern": {"type" : "string"},
+          "substitution" : {"type" : "integer"}
+        }
+      },
       "host_rewrite" : {"type" : "string"},
       "auto_host_rewrite" : {"type" : "boolean"},
       "case_sensitive" : {"type" : "boolean"},

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -26,6 +26,7 @@
 #include "common/router/router_ratelimit.h"
 #include "common/stats/symbol_table_impl.h"
 
+#include "absl/strings/match.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -371,6 +372,83 @@ private:
 };
 
 /**
+ * Base implementation for path rewriters
+ */
+class PathRewriter {
+public:
+  virtual bool apply() const = 0;
+  virtual std::string rewrite(std::string path, const std::string& matched_path,
+                              bool case_sensitive) const = 0;
+  virtual ~PathRewriter(){};
+};
+
+/**
+ * Path rewrite through prefix replacement
+ */
+class PrefixPathRewriter : public PathRewriter {
+public:
+  PrefixPathRewriter(std::string prefix) : PathRewriter(), prefix_(prefix) {}
+
+  bool apply() const { return !prefix_.empty(); }
+
+  std::string rewrite(std::string path, const std::string& matched_path,
+                      bool case_sensitive) const {
+    ASSERT(case_sensitive ? absl::StartsWith(path, matched_path)
+                          : absl::StartsWithIgnoreCase(path, matched_path));
+    return path.replace(0, matched_path.size(), prefix_);
+  }
+
+  ~PrefixPathRewriter(){};
+
+private:
+  std::string prefix_;
+};
+
+/**
+ * Path rewrite via regex
+ */
+class RegexPathRewriter : public PathRewriter {
+public:
+  RegexPathRewriter(std::string pattern, std::string substitution)
+      : PathRewriter(), pattern_(pattern), substitution_(substitution) {}
+
+  bool apply() const { return !substitution_.empty(); }
+
+  std::string rewrite(std::string path, const std::string& matched_path,
+                      bool case_sensitive) const {
+    ASSERT(case_sensitive ? absl::StartsWith(path, matched_path)
+                          : absl::StartsWithIgnoreCase(path, matched_path));
+    return std::regex_replace(matched_path, pattern_, substitution_);
+  }
+
+  ~RegexPathRewriter(){};
+
+private:
+  std::regex pattern_;
+  std::string substitution_;
+};
+
+/**
+ * Construct a path rewriter
+ */
+class RewriteBuilder {
+public:
+  static PathRewriter& build(const envoy::api::v2::route::Route& route) {
+    if (!route.redirect().prefix_rewrite().empty()) {
+      static PrefixPathRewriter p(route.redirect().prefix_rewrite());
+      return p;
+    }
+    if (!route.route().prefix_rewrite().empty()) {
+      static PrefixPathRewriter p(route.route().prefix_rewrite());
+      return p;
+    }
+    static RegexPathRewriter p(route.route().regex_rewrite().pattern(),
+                               route.route().regex_rewrite().substitution());
+    return p;
+  };
+};
+
+/**
  * Base implementation for all route entries.
  */
 class RouteEntryImplBase : public RouteEntry,
@@ -467,16 +545,15 @@ protected:
   const bool case_sensitive_;
   const std::string prefix_rewrite_;
   const std::string host_rewrite_;
+  const PathRewriter& path_rewriter_;
   bool include_vh_rate_limits_;
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
 
   /**
-   * returns the correct path rewrite string for this route.
+   * returns the path rewriter instance for the route
    */
-  const std::string& getPathRewrite() const {
-    return (isRedirect()) ? prefix_rewrite_redirect_ : prefix_rewrite_;
-  }
+  const PathRewriter& getPathRewriter() const { return path_rewriter_; }
 
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path,
                           bool insert_envoy_original_path) const;

--- a/test/tools/router_check/test/config/TestRoutes.golden.json
+++ b/test/tools/router_check/test/config/TestRoutes.golden.json
@@ -304,5 +304,16 @@
         }
       ]
     }
-  }
+  },
+   {
+     "test_name": "RegexPathRewrite",
+     "input": {
+       ":authority": "api.lyft.com",
+       ":path": "/v1/posts/123/upvote?foo=bar",
+       ":method": "GET"
+     },
+     "validate": {
+       "path_rewrite": "/public/v1/blog_posts/123/upvote?foo=bar"
+     }
+   }
 ]

--- a/test/tools/router_check/test/config/TestRoutes.yaml
+++ b/test/tools/router_check/test/config/TestRoutes.yaml
@@ -89,6 +89,13 @@ virtual_hosts:
           prefix_rewrite: /oranGES
           cluster: instant-server
       - match:
+          regex: "^/v1/posts/([^/]+?)/upvote/?"
+        route:
+          regex_rewrite:
+            pattern: "^/v1/posts/([^/]+?)/(.*)$"
+            substitution: "/public/v1/blog_posts/$1/$2"
+          cluster: instant-server
+      - match:
           prefix: /customheaders
         route:
           cluster: ats


### PR DESCRIPTION
Co-Authored-By: Gabriel Taylor Russ <gabriel.taylor.russ@gmail.com>

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

Description: Support regex path rewrites
Risk Level: Medium, modifies an existing rewrite action
Testing: `bazel test //test/common/router:config_impl_test`
Docs Changes: *TODO*
Release Notes: *TODO*
Fixes #2092 

TODO: 

- [ ] Add a few base tests for regex path
- [ ] Add a test specifically showing rewrite happening after the RBAC filter 

Notes for reviewer:
- This largely is a rebase and update of existing work from Gabriel
- The RouteMatcherTest.TestRoutes &  RouteConfigurationV2.RedirectPrefixRewrite fail because the route always seems to select the very first prefix in the list and never updates the prefix for different matched paths
  - Any thoughts on the mistake that I'm making here?
- I think the RouteConfigurationV2.RegexPrefixWithNoRewriteWorksWhenPathChanged fails because we call the rewrite function every time but do nothing (this change was made based on feedback in the original PR for code-reuse)
  - Should this test be updated to allow the rewrite to happen but have an expect to make sure nothing changed?
