### PR TITLE
Listener: Filter chain manager refactor cont

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -269,7 +269,6 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/listener:well_known_names",
-        "//source/extensions/filters/network:well_known_names",
         "//source/extensions/transport_sockets:well_known_names",
         "//source/extensions/transport_sockets/tls:context_config_lib",
         "//source/extensions/transport_sockets/tls:context_lib",
@@ -289,9 +288,6 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/network:cidr_range_lib",
         "//source/common/network:lc_trie_lib",
-        "//source/extensions/filters/listener:well_known_names",
-        "//source/extensions/filters/network:well_known_names",
-        "//source/extensions/transport_sockets:well_known_names",
         "//source/server:configuration_lib",
     ],
 )

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -284,9 +284,15 @@ envoy_cc_library(
     hdrs = ["filter_chain_manager_impl.h"],
     deps = [
         "//include/envoy/server:listener_manager_interface",
+        "//include/envoy/server:transport_socket_config_interface",
         "//source/common/common:empty_string",
+        "//source/common/config:utility_lib",
         "//source/common/network:cidr_range_lib",
         "//source/common/network:lc_trie_lib",
+        "//source/extensions/filters/listener:well_known_names",
+        "//source/extensions/filters/network:well_known_names",
+        "//source/extensions/transport_sockets:well_known_names",
+        "//source/server:configuration_lib",
     ],
 )
 

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -273,7 +273,6 @@ std::pair<T, std::vector<Network::Address::CidrRange>> makeCidrListEntry(const s
 
 const Network::FilterChain*
 FilterChainManagerImpl::findFilterChain(const Network::ConnectionSocket& socket) const {
-  ENVOY_LOG(error, "will call socket local address()");
   const auto& address = socket.localAddress();
 
   // Match on destination port (only for IP addresses).

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -7,10 +7,6 @@
 
 #include "server/configuration_impl.h"
 
-#include "extensions/filters/listener/well_known_names.h"
-#include "extensions/filters/network/well_known_names.h"
-#include "extensions/transport_sockets/well_known_names.h"
-
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -37,7 +37,6 @@ void FilterChainManagerImpl::addFilterChain(
   std::unordered_set<envoy::api::v2::listener::FilterChainMatch, MessageUtil, MessageUtil>
       filter_chains;
   for (const auto& filter_chain : filter_chain_span) {
-
     const auto& filter_chain_match = filter_chain->filter_chain_match();
     if (!filter_chain_match.address_suffix().empty() || filter_chain_match.has_suffix_len()) {
       throw EnvoyException(fmt::format("error adding listener '{}': contains filter chains with "
@@ -109,21 +108,7 @@ void FilterChainManagerImpl::addFilterChain(
         filter_chain_match.source_type(), source_ips, filter_chain_match.source_ports(),
         std::shared_ptr<Network::FilterChain>(b.buildFilterChain(*filter_chain)));
   }
-}
-void FilterChainManagerImpl::addFilterChain(
-    uint16_t destination_port, const std::vector<std::string>& destination_ips,
-    const std::vector<std::string>& server_names, const std::string& transport_protocol,
-    const std::vector<std::string>& application_protocols,
-    const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
-    const std::vector<std::string>& source_ips,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
-    Network::TransportSocketFactoryPtr&& transport_socket_factory,
-    std::vector<Network::FilterFactoryCb> filters_factory) {
-  const auto filter_chain = std::make_shared<FilterChainImpl>(std::move(transport_socket_factory),
-                                                              std::move(filters_factory));
-  addFilterChainForDestinationPorts(destination_ports_map_, destination_port, destination_ips,
-                                    server_names, transport_protocol, application_protocols,
-                                    source_type, source_ips, source_ports, filter_chain);
+  convertIPsToTries();
 }
 
 void FilterChainManagerImpl::addFilterChainForDestinationPorts(

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -28,9 +28,8 @@ public:
 class FilterChainManagerImpl : public Network::FilterChainManager,
                                Logger::Loggable<Logger::Id::config> {
 public:
-  FilterChainManagerImpl(Network::Address::InstanceConstSharedPtr address,
-                         ProtobufMessage::ValidationVisitor& visitor)
-      : address_(address), validation_visitor_(visitor) {}
+  explicit FilterChainManagerImpl(Network::Address::InstanceConstSharedPtr address)
+      : address_(address) {}
 
   // Network::FilterChainManager
   const Network::FilterChain*
@@ -129,7 +128,6 @@ private:
   // and application protocols, using structures defined above.
   DestinationPortsMap destination_ports_map_;
   Network::Address::InstanceConstSharedPtr address_;
-  ProtobufMessage::ValidationVisitor& validation_visitor_;
 };
 
 class FilterChainImpl : public Network::FilterChain {

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "envoy/api/v2/listener/listener.pb.h"
-#include "envoy/protobuf/message_validator.h"
 #include "envoy/server/transport_socket_config.h"
 
 #include "common/common/logger.h"
@@ -19,7 +18,7 @@ class FilterChainFactoryBuilder {
 public:
   virtual ~FilterChainFactoryBuilder() = default;
   virtual std::unique_ptr<Network::FilterChain>
-  buildFilterChain(const ::envoy::api::v2::listener::FilterChain& filter_chain) const = 0;
+  buildFilterChain(const ::envoy::api::v2::listener::FilterChain& filter_chain) const PURE;
 };
 
 /**
@@ -28,7 +27,7 @@ public:
 class FilterChainManagerImpl : public Network::FilterChainManager,
                                Logger::Loggable<Logger::Id::config> {
 public:
-  explicit FilterChainManagerImpl(Network::Address::InstanceConstSharedPtr address)
+  explicit FilterChainManagerImpl(const Network::Address::InstanceConstSharedPtr& address)
       : address_(address) {}
 
   // Network::FilterChainManager
@@ -127,7 +126,7 @@ private:
   // Mapping of FilterChain's configured destination ports, IPs, server names, transport protocols
   // and application protocols, using structures defined above.
   DestinationPortsMap destination_ports_map_;
-  Network::Address::InstanceConstSharedPtr address_;
+  const Network::Address::InstanceConstSharedPtr address_;
 };
 
 class FilterChainImpl : public Network::FilterChain {

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -36,22 +36,9 @@ public:
   const Network::FilterChain*
   findFilterChain(const Network::ConnectionSocket& socket) const override;
 
-  // Currently for listener only
   void
   addFilterChain(absl::Span<const ::envoy::api::v2::listener::FilterChain* const> filter_chain_span,
                  FilterChainFactoryBuilder& b);
-
-  void
-  addFilterChain(uint16_t destination_port, const std::vector<std::string>& destination_ips,
-                 const std::vector<std::string>& server_names,
-                 const std::string& transport_protocol,
-                 const std::vector<std::string>& application_protocols,
-                 const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
-                 const std::vector<std::string>& source_ips,
-                 const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
-                 Network::TransportSocketFactoryPtr&& transport_socket_factory,
-                 std::vector<Network::FilterFactoryCb> filters_factory);
-  void finishFilterChain() { convertIPsToTries(); }
   static bool isWildcardServerName(const std::string& name);
 
 private:

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1,5 +1,7 @@
 #include "server/listener_manager_impl.h"
 
+#include <algorithm>
+
 #include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/transport_socket_config.h"
@@ -181,10 +183,30 @@ ProdListenerComponentFactory::createDrainManager(envoy::api::v2::Listener::Drain
   return DrainManagerPtr{new DrainManagerImpl(server_, drain_type)};
 }
 
+// void makeTransportSocketFactory(envoy.api.v2.core.TransportSocket& transport_socket,
+//                                 ProtobufMessage::ValidationVisitor& vistor) {
+//   if (!filter_chain.has_transport_socket()) {
+//     if (filter_chain.has_tls_context()) {
+//       transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
+//       MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config());
+//     } else {
+//       transport_socket.set_name(
+//           Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
+//     }
+//   }
+
+//   auto& config_factory = Config::Utility::getAndCheckFactory<
+//       Server::Configuration::DownstreamTransportSocketConfigFactory>(transport_socket.name());
+//   ProtobufTypes::MessagePtr message =
+//       Config::Utility::translateToFactoryConfig(transport_socket, visitor, config_factory);
+//   config_factory.createTransportSocketFactory(*message, factory_context, server_names),
+// }
+
 ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::string& version_info,
                            ListenerManagerImpl& parent, const std::string& name, bool modifiable,
                            bool workers_started, uint64_t hash)
     : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
+      filter_chain_manager_(address_, parent_.server_.messageValidationVisitor()),
       socket_type_(Network::Utility::protobufAddressSocketType(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
       listener_scope_(
@@ -272,93 +294,25 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
       filter_chains;
 
   // TODO(lambdai): move the trie construction to FilterChainManagerImpl
-  for (const auto& filter_chain : config.filter_chains()) {
-    const auto& filter_chain_match = filter_chain.filter_chain_match();
-    if (!filter_chain_match.address_suffix().empty() || filter_chain_match.has_suffix_len()) {
-      throw EnvoyException(fmt::format("error adding listener '{}': contains filter chains with "
-                                       "unimplemented fields",
-                                       address_->asString()));
-    }
-    if (filter_chains.find(filter_chain_match) != filter_chains.end()) {
-      throw EnvoyException(fmt::format("error adding listener '{}': multiple filter chains with "
-                                       "the same matching rules are defined",
-                                       address_->asString()));
-    }
-    filter_chains.insert(filter_chain_match);
-
-    // If the cluster doesn't have transport socket configured, then use the default "raw_buffer"
-    // transport socket or BoringSSL-based "tls" transport socket if TLS settings are configured.
-    // We copy by value first then override if necessary.
-    auto transport_socket = filter_chain.transport_socket();
-    if (!filter_chain.has_transport_socket()) {
-      if (filter_chain.has_tls_context()) {
-        transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
-        MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config());
-      } else {
-        transport_socket.set_name(
-            Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
-      }
-    }
-
-    auto& config_factory = Config::Utility::getAndCheckFactory<
-        Server::Configuration::DownstreamTransportSocketConfigFactory>(transport_socket.name());
-    ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
-        transport_socket, parent_.server_.messageValidationVisitor(), config_factory);
-
-    // Validate IP addresses.
-    std::vector<std::string> destination_ips;
-    destination_ips.reserve(filter_chain_match.prefix_ranges().size());
-    for (const auto& destination_ip : filter_chain_match.prefix_ranges()) {
-      const auto& cidr_range = Network::Address::CidrRange::create(destination_ip);
-      destination_ips.push_back(cidr_range.asString());
-    }
-
-    std::vector<std::string> server_names(filter_chain_match.server_names().begin(),
-                                          filter_chain_match.server_names().end());
-
-    // Reject partial wildcards, we don't match on them.
-    for (const auto& server_name : server_names) {
-      if (server_name.find('*') != std::string::npos &&
-          !FilterChainManagerImpl::isWildcardServerName(server_name)) {
-        throw EnvoyException(
-            fmt::format("error adding listener '{}': partial wildcards are not supported in "
-                        "\"server_names\"",
-                        address_->asString()));
-      }
-    }
-
-    std::vector<std::string> source_ips;
-    source_ips.reserve(filter_chain_match.source_prefix_ranges().size());
-    for (const auto& source_ip : filter_chain_match.source_prefix_ranges()) {
-      const auto& cidr_range = Network::Address::CidrRange::create(source_ip);
-      source_ips.push_back(cidr_range.asString());
-    }
-
-    std::vector<std::string> application_protocols(
-        filter_chain_match.application_protocols().begin(),
-        filter_chain_match.application_protocols().end());
-    Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-        parent_.server_.admin(), parent_.server_.sslContextManager(), *listener_scope_,
-        parent_.server_.clusterManager(), parent_.server_.localInfo(), parent_.server_.dispatcher(),
-        parent_.server_.random(), parent_.server_.stats(), parent_.server_.singletonManager(),
-        parent_.server_.threadLocal(), parent_.server_.messageValidationVisitor(),
-        parent_.server_.api());
-    factory_context.setInitManager(initManager());
-    filter_chain_manager_.addFilterChain(
-        PROTOBUF_GET_WRAPPED_OR_DEFAULT(filter_chain_match, destination_port, 0), destination_ips,
-        server_names, filter_chain_match.transport_protocol(), application_protocols,
-        filter_chain_match.source_type(), source_ips, filter_chain_match.source_ports(),
-        config_factory.createTransportSocketFactory(*message, factory_context, server_names),
-        parent_.factory_.createNetworkFilterFactoryList(filter_chain.filters(), *this));
-
-    need_tls_inspector |= filter_chain_match.transport_protocol() == "tls" ||
-                          (filter_chain_match.transport_protocol().empty() &&
-                           (!server_names.empty() || !application_protocols.empty()));
-  }
+  Server::Configuration::TransportSocketFactoryContextImpl factory_context(
+      parent_.server_.admin(), parent_.server_.sslContextManager(), *listener_scope_,
+      parent_.server_.clusterManager(), parent_.server_.localInfo(), parent_.server_.dispatcher(),
+      parent_.server_.random(), parent_.server_.stats(), parent_.server_.singletonManager(),
+      parent_.server_.threadLocal(), parent_.server_.messageValidationVisitor(),
+      parent_.server_.api());
+  factory_context.setInitManager(initManager());
+  ListenerFilterChainFactoryBuilder builder(*this, factory_context);
+  filter_chain_manager_.addFilterChain(config.filter_chains(), builder);
 
   // Convert both destination and source IP CIDRs to tries for faster lookups.
   filter_chain_manager_.finishFilterChain();
-
+  need_tls_inspector |= std::any_of(
+      config.filter_chains().begin(), config.filter_chains().end(), [](const auto& filter_chain) {
+        const auto& matcher = filter_chain.filter_chain_match();
+        return matcher.transport_protocol() == "tls" ||
+               (matcher.transport_protocol().empty() &&
+                (!matcher.server_names().empty() || !matcher.application_protocols().empty()));
+      });
   // Automatically inject TLS Inspector if it wasn't configured explicitly and it's needed.
   if (need_tls_inspector) {
     for (const auto& filter : config.listener_filters()) {
@@ -851,6 +805,42 @@ void ListenerManagerImpl::stopWorkers() {
   for (const auto& worker : workers_) {
     worker->stop();
   }
+}
+
+ListenerFilterChainFactoryBuilder::ListenerFilterChainFactoryBuilder(
+    ListenerImpl& listener,
+    Server::Configuration::TransportSocketFactoryContextImpl& factory_context)
+    : parent_(listener), factory_context_(factory_context) {}
+
+std::unique_ptr<Network::FilterChain> ListenerFilterChainFactoryBuilder::buildFilterChain(
+    const ::envoy::api::v2::listener::FilterChain& filter_chain) const {
+  // If the cluster doesn't have transport socket configured, then use the default "raw_buffer"
+  // transport socket or BoringSSL-based "tls" transport socket if TLS settings are configured.
+  // We copy by value first then override if necessary.
+  auto transport_socket = filter_chain.transport_socket();
+  if (!filter_chain.has_transport_socket()) {
+    if (filter_chain.has_tls_context()) {
+      transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
+      MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config());
+    } else {
+      transport_socket.set_name(
+          Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
+    }
+  }
+
+  auto& config_factory = Config::Utility::getAndCheckFactory<
+      Server::Configuration::DownstreamTransportSocketConfigFactory>(transport_socket.name());
+  ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+      transport_socket, parent_.messageValidationVisitor(), config_factory);
+
+  // TODO: use span to avoid create vector from repeated fields
+  std::vector<std::string> server_names(filter_chain.filter_chain_match().server_names().begin(),
+                                        filter_chain.filter_chain_match().server_names().end());
+
+  return std::make_unique<FilterChainImpl>(
+      config_factory.createTransportSocketFactory(*message, factory_context_,
+                                                  std::move(server_names)),
+      parent_.parent_.factory_.createNetworkFilterFactoryList(filter_chain.filters(), parent_));
 }
 
 } // namespace Server

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -25,7 +25,6 @@
 #include "server/transport_socket_config_impl.h"
 
 #include "extensions/filters/listener/well_known_names.h"
-#include "extensions/filters/network/well_known_names.h"
 #include "extensions/transport_sockets/well_known_names.h"
 
 #include "absl/strings/match.h"

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -282,7 +282,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
   // Convert both destination and source IP CIDRs to tries for faster lookups.
   filter_chain_manager_.finishFilterChain();
 
-  bool need_tls_inspector =
+  const bool need_tls_inspector =
       std::any_of(
           config.filter_chains().begin(), config.filter_chains().end(),
           [](const auto& filter_chain) {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -279,9 +279,6 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
   factory_context.setInitManager(initManager());
   ListenerFilterChainFactoryBuilder builder(*this, factory_context);
   filter_chain_manager_.addFilterChain(config.filter_chains(), builder);
-  // Convert both destination and source IP CIDRs to tries for faster lookups.
-  filter_chain_manager_.finishFilterChain();
-
   const bool need_tls_inspector =
       std::any_of(
           config.filter_chains().begin(), config.filter_chains().end(),

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -187,7 +187,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                            ListenerManagerImpl& parent, const std::string& name, bool modifiable,
                            bool workers_started, uint64_t hash)
     : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
-      filter_chain_manager_(address_, parent_.server_.messageValidationVisitor()),
+      filter_chain_manager_(address_),
       socket_type_(Network::Utility::protobufAddressSocketType(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
       listener_scope_(
@@ -805,7 +805,6 @@ std::unique_ptr<Network::FilterChain> ListenerFilterChainFactoryBuilder::buildFi
   ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
       transport_socket, parent_.messageValidationVisitor(), config_factory);
 
-  // TODO: use span to avoid create vector from repeated fields
   std::vector<std::string> server_names(filter_chain.filter_chain_match().server_names().begin(),
                                         filter_chain.filter_chain_match().server_names().end());
 

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -288,11 +288,11 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                    (matcher.transport_protocol().empty() &&
                     (!matcher.server_names().empty() || !matcher.application_protocols().empty()));
           }) &&
-      std::all_of(config.listener_filters().begin(), config.listener_filters().end(),
-                  [](const auto& filter) {
-                    return filter.name() !=
-                           Extensions::ListenerFilters::ListenerFilterNames::get().TlsInspector;
-                  });
+      not std::any_of(config.listener_filters().begin(), config.listener_filters().end(),
+                      [](const auto& filter) {
+                        return filter.name() ==
+                               Extensions::ListenerFilters::ListenerFilterNames::get().TlsInspector;
+                      });
   // Automatically inject TLS Inspector if it wasn't configured explicitly and it's needed.
   if (need_tls_inspector) {
     const std::string message =

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -19,10 +19,6 @@
 #include "server/filter_chain_manager_impl.h"
 #include "server/lds_api.h"
 
-#include "extensions/filters/listener/well_known_names.h"
-#include "extensions/filters/network/well_known_names.h"
-#include "extensions/transport_sockets/well_known_names.h"
-
 namespace Envoy {
 namespace Server {
 
@@ -372,7 +368,7 @@ private:
   const std::string version_info_;
   Network::Socket::OptionsSharedPtr listen_socket_options_;
   const std::chrono::milliseconds listener_filters_timeout_;
-  // to access ListenerManagerImpl::factory_
+  // to access ListenerManagerImpl::factory_.
   friend class ListenerFilterChainFactoryBuilder;
 };
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -188,6 +188,37 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "filter_chain_manager_impl_test",
+    srcs = ["filter_chain_manager_impl_test.cc"],
+    data = ["//test/extensions/transport_sockets/tls/test_data:certs"],
+    deps = [
+        ":utility_lib",
+        "//source/common/api:os_sys_calls_lib",
+        "//source/common/config:metadata_lib",
+        "//source/common/network:addr_family_aware_socket_option_lib",
+        "//source/common/network:listen_socket_lib",
+        "//source/common/network:socket_option_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/protobuf",
+        "//source/extensions/filters/listener/original_dst:config",
+        "//source/extensions/filters/listener/tls_inspector:config",
+        "//source/extensions/filters/network/http_connection_manager:config",
+        "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//source/extensions/transport_sockets/tls:ssl_socket_lib",
+        "//source/server:filter_chain_manager_lib",
+        "//source/server:listener_manager_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:registry_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_time_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ],
+)
+
 envoy_cc_fuzz_test(
     name = "server_fuzz_test",
     srcs = ["server_fuzz_test.cc"],

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -133,15 +133,13 @@ public:
 };
 
 TEST_F(FilterChainManagerImplTest, FilterChainMatchNothing) {
-  auto filter_chain =
-      findFilterChainHelper(10000, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  auto filter_chain = findFilterChainHelper(10000, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
   EXPECT_EQ(filter_chain, nullptr);
 }
 
 TEST_F(FilterChainManagerImplTest, AddSingleFilterChain) {
   addSingleFilterChainHelper(filter_chain_template_);
-  auto* filter_chain =
-      findFilterChainHelper(10000, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  auto* filter_chain = findFilterChainHelper(10000, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
   EXPECT_NE(filter_chain, nullptr);
 }
 } // namespace Server

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -51,9 +51,11 @@ namespace Server {
 class MockFilterChainFactoryBuilder : public FilterChainFactoryBuilder {
   std::unique_ptr<Network::FilterChain>
   buildFilterChain(const ::envoy::api::v2::listener::FilterChain&) const override {
-    return nullptr;
+    // A place holder to be found
+    return std::make_unique<Network::MockFilterChain>();
   }
 };
+
 class FilterChainManagerImplTest : public testing::Test {
 public:
   void SetUp() override {
@@ -110,7 +112,7 @@ public:
 
   // Reuseable template
   const std::string filter_chain_yaml = R"EOF(
-    - filter_chain_match:
+      filter_chain_match:
         destination_port: 10000
       tls_context:
         common_tls_context:
@@ -131,14 +133,14 @@ public:
 };
 
 TEST_F(FilterChainManagerImplTest, FilterChainMatchNothing) {
-  const auto* filter_chain =
+  auto filter_chain =
       findFilterChainHelper(10000, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
   EXPECT_EQ(filter_chain, nullptr);
 }
 
 TEST_F(FilterChainManagerImplTest, AddSingleFilterChain) {
   addSingleFilterChainHelper(filter_chain_template_);
-  const auto* filter_chain =
+  auto* filter_chain =
       findFilterChainHelper(10000, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
   EXPECT_NE(filter_chain, nullptr);
 }

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -1,0 +1,123 @@
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/admin/v2alpha/config_dump.pb.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "common/api/os_sys_calls_impl.h"
+#include "common/config/metadata.h"
+#include "common/network/address_impl.h"
+#include "common/network/io_socket_handle_impl.h"
+#include "common/network/listen_socket_impl.h"
+#include "common/network/socket_option_impl.h"
+#include "common/network/utility.h"
+#include "common/protobuf/protobuf.h"
+
+#include "server/configuration_impl.h"
+#include "server/filter_chain_manager_impl.h"
+#include "server/listener_manager_impl.h"
+
+#include "extensions/filters/listener/original_dst/original_dst.h"
+#include "extensions/transport_sockets/tls/ssl_socket.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/server/utility.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/escaping.h"
+#include "absl/strings/match.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::InSequence;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::Throw;
+
+namespace Envoy {
+namespace Server {
+class FilterChainManagerImplTest : public testing::Test {
+public:
+  void SetUp() override {
+    local_address_.reset(new Network::Address::Ipv4Instance("127.0.0.1", 1234));
+    remote_address_.reset(new Network::Address::Ipv4Instance("127.0.0.1", 1234));
+  }
+
+  // Helper for test
+  const Network::FilterChain*
+  findFilterChainHelper(uint16_t destination_port, const std::string& destination_address,
+                        const std::string& server_name, const std::string& transport_protocol,
+                        const std::vector<std::string>& application_protocols,
+                        const std::string& source_address, uint16_t source_port) {
+    auto mock_socket = std::make_shared<NiceMock<Network::MockConnectionSocket>>();
+    sockets_.push_back(mock_socket);
+
+    if (absl::StartsWith(destination_address, "/")) {
+      local_address_ = std::make_shared<Network::Address::PipeInstance>(destination_address);
+    } else {
+      local_address_ =
+          Network::Utility::parseInternetAddress(destination_address, destination_port);
+    }
+    ON_CALL(*mock_socket, localAddress()).WillByDefault(ReturnRef(local_address_));
+
+    ON_CALL(*mock_socket, requestedServerName())
+        .WillByDefault(Return(absl::string_view(server_name)));
+    ON_CALL(*mock_socket, detectedTransportProtocol())
+        .WillByDefault(Return(absl::string_view(transport_protocol)));
+    ON_CALL(*mock_socket, requestedApplicationProtocols())
+        .WillByDefault(ReturnRef(application_protocols));
+
+    if (absl::StartsWith(source_address, "/")) {
+      remote_address_ = std::make_shared<Network::Address::PipeInstance>(source_address);
+    } else {
+      remote_address_ = Network::Utility::parseInternetAddress(source_address, source_port);
+    }
+    ON_CALL(*mock_socket, remoteAddress()).WillByDefault(ReturnRef(remote_address_));
+    return filter_chain_manager_.findFilterChain(*mock_socket);
+  }
+
+  void addFilterChainHelper(
+      uint16_t destination_port, const std::vector<std::string>& destination_ips,
+      const std::vector<std::string>& server_names, const std::string& transport_protocol,
+      const std::vector<std::string>& application_protocols,
+      const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
+      const std::vector<std::string>& source_ips,
+      const Protobuf::RepeatedField<Protobuf::uint32>& source_ports) {
+    Network::TransportSocketFactoryPtr dummy_mock_socketfactory{};
+    std::vector<Network::FilterFactoryCb> dummy_filter_factory{};
+    filter_chain_manager_.addFilterChain(
+        destination_port, destination_ips, server_names, transport_protocol, application_protocols,
+        source_type, source_ips, source_ports, std::move(dummy_mock_socketfactory),
+        std::move(dummy_filter_factory));
+  }
+
+  // Intermedia state
+  Network::Address::InstanceConstSharedPtr local_address_;
+  Network::Address::InstanceConstSharedPtr remote_address_;
+
+  std::vector<std::shared_ptr<Network::MockConnectionSocket>> sockets_;
+
+  // Test target
+  FilterChainManagerImpl filter_chain_manager_{
+      std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234),
+      ProtobufMessage::getNullValidationVisitor()};
+};
+
+TEST_F(FilterChainManagerImplTest, FilterChainMatchNothing) {
+  auto filter_chain =
+      findFilterChainHelper(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
+  EXPECT_EQ(filter_chain, nullptr);
+}
+} // namespace Server
+} // namespace Envoy

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -49,9 +49,10 @@ namespace Envoy {
 namespace Server {
 
 class MockFilterChainFactoryBuilder : public FilterChainFactoryBuilder {
+
   std::unique_ptr<Network::FilterChain>
   buildFilterChain(const ::envoy::api::v2::listener::FilterChain&) const override {
-    // A place holder to be found
+    // Wont dereference but require not nullptr.
     return std::make_unique<Network::MockFilterChain>();
   }
 };
@@ -128,8 +129,7 @@ public:
 
   // Test target
   FilterChainManagerImpl filter_chain_manager_{
-      std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234),
-      ProtobufMessage::getNullValidationVisitor()};
+      std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234)};
 };
 
 TEST_F(FilterChainManagerImplTest, FilterChainMatchNothing) {

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -52,7 +52,7 @@ class MockFilterChainFactoryBuilder : public FilterChainFactoryBuilder {
 
   std::unique_ptr<Network::FilterChain>
   buildFilterChain(const ::envoy::api::v2::listener::FilterChain&) const override {
-    // Wont dereference but require not nullptr.
+    // Won't dereference but requires not nullptr.
     return std::make_unique<Network::MockFilterChain>();
   }
 };
@@ -67,7 +67,6 @@ public:
         filter_chain_template_);
   }
 
-  // Helper for test
   const Network::FilterChain*
   findFilterChainHelper(uint16_t destination_port, const std::string& destination_address,
                         const std::string& server_name, const std::string& transport_protocol,
@@ -106,12 +105,12 @@ public:
         filter_chain_factory_builder_);
   }
 
-  // Intermedia state
+  // Intermedia states.
   Network::Address::InstanceConstSharedPtr local_address_;
   Network::Address::InstanceConstSharedPtr remote_address_;
   std::vector<std::shared_ptr<Network::MockConnectionSocket>> sockets_;
 
-  // Reuseable template
+  // Reuseable template.
   const std::string filter_chain_yaml = R"EOF(
       filter_chain_match:
         destination_port: 10000
@@ -127,7 +126,7 @@ public:
   envoy::api::v2::listener::FilterChain filter_chain_template_;
   MockFilterChainFactoryBuilder filter_chain_factory_builder_;
 
-  // Test target
+  // Test target.
   FilterChainManagerImpl filter_chain_manager_{
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234)};
 };

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -50,8 +50,8 @@ namespace Server {
 class FilterChainManagerImplTest : public testing::Test {
 public:
   void SetUp() override {
-    local_address_.reset(new Network::Address::Ipv4Instance("127.0.0.1", 1234));
-    remote_address_.reset(new Network::Address::Ipv4Instance("127.0.0.1", 1234));
+    local_address_ = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234);
+    remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 1234);
   }
 
   // Helper for test
@@ -115,7 +115,7 @@ public:
 };
 
 TEST_F(FilterChainManagerImplTest, FilterChainMatchNothing) {
-  auto filter_chain =
+  const auto* filter_chain =
       findFilterChainHelper(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
   EXPECT_EQ(filter_chain, nullptr);
 }

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -2349,7 +2349,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithOverlappi
 
   EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException,
-                            "error adding listener: multiple filter chains with "
+                            "error adding listener '127.0.0.1:1234': multiple filter chains with "
                             "overlapping matching rules are defined");
 }
 


### PR DESCRIPTION
Description:
This PR is a follow up of https://github.com/envoyproxy/envoy/pull/7152
The background is FilterChainDiscoveryService(does not exist yet) will update filterchain independently from LDS. 

What this PR does:
1. Moving more factory logic from listener to filter chain manager.
2. Recover the exception message where binded address is lost in #7152 
4.  A scaffold of FilterChainManagerImplTest but not utilized fully.
As this PR is not that trivial, the tests are not moved test from `ListenerTest`. Will do in following PRs.

Risk Level: Mid
Testing: existing Listener test.

