### PR TITLE
upstream: downgrade dns log level

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -148,7 +148,7 @@ void DnsResolverImpl::updateAresTimer() {
   if (timeout_result != nullptr) {
     const auto ms =
         std::chrono::milliseconds(timeout_result->tv_sec * 1000 + timeout_result->tv_usec / 1000);
-    ENVOY_LOG(debug, "Setting DNS resolution timer for {} milliseconds", ms.count());
+    ENVOY_LOG(trace, "Setting DNS resolution timer for {} milliseconds", ms.count());
     timer_->enableTimer(ms);
   } else {
     timer_->disableTimer();


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>
Description: The DNS timer log is pretty noisy when `upstream` is enabled for debug and comes every few milli seconds. This PR downgrades it to `trace` level.
Risk Level: Low
Testing:N/A
Docs Changes: N/A
Release Notes:N/A

