### PR TITLE
tools: add .java to list of linted suffixes

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -17,7 +17,7 @@ import traceback
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/", "./bazel-", "./.cache",
                      "./source/extensions/extensions_build_config.bzl",
                      "./tools/testdata/check_format/", "./tools/pyformat/")
-SUFFIXES = (".cc", ".h", "BUILD", "WORKSPACE", ".bzl", ".md", ".rst", ".proto")
+SUFFIXES = (".cc", ".h", "BUILD", "WORKSPACE", ".bzl", ".java", ".md", ".rst", ".proto")
 DOCS_SUFFIX = (".md", ".rst")
 PROTO_SUFFIX = (".proto")
 


### PR DESCRIPTION
This will allow other projects that use this script to use `clang-format` with `.java` files.

Signed-off-by: Michael Rebello <mrebello@lyft.com>

Testing: Done locally
