### PR TITLE
upstream: refactor logical/real host

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -70,6 +70,8 @@ Version history
   that allows ignoring new hosts for the purpose of load balancing calculations until they have
   been health checked for the first time.
 * upstream: added runtime error checking to prevent setting dns type to STRICT_DNS or LOGICAL_DNS when custom resolver name is specified.
+* upstream: the :ref:`logical DNS cluster <arch_overview_service_discovery_types_logical_dns>` now
+  displays the current resolved IP address in admin output instead of 0.0.0.0.
 
 1.10.0 (Apr 5, 2019)
 ====================

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -113,11 +113,6 @@ public:
   virtual Network::Address::InstanceConstSharedPtr healthCheckAddress() const PURE;
 
   /**
-   * Set the address used to health check the host.
-   */
-  virtual void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) PURE;
-
-  /**
    * @return the priority of the host.
    */
   virtual uint32_t priority() const PURE;

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -209,13 +209,22 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "logical_host_lib",
+    srcs = ["logical_host.cc"],
+    hdrs = ["logical_host.h"],
+    deps = [
+        ":upstream_includes",
+    ],
+)
+
+envoy_cc_library(
     name = "logical_dns_cluster_lib",
     srcs = ["logical_dns_cluster.cc"],
     hdrs = ["logical_dns_cluster.h"],
     deps = [
         ":cluster_factory_lib",
+        ":logical_host_lib",
         ":upstream_includes",
-        "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_factory_interface",
         "//source/common/common:empty_string",
         "//source/common/config:utility_lib",

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -19,15 +19,15 @@ namespace Upstream {
 
 LogicalDnsCluster::LogicalDnsCluster(
     const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
-    Network::DnsResolverSharedPtr dns_resolver, ThreadLocal::SlotAllocator& tls,
+    Network::DnsResolverSharedPtr dns_resolver,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api)
     : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api),
       dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(cluster, dns_refresh_rate, 5000))),
-      tls_(tls.allocateSlot()), resolve_timer_(factory_context.dispatcher().createTimer(
-                                    [this]() -> void { startResolve(); })),
+      resolve_timer_(
+          factory_context.dispatcher().createTimer([this]() -> void { startResolve(); })),
       local_info_(factory_context.localInfo()),
       load_assignment_(cluster.has_load_assignment()
                            ? cluster.load_assignment()
@@ -53,10 +53,6 @@ LogicalDnsCluster::LogicalDnsCluster(
   hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
   Network::Utility::portFromTcpUrl(dns_url_);
   dns_lookup_family_ = getDnsLookupFamilyFromCluster(cluster);
-
-  tls_->set([](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    return std::make_shared<PerThreadCurrentHostData>();
-  });
 }
 
 void LogicalDnsCluster::startPreInit() { startResolve(); }
@@ -87,20 +83,9 @@ void LogicalDnsCluster::startResolve() {
               Network::Utility::getAddressWithPort(*address_list.front(),
                                                    Network::Utility::portFromTcpUrl(dns_url_));
           if (!logical_host_) {
-            // TODO(mattklein123): The logical host is only used in /clusters admin output. We used
-            // to show the friendly DNS name in that output, but currently there is no way to
-            // express a DNS name inside of an Address::Instance. For now this is OK but we might
-            // want to do better again later.
-            switch (address_list.front()->ip()->version()) {
-            case Network::Address::IpVersion::v4:
-              logical_host_.reset(
-                  new LogicalHost(info_, hostname_, Network::Utility::getIpv4AnyAddress(), *this));
-              break;
-            case Network::Address::IpVersion::v6:
-              logical_host_.reset(
-                  new LogicalHost(info_, hostname_, Network::Utility::getIpv6AnyAddress(), *this));
-              break;
-            }
+            logical_host_.reset(
+                new LogicalHost(info_, hostname_, new_address, localityLbEndpoint(), lbEndpoint()));
+
             const auto& locality_lb_endpoint = localityLbEndpoint();
             PriorityStateManager priority_state_manager(*this, local_info_, nullptr);
             priority_state_manager.initializePriorityFor(locality_lb_endpoint);
@@ -115,32 +100,15 @@ void LogicalDnsCluster::startResolve() {
           if (!current_resolved_address_ || !(*new_address == *current_resolved_address_)) {
             current_resolved_address_ = new_address;
 
-            // Make sure that we have an updated health check address.
-            logical_host_->setHealthCheckAddress(new_address);
-
-            // Capture URL to avoid a race with another update.
-            tls_->runOnAllThreads([this, new_address]() -> void {
-              PerThreadCurrentHostData& data = tls_->getTyped<PerThreadCurrentHostData>();
-              data.current_resolved_address_ = new_address;
-            });
+            // Make sure that we have an updated address for admin display, health
+            // checking, and creating real host connections.
+            logical_host_->setNewAddress(new_address, lbEndpoint());
           }
         }
 
         onPreInitComplete();
         resolve_timer_->enableTimer(dns_refresh_rate_ms_);
       });
-}
-
-Upstream::Host::CreateConnectionData LogicalDnsCluster::LogicalHost::createConnection(
-    Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Network::TransportSocketOptionsSharedPtr transport_socket_options) const {
-  PerThreadCurrentHostData& data = parent_.tls_->getTyped<PerThreadCurrentHostData>();
-  ASSERT(data.current_resolved_address_);
-  return {HostImpl::createConnection(dispatcher, *parent_.info_, data.current_resolved_address_,
-                                     options, transport_socket_options),
-          HostDescriptionConstSharedPtr{new RealHostDescription(
-              data.current_resolved_address_, parent_.localityLbEndpoint(), parent_.lbEndpoint(),
-              shared_from_this(), parent_.symbolTable())}};
 }
 
 std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>
@@ -151,7 +119,7 @@ LogicalDnsClusterFactory::createClusterImpl(
   auto selected_dns_resolver = selectDnsResolver(cluster, context);
 
   return std::make_pair(std::make_shared<LogicalDnsCluster>(
-                            cluster, context.runtime(), selected_dns_resolver, context.tls(),
+                            cluster, context.runtime(), selected_dns_resolver,
                             socket_factory_context, std::move(stats_scope), context.addedViaApi()),
                         nullptr);
 }

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -6,10 +6,10 @@
 #include <string>
 
 #include "envoy/stats/scope.h"
-#include "envoy/thread_local/thread_local.h"
 
 #include "common/common/empty_string.h"
 #include "common/upstream/cluster_factory_impl.h"
+#include "common/upstream/logical_host.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "extensions/clusters/well_known_names.h"
@@ -33,7 +33,7 @@ namespace Upstream {
 class LogicalDnsCluster : public ClusterImplBase {
 public:
   LogicalDnsCluster(const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
-                    Network::DnsResolverSharedPtr dns_resolver, ThreadLocal::SlotAllocator& tls,
+                    Network::DnsResolverSharedPtr dns_resolver,
                     Server::Configuration::TransportSocketFactoryContext& factory_context,
                     Stats::ScopePtr&& stats_scope, bool added_via_api);
 
@@ -43,94 +43,6 @@ public:
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
 
 private:
-  struct LogicalHost : public HostImpl {
-    LogicalHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
-                Network::Address::InstanceConstSharedPtr address, LogicalDnsCluster& parent)
-        : HostImpl(cluster, hostname, address, parent.lbEndpoint().metadata(),
-                   parent.lbEndpoint().load_balancing_weight().value(),
-                   parent.localityLbEndpoint().locality(),
-                   parent.lbEndpoint().endpoint().health_check_config(),
-                   parent.localityLbEndpoint().priority(), parent.lbEndpoint().health_status()),
-          parent_(parent) {}
-
-    // Upstream::Host
-    CreateConnectionData createConnection(
-        Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-        Network::TransportSocketOptionsSharedPtr transport_socket_options) const override;
-
-    // Upstream::HostDescription
-    // Override setting health check address, since for logical DNS the registered host has 0.0.0.0
-    // as its address (see @mattklein123's comment in logical_dns_cluster.cc why this is),
-    // while the health check address needs the resolved address to do the health checking, so we
-    // set it here.
-    void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr address) override {
-      const auto& port_value = parent_.lbEndpoint().endpoint().health_check_config().port_value();
-      health_check_address_ =
-          port_value == 0 ? address : Network::Utility::getAddressWithPort(*address, port_value);
-    }
-
-    LogicalDnsCluster& parent_;
-  };
-
-  struct RealHostDescription : public HostDescription {
-    RealHostDescription(Network::Address::InstanceConstSharedPtr address,
-                        const envoy::api::v2::endpoint::LocalityLbEndpoints& locality_lb_endpoint,
-                        const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint,
-                        HostConstSharedPtr logical_host, Stats::SymbolTable& symbol_table)
-        : address_(address), logical_host_(logical_host),
-          metadata_(std::make_shared<envoy::api::v2::core::Metadata>(lb_endpoint.metadata())),
-          health_check_address_(
-              lb_endpoint.endpoint().health_check_config().port_value() == 0
-                  ? address
-                  : Network::Utility::getAddressWithPort(
-                        *address, lb_endpoint.endpoint().health_check_config().port_value())),
-          locality_lb_endpoint_(locality_lb_endpoint), lb_endpoint_(lb_endpoint),
-          locality_zone_stat_name_(locality().zone(), symbol_table) {}
-
-    // Upstream:HostDescription
-    bool canary() const override { return false; }
-    void canary(bool) override {}
-    const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
-      return metadata_;
-    }
-    void metadata(const envoy::api::v2::core::Metadata&) override {}
-
-    const ClusterInfo& cluster() const override { return logical_host_->cluster(); }
-    HealthCheckHostMonitor& healthChecker() const override {
-      return logical_host_->healthChecker();
-    }
-    Outlier::DetectorHostMonitor& outlierDetector() const override {
-      return logical_host_->outlierDetector();
-    }
-    const HostStats& stats() const override { return logical_host_->stats(); }
-    const std::string& hostname() const override { return logical_host_->hostname(); }
-    Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-    const envoy::api::v2::core::Locality& locality() const override {
-      return locality_lb_endpoint_.locality();
-    }
-    Stats::StatName localityZoneStatName() const override {
-      return locality_zone_stat_name_.statName();
-    }
-    Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
-      return health_check_address_;
-    }
-    // Setting health check address is usually done at initialization. This is NOP by default.
-    void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) override {}
-    uint32_t priority() const override { return locality_lb_endpoint_.priority(); }
-    void priority(uint32_t priority) override { locality_lb_endpoint_.set_priority(priority); }
-    Network::Address::InstanceConstSharedPtr address_;
-    HostConstSharedPtr logical_host_;
-    const std::shared_ptr<envoy::api::v2::core::Metadata> metadata_;
-    Network::Address::InstanceConstSharedPtr health_check_address_;
-    envoy::api::v2::endpoint::LocalityLbEndpoints locality_lb_endpoint_;
-    const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint_;
-    Stats::StatNameManagedStorage locality_zone_stat_name_;
-  };
-
-  struct PerThreadCurrentHostData : public ThreadLocal::ThreadLocalObject {
-    Network::Address::InstanceConstSharedPtr current_resolved_address_;
-  };
-
   const envoy::api::v2::endpoint::LocalityLbEndpoints& localityLbEndpoint() const {
     // This is checked in the constructor, i.e. at config load time.
     ASSERT(load_assignment_.endpoints().size() == 1);
@@ -151,12 +63,11 @@ private:
   Network::DnsResolverSharedPtr dns_resolver_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
   Network::DnsLookupFamily dns_lookup_family_;
-  ThreadLocal::SlotPtr tls_;
   Event::TimerPtr resolve_timer_;
   std::string dns_url_;
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr current_resolved_address_;
-  HostSharedPtr logical_host_;
+  LogicalHostSharedPtr logical_host_;
   Network::ActiveDnsQuery* active_dns_query_{};
   const LocalInfo::LocalInfo& local_info_;
   const envoy::api::v2::ClusterLoadAssignment load_assignment_;

--- a/source/common/upstream/logical_host.cc
+++ b/source/common/upstream/logical_host.cc
@@ -1,0 +1,16 @@
+#include "common/upstream/logical_host.h"
+
+namespace Envoy {
+namespace Upstream {
+
+Upstream::Host::CreateConnectionData LogicalHost::createConnection(
+    Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
+    Network::TransportSocketOptionsSharedPtr transport_socket_options) const {
+  const auto current_address = address();
+  return {HostImpl::createConnection(dispatcher, cluster(), current_address, options,
+                                     transport_socket_options),
+          std::make_shared<RealHostDescription>(current_address, shared_from_this())};
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/logical_host.h
+++ b/source/common/upstream/logical_host.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "common/upstream/upstream_impl.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * A host implementation that can have its address changed in order to create temporal "real"
+ * hosts.
+ */
+class LogicalHost : public HostImpl {
+public:
+  LogicalHost(const ClusterInfoConstSharedPtr& cluster, const std::string& hostname,
+              const Network::Address::InstanceConstSharedPtr& address,
+              const envoy::api::v2::endpoint::LocalityLbEndpoints& locality_lb_endpoint,
+              const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint)
+      : HostImpl(cluster, hostname, address, lb_endpoint.metadata(),
+                 lb_endpoint.load_balancing_weight().value(), locality_lb_endpoint.locality(),
+                 lb_endpoint.endpoint().health_check_config(), locality_lb_endpoint.priority(),
+                 lb_endpoint.health_status()) {}
+
+  // Set the new address. Updates are typically rare so a R/W lock is used to address updates.
+  // Note that the health check address update requires no lock to be held since it is only
+  // used on the main thread.
+  void setNewAddress(const Network::Address::InstanceConstSharedPtr& address,
+                     const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint) {
+    const auto& port_value = lb_endpoint.endpoint().health_check_config().port_value();
+    health_check_address_ =
+        port_value == 0 ? address : Network::Utility::getAddressWithPort(*address, port_value);
+
+    absl::WriterMutexLock lock(&address_lock_);
+    address_ = address;
+  }
+
+  // Upstream::Host
+  CreateConnectionData createConnection(
+      Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
+      Network::TransportSocketOptionsSharedPtr transport_socket_options) const override;
+
+  // Upstream::HostDescription
+  Network::Address::InstanceConstSharedPtr address() const override {
+    absl::ReaderMutexLock lock(&address_lock_);
+    return HostImpl::address();
+  }
+
+private:
+  mutable absl::Mutex address_lock_;
+};
+
+using LogicalHostSharedPtr = std::shared_ptr<LogicalHost>;
+
+/**
+ * A real host that forwards most of its calls to a logical host, but returns a snapped address.
+ */
+class RealHostDescription : public HostDescription {
+public:
+  RealHostDescription(Network::Address::InstanceConstSharedPtr address,
+                      HostConstSharedPtr logical_host)
+      : address_(address), logical_host_(logical_host) {}
+
+  // Upstream:HostDescription
+  bool canary() const override { return false; }
+  void canary(bool) override {}
+  const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
+    return logical_host_->metadata();
+  }
+  void metadata(const envoy::api::v2::core::Metadata&) override {}
+
+  const ClusterInfo& cluster() const override { return logical_host_->cluster(); }
+  HealthCheckHostMonitor& healthChecker() const override { return logical_host_->healthChecker(); }
+  Outlier::DetectorHostMonitor& outlierDetector() const override {
+    return logical_host_->outlierDetector();
+  }
+  const HostStats& stats() const override { return logical_host_->stats(); }
+  const std::string& hostname() const override { return logical_host_->hostname(); }
+  Network::Address::InstanceConstSharedPtr address() const override { return address_; }
+  const envoy::api::v2::core::Locality& locality() const override {
+    return logical_host_->locality();
+  }
+  Stats::StatName localityZoneStatName() const override {
+    return logical_host_->localityZoneStatName();
+  }
+  Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
+    // Should never be called since real hosts are used only for forwarding and not health
+    // checking.
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+  uint32_t priority() const override { return logical_host_->priority(); }
+  void priority(uint32_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+
+private:
+  const Network::Address::InstanceConstSharedPtr address_;
+  const HostConstSharedPtr logical_host_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -135,8 +135,6 @@ public:
   Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
     return health_check_address_;
   }
-  // Setting health check address is usually done at initialization. This is NOP by default.
-  void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) override {}
   const envoy::api::v2::core::Locality& locality() const override { return locality_; }
   Stats::StatName localityZoneStatName() const override {
     return locality_zone_stat_name_.statName();

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -80,7 +80,6 @@ public:
 
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
-  MOCK_METHOD1(setHealthCheckAddress, void(Network::Address::InstanceConstSharedPtr));
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_METHOD1(canary, void(bool new_canary));
   MOCK_CONST_METHOD0(metadata, const std::shared_ptr<envoy::api::v2::core::Metadata>());
@@ -149,7 +148,6 @@ public:
 
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
-  MOCK_METHOD1(setHealthCheckAddress, void(Network::Address::InstanceConstSharedPtr));
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_METHOD1(canary, void(bool new_canary));
   MOCK_CONST_METHOD0(metadata, const std::shared_ptr<envoy::api::v2::core::Metadata>());


### PR DESCRIPTION
This change refactors logical/real host to be a common
concept that can be used by the dynamic forward proxy support.
In doing so, the threading has been switched from using TLS to
R/W locks to make dropping the code into multiple locations
easier. It also fixes a longstanding issue with logical DNS
where the current address is reported as "0.0.0.0" in admin
output.

Fixes https://github.com/envoyproxy/envoy/issues/5225
Part of https://github.com/envoyproxy/envoy/issues/1606

Signed-off-by: Matt Klein <mklein@lyft.com>

Risk Level: Medium
Testing: Existing and modified tests
Docs Changes: N/A
Release Notes: Added
