### PR TITLE
transport_socket: permissive transport socket for opportunistic encryption

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,4 +37,4 @@ extensions/filters/common/original_src @snowp @klarose
 # redis cluster extension
 /*/extensions/clusters/redis @msukalski @henryyyang @mattklein123
 # permissive transport socket extension
-/*/extensions/transport_sockets/permissive @crazyxy
+/*/extensions/transport_sockets/permissive @lizan @crazyxy

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,3 +36,5 @@ extensions/filters/common/original_src @snowp @klarose
 /*/extensions/filters/network/zookeeper_proxy @rgs1 @snowp
 # redis cluster extension
 /*/extensions/clusters/redis @msukalski @henryyyang @mattklein123
+# permissive transport socket extension
+/*/extensions/transport_sockets/permissive @crazyxy

--- a/api/envoy/config/transport_socket/permissive/v2alpha/BUILD
+++ b/api/envoy/config/transport_socket/permissive/v2alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "permissive",
+    srcs = ["permissive.proto"],
+    deps = [
+        "//envoy/api/v2/core:base",
+    ],
+)

--- a/api/envoy/config/transport_socket/permissive/v2alpha/permissive.proto
+++ b/api/envoy/config/transport_socket/permissive/v2alpha/permissive.proto
@@ -16,14 +16,11 @@ import "validate/validate.proto";
 // Configuration for permissive transport socket. This wraps transport sockets, providing the
 // ability to fall back from primary to secondary transport socket.
 message Permissive {
-  // Value indicates whether falling back from primary to secondary is allowed.
-  bool allow_fallback = 1;
-
   // The primary transport socket.
-  api.v2.core.TransportSocket primary_transport_socket = 2
+  api.v2.core.TransportSocket primary_transport_socket = 1
       [(validate.rules).message.required = true];
 
   // The secondary transport socket.
-  api.v2.core.TransportSocket secondary_transport_socket = 3
+  api.v2.core.TransportSocket secondary_transport_socket = 2
       [(validate.rules).message.required = true];
 }

--- a/api/envoy/config/transport_socket/permissive/v2alpha/permissive.proto
+++ b/api/envoy/config/transport_socket/permissive/v2alpha/permissive.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package envoy.config.transport_socket.permissive.v2alpha;
+
+option java_outer_classname = "PermissiveProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.transport_socket.permissive.v2alpha";
+option go_package = "v2";
+
+// [#protodoc-title: Permissive]
+
+import "envoy/api/v2/core/base.proto";
+
+import "validate/validate.proto";
+
+// Configuration for permissive transport socket. This wraps transport sockets, providing the
+// ability to fall back from primary to secondary transport socket.
+message Permissive {
+  // Value indicates whether falling back from primary to secondary is allowed.
+  bool allow_fallback = 1;
+
+  // The primary transport socket.
+  api.v2.core.TransportSocket primary_transport_socket = 2
+      [(validate.rules).message.required = true];
+
+  // The secondary transport socket.
+  api.v2.core.TransportSocket secondary_transport_socket = 3
+      [(validate.rules).message.required = true];
+}

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -67,6 +67,7 @@ Version history
   more info in the `bazel docs <https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#enabling-optional-features>`_.
 * tool: added :repo:`proto <test/tools/router_check/validation.proto>` support for :ref:`router check tool <install_tools_route_table_check_tool>` tests.
 * tracing: add trace sampling configuration to the route, to override the route level.
+* transport_socket: add permissive transport socket to support opportunistic encryption.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
 * upstream: an EDS management server can now force removal of a host that is still passing active
   health checking by first marking the host as failed via EDS health check and subsequently removing

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -21,7 +21,7 @@ enum class PostIoAction {
   Close,
   // Keep the connection open.
   KeepOpen,
-  // Close current connection and create an new connection.
+  // Close current connection and create a new connection.
   Reconnect
 };
 

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -20,7 +20,9 @@ enum class PostIoAction {
   // Close the connection.
   Close,
   // Keep the connection open.
-  KeepOpen
+  KeepOpen,
+  // Close current connection and create an new connection.
+  Reconnect
 };
 
 /**

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -128,6 +128,7 @@ EXTENSIONS = {
 
     "envoy.transport_sockets.alts":                     "//source/extensions/transport_sockets/alts:config",
     "envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
+    "envoy.transport_sockets.permissive":               "//source/extensions/transport_sockets/permissive:config",
 
     # Retry host predicates
     "envoy.retry_host_predicates.previous_hosts":          "//source/extensions/retry/host/previous_hosts:config",

--- a/source/extensions/transport_sockets/permissive/BUILD
+++ b/source/extensions/transport_sockets/permissive/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/transport_sockets:well_known_names",
+        "@envoy_api//envoy/config/transport_socket/permissive/v2alpha:permissive_cc",
     ],
 )
 

--- a/source/extensions/transport_sockets/permissive/BUILD
+++ b/source/extensions/transport_sockets/permissive/BUILD
@@ -31,8 +31,18 @@ envoy_cc_library(
     srcs = ["permissive_socket.cc"],
     hdrs = ["permissive_socket.h"],
     deps = [
+        ":proxy_transport_socket_callbacks_lib",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:transport_socket_interface",
         "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "proxy_transport_socket_callbacks_lib",
+    hdrs = ["proxy_transport_socket_callbacks.h"],
+    deps = [
+        "//include/envoy/network:io_handle_interface",
+        "//include/envoy/network:transport_socket_interface",
     ],
 )

--- a/source/extensions/transport_sockets/permissive/BUILD
+++ b/source/extensions/transport_sockets/permissive/BUILD
@@ -1,0 +1,37 @@
+licenses(["notice"])  # Apache 2
+
+# Built-in permissive connection transport socket.
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":permissive_socket_lib",
+        "//include/envoy/network:transport_socket_interface",
+        "//include/envoy/registry",
+        "//include/envoy/server:transport_socket_config_interface",
+        "//source/common/config:utility_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/extensions/transport_sockets:well_known_names",
+    ],
+)
+
+envoy_cc_library(
+    name = "permissive_socket_lib",
+    srcs = ["permissive_socket.cc"],
+    hdrs = ["permissive_socket.h"],
+    deps = [
+        "//include/envoy/network:connection_interface",
+        "//include/envoy/network:transport_socket_interface",
+        "//source/common/buffer:buffer_lib",
+    ],
+)

--- a/source/extensions/transport_sockets/permissive/config.cc
+++ b/source/extensions/transport_sockets/permissive/config.cc
@@ -1,0 +1,42 @@
+#include "extensions/transport_sockets/permissive/config.h"
+
+#include "common/config/utility.h"
+#include "common/protobuf/utility.h"
+
+#include "extensions/transport_sockets/permissive/permissive_socket.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Permissive {
+
+Network::TransportSocketFactoryPtr
+UpstreamPermissiveSocketConfigFactory::createTransportSocketFactory(
+    const Protobuf::Message& message,
+    Server::Configuration::TransportSocketFactoryContext& context) {
+  auto& tls_config_factory = Config::Utility::getAndCheckFactory<
+      Server::Configuration::UpstreamTransportSocketConfigFactory>(TransportSocketNames::get().Tls);
+  auto tls_transport_socket_factory =
+      tls_config_factory.createTransportSocketFactory(message, context);
+
+  auto& raw_buffer_config_factory = Config::Utility::getAndCheckFactory<
+      Server::Configuration::UpstreamTransportSocketConfigFactory>(
+      TransportSocketNames::get().RawBuffer);
+  auto raw_buffer_transport_socket_factory =
+      raw_buffer_config_factory.createTransportSocketFactory(message, context);
+
+  return std::make_unique<PermissiveSocketFactory>(std::move(tls_transport_socket_factory),
+                                                   std::move(raw_buffer_transport_socket_factory));
+}
+
+ProtobufTypes::MessagePtr UpstreamPermissiveSocketConfigFactory::createEmptyConfigProto() {
+  return std::make_unique<envoy::api::v2::auth::UpstreamTlsContext>();
+}
+
+REGISTER_FACTORY(UpstreamPermissiveSocketConfigFactory,
+                 Server::Configuration::UpstreamTransportSocketConfigFactory);
+
+} // namespace Permissive
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/transport_sockets/permissive/config.cc
+++ b/source/extensions/transport_sockets/permissive/config.cc
@@ -47,7 +47,7 @@ UpstreamPermissiveSocketConfigFactory::createTransportSocketFactory(
   auto secondary_transport_socket_factory = secondary_config_factory.createTransportSocketFactory(
       *secondary_transport_socket_factory_config, context);
 
-  // Theoretically, falling back from unsecure to secure is unrealistic.
+  // Theoretically, falling back from insecure to secure is unrealistic.
   ASSERT(!permissive_config.allow_fallback() ||
          (primary_transport_socket_factory->implementsSecureTransport() ||
           (!primary_transport_socket_factory->implementsSecureTransport() &&

--- a/source/extensions/transport_sockets/permissive/config.cc
+++ b/source/extensions/transport_sockets/permissive/config.cc
@@ -48,12 +48,14 @@ UpstreamPermissiveSocketConfigFactory::createTransportSocketFactory(
       *secondary_transport_socket_factory_config, context);
 
   // Theoretically, falling back from unsecure to secure is unrealistic.
-  ASSERT(primary_transport_socket_factory->implementsSecureTransport() ||
-         (!primary_transport_socket_factory->implementsSecureTransport() &&
-          !secondary_transport_socket_factory->implementsSecureTransport()));
+  ASSERT(!permissive_config.allow_fallback() ||
+         (primary_transport_socket_factory->implementsSecureTransport() ||
+          (!primary_transport_socket_factory->implementsSecureTransport() &&
+           !secondary_transport_socket_factory->implementsSecureTransport())));
 
   return std::make_unique<PermissiveSocketFactory>(std::move(primary_transport_socket_factory),
-                                                   std::move(secondary_transport_socket_factory));
+                                                   std::move(secondary_transport_socket_factory),
+                                                   permissive_config.allow_fallback());
 }
 
 ProtobufTypes::MessagePtr UpstreamPermissiveSocketConfigFactory::createEmptyConfigProto() {

--- a/source/extensions/transport_sockets/permissive/config.cc
+++ b/source/extensions/transport_sockets/permissive/config.cc
@@ -1,5 +1,8 @@
 #include "extensions/transport_sockets/permissive/config.h"
 
+#include "envoy/config/transport_socket/permissive/v2alpha/permissive.pb.h"
+#include "envoy/config/transport_socket/permissive/v2alpha/permissive.pb.validate.h"
+
 #include "common/config/utility.h"
 #include "common/protobuf/utility.h"
 
@@ -14,23 +17,47 @@ Network::TransportSocketFactoryPtr
 UpstreamPermissiveSocketConfigFactory::createTransportSocketFactory(
     const Protobuf::Message& message,
     Server::Configuration::TransportSocketFactoryContext& context) {
-  auto& tls_config_factory = Config::Utility::getAndCheckFactory<
-      Server::Configuration::UpstreamTransportSocketConfigFactory>(TransportSocketNames::get().Tls);
-  auto tls_transport_socket_factory =
-      tls_config_factory.createTransportSocketFactory(message, context);
 
-  auto& raw_buffer_config_factory = Config::Utility::getAndCheckFactory<
+  const auto& permissive_config = MessageUtil::downcastAndValidate<
+      const envoy::config::transport_socket::permissive::v2alpha::Permissive&>(message);
+
+  // Create factory for primary transport socket.
+  auto& primary_config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::UpstreamTransportSocketConfigFactory>(
-      TransportSocketNames::get().RawBuffer);
-  auto raw_buffer_transport_socket_factory =
-      raw_buffer_config_factory.createTransportSocketFactory(message, context);
+      permissive_config.primary_transport_socket().name());
 
-  return std::make_unique<PermissiveSocketFactory>(std::move(tls_transport_socket_factory),
-                                                   std::move(raw_buffer_transport_socket_factory));
+  ProtobufTypes::MessagePtr primary_transport_socket_factory_config =
+      Config::Utility::translateToFactoryConfig(permissive_config.primary_transport_socket(),
+                                                context.messageValidationVisitor(),
+                                                primary_config_factory);
+
+  auto primary_transport_socket_factory = primary_config_factory.createTransportSocketFactory(
+      *primary_transport_socket_factory_config, context);
+
+  // Create factory for secondary transport socket.
+  auto& secondary_config_factory = Config::Utility::getAndCheckFactory<
+      Server::Configuration::UpstreamTransportSocketConfigFactory>(
+      permissive_config.secondary_transport_socket().name());
+
+  ProtobufTypes::MessagePtr secondary_transport_socket_factory_config =
+      Config::Utility::translateToFactoryConfig(permissive_config.secondary_transport_socket(),
+                                                context.messageValidationVisitor(),
+                                                secondary_config_factory);
+
+  auto secondary_transport_socket_factory = secondary_config_factory.createTransportSocketFactory(
+      *secondary_transport_socket_factory_config, context);
+
+  // Theoretically, falling back from unsecure to secure is unrealistic.
+  ASSERT(primary_transport_socket_factory->implementsSecureTransport() ||
+         (!primary_transport_socket_factory->implementsSecureTransport() &&
+          !secondary_transport_socket_factory->implementsSecureTransport()));
+
+  return std::make_unique<PermissiveSocketFactory>(std::move(primary_transport_socket_factory),
+                                                   std::move(secondary_transport_socket_factory));
 }
 
 ProtobufTypes::MessagePtr UpstreamPermissiveSocketConfigFactory::createEmptyConfigProto() {
-  return std::make_unique<envoy::api::v2::auth::UpstreamTlsContext>();
+  return std::make_unique<envoy::config::transport_socket::permissive::v2alpha::Permissive>();
 }
 
 REGISTER_FACTORY(UpstreamPermissiveSocketConfigFactory,

--- a/source/extensions/transport_sockets/permissive/config.cc
+++ b/source/extensions/transport_sockets/permissive/config.cc
@@ -48,14 +48,12 @@ UpstreamPermissiveSocketConfigFactory::createTransportSocketFactory(
       *secondary_transport_socket_factory_config, context);
 
   // Theoretically, falling back from insecure to secure is unrealistic.
-  ASSERT(!permissive_config.allow_fallback() ||
-         (primary_transport_socket_factory->implementsSecureTransport() ||
-          (!primary_transport_socket_factory->implementsSecureTransport() &&
-           !secondary_transport_socket_factory->implementsSecureTransport())));
+  ASSERT(primary_transport_socket_factory->implementsSecureTransport() ||
+         (!primary_transport_socket_factory->implementsSecureTransport() &&
+          !secondary_transport_socket_factory->implementsSecureTransport()));
 
   return std::make_unique<PermissiveSocketFactory>(std::move(primary_transport_socket_factory),
-                                                   std::move(secondary_transport_socket_factory),
-                                                   permissive_config.allow_fallback());
+                                                   std::move(secondary_transport_socket_factory));
 }
 
 ProtobufTypes::MessagePtr UpstreamPermissiveSocketConfigFactory::createEmptyConfigProto() {

--- a/source/extensions/transport_sockets/permissive/config.h
+++ b/source/extensions/transport_sockets/permissive/config.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "envoy/registry/registry.h"
+#include "envoy/server/transport_socket_config.h"
+
+#include "extensions/transport_sockets/well_known_names.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Permissive {
+
+class PermissiveSocketConfigFactory
+    : public virtual Server::Configuration::TransportSocketConfigFactory {
+public:
+  virtual ~PermissiveSocketConfigFactory() {}
+  std::string name() const override { return TransportSocketNames::get().Permissive; }
+};
+
+// Permissive socket is only used for upstream connection.
+class UpstreamPermissiveSocketConfigFactory
+    : public Server::Configuration::UpstreamTransportSocketConfigFactory,
+      public PermissiveSocketConfigFactory {
+public:
+  Network::TransportSocketFactoryPtr createTransportSocketFactory(
+      const Protobuf::Message& config,
+      Server::Configuration::TransportSocketFactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+};
+
+DECLARE_FACTORY(UpstreamPermissiveSocketConfigFactory);
+
+} // namespace Permissive
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/transport_sockets/permissive/permissive_socket.cc
+++ b/source/extensions/transport_sockets/permissive/permissive_socket.cc
@@ -1,0 +1,126 @@
+#include "extensions/transport_sockets/permissive/permissive_socket.h"
+
+#include "common/common/assert.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Permissive {
+
+PermissiveSocket::PermissiveSocket(Network::TransportSocketPtr&& tls_transport_socket,
+                                   Network::TransportSocketPtr&& raw_buffer_transport_socket)
+    : tls_transport_socket_(std::move(tls_transport_socket)),
+      raw_buffer_transport_socket_(std::move(raw_buffer_transport_socket)) {}
+
+void PermissiveSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) {
+  callbacks_ = &callbacks;
+  if (downgraded_) {
+    raw_buffer_transport_socket_->setTransportSocketCallbacks(callbacks);
+  } else {
+    tls_transport_socket_->setTransportSocketCallbacks(callbacks);
+  }
+}
+
+Network::IoResult PermissiveSocket::doRead(Buffer::Instance& buffer) {
+  if (downgraded_) {
+    return raw_buffer_transport_socket_->doRead(buffer);
+  } else {
+    Network::IoResult io_result = tls_transport_socket_->doRead(buffer);
+    checkIoResult(io_result);
+    return io_result;
+  }
+}
+
+Network::IoResult PermissiveSocket::doWrite(Buffer::Instance& buffer, bool end_stream) {
+  if (downgraded_) {
+    return raw_buffer_transport_socket_->doWrite(buffer, end_stream);
+  } else {
+    Network::IoResult io_result = tls_transport_socket_->doWrite(buffer, end_stream);
+    checkIoResult(io_result);
+    return io_result;
+  }
+}
+
+std::string PermissiveSocket::protocol() const {
+  if (downgraded_) {
+    return raw_buffer_transport_socket_->protocol();
+  } else {
+    return tls_transport_socket_->protocol();
+  }
+}
+
+absl::string_view PermissiveSocket::failureReason() const {
+  if (downgraded_) {
+    return raw_buffer_transport_socket_->failureReason();
+  } else {
+    return tls_transport_socket_->failureReason();
+  }
+}
+
+void PermissiveSocket::onConnected() {
+  if (downgraded_) {
+    raw_buffer_transport_socket_->onConnected();
+  } else {
+    tls_transport_socket_->onConnected();
+  }
+}
+
+bool PermissiveSocket::canFlushClose() {
+  if (downgraded_) {
+    return raw_buffer_transport_socket_->canFlushClose();
+  } else {
+    return tls_transport_socket_->canFlushClose();
+  }
+}
+
+void PermissiveSocket::closeSocket(Network::ConnectionEvent event) {
+  if (downgraded_) {
+    raw_buffer_transport_socket_->closeSocket(event);
+  } else {
+    tls_transport_socket_->closeSocket(event);
+  }
+}
+
+const Ssl::ConnectionInfo* PermissiveSocket::ssl() const {
+  if (downgraded_) {
+    return raw_buffer_transport_socket_->ssl();
+  } else {
+    return tls_transport_socket_->ssl();
+  }
+}
+
+void PermissiveSocket::checkIoResult(Network::IoResult& io_result) {
+  ASSERT(!downgraded_);
+
+  /**
+   * The function is for checking if the TLS handshake succeeded or not. If handshake failed,
+   * fallback to plaintext connection.
+   *  * check handshake_complete_. If handshake_complete_ is true, it means handshake
+   * completed. Since handshake_complete_ is private in ssl_socket, we can call canFlushClose()
+   * instead.
+   *  * check if the action is Network::PostIoAction::Close.
+   */
+  if (!canFlushClose() && io_result.action_ == Network::PostIoAction::Close) {
+    // TODO(crazyxy): add metrics
+    downgraded_ = true;
+    ENVOY_CONN_LOG(trace, "TLS connection downgrade to plaintext", callbacks_->connection());
+
+    // The underlying TCP connection is supposed to be closed. Raise the event to rebuild the TCP
+    // connection.
+    io_result.action_ = Network::PostIoAction::Reconnect;
+  }
+}
+
+Network::TransportSocketPtr PermissiveSocketFactory::createTransportSocket(
+    Network::TransportSocketOptionsSharedPtr options) const {
+  return std::make_unique<PermissiveSocket>(
+      tls_transport_socket_factory_->createTransportSocket(options),
+      raw_buffer_transport_socket_facotry_->createTransportSocket(options));
+}
+
+bool PermissiveSocketFactory::implementsSecureTransport() const { return false; }
+
+} // namespace Permissive
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/transport_sockets/permissive/permissive_socket.h
+++ b/source/extensions/transport_sockets/permissive/permissive_socket.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
+
+#include "common/common/logger.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Permissive {
+
+/**
+ * Transport socket wrapper for ssl_socket and raw_buffer_socket.
+ */
+class PermissiveSocket : public Network::TransportSocket,
+                         protected Logger::Loggable<Logger::Id::connection> {
+public:
+  PermissiveSocket(Network::TransportSocketPtr&& tls_transport_socket,
+                   Network::TransportSocketPtr&& raw_buffer_transport_socket);
+
+  // Network::TransportSocket
+  void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
+  std::string protocol() const override;
+  absl::string_view failureReason() const override;
+  bool canFlushClose() override;
+  void closeSocket(Network::ConnectionEvent) override;
+  void onConnected() override;
+  Network::IoResult doRead(Buffer::Instance& buffer) override;
+  Network::IoResult doWrite(Buffer::Instance& buffer, bool end_stream) override;
+  const Ssl::ConnectionInfo* ssl() const override;
+
+  bool isDowngraded() const { return downgraded_; }
+
+private:
+  void checkIoResult(Network::IoResult& io_result);
+
+  bool downgraded_{};
+  Network::TransportSocketCallbacks* callbacks_{};
+  Network::TransportSocketPtr tls_transport_socket_;
+  Network::TransportSocketPtr raw_buffer_transport_socket_;
+};
+
+class PermissiveSocketFactory : public Network::TransportSocketFactory {
+public:
+  PermissiveSocketFactory(Network::TransportSocketFactoryPtr&& tls_transport_socket_factory,
+                          Network::TransportSocketFactoryPtr&& raw_buffer_transport_socket_factory)
+      : tls_transport_socket_factory_(std::move(tls_transport_socket_factory)),
+        raw_buffer_transport_socket_facotry_(std::move(raw_buffer_transport_socket_factory)) {}
+
+  // Network::TransportSocketFactory
+  Network::TransportSocketPtr
+  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  bool implementsSecureTransport() const override;
+
+private:
+  Network::TransportSocketFactoryPtr tls_transport_socket_factory_;
+  Network::TransportSocketFactoryPtr raw_buffer_transport_socket_facotry_;
+};
+
+} // namespace Permissive
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/transport_sockets/permissive/permissive_socket.h
+++ b/source/extensions/transport_sockets/permissive/permissive_socket.h
@@ -6,6 +6,8 @@
 
 #include "common/common/logger.h"
 
+#include "extensions/transport_sockets/permissive/proxy_transport_socket_callbacks.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
@@ -37,7 +39,7 @@ private:
   void checkIoResult(Network::IoResult& io_result);
 
   bool is_fallback_{};
-  Network::TransportSocketCallbacks* callbacks_{};
+  ProxyTransportSocketCallbacksPtr callbacks_;
   Network::TransportSocketPtr primary_transport_socket_;
   Network::TransportSocketPtr secondary_transport_socket_;
 };

--- a/source/extensions/transport_sockets/permissive/permissive_socket.h
+++ b/source/extensions/transport_sockets/permissive/permissive_socket.h
@@ -38,16 +38,16 @@ private:
 
   bool downgraded_{};
   Network::TransportSocketCallbacks* callbacks_{};
-  Network::TransportSocketPtr tls_transport_socket_;
-  Network::TransportSocketPtr raw_buffer_transport_socket_;
+  Network::TransportSocketPtr primary_transport_socket_;
+  Network::TransportSocketPtr secondary_transport_socket_;
 };
 
 class PermissiveSocketFactory : public Network::TransportSocketFactory {
 public:
-  PermissiveSocketFactory(Network::TransportSocketFactoryPtr&& tls_transport_socket_factory,
-                          Network::TransportSocketFactoryPtr&& raw_buffer_transport_socket_factory)
-      : tls_transport_socket_factory_(std::move(tls_transport_socket_factory)),
-        raw_buffer_transport_socket_facotry_(std::move(raw_buffer_transport_socket_factory)) {}
+  PermissiveSocketFactory(Network::TransportSocketFactoryPtr&& primary_transport_socket_factory,
+                          Network::TransportSocketFactoryPtr&& secondary_transport_socket_factory)
+      : primary_transport_socket_factory_(std::move(primary_transport_socket_factory)),
+        secondary_transport_socket_factory_(std::move(secondary_transport_socket_factory)) {}
 
   // Network::TransportSocketFactory
   Network::TransportSocketPtr
@@ -55,8 +55,8 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  Network::TransportSocketFactoryPtr tls_transport_socket_factory_;
-  Network::TransportSocketFactoryPtr raw_buffer_transport_socket_facotry_;
+  Network::TransportSocketFactoryPtr primary_transport_socket_factory_;
+  Network::TransportSocketFactoryPtr secondary_transport_socket_factory_;
 };
 
 } // namespace Permissive

--- a/source/extensions/transport_sockets/permissive/permissive_socket.h
+++ b/source/extensions/transport_sockets/permissive/permissive_socket.h
@@ -18,7 +18,7 @@ class PermissiveSocket : public Network::TransportSocket,
                          protected Logger::Loggable<Logger::Id::connection> {
 public:
   PermissiveSocket(Network::TransportSocketPtr&& primary_transport_socket,
-                   Network::TransportSocketPtr&& secondary_transport_socket, bool allow_fallback);
+                   Network::TransportSocketPtr&& secondary_transport_socket);
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
@@ -37,7 +37,6 @@ private:
   void checkIoResult(Network::IoResult& io_result);
 
   bool is_fallback_{};
-  bool allow_fallback_{};
   Network::TransportSocketCallbacks* callbacks_{};
   Network::TransportSocketPtr primary_transport_socket_;
   Network::TransportSocketPtr secondary_transport_socket_;
@@ -46,10 +45,8 @@ private:
 class PermissiveSocketFactory : public Network::TransportSocketFactory {
 public:
   PermissiveSocketFactory(Network::TransportSocketFactoryPtr&& primary_transport_socket_factory,
-                          Network::TransportSocketFactoryPtr&& secondary_transport_socket_factory,
-                          bool allow_fallback)
-      : allow_fallback_(allow_fallback),
-        primary_transport_socket_factory_(std::move(primary_transport_socket_factory)),
+                          Network::TransportSocketFactoryPtr&& secondary_transport_socket_factory)
+      : primary_transport_socket_factory_(std::move(primary_transport_socket_factory)),
         secondary_transport_socket_factory_(std::move(secondary_transport_socket_factory)) {}
 
   // Network::TransportSocketFactory
@@ -58,7 +55,6 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  bool allow_fallback_{};
   Network::TransportSocketFactoryPtr primary_transport_socket_factory_;
   Network::TransportSocketFactoryPtr secondary_transport_socket_factory_;
 };

--- a/source/extensions/transport_sockets/permissive/proxy_transport_socket_callbacks.h
+++ b/source/extensions/transport_sockets/permissive/proxy_transport_socket_callbacks.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "envoy/network/transport_socket.h"
+#include "envoy/network/io_handle.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Permissive {
+
+class ProxyTransportSocketCallbacks : public Network::TransportSocketCallbacks {
+public:
+  explicit ProxyTransportSocketCallbacks(Network::TransportSocketCallbacks& parent)
+      : parent_(parent) {}
+
+  // Network::TransportSocketCallbacks
+  Network::IoHandle& ioHandle() override { return parent_.ioHandle(); }
+  const Network::IoHandle& ioHandle() const override { return parent_.ioHandle(); }
+  Network::Connection& connection() override { return parent_.connection(); }
+  bool shouldDrainReadBuffer() override { return parent_.shouldDrainReadBuffer(); }
+  void setReadBufferReady() override { parent_.setReadBufferReady(); }
+  void raiseEvent(Network::ConnectionEvent event) override {
+    event_raised_ |= (1 << static_cast<uint32_t>(event));
+    parent_.raiseEvent(event);
+  }
+
+  bool eventRaised(Network::ConnectionEvent event) {
+    return (1 << static_cast<uint32_t>(event)) & event_raised_;
+  }
+
+  void clearEvents() { event_raised_ = 0; }
+
+private:
+  Network::TransportSocketCallbacks& parent_;
+  uint32_t event_raised_;
+};
+
+using ProxyTransportSocketCallbacksPtr = std::unique_ptr<ProxyTransportSocketCallbacks>;
+
+} // namespace Permissive
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/transport_sockets/permissive/proxy_transport_socket_callbacks.h
+++ b/source/extensions/transport_sockets/permissive/proxy_transport_socket_callbacks.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "envoy/network/transport_socket.h"
 #include "envoy/network/io_handle.h"
+#include "envoy/network/transport_socket.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/transport_sockets/well_known_names.h
+++ b/source/extensions/transport_sockets/well_known_names.h
@@ -18,6 +18,7 @@ public:
   const std::string Tap = "envoy.transport_sockets.tap";
   const std::string RawBuffer = "raw_buffer";
   const std::string Tls = "tls";
+  const std::string Permissive = "envoy.transport_sockets.permissive";
 };
 
 using TransportSocketNames = ConstSingleton<TransportSocketNameValues>;

--- a/test/extensions/transport_sockets/permissive/BUILD
+++ b/test/extensions/transport_sockets/permissive/BUILD
@@ -1,0 +1,26 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "permissive_socket_test",
+    srcs = ["permissive_socket_test.cc"],
+    extension_name = "envoy.transport_sockets.permissive",
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:empty_string",
+        "//source/extensions/transport_sockets/permissive:config",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_mocks",
+    ],
+)

--- a/test/extensions/transport_sockets/permissive/permissive_socket_test.cc
+++ b/test/extensions/transport_sockets/permissive/permissive_socket_test.cc
@@ -1,0 +1,223 @@
+#include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/empty_string.h"
+
+#include "extensions/transport_sockets/permissive/permissive_socket.h"
+
+#include "test/mocks/network/mocks.h"
+
+using testing::_;
+using testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace TransportSockets {
+namespace Permissive {
+namespace {
+
+class MockRawBufferTransportSocket : public Network::TransportSocket {
+public:
+  ~MockRawBufferTransportSocket() {}
+
+  // Network::TransportSocket
+  MOCK_METHOD1(setTransportSocketCallbacks, void(Network::TransportSocketCallbacks&));
+  MOCK_CONST_METHOD0(protocol, std::string());
+  MOCK_CONST_METHOD0(failureReason, absl::string_view());
+  MOCK_METHOD0(canFlushClose, bool());
+  MOCK_METHOD1(closeSocket, void(Network::ConnectionEvent));
+  MOCK_METHOD1(doRead, Network::IoResult(Buffer::Instance&));
+  MOCK_METHOD2(doWrite, Network::IoResult(Buffer::Instance&, bool));
+  MOCK_METHOD0(onConnected, void());
+  MOCK_CONST_METHOD0(ssl, const Ssl::ConnectionInfo*());
+};
+
+class MockSslTransportSocket : public Network::TransportSocket, public Envoy::Ssl::ConnectionInfo {
+public:
+  ~MockSslTransportSocket() {}
+
+  // Network::TransportSocket
+  MOCK_METHOD1(setTransportSocketCallbacks, void(Network::TransportSocketCallbacks&));
+  MOCK_CONST_METHOD0(protocol, std::string());
+  MOCK_CONST_METHOD0(failureReason, absl::string_view());
+  MOCK_METHOD0(canFlushClose, bool());
+  MOCK_METHOD1(closeSocket, void(Network::ConnectionEvent));
+  MOCK_METHOD1(doRead, Network::IoResult(Buffer::Instance&));
+  MOCK_METHOD2(doWrite, Network::IoResult(Buffer::Instance&, bool));
+  MOCK_METHOD0(onConnected, void());
+  MOCK_CONST_METHOD0(ssl, const Ssl::ConnectionInfo*());
+
+  // Ssl::ConnectionInfo
+  MOCK_CONST_METHOD0(peerCertificatePresented, bool());
+  MOCK_CONST_METHOD0(uriSanLocalCertificate, std::vector<std::string>());
+  MOCK_CONST_METHOD0(sha256PeerCertificateDigest, const std::string&());
+  MOCK_CONST_METHOD0(serialNumberPeerCertificate, std::string());
+  MOCK_CONST_METHOD0(issuerPeerCertificate, std::string());
+  MOCK_CONST_METHOD0(subjectPeerCertificate, std::string());
+  MOCK_CONST_METHOD0(subjectLocalCertificate, std::string());
+  MOCK_CONST_METHOD0(uriSanPeerCertificate, std::vector<std::string>());
+  MOCK_CONST_METHOD0(urlEncodedPemEncodedPeerCertificate, const std::string&());
+  MOCK_CONST_METHOD0(urlEncodedPemEncodedPeerCertificateChain, const std::string&());
+  MOCK_CONST_METHOD0(dnsSansPeerCertificate, std::vector<std::string>());
+  MOCK_CONST_METHOD0(dnsSansLocalCertificate, std::vector<std::string>());
+  MOCK_CONST_METHOD0(validFromPeerCertificate, absl::optional<SystemTime>());
+  MOCK_CONST_METHOD0(expirationPeerCertificate, absl::optional<SystemTime>());
+  MOCK_CONST_METHOD0(sessionId, std::string());
+  MOCK_CONST_METHOD0(ciphersuiteId, uint16_t());
+  MOCK_CONST_METHOD0(ciphersuiteString, std::string());
+  MOCK_CONST_METHOD0(tlsVersion, std::string());
+};
+
+class PermissiveSocketTest : public testing::Test {
+protected:
+  PermissiveSocketTest()
+      : raw_buffer_transport_socket_(new MockRawBufferTransportSocket),
+        ssl_transport_socket_(new MockSslTransportSocket) {
+    auto unique_raw_buffer_transport_socket =
+        std::unique_ptr<MockRawBufferTransportSocket>(raw_buffer_transport_socket_);
+    auto unique_ssl_transport_socket =
+        std::unique_ptr<MockSslTransportSocket>(ssl_transport_socket_);
+    permissive_transport_socket_ = std::make_unique<PermissiveSocket>(
+        std::move(unique_ssl_transport_socket), std::move(unique_raw_buffer_transport_socket));
+  }
+
+  void downgrade() {
+    EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+    Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
+    EXPECT_CALL(*ssl_transport_socket_, doRead(_)).WillOnce(Return(io_result));
+    EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).WillOnce(Return(false));
+    permissive_transport_socket_->doRead(read_buffer_);
+    EXPECT_TRUE(permissive_transport_socket_->isDowngraded());
+  }
+
+  std::unique_ptr<PermissiveSocket> permissive_transport_socket_;
+  MockRawBufferTransportSocket* raw_buffer_transport_socket_;
+  MockSslTransportSocket* ssl_transport_socket_;
+
+  Buffer::OwnedImpl write_buffer_;
+  Buffer::OwnedImpl read_buffer_;
+};
+
+TEST_F(PermissiveSocketTest, DowngradeOnWrite) {
+  EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+
+  Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
+  EXPECT_CALL(*ssl_transport_socket_, doWrite(BufferStringEqual("hello"), false))
+      .WillOnce(Return(io_result));
+  EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).WillOnce(Return(false));
+
+  write_buffer_.add("hello");
+  io_result = permissive_transport_socket_->doWrite(write_buffer_, false);
+
+  EXPECT_EQ(Network::PostIoAction::Reconnect, io_result.action_);
+  EXPECT_TRUE(permissive_transport_socket_->isDowngraded());
+}
+
+TEST_F(PermissiveSocketTest, DowngradeOnRead) {
+  EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+
+  Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
+  EXPECT_CALL(*ssl_transport_socket_, doRead(_)).WillOnce(Return(io_result));
+  EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).WillOnce(Return(false));
+
+  io_result = permissive_transport_socket_->doRead(read_buffer_);
+
+  EXPECT_EQ(Network::PostIoAction::Reconnect, io_result.action_);
+  EXPECT_TRUE(permissive_transport_socket_->isDowngraded());
+}
+
+TEST_F(PermissiveSocketTest, DoNotDowngradeWhenHandShakeNotCompleteSocketKeepOpen) {
+  EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+
+  Network::IoResult io_result = {Network::PostIoAction::KeepOpen, 0, false};
+
+  EXPECT_CALL(*ssl_transport_socket_, doRead(_)).WillOnce(Return(io_result));
+  EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).WillOnce(Return(false));
+
+  io_result = permissive_transport_socket_->doRead(read_buffer_);
+
+  EXPECT_EQ(Network::PostIoAction::KeepOpen, io_result.action_);
+  EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+}
+
+TEST_F(PermissiveSocketTest, DoNotDowngradeWhenHandShakeCompleteSocketClosed) {
+  EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+
+  Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
+
+  EXPECT_CALL(*ssl_transport_socket_, doRead(_)).WillOnce(Return(io_result));
+  EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).WillOnce(Return(true));
+
+  io_result = permissive_transport_socket_->doRead(read_buffer_);
+
+  EXPECT_EQ(Network::PostIoAction::Close, io_result.action_);
+  EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
+}
+
+TEST_F(PermissiveSocketTest, ProtocolBeforeAndAfterDowngrade) {
+  EXPECT_CALL(*ssl_transport_socket_, protocol()).WillOnce(Return("h2"));
+  EXPECT_EQ("h2", permissive_transport_socket_->protocol());
+
+  downgrade();
+  EXPECT_CALL(*raw_buffer_transport_socket_, protocol()).WillOnce(Return(EMPTY_STRING));
+  EXPECT_EQ(EMPTY_STRING, permissive_transport_socket_->protocol());
+}
+
+TEST_F(PermissiveSocketTest, FailureReasonBeforeAndAfterDowngrade) {
+  std::string reason = "connection failure";
+  EXPECT_CALL(*ssl_transport_socket_, failureReason()).WillOnce(Return(reason));
+  EXPECT_EQ(reason, permissive_transport_socket_->failureReason());
+
+  downgrade();
+
+  EXPECT_CALL(*raw_buffer_transport_socket_, failureReason()).WillOnce(Return(reason));
+  EXPECT_EQ(reason, permissive_transport_socket_->failureReason());
+}
+
+TEST_F(PermissiveSocketTest, OnConnectedBeforeAndAfterDowngrade) {
+  EXPECT_CALL(*ssl_transport_socket_, onConnected()).Times(1);
+  permissive_transport_socket_->onConnected();
+
+  downgrade();
+
+  EXPECT_CALL(*raw_buffer_transport_socket_, onConnected()).Times(1);
+  permissive_transport_socket_->onConnected();
+}
+
+TEST_F(PermissiveSocketTest, CanFlushCloseBeforeAndAfterDowngrade) {
+  EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).Times(1);
+  permissive_transport_socket_->canFlushClose();
+
+  downgrade();
+
+  EXPECT_CALL(*raw_buffer_transport_socket_, canFlushClose()).Times(1);
+  permissive_transport_socket_->canFlushClose();
+}
+
+TEST_F(PermissiveSocketTest, CloseSocketBeforeAndAfterDowngrade) {
+  EXPECT_CALL(*ssl_transport_socket_, closeSocket(Network::ConnectionEvent::LocalClose)).Times(1);
+  permissive_transport_socket_->closeSocket(Network::ConnectionEvent::LocalClose);
+
+  downgrade();
+
+  EXPECT_CALL(*raw_buffer_transport_socket_, closeSocket(Network::ConnectionEvent::LocalClose))
+      .Times(1);
+  permissive_transport_socket_->closeSocket(Network::ConnectionEvent::LocalClose);
+}
+
+TEST_F(PermissiveSocketTest, CheckSslBeforeAndAfterDowngrade) {
+  EXPECT_CALL(*ssl_transport_socket_, ssl()).WillOnce(Return(ssl_transport_socket_));
+  EXPECT_NE(nullptr, permissive_transport_socket_->ssl());
+
+  downgrade();
+
+  EXPECT_CALL(*raw_buffer_transport_socket_, ssl()).WillOnce(Return(nullptr));
+  EXPECT_EQ(nullptr, permissive_transport_socket_->ssl());
+}
+
+} // namespace
+} // namespace Permissive
+} // namespace TransportSockets
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/transport_sockets/permissive/permissive_socket_test.cc
+++ b/test/extensions/transport_sockets/permissive/permissive_socket_test.cc
@@ -9,6 +9,8 @@
 #include "test/mocks/network/mocks.h"
 
 using testing::_;
+using ::testing::InSequence;
+using testing::NiceMock;
 using testing::Return;
 
 namespace Envoy {
@@ -72,8 +74,8 @@ public:
 class PermissiveSocketTest : public testing::Test {
 protected:
   PermissiveSocketTest()
-      : raw_buffer_transport_socket_(new MockRawBufferTransportSocket),
-        ssl_transport_socket_(new MockSslTransportSocket) {
+      : raw_buffer_transport_socket_(new NiceMock<MockRawBufferTransportSocket>),
+        ssl_transport_socket_(new NiceMock<MockSslTransportSocket>) {
     auto unique_raw_buffer_transport_socket =
         std::unique_ptr<MockRawBufferTransportSocket>(raw_buffer_transport_socket_);
     auto unique_ssl_transport_socket =
@@ -100,6 +102,8 @@ protected:
 };
 
 TEST_F(PermissiveSocketTest, DowngradeOnWrite) {
+  InSequence s;
+
   EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
 
   Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
@@ -115,6 +119,8 @@ TEST_F(PermissiveSocketTest, DowngradeOnWrite) {
 }
 
 TEST_F(PermissiveSocketTest, DowngradeOnRead) {
+  InSequence s;
+
   EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
 
   Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
@@ -128,6 +134,8 @@ TEST_F(PermissiveSocketTest, DowngradeOnRead) {
 }
 
 TEST_F(PermissiveSocketTest, DoNotDowngradeWhenHandShakeNotCompleteSocketKeepOpen) {
+  InSequence s;
+
   EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
 
   Network::IoResult io_result = {Network::PostIoAction::KeepOpen, 0, false};
@@ -142,6 +150,8 @@ TEST_F(PermissiveSocketTest, DoNotDowngradeWhenHandShakeNotCompleteSocketKeepOpe
 }
 
 TEST_F(PermissiveSocketTest, DoNotDowngradeWhenHandShakeCompleteSocketClosed) {
+  InSequence s;
+
   EXPECT_FALSE(permissive_transport_socket_->isDowngraded());
 
   Network::IoResult io_result = {Network::PostIoAction::Close, 0, false};
@@ -156,6 +166,8 @@ TEST_F(PermissiveSocketTest, DoNotDowngradeWhenHandShakeCompleteSocketClosed) {
 }
 
 TEST_F(PermissiveSocketTest, ProtocolBeforeAndAfterDowngrade) {
+  InSequence s;
+
   EXPECT_CALL(*ssl_transport_socket_, protocol()).WillOnce(Return("h2"));
   EXPECT_EQ("h2", permissive_transport_socket_->protocol());
 
@@ -165,6 +177,8 @@ TEST_F(PermissiveSocketTest, ProtocolBeforeAndAfterDowngrade) {
 }
 
 TEST_F(PermissiveSocketTest, FailureReasonBeforeAndAfterDowngrade) {
+  InSequence s;
+
   std::string reason = "connection failure";
   EXPECT_CALL(*ssl_transport_socket_, failureReason()).WillOnce(Return(reason));
   EXPECT_EQ(reason, permissive_transport_socket_->failureReason());
@@ -176,6 +190,8 @@ TEST_F(PermissiveSocketTest, FailureReasonBeforeAndAfterDowngrade) {
 }
 
 TEST_F(PermissiveSocketTest, OnConnectedBeforeAndAfterDowngrade) {
+  InSequence s;
+
   EXPECT_CALL(*ssl_transport_socket_, onConnected()).Times(1);
   permissive_transport_socket_->onConnected();
 
@@ -186,6 +202,8 @@ TEST_F(PermissiveSocketTest, OnConnectedBeforeAndAfterDowngrade) {
 }
 
 TEST_F(PermissiveSocketTest, CanFlushCloseBeforeAndAfterDowngrade) {
+  InSequence s;
+
   EXPECT_CALL(*ssl_transport_socket_, canFlushClose()).Times(1);
   permissive_transport_socket_->canFlushClose();
 
@@ -196,6 +214,8 @@ TEST_F(PermissiveSocketTest, CanFlushCloseBeforeAndAfterDowngrade) {
 }
 
 TEST_F(PermissiveSocketTest, CloseSocketBeforeAndAfterDowngrade) {
+  InSequence s;
+
   EXPECT_CALL(*ssl_transport_socket_, closeSocket(Network::ConnectionEvent::LocalClose)).Times(1);
   permissive_transport_socket_->closeSocket(Network::ConnectionEvent::LocalClose);
 
@@ -207,6 +227,8 @@ TEST_F(PermissiveSocketTest, CloseSocketBeforeAndAfterDowngrade) {
 }
 
 TEST_F(PermissiveSocketTest, CheckSslBeforeAndAfterDowngrade) {
+  InSequence s;
+
   EXPECT_CALL(*ssl_transport_socket_, ssl()).WillOnce(Return(ssl_transport_socket_));
   EXPECT_NE(nullptr, permissive_transport_socket_->ssl());
 


### PR DESCRIPTION
Description: add permissive transport socket for opportunistic encryption
Risk Level: Low
Testing: unit test, manual testing
Docs Changes: N/A
Release Notes: https://github.com/envoyproxy/envoy/compare/master...crazyxy:oe?expand=1#diff-d8d3e33358b55e6c0466dd1bb5f40c79
Fixes #Issue: https://github.com/envoyproxy/envoy/issues/7135
