### PR TITLE
csrf filter: add support for additional source origins

### DIFF
--- a/api/envoy/config/filter/http/csrf/v2/BUILD
+++ b/api/envoy/config/filter/http/csrf/v2/BUILD
@@ -5,5 +5,8 @@ licenses(["notice"])  # Apache 2
 api_proto_library_internal(
     name = "csrf",
     srcs = ["csrf.proto"],
-    deps = ["//envoy/api/v2/core:base"],
+    deps = [
+        "//envoy/api/v2/core:base",
+        "//envoy/type/matcher:string",
+    ],
 )

--- a/api/envoy/config/filter/http/csrf/v2/csrf.proto
+++ b/api/envoy/config/filter/http/csrf/v2/csrf.proto
@@ -47,5 +47,5 @@ message CsrfPolicy {
   //
   // More information on how this can be configured via runtime can be found
   // :ref:`here <csrf-configuration>`.
-  envoy.type.matcher.ListStringMatcher additional_origins = 3;
+  repeated envoy.type.matcher.StringMatcher additional_origins = 3;
 }

--- a/api/envoy/config/filter/http/csrf/v2/csrf.proto
+++ b/api/envoy/config/filter/http/csrf/v2/csrf.proto
@@ -15,9 +15,27 @@ import "gogoproto/gogo.proto";
 // [#protodoc-title: CSRF]
 // Cross-Site Request Forgery :ref:`configuration overview <config_http_filters_csrf>`.
 
+// Origin Matcher for CSRF policy configuration.
+message OriginMatcher {
+  // A string containing either an exact origin or regex pattern.
+  string origin = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Origin matchers support both exact matches and regex patterns.
+  enum OriginType {
+    // The origin value will be evaluated exactly as is.
+    EXACT = 0;
+
+    // The origin value will be evaluated as regex.
+    REGEX = 1;
+  }
+
+  // The type of the the origin string.
+  OriginType type = 2 [(validate.rules).enum.defined_only = true];
+}
+
 // CSRF filter config.
 message CsrfPolicy {
-  // Specify if CSRF is enabled.
+  // Specifies if CSRF is enabled.
   //
   // More information on how this can be controlled via runtime can be found
   // :ref:`here <csrf-runtime>`.
@@ -40,4 +58,11 @@ message CsrfPolicy {
   //   This field defaults to 100/:ref:`HUNDRED
   //   <envoy_api_enum_type.FractionalPercent.DenominatorType>`.
   envoy.api.v2.core.RuntimeFractionalPercent shadow_enabled = 2;
+
+  // Specifies additional source origins that will be allowed in addition to
+  // the destination origin.
+  //
+  // More information on how this can be configured via runtime can be found
+  // :ref:`here <csrf-configuration>`.
+  repeated OriginMatcher additional_origins = 3;
 }

--- a/api/envoy/config/filter/http/csrf/v2/csrf.proto
+++ b/api/envoy/config/filter/http/csrf/v2/csrf.proto
@@ -8,30 +8,13 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.csrf.v2";
 option go_package = "v2";
 
 import "envoy/api/v2/core/base.proto";
+import "envoy/type/matcher/string.proto";
 
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";
 
 // [#protodoc-title: CSRF]
 // Cross-Site Request Forgery :ref:`configuration overview <config_http_filters_csrf>`.
-
-// Origin Matcher for CSRF policy configuration.
-message OriginMatcher {
-  // A string containing either an exact origin or regex pattern.
-  string origin = 1 [(validate.rules).string.min_bytes = 1];
-
-  // Origin matchers support both exact matches and regex patterns.
-  enum OriginType {
-    // The origin value will be evaluated exactly as is.
-    EXACT = 0;
-
-    // The origin value will be evaluated as regex.
-    REGEX = 1;
-  }
-
-  // The type of the the origin string.
-  OriginType type = 2 [(validate.rules).enum.defined_only = true];
-}
 
 // CSRF filter config.
 message CsrfPolicy {
@@ -64,5 +47,5 @@ message CsrfPolicy {
   //
   // More information on how this can be configured via runtime can be found
   // :ref:`here <csrf-configuration>`.
-  repeated OriginMatcher additional_origins = 3;
+  envoy.type.matcher.ListStringMatcher additional_origins = 3;
 }

--- a/docs/root/configuration/http_filters/csrf_filter.rst
+++ b/docs/root/configuration/http_filters/csrf_filter.rst
@@ -26,7 +26,8 @@ a request originated from the same host.
 
 When the filter is evaluating a request, it ensures both pieces of information are present
 and compares their values. If the source origin is missing or the origins do not match
-the request is rejected.
+the request is rejected. The exception to this being if the source origin has been
+added to the policy as valid.
 
   .. note::
     Due to differing functionality between browsers this filter will determine
@@ -43,6 +44,23 @@ For more information on CSRF please refer to the pages below.
   .. note::
 
     This filter should be configured with the name *envoy.csrf*.
+
+.. _csrf-configuration
+
+Configuration
+-------------
+
+The CSRF filter supports the ability to extend the source origins it will consider
+valid. The reason it is able to do this while still mitigating cross-site request
+forgery attempts is because the target origin has already been reached by the time
+front-envoy is applying the filter. This means that while endpoints may support
+cross-origin requests they are still protected from malicious third-parties who
+have not been whitelisted.
+
+It's important to note that requests should generally originate from the same
+origin as the target but there are use cases where that may not be possible.
+For example, if you are hosting a static site on a third-party vendor but need
+to make requests for tracking purposes.
 
 .. _csrf-runtime:
 

--- a/docs/root/configuration/http_filters/csrf_filter.rst
+++ b/docs/root/configuration/http_filters/csrf_filter.rst
@@ -62,6 +62,12 @@ origin as the target but there are use cases where that may not be possible.
 For example, if you are hosting a static site on a third-party vendor but need
 to make requests for tracking purposes.
 
+.. warning::
+
+  Additional origins can be either an exact string, regex pattern, prefix string,
+  or suffix string. It's advised to be cautious when adding regex, prefix, or suffix
+  origins since an ambiguous origin can pose a security vulnerability.
+
 .. _csrf-runtime:
 
 Runtime

--- a/docs/root/configuration/http_filters/csrf_filter.rst
+++ b/docs/root/configuration/http_filters/csrf_filter.rst
@@ -45,7 +45,7 @@ For more information on CSRF please refer to the pages below.
 
     This filter should be configured with the name *envoy.csrf*.
 
-.. _csrf-configuration
+.. _csrf-configuration:
 
 Configuration
 -------------

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -13,6 +13,7 @@ Version history
 * api: track and report requests issued since last load report.
 * build: releases are built with Clang and linked with LLD.
 * control-plane: management servers can respond with HTTP 304 to indicate that config is up to date for Envoy proxies polling a :ref:`REST API Config Type <envoy_api_field_core.ApiConfigSource.api_type>`
+* csrf: added support for whitelisting additional source origins.
 * dubbo_proxy: support the :ref:`Dubbo proxy filter <config_network_filters_dubbo_proxy>`.
 * eds: added support to specify max time for which endpoints can be used :ref:`gRPC filter <envoy_api_msg_ClusterLoadAssignment.Policy>`.
 * event: added :ref:`loop duration and poll delay statistics <operations_performance>`.

--- a/examples/csrf/index.html
+++ b/examples/csrf/index.html
@@ -56,6 +56,7 @@
             <input type="radio" name="csrf" value="shadow"/> Shadow Mode<br/>
             <input type="radio" name="csrf" value="enabled"/> Enabled<br/>
             <input type="radio" name="csrf" value="ignored"/> Ignored<br/>
+            <input type="radio" name="csrf" value="additional_origin"/> Additional Origin<br/>
             <br/>
         </div>
         <div style="float:left;">

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -67,6 +67,19 @@ static_resources:
                         numerator: 100
                         denominator: HUNDRED
               - match:
+                  prefix: "/csrf/additional_origin"
+                route:
+                  cluster: generic_service
+                per_filter_config:
+                  envoy.csrf:
+                    filter_enabled:
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    additional_origins:
+                    - origin: .*
+                      type: REGEX
+              - match:
                   prefix: "/"
                 route:
                   cluster: generic_service

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -77,8 +77,7 @@ static_resources:
                         numerator: 100
                         denominator: HUNDRED
                     additional_origins:
-                    - origin: .*
-                      type: REGEX
+                    - regex: .*
               - match:
                   prefix: "/"
                 route:

--- a/source/extensions/filters/http/csrf/BUILD
+++ b/source/extensions/filters/http/csrf/BUILD
@@ -18,6 +18,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:filter_interface",
         "//source/common/buffer:buffer_lib",
+        "//source/common/common:matchers_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -128,7 +128,7 @@ bool CsrfFilter::isValid(const absl::string_view source_origin, Http::HeaderMap&
   }
 
   for (const auto& additional_origin : policy_->additional_origins()) {
-    if (additional_origin.matches(source_origin)) {
+    if (additional_origin.match(source_origin)) {
       return true;
     }
   }

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -91,8 +91,7 @@ Http::FilterHeadersStatus CsrfFilter::decodeHeaders(Http::HeaderMap& headers, bo
     config_->stats().missing_source_origin_.inc();
   }
 
-  const absl::string_view target_origin = targetOriginValue(headers);
-  if (source_origin != target_origin) {
+  if (!isValid(source_origin, headers)) {
     is_valid = false;
     config_->stats().request_invalid_.inc();
   }
@@ -120,6 +119,21 @@ void CsrfFilter::determinePolicy() {
   } else {
     policy_ = config_->policy();
   }
+}
+
+bool CsrfFilter::isValid(const absl::string_view source_origin, Http::HeaderMap& headers) {
+  const absl::string_view target_origin = targetOriginValue(headers);
+  if (source_origin == target_origin) {
+    return true;
+  }
+
+  for (const auto& additional_origin : policy_->additional_origins()) {
+    if (additional_origin.matches(source_origin)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 } // namespace Csrf

--- a/source/extensions/filters/http/csrf/csrf_filter.h
+++ b/source/extensions/filters/http/csrf/csrf_filter.h
@@ -38,7 +38,7 @@ class CsrfPolicy : public Router::RouteSpecificFilterConfig {
 public:
   CsrfPolicy(const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
              Runtime::Loader& runtime) : policy_(policy), runtime_(runtime) {
-    for (const auto& additional_origin : policy.additional_origins().patterns()) {
+    for (const auto& additional_origin : policy.additional_origins()) {
       additional_origins_.emplace_back(Matchers::StringMatcher(additional_origin));
     }
   }

--- a/source/extensions/filters/http/csrf/csrf_filter.h
+++ b/source/extensions/filters/http/csrf/csrf_filter.h
@@ -43,7 +43,7 @@ public:
   }
 
   bool matches(const absl::string_view source_origin) const {
-    if (exact_origin_ != "") {
+    if (!exact_origin_.empty()) {
       return source_origin == exact_origin_;
     }
     return std::regex_match(source_origin.begin(), source_origin.end(), regex_origin_);
@@ -62,7 +62,7 @@ public:
   CsrfPolicy(const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
              Runtime::Loader& runtime) : policy_(policy), runtime_(runtime) {
     for (const auto& additional_origin : policy.additional_origins()) {
-      additional_origins_.push_back(OriginMatcher(additional_origin));
+      additional_origins_.emplace_back(OriginMatcher(additional_origin));
     }
   }
 

--- a/source/extensions/filters/http/csrf/csrf_filter.h
+++ b/source/extensions/filters/http/csrf/csrf_filter.h
@@ -7,6 +7,7 @@
 #include "envoy/stats/stats_macros.h"
 
 #include "common/buffer/buffer_impl.h"
+#include "common/common/matchers.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -30,30 +31,6 @@ struct CsrfStats {
   ALL_CSRF_STATS(GENERATE_COUNTER_STRUCT)
 };
 
-class OriginMatcher {
-public:
-  OriginMatcher(const envoy::config::filter::http::csrf::v2::OriginMatcher& matcher) {
-    const envoy::config::filter::http::csrf::v2::OriginMatcher::OriginType type = matcher.type();
-    if (type == envoy::config::filter::http::csrf::v2::OriginMatcher::REGEX) {
-      regex_origin_ = RegexUtil::parseRegex(matcher.origin());
-    }
-    else if (type == envoy::config::filter::http::csrf::v2::OriginMatcher::EXACT) {
-      exact_origin_ = matcher.origin();
-    }
-  }
-
-  bool matches(const absl::string_view source_origin) const {
-    if (!exact_origin_.empty()) {
-      return source_origin == exact_origin_;
-    }
-    return std::regex_match(source_origin.begin(), source_origin.end(), regex_origin_);
-  }
-
-private:
-  std::string exact_origin_;
-  std::regex regex_origin_;
-};
-
 /**
  * Configuration for CSRF policy.
  */
@@ -61,8 +38,8 @@ class CsrfPolicy : public Router::RouteSpecificFilterConfig {
 public:
   CsrfPolicy(const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
              Runtime::Loader& runtime) : policy_(policy), runtime_(runtime) {
-    for (const auto& additional_origin : policy.additional_origins()) {
-      additional_origins_.emplace_back(OriginMatcher(additional_origin));
+    for (const auto& additional_origin : policy.additional_origins().patterns()) {
+      additional_origins_.emplace_back(Matchers::StringMatcher(additional_origin));
     }
   }
 
@@ -81,11 +58,11 @@ public:
                                               shadow_enabled.default_value());
   }
 
-  const std::list<OriginMatcher>& additional_origins() const { return additional_origins_; };
+  const std::vector<Matchers::StringMatcher>& additional_origins() const { return additional_origins_; };
 
 private:
   const envoy::config::filter::http::csrf::v2::CsrfPolicy policy_;
-  std::list<OriginMatcher> additional_origins_;
+  std::vector<Matchers::StringMatcher> additional_origins_;
   Runtime::Loader& runtime_;
 
 };

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -40,10 +40,10 @@ public:
         envoy::type::FractionalPercent::HUNDRED);
     shadow_enabled->set_runtime_key("csrf.shadow_enabled");
 
-    const auto& add_exact_origin = policy.mutable_additional_origins()->add_patterns();
+    const auto& add_exact_origin = policy.mutable_additional_origins()->Add();
     add_exact_origin->set_exact("additionalhost");
 
-    const auto& add_regex_origin = policy.mutable_additional_origins()->add_patterns();
+    const auto& add_regex_origin = policy.mutable_additional_origins()->Add();
     add_regex_origin->set_regex(R"(www\-[0-9]\.allow\.com)");
 
     return std::make_shared<CsrfFilterConfig>(policy, "test", stats_, runtime_);

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -45,7 +45,7 @@ public:
     add_exact_origin->set_type(envoy::config::filter::http::csrf::v2::OriginMatcher::EXACT);
 
     const auto& add_regex_origin = policy.mutable_additional_origins()->Add();
-    add_regex_origin->set_origin("www\\-[0-9]\\.allow\\.com");
+    add_regex_origin->set_origin(R"(www\-[0-9]\.allow\.com)");
     add_regex_origin->set_type(envoy::config::filter::http::csrf::v2::OriginMatcher::REGEX);
 
     return std::make_shared<CsrfFilterConfig>(policy, "test", stats_, runtime_);

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -40,13 +40,11 @@ public:
         envoy::type::FractionalPercent::HUNDRED);
     shadow_enabled->set_runtime_key("csrf.shadow_enabled");
 
-    const auto& add_exact_origin = policy.mutable_additional_origins()->Add();
-    add_exact_origin->set_origin("additionalhost");
-    add_exact_origin->set_type(envoy::config::filter::http::csrf::v2::OriginMatcher::EXACT);
+    const auto& add_exact_origin = policy.mutable_additional_origins()->add_patterns();
+    add_exact_origin->set_exact("additionalhost");
 
-    const auto& add_regex_origin = policy.mutable_additional_origins()->Add();
-    add_regex_origin->set_origin(R"(www\-[0-9]\.allow\.com)");
-    add_regex_origin->set_type(envoy::config::filter::http::csrf::v2::OriginMatcher::REGEX);
+    const auto& add_regex_origin = policy.mutable_additional_origins()->add_patterns();
+    add_regex_origin->set_regex(R"(www\-[0-9]\.allow\.com)");
 
     return std::make_shared<CsrfFilterConfig>(policy, "test", stats_, runtime_);
   }

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -39,6 +39,15 @@ public:
     shadow_enabled->mutable_default_value()->set_denominator(
         envoy::type::FractionalPercent::HUNDRED);
     shadow_enabled->set_runtime_key("csrf.shadow_enabled");
+
+    const auto& add_exact_origin = policy.mutable_additional_origins()->Add();
+    add_exact_origin->set_origin("additionalhost");
+    add_exact_origin->set_type(envoy::config::filter::http::csrf::v2::OriginMatcher::EXACT);
+
+    const auto& add_regex_origin = policy.mutable_additional_origins()->Add();
+    add_regex_origin->set_origin("www\\-[0-9]\\.allow\\.com");
+    add_regex_origin->set_type(envoy::config::filter::http::csrf::v2::OriginMatcher::REGEX);
+
     return std::make_shared<CsrfFilterConfig>(policy, "test", stats_, runtime_);
   }
 
@@ -321,6 +330,43 @@ TEST_F(CsrfFilterTest, NoVHostCsrfEntry) {
   Http::TestHeaderMapImpl request_headers{{":method", "DELETE"}, {"origin", "localhost"}};
 
   setVirtualHostPolicy(nullptr);
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
+
+  EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
+  EXPECT_EQ(1U, config_->stats().request_invalid_.value());
+  EXPECT_EQ(0U, config_->stats().request_valid_.value());
+}
+
+TEST_F(CsrfFilterTest, RequestFromAdditionalExactOrigin) {
+  Http::TestHeaderMapImpl request_headers{{":method", "PUT"}, {"origin", "additionalhost"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
+
+  EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
+  EXPECT_EQ(0U, config_->stats().request_invalid_.value());
+  EXPECT_EQ(1U, config_->stats().request_valid_.value());
+}
+
+TEST_F(CsrfFilterTest, RequestFromAdditionalRegexOrigin) {
+  Http::TestHeaderMapImpl request_headers{{":method", "PUT"}, {"origin", "www-1.allow.com"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
+
+  EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
+  EXPECT_EQ(0U, config_->stats().request_invalid_.value());
+  EXPECT_EQ(1U, config_->stats().request_valid_.value());
+}
+
+TEST_F(CsrfFilterTest, RequestFromInvalidAdditionalRegexOrigin) {
+  Http::TestHeaderMapImpl request_headers{{":method", "PUT"}, {"origin", "www.allow.com"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Add feature to CSRF filter to support whitelisting additional source origins.
Risk Level: Low
Testing: Included unit tests and sandbox changes (manually tested)
Docs Changes: Included
Release Notes: Included