### PR TITLE
Making proto_library targets public.

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -75,7 +75,7 @@ def api_go_grpc_library(name, proto, deps = []):
     )
 
 # This is api_proto_library plus some logic internal to //envoy/api.
-def api_proto_library_internal(visibility = ["//visibility:private"], **kwargs):
+def api_proto_library_internal(visibility = ["//visibility:public"], **kwargs):
     # //envoy/docs/build.sh needs visibility in order to generate documents.
     if visibility == ["//visibility:private"]:
         visibility = ["//docs"]
@@ -90,7 +90,7 @@ def api_proto_library_internal(visibility = ["//visibility:private"], **kwargs):
 # from api_proto_library.
 def api_proto_library(
         name,
-        visibility = ["//visibility:private"],
+        visibility = ["//visibility:public"],
         srcs = [],
         deps = [],
         external_proto_deps = [],


### PR DESCRIPTION
I've thought about it long and hard, trying to find which targets would actually make sense to make public, but at the end of the day, there's no good reason to keep any `proto_library` fully private.

The reasoning is that the current setup works fine if the dependents are only using protobuf for the serialization mechanism, and the defined languages, but as soon as one wants to use another serializer, say for instance, upb, or use another unlisted language, then one needs to start implementing their own rules, depending on the `proto_library` targets you currently have.

Therefore, the model of hiding all of the `proto_library` targets isn't scaling with the reality of what people want to do. The public default is the right thing to do imho.