### PR TITLE
Fix build on clion

### DIFF
--- a/source/extensions/quic_listeners/quiche/platform/quic_sleep_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_sleep_impl.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+//
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "quiche/quic/core/quic_time.h"
+
+namespace quic {
+
+inline void QuicSleepImpl(QuicTime::Delta duration) {
+  absl::SleepFor(absl::Microseconds(duration.ToMicroseconds()));
+}
+
+} // namespace quic


### PR DESCRIPTION
Description: This adds a missing header that enables building envoy on clion with bazel plugin
Risk Level: low
Testing: manual
Docs Changes: none
Release Notes: fixed building envoy using clion with bazel plugin

Without this header envoy will fail to build with this message:

```
Syncing project: Sync (incremental)...
Updating VCS...
Running Bazel info...
Command: /home/slonka/bin/bazel info --tool_tag=ijwb:CLion --curses=no --color=yes --progress_in_terminal_title=no --

WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
/home/slonka/projects/envoy/tools/bazel.rc
Command: git diff --name-status --no-renames 0497ce9f20199b5bc0b8b4111ae4bf39e18e8387

Computing VCS working set...
Your working set is empty
Sync targets from project view:
  //...:all

Building blaze targets...
Command: /home/slonka/bin/bazel build --tool_tag=ijwb:CLion --keep_going --build_event_binary_file=/tmp/intellij-bep-4f423c0e-43e2-437b-b11b-3c7266cf11c6 --nobuild_event_binary_file_path_conversion --curses=no --color=yes --progress_in_terminal_title=no --aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect --override_repository=intellij_aspect=/home/slonka/.CLion2019.1/config/plugins/clwb/aspect --output_groups=intellij-info-cpp,intellij-info-generic,intellij-info-py,intellij-resolve-cpp,intellij-resolve-py -- //...:all

WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
/home/slonka/projects/envoy/tools/bazel.rc
Loading: 
Loading: 0 packages loaded
Loading: 135 packages loaded
    currently loading: test/extensions/filters/http/common ... (2 packages)
Analyzing: 2014 targets (173 packages loaded, 0 targets configured)
Analyzing: 2014 targets (187 packages loaded, 1007 targets configured)
Analyzing: 2014 targets (193 packages loaded, 1989 targets configured)
Analyzing: 2014 targets (194 packages loaded, 3589 targets configured)
INFO: Analyzed 2014 targets (195 packages loaded, 5097 targets configured).
Building: checking cached actions
INFO: Found 2014 targets...
[0 / 2] [Prepa] BazelWorkspaceStatusAction stable-status.txt
INFO: From Generating Descriptor Set proto_library //test/common/router:route_fuzz_proto:
external/com_google_protobuf: warning: directory does not exist.
[2,404 / 2,406] [Prepa] Writing file test/extensions/filters/http/buffer/buffer_filter_integration_test_lib_internal_only--1744775942.intellij-info.txt
[2,754 / 2,757] [Prepa] Writing file test/extensions/tracers/datadog/datadog_tracer_impl_test_lib_internal_only-96007905.intellij-info.txt
[3,159 / 3,159] checking cached actions
ERROR: missing input file '//source/extensions/quic_listeners/quiche/platform:quic_sleep_impl.h'
ERROR: /home/slonka/projects/envoy/source/extensions/quic_listeners/quiche/platform/BUILD:255:1: //source/extensions/quic_listeners/quiche/platform:quic_platform_sleep_impl_lib: missing input file '//source/extensions/quic_listeners/quiche/platform:quic_sleep_impl.h'
```