### PR TITLE
test: fixing a simtime bug with enabled()

### DIFF
--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -62,7 +62,7 @@ public:
   void enableTimer(const std::chrono::milliseconds& duration) override;
   bool enabled() override {
     Thread::LockGuard lock(time_system_.mutex_);
-    return armed_;
+    return armed_ || base_timer_->enabled();
   }
 
   void disableTimerLockHeld() EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_);

--- a/test/test_common/simulated_time_system_test.cc
+++ b/test/test_common/simulated_time_system_test.cc
@@ -233,6 +233,12 @@ TEST_F(SimulatedTimeSystemTest, DuplicateTimer) {
   thread->join();
 }
 
+TEST_F(SimulatedTimeSystemTest, Enabled) {
+  TimerPtr timer = scheduler_->createTimer({});
+  timer->enableTimer(std::chrono::milliseconds(0));
+  EXPECT_TRUE(timer->enabled());
+}
+
 } // namespace
 } // namespace Test
 } // namespace Event


### PR DESCRIPTION
In a more interesting (and harder to debug) case is it's possible to set an alarm for a non-zero time, have the sim time manager in a different thread advance and activate it, and so have
timer->enableTimer(std::chrono::milliseconds(1));
RELEASE_ASSERT(timer->enabled(), "what?");
fail.  

This unit tests the simpler version where when we disable in activateLockHeld it results in simtime alarm behaving differently than regular alarm, insofar as TimerImplTest.TimerEnabledDisabled verifies arming a 0 duration timer should flag it as enabled.

Risk Level: low (test only)
Testing: new UT, greatly reduces flakes in backup-fuzzed integration tests 
Docs Changes: n/a
Release Notes: n/a
