### PR TITLE
proto: add tds dummy

### DIFF
--- a/api/envoy/service/discovery/v2/tds.proto
+++ b/api/envoy/service/discovery/v2/tds.proto
@@ -12,6 +12,11 @@ import "envoy/api/v2/discovery.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
 
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message TdsDummy {
+}
+
 // Discovery service for Runtime resources.
 // [#not-implemented-hide:]
 service RuntimeDiscoveryService {

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -262,6 +262,7 @@ envoy_cc_library(
     deps = [
         "@envoy_api//envoy/service/discovery/v2:ads_cc",
         "@envoy_api//envoy/service/discovery/v2:sds_cc",
+        "@envoy_api//envoy/service/discovery/v2:tds_cc",
         "@envoy_api//envoy/service/ratelimit/v2:rls_cc",
     ],
 )

--- a/source/common/config/protobuf_link_hacks.h
+++ b/source/common/config/protobuf_link_hacks.h
@@ -2,6 +2,7 @@
 
 #include "envoy/service/discovery/v2/ads.pb.h"
 #include "envoy/service/discovery/v2/sds.pb.h"
+#include "envoy/service/discovery/v2/tds.pb.h"
 #include "envoy/service/ratelimit/v2/rls.pb.h"
 
 namespace Envoy {
@@ -11,4 +12,5 @@ namespace Envoy {
 const envoy::service::discovery::v2::AdsDummy _ads_dummy;
 const envoy::service::ratelimit::v2::RateLimitRequest _rls_dummy;
 const envoy::service::discovery::v2::SdsDummy _sds_dummy;
+const envoy::service::discovery::v2::TdsDummy _tds_dummy;
 } // namespace Envoy


### PR DESCRIPTION
Description: Creates dummy target for tds to force linking (see comment).
Risk Level: low
Testing: compiled and ran locally