### PR TITLE
docs: add aspell-en to fedora instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -40,7 +40,7 @@ for how to update or override dependencies.
 
     On Fedora (maybe also other red hat distros), run the following:
     ```
-    dnf install cmake libtool libstdc++ ninja-build lld patch
+    dnf install cmake libtool libstdc++ ninja-build lld patch aspell-en
     ```
 
     On macOS, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):


### PR DESCRIPTION
I had to install it in fedora 30 for the git hooks to work.

Description:
Risk Level: Low (just docs)
Testing: N\A
Docs Changes: N\A
Release Notes:  N\A
