### PR TITLE
orca: split cost and utilization into separate maps.

### DIFF
--- a/api/udpa/data/orca/v1/orca_load_report.proto
+++ b/api/udpa/data/orca/v1/orca_load_report.proto
@@ -26,10 +26,11 @@ message OrcaLoadReport {
   // responsible for.
   uint64 rps = 3;
 
-  // Application specific requests costs. Each value may be an absolute cost (e.g.
-  // 3487 bytes of storage) or utilization associated with the request,
-  // expressed as a fraction of total resources available. Utilization
-  // metrics should be derived from a sample or measurement taken
-  // during the request.
-  map<string, double> request_cost_or_utilization = 4;
+  // Application specific requests costs. Each value is an absolute cost (e.g. 3487 bytes of
+  // storage) associated with the request.
+  map<string, double> request_cost = 4;
+
+  // Resource utilization values. Each value is expressed as a fraction of total resources
+  // available, derived from the latest sample or measurement.
+  map<string, double> utilization = 5;
 }

--- a/api/udpa/data/orca/v1/orca_load_report.proto
+++ b/api/udpa/data/orca/v1/orca_load_report.proto
@@ -31,5 +31,6 @@ message OrcaLoadReport {
 
   // Resource utilization values. Each value is expressed as a fraction of total resources
   // available, derived from the latest sample or measurement.
-  map<string, double> utilization = 5;
+  map<string, double> utilization = 5
+      [(validate.rules).map.values.double.gte = 0, (validate.rules).map.values.double.lte = 1];
 }

--- a/api/udpa/data/orca/v1/orca_load_report.proto
+++ b/api/udpa/data/orca/v1/orca_load_report.proto
@@ -14,12 +14,11 @@ import "validate/validate.proto";
 
 message OrcaLoadReport {
   // CPU utilization expressed as a fraction of available CPU resources. This
-  // should be derived from a sample or measurement taken during the request.
+  // should be derived from the latest sample or measurement.
   double cpu_utilization = 1 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
   // Memory utilization expressed as a fraction of available memory
-  // resources. This should be derived from a sample or measurement taken
-  // during the request.
+  // resources. This should be derived from the latest sample or measurement.
   double mem_utilization = 2 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
   // Total RPS being served by an endpoint. This should cover all services that an endpoint is


### PR DESCRIPTION
Signed-off-by: Kun Zhang <zhangkun@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
The cost and utilization are fundamentally different in the way they
are defined.  There is no benefit to stuff them together, and only
causes confusion and difficulties in aggregation should anyone ever
try to do it.

Risk Level:
Low

Testing:
N/A

Docs Changes:
N/A

Release Notes:
N/A