### PR TITLE
fix regression in router that can cause a crash on response timeout

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -667,10 +667,10 @@ void Filter::onResponseTimeout() {
       if (!upstream_request->outlier_detection_timeout_recorded_) {
         updateOutlierDetection(timeout_response_code_, *upstream_request);
       }
-      upstream_request->resetStream();
 
       chargeUpstreamAbort(timeout_response_code_, false, *upstream_request);
     }
+    upstream_request->resetStream();
   }
 
   onUpstreamTimeoutAbort(StreamInfo::ResponseFlag::UpstreamRequestTimeout,

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -47,6 +47,53 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
   EXPECT_EQ("504", response->headers().Status()->value().getStringView());
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/7154 in which
+// resetStream() was only called after a response timeout for upstream requests
+// that had not received headers yet. This meant that decodeData might be
+// called on a destroyed UpstreamRequest.
+TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpstream) {
+  initialize();
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
+                                          {":path", "/test/long/url"},
+                                          {":scheme", "http"},
+                                          {":authority", "host"},
+                                          {"x-forwarded-for", "10.0.0.1"},
+                                          {"x-envoy-upstream-rq-timeout-ms", "100"}};
+  auto encoder_decoder = codec_client_->startRequest(request_headers);
+
+  auto response = std::move(encoder_decoder.second);
+  request_encoder_ = &encoder_decoder.first;
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+
+  codec_client_->sendData(*request_encoder_, 100, true);
+
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  // Respond with headers, not end of stream.
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  response->waitForHeaders();
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+
+  // Trigger global timeout.
+  timeSystem().sleep(std::chrono::milliseconds(200));
+
+  // Respond with body.
+  upstream_request_->encodeData(100, true);
+
+  response->waitForReset();
+
+  codec_client_->close();
+
+  EXPECT_TRUE(upstream_request_->complete());
+}
+
 // Sends a request with a global timeout and per try timeout specified, sleeps
 // for longer than the per try but slightly less than the global timeout.
 // Ensures that two requests are attempted and a timeout is returned

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -61,7 +61,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpst
                                           {":authority", "host"},
                                           {"x-forwarded-for", "10.0.0.1"},
                                           {"x-envoy-upstream-rq-timeout-ms", "100"}};
-  auto encoder_decoder = codec_client_->startRequest(request_headers);
+  std::pair<Http::StreamEncoder&, IntegrationStreamDecoderPtr> encoder_decoder = codec_client_->startRequest(request_headers);
 
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -85,8 +85,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpst
   // Trigger global timeout.
   timeSystem().sleep(std::chrono::milliseconds(200));
 
-  // Respond with body.
-  upstream_request_->encodeData(100, true);
+  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
   response->waitForReset();
 

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -61,7 +61,8 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpst
                                           {":authority", "host"},
                                           {"x-forwarded-for", "10.0.0.1"},
                                           {"x-envoy-upstream-rq-timeout-ms", "100"}};
-  std::pair<Http::StreamEncoder&, IntegrationStreamDecoderPtr> encoder_decoder = codec_client_->startRequest(request_headers);
+  std::pair<Http::StreamEncoder&, IntegrationStreamDecoderPtr> encoder_decoder =
+      codec_client_->startRequest(request_headers);
 
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;


### PR DESCRIPTION
Prior to the recent retry hedging change, upstream requests were always
reset as they should be when a response timeout is triggered. The retry
hedging change inadvertently changed the logic so that the upstream
request is only reset if it hadn't seen headers. However it's possible
to hit the timeout after seeing headers and before end_stream which
would result in a crash as the body or trailers are attempted to be
decoded using a null pointer.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Fixes a regression in the router that can cause a crash when an upstream request has seen headers but not end_stream when a response timeout is hit
Risk Level: low
Testing: integration test
Docs Changes: N/A
Release Notes: N/A
Fixes #7154 
