### PR TITLE
ci: Delete source/extensions/quic_listeners/quiche/platform:quic_platform_sleep_impl_lib

### DIFF
--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -253,13 +253,6 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "quic_platform_sleep_impl_lib",
-    hdrs = ["quic_sleep_impl.h"],
-    visibility = ["//visibility:public"],
-    deps = ["@com_googlesource_quiche//:quic_core_time_lib"],
-)
-
-envoy_cc_library(
     name = "spdy_platform_impl_lib",
     hdrs = [
         "spdy_arraysize_impl.h",


### PR DESCRIPTION
Description:

Delete source/extensions/quic_listeners/quiche/platform:quic_platform_sleep_impl_lib, it is added by mistake. The library is already in source/extensions/quic_listeners/quiche/platform/BUILD.

Risk Level: none.
Testing:

bazel test --test_output=all test/extensions/quic_listeners/quiche/platform:all @com_googlesource_quiche//:all

Docs Changes: none
Release Notes: none

