### PR TITLE
docs: link http filter and network filters in listener proto

### DIFF
--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -26,16 +26,8 @@ option (gogoproto.equal_all) = true;
 
 message Filter {
   // The name of the filter to instantiate. The name must match a supported
-  // filter. The built-in filters are:
-  //
-  // [#comment:TODO(mattklein123): Auto generate the following list]
-  // * :ref:`envoy.client_ssl_auth<config_network_filters_client_ssl_auth>`
-  // * :ref:`envoy.echo <config_network_filters_echo>`
-  // * :ref:`envoy.http_connection_manager <config_http_conn_man>`
-  // * :ref:`envoy.mongo_proxy <config_network_filters_mongo_proxy>`
-  // * :ref:`envoy.ratelimit <config_network_filters_rate_limit>`
-  // * :ref:`envoy.redis_proxy <config_network_filters_redis_proxy>`
-  // * :ref:`envoy.tcp_proxy <config_network_filters_tcp_proxy>`
+  // filter. Refer to :ref:`HTTP filters<config_http_filters>` and
+  // :ref:`Network filters<config_network_filters>` for built-in filters.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Filter specific configuration which depends on the filter being

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -25,7 +25,7 @@ option (gogoproto.equal_all) = true;
 // Listener :ref:`configuration overview <config_listeners>`
 
 message Filter {
-  // The name of the filter to instantiate. The name must match a 
+  // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_network_filters>`.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
@@ -190,7 +190,7 @@ message FilterChain {
 }
 
 message ListenerFilter {
-  // The name of the filter to instantiate. The name must match a 
+  // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_listener_filters>`.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -25,9 +25,8 @@ option (gogoproto.equal_all) = true;
 // Listener :ref:`configuration overview <config_listeners>`
 
 message Filter {
-  // The name of the filter to instantiate. The name must match a supported
-  // filter. Refer to :ref:`HTTP filters<config_http_filters>` and
-  // :ref:`Network filters<config_network_filters>` for built-in filters.
+  // The name of the filter to instantiate. The name must match a 
+  // :ref:`supported filter <config_network_filters>`.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Filter specific configuration which depends on the filter being
@@ -191,12 +190,8 @@ message FilterChain {
 }
 
 message ListenerFilter {
-  // The name of the filter to instantiate. The name must match a supported
-  // filter. The built-in filters are:
-  //
-  // [#comment:TODO(mattklein123): Auto generate the following list]
-  // * :ref:`envoy.listener.original_dst <config_listener_filters_original_dst>`
-  // * :ref:`envoy.listener.tls_inspector <config_listener_filters_tls_inspector>`
+  // The name of the filter to instantiate. The name must match a 
+  // :ref:`supported filter <config_listener_filters>`.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Filter specific configuration which depends on the filter being instantiated.

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -552,32 +552,8 @@ message ScopedRds {
 }
 
 message HttpFilter {
-  // The name of the filter to instantiate. The name must match a supported
-  // filter. The built-in filters are:
-  //
-  // [#comment:TODO(mattklein123): Auto generate the following list]
-  // * :ref:`envoy.buffer <config_http_filters_buffer>`
-  // * :ref:`envoy.cors <config_http_filters_cors>`
-  // * :ref:`envoy.ext_authz <config_http_filters_ext_authz>`
-  // * :ref:`envoy.fault <config_http_filters_fault_injection>`
-  // * :ref:`envoy.filters.http.csrf <config_http_filters_csrf>`
-  // * :ref:`envoy.filters.http.header_to_metadata <config_http_filters_header_to_metadata>`
-  // * :ref:`envoy.filters.http.grpc_http1_reverse_bridge \
-  //   <config_http_filters_grpc_http1_reverse_bridge>`
-  // * :ref:`envoy.filters.http.jwt_authn <config_http_filters_jwt_authn>`
-  // * :ref:`envoy.filters.http.rbac <config_http_filters_rbac>`
-  // * :ref:`envoy.filters.http.tap <config_http_filters_tap>`
-  // * :ref:`envoy.gzip <config_http_filters_gzip>`
-  // * :ref:`envoy.http_dynamo_filter <config_http_filters_dynamo>`
-  // * :ref:`envoy.grpc_http1_bridge <config_http_filters_grpc_bridge>`
-  // * :ref:`envoy.grpc_json_transcoder <config_http_filters_grpc_json_transcoder>`
-  // * :ref:`envoy.grpc_web <config_http_filters_grpc_web>`
-  // * :ref:`envoy.health_check <config_http_filters_health_check>`
-  // * :ref:`envoy.ip_tagging <config_http_filters_ip_tagging>`
-  // * :ref:`envoy.lua <config_http_filters_lua>`
-  // * :ref:`envoy.rate_limit <config_http_filters_rate_limit>`
-  // * :ref:`envoy.router <config_http_filters_router>`
-  // * :ref:`envoy.squash <config_http_filters_squash>`
+  // The name of the filter to instantiate. The name must match a 
+  // :ref:`supported filter <config_http_filters>`.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Filter specific configuration which depends on the filter being instantiated. See the supported

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -552,7 +552,7 @@ message ScopedRds {
 }
 
 message HttpFilter {
-  // The name of the filter to instantiate. The name must match a 
+  // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_http_filters>`.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>
Description: While reviewing a Istio PR I realized we have a hard coded minimal list of filters in the `listener.proto`. This PR links it to full list of http and network filters.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A