### PR TITLE
tools: ignore `./bazel-*` in check_repositories.sh

### DIFF
--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -4,7 +4,7 @@ set -eu
 
 # Check whether any git repositories are defined.
 # Git repository definition contains `commit` and `remote` fields.
-if grep -nr "commit =\|remote =" --include=*.bzl .; then
+if grep -nr "commit =\|remote =" --include=*.bzl --exclude=./bazel-* .; then
   echo "Using git repositories is not allowed."
   echo "To ensure that all dependencies can be stored offline in distdir, only HTTP repositories are allowed."
   exit 1


### PR DESCRIPTION
We currently ignore `./bazel-*` in the `check_format.py` script, but not here. Adding it here as an ignored directory as well to prevent lint failures when using `envoy` as a submodule, such as the following:

```
  Checking repositories definitions
./bazel-envoy-mobile/external/bazel_tools/tools/build_defs/repo/git.bzl:68:        remote = ctx.attr.remote,
./bazel-envoy-mobile/external/bazel_tools/tools/build_defs/repo/git.bzl:96:    actual_commit = ctx.execute([
Using git repositories is not allowed.
To ensure that all dependencies can be stored offline in distdir, only HTTP repositories are allowed.
```

Signed-off-by: Michael Rebello <mrebello@lyft.com>

Risk Level: Low
Testing: Done locally