### PR TITLE
Use git grep as opposed to system grep

### DIFF
--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -4,7 +4,7 @@ set -eu
 
 # Check whether any git repositories are defined.
 # Git repository definition contains `commit` and `remote` fields.
-if grep -nr "commit =\|remote =" --include=*.bzl .; then
+if git grep -n "commit =\|remote =" *.bzl; then
   echo "Using git repositories is not allowed."
   echo "To ensure that all dependencies can be stored offline in distdir, only HTTP repositories are allowed."
   exit 1


### PR DESCRIPTION
When running on a system where BSD grep is on the PATH the check fails because bsd-grep follows symlinks on `grep -r`. This causes the check to find all the transitive dependencies that are using git on the `bazel-envoy` symbolic link directory.

Note this is also a better option because we only care about greping the files that are included in the repo and nothing else

Risk Level: Low
Testing: Done locally, added a bzl file with `remote =` strings and it correctly failed.