### PR TITLE
docs: fix requirements for csrf sandbox

### DIFF
--- a/docs/root/start/sandboxes/csrf.rst
+++ b/docs/root/start/sandboxes/csrf.rst
@@ -34,7 +34,7 @@ The following documentation runs through the setup of both services.
 
 **Step 1: Install Docker**
 
-Ensure that you have a recent versions of ``docker``, ``docker-compose``, and ``docker-machine``.
+Ensure that you have a recent versions of ``docker`` and ``docker-compose``.
 
 A simple way to achieve this is via the `Docker Toolbox <https://www.docker.com/products/docker-toolbox>`_.
 


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Remove docker-machine dependency from CSRF sandbox docs
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
