### PR TITLE
[style] convert NULL to nullptr

### DIFF
--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -15,7 +15,7 @@ int64_t getCurrentThreadId() {
   return static_cast<int64_t>(syscall(SYS_gettid));
 #elif defined(__APPLE__)
   uint64_t tid;
-  pthread_threadid_np(NULL, &tid);
+  pthread_threadid_np(nullptr, &tid);
   return tid;
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -132,7 +132,7 @@ Network::PostIoAction TsiSocket::doHandshakeNextDone(NextResultPtr&& next_result
     // returns TSI_OK assuming there is no fatal error. Asserting OK.
     tsi_frame_protector* frame_protector;
     status =
-        tsi_handshaker_result_create_frame_protector(handshaker_result, NULL, &frame_protector);
+        tsi_handshaker_result_create_frame_protector(handshaker_result, nullptr, &frame_protector);
     ASSERT(status == TSI_OK);
     frame_protector_ = std::make_unique<TsiFrameProtector>(frame_protector);
 

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -54,7 +54,7 @@ const ASN1_TIME& epochASN1_Time() {
   static ASN1_TIME* e = []() -> ASN1_TIME* {
     ASN1_TIME* epoch = ASN1_TIME_new();
     const time_t epoch_time = 0;
-    RELEASE_ASSERT(ASN1_TIME_set(epoch, epoch_time) != NULL, "");
+    RELEASE_ASSERT(ASN1_TIME_set(epoch, epoch_time) != nullptr, "");
     return epoch;
   }();
   return *e;
@@ -63,7 +63,7 @@ const ASN1_TIME& epochASN1_Time() {
 inline bssl::UniquePtr<ASN1_TIME> currentASN1_Time(TimeSource& time_source) {
   bssl::UniquePtr<ASN1_TIME> current_asn_time(ASN1_TIME_new());
   const time_t current_time = std::chrono::system_clock::to_time_t(time_source.systemTime());
-  RELEASE_ASSERT(ASN1_TIME_set(current_asn_time.get(), current_time) != NULL, "");
+  RELEASE_ASSERT(ASN1_TIME_set(current_asn_time.get(), current_time) != nullptr, "");
   return current_asn_time;
 }
 

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -31,7 +31,7 @@ std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std:
     SSL_set_alpn_protos(ssl.get(), reinterpret_cast<const uint8_t*>(alpn.data()), alpn.size());
   }
   SSL_do_handshake(ssl.get());
-  const uint8_t* data = NULL;
+  const uint8_t* data = nullptr;
   size_t data_len = 0;
   BIO_mem_contents(out, &data, &data_len);
   ASSERT(data_len > 0);

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -562,7 +562,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
   Network::MockConnectionCallbacks server_connection_callbacks;
   EXPECT_CALL(callbacks, onAccept_(_, _))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {
-        std::string sni = options.transportSocketOptions() != NULL &&
+        std::string sni = options.transportSocketOptions() != nullptr &&
                                   options.transportSocketOptions()->serverNameOverride().has_value()
                               ? options.transportSocketOptions()->serverNameOverride().value()
                               : options.clientCtxProto().sni();

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -314,7 +314,7 @@ void TestEnvironment::setEnvVar(const std::string& name, const std::string& valu
 #ifdef WIN32
   if (!overwrite) {
     size_t requiredSize;
-    const int rc = ::getenv_s(&requiredSize, NULL, 0, name.c_str());
+    const int rc = ::getenv_s(&requiredSize, nullptr, 0, name.c_str());
     ASSERT_EQ(rc, 0);
     if (requiredSize != 0) {
       return;


### PR DESCRIPTION
Description: A few cases of `NULL` where `nullptr` can be used. Didn't touch code under the chromium namespace as I'm not sure if that's meant to mirror the chromium code without modification.
Risk Level: None
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>