### PR TITLE
bootstrap: allow /dev/fd/<fd> paths for config files

### DIFF
--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -131,6 +131,8 @@ TEST_F(FileSystemImplTest, IllegalPath) {
 #else
   EXPECT_TRUE(file_system_.illegalPath("/dev"));
   EXPECT_TRUE(file_system_.illegalPath("/dev/"));
+  // Exception to allow opening from file descriptors. See #7258.
+  EXPECT_FALSE(file_system_.illegalPath("/dev/fd/0"));
   EXPECT_TRUE(file_system_.illegalPath("/proc"));
   EXPECT_TRUE(file_system_.illegalPath("/proc/"));
   EXPECT_TRUE(file_system_.illegalPath("/sys"));

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -385,6 +385,7 @@ cstring
 ctor
 ctrl
 customizations
+darwin
 dbg
 de
 dechunking
@@ -631,6 +632,7 @@ pthreads
 pton
 ptr
 ptrs
+pts
 pwd
 py
 qps
@@ -718,6 +720,7 @@ structs
 subexpr
 subdirs
 symlink
+symlinks
 symlinked
 sync
 sys


### PR DESCRIPTION
Signed-off-by: Paul Banks <banks@banksco.de>


**Description**:

As noted in #7528 the newly added sanity checking of possibly sensitive file paths prevents legitimate usage of passing bootstrap via a non-CLOEXEC file descriptor from a generator helper that execs Envoy.

This PR relaxes the validation such that any path resolving to a canonical path with the prefix `/dev/fd/` is considered valid.

**Risk Level**: Low
**Testing**: Unit test case is added that was failing before the change and passes afterwards. In addition I've manually verified that the old behaviour of allowing /dev/fd/<fd> paths works with my dev binary.
**Docs Changes**: None, I didn't find this limitation documented currently.
**Release Notes**: N/A (I didn't see the original change to make /dev invalid in 1.10 notes so I assume this doesn't warrant going in either.)

Fixes #7258
