### PR TITLE
test: fix build failures by ignoring corpus generation on ppc build and clean headers

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -273,3 +273,17 @@ alias(
         },
     ),
 )
+
+alias(
+    name = "x86",
+    actual = select(
+        {
+            ":darwin_x86_64": ":darwin_x86_64",
+            ":ios_x86_64": "ios_x86_64",
+            "linux_x86_64": "linux_x86_64",
+            "windows_x86_64": "windows_x86_64",
+            # If we're not on an x86 platform return a value that will never match in the select() statement calling this since it would have already been matched above.
+            "//conditions:default": ":darwin_x86_64",
+        },
+    ),
+)

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -174,16 +174,14 @@ filegroup(
     name = "route_corpus",
     testonly = 1,
     srcs = select({
-        "ppc_build": [],
-        "//conditions:default": [":corpus_from_config_impl"],
+        # TODO(asraa): Clean this up for cross-compilation. Right now we assume
+        # the host and target are the same on x86 builds, so we only execute the
+        # corpus generation binary on x86 platforms.
+        "//bazel:x86": [":corpus_from_config_impl"],
+        "//conditions:default": [],
     }) + glob([
         "route_corpus/**",
     ]),
-)
-
-config_setting(
-    name = "ppc_build",
-    values = {"cpu": "ppc"},
 )
 
 envoy_cc_fuzz_test(

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -173,7 +173,17 @@ envoy_directory_genrule(
 filegroup(
     name = "route_corpus",
     testonly = 1,
-    srcs = [":corpus_from_config_impl"] + glob(["route_corpus/**"]),
+    srcs = select({
+        "ppc_build": [],
+        "//conditions:default": [":corpus_from_config_impl"],
+    }) + glob([
+        "route_corpus/**",
+    ]),
+)
+
+config_setting(
+    name = "ppc_build",
+    values = {"cpu": "ppc"},
 )
 
 envoy_cc_fuzz_test(

--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5077190058704896
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5077190058704896
@@ -1,0 +1,1 @@
+config {   internal_only_headers: "\0  " } 

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -17,7 +17,19 @@ DEFINE_PROTO_FUZZER(const test::common::router::RouteTestCase& input) {
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
     NiceMock<Server::Configuration::MockFactoryContext> factory_context;
     MessageUtil::validate(input.config());
-    ConfigImpl config(input.config(), factory_context, true);
+    envoy::api::v2::RouteConfiguration route_config = input.config();
+    route_config.mutable_request_headers_to_add()->CopyFrom(
+        Fuzz::replaceInvalidHeaders(input.config().request_headers_to_add()));
+    route_config.mutable_response_headers_to_add()->CopyFrom(
+        Fuzz::replaceInvalidHeaders(input.config().response_headers_to_add()));
+    auto internal_only_headers = route_config.mutable_internal_only_headers();
+    std::for_each(internal_only_headers->begin(), internal_only_headers->end(),
+                  [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+    std::for_each(route_config.mutable_request_headers_to_remove()->begin(),
+                  route_config.mutable_request_headers_to_remove()->end(),
+                  [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+
+    ConfigImpl config(route_config, factory_context, true);
     Http::TestHeaderMapImpl headers = Fuzz::fromHeaders(input.headers());
     // It's a precondition of routing that {:authority, :path, x-forwarded-proto} headers exists,
     // HCM enforces this.

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -11,25 +11,30 @@ namespace Envoy {
 namespace Router {
 namespace {
 
+// Return a new RouteConfiguration with invalid characters replaces in all header fields.
+envoy::api::v2::RouteConfiguration
+replaceInvalidHeaders(envoy::api::v2::RouteConfiguration route_config) {
+  envoy::api::v2::RouteConfiguration clean_config = route_config;
+  clean_config.mutable_request_headers_to_add()->CopyFrom(
+      Fuzz::replaceInvalidHeaders(route_config.request_headers_to_add()));
+  clean_config.mutable_response_headers_to_add()->CopyFrom(
+      Fuzz::replaceInvalidHeaders(route_config.response_headers_to_add()));
+  auto internal_only_headers = clean_config.mutable_internal_only_headers();
+  std::for_each(internal_only_headers->begin(), internal_only_headers->end(),
+                [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+  auto request_headers_to_remove = clean_config.mutable_request_headers_to_remove();
+  std::for_each(request_headers_to_remove->begin(), request_headers_to_remove->end(),
+                [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+  return clean_config;
+}
+
 // TODO(htuch): figure out how to generate via a genrule from config_impl_test the full corpus.
 DEFINE_PROTO_FUZZER(const test::common::router::RouteTestCase& input) {
   try {
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
     NiceMock<Server::Configuration::MockFactoryContext> factory_context;
     MessageUtil::validate(input.config());
-    envoy::api::v2::RouteConfiguration route_config = input.config();
-    route_config.mutable_request_headers_to_add()->CopyFrom(
-        Fuzz::replaceInvalidHeaders(input.config().request_headers_to_add()));
-    route_config.mutable_response_headers_to_add()->CopyFrom(
-        Fuzz::replaceInvalidHeaders(input.config().response_headers_to_add()));
-    auto internal_only_headers = route_config.mutable_internal_only_headers();
-    std::for_each(internal_only_headers->begin(), internal_only_headers->end(),
-                  [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
-    std::for_each(route_config.mutable_request_headers_to_remove()->begin(),
-                  route_config.mutable_request_headers_to_remove()->end(),
-                  [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
-
-    ConfigImpl config(route_config, factory_context, true);
+    ConfigImpl config(replaceInvalidHeaders(input.config()), factory_context, true);
     Http::TestHeaderMapImpl headers = Fuzz::fromHeaders(input.headers());
     // It's a precondition of routing that {:authority, :path, x-forwarded-proto} headers exists,
     // HCM enforces this.


### PR DESCRIPTION
Fix build failures by removing corpus generation from a binary when building on a ppc in route_fuzz_test and clean invalid characters from header entries in the fuzz test.

Risk Level: Low
Testing: Add crashing corpus entry.
Fixes bug: 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15070
