### PR TITLE
stats: Resolve loss of importMode for gauges that are initialized first, then merged.

### DIFF
--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -97,11 +97,8 @@ public:
    */
   struct Flags {
     static const uint8_t Used = 0x01;
-    // TODO(fredlas) these logic flags should be removed if we move to indicating combine logic in
-    // the stat declaration macros themselves. (Now that stats no longer use shared memory, it's
-    // safe to mess with what these flag bits mean whenever we want).
     static const uint8_t LogicAccumulate = 0x02;
-    static const uint8_t ImportModeUninitialized = 0x04; // Stat was discovered during import.
+    static const uint8_t NeverImport = 0x04;
   };
   virtual SymbolTable& symbolTable() PURE;
   virtual const SymbolTable& constSymbolTable() const PURE;

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -180,6 +180,8 @@ public:
 
     switch (import_mode) {
     case ImportMode::Uninitialized:
+      // mergeImportNode(ImportMode::Uninitialized) is called when merging an
+      // existing stat with importMode() == Accumulate or NeverImport.
       break;
     case ImportMode::Accumulate:
       ASSERT(current == ImportMode::Uninitialized);

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -173,15 +173,20 @@ public:
   }
 
   void mergeImportMode(ImportMode import_mode) override {
+    ImportMode current = importMode();
+    if (current == import_mode) {
+      return;
+    }
+
     switch (import_mode) {
     case ImportMode::Uninitialized:
       break;
     case ImportMode::Accumulate:
-      ASSERT(canTransitionToImportMode(ImportMode::Accumulate));
+      ASSERT(current == ImportMode::Uninitialized);
       data_.flags_ |= Flags::LogicAccumulate;
       break;
     case ImportMode::NeverImport:
-      ASSERT(canTransitionToImportMode(ImportMode::NeverImport));
+      ASSERT(current == ImportMode::Uninitialized);
       // A previous revision of Envoy may have transferred a gauge that it
       // thought was Accumulate. But the new version thinks it's NeverImport, so
       // we clear the accumulated value.
@@ -195,11 +200,6 @@ public:
   SymbolTable& symbolTable() override { return alloc_.symbolTable(); }
 
 protected:
-  bool canTransitionToImportMode(ImportMode new_import_mode) const {
-    ImportMode current = importMode();
-    return current == ImportMode::Uninitialized || current == new_import_mode;
-  }
-
   StatData& data_;
   StatDataAllocatorImpl<StatData>& alloc_;
 };

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -119,15 +119,19 @@ public:
             absl::string_view tag_extracted_name, const std::vector<Tag>& tags,
             ImportMode import_mode)
       : MetricImpl(tag_extracted_name, tags, alloc.symbolTable()), data_(data), alloc_(alloc) {
-    if (import_mode == ImportMode::Accumulate) {
+    switch (import_mode) {
+    case ImportMode::Accumulate:
       data_.flags_ |= Flags::LogicAccumulate;
-    } else if (import_mode == ImportMode::NeverImport) {
+      break;
+    case ImportMode::NeverImport:
       data_.flags_ |= Flags::NeverImport;
-    } else {
+      break;
+    case ImportMode::Uninitialized:
       // Note that we don't clear any flag bits for import_mode==Uninitialized,
       // as we may have an established import_mode when this stat was created in
       // an alternate scope. See
       // https://github.com/envoyproxy/envoy/issues/7227.
+      break;
     }
   }
   ~GaugeImpl() override {

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -119,10 +119,15 @@ public:
             absl::string_view tag_extracted_name, const std::vector<Tag>& tags,
             ImportMode import_mode)
       : MetricImpl(tag_extracted_name, tags, alloc.symbolTable()), data_(data), alloc_(alloc) {
-    if (import_mode == ImportMode::Uninitialized) {
-      data_.flags_ |= Flags::ImportModeUninitialized;
-    } else if (import_mode == ImportMode::Accumulate) {
+    if (import_mode == ImportMode::Accumulate) {
       data_.flags_ |= Flags::LogicAccumulate;
+    } else if (import_mode == ImportMode::NeverImport) {
+      data_.flags_ |= Flags::NeverImport;
+    } else {
+      // Note that we don't clear any flag bits for import_mode==Uninitialized,
+      // as we may have an established import_mode when this stat was created in
+      // an alternate scope. See
+      // https://github.com/envoyproxy/envoy/issues/7227.
     }
   }
   ~GaugeImpl() override {
@@ -155,29 +160,30 @@ public:
   bool used() const override { return data_.flags_ & Flags::Used; }
 
   ImportMode importMode() const override {
-    if (data_.flags_ & Flags::ImportModeUninitialized) {
-      return ImportMode::Uninitialized;
+    if (data_.flags_ & Flags::NeverImport) {
+      return ImportMode::NeverImport;
     } else if (data_.flags_ & Flags::LogicAccumulate) {
       return ImportMode::Accumulate;
     }
-    return ImportMode::NeverImport;
+    return ImportMode::Uninitialized;
   }
 
   void mergeImportMode(ImportMode import_mode) override {
-    if (import_mode != ImportMode::Uninitialized &&
-        (data_.flags_ & Flags::ImportModeUninitialized)) {
-      data_.flags_ &= ~Flags::ImportModeUninitialized;
-      if (import_mode == ImportMode::Accumulate) {
-        data_.flags_ |= Flags::LogicAccumulate;
-      } else {
-        // A previous revision of Envoy must have transferred a gauge that it
-        // thought was Accumulate. But the new version thinks its NeverImport,
-        // so we clear the accumulated value.
-        data_.value_ = 0;
-        data_.flags_ &= ~Flags::Used;
-      }
+    ImportMode current = importMode();
+    if (import_mode == ImportMode::Uninitialized || current == import_mode) {
+      return;
+    }
+
+    ASSERT(current == ImportMode::Uninitialized);
+    if (import_mode == ImportMode::Accumulate) {
+      data_.flags_ |= Flags::LogicAccumulate;
     } else {
-      ASSERT(importMode() == import_mode);
+      // A previous revision of Envoy may have transferred a gauge that it
+      // thought was Accumulate. But the new version thinks it's NeverImport, so
+      // we clear the accumulated value.
+      data_.value_ = 0;
+      data_.flags_ &= ~Flags::Used;
+      data_.flags_ |= Flags::NeverImport;
     }
   }
 

--- a/source/common/stats/stat_merger.cc
+++ b/source/common/stats/stat_merger.cc
@@ -1,7 +1,5 @@
 #include "common/stats/stat_merger.h"
 
-#include <regex>
-
 namespace Envoy {
 namespace Stats {
 
@@ -15,15 +13,34 @@ void StatMerger::mergeCounters(const Protobuf::Map<std::string, uint64_t>& count
 
 void StatMerger::mergeGauges(const Protobuf::Map<std::string, uint64_t>& gauges) {
   for (const auto& gauge : gauges) {
+    // Merging gauges via RPC from the parent has 3 case; case 2 and 4b are the
+    // most common.
+    //
+    // 1. Parent process thinks gauge is NeverImport: no data sent, and we
+    //    do not run this loop for such a gauge. Only if the parent process
+    //    thinks the gauge is Accumulate do we consider cases 2-4.
+    // 2. Child thinks gauge is Accumulate : data is combined in
+    //    gauge_ref.add() below.
+    // 3. Child thinks gauge is NeverImport: we skip this loop entry via
+    //    'continue'.
+    // 4. Child has not yet initialized gauge yet -- this merge is the
+    //    first time the child learns of the gauge. It's possible the child
+    //    will think the gauge is NeverImport due to a code change. But for
+    //    now we will leave the gauge in the child process as
+    //    import_mode==Uninitialized, and accumulate the parent value in
+    //    gauge_ref.add(). Gauges in this mode will not be included in
+    //    stats-sinks or the admin /stats calls, until the child initializes
+    //    the gauge, in which case:
+    // 4a. Child later initializes gauges as NeverImport: the parent value is
+    //     cleared during the mergeImportMode call.
+    // 4b. Child later initializes gauges as Accumulate: the parent value is
+    //     retained.
+
     StatNameManagedStorage storage(gauge.first, temp_scope_->symbolTable());
     StatName stat_name = storage.statName();
     absl::optional<std::reference_wrapper<const Gauge>> gauge_opt =
         temp_scope_->findGauge(stat_name);
 
-    // If the stat named in the protobuf map is already initialized, and has a
-    // mode of NeverImport, then we simply skip over the map entry. This is a
-    // case where a new revision of Envoy has been built where a previously
-    // Accumulated gauge has been switched to NeverImport mode.
     Gauge::ImportMode import_mode = Gauge::ImportMode::Uninitialized;
     if (gauge_opt) {
       import_mode = gauge_opt->get().importMode();
@@ -32,23 +49,16 @@ void StatMerger::mergeGauges(const Protobuf::Map<std::string, uint64_t>& gauges)
       }
     }
 
-    // We establish here a tentative import-mode of Uninitialized. Gauges in
-    // this mode will not be reported in stats sinks or in the admin /stats
-    // endpoint. However, we'll retain the transferred value, and if the running
-    // system initialized the stat as Accumulate, we'll have the accumulated
-    // value ready to go. If the system re-initializes it as NeverImport, we'll
-    // clear the value during the mergeImportMode call.
     auto& gauge_ref = temp_scope_->gaugeFromStatName(stat_name, import_mode);
     uint64_t& parent_value_ref = parent_gauge_values_[gauge_ref.statName()];
     uint64_t old_parent_value = parent_value_ref;
     uint64_t new_parent_value = gauge.second;
     parent_value_ref = new_parent_value;
 
-    if (new_parent_value > old_parent_value) {
-      gauge_ref.add(new_parent_value - old_parent_value);
-    } else {
-      gauge_ref.sub(old_parent_value - new_parent_value);
-    }
+    // Note that new_parent_value may be less than old_parent_value, in which
+    // case 2s complement does its magic (-1 == 0xffffffffffffffff) and adding
+    // that to the gauge's current value works the same as subtraction.
+    gauge_ref.add(new_parent_value - old_parent_value);
   }
 }
 

--- a/source/common/stats/stat_merger.cc
+++ b/source/common/stats/stat_merger.cc
@@ -13,7 +13,7 @@ void StatMerger::mergeCounters(const Protobuf::Map<std::string, uint64_t>& count
 
 void StatMerger::mergeGauges(const Protobuf::Map<std::string, uint64_t>& gauges) {
   for (const auto& gauge : gauges) {
-    // Merging gauges via RPC from the parent has 3 case; case 2 and 4b are the
+    // Merging gauges via RPC from the parent has 4 cases; case 2 and 4b are the
     // most common.
     //
     // 1. Parent process thinks gauge is NeverImport: no data sent, and we
@@ -22,7 +22,9 @@ void StatMerger::mergeGauges(const Protobuf::Map<std::string, uint64_t>& gauges)
     // 2. Child thinks gauge is Accumulate : data is combined in
     //    gauge_ref.add() below.
     // 3. Child thinks gauge is NeverImport: we skip this loop entry via
-    //    'continue'.
+    //    'continue'. This only happens with a code-change where the child
+    //    contains a code-change relative to parent, switching a Gauge from
+    //    Accumulate to NeverImport.
     // 4. Child has not yet initialized gauge yet -- this merge is the
     //    first time the child learns of the gauge. It's possible the child
     //    will think the gauge is NeverImport due to a code change. But for

--- a/test/common/stats/stat_merger_test.cc
+++ b/test/common/stats/stat_merger_test.cc
@@ -207,7 +207,6 @@ TEST_F(StatMergerThreadLocalTest, newStatFromParent) {
   {
     StatMerger stat_merger(store_);
 
-    Protobuf::Map<std::string, uint64_t> counter_values;
     Protobuf::Map<std::string, uint64_t> counter_deltas;
     Protobuf::Map<std::string, uint64_t> gauges;
     counter_deltas["newcounter0"] = 0;
@@ -229,6 +228,19 @@ TEST_F(StatMergerThreadLocalTest, newStatFromParent) {
   EXPECT_FALSE(TestUtility::findCounter(store_, "newcounter2"));
   EXPECT_TRUE(TestUtility::findGauge(store_, "newgauge1"));
   EXPECT_FALSE(TestUtility::findGauge(store_, "newgauge2"));
+}
+
+TEST_F(StatMergerThreadLocalTest, retainImportModeAfterMerge) {
+  Gauge& gauge = store_.gauge("mygauge", Gauge::ImportMode::Accumulate);
+  EXPECT_EQ(Gauge::ImportMode::Accumulate, gauge.importMode());
+  {
+    StatMerger stat_merger(store_);
+    Protobuf::Map<std::string, uint64_t> counter_deltas;
+    Protobuf::Map<std::string, uint64_t> gauges;
+    gauges["mygauge"] = 1;
+    stat_merger.mergeStats(counter_deltas, gauges);
+  }
+  EXPECT_EQ(Gauge::ImportMode::Accumulate, gauge.importMode());
 }
 
 } // namespace

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -116,6 +116,10 @@ do
     --max-obj-name-len 500 2>&1)
   check [ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]
 
+  # Verify we can see server.live in the admin port.
+  SERVER_LIVE_0=$(curl -sg http://${ADMIN_ADDRESS_0}/stats | grep server.live)
+  check [ "$SERVER_LIVE_0" = "server.live: 1" ];
+
   enableHeapCheck
 
   start_test Starting epoch 1
@@ -128,6 +132,10 @@ do
 
   # Wait for stat flushing
   sleep 7
+
+  ADMIN_ADDRESS_1=$(cat "${ADMIN_ADDRESS_PATH_1}")
+  SERVER_LIVE_1=$(curl -sg http://${ADMIN_ADDRESS_1}/stats | grep server.live)
+  check [ "$SERVER_LIVE_1" = "server.live: 2" ];
 
   start_test Checking that listener addresses have not changed
   HOT_RESTART_JSON_1="${TEST_TMPDIR}"/hot_restart.1."${TEST_INDEX}".yaml


### PR DESCRIPTION
Description: Fixes a problem where a gauge that was first created by the child process would then not import correctly from the parent, adding unit-test and system-test for this. The code looked like it handled this, but the problem was that we were doing a scope lookup for the old stat and that was failing, but the stat was in the alloc table and so should have been re-used.

The cleanest way I could think of to fix this was to change the flag-bits so that all zeros mean Uninitialized, which is how HeapStatData::alloc allocates new stats. Then, when constructing the Gauge object in a scope, we can simply respect those bits if they are set. 
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Fixes: #7227 

