### PR TITLE
clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,readability-container-size-empty'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
-WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move,readability-container-size-empty'
+WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move,readability-container-size-empty,performance-faster-string-find'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -58,7 +58,7 @@ using SchedulerPtr = std::unique_ptr<Scheduler>;
  */
 class TimeSystem : public TimeSource {
 public:
-  virtual ~TimeSystem() = default;
+  ~TimeSystem() override = default;
 
   using Duration = MonotonicTime::duration;
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <string.h>
-
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -133,9 +132,7 @@ public:
    *
    * @return an absl::string_view.
    */
-  absl::string_view getStringView() const {
-    return absl::string_view(buffer_.ref_, string_length_);
-  }
+  absl::string_view getStringView() const { return {buffer_.ref_, string_length_}; }
 
   /**
    * Return the string to a default state. Reference strings are not touched. Both inline/dynamic
@@ -478,7 +475,7 @@ public:
    * @param context supplies the context passed to iterate().
    * @return Iterate::Continue to continue iteration.
    */
-  typedef Iterate (*ConstIterateCb)(const HeaderEntry& header, void* context);
+  using ConstIterateCb = Iterate (*)(const HeaderEntry&, void*);
 
   /**
    * Iterate over a constant header map.

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -52,7 +52,7 @@ public:
    * Gets the current map of factory implementations. This is an ordered map for sorting reasons.
    */
   static std::map<std::string, Base*>& factories() {
-    static std::map<std::string, Base*>* factories = new std::map<std::string, Base*>;
+    static auto* factories = new std::map<std::string, Base*>;
     return *factories;
   }
 

--- a/include/envoy/stats/timespan.h
+++ b/include/envoy/stats/timespan.h
@@ -37,7 +37,7 @@ public:
   /**
    * Complete the timespan and send the time to the histogram.
    */
-  void complete() { histogram_.recordValue(getRawDuration().count()); }
+  void complete() override { histogram_.recordValue(getRawDuration().count()); }
 
   /**
    * Get duration in the time unit since the creation of the span.

--- a/include/envoy/upstream/types.h
+++ b/include/envoy/upstream/types.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include "common/common/phantom.h"

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -238,7 +238,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
       pos += 1;
       int command_end_position = pos + token.length();
 
-      if (token.find("REQ(") == 0) {
+      if (absl::StartsWith(token, "REQ(")) {
         std::string main_header, alternative_header;
         absl::optional<size_t> max_length;
 
@@ -246,7 +246,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
 
         formatters.emplace_back(FormatterProviderPtr{
             new RequestHeaderFormatter(main_header, alternative_header, max_length)});
-      } else if (token.find("RESP(") == 0) {
+      } else if (absl::StartsWith(token, "RESP(")) {
         std::string main_header, alternative_header;
         absl::optional<size_t> max_length;
 
@@ -254,7 +254,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
 
         formatters.emplace_back(FormatterProviderPtr{
             new ResponseHeaderFormatter(main_header, alternative_header, max_length)});
-      } else if (token.find("TRAILER(") == 0) {
+      } else if (absl::StartsWith(token, "TRAILER(")) {
         std::string main_header, alternative_header;
         absl::optional<size_t> max_length;
 
@@ -262,7 +262,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
 
         formatters.emplace_back(FormatterProviderPtr{
             new ResponseTrailerFormatter(main_header, alternative_header, max_length)});
-      } else if (token.find(DYNAMIC_META_TOKEN) == 0) {
+      } else if (absl::StartsWith(token, DYNAMIC_META_TOKEN)) {
         std::string filter_namespace;
         absl::optional<size_t> max_length;
         std::vector<std::string> path;
@@ -271,7 +271,7 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
         parseCommand(token, start, ":", filter_namespace, path, max_length);
         formatters.emplace_back(
             FormatterProviderPtr{new DynamicMetadataFormatter(filter_namespace, path, max_length)});
-      } else if (token.find("START_TIME") == 0) {
+      } else if (absl::StartsWith(token, "START_TIME")) {
         const size_t parameters_length = pos + StartTimeParamStart + 1;
         const size_t parameters_end = command_end_position - parameters_length;
 

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -1,9 +1,10 @@
 #include "common/api/os_sys_calls_impl.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include <cerrno>
 
 namespace Envoy {
 namespace Api {

--- a/source/common/api/os_sys_calls_impl_hot_restart.cc
+++ b/source/common/api/os_sys_calls_impl_hot_restart.cc
@@ -1,6 +1,6 @@
 #include "common/api/os_sys_calls_impl_hot_restart.h"
 
-#include <errno.h>
+#include <cerrno>
 
 namespace Envoy {
 namespace Api {

--- a/source/common/api/os_sys_calls_impl_linux.cc
+++ b/source/common/api/os_sys_calls_impl_linux.cc
@@ -4,8 +4,9 @@
 
 #include "common/api/os_sys_calls_impl_linux.h"
 
-#include <errno.h>
 #include <sched.h>
+
+#include <cerrno>
 
 namespace Envoy {
 namespace Api {

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -507,7 +507,7 @@ public:
 
   // LibEventInstance
   Event::Libevent::BufferPtr& buffer() override { return buffer_; }
-  virtual void postProcess() override;
+  void postProcess() override;
 
   /**
    * Create a new slice at the end of the buffer, and copy the supplied content into it.

--- a/source/common/buffer/zero_copy_input_stream_impl.h
+++ b/source/common/buffer/zero_copy_input_stream_impl.h
@@ -34,10 +34,10 @@ public:
   // Note Next() will return true with no data until more data is available if the stream is not
   // finished. It is the caller's responsibility to finish the stream or wrap with
   // LimitingInputStream before passing to protobuf code to avoid a spin loop.
-  virtual bool Next(const void** data, int* size) override;
-  virtual void BackUp(int count) override;
-  virtual bool Skip(int count) override; // Not implemented
-  virtual ProtobufTypes::Int64 ByteCount() const override { return byte_count_; }
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override; // Not implemented
+  ProtobufTypes::Int64 ByteCount() const override { return byte_count_; }
 
 protected:
   Buffer::InstancePtr buffer_;

--- a/source/common/common/assert.cc
+++ b/source/common/common/assert.cc
@@ -30,7 +30,7 @@ private:
 
 std::function<void()> ActionRegistrationImpl::debug_assertion_failure_record_action_;
 
-ActionRegistrationPtr setDebugAssertionFailureRecordAction(std::function<void()> action) {
+ActionRegistrationPtr setDebugAssertionFailureRecordAction(const std::function<void()>& action) {
   return std::make_unique<ActionRegistrationImpl>(action);
 }
 

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -30,7 +30,7 @@ using ActionRegistrationPtr = std::unique_ptr<ActionRegistration>;
  * @param action The action to take when an assertion fails.
  * @return A registration object. The registration is removed when the object is destructed.
  */
-ActionRegistrationPtr setDebugAssertionFailureRecordAction(std::function<void()> action);
+ActionRegistrationPtr setDebugAssertionFailureRecordAction(const std::function<void()>& action);
 
 /**
  * Invokes the action set by setDebugAssertionFailureRecordAction, or does nothing if

--- a/source/common/common/empty_string.h
+++ b/source/common/common/empty_string.h
@@ -3,5 +3,5 @@
 #include <string>
 
 namespace Envoy {
-static const std::string EMPTY_STRING = "";
+static const std::string EMPTY_STRING;
 } // namespace Envoy

--- a/source/common/common/linked_object.h
+++ b/source/common/common/linked_object.h
@@ -76,11 +76,11 @@ public:
   }
 
 protected:
-  LinkedObject() : inserted_(false) {}
+  LinkedObject() = default;
 
 private:
   typename ListType::iterator entry_;
-  bool inserted_; // iterators do not have any "invalid" value so we need this boolean for sanity
-                  // checking.
+  bool inserted_{false}; // iterators do not have any "invalid" value so we need this boolean for
+                         // sanity checking.
 };
 } // namespace Envoy

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -74,7 +74,7 @@ public:
    * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
    * fine spdlog::info corresponds to LOGGER.info method.
    */
-  typedef enum {
+  using levels = enum {
     trace = spdlog::level::trace,
     debug = spdlog::level::debug,
     info = spdlog::level::info,
@@ -82,7 +82,7 @@ public:
     error = spdlog::level::err,
     critical = spdlog::level::critical,
     off = spdlog::level::off
-  } levels;
+  };
 
   spdlog::string_view_t levelString() const {
     return spdlog::level::level_string_views[logger_->level()];

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -107,7 +107,7 @@ class ListMatcher : public ValueMatcher {
 public:
   ListMatcher(const envoy::type::matcher::ListMatcher& matcher);
 
-  bool match(const ProtobufWkt::Value& value) const;
+  bool match(const ProtobufWkt::Value& value) const override;
 
 private:
   const envoy::type::matcher::ListMatcher matcher_;

--- a/source/common/common/non_copyable.h
+++ b/source/common/common/non_copyable.h
@@ -6,7 +6,7 @@ namespace Envoy {
  */
 class NonCopyable {
 protected:
-  NonCopyable() {}
+  NonCopyable() = default;
 
 private:
   NonCopyable(const NonCopyable&);

--- a/source/common/common/perf_annotation.cc
+++ b/source/common/common/perf_annotation.cc
@@ -30,7 +30,7 @@ void PerfOperation::record(absl::string_view category, absl::string_view descrip
 // The ctor is explicitly declared private to encourage clients to use getOrCreate(), at
 // least for now. Given that it's declared it must be instantiated. It's not inlined
 // because the constructor is non-trivial due to the contained unordered_map.
-PerfAnnotationContext::PerfAnnotationContext() {}
+PerfAnnotationContext::PerfAnnotationContext() = default;
 
 void PerfAnnotationContext::record(std::chrono::nanoseconds duration, absl::string_view category,
                                    absl::string_view description) {
@@ -146,7 +146,7 @@ void PerfAnnotationContext::clear() {
 }
 
 PerfAnnotationContext* PerfAnnotationContext::getOrCreate() {
-  static PerfAnnotationContext* context = new PerfAnnotationContext();
+  static auto* context = new PerfAnnotationContext();
   return context;
 }
 

--- a/source/common/common/scalar_to_byte_vector.h
+++ b/source/common/common/scalar_to_byte_vector.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
-
+#include <cinttypes>
 #include <vector>
 
 namespace Envoy {

--- a/source/common/common/stack_array.h
+++ b/source/common/common/stack_array.h
@@ -7,7 +7,7 @@
 #include <alloca.h>
 #endif
 
-#include <stddef.h>
+#include <cstddef>
 
 #include "common/common/assert.h"
 

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -719,7 +719,7 @@ public:
   /**
    * @return a string_view into the InlineString.
    */
-  absl::string_view toStringView() const { return absl::string_view(data_, size_); }
+  absl::string_view toStringView() const { return {data_, size_}; }
 
   /**
    * @return the number of bytes in the string

--- a/source/common/config/metadata.cc
+++ b/source/common/config/metadata.cc
@@ -13,7 +13,7 @@ const ProtobufWkt::Value& Metadata::metadataValue(const envoy::api::v2::core::Me
   const ProtobufWkt::Struct* data_struct = &(filter_it->second);
   const ProtobufWkt::Value* val = nullptr;
   // go through path to select sub entries
-  for (const auto p : path) {
+  for (const auto& p : path) {
     if (nullptr == data_struct) { // sub entry not found
       return ProtobufWkt::Value::default_instance();
     }

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -44,62 +44,62 @@ TagNameValues::TagNameValues() {
 
   // mongo.[<stat_prefix>.]collection.[<collection>.]callsite.(<callsite>.)query.<base_stat>
   addRegex(MONGO_CALLSITE,
-           "^mongo(?=\\.).*?\\.collection(?=\\.).*?\\.callsite\\.((.*?)\\.).*?query.\\w+?$",
+           R"(^mongo(?=\.).*?\.collection(?=\.).*?\.callsite\.((.*?)\.).*?query.\w+?$)",
            ".collection.");
 
   // http.[<stat_prefix>.]dynamodb.table.(<table_name>.) or
   // http.[<stat_prefix>.]dynamodb.error.(<table_name>.)*
-  addRegex(DYNAMO_TABLE, "^http(?=\\.).*?\\.dynamodb.(?:table|error)\\.((.*?)\\.)", ".dynamodb.");
+  addRegex(DYNAMO_TABLE, R"(^http(?=\.).*?\.dynamodb.(?:table|error)\.((.*?)\.))", ".dynamodb.");
 
   // mongo.[<stat_prefix>.]collection.(<collection>.)query.<base_stat>
-  addRegex(MONGO_COLLECTION, "^mongo(?=\\.).*?\\.collection\\.((.*?)\\.).*?query.\\w+?$",
+  addRegex(MONGO_COLLECTION, R"(^mongo(?=\.).*?\.collection\.((.*?)\.).*?query.\w+?$)",
            ".collection.");
 
   // mongo.[<stat_prefix>.]cmd.(<cmd>.)<base_stat>
-  addRegex(MONGO_CMD, "^mongo(?=\\.).*?\\.cmd\\.((.*?)\\.)\\w+?$", ".cmd.");
+  addRegex(MONGO_CMD, R"(^mongo(?=\.).*?\.cmd\.((.*?)\.)\w+?$)", ".cmd.");
 
   // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.](<grpc_method>.)<base_stat>
-  addRegex(GRPC_BRIDGE_METHOD, "^cluster(?=\\.).*?\\.grpc(?=\\.).*\\.((.*?)\\.)\\w+?$", ".grpc.");
+  addRegex(GRPC_BRIDGE_METHOD, R"(^cluster(?=\.).*?\.grpc(?=\.).*\.((.*?)\.)\w+?$)", ".grpc.");
 
   // http.[<stat_prefix>.]user_agent.(<user_agent>.)<base_stat>
-  addRegex(HTTP_USER_AGENT, "^http(?=\\.).*?\\.user_agent\\.((.*?)\\.)\\w+?$", ".user_agent.");
+  addRegex(HTTP_USER_AGENT, R"(^http(?=\.).*?\.user_agent\.((.*?)\.)\w+?$)", ".user_agent.");
 
   // vhost.[<virtual host name>.]vcluster.(<virtual_cluster_name>.)<base_stat>
-  addRegex(VIRTUAL_CLUSTER, "^vhost(?=\\.).*?\\.vcluster\\.((.*?)\\.)\\w+?$", ".vcluster.");
+  addRegex(VIRTUAL_CLUSTER, R"(^vhost(?=\.).*?\.vcluster\.((.*?)\.)\w+?$)", ".vcluster.");
 
   // http.[<stat_prefix>.]fault.(<downstream_cluster>.)<base_stat>
-  addRegex(FAULT_DOWNSTREAM_CLUSTER, "^http(?=\\.).*?\\.fault\\.((.*?)\\.)\\w+?$", ".fault.");
+  addRegex(FAULT_DOWNSTREAM_CLUSTER, R"(^http(?=\.).*?\.fault\.((.*?)\.)\w+?$)", ".fault.");
 
   // listener.[<address>.]ssl.cipher.(<cipher>)
-  addRegex(SSL_CIPHER, "^listener(?=\\.).*?\\.ssl\\.cipher(\\.(.*?))$");
+  addRegex(SSL_CIPHER, R"(^listener(?=\.).*?\.ssl\.cipher(\.(.*?))$)");
 
   // cluster.[<cluster_name>.]ssl.ciphers.(<cipher>)
-  addRegex(SSL_CIPHER_SUITE, "^cluster(?=\\.).*?\\.ssl\\.ciphers(\\.(.*?))$", ".ssl.ciphers.");
+  addRegex(SSL_CIPHER_SUITE, R"(^cluster(?=\.).*?\.ssl\.ciphers(\.(.*?))$)", ".ssl.ciphers.");
 
   // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.)*
-  addRegex(GRPC_BRIDGE_SERVICE, "^cluster(?=\\.).*?\\.grpc\\.((.*?)\\.)", ".grpc.");
+  addRegex(GRPC_BRIDGE_SERVICE, R"(^cluster(?=\.).*?\.grpc\.((.*?)\.))", ".grpc.");
 
   // tcp.(<stat_prefix>.)<base_stat>
-  addRegex(TCP_PREFIX, "^tcp\\.((.*?)\\.)\\w+?$");
+  addRegex(TCP_PREFIX, R"(^tcp\.((.*?)\.)\w+?$)");
 
   // auth.clientssl.(<stat_prefix>.)<base_stat>
-  addRegex(CLIENTSSL_PREFIX, "^auth\\.clientssl\\.((.*?)\\.)\\w+?$");
+  addRegex(CLIENTSSL_PREFIX, R"(^auth\.clientssl\.((.*?)\.)\w+?$)");
 
   // ratelimit.(<stat_prefix>.)<base_stat>
-  addRegex(RATELIMIT_PREFIX, "^ratelimit\\.((.*?)\\.)\\w+?$");
+  addRegex(RATELIMIT_PREFIX, R"(^ratelimit\.((.*?)\.)\w+?$)");
 
   // cluster.(<cluster_name>.)*
   addRegex(CLUSTER_NAME, "^cluster\\.((.*?)\\.)");
 
   // listener.[<address>.]http.(<stat_prefix>.)*
-  addRegex(HTTP_CONN_MANAGER_PREFIX, "^listener(?=\\.).*?\\.http\\.((.*?)\\.)", ".http.");
+  addRegex(HTTP_CONN_MANAGER_PREFIX, R"(^listener(?=\.).*?\.http\.((.*?)\.))", ".http.");
 
   // http.(<stat_prefix>.)*
   addRegex(HTTP_CONN_MANAGER_PREFIX, "^http\\.((.*?)\\.)");
 
   // listener.(<address>.)*
   addRegex(LISTENER_ADDRESS,
-           "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)");
+           R"(^listener\.(((?:[_.[:digit:]]*|[_\[\]aAbBcCdDeEfF[:digit:]]*))\.))");
 
   // vhost.(<virtual host name>.)*
   addRegex(VIRTUAL_HOST, "^vhost\\.((.*?)\\.)");
@@ -108,10 +108,10 @@ TagNameValues::TagNameValues() {
   addRegex(MONGO_PREFIX, "^mongo\\.((.*?)\\.)");
 
   // http.[<stat_prefix>.]rds.(<route_config_name>.)<base_stat>
-  addRegex(RDS_ROUTE_CONFIG, "^http(?=\\.).*?\\.rds\\.((.*?)\\.)\\w+?$", ".rds.");
+  addRegex(RDS_ROUTE_CONFIG, R"(^http(?=\.).*?\.rds\.((.*?)\.)\w+?$)", ".rds.");
 
   // listener_manager.(worker_<id>.)*
-  addRegex(WORKER_ID, "^listener_manager\\.((worker_\\d+)\\.)", "listener_manager.worker_");
+  addRegex(WORKER_ID, R"(^listener_manager\.((worker_\d+)\.))", "listener_manager.worker_");
 }
 
 void TagNameValues::addRegex(const std::string& name, const std::string& regex,

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -47,7 +47,7 @@ void FileEventImpl::assignEvents(uint32_t events) {
           (events & FileReadyType::Write ? EV_WRITE : 0) |
           (events & FileReadyType::Closed ? EV_CLOSED : 0),
       [](evutil_socket_t, short what, void* arg) -> void {
-        FileEventImpl* event = static_cast<FileEventImpl*>(arg);
+        auto* event = static_cast<FileEventImpl*>(arg);
         uint32_t events = 0;
         if (what & EV_READ) {
           events |= FileReadyType::Read;

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -1,6 +1,6 @@
 #include "common/event/libevent.h"
 
-#include <signal.h>
+#include <csignal>
 
 #include "common/common/assert.h"
 

--- a/source/common/filesystem/file_shared_impl.h
+++ b/source/common/filesystem/file_shared_impl.h
@@ -13,7 +13,7 @@ class IoFileError : public Api::IoError {
 public:
   explicit IoFileError(int sys_errno) : errno_(sys_errno) {}
 
-  ~IoFileError() override {}
+  ~IoFileError() override = default;
 
   Api::IoError::IoErrorCode getErrorCode() const override;
   std::string getErrorDetails() const override;

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -63,7 +63,7 @@ void WatcherImpl::onInotifyEvent() {
     const size_t event_count = rc;
     size_t index = 0;
     while (index < event_count) {
-      inotify_event* file_event = reinterpret_cast<inotify_event*>(&buffer[index]);
+      auto* file_event = reinterpret_cast<inotify_event*>(&buffer[index]);
       ASSERT(callback_map_.count(file_event->wd) == 1);
 
       std::string file;

--- a/source/common/filesystem/inotify/watcher_impl.h
+++ b/source/common/filesystem/inotify/watcher_impl.h
@@ -21,7 +21,7 @@ namespace Filesystem {
 class WatcherImpl : public Watcher, Logger::Loggable<Logger::Id::file> {
 public:
   WatcherImpl(Event::Dispatcher& dispatcher);
-  ~WatcherImpl();
+  ~WatcherImpl() override;
 
   // Filesystem::Watcher
   void addWatch(const std::string& path, uint32_t events, OnChangedCb cb) override;

--- a/source/common/filesystem/posix/directory_iterator_impl.cc
+++ b/source/common/filesystem/posix/directory_iterator_impl.cc
@@ -7,7 +7,7 @@ namespace Envoy {
 namespace Filesystem {
 
 DirectoryIteratorImpl::DirectoryIteratorImpl(const std::string& directory_path)
-    : DirectoryIterator(), directory_path_(directory_path), dir_(nullptr),
+    : directory_path_(directory_path), dir_(nullptr),
       os_sys_calls_(Api::OsSysCallsSingleton::get()) {
   openDirectory();
   nextEntry();

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -13,7 +13,7 @@ namespace Filesystem {
 class FileImplPosix : public FileSharedImpl {
 public:
   FileImplPosix(const std::string& path) : FileSharedImpl(path) {}
-  ~FileImplPosix();
+  ~FileImplPosix() override;
 
 protected:
   // Filesystem::FileSharedImpl

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -164,7 +164,7 @@ private:
 
   struct NullVirtualHost : public Router::VirtualHost {
     // Router::VirtualHost
-    Stats::StatName statName() const override { return Stats::StatName(); }
+    Stats::StatName statName() const override { return {}; }
     const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
     const Router::Config& routeConfig() const override { return route_configuration_; }
@@ -368,7 +368,7 @@ public:
                    const AsyncClient::RequestOptions& options);
 
   // AsyncClient::Request
-  virtual void cancel() override;
+  void cancel() override;
 
 private:
   void initialize();

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -36,7 +36,7 @@ CodecClient::CodecClient(Type type, Network::ClientConnectionPtr&& connection,
   connection_->noDelay(true);
 }
 
-CodecClient::~CodecClient() {}
+CodecClient::~CodecClient() = default;
 
 void CodecClient::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -53,7 +53,7 @@ public:
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info,
                         Upstream::ClusterManager& cluster_manager,
                         Server::OverloadManager* overload_manager, TimeSource& time_system);
-  ~ConnectionManagerImpl();
+  ~ConnectionManagerImpl() override;
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
   static ConnectionManagerTracingStats generateTracingStats(const std::string& prefix,

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -19,7 +19,7 @@ protected:
   struct PendingRequest : LinkedObject<PendingRequest>, public ConnectionPool::Cancellable {
     PendingRequest(ConnPoolImplBase& parent, StreamDecoder& decoder,
                    ConnectionPool::Callbacks& callbacks);
-    ~PendingRequest();
+    ~PendingRequest() override;
 
     // ConnectionPool::Cancellable
     void cancel() override { parent_.onPendingRequestCancel(*this); }

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -315,7 +315,7 @@ http_parser_settings ConnectionImpl::settings_{
 };
 
 const ToLowerTable& ConnectionImpl::toLowerTable() {
-  static ToLowerTable* table = new ToLowerTable();
+  static auto* table = new ToLowerTable();
   return *table;
 }
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -34,7 +34,7 @@ public:
                Upstream::ResourcePriority priority,
                const Network::ConnectionSocket::OptionsSharedPtr& options);
 
-  ~ConnPoolImpl();
+  ~ConnPoolImpl() override;
 
   // ConnectionPool::Instance
   Http::Protocol protocol() const override { return Http::Protocol::Http11; }
@@ -55,7 +55,7 @@ protected:
                          public StreamDecoderWrapper,
                          public StreamCallbacks {
     StreamWrapper(StreamDecoder& response_decoder, ActiveClient& parent);
-    ~StreamWrapper();
+    ~StreamWrapper() override;
 
     // StreamEncoderWrapper
     void onEncodeComplete() override;
@@ -84,7 +84,7 @@ protected:
                         public Network::ConnectionCallbacks,
                         public Event::DeferredDeletable {
     ActiveClient(ConnPoolImpl& parent);
-    ~ActiveClient();
+    ~ActiveClient() override;
 
     void onConnectTimeout();
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -738,7 +738,7 @@ void ConnectionImpl::sendSettings(const Http2Settings& http2_settings, bool disa
     ASSERT(rc == 0);
   } else {
     // nghttp2_submit_settings need to be called at least once
-    int rc = nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, 0, 0);
+    int rc = nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, nullptr, 0);
     ASSERT(rc == 0);
   }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -168,8 +168,8 @@ protected:
     void addCallbacks(StreamCallbacks& callbacks) override { addCallbacks_(callbacks); }
     void removeCallbacks(StreamCallbacks& callbacks) override { removeCallbacks_(callbacks); }
     void resetStream(StreamResetReason reason) override;
-    virtual void readDisable(bool disable) override;
-    virtual uint32_t bufferLimit() override { return pending_recv_data_.highWatermark(); }
+    void readDisable(bool disable) override;
+    uint32_t bufferLimit() override { return pending_recv_data_.highWatermark(); }
 
     void setWriteBufferWatermarks(uint32_t low_watermark, uint32_t high_watermark) {
       pending_recv_data_.setWatermarks(low_watermark, high_watermark);

--- a/source/common/http/rest_api_fetcher.h
+++ b/source/common/http/rest_api_fetcher.h
@@ -20,7 +20,7 @@ protected:
                  Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                  std::chrono::milliseconds refresh_interval,
                  std::chrono::milliseconds request_timeout);
-  ~RestApiFetcher();
+  ~RestApiFetcher() override;
 
   /**
    * Start the fetch sequence. This should be called once.

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -304,7 +304,7 @@ Ipv6Instance::Ipv6Instance(const std::string& address, uint32_t port) : Instance
 Ipv6Instance::Ipv6Instance(uint32_t port) : Ipv6Instance("", port) {}
 
 bool Ipv6Instance::operator==(const Instance& rhs) const {
-  const Ipv6Instance* rhs_casted = dynamic_cast<const Ipv6Instance*>(&rhs);
+  const auto* rhs_casted = dynamic_cast<const Ipv6Instance*>(&rhs);
   return (rhs_casted && (ip_.ipv6_.address() == rhs_casted->ip_.ipv6_.address()) &&
           (ip_.port() == rhs_casted->ip_.port()));
 }

--- a/source/common/network/cidr_range.h
+++ b/source/common/network/cidr_range.h
@@ -129,7 +129,7 @@ public:
   IpList(const std::vector<std::string>& subnets);
   IpList(const Json::Object& config, const std::string& member_name);
   IpList(const Protobuf::RepeatedPtrField<envoy::api::v2::core::CidrRange>& cidrs);
-  IpList(){};
+  IpList() = default;
 
   bool contains(const Instance& address) const;
   bool empty() const { return ip_list_.empty(); }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -53,7 +53,7 @@ public:
   ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPtr&& socket,
                  TransportSocketPtr&& transport_socket, bool connected);
 
-  ~ConnectionImpl();
+  ~ConnectionImpl() override;
 
   // Network::FilterManager
   void addWriteFilter(WriteFilterSharedPtr filter) override;

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -72,7 +72,7 @@ Api::IoCallUint64Result IoSocketHandleImpl::writev(const Buffer::RawSlice* slice
 
 Api::IoCallUint64Result IoSocketHandleImpl::sendto(const Buffer::RawSlice& slice, int flags,
                                                    const Address::Instance& address) {
-  const Address::InstanceBase* address_base = dynamic_cast<const Address::InstanceBase*>(&address);
+  const auto* address_base = dynamic_cast<const Address::InstanceBase*>(&address);
   sockaddr* sock_addr = const_cast<sockaddr*>(address_base->sockAddr());
 
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
@@ -84,7 +84,7 @@ Api::IoCallUint64Result IoSocketHandleImpl::sendto(const Buffer::RawSlice& slice
 Api::IoCallUint64Result IoSocketHandleImpl::sendmsg(const Buffer::RawSlice* slices,
                                                     uint64_t num_slice, int flags,
                                                     const Address::Instance& address) {
-  const Address::InstanceBase* address_base = dynamic_cast<const Address::InstanceBase*>(&address);
+  const auto* address_base = dynamic_cast<const Address::InstanceBase*>(&address);
   sockaddr* sock_addr = const_cast<sockaddr*>(address_base->sockAddr());
 
   STACK_ARRAY(iov, iovec, num_slice);

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -238,7 +238,7 @@ private:
    */
   template <class IpType, uint32_t address_size = CHAR_BIT * sizeof(IpType)> struct IpPrefix {
 
-    IpPrefix() {}
+    IpPrefix() = default;
 
     IpPrefix(const IpType& ip, uint32_t length, const T& data) : ip_(ip), length_(length) {
       data_.insert(data);

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -20,7 +20,7 @@ class UdpListenerImpl : public BaseListenerImpl,
 public:
   UdpListenerImpl(Event::DispatcherImpl& dispatcher, Socket& socket, UdpListenerCallbacks& cb);
 
-  ~UdpListenerImpl();
+  ~UdpListenerImpl() override;
 
   // Network::Listener Interface
   void disable() override;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -65,7 +65,7 @@ namespace {
 
 std::string hostFromUrl(const std::string& url, const std::string& scheme,
                         const std::string& scheme_name) {
-  if (url.find(scheme) != 0) {
+  if (!absl::StartsWith(url, scheme)) {
     throw EnvoyException(fmt::format("expected {} scheme, got: {}", scheme_name, url));
   }
 
@@ -80,7 +80,7 @@ std::string hostFromUrl(const std::string& url, const std::string& scheme,
 
 uint32_t portFromUrl(const std::string& url, const std::string& scheme,
                      const std::string& scheme_name) {
-  if (url.find(scheme) != 0) {
+  if (!absl::StartsWith(url, scheme)) {
     throw EnvoyException(fmt::format("expected {} scheme, got: {}", scheme_name, url));
   }
 
@@ -163,7 +163,7 @@ Address::InstanceConstSharedPtr Utility::parseInternetAddressAndPort(const std::
     return std::make_shared<Address::Ipv6Instance>(sa6, v6only);
   }
   // Treat it as an IPv4 address followed by a port.
-  auto pos = ip_address.rfind(":");
+  auto pos = ip_address.rfind(':');
   if (pos == std::string::npos) {
     throwWithMalformedIp(ip_address);
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -664,7 +664,7 @@ RouteEntryImplBase::parseOpaqueConfig(const envoy::api::v2::route::Route& route)
     if (filter_metadata == route.metadata().filter_metadata().end()) {
       return ret;
     }
-    for (auto it : filter_metadata->second.fields()) {
+    for (const auto& it : filter_metadata->second.fields()) {
       if (it.second.kind_case() == ProtobufWkt::Value::kStringValue) {
         ret.emplace(it.first, it.second.string_value());
       }

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -92,7 +92,7 @@ private:
 class NullHistogramImpl : public Histogram, NullMetricImpl {
 public:
   explicit NullHistogramImpl(SymbolTable& symbol_table) : NullMetricImpl(symbol_table) {}
-  ~NullHistogramImpl() {
+  ~NullHistogramImpl() override {
     // MetricImpl must be explicitly cleared() before destruction, otherwise it
     // will not be able to access the SymbolTable& to free the symbols. An RAII
     // alternative would be to store the SymbolTable reference in the

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -85,7 +85,7 @@ protected:
   HealthCheckerImplBase(const Cluster& cluster, const envoy::api::v2::core::HealthCheck& config,
                         Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
                         Runtime::RandomGenerator& random, HealthCheckEventLoggerPtr&& event_logger);
-  ~HealthCheckerImplBase();
+  ~HealthCheckerImplBase() override;
 
   virtual ActiveHealthCheckSessionPtr makeSession(HostSharedPtr host) PURE;
   virtual envoy::data::core::v2alpha::HealthCheckerType healthCheckerType() const PURE;

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -68,7 +68,7 @@ private:
                                         public Http::StreamDecoder,
                                         public Http::StreamCallbacks {
     HttpActiveHealthCheckSession(HttpHealthCheckerImpl& parent, const HostSharedPtr& host);
-    ~HttpActiveHealthCheckSession();
+    ~HttpActiveHealthCheckSession() override;
 
     void onResponseComplete();
     enum class HealthCheckResult { Succeeded, Degraded, Failed };
@@ -241,7 +241,7 @@ private:
   struct TcpActiveHealthCheckSession : public ActiveHealthCheckSession {
     TcpActiveHealthCheckSession(TcpHealthCheckerImpl& parent, const HostSharedPtr& host)
         : ActiveHealthCheckSession(parent, host), parent_(parent) {}
-    ~TcpActiveHealthCheckSession();
+    ~TcpActiveHealthCheckSession() override;
 
     void onData(Buffer::Instance& data);
     void onEvent(Network::ConnectionEvent event);
@@ -287,7 +287,7 @@ private:
                                         public Http::StreamDecoder,
                                         public Http::StreamCallbacks {
     GrpcActiveHealthCheckSession(GrpcHealthCheckerImpl& parent, const HostSharedPtr& host);
-    ~GrpcActiveHealthCheckSession();
+    ~GrpcActiveHealthCheckSession() override;
 
     void onRpcComplete(Grpc::Status::GrpcStatus grpc_status, const std::string& grpc_message,
                        bool end_stream);

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -37,7 +37,7 @@ public:
                     Server::Configuration::TransportSocketFactoryContext& factory_context,
                     Stats::ScopePtr&& stats_scope, bool added_via_api);
 
-  ~LogicalDnsCluster();
+  ~LogicalDnsCluster() override;
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -10,7 +10,7 @@ template <typename KEY_TYPE, typename POOL_TYPE>
 PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::PriorityConnPoolMap(Envoy::Event::Dispatcher& dispatcher,
                                                               const HostConstSharedPtr& host) {
   for (size_t pool_map_index = 0; pool_map_index < NumResourcePriorities; ++pool_map_index) {
-    ResourcePriority priority = static_cast<ResourcePriority>(pool_map_index);
+    auto priority = static_cast<ResourcePriority>(pool_map_index);
     conn_pool_maps_[pool_map_index].reset(new ConnPoolMapType(dispatcher, host, priority));
   }
 }

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -29,7 +29,7 @@ public:
       const absl::optional<envoy::api::v2::Cluster::RingHashLbConfig>& lb_ring_hash_config,
       const absl::optional<envoy::api::v2::Cluster::LeastRequestLbConfig>& least_request_config,
       const envoy::api::v2::Cluster::CommonLbConfig& common_config);
-  ~SubsetLoadBalancer();
+  ~SubsetLoadBalancer() override;
 
   // Upstream::LoadBalancer
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -135,7 +135,7 @@ private:
   // Entry in the subset hierarchy.
   class LbSubsetEntry {
   public:
-    LbSubsetEntry() {}
+    LbSubsetEntry() = default;
 
     bool initialized() const { return priority_subset_ != nullptr; }
     bool active() const { return initialized() && !priority_subset_->empty(); }

--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -1,7 +1,8 @@
 #include "exe/signal_action.h"
 
-#include <signal.h>
 #include <sys/mman.h>
+
+#include <csignal>
 
 #include "common/common/assert.h"
 

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -160,7 +160,7 @@ ProcessCluster(const NetworkFilters::Common::Redis::RespValue& value) {
   }
 
   std::string address = array[0].asString();
-  bool ipv6 = (address.find(":") != std::string::npos);
+  bool ipv6 = (address.find(':') != std::string::npos);
   if (ipv6) {
     return std::make_shared<Network::Address::Ipv6Instance>(address, array[1].asInteger());
   }

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -100,7 +100,7 @@ public:
 
   struct ClusterSlotsRequest : public Extensions::NetworkFilters::Common::Redis::RespValue {
   public:
-    ClusterSlotsRequest() : Extensions::NetworkFilters::Common::Redis::RespValue() {
+    ClusterSlotsRequest() {
       type(Extensions::NetworkFilters::Common::Redis::RespType::Array);
       std::vector<NetworkFilters::Common::Redis::RespValue> values(2);
       values[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
@@ -193,7 +193,7 @@ private:
     RedisDiscoverySession(RedisCluster& parent,
                           NetworkFilters::Common::Redis::Client::ClientFactory& client_factory);
 
-    ~RedisDiscoverySession();
+    ~RedisDiscoverySession() override;
 
     void registerDiscoveryAddress(
         const std::list<Network::Address::InstanceConstSharedPtr>& address_list,

--- a/source/extensions/common/tap/extension_config_base.h
+++ b/source/extensions/common/tap/extension_config_base.h
@@ -27,7 +27,7 @@ protected:
                       TapConfigFactoryPtr&& config_factory, Server::Admin& admin,
                       Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
                       Event::Dispatcher& main_thread_dispatcher);
-  ~ExtensionConfigBase();
+  ~ExtensionConfigBase() override;
 
   // All tap configurations derive from TapConfig for type safety. In order to use a common
   // extension base class (with TLS logic, etc.) we must dynamic cast to the actual tap

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -54,7 +54,7 @@ bool Config::configToVector(const ProtobufRepeatedRule& proto_rules,
 
 HeaderToMetadataFilter::HeaderToMetadataFilter(const ConfigSharedPtr config) : config_(config) {}
 
-HeaderToMetadataFilter::~HeaderToMetadataFilter() {}
+HeaderToMetadataFilter::~HeaderToMetadataFilter() = default;
 
 Http::FilterHeadersStatus HeaderToMetadataFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   if (config_->doRequest()) {

--- a/source/extensions/filters/http/squash/squash_filter.h
+++ b/source/extensions/filters/http/squash/squash_filter.h
@@ -71,7 +71,7 @@ class SquashFilter : public Http::StreamDecoderFilter,
                      protected Logger::Loggable<Logger::Id::filter> {
 public:
   SquashFilter(SquashFilterConfigSharedPtr config, Upstream::ClusterManager& cm);
-  ~SquashFilter();
+  ~SquashFilter() override;
 
   // Http::StreamFilterBase
   void onDestroy() override;

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.h
@@ -136,9 +136,9 @@ public:
   void numberToSkip(int32_t skip) override { number_to_skip_ = skip; }
   int32_t numberToReturn() const override { return number_to_return_; }
   void numberToReturn(int32_t to_return) override { number_to_return_ = to_return; }
-  virtual const Bson::Document* query() const override { return query_.get(); }
+  const Bson::Document* query() const override { return query_.get(); }
   void query(Bson::DocumentSharedPtr&& query) override { query_ = std::move(query); }
-  virtual const Bson::Document* returnFieldsSelector() const override {
+  const Bson::Document* returnFieldsSelector() const override {
     return return_fields_selector_.get();
   }
   void returnFieldsSelector(Bson::DocumentSharedPtr&& fields) override {

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -188,13 +188,13 @@ InstanceImpl::ThreadLocalPool::makeRequestToHost(const std::string& host_address
     return nullptr;
   }
 
-  auto colon_pos = host_address.rfind(":");
+  auto colon_pos = host_address.rfind(':');
   if ((colon_pos == std::string::npos) || (colon_pos == (host_address.size() - 1))) {
     return nullptr;
   }
 
   const std::string ip_address = host_address.substr(0, colon_pos);
-  const bool ipv6 = (ip_address.find(":") != std::string::npos);
+  const bool ipv6 = (ip_address.find(':') != std::string::npos);
   std::string host_address_map_key;
   Network::Address::InstanceConstSharedPtr address_ptr;
 

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.h
@@ -18,7 +18,7 @@ namespace ThriftProxy {
  */
 class BinaryProtocolImpl : public Protocol {
 public:
-  BinaryProtocolImpl() {}
+  BinaryProtocolImpl() = default;
 
   // Protocol
   const std::string& name() const override { return ProtocolNames::get().BINARY; }
@@ -89,7 +89,7 @@ private:
  */
 class LaxBinaryProtocolImpl : public BinaryProtocolImpl {
 public:
-  LaxBinaryProtocolImpl() {}
+  LaxBinaryProtocolImpl() = default;
 
   const std::string& name() const override { return ProtocolNames::get().LAX_BINARY; }
 

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -142,7 +142,7 @@ class Router : public Tcp::ConnectionPool::UpstreamCallbacks,
 public:
   Router(Upstream::ClusterManager& cluster_manager) : cluster_manager_(cluster_manager) {}
 
-  ~Router() {}
+  ~Router() override = default;
 
   // ThriftFilters::DecoderFilter
   void onDestroy() override;
@@ -174,7 +174,7 @@ private:
     UpstreamRequest(Router& parent, Tcp::ConnectionPool::Instance& pool,
                     MessageMetadataSharedPtr& metadata, TransportType transport_type,
                     ProtocolType protocol_type);
-    ~UpstreamRequest();
+    ~UpstreamRequest() override;
 
     FilterStatus start();
     void resetStream();

--- a/source/extensions/grpc_credentials/file_based_metadata/config.h
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.h
@@ -37,7 +37,7 @@ public:
 class FileBasedMetadataAuthenticator : public grpc::MetadataCredentialsPlugin {
 public:
   FileBasedMetadataAuthenticator(
-      const envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig config, Api::Api& api)
+      const envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig& config, Api::Api& api)
       : config_(config), api_(api) {}
 
   grpc::Status GetMetadata(grpc::string_ref, grpc::string_ref, const grpc::AuthContext&,

--- a/source/extensions/quic_listeners/quiche/envoy_quic_alarm_factory.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_alarm_factory.h
@@ -22,7 +22,7 @@ public:
   EnvoyQuicAlarmFactory(Event::Scheduler& scheduler, quic::QuicClock& clock)
       : scheduler_(scheduler), clock_(clock) {}
 
-  ~EnvoyQuicAlarmFactory() override {}
+  ~EnvoyQuicAlarmFactory() override = default;
 
   // QuicAlarmFactory
   quic::QuicAlarm* CreateAlarm(quic::QuicAlarm::Delegate* delegate) override;

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -70,7 +70,7 @@ private:
 
   static Http::HeaderMap::Iterate headerMapCallback(const Http::HeaderEntry& header,
                                                     void* context) {
-    OpenTracingCb* callback = static_cast<OpenTracingCb*>(context);
+    auto* callback = static_cast<OpenTracingCb*>(context);
     opentracing::string_view key{header.key().getStringView().data(),
                                  header.key().getStringView().length()};
     opentracing::string_view value{header.value().getStringView().data(),

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -35,7 +35,7 @@ namespace Envoy {
  */
 class BackwardsTrace : Logger::Loggable<Logger::Id::backtrace> {
 public:
-  BackwardsTrace() {}
+  BackwardsTrace() = default;
 
   /**
    * Capture a stack trace.

--- a/source/server/config_validation/connection.h
+++ b/source/server/config_validation/connection.h
@@ -28,7 +28,7 @@ public:
 
   // connect may be called in config verification mode.
   // It is redefined as no-op. Calling parent's method triggers connection to upstream host.
-  virtual void connect() override {}
+  void connect() override {}
 };
 
 } // namespace Network

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -130,7 +130,7 @@ private:
     ActiveTcpListener(ConnectionHandlerImpl& parent, Network::ListenerPtr&& listener,
                       Network::ListenerConfig& config);
 
-    ~ActiveTcpListener();
+    ~ActiveTcpListener() override;
 
     // Network::ListenerCallbacks
     void onAccept(Network::ConnectionSocketPtr&& socket,
@@ -160,7 +160,7 @@ private:
                             public Network::ConnectionCallbacks {
     ActiveConnection(ActiveTcpListener& listener, Network::ConnectionPtr&& new_connection,
                      TimeSource& time_system);
-    ~ActiveConnection();
+    ~ActiveConnection() override;
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override {
@@ -192,7 +192,7 @@ private:
           iter_(accept_filters_.end()) {
       listener_.stats_.downstream_pre_cx_active_.inc();
     }
-    ~ActiveSocket() {
+    ~ActiveSocket() override {
       accept_filters_.clear();
       listener_.stats_.downstream_pre_cx_active_.dec();
     }

--- a/source/server/guarddog_impl.h
+++ b/source/server/guarddog_impl.h
@@ -67,7 +67,7 @@ public:
   GuardDogImpl(Stats::Scope& stats_scope, const Server::Configuration::Main& config, Api::Api& api,
                std::unique_ptr<TestInterlockHook>&& test_interlock);
   GuardDogImpl(Stats::Scope& stats_scope, const Server::Configuration::Main& config, Api::Api& api);
-  ~GuardDogImpl();
+  ~GuardDogImpl() override;
 
   /**
    * Exposed for testing purposes only (but harmless to call):

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -1,10 +1,10 @@
 #include "server/hot_restart_impl.h"
 
-#include <signal.h>
 #include <sys/prctl.h>
 #include <sys/types.h>
 #include <sys/un.h>
 
+#include <csignal>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -21,9 +21,7 @@ public:
   void initialize(Event::Dispatcher&, Server::Instance&) override {}
   void sendParentAdminShutdownRequest(time_t&) override {}
   void sendParentTerminateRequest() override {}
-  ServerStatsFromParent mergeParentStatsIfAny(Stats::StoreRoot&) override {
-    return ServerStatsFromParent();
-  }
+  ServerStatsFromParent mergeParentStatsIfAny(Stats::StoreRoot&) override { return {}; }
   void shutdown() override {}
   std::string version() override { return "disabled"; }
   Thread::BasicLockable& logLock() override { return log_lock_; }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -181,7 +181,7 @@ public:
   Runtime::RandomGenerator& random() override { return *random_generator_; }
   Runtime::Loader& runtime() override;
   void shutdown() override;
-  bool isShutdown() override final { return shutdown_; }
+  bool isShutdown() final { return shutdown_; }
   void shutdownAdmin() override;
   Singleton::Manager& singletonManager() override { return *singleton_manager_; }
   bool healthCheckFailed() override;

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "common/grpc/google_grpc_creds_impl.h"
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -545,7 +545,7 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
   }));
 
   // This test also verifies that decoder/encoder filters have onDestroy() called only once.
-  MockStreamFilter* filter = new MockStreamFilter();
+  auto* filter = new MockStreamFilter();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
         callbacks.addStreamFilter(StreamFilterSharedPtr{filter});
@@ -584,7 +584,7 @@ TEST_F(HttpConnectionManagerImplTest, PathFailedtoSanitize) {
   }));
 
   // This test also verifies that decoder/encoder filters have onDestroy() called only once.
-  MockStreamFilter* filter = new MockStreamFilter();
+  auto* filter = new MockStreamFilter();
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
         callbacks.addStreamFilter(StreamFilterSharedPtr{filter});
@@ -614,7 +614,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterShouldUseSantizedPath) {
   const std::string original_path = "/x/%2E%2e/z";
   const std::string normalized_path = "/z";
 
-  MockStreamFilter* filter = new MockStreamFilter();
+  auto* filter = new MockStreamFilter();
 
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
@@ -680,7 +680,7 @@ TEST_F(HttpConnectionManagerImplTest, RouteShouldUseSantizedPath) {
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   setup(false, "");
 
-  NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
+  auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
@@ -748,7 +748,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorator) {
   setup(false, "");
 
-  NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
+  auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
@@ -811,7 +811,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecoratorOverrideOp) {
   setup(false, "");
 
-  NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
+  auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
@@ -889,7 +889,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
                                      percent1,
                                      false});
 
-  NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
+  auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
@@ -967,7 +967,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
                                      percent1,
                                      false});
 
-  NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
+  auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
@@ -2049,7 +2049,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
   setup(false, "envoy-custom-server", false);
 
   // Store the basic request encoder during filter chain setup.
-  MockStreamFilter* filter = new MockStreamFilter();
+  auto* filter = new MockStreamFilter();
   EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
 
   EXPECT_CALL(*filter, decodeHeaders(_, false))

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -3991,7 +3991,7 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRemoteReset));
   EXPECT_CALL(callbacks_.stream_info_, onUpstreamHostSelected(_))
-      .WillRepeatedly(Invoke([&](const Upstream::HostDescriptionConstSharedPtr host) -> void {
+      .WillRepeatedly(Invoke([&](const Upstream::HostDescriptionConstSharedPtr& host) -> void {
         EXPECT_EQ(host_address_, host->address());
       }));
 

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -715,7 +715,7 @@ public:
   void testAcceptsAll(const LookupStatFn lookup_stat) {
     InSequence s;
 
-    MockStatsMatcher* matcher = new MockStatsMatcher;
+    auto* matcher = new MockStatsMatcher;
     matcher->accepts_all_ = true;
     StatsMatcherPtr matcher_ptr(matcher);
     store_.setStatsMatcher(std::move(matcher_ptr));

--- a/test/extensions/filters/common/ext_authz/mocks.cc
+++ b/test/extensions/filters/common/ext_authz/mocks.cc
@@ -6,11 +6,11 @@ namespace Filters {
 namespace Common {
 namespace ExtAuthz {
 
-MockClient::MockClient() {}
-MockClient::~MockClient() {}
+MockClient::MockClient() = default;
+MockClient::~MockClient() = default;
 
-MockRequestCallbacks::MockRequestCallbacks() {}
-MockRequestCallbacks::~MockRequestCallbacks() {}
+MockRequestCallbacks::MockRequestCallbacks() = default;
+MockRequestCallbacks::~MockRequestCallbacks() = default;
 
 } // namespace ExtAuthz
 } // namespace Common

--- a/test/extensions/filters/common/ratelimit/mocks.cc
+++ b/test/extensions/filters/common/ratelimit/mocks.cc
@@ -6,8 +6,8 @@ namespace Filters {
 namespace Common {
 namespace RateLimit {
 
-MockClient::MockClient() {}
-MockClient::~MockClient() {}
+MockClient::MockClient() = default;
+MockClient::~MockClient() = default;
 
 } // namespace RateLimit
 } // namespace Common

--- a/test/extensions/filters/http/dynamo/dynamo_request_parser_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_request_parser_test.cc
@@ -69,7 +69,7 @@ TEST(DynamoRequestParser, parseTableNameSingleOperation) {
   }
 
   {
-    Json::ObjectSharedPtr json_data = Json::Factory::loadFromString("{\"TableName\":\"Pets\"}");
+    Json::ObjectSharedPtr json_data = Json::Factory::loadFromString(R"({"TableName":"Pets"})");
     EXPECT_EQ("Pets", RequestParser::parseTable("GetItem", *json_data).table_name);
   }
 }
@@ -197,7 +197,7 @@ TEST(DynamoRequestParser, parseBatchUnProcessedKeys) {
 
   {
     std::vector<std::string> unprocessed_tables = RequestParser::parseBatchUnProcessedKeys(
-        *Json::Factory::loadFromString("{\"UnprocessedKeys\":{\"table_1\" :{}}}"));
+        *Json::Factory::loadFromString(R"({"UnprocessedKeys":{"table_1" :{}}})"));
     EXPECT_EQ("table_1", unprocessed_tables[0]);
     EXPECT_EQ(1u, unprocessed_tables.size());
   }
@@ -236,7 +236,7 @@ TEST(DynamoRequestParser, parsePartitionIds) {
   }
   {
     std::vector<RequestParser::PartitionDescriptor> partitions = RequestParser::parsePartitions(
-        *Json::Factory::loadFromString("{\"ConsumedCapacity\":{ \"Partitions\":{}}}"));
+        *Json::Factory::loadFromString(R"({"ConsumedCapacity":{ "Partitions":{}}})"));
     EXPECT_EQ(0u, partitions.size());
   }
   {

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -135,7 +135,7 @@ protected:
 
     response_headers.iterate(
         [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
-          IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);
+          auto* response = static_cast<IntegrationStreamDecoder*>(context);
           Http::LowerCaseString lower_key{std::string(entry.key().getStringView())};
           EXPECT_EQ(entry.value().getStringView(),
                     response->headers().get(lower_key)->value().getStringView());

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 class LuaHeaderMapWrapperTest : public Filters::Common::Lua::LuaWrappersTestBase<HeaderMapWrapper> {
 public:
-  virtual void setup(const std::string& script) {
+  void setup(const std::string& script) override {
     Filters::Common::Lua::LuaWrappersTestBase<HeaderMapWrapper>::setup(script);
     state_->registerType<HeaderMapIterator>();
   }
@@ -220,7 +220,7 @@ TEST_F(LuaHeaderMapWrapperTest, IteratorAcrossYield) {
 class LuaStreamInfoWrapperTest
     : public Filters::Common::Lua::LuaWrappersTestBase<StreamInfoWrapper> {
 public:
-  virtual void setup(const std::string& script) {
+  void setup(const std::string& script) override {
     Filters::Common::Lua::LuaWrappersTestBase<StreamInfoWrapper>::setup(script);
     state_->registerType<DynamicMetadataMapWrapper>();
     state_->registerType<DynamicMetadataMapIterator>();

--- a/test/extensions/filters/http/squash/squash_filter_integration_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_integration_test.cc
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-
 #include <cstdlib>
 
 #include "common/protobuf/protobuf.h"
@@ -21,7 +19,7 @@ class SquashFilterIntegrationTest : public testing::TestWithParam<Network::Addre
 public:
   SquashFilterIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
-  ~SquashFilterIntegrationTest() {
+  ~SquashFilterIntegrationTest() override {
     if (fake_squash_connection_) {
       AssertionResult result = fake_squash_connection_->close();
       RELEASE_ASSERT(result, result.message());

--- a/test/extensions/filters/network/common/redis/mocks.cc
+++ b/test/extensions/filters/network/common/redis/mocks.cc
@@ -28,10 +28,10 @@ MockEncoder::MockEncoder() {
           }));
 }
 
-MockEncoder::~MockEncoder() {}
+MockEncoder::~MockEncoder() = default;
 
-MockDecoder::MockDecoder() {}
-MockDecoder::~MockDecoder() {}
+MockDecoder::MockDecoder() = default;
+MockDecoder::~MockDecoder() = default;
 
 namespace Client {
 
@@ -45,13 +45,13 @@ MockClient::MockClient() {
   }));
 }
 
-MockClient::~MockClient() {}
+MockClient::~MockClient() = default;
 
-MockPoolRequest::MockPoolRequest() {}
-MockPoolRequest::~MockPoolRequest() {}
+MockPoolRequest::MockPoolRequest() = default;
+MockPoolRequest::~MockPoolRequest() = default;
 
-MockPoolCallbacks::MockPoolCallbacks() {}
-MockPoolCallbacks::~MockPoolCallbacks() {}
+MockPoolCallbacks::MockPoolCallbacks() = default;
+MockPoolCallbacks::~MockPoolCallbacks() = default;
 
 } // namespace Client
 

--- a/test/extensions/filters/network/dubbo_proxy/mocks.cc
+++ b/test/extensions/filters/network/dubbo_proxy/mocks.cc
@@ -34,18 +34,18 @@ MockProtocol::MockProtocol() {
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, type()).WillByDefault(Return(type_));
 }
-MockProtocol::~MockProtocol() {}
+MockProtocol::~MockProtocol() = default;
 
 MockDeserializer::MockDeserializer() {
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, type()).WillByDefault(Return(type_));
 }
-MockDeserializer::~MockDeserializer() {}
+MockDeserializer::~MockDeserializer() = default;
 
 namespace DubboFilters {
 
-MockFilterChainFactoryCallbacks::MockFilterChainFactoryCallbacks() {}
-MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() {}
+MockFilterChainFactoryCallbacks::MockFilterChainFactoryCallbacks() = default;
+MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() = default;
 
 MockDecoderFilter::MockDecoderFilter() {
   ON_CALL(*this, transportBegin()).WillByDefault(Return(Network::FilterStatus::Continue));
@@ -63,7 +63,7 @@ MockDecoderFilter::MockDecoderFilter() {
         return Network::FilterStatus::Continue;
       }));
 }
-MockDecoderFilter::~MockDecoderFilter() {}
+MockDecoderFilter::~MockDecoderFilter() = default;
 
 MockDecoderFilterCallbacks::MockDecoderFilterCallbacks() {
   route_.reset(new NiceMock<Router::MockRoute>());
@@ -73,16 +73,16 @@ MockDecoderFilterCallbacks::MockDecoderFilterCallbacks() {
   ON_CALL(*this, route()).WillByDefault(Return(route_));
   ON_CALL(*this, streamInfo()).WillByDefault(ReturnRef(stream_info_));
 }
-MockDecoderFilterCallbacks::~MockDecoderFilterCallbacks() {}
+MockDecoderFilterCallbacks::~MockDecoderFilterCallbacks() = default;
 
-MockDirectResponse::MockDirectResponse() {}
-MockDirectResponse::~MockDirectResponse() {}
+MockDirectResponse::MockDirectResponse() = default;
+MockDirectResponse::~MockDirectResponse() = default;
 
 MockFilterConfigFactory::MockFilterConfigFactory()
     : MockFactoryBase("envoy.filters.dubbo.mock_filter"),
       mock_filter_(std::make_shared<NiceMock<MockDecoderFilter>>()) {}
 
-MockFilterConfigFactory::~MockFilterConfigFactory() {}
+MockFilterConfigFactory::~MockFilterConfigFactory() = default;
 
 FilterFactoryCb
 MockFilterConfigFactory::createFilterFactoryFromProtoTyped(const ProtobufWkt::Struct& proto_config,
@@ -103,10 +103,10 @@ namespace Router {
 MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
 }
-MockRouteEntry::~MockRouteEntry() {}
+MockRouteEntry::~MockRouteEntry() = default;
 
 MockRoute::MockRoute() { ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_)); }
-MockRoute::~MockRoute() {}
+MockRoute::~MockRoute() = default;
 
 } // namespace Router
 

--- a/test/extensions/filters/network/mysql_proxy/mysql_codec_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_codec_test.cc
@@ -838,7 +838,7 @@ TEST_F(MySQLCodecTest, MySQLLoginOldAuthSwitch) {
 TEST_F(MySQLCodecTest, MySQLLoginOkIncompleteRespCode) {
   ClientLoginResponse mysql_loginok_encode{};
   mysql_loginok_encode.setRespCode(MYSQL_UT_RESP_OK);
-  std::string data = "";
+  std::string data;
 
   Buffer::InstancePtr decode_data(new Buffer::OwnedImpl(data));
   ClientLoginResponse mysql_loginok_decode{};

--- a/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
@@ -786,7 +786,7 @@ TEST_F(MySQLFilterTest, MySqlHandshake320WrongServerRespCode) {
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(*server_resp_ok_data, false));
   EXPECT_EQ(MySQLSession::State::MYSQL_NOT_HANDLED, filter_->getSession().getState());
 
-  std::string msg_data = "";
+  std::string msg_data;
   std::string mysql_msg = BufferHelper::encodeHdr(msg_data, 3);
   Buffer::InstancePtr client_query_data(new Buffer::OwnedImpl(mysql_msg));
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(*client_query_data, false));

--- a/test/extensions/filters/network/thrift_proxy/auto_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/auto_protocol_impl_test.cc
@@ -56,7 +56,7 @@ public:
 
 TEST(ProtocolNames, FromType) {
   for (int i = 0; i <= static_cast<int>(ProtocolType::LastProtocolType); i++) {
-    ProtocolType type = static_cast<ProtocolType>(i);
+    auto type = static_cast<ProtocolType>(i);
     EXPECT_NE("", ProtocolNames::get().fromType(type));
   }
 }
@@ -158,7 +158,7 @@ TEST_F(AutoProtocolTest, ReadMessageBegin) {
 }
 
 TEST_F(AutoProtocolTest, ReadDelegation) {
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  auto* proto = new NiceMock<MockProtocol>();
   AutoProtocolImpl auto_proto;
   auto_proto.setProtocol(ProtocolPtr{proto});
 
@@ -281,7 +281,7 @@ TEST_F(AutoProtocolTest, ReadDelegation) {
 }
 
 TEST_F(AutoProtocolTest, WriteDelegation) {
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  auto* proto = new NiceMock<MockProtocol>();
   AutoProtocolImpl auto_proto;
   auto_proto.setProtocol(ProtocolPtr{proto});
 
@@ -369,7 +369,7 @@ TEST_F(AutoProtocolTest, WriteDelegation) {
 
 // Test that protocol-upgrade methods are delegated to the detected protocol.
 TEST_F(AutoProtocolTest, ProtocolUpgradeDelegation) {
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  auto* proto = new NiceMock<MockProtocol>();
   AutoProtocolImpl auto_proto;
   auto_proto.setProtocol(ProtocolPtr{proto});
 

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -55,7 +55,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, StatsConfigParameterizedTest,
 
 TEST_P(StatsConfigParameterizedTest, UdpSinkDefaultPrefix) {
   const std::string name = StatsSinkNames::get().Statsd;
-  auto defaultPrefix = Common::Statsd::getDefaultPrefix();
+  const auto& defaultPrefix = Common::Statsd::getDefaultPrefix();
 
   envoy::config::metrics::v2::StatsdSink sink_config;
   envoy::api::v2::core::Address& address = *sink_config.mutable_address();
@@ -120,7 +120,7 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
   const std::string name = StatsSinkNames::get().Statsd;
 
   envoy::config::metrics::v2::StatsdSink sink_config;
-  auto defaultPrefix = Common::Statsd::getDefaultPrefix();
+  const auto& defaultPrefix = Common::Statsd::getDefaultPrefix();
   sink_config.set_tcp_cluster_name("fake_cluster");
 
   Server::Configuration::StatsSinkFactory* factory =

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -285,24 +285,24 @@ public:
 
           if (use_eds_) {
             addHeader(route_config->mutable_response_headers_to_add(), "x-routeconfig-dynamic",
-                      "%UPSTREAM_METADATA([\"test.namespace\", \"key\"])%", append);
+                      R"(%UPSTREAM_METADATA(["test.namespace", "key"])%)", append);
 
             // Iterate over VirtualHosts, nested Routes and WeightedClusters, adding a dynamic
             // response header.
             for (auto& vhost : *route_config->mutable_virtual_hosts()) {
               addHeader(vhost.mutable_response_headers_to_add(), "x-vhost-dynamic",
-                        "vhost:%UPSTREAM_METADATA([\"test.namespace\", \"key\"])%", append);
+                        R"(vhost:%UPSTREAM_METADATA(["test.namespace", "key"])%)", append);
 
               for (auto& route : *vhost.mutable_routes()) {
                 addHeader(route.mutable_response_headers_to_add(), "x-route-dynamic",
-                          "route:%UPSTREAM_METADATA([\"test.namespace\", \"key\"])%", append);
+                          R"(route:%UPSTREAM_METADATA(["test.namespace", "key"])%)", append);
 
                 if (route.has_route()) {
                   auto* route_action = route.mutable_route();
                   if (route_action->has_weighted_clusters()) {
                     for (auto& c : *route_action->mutable_weighted_clusters()->mutable_clusters()) {
                       addHeader(c.mutable_response_headers_to_add(), "x-weighted-cluster-dynamic",
-                                "weighted:%UPSTREAM_METADATA([\"test.namespace\", \"key\"])%",
+                                R"(weighted:%UPSTREAM_METADATA(["test.namespace", "key"])%)",
                                 append);
                     }
                   }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -126,7 +126,7 @@ void IntegrationStreamDecoder::decodeTrailers(Http::HeaderMapPtr&& trailers) {
 
 void IntegrationStreamDecoder::decodeMetadata(Http::MetadataMapPtr&& metadata_map) {
   // Combines newly received metadata with the existing metadata.
-  for (const auto metadata : *metadata_map) {
+  for (const auto& metadata : *metadata_map) {
     duplicated_metadata_key_count_[metadata.first]++;
     metadata_map_->insert(metadata);
   }

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -395,7 +395,7 @@ TEST_P(IntegrationAdminTest, Admin) {
       "type.googleapis.com/envoy.admin.v2alpha.ScopedRoutesConfigDump",
       "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump"};
 
-  for (Json::ObjectSharedPtr obj_ptr : json->getObjectArray("configs")) {
+  for (const Json::ObjectSharedPtr& obj_ptr : json->getObjectArray("configs")) {
     EXPECT_TRUE(expected_types[index].compare(obj_ptr->getString("@type")) == 0);
     index++;
   }

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -520,7 +520,7 @@ TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
   auto downstream_request = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
-  Buffer::OwnedImpl data("{\"TableName\":\"locations\"}");
+  Buffer::OwnedImpl data(R"({"TableName":"locations"})");
   codec_client_->sendData(*downstream_request, data, true);
   waitForNextUpstreamRequest();
 

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -111,7 +111,7 @@ TEST_P(StatsIntegrationTest, WithTagSpecifierWithRegex) {
     bootstrap.mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
     auto tag_specifier = bootstrap.mutable_stats_config()->mutable_stats_tags()->Add();
     tag_specifier->set_tag_name("my.http_conn_manager_prefix");
-    tag_specifier->set_regex("^(?:|listener(?=\\.).*?\\.)http\\.((.*?)\\.)");
+    tag_specifier->set_regex(R"(^(?:|listener(?=\.).*?\.)http\.((.*?)\.))");
   });
   initialize();
 

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -56,7 +56,7 @@ void UdsListenerIntegrationTest::initialize() {
     admin_addr->mutable_pipe()->set_path(getAdminSocketName());
 
     auto* listeners = bootstrap.mutable_static_resources()->mutable_listeners();
-    RELEASE_ASSERT(listeners->size() > 0, "");
+    RELEASE_ASSERT(!listeners->empty(), "");
     auto filter_chains = listeners->Get(0).filter_chains();
     listeners->Clear();
     auto* listener = listeners->Add();

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -40,11 +40,11 @@ Api::IoCallBoolResult MockFile::close() {
   return result;
 }
 
-MockInstance::MockInstance() {}
-MockInstance::~MockInstance() {}
+MockInstance::MockInstance() = default;
+MockInstance::~MockInstance() = default;
 
-MockWatcher::MockWatcher() {}
-MockWatcher::~MockWatcher() {}
+MockWatcher::MockWatcher() = default;
+MockWatcher::~MockWatcher() = default;
 
 } // namespace Filesystem
 } // namespace Envoy

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -16,7 +16,7 @@ namespace Filesystem {
 class MockFile : public File {
 public:
   MockFile();
-  ~MockFile();
+  ~MockFile() override;
 
   // Filesystem::File
   Api::IoCallBoolResult open() override;
@@ -43,7 +43,7 @@ private:
 class MockInstance : public Instance {
 public:
   MockInstance();
-  ~MockInstance();
+  ~MockInstance() override;
 
   // Filesystem::Instance
   MOCK_METHOD1(createFile, FilePtr(const std::string&));
@@ -57,7 +57,7 @@ public:
 class MockWatcher : public Watcher {
 public:
   MockWatcher();
-  ~MockWatcher();
+  ~MockWatcher() override;
 
   MOCK_METHOD3(addWatch, void(const std::string&, uint32_t, OnChangedCb));
 };

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -19,26 +19,26 @@ using testing::SaveArg;
 namespace Envoy {
 namespace Http {
 
-MockConnectionCallbacks::MockConnectionCallbacks() {}
-MockConnectionCallbacks::~MockConnectionCallbacks() {}
+MockConnectionCallbacks::MockConnectionCallbacks() = default;
+MockConnectionCallbacks::~MockConnectionCallbacks() = default;
 
-MockServerConnectionCallbacks::MockServerConnectionCallbacks() {}
-MockServerConnectionCallbacks::~MockServerConnectionCallbacks() {}
+MockServerConnectionCallbacks::MockServerConnectionCallbacks() = default;
+MockServerConnectionCallbacks::~MockServerConnectionCallbacks() = default;
 
-MockStreamCallbacks::MockStreamCallbacks() {}
-MockStreamCallbacks::~MockStreamCallbacks() {}
+MockStreamCallbacks::MockStreamCallbacks() = default;
+MockStreamCallbacks::~MockStreamCallbacks() = default;
 
 MockServerConnection::MockServerConnection() {
   ON_CALL(*this, protocol()).WillByDefault(Return(protocol_));
 }
 
-MockServerConnection::~MockServerConnection() {}
+MockServerConnection::~MockServerConnection() = default;
 
-MockClientConnection::MockClientConnection() {}
-MockClientConnection::~MockClientConnection() {}
+MockClientConnection::MockClientConnection() = default;
+MockClientConnection::~MockClientConnection() = default;
 
-MockFilterChainFactory::MockFilterChainFactory() {}
-MockFilterChainFactory::~MockFilterChainFactory() {}
+MockFilterChainFactory::MockFilterChainFactory() = default;
+MockFilterChainFactory::~MockFilterChainFactory() = default;
 
 template <class T> static void initializeMockStreamFilterCallbacks(T& callbacks) {
   callbacks.cluster_info_.reset(new NiceMock<Upstream::MockClusterInfo>());
@@ -67,7 +67,7 @@ MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
   ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
 }
 
-MockStreamDecoderFilterCallbacks::~MockStreamDecoderFilterCallbacks() {}
+MockStreamDecoderFilterCallbacks::~MockStreamDecoderFilterCallbacks() = default;
 
 MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {
   initializeMockStreamFilterCallbacks(*this);
@@ -76,7 +76,7 @@ MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {
   ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
 }
 
-MockStreamEncoderFilterCallbacks::~MockStreamEncoderFilterCallbacks() {}
+MockStreamEncoderFilterCallbacks::~MockStreamEncoderFilterCallbacks() = default;
 
 MockStreamDecoderFilter::MockStreamDecoderFilter() {
   ON_CALL(*this, setDecoderFilterCallbacks(_))
@@ -84,7 +84,7 @@ MockStreamDecoderFilter::MockStreamDecoderFilter() {
           [this](StreamDecoderFilterCallbacks& callbacks) -> void { callbacks_ = &callbacks; }));
 }
 
-MockStreamDecoderFilter::~MockStreamDecoderFilter() {}
+MockStreamDecoderFilter::~MockStreamDecoderFilter() = default;
 
 MockStreamEncoderFilter::MockStreamEncoderFilter() {
   ON_CALL(*this, setEncoderFilterCallbacks(_))
@@ -92,7 +92,7 @@ MockStreamEncoderFilter::MockStreamEncoderFilter() {
           [this](StreamEncoderFilterCallbacks& callbacks) -> void { callbacks_ = &callbacks; }));
 }
 
-MockStreamEncoderFilter::~MockStreamEncoderFilter() {}
+MockStreamEncoderFilter::~MockStreamEncoderFilter() = default;
 
 MockStreamFilter::MockStreamFilter() {
   ON_CALL(*this, setDecoderFilterCallbacks(_))
@@ -105,27 +105,27 @@ MockStreamFilter::MockStreamFilter() {
       }));
 }
 
-MockStreamFilter::~MockStreamFilter() {}
+MockStreamFilter::~MockStreamFilter() = default;
 
 MockAsyncClient::MockAsyncClient() {
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
 }
-MockAsyncClient::~MockAsyncClient() {}
+MockAsyncClient::~MockAsyncClient() = default;
 
-MockAsyncClientCallbacks::MockAsyncClientCallbacks() {}
-MockAsyncClientCallbacks::~MockAsyncClientCallbacks() {}
+MockAsyncClientCallbacks::MockAsyncClientCallbacks() = default;
+MockAsyncClientCallbacks::~MockAsyncClientCallbacks() = default;
 
-MockAsyncClientStreamCallbacks::MockAsyncClientStreamCallbacks() {}
-MockAsyncClientStreamCallbacks::~MockAsyncClientStreamCallbacks() {}
+MockAsyncClientStreamCallbacks::MockAsyncClientStreamCallbacks() = default;
+MockAsyncClientStreamCallbacks::~MockAsyncClientStreamCallbacks() = default;
 
 MockAsyncClientRequest::MockAsyncClientRequest(MockAsyncClient* client) : client_(client) {}
 MockAsyncClientRequest::~MockAsyncClientRequest() { client_->onRequestDestroy(); }
 
-MockAsyncClientStream::MockAsyncClientStream() {}
-MockAsyncClientStream::~MockAsyncClientStream() {}
+MockAsyncClientStream::MockAsyncClientStream() = default;
+MockAsyncClientStream::~MockAsyncClientStream() = default;
 
-MockFilterChainFactoryCallbacks::MockFilterChainFactoryCallbacks() {}
-MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() {}
+MockFilterChainFactoryCallbacks::MockFilterChainFactoryCallbacks() = default;
+MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() = default;
 
 } // namespace Http
 

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -10,7 +10,7 @@ namespace Http {
 class MockStream : public Stream {
 public:
   MockStream();
-  ~MockStream();
+  ~MockStream() override;
 
   // Http::Stream
   MOCK_METHOD1(addCallbacks, void(StreamCallbacks& callbacks));

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -9,7 +9,7 @@ namespace Http {
 class MockStreamDecoder : public StreamDecoder {
 public:
   MockStreamDecoder();
-  ~MockStreamDecoder();
+  ~MockStreamDecoder() override;
 
   void decode100ContinueHeaders(HeaderMapPtr&& headers) override {
     decode100ContinueHeaders_(headers);

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -18,7 +18,7 @@ namespace Envoy {
 namespace Stats {
 
 MockMetric::MockMetric() : name_(*this), tag_pool_(*symbol_table_) {}
-MockMetric::~MockMetric() {}
+MockMetric::~MockMetric() = default;
 
 MockMetric::MetricName::~MetricName() {
   if (stat_name_storage_ != nullptr) {
@@ -73,14 +73,14 @@ MockCounter::MockCounter() {
   ON_CALL(*this, value()).WillByDefault(ReturnPointee(&value_));
   ON_CALL(*this, latch()).WillByDefault(ReturnPointee(&latch_));
 }
-MockCounter::~MockCounter() {}
+MockCounter::~MockCounter() = default;
 
 MockGauge::MockGauge() : used_(false), value_(0), import_mode_(ImportMode::Accumulate) {
   ON_CALL(*this, used()).WillByDefault(ReturnPointee(&used_));
   ON_CALL(*this, value()).WillByDefault(ReturnPointee(&value_));
   ON_CALL(*this, importMode()).WillByDefault(ReturnPointee(&import_mode_));
 }
-MockGauge::~MockGauge() {}
+MockGauge::~MockGauge() = default;
 
 MockHistogram::MockHistogram() {
   ON_CALL(*this, recordValue(_)).WillByDefault(Invoke([this](uint64_t value) {
@@ -89,7 +89,7 @@ MockHistogram::MockHistogram() {
     }
   }));
 }
-MockHistogram::~MockHistogram() {}
+MockHistogram::~MockHistogram() = default;
 
 MockParentHistogram::MockParentHistogram() {
   ON_CALL(*this, recordValue(_)).WillByDefault(Invoke([this](uint64_t value) {
@@ -101,7 +101,7 @@ MockParentHistogram::MockParentHistogram() {
   ON_CALL(*this, cumulativeStatistics()).WillByDefault(ReturnRef(*histogram_stats_));
   ON_CALL(*this, used()).WillByDefault(ReturnPointee(&used_));
 }
-MockParentHistogram::~MockParentHistogram() {}
+MockParentHistogram::~MockParentHistogram() = default;
 
 MockMetricSnapshot::MockMetricSnapshot() {
   ON_CALL(*this, counters()).WillByDefault(ReturnRef(counters_));
@@ -109,10 +109,10 @@ MockMetricSnapshot::MockMetricSnapshot() {
   ON_CALL(*this, histograms()).WillByDefault(ReturnRef(histograms_));
 }
 
-MockMetricSnapshot::~MockMetricSnapshot() {}
+MockMetricSnapshot::~MockMetricSnapshot() = default;
 
-MockSink::MockSink() {}
-MockSink::~MockSink() {}
+MockSink::MockSink() = default;
+MockSink::~MockSink() = default;
 
 MockStore::MockStore() : StoreImpl(*fake_symbol_table_) {
   ON_CALL(*this, counter(_)).WillByDefault(ReturnRef(counter_));
@@ -124,14 +124,14 @@ MockStore::MockStore() : StoreImpl(*fake_symbol_table_) {
     return *histogram;
   }));
 }
-MockStore::~MockStore() {}
+MockStore::~MockStore() = default;
 
 MockIsolatedStatsStore::MockIsolatedStatsStore()
     : IsolatedStoreImpl(Test::Global<Stats::FakeSymbolTableImpl>::get()) {}
-MockIsolatedStatsStore::~MockIsolatedStatsStore() {}
+MockIsolatedStatsStore::~MockIsolatedStatsStore() = default;
 
-MockStatsMatcher::MockStatsMatcher() {}
-MockStatsMatcher::~MockStatsMatcher() {}
+MockStatsMatcher::MockStatsMatcher() = default;
+MockStatsMatcher::~MockStatsMatcher() = default;
 
 } // namespace Stats
 } // namespace Envoy

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -730,7 +730,7 @@ TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
 
   InSequence s;
 
-  MockLdsApi* lds_api = new MockLdsApi();
+  auto* lds_api = new MockLdsApi();
   EXPECT_CALL(listener_factory_, createLdsApi_(_)).WillOnce(Return(lds_api));
   envoy::api::v2::core::ConfigSource lds_config;
   manager_->createLdsApi(lds_config);

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -188,26 +188,26 @@ std::string TestEnvironment::substitute(const std::string& str,
       {"test_rundir", TestEnvironment::runfilesDirectory()},
   };
   std::string out_json_string = str;
-  for (auto it : path_map) {
+  for (const auto& it : path_map) {
     const std::regex port_regex("\\{\\{ " + it.first + " \\}\\}");
     out_json_string = std::regex_replace(out_json_string, port_regex, it.second);
   }
 
   // Substitute IP loopback addresses.
-  const std::regex loopback_address_regex("\\{\\{ ip_loopback_address \\}\\}");
+  const std::regex loopback_address_regex(R"(\{\{ ip_loopback_address \}\})");
   out_json_string = std::regex_replace(out_json_string, loopback_address_regex,
                                        Network::Test::getLoopbackAddressString(version));
-  const std::regex ntop_loopback_address_regex("\\{\\{ ntop_ip_loopback_address \\}\\}");
+  const std::regex ntop_loopback_address_regex(R"(\{\{ ntop_ip_loopback_address \}\})");
   out_json_string = std::regex_replace(out_json_string, ntop_loopback_address_regex,
                                        Network::Test::getLoopbackAddressString(version));
 
   // Substitute IP any addresses.
-  const std::regex any_address_regex("\\{\\{ ip_any_address \\}\\}");
+  const std::regex any_address_regex(R"(\{\{ ip_any_address \}\})");
   out_json_string = std::regex_replace(out_json_string, any_address_regex,
                                        Network::Test::getAnyAddressString(version));
 
   // Substitute dns lookup family.
-  const std::regex lookup_family_regex("\\{\\{ dns_lookup_family \\}\\}");
+  const std::regex lookup_family_regex(R"(\{\{ dns_lookup_family \}\})");
   switch (version) {
   case Network::Address::IpVersion::v4:
     out_json_string = std::regex_replace(out_json_string, lookup_family_regex, "v4_only");
@@ -251,13 +251,13 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
   std::string out_json_string = readFileToStringForTest(json_path);
 
   // Substitute params.
-  for (auto it : param_map) {
+  for (const auto& it : param_map) {
     const std::regex param_regex("\\{\\{ " + it.first + " \\}\\}");
     out_json_string = std::regex_replace(out_json_string, param_regex, it.second);
   }
 
   // Substitute ports.
-  for (auto it : port_map) {
+  for (const auto& it : port_map) {
     const std::regex port_regex("\\{\\{ " + it.first + " \\}\\}");
     out_json_string = std::regex_replace(out_json_string, port_regex, std::to_string(it.second));
   }

--- a/test/test_common/test_time.cc
+++ b/test/test_common/test_time.cc
@@ -6,7 +6,7 @@
 
 namespace Envoy {
 
-DangerousDeprecatedTestTime::DangerousDeprecatedTestTime() {}
+DangerousDeprecatedTestTime::DangerousDeprecatedTestTime() = default;
 
 namespace Event {
 

--- a/test/test_common/thread_factory_for_test.cc
+++ b/test/test_common/thread_factory_for_test.cc
@@ -7,9 +7,9 @@ namespace Thread {
 // TODO(sesmith177) Tests should get the ThreadFactory from the same location as the main code
 ThreadFactory& threadFactoryForTest() {
 #ifdef WIN32
-  static ThreadFactoryImplWin32* thread_factory = new ThreadFactoryImplWin32();
+  static auto* thread_factory = new ThreadFactoryImplWin32();
 #else
-  static ThreadFactoryImplPosix* thread_factory = new ThreadFactoryImplPosix();
+  static auto* thread_factory = new ThreadFactoryImplPosix();
 #endif
   return *thread_factory;
 }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -283,7 +283,7 @@ std::string TestUtility::convertTime(const std::string& input, const std::string
 }
 
 // static
-bool TestUtility::gaugesZeroed(const std::vector<Stats::GaugeSharedPtr> gauges) {
+bool TestUtility::gaugesZeroed(const std::vector<Stats::GaugeSharedPtr>& gauges) {
   // Returns true if all gauges are 0 except the circuit_breaker remaining resource
   // gauges which default to the resource max.
   std::regex omitted(".*circuit_breakers\\..*\\.remaining.*");
@@ -353,11 +353,10 @@ const uint32_t Http2Settings::DEFAULT_INITIAL_STREAM_WINDOW_SIZE;
 const uint32_t Http2Settings::DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE;
 const uint32_t Http2Settings::MIN_INITIAL_STREAM_WINDOW_SIZE;
 
-TestHeaderMapImpl::TestHeaderMapImpl() : HeaderMapImpl() {}
+TestHeaderMapImpl::TestHeaderMapImpl() = default;
 
 TestHeaderMapImpl::TestHeaderMapImpl(
-    const std::initializer_list<std::pair<std::string, std::string>>& values)
-    : HeaderMapImpl() {
+    const std::initializer_list<std::pair<std::string, std::string>>& values) {
   for (auto& value : values) {
     addCopy(value.first, value.second);
   }

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <stdlib.h>
-
+#include <cstdlib>
 #include <list>
 #include <random>
 #include <string>
@@ -407,7 +406,7 @@ public:
    * @param vector of gauges to check.
    * @return bool indicating that passed gauges not matching the omitted regex have a value of 0.
    */
-  static bool gaugesZeroed(const std::vector<Stats::GaugeSharedPtr> gauges);
+  static bool gaugesZeroed(const std::vector<Stats::GaugeSharedPtr>& gauges);
 
   // Strict variants of Protobuf::MessageUtil
   static void loadFromJson(const std::string& json, Protobuf::Message& message) {


### PR DESCRIPTION
Description: Resolve a handful of clang-tidy warnings, mostly relating to:
- `abseil-string-find-startswith`
- `modernize-use-override`
- `modernize-use-equals-default`
- `modernize-raw-string-literal`
- `modernize-return-braced-init-list`
- `modernize-deprecated-headers`

Also added `performance-faster-string-find` to the list of clang-tidy errors, as I believe all the remaining instances of that warning have been resolved. This related to issue #4863 cc @lizan 
Risk Level: Low
Testing: No changes
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>