### PR TITLE
filter: check if connection is open before and after filter read/write

### DIFF
--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -95,8 +95,8 @@ FilterStatus FilterManagerImpl::onWrite(ActiveWriteFilter* filter,
   for (; entry != downstream_filters_.end(); entry++) {
     StreamBuffer write_buffer = buffer_source.getWriteBuffer();
     FilterStatus status = (*entry)->filter_->onWrite(write_buffer.buffer, write_buffer.end_stream);
-    if (status == FilterStatus::StopIteration) {
-      return status;
+    if (status == FilterStatus::StopIteration || connection_.state() != Connection::State::Open) {
+      return FilterStatus::StopIteration;
     }
   }
 

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -109,7 +109,7 @@ TEST_F(NetworkFilterManagerTest, All) {
   manager.onWrite();
 }
 
-TEST_F(NetworkFilterManagerTest, CloseConnectionAndReturnStop) {
+TEST_F(NetworkFilterManagerTest, CloseConnectionAndReturnContinue) {
   InSequence s;
 
   Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -109,7 +109,7 @@ TEST_F(NetworkFilterManagerTest, All) {
   manager.onWrite();
 }
 
-TEST_F(NetworkFilterManagerTest, CloseConnectionAndReturnContinue) {
+TEST_F(NetworkFilterManagerTest, ConnectionClosedBeforeRunningFilter) {
   InSequence s;
 
   Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
@@ -123,28 +123,48 @@ TEST_F(NetworkFilterManagerTest, CloseConnectionAndReturnContinue) {
   read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
   EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
 
-  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::StopIteration));
-  EXPECT_EQ(manager.initializeReadFilters(), true);
-
-  EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
-  read_filter->callbacks_->continueReading();
-
-  read_buffer_.add("hello");
-  read_end_stream_ = false;
-  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Open));
-  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), false))
-      .WillOnce(Return(FilterStatus::Continue));
   EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closing));
+  EXPECT_CALL(*read_filter, onNewConnection()).Times(0);
+  EXPECT_CALL(*read_filter, onData(_, _)).Times(0);
+  EXPECT_CALL(*filter, onNewConnection()).Times(0);
   EXPECT_CALL(*filter, onData(_, _)).Times(0);
   manager.onRead();
 
-  write_end_stream_ = false;
   EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closed));
   EXPECT_CALL(*filter, onWrite(_, _)).Times(0);
   manager.onWrite();
 }
 
-TEST_F(NetworkFilterManagerTest, CloseConnectionAndCallback) {
+TEST_F(NetworkFilterManagerTest, FilterReturnStopAndNoCallback) {
+  InSequence s;
+
+  Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
+  MockReadFilter* read_filter(new MockReadFilter());
+  MockWriteFilter* write_filter(new MockWriteFilter());
+  MockFilter* filter(new LocalMockFilter());
+
+  FilterManagerImpl manager(connection_);
+  manager.addReadFilter(ReadFilterSharedPtr{read_filter});
+  manager.addWriteFilter(WriteFilterSharedPtr{write_filter});
+  manager.addFilter(FilterSharedPtr{filter});
+
+  read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
+  EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
+
+  read_buffer_.add("hello");
+  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), _))
+      .WillOnce(Return(FilterStatus::StopIteration));
+  EXPECT_CALL(*filter, onNewConnection()).Times(0);
+  EXPECT_CALL(*filter, onData(_, _)).Times(0);
+  manager.onRead();
+
+  EXPECT_CALL(*filter, onWrite(_, _)).WillOnce(Return(FilterStatus::StopIteration));
+  EXPECT_CALL(*write_filter, onWrite(_, _)).Times(0);
+  manager.onWrite();
+}
+
+TEST_F(NetworkFilterManagerTest, ReadFilterCloseConnectionAndReturnContinue) {
   InSequence s;
 
   Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
@@ -158,26 +178,132 @@ TEST_F(NetworkFilterManagerTest, CloseConnectionAndCallback) {
   read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
   EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
 
-  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::StopIteration));
+  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
   EXPECT_EQ(manager.initializeReadFilters(), true);
 
+  read_buffer_.add("hello");
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Open));
+  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), _))
+      .WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closing));
+  EXPECT_CALL(*filter, onData(_, _)).Times(0);
+  manager.onRead();
+
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closed));
+  EXPECT_CALL(*filter, onWrite(_, _)).Times(0);
+  manager.onWrite();
+}
+
+TEST_F(NetworkFilterManagerTest, WriteFilterCloseConnectionAndReturnContinue) {
+  InSequence s;
+
+  Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
+  MockReadFilter* read_filter(new MockReadFilter());
+  MockWriteFilter* write_filter(new MockWriteFilter());
+  MockFilter* filter(new LocalMockFilter());
+
+  FilterManagerImpl manager(connection_);
+  manager.addReadFilter(ReadFilterSharedPtr{read_filter});
+  manager.addWriteFilter(WriteFilterSharedPtr{write_filter});
+  manager.addFilter(FilterSharedPtr{filter});
+
+  read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
+  EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
+
+  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
   EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
-  read_filter->callbacks_->continueReading();
+  EXPECT_EQ(manager.initializeReadFilters(), true);
 
   read_buffer_.add("hello");
-  read_end_stream_ = false;
-  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), false))
+  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), _))
+      .WillOnce(Return(FilterStatus::StopIteration));
+  manager.onRead();
+
+  read_buffer_.add("world");
+  EXPECT_CALL(*filter, onData(BufferStringEqual("helloworld"), _))
+      .WillOnce(Return(FilterStatus::Continue));
+  read_filter->callbacks_->continueReading();
+
+  write_buffer_.add("foo");
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Open));
+  EXPECT_CALL(*filter, onWrite(BufferStringEqual("foo"), _))
+      .WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closing));
+  EXPECT_CALL(*write_filter, onWrite(_, _)).Times(0);
+  manager.onWrite();
+}
+
+TEST_F(NetworkFilterManagerTest, ReadCloseConnectionReturnStopAndCallback) {
+  InSequence s;
+
+  Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
+  MockReadFilter* read_filter(new MockReadFilter());
+  MockWriteFilter* write_filter(new MockWriteFilter());
+  MockFilter* filter(new LocalMockFilter());
+
+  FilterManagerImpl manager(connection_);
+  manager.addReadFilter(ReadFilterSharedPtr{read_filter});
+  manager.addWriteFilter(WriteFilterSharedPtr{write_filter});
+  manager.addFilter(FilterSharedPtr{filter});
+
+  read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
+  EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
+
+  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  EXPECT_EQ(manager.initializeReadFilters(), true);
+
+  read_buffer_.add("hello");
+  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), _))
       .WillOnce(Return(FilterStatus::StopIteration));
   manager.onRead();
 
   EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closing));
   EXPECT_CALL(*filter, onData(_, _)).Times(0);
-
   read_filter->callbacks_->continueReading();
 
-  write_end_stream_ = false;
   EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closed));
   EXPECT_CALL(*filter, onWrite(_, _)).Times(0);
+  manager.onWrite();
+}
+
+TEST_F(NetworkFilterManagerTest, WriteCloseConnectionReturnStopAndCallback) {
+  InSequence s;
+
+  Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
+  MockReadFilter* read_filter(new MockReadFilter());
+  MockWriteFilter* write_filter(new MockWriteFilter());
+  MockFilter* filter(new LocalMockFilter());
+
+  FilterManagerImpl manager(connection_);
+  manager.addReadFilter(ReadFilterSharedPtr{read_filter});
+  manager.addWriteFilter(WriteFilterSharedPtr{write_filter});
+  manager.addFilter(FilterSharedPtr{filter});
+
+  read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionConstSharedPtr{host_description});
+  EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
+
+  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  EXPECT_EQ(manager.initializeReadFilters(), true);
+
+  read_buffer_.add("hello");
+  EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello"), _))
+      .WillOnce(Return(FilterStatus::Continue));
+  EXPECT_CALL(*filter, onData(BufferStringEqual("hello"), _))
+      .WillOnce(Return(FilterStatus::Continue));
+  manager.onRead();
+
+  write_buffer_.add("foo");
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Open));
+  EXPECT_CALL(*filter, onWrite(BufferStringEqual("foo"), _))
+      .WillOnce(Return(FilterStatus::StopIteration));
+  manager.onWrite();
+
+  EXPECT_CALL(connection_, state()).WillOnce(Return(Connection::State::Closed));
+  EXPECT_CALL(*filter, onWrite(_, _)).Times(0);
+  EXPECT_CALL(*write_filter, onWrite(_, _)).Times(0);
   manager.onWrite();
 }
 


### PR DESCRIPTION
Signed-off-by: Yan Xue <yxyan@google.com>

Description: Check if connection is open before and after filter read/write. In `onData` or `onWrite`, filter could close the underlying connection.
Risk Level: Low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
