### PR TITLE
Added missing metrics to http1/http2 conn pool

### DIFF
--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -127,24 +127,13 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
     // The client died.
     ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", *client.codec_client_,
                    client.codec_client_->connectionFailureReason());
-
-    if (event == Network::ConnectionEvent::RemoteClose) {
-      host_->cluster().stats().upstream_cx_destroy_remote_.inc();
-    } else {
-      host_->cluster().stats().upstream_cx_destroy_local_.inc();
-    }
-    host_->cluster().stats().upstream_cx_destroy_.inc();
-
+                   
+    Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
     ActiveClientPtr removed;
     bool check_for_drained = true;
     if (client.stream_wrapper_) {
       if (!client.stream_wrapper_->decode_complete_) {
-        if (event == Network::ConnectionEvent::RemoteClose) {
-          host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
-        } else {
-          host_->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
-        }
-        host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
+        Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
       }
 
       // There is an active request attached to this client. The underlying codec client will

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -127,7 +127,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
     // The client died.
     ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", *client.codec_client_,
                    client.codec_client_->connectionFailureReason());
-                   
+
     Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
     ActiveClientPtr removed;
     bool check_for_drained = true;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -134,7 +134,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
       host_->cluster().stats().upstream_cx_destroy_local_.inc();
     }
     host_->cluster().stats().upstream_cx_destroy_.inc();
-  
+
     ActiveClientPtr removed;
     bool check_for_drained = true;
     if (client.stream_wrapper_) {

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -127,15 +127,22 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
     // The client died.
     ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", *client.codec_client_,
                    client.codec_client_->connectionFailureReason());
+
+    if (event == Network::ConnectionEvent::RemoteClose) {
+      host_->cluster().stats().upstream_cx_destroy_remote_.inc();
+    } else {
+      host_->cluster().stats().upstream_cx_destroy_local_.inc();
+    }
+    host_->cluster().stats().upstream_cx_destroy_.inc();
+  
     ActiveClientPtr removed;
     bool check_for_drained = true;
     if (client.stream_wrapper_) {
       if (!client.stream_wrapper_->decode_complete_) {
-        if (event == Network::ConnectionEvent::LocalClose) {
-          host_->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
-        }
         if (event == Network::ConnectionEvent::RemoteClose) {
           host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
+        } else {
+          host_->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
         }
         host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
       }

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -154,7 +154,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
       host_->cluster().stats().upstream_cx_destroy_local_.inc();
     }
     host_->cluster().stats().upstream_cx_destroy_.inc();
-    
+
     if (client.closed_with_active_rq_) {
       host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
       if (event == Network::ConnectionEvent::RemoteClose) {

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -148,20 +148,9 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
       event == Network::ConnectionEvent::LocalClose) {
     ENVOY_CONN_LOG(debug, "client disconnected", *client.client_);
 
-    if (event == Network::ConnectionEvent::RemoteClose) {
-      host_->cluster().stats().upstream_cx_destroy_remote_.inc();
-    } else {
-      host_->cluster().stats().upstream_cx_destroy_local_.inc();
-    }
-    host_->cluster().stats().upstream_cx_destroy_.inc();
-
+    Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
     if (client.closed_with_active_rq_) {
-      host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
-      if (event == Network::ConnectionEvent::RemoteClose) {
-        host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
-      } else {
-        host_->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
-      }
+     Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
     }
 
     if (client.connect_timer_) {

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -146,8 +146,15 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(Http::StreamDecoder& respon
 void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-
     ENVOY_CONN_LOG(debug, "client disconnected", *client.client_);
+
+    if (event == Network::ConnectionEvent::RemoteClose) {
+      host_->cluster().stats().upstream_cx_destroy_remote_.inc();
+    } else {
+      host_->cluster().stats().upstream_cx_destroy_local_.inc();
+    }
+    host_->cluster().stats().upstream_cx_destroy_.inc();
+    
     if (client.closed_with_active_rq_) {
       host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
       if (event == Network::ConnectionEvent::RemoteClose) {

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -150,7 +150,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
 
     Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
     if (client.closed_with_active_rq_) {
-     Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
+      Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
     }
 
     if (client.connect_timer_) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1273,5 +1273,25 @@ Network::DnsLookupFamily getDnsLookupFamilyFromCluster(const envoy::api::v2::Clu
   }
 }
 
+void reportUpstreamCxDestroy(Upstream::HostDescriptionConstSharedPtr host,
+                             Network::ConnectionEvent event) {
+  host->cluster().stats().upstream_cx_destroy_.inc();
+  if (event == Network::ConnectionEvent::RemoteClose) {
+    host->cluster().stats().upstream_cx_destroy_remote_.inc();
+  } else {
+    host->cluster().stats().upstream_cx_destroy_local_.inc();
+  }
+}
+
+void reportUpstreamCxDestroyActiveRequest(Upstream::HostDescriptionConstSharedPtr host,
+                                          Network::ConnectionEvent event) {
+  host->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
+  if (event == Network::ConnectionEvent::RemoteClose) {
+    host->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
+  } else {
+    host->cluster().stats().upstream_cx_destroy_local_with_active_rq_.inc();
+  }
+}
+
 } // namespace Upstream
 } // namespace Envoy

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1273,7 +1273,7 @@ Network::DnsLookupFamily getDnsLookupFamilyFromCluster(const envoy::api::v2::Clu
   }
 }
 
-void reportUpstreamCxDestroy(Upstream::HostDescriptionConstSharedPtr host,
+void reportUpstreamCxDestroy(const Upstream::HostDescriptionConstSharedPtr& host,
                              Network::ConnectionEvent event) {
   host->cluster().stats().upstream_cx_destroy_.inc();
   if (event == Network::ConnectionEvent::RemoteClose) {
@@ -1283,7 +1283,7 @@ void reportUpstreamCxDestroy(Upstream::HostDescriptionConstSharedPtr host,
   }
 }
 
-void reportUpstreamCxDestroyActiveRequest(Upstream::HostDescriptionConstSharedPtr host,
+void reportUpstreamCxDestroyActiveRequest(const Upstream::HostDescriptionConstSharedPtr& host,
                                           Network::ConnectionEvent event) {
   host->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
   if (event == Network::ConnectionEvent::RemoteClose) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -822,5 +822,17 @@ protected:
  */
 Network::DnsLookupFamily getDnsLookupFamilyFromCluster(const envoy::api::v2::Cluster& cluster);
 
+/**
+ * Utility function to report upstream cx destroy metrics
+ */
+void reportUpstreamCxDestroy(Upstream::HostDescriptionConstSharedPtr host,
+                             Network::ConnectionEvent event);
+
+/**
+ * Utility function to report upstream cx destroy active request metrics
+ */
+void reportUpstreamCxDestroyActiveRequest(Upstream::HostDescriptionConstSharedPtr host,
+                                          Network::ConnectionEvent event);
+
 } // namespace Upstream
 } // namespace Envoy

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -825,13 +825,13 @@ Network::DnsLookupFamily getDnsLookupFamilyFromCluster(const envoy::api::v2::Clu
 /**
  * Utility function to report upstream cx destroy metrics
  */
-void reportUpstreamCxDestroy(Upstream::HostDescriptionConstSharedPtr host,
+void reportUpstreamCxDestroy(const Upstream::HostDescriptionConstSharedPtr& host,
                              Network::ConnectionEvent event);
 
 /**
  * Utility function to report upstream cx destroy active request metrics
  */
-void reportUpstreamCxDestroyActiveRequest(Upstream::HostDescriptionConstSharedPtr host,
+void reportUpstreamCxDestroyActiveRequest(const Upstream::HostDescriptionConstSharedPtr& host,
                                           Network::ConnectionEvent event);
 
 } // namespace Upstream

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -718,6 +718,9 @@ TEST_F(Http1ConnPoolImplTest, ConcurrentConnections) {
   conn_pool_.test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http1ConnPoolImplTest, DrainCallback) {
@@ -797,6 +800,9 @@ TEST_F(Http1ConnPoolImplTest, RemoteCloseToCompleteResponse) {
   EXPECT_CALL(conn_pool_, onClientDestroy());
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http1ConnPoolImplTest, NoActiveConnectionsByDefault) {
@@ -840,6 +846,9 @@ TEST_F(Http1ConnPoolImplTest, PendingRequestIsConsideredActive) {
   conn_pool_.drainConnections();
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 } // namespace

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -234,6 +234,9 @@ TEST_F(Http2ConnPoolImplTest, DrainConnections) {
   test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 // Verifies that requests are queued up in the conn pool until the connection becomes ready.
@@ -268,6 +271,9 @@ TEST_F(Http2ConnPoolImplTest, PendingRequests) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 // Verifies that requests are queued up in the conn pool and fail when the connection
@@ -298,6 +304,9 @@ TEST_F(Http2ConnPoolImplTest, PendingRequestsFailure) {
   test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy()).Times(2);
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 // Verifies that requests are queued up in the conn pool and respect max request circuit breaking
@@ -332,6 +341,9 @@ TEST_F(Http2ConnPoolImplTest, PendingRequestsRequestOverflow) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 // Verifies that we honor the max pending requests circuit breaker.
@@ -366,6 +378,9 @@ TEST_F(Http2ConnPoolImplTest, PendingRequestsMaxPendingCircuitBreaker) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+  
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, VerifyConnectionTimingStats) {
@@ -385,6 +400,9 @@ TEST_F(Http2ConnPoolImplTest, VerifyConnectionTimingStats) {
               deliverHistogramToSinks(Property(&Stats::Metric::name, "upstream_cx_length_ms"), _));
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 /**
@@ -404,6 +422,9 @@ TEST_F(Http2ConnPoolImplTest, VerifyBufferLimits) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, RequestAndResponse) {
@@ -426,6 +447,9 @@ TEST_F(Http2ConnPoolImplTest, RequestAndResponse) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, LocalReset) {
@@ -441,6 +465,8 @@ TEST_F(Http2ConnPoolImplTest, LocalReset) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_tx_reset_.value());
   EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.rq_open_.value());
 }
@@ -458,6 +484,8 @@ TEST_F(Http2ConnPoolImplTest, RemoteReset) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_rx_reset_.value());
   EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.rq_open_.value());
 }
@@ -480,6 +508,9 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectWithActiveRequest) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, DrainDisconnectDrainingWithActiveRequest) {
@@ -512,6 +543,9 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectDrainingWithActiveRequest) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, DrainPrimary) {
@@ -611,6 +645,9 @@ TEST_F(Http2ConnPoolImplTest, ConnectTimeout) {
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_connect_fail_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_connect_timeout_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_pending_failure_eject_.value());
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_local_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, MaxGlobalRequests) {
@@ -631,6 +668,9 @@ TEST_F(Http2ConnPoolImplTest, MaxGlobalRequests) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }
 
 TEST_F(Http2ConnPoolImplTest, GoAway) {

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -378,7 +378,7 @@ TEST_F(Http2ConnPoolImplTest, PendingRequestsMaxPendingCircuitBreaker) {
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
-  
+
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_destroy_remote_.value());
 }


### PR DESCRIPTION
Signed-off-by: Lukasz Dziedziak <lukasz.dziedziak@allegro.pl>

Description: There were missing metrics in HTTP connection pool
```
upstream_cx_destroy
upstream_cx_destroy_local
upstream_cx_destroy_remote
```
Risk Level: low
Testing: Added validation of metrics to unit tests
Docs Changes:
Release Notes:
Fixes #6478 
