### PR TITLE
registry: add macro to force factory registration when linking statically

### DIFF
--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -131,7 +131,7 @@ private:
  * Macro used for static registration.
  */
 #define REGISTER_FACTORY(FACTORY, BASE)                                                            \
-  void forceStaticLink##FACTORY() {}                                                               \
+  void forceRegister##FACTORY() {}                                                                 \
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \
       FACTORY##_registered

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -132,8 +132,7 @@ private:
  * Macro used for static registration.
  */
 #define REGISTER_FACTORY(FACTORY, BASE)                                                            \
-  void forceRegister##FACTORY() {}                                                                 \
-  ABSL_ATTRIBUTE_UNUSED                                                                            \
+  ABSL_ATTRIBUTE_UNUSED void forceRegister##FACTORY() {}                                           \
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \
       FACTORY##_registered
@@ -145,7 +144,7 @@ private:
  * not run until a function in the compilation unit is invoked. The force function can be invoked
  * from a static library wrapper.
  */
-#define DECLARE_FACTORY(FACTORY) void forceRegister##FACTORY() ABSL_ATTRIBUTE_UNUSED
+#define DECLARE_FACTORY(FACTORY) ABSL_ATTRIBUTE_UNUSED void forceRegister##FACTORY()
 
 } // namespace Registry
 } // namespace Envoy

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -46,6 +46,7 @@ public:
 
     return absl::StrJoin(ret, ",");
   }
+
   /**
    * Gets the current map of factory implementations. This is an ordered map for sorting reasons.
    */
@@ -130,9 +131,19 @@ private:
  * Macro used for static registration.
  */
 #define REGISTER_FACTORY(FACTORY, BASE)                                                            \
+  void forceStaticLink##FACTORY() {}                                                               \
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \
       FACTORY##_registered
+
+/**
+ * Macro used for static registration declaration.
+ * Calling forceRegister...(); can be used to force the static factory initializer to run in a
+ * setting in which Envoy is bundled as a static archive. In this case, the static initializer is
+ * not run until a function in the compilation unit is invoked. The force function can be invoked
+ * from a static library wrapper.
+ */
+#define DECLARE_FACTORY(FACTORY) void forceRegister##FACTORY()
 
 } // namespace Registry
 } // namespace Envoy

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -132,7 +132,8 @@ private:
  * Macro used for static registration.
  */
 #define REGISTER_FACTORY(FACTORY, BASE)                                                            \
-  void forceRegister##FACTORY() {} ABSL_ATTRIBUTE_UNUSED                                           \
+  void forceRegister##FACTORY() {}                                                                 \
+  ABSL_ATTRIBUTE_UNUSED                                                                            \
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \
       FACTORY##_registered

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -9,6 +9,7 @@
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 
+#include "absl/base/attributes.h"
 #include "absl/strings/str_join.h"
 
 namespace Envoy {
@@ -131,7 +132,7 @@ private:
  * Macro used for static registration.
  */
 #define REGISTER_FACTORY(FACTORY, BASE)                                                            \
-  void forceRegister##FACTORY() {}                                                                 \
+  void forceRegister##FACTORY() {} ABSL_ATTRIBUTE_UNUSED                                           \
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \
       FACTORY##_registered
@@ -143,7 +144,7 @@ private:
  * not run until a function in the compilation unit is invoked. The force function can be invoked
  * from a static library wrapper.
  */
-#define DECLARE_FACTORY(FACTORY) void forceRegister##FACTORY()
+#define DECLARE_FACTORY(FACTORY) void forceRegister##FACTORY() ABSL_ATTRIBUTE_UNUSED
 
 } // namespace Registry
 } // namespace Envoy

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -174,5 +174,7 @@ private:
                     Stats::ScopePtr&& stats_scope) override;
 };
 
+DECLARE_FACTORY(LogicalDnsClusterFactory);
+
 } // namespace Upstream
 } // namespace Envoy

--- a/source/extensions/filters/http/router/config.cc
+++ b/source/extensions/filters/http/router/config.cc
@@ -1,7 +1,6 @@
 #include "extensions/filters/http/router/config.h"
 
 #include "envoy/config/filter/http/router/v2/router.pb.validate.h"
-#include "envoy/registry/registry.h"
 
 #include "common/config/filter_json.h"
 #include "common/json/config_schemas.h"

--- a/source/extensions/filters/http/router/config.h
+++ b/source/extensions/filters/http/router/config.h
@@ -2,6 +2,7 @@
 
 #include "envoy/config/filter/http/router/v2/router.pb.h"
 #include "envoy/config/filter/http/router/v2/router.pb.validate.h"
+#include "envoy/registry/registry.h"
 
 #include "common/protobuf/protobuf.h"
 
@@ -30,6 +31,8 @@ private:
       const envoy::config::filter::http::router::v2::Router& proto_config,
       const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
 };
+
+DECLARE_FACTORY(RouterFilterConfig);
 
 } // namespace RouterFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -7,7 +7,6 @@
 
 #include "envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.validate.h"
 #include "envoy/filesystem/filesystem.h"
-#include "envoy/registry/registry.h"
 #include "envoy/server/admin.h"
 
 #include "common/access_log/access_log_impl.h"

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -47,6 +47,8 @@ private:
       Server::Configuration::FactoryContext& context) override;
 };
 
+DECLARE_FACTORY(HttpConnectionManagerFilterConfigFactory);
+
 /**
  * Determines if an address is internal based on user provided config.
  */

--- a/source/extensions/transport_sockets/raw_buffer/config.cc
+++ b/source/extensions/transport_sockets/raw_buffer/config.cc
@@ -1,7 +1,5 @@
 #include "extensions/transport_sockets/raw_buffer/config.h"
 
-#include "envoy/registry/registry.h"
-
 #include "common/network/raw_buffer_socket.h"
 
 namespace Envoy {

--- a/source/extensions/transport_sockets/raw_buffer/config.h
+++ b/source/extensions/transport_sockets/raw_buffer/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/registry/registry.h"
 #include "envoy/server/transport_socket_config.h"
 
 #include "extensions/transport_sockets/well_known_names.h"
@@ -38,6 +39,10 @@ public:
                                Server::Configuration::TransportSocketFactoryContext& context,
                                const std::vector<std::string>& server_names) override;
 };
+
+DECLARE_FACTORY(UpstreamRawBufferSocketFactory);
+
+DECLARE_FACTORY(DownstreamRawBufferSocketFactory);
 
 } // namespace RawBuffer
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/tls/config.cc
+++ b/source/extensions/transport_sockets/tls/config.cc
@@ -2,7 +2,6 @@
 
 #include "envoy/api/v2/auth/cert.pb.h"
 #include "envoy/api/v2/auth/cert.pb.validate.h"
-#include "envoy/registry/registry.h"
 
 #include "common/protobuf/utility.h"
 

--- a/source/extensions/transport_sockets/tls/config.h
+++ b/source/extensions/transport_sockets/tls/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/registry/registry.h"
 #include "envoy/server/transport_socket_config.h"
 
 #include "extensions/transport_sockets/well_known_names.h"
@@ -28,6 +29,8 @@ public:
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 };
 
+DECLARE_FACTORY(UpstreamSslSocketFactory);
+
 class DownstreamSslSocketFactory
     : public Server::Configuration::DownstreamTransportSocketConfigFactory,
       public SslSocketConfigFactory {
@@ -38,6 +41,8 @@ public:
                                const std::vector<std::string>& server_names) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 };
+
+DECLARE_FACTORY(DownstreamSslSocketFactory);
 
 } // namespace Tls
 } // namespace TransportSockets


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: When Envoy is linked as a static library, static factory registration doesn't occur until the compilation unit that contains a given register call is invoked. This will usually be too late for initialization. This commit creates a macro that provides hooks that can be used to force static initialization and factory registration, and adds said hooks to a handful of registrations necessary for a minimal Envoy configuration. Eventually, we should add the new DECLARE_FACTORY macro everywhere we use REGISTER_FACTORY, but it seems like something we can backfill.

Risk Level: low
Testing: locally compiled and ran as static library
