### PR TITLE
fuzz: remove CR/LF from headers in codec_impl_fuzz_test 

### DIFF
--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-codec_impl_fuzz_test-5692024096817152
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-codec_impl_fuzz_test-5692024096817152
@@ -1,0 +1,23 @@
+h2_settings {
+  client {
+    hpack_table_size: 103
+    max_concurrent_streams: 103
+    initial_stream_window_size: 103
+  }
+}
+actions {
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "transfer-encodinG"
+        value: "Yh2_settings {\n  client {\n    hpack_table_size: 103\n    max_concurrent_streams: 103\n    initial_stream_window_size: 103\n  }\n}\nactions {\n}\nactions {\n  new_stream {\n    request_headers {\n      headers {\n        key: \"transfer-encodinG\"\n        value: \"Y\"\n      }\n    }\n  }\n}\n"
+      }
+    }
+  }
+}

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -11,27 +11,60 @@
 namespace Envoy {
 namespace Fuzz {
 
+// The HeaderMap code assumes that input does not contain certain characters, and
+// this is validated by the HTTP parser. Some fuzzers will create strings with
+// these characters, however, and this creates not very interesting fuzz test
+// failures as an assertion is rapidly hit in the LowerCaseString constructor
+// before we get to anything interesting.
+//
+// This method will replace any of those characters found with spaces.
+inline std::string replaceInvalidCharacters(absl::string_view string) {
+  std::string filtered;
+  filtered.reserve(string.length());
+  for (const char& c : string) {
+    switch (c) {
+    case '\0':
+      FALLTHRU;
+    case '\r':
+      FALLTHRU;
+    case '\n':
+      filtered.push_back(' ');
+      break;
+    default:
+      filtered.push_back(c);
+    }
+  }
+  return filtered;
+}
+
+// Return a new RepeatedPtrField of HeaderValueOptions with invalid characters removed.
+inline Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption> replaceInvalidHeaders(
+    const Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption>& headers_to_add) {
+  Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption> processed;
+  for (const auto& header : headers_to_add) {
+    auto* header_value_option = processed.Add();
+    auto* mutable_header = header_value_option->mutable_header();
+    mutable_header->set_key(replaceInvalidCharacters(header.header().key()));
+    mutable_header->set_value(replaceInvalidCharacters(header.header().value()));
+    header_value_option->mutable_append()->CopyFrom(header.append());
+  }
+  return processed;
+}
+
 // Convert from test proto Headers to TestHeaderMapImpl.
 inline Http::TestHeaderMapImpl fromHeaders(
     const test::fuzz::Headers& headers,
     const std::unordered_set<std::string>& ignore_headers = std::unordered_set<std::string>()) {
   Http::TestHeaderMapImpl header_map;
   for (const auto& header : headers.headers()) {
-    // HeaderMapImpl and places such as the route lookup should never see strings with embedded NULL
-    // values, the HTTP codecs should reject them. So, don't inject any such strings into the fuzz
-    // tests.
-    const auto clean = [](const std::string& s) {
-      const auto n = s.find('\0');
-      if (n == std::string::npos) {
-        return s;
-      }
-      return s.substr(0, n);
-    };
-    // When we are injecting headers, we don't allow the key to ever be empty,
-    // since calling code is not supposed to do this.
-    const std::string key = header.key().empty() ? "not-empty" : clean(header.key());
+    // HeaderMapImpl and places such as the route lookup should never see strings with embedded
+    // {NULL, CR, LF} values, the HTTP codecs should reject them. So, don't inject any such strings
+    // into the fuzz tests and replace these invalid characters with spaces.
+    // When we are injecting headers, we don't allow the key to ever be empty, since calling code is
+    // not supposed to do this.
+    const std::string key = header.key().empty() ? "not-empty" : replaceInvalidCharacters(header.key());
     if (ignore_headers.find(StringUtil::toLower(key)) != ignore_headers.end()) {
-      header_map.addCopy(key, clean(header.value()));
+      header_map.addCopy(key, replaceInvalidCharacters(header.value()));
     }
   }
   return header_map;
@@ -82,45 +115,6 @@ inline TestStreamInfo fromStreamInfo(const test::fuzz::StreamInfo& stream_info,
   return test_stream_info;
 }
 
-// The HeaderMap code assumes that input does not contain certain characters, and
-// this is validated by the HTTP parser. Some fuzzers will create strings with
-// these characters, however, and this creates not very interesting fuzz test
-// failures as an assertion is rapidly hit in the LowerCaseString constructor
-// before we get to anything interesting.
-//
-// This method will replace any of those characters found with spaces.
-inline std::string replaceInvalidCharacters(absl::string_view string) {
-  std::string filtered;
-  filtered.reserve(string.length());
-  for (const char& c : string) {
-    switch (c) {
-    case '\0':
-      FALLTHRU;
-    case '\r':
-      FALLTHRU;
-    case '\n':
-      filtered.push_back(' ');
-      break;
-    default:
-      filtered.push_back(c);
-    }
-  }
-  return filtered;
-}
-
-// Return a new RepeatedPtrField of HeaderValueOptions with invalid characters removed.
-inline Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption> replaceInvalidHeaders(
-    const Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption>& headers_to_add) {
-  Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption> processed;
-  for (const auto& header : headers_to_add) {
-    auto* header_value_option = processed.Add();
-    auto* mutable_header = header_value_option->mutable_header();
-    mutable_header->set_key(replaceInvalidCharacters(header.header().key()));
-    mutable_header->set_value(replaceInvalidCharacters(header.header().value()));
-    header_value_option->mutable_append()->CopyFrom(header.append());
-  }
-  return processed;
-}
 
 } // namespace Fuzz
 } // namespace Envoy

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -62,7 +62,8 @@ inline Http::TestHeaderMapImpl fromHeaders(
     // into the fuzz tests and replace these invalid characters with spaces.
     // When we are injecting headers, we don't allow the key to ever be empty, since calling code is
     // not supposed to do this.
-    const std::string key = header.key().empty() ? "not-empty" : replaceInvalidCharacters(header.key());
+    const std::string key =
+        header.key().empty() ? "not-empty" : replaceInvalidCharacters(header.key());
     if (ignore_headers.find(StringUtil::toLower(key)) != ignore_headers.end()) {
       header_map.addCopy(key, replaceInvalidCharacters(header.value()));
     }
@@ -114,7 +115,6 @@ inline TestStreamInfo fromStreamInfo(const test::fuzz::StreamInfo& stream_info,
           "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US"));
   return test_stream_info;
 }
-
 
 } // namespace Fuzz
 } // namespace Envoy


### PR DESCRIPTION
Uses replaceInvalidCharacters to clean header keys in codec_impl_fuzz test.

Risk Level: Low
Testing: Added crashing corpus entry.

Issue linked by: 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15070


