### PR TITLE
Remove the http1 connection pool delay.

### DIFF
--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -113,8 +113,7 @@ protected:
   void onConnectionEvent(ActiveClient& client, Network::ConnectionEvent event);
   void onDownstreamReset(ActiveClient& client);
   void onResponseComplete(ActiveClient& client);
-  void onUpstreamReady();
-  void processIdleClient(ActiveClient& client, bool delay);
+  void processIdleClient(ActiveClient& client);
 
   Stats::TimespanPtr conn_connect_ms_;
   Event::Dispatcher& dispatcher_;
@@ -122,8 +121,6 @@ protected:
   std::list<ActiveClientPtr> busy_clients_;
   std::list<DrainedCb> drained_callbacks_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
-  Event::TimerPtr upstream_ready_timer_;
-  bool upstream_ready_enabled_{false};
 };
 
 /**

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -43,12 +43,10 @@ namespace {
 class ConnPoolImplForTest : public ConnPoolImpl {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher,
-                      Upstream::ClusterInfoConstSharedPtr cluster,
-                      NiceMock<Event::MockTimer>* upstream_ready_timer)
+                      Upstream::ClusterInfoConstSharedPtr cluster)
       : ConnPoolImpl(dispatcher, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
                      Upstream::ResourcePriority::Default, nullptr),
-        api_(Api::createApiForTest()), mock_dispatcher_(dispatcher),
-        mock_upstream_ready_timer_(upstream_ready_timer) {}
+        api_(Api::createApiForTest()), mock_dispatcher_(dispatcher) {}
 
   ~ConnPoolImplForTest() {
     EXPECT_EQ(0U, ready_clients_.size());
@@ -102,20 +100,8 @@ public:
     ON_CALL(*test_client.codec_, protocol()).WillByDefault(Return(protocol));
   }
 
-  void expectEnableUpstreamReady() {
-    EXPECT_FALSE(upstream_ready_enabled_);
-    EXPECT_CALL(*mock_upstream_ready_timer_, enableTimer(_)).Times(1).RetiresOnSaturation();
-  }
-
-  void expectAndRunUpstreamReady() {
-    EXPECT_TRUE(upstream_ready_enabled_);
-    mock_upstream_ready_timer_->callback_();
-    EXPECT_FALSE(upstream_ready_enabled_);
-  }
-
   Api::ApiPtr api_;
   Event::MockDispatcher& mock_dispatcher_;
-  NiceMock<Event::MockTimer>* mock_upstream_ready_timer_;
   std::vector<TestCodecClient> test_clients_;
 };
 
@@ -124,9 +110,7 @@ public:
  */
 class Http1ConnPoolImplTest : public testing::Test {
 public:
-  Http1ConnPoolImplTest()
-      : upstream_ready_timer_(new NiceMock<Event::MockTimer>(&dispatcher_)),
-        conn_pool_(dispatcher_, cluster_, upstream_ready_timer_) {}
+  Http1ConnPoolImplTest() : conn_pool_(dispatcher_, cluster_) {}
 
   ~Http1ConnPoolImplTest() {
     EXPECT_TRUE(TestUtility::gaugesZeroed(cluster_->stats_store_.gauges()));
@@ -134,7 +118,6 @@ public:
 
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
-  NiceMock<Event::MockTimer>* upstream_ready_timer_;
   ConnPoolImplForTest conn_pool_;
   NiceMock<Runtime::MockLoader> runtime_;
 };
@@ -470,7 +453,6 @@ TEST_F(Http1ConnPoolImplTest, MaxConnections) {
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   // Finishing request 1 will immediately bind to request 2.
-  conn_pool_.expectEnableUpstreamReady();
   EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
       .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
   EXPECT_CALL(callbacks2.pool_ready_, ready());
@@ -479,7 +461,6 @@ TEST_F(Http1ConnPoolImplTest, MaxConnections) {
   Http::HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
-  conn_pool_.expectAndRunUpstreamReady();
   callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
   // N.B. clang_tidy insists that we use std::make_unique which can not infer std::initialize_list.
   response_headers = std::make_unique<TestHeaderMapImpl>(
@@ -487,69 +468,6 @@ TEST_F(Http1ConnPoolImplTest, MaxConnections) {
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
   // Cause the connection to go away.
-  EXPECT_CALL(conn_pool_, onClientDestroy());
-  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-  dispatcher_.clearDeferredDeleteList();
-}
-
-/**
- * Test when upstream closes connection without 'connection: close' like
- * https://github.com/envoyproxy/envoy/pull/2715
- */
-TEST_F(Http1ConnPoolImplTest, ConnectionCloseWithoutHeader) {
-  InSequence s;
-
-  // Request 1 should kick off a new connection.
-  NiceMock<Http::MockStreamDecoder> outer_decoder1;
-  ConnPoolCallbacks callbacks;
-  conn_pool_.expectClientCreate();
-  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder1, callbacks);
-
-  EXPECT_NE(nullptr, handle);
-
-  // Request 2 should not kick off a new connection.
-  NiceMock<Http::MockStreamDecoder> outer_decoder2;
-  ConnPoolCallbacks callbacks2;
-  handle = conn_pool_.newStream(outer_decoder2, callbacks2);
-  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_overflow_.value());
-
-  EXPECT_NE(nullptr, handle);
-
-  // Connect event will bind to request 1.
-  NiceMock<Http::MockStreamEncoder> request_encoder;
-  Http::StreamDecoder* inner_decoder;
-  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
-      .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
-  EXPECT_CALL(callbacks.pool_ready_, ready());
-
-  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
-
-  // Finishing request 1 will schedule binding the connection to request 2.
-  conn_pool_.expectEnableUpstreamReady();
-
-  callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
-  Http::HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
-  inner_decoder->decodeHeaders(std::move(response_headers), true);
-
-  // Cause the connection to go away.
-  conn_pool_.expectClientCreate();
-  EXPECT_CALL(conn_pool_, onClientDestroy());
-  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-  dispatcher_.clearDeferredDeleteList();
-
-  conn_pool_.expectAndRunUpstreamReady();
-
-  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
-      .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
-  EXPECT_CALL(callbacks2.pool_ready_, ready());
-  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
-
-  callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
-  // N.B. clang_tidy insists that we use std::make_unique which can not infer std::initialize_list.
-  response_headers = std::make_unique<TestHeaderMapImpl>(
-      std::initializer_list<std::pair<std::string, std::string>>{{":status", "200"}});
-  inner_decoder->decodeHeaders(std::move(response_headers), true);
-
   EXPECT_CALL(conn_pool_, onClientDestroy());
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
@@ -702,11 +620,9 @@ TEST_F(Http1ConnPoolImplTest, ConcurrentConnections) {
   ActiveTestRequest r3(*this, 0, ActiveTestRequest::Type::Pending);
 
   // Finish r1, which gets r3 going.
-  conn_pool_.expectEnableUpstreamReady();
   r3.expectNewStream();
 
   r1.completeResponse(false);
-  conn_pool_.expectAndRunUpstreamReady();
   r3.startRequest();
   EXPECT_EQ(3U, cluster_->stats_.upstream_rq_total_.value());
 


### PR DESCRIPTION
Remove the http1 connection pool delay.

This feature is incomplete in that libevent doesn't guarantee ordering of events
so delaying for a single poll cycle does not address the issue.
Also because the connection is left in the ready queue it is
available for another request coming in the same pool cycle or
in the next poll cycle before ready connection is processed.
Finally, this would only catch connections closed immediately
which should be very infrequent since the HTTP/1.0 fix which
eliminated those cases where a missing Connection: keep-alive
was not interpreted as Connection: close, resulting in reuse
of a connection which was immedately closed.

See https://github.com/envoyproxy/envoy/pull/7159 for details.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level: low
Testing: existing tests
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
