### PR TITLE
test: add process_object_ to BaseIntegrationTest

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -447,6 +447,7 @@ envoy_cc_test(
         "//source/extensions/filters/http/grpc_http1_bridge:config",
         "//source/extensions/filters/http/health_check:config",
         "//test/integration/filters:clear_route_cache_filter_lib",
+        "//test/integration/filters:process_context_lib",
         "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",
     ],

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -112,6 +112,23 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test_library(
+    name = "process_context_lib",
+    srcs = [
+        "process_context_filter.cc",
+    ],
+    hdrs = [
+        "process_context_filter.h",
+    ],
+    deps = [
+        "//include/envoy/http:filter_interface",
+        "//include/envoy/registry",
+        "//include/envoy/server:process_context_interface",
+        "//source/extensions/filters/http/common:empty_http_filter_config_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_test_library(
     name = "stop_iteration_and_continue",
     srcs = [
         "stop_iteration_and_continue_filter.cc",

--- a/test/integration/filters/process_context_filter.cc
+++ b/test/integration/filters/process_context_filter.cc
@@ -1,0 +1,56 @@
+#include "test/integration/filters/process_context_filter.h"
+
+#include <memory>
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "extensions/filters/http/common/empty_http_filter_config.h"
+#include "extensions/filters/http/common/pass_through_filter.h"
+
+namespace Envoy {
+
+// A test filter that rejects all requests if the ProcessObject held by the
+// ProcessContext is unhealthy, and responds OK to all requests otherwise.
+class ProcessContextFilter : public Http::PassThroughFilter {
+public:
+  ProcessContextFilter(ProcessContext& process_context)
+      : process_object_(dynamic_cast<ProcessObjectForFilter&>(process_context.get())) {}
+  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
+    if (!process_object_.isHealthy()) {
+      decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,
+                                         "ProcessObjectForFilter is unhealthy", nullptr,
+                                         absl::nullopt, "");
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+    decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "ProcessObjectForFilter is healthy",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+private:
+  ProcessObjectForFilter& process_object_;
+};
+
+class ProcessContextFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpFilterConfig {
+public:
+  ProcessContextFilterConfig() : EmptyHttpFilterConfig("process-context-filter") {}
+
+  Http::FilterFactoryCb
+  createFilter(const std::string&,
+               Server::Configuration::FactoryContext& factory_context) override {
+    return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {
+      callbacks.addStreamFilter(
+          std::make_shared<ProcessContextFilter>(factory_context.processContext()));
+    };
+  }
+};
+
+static Registry::RegisterFactory<ProcessContextFilterConfig,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+
+} // namespace Envoy

--- a/test/integration/filters/process_context_filter.h
+++ b/test/integration/filters/process_context_filter.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "envoy/server/process_context.h"
+
+namespace Envoy {
+
+class ProcessObjectForFilter : public ProcessObject {
+public:
+  explicit ProcessObjectForFilter(bool is_healthy) : is_healthy_(is_healthy) {}
+  ~ProcessObjectForFilter() override {}
+
+  bool isHealthy() { return is_healthy_; }
+
+private:
+  bool is_healthy_;
+};
+} // namespace Envoy

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -409,7 +409,7 @@ void BaseIntegrationTest::createGeneratedApiTestServer(const std::string& bootst
                                                        const std::vector<std::string>& port_names) {
   test_server_ = IntegrationTestServer::create(bootstrap_path, version_, on_server_init_function_,
                                                deterministic_, timeSystem(), *api_,
-                                               defer_listener_finalization_);
+                                               defer_listener_finalization_, process_object_);
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0 &&
       !defer_listener_finalization_) {
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "envoy/server/process_context.h"
+
 #include "common/http/codec_client.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
@@ -20,6 +22,7 @@
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/test_time.h"
 
+#include "absl/types/optional.h"
 #include "spdlog/spdlog.h"
 
 namespace Envoy {
@@ -322,6 +325,8 @@ protected:
   InstanceConstSharedPtrFn upstream_address_fn_;
   // The config for envoy start-up.
   ConfigHelper config_helper_;
+  // The ProcessObject to use when constructing the envoy server.
+  absl::optional<std::reference_wrapper<ProcessObject>> process_object_{absl::nullopt};
 
   // Steps that should be done in parallel with the envoy server starting. E.g., xDS
   // pre-init, control plane synchronization needed for server start.


### PR DESCRIPTION
Signed-off-by: Ashley Hedberg <ahedberg@google.com>

Description: Adds a process_object_ member to BaseIntegrationTest. If an integration test subclassing from BaseIntegrationTest sets this member, the envoy server will be started with a ProcessContext referencing that object.
Risk Level: low (test-only, defaults to nullopt)
Testing: bazel test //test/... - not sure if stats_integration_test failures were related. Also not sure where to add a test for this, but happy to do so (I have an internal test that proves this does what I wanted it to).
Docs Changes: none
Release Notes: n/a
Fixes #6969