### PR TITLE
fuzz: catch newline characters in request / response header access logs

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -24,7 +24,8 @@ static const std::string UnspecifiedValueString = "-";
 namespace {
 
 // Matches newline pattern in a StartTimeFormatter format string.
-const std::regex& getNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n")};
+const std::regex& getStartTimeNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n")};
+const std::regex& getNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "\n")};
 
 // Helper that handles the case when the ConnectionInfo is missing or if the desired value is
 // empty.
@@ -169,6 +170,11 @@ void AccessLogFormatParser::parseCommandHeader(const std::string& token, const s
   } else {
     alternative_header = "";
   }
+  // The main and alternative header should not contain invalid characters {NUL, LR, CF}.
+  if (std::regex_search(main_header, getNewlinePattern()) ||
+      std::regex_search(alternative_header, getNewlinePattern())) {
+    throw EnvoyException("Invalid header configuration. Format string contains newline.");
+  }
 }
 
 void AccessLogFormatParser::parseCommand(const std::string& token, const size_t start,
@@ -280,7 +286,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
                                      : "";
         // Validate the input specifier here. The formatted string may be destined for a header, and
         // should not contain invalid characters {NUL, LR, CF}.
-        if (std::regex_search(args, getNewlinePattern())) {
+        if (std::regex_search(args, getStartTimeNewlinePattern())) {
           throw EnvoyException("Invalid header configuration. Format string contains newline.");
         }
         formatters.emplace_back(FormatterProviderPtr{new StartTimeFormatter(args)});

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -24,7 +24,8 @@ static const std::string UnspecifiedValueString = "-";
 namespace {
 
 // Matches newline pattern in a StartTimeFormatter format string.
-const std::regex& getStartTimeNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n")};
+const std::regex& getStartTimeNewlinePattern(){
+    CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n")};
 const std::regex& getNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "\n")};
 
 // Helper that handles the case when the ConnectionInfo is missing or if the desired value is

--- a/test/common/access_log/access_log_formatter_corpus/clusterfuzz-testcase-minimized-access_log_formatter_fuzz_test-5630958620901376
+++ b/test/common/access_log/access_log_formatter_corpus/clusterfuzz-testcase-minimized-access_log_formatter_fuzz_test-5630958620901376
@@ -1,0 +1,9 @@
+format: "%RESP(\n )% %REQ(\n)%"
+response_trailers {
+}
+stream_info {
+  start_time: 7313138969067071779
+  response_code {
+    value: 262144
+  }
+}

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -1043,6 +1043,8 @@ TEST(AccessLogFormatterTest, ParserFailures) {
       "%protocol%",
       "%REQ(TEST):%",
       "%REQ(TEST):3q4%",
+      "%REQ(\n)%",
+      "%REQ(?\n)%",
       "%RESP(TEST):%",
       "%RESP(X?Y):%",
       "%RESP(X?Y):343o24%",


### PR DESCRIPTION
Fixes fuzz bug where request / response header access logs contained newline characters and caused errors when moving these strings to LowerCaseStrings.

Risk Level: Low
Testing: Corpus entry added
Fixes Issue 
https://oss-fuzz.com/testcase-detail/5630958620901376