### PR TITLE
fuzz: replace invalid characters *everywhere* (in virtual hosts)

### DIFF
--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5731276071370752
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5731276071370752
@@ -1,0 +1,27 @@
+config {
+  virtual_hosts {
+    name: "e"
+    domains: "e"
+    cors {
+      filter_enabled {
+        default_value {
+        }
+      }
+      shadow_enabled {
+        default_value {
+        }
+      }
+    }
+    response_headers_to_add {
+      header {
+        key: "A\000\000\000\000\000\000\000"
+      }
+    }
+  }
+  vhds {
+    config_source {
+      ads {
+      }
+    }
+  }
+}

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -11,20 +11,38 @@ namespace Envoy {
 namespace Router {
 namespace {
 
-// Return a new RouteConfiguration with invalid characters replaces in all header fields.
-envoy::api::v2::RouteConfiguration
-replaceInvalidHeaders(envoy::api::v2::RouteConfiguration route_config) {
-  envoy::api::v2::RouteConfiguration clean_config = route_config;
+// A templated method to replace invalid characters in a protocol buffer that contains
+// (request/response)_headers_to_(add/remove).
+template <class T> T replaceInvalidHeaders(const T& config) {
+  T clean_config = config;
   clean_config.mutable_request_headers_to_add()->CopyFrom(
-      Fuzz::replaceInvalidHeaders(route_config.request_headers_to_add()));
+      Fuzz::replaceInvalidHeaders(config.request_headers_to_add()));
   clean_config.mutable_response_headers_to_add()->CopyFrom(
-      Fuzz::replaceInvalidHeaders(route_config.response_headers_to_add()));
-  auto internal_only_headers = clean_config.mutable_internal_only_headers();
-  std::for_each(internal_only_headers->begin(), internal_only_headers->end(),
-                [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+      Fuzz::replaceInvalidHeaders(config.response_headers_to_add()));
   auto request_headers_to_remove = clean_config.mutable_request_headers_to_remove();
   std::for_each(request_headers_to_remove->begin(), request_headers_to_remove->end(),
                 [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+  auto response_headers_to_remove = clean_config.mutable_response_headers_to_remove();
+  std::for_each(response_headers_to_remove->begin(), response_headers_to_remove->end(),
+                [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+  return clean_config;
+}
+
+// Removes invalid headers from the RouteConfiguration as well as in each of the virtual hosts.
+envoy::api::v2::RouteConfiguration
+cleanRouteConfig(envoy::api::v2::RouteConfiguration route_config) {
+  envoy::api::v2::RouteConfiguration clean_config =
+      replaceInvalidHeaders<envoy::api::v2::RouteConfiguration>(route_config);
+  auto internal_only_headers = clean_config.mutable_internal_only_headers();
+  std::for_each(internal_only_headers->begin(), internal_only_headers->end(),
+                [](std::string& n) { n = Fuzz::replaceInvalidCharacters(n); });
+  // Remove invalid characters in each virtual host.
+  auto virtual_hosts = clean_config.mutable_virtual_hosts();
+  std::for_each(virtual_hosts->begin(), virtual_hosts->end(),
+                [](envoy::api::v2::route::VirtualHost& virtual_host) {
+                  virtual_host =
+                      replaceInvalidHeaders<envoy::api::v2::route::VirtualHost>(virtual_host);
+                });
   return clean_config;
 }
 
@@ -34,7 +52,7 @@ DEFINE_PROTO_FUZZER(const test::common::router::RouteTestCase& input) {
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
     NiceMock<Server::Configuration::MockFactoryContext> factory_context;
     MessageUtil::validate(input.config());
-    ConfigImpl config(replaceInvalidHeaders(input.config()), factory_context, true);
+    ConfigImpl config(cleanRouteConfig(input.config()), factory_context, true);
     Http::TestHeaderMapImpl headers = Fuzz::fromHeaders(input.headers());
     // It's a precondition of routing that {:authority, :path, x-forwarded-proto} headers exists,
     // HCM enforces this.


### PR DESCRIPTION
Removes invalid characters in headers referenced in each virtual host in the route configuration.

Risk Level: Low
Testing: Added crashing corpus entry

Signed-off-by: Asra Ali <asraa@google.com>