### PR TITLE
fuzz: fix invalid headers in utility fuzz test

### DIFF
--- a/test/common/http/utility_corpus/clusterfuzz-testcase-utility_fuzz_test-5206456636276736
+++ b/test/common/http/utility_corpus/clusterfuzz-testcase-utility_fuzz_test-5206456636276736
@@ -1,0 +1,3 @@
+get_last_address_from_xff {
+  xff: " \000\000\000\000\000\000\000"
+}

--- a/test/common/http/utility_fuzz_test.cc
+++ b/test/common/http/utility_fuzz_test.cc
@@ -27,7 +27,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::UtilityTestCase& input) {
   case test::common::http::UtilityTestCase::kGetLastAddressFromXff: {
     const auto& get_last_address_from_xff = input.get_last_address_from_xff();
     Http::TestHeaderMapImpl headers;
-    headers.addCopy("x-forwarded-for", get_last_address_from_xff.xff());
+    headers.addCopy("x-forwarded-for", replaceInvalidCharacters(get_last_address_from_xff.xff()));
     // Take num_to_skip modulo 32 to avoid wasting time in lala land.
     Http::Utility::getLastAddressFromXFF(headers, get_last_address_from_xff.num_to_skip() % 32);
     break;


### PR DESCRIPTION
Replaces invalid characters in xff string.

Risk Level: Low
Testing: Add crashing corpus entry.

Referenced in oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15070

Signed-off-by: Asra Ali <asraa@google.com>

