### PR TITLE
server: drop unused dependency on tls from config_validation

### DIFF
--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -104,7 +104,6 @@ envoy_cc_library(
         "//source/common/runtime:runtime_lib",
         "//source/common/stats:stats_lib",
         "//source/common/thread_local:thread_local_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//source/server:configuration_lib",
         "//source/server:server_lib",
         "//source/server/http:admin_lib",

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -25,8 +25,6 @@
 #include "server/listener_manager_impl.h"
 #include "server/server.h"
 
-#include "extensions/transport_sockets/tls/context_manager_impl.h"
-
 #include "absl/types/optional.h"
 
 namespace Envoy {


### PR DESCRIPTION
Description: drop unused dependency on TLS from `config_validation`
Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
