### PR TITLE
http: fix 2 cases where HCM/codec stream state diverge

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -451,7 +451,7 @@ private:
     // All state for the stream. Put here for readability.
     struct State {
       State()
-          : remote_complete_(false), local_complete_(false), local_complete_to_codec_(false),
+          : remote_complete_(false), local_complete_(false), codec_saw_local_complete_(false),
             saw_connection_close_(false), successful_upgrade_(false), created_filter_chain_(false),
             is_internally_created_(false) {}
 
@@ -466,7 +466,7 @@ private:
       bool local_complete_ : 1; // This indicates that local is complete prior to filter processing.
                                 // A filter can still stop the stream from being complete as seen
                                 // by the codec.
-      bool local_complete_to_codec_ : 1; // This indicates that local is complete as written all
+      bool codec_saw_local_complete_ : 1; // This indicates that local is complete as written all
                                          // the way through to the codec.
       bool saw_connection_close_ : 1;
       bool successful_upgrade_ : 1;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -467,7 +467,7 @@ private:
                                 // A filter can still stop the stream from being complete as seen
                                 // by the codec.
       bool codec_saw_local_complete_ : 1; // This indicates that local is complete as written all
-                                         // the way through to the codec.
+                                          // the way through to the codec.
       bool saw_connection_close_ : 1;
       bool successful_upgrade_ : 1;
       bool created_filter_chain_ : 1;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -451,8 +451,8 @@ private:
     // All state for the stream. Put here for readability.
     struct State {
       State()
-          : remote_complete_(false), local_complete_(false), saw_connection_close_(false),
-            successful_upgrade_(false), created_filter_chain_(false),
+          : remote_complete_(false), local_complete_(false), local_complete_to_codec_(false),
+            saw_connection_close_(false), successful_upgrade_(false), created_filter_chain_(false),
             is_internally_created_(false) {}
 
       uint32_t filter_call_state_{0};
@@ -463,7 +463,11 @@ private:
       bool decoder_filters_streaming_{true};
       bool destroyed_{false};
       bool remote_complete_ : 1;
-      bool local_complete_ : 1;
+      bool local_complete_ : 1; // This indicates that local is complete prior to filter processing.
+                                // A filter can still stop the stream from being complete as seen
+                                // by the codec.
+      bool local_complete_to_codec_ : 1; // This indicates that local is complete as written all
+                                         // the way through to the codec.
       bool saw_connection_close_ : 1;
       bool successful_upgrade_ : 1;
       bool created_filter_chain_ : 1;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -511,6 +511,7 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
   ENVOY_CONN_LOG(trace, "sent frame type={}", connection_, static_cast<uint64_t>(frame->hd.type));
   switch (frame->hd.type) {
   case NGHTTP2_GOAWAY: {
+    ENVOY_CONN_LOG(debug, "sent goaway code={}", connection_, frame->goaway.error_code);
     if (frame->goaway.error_code != NGHTTP2_NO_ERROR) {
       return NGHTTP2_ERR_CALLBACK_FAILURE;
     }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2297,7 +2297,7 @@ TEST_F(HttpConnectionManagerImplTest, DownstreamProtocolError) {
     throw CodecProtocolException("protocol error");
   }));
 
-  EXPECT_CALL(response_encoder_.stream_, resetStream(StreamResetReason::ConnectionTermination));
+  EXPECT_CALL(response_encoder_.stream_, removeCallbacks(_));
   EXPECT_CALL(filter_factory_, createFilterChain(_)).Times(0);
 
   // A protocol exception should result in reset of the streams followed by a remote or local close

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2297,6 +2297,7 @@ TEST_F(HttpConnectionManagerImplTest, DownstreamProtocolError) {
     throw CodecProtocolException("protocol error");
   }));
 
+  EXPECT_CALL(response_encoder_.stream_, resetStream(StreamResetReason::ConnectionTermination));
   EXPECT_CALL(filter_factory_, createFilterChain(_)).Times(0);
 
   // A protocol exception should result in reset of the streams followed by a remote or local close
@@ -3350,6 +3351,53 @@ TEST_F(HttpConnectionManagerImplTest, FilterHeadReply) {
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");
   conn_manager_->onData(fake_input, false);
+}
+
+// Verify that if an encoded stream has been ended, but gets stopped by a filter chain, we end
+// up resetting the stream in the doEndStream() path (e.g., via filter reset due to timeout, etc.),
+// we emit a reset to the codec.
+TEST_F(HttpConnectionManagerImplTest, ResetWithStoppedFilter) {
+  InSequence s;
+  setup(false, "");
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+    StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+    HeaderMapPtr headers{
+        new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
+    decoder->decodeHeaders(std::move(headers), true);
+    data.drain(4);
+  }));
+
+  setupFilterChain(1, 1);
+
+  EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
+      .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
+        decoder_filters_[0]->callbacks_->sendLocalReply(Code::BadRequest, "Bad request", nullptr,
+                                                        absl::nullopt, "");
+        return FilterHeadersStatus::Continue;
+      }));
+
+  EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, false))
+      .WillOnce(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+        EXPECT_EQ("11", headers.ContentLength()->value().getStringView());
+        return FilterHeadersStatus::Continue;
+      }));
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
+  EXPECT_CALL(*encoder_filters_[0], encodeData(_, true))
+      .WillOnce(Invoke([&](Buffer::Instance&, bool) -> FilterDataStatus {
+        return FilterDataStatus::StopIterationAndBuffer;
+      }));
+
+  EXPECT_CALL(*encoder_filters_[0], encodeComplete());
+  EXPECT_CALL(*decoder_filters_[0], decodeComplete());
+
+  // Kick off the incoming data.
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+
+  EXPECT_CALL(response_encoder_.stream_, resetStream(_));
+  expectOnDestroy();
+  encoder_filters_[0]->callbacks_->resetStream();
 }
 
 TEST_F(HttpConnectionManagerImplTest, FilterContinueAndEndStreamHeaders) {

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -430,7 +430,7 @@ TEST_P(Http2IntegrationTest, GrpcRouterNotFound) {
 
 TEST_P(Http2IntegrationTest, GrpcRetry) { testGrpcRetry(); }
 
-// fixfix
+// Verify the case where there is an HTTP/2 codec/protocol error with an active stream.
 TEST_P(Http2IntegrationTest, CodecErrorAfterStreamStart) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -430,6 +430,23 @@ TEST_P(Http2IntegrationTest, GrpcRouterNotFound) {
 
 TEST_P(Http2IntegrationTest, GrpcRetry) { testGrpcRetry(); }
 
+// fixfix
+TEST_P(Http2IntegrationTest, CodecErrorAfterStreamStart) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Sends a request.
+  auto response = codec_client_->makeRequestWithBody(default_request_headers_, 10);
+  waitForNextUpstreamRequest();
+
+  // Send bogus raw data on the connection.
+  Buffer::OwnedImpl bogus_data("some really bogus data");
+  codec_client_->rawConnection().write(bogus_data, false);
+
+  // Verifies reset is received.
+  response->waitForReset();
+}
+
 TEST_P(Http2IntegrationTest, BadMagic) {
   initialize();
   Buffer::OwnedImpl buffer("hello");

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -39,6 +39,7 @@ public:
   bool waitForDisconnect(std::chrono::milliseconds time_to_wait = std::chrono::milliseconds(0));
   Network::ClientConnection* connection() const { return connection_.get(); }
   Network::ConnectionEvent last_connection_event() const { return last_connection_event_; }
+  Network::Connection& rawConnection() { return *connection_; }
 
 private:
   struct ConnectionCallbacks : public Network::ConnectionCallbacks {


### PR DESCRIPTION
This change fixes two different cases in which it becomes possible
for the codec and the HCM to have differing views of active streams.
This can lead to crashes when the codec tries to notify the HCM about
stream state changes.

Fixes https://github.com/envoyproxy/envoy/issues/7193
Fixes https://github.com/envoyproxy/envoy/issues/6872

Risk Level: High
Testing: New UTs. Integration tests.
Docs Changes: N/A
Release Notes: N/A
