### PR TITLE
fuzz: fix build failure by moving std::experimental::filesystem to std::filesystem

### DIFF
--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -4,8 +4,8 @@
 #include <unistd.h>
 
 #ifdef __has_include
-#if __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
+#if __has_include(<filesystem>)
+#include <filesystem>
 #endif
 #endif
 #include <fstream>
@@ -38,7 +38,7 @@ std::string makeTempDir(char* name_template) {
   char* dirname = ::_mktemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, strerror(errno)));
-  std::experimental::filesystem::create_directories(dirname);
+  std::filesystem::create_directories(dirname);
 #else
   char* dirname = ::mkdtemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
@@ -80,9 +80,9 @@ void TestEnvironment::createPath(const std::string& path) {
 #ifdef __cpp_lib_experimental_filesystem
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  std::experimental::filesystem::create_directories(std::experimental::filesystem::path(path));
+  std::filesystem::create_directories(std::filesystem::path(path));
 #else
-  // No support on this system for std::experimental::filesystem.
+  // No support on this system for std::filesystem.
   RELEASE_ASSERT(::system(("mkdir -p " + path).c_str()) == 0, "");
 #endif
 }
@@ -91,10 +91,10 @@ void TestEnvironment::createParentPath(const std::string& path) {
 #ifdef __cpp_lib_experimental_filesystem
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  std::experimental::filesystem::create_directories(
-      std::experimental::filesystem::path(path).parent_path());
+  std::filesystem::create_directories(
+      std::filesystem::path(path).parent_path());
 #else
-  // No support on this system for std::experimental::filesystem.
+  // No support on this system for std::filesystem.
   RELEASE_ASSERT(::system(("mkdir -p $(dirname " + path + ")").c_str()) == 0, "");
 #endif
 }
@@ -104,12 +104,12 @@ void TestEnvironment::removePath(const std::string& path) {
 #ifdef __cpp_lib_experimental_filesystem
   // We don't want to rely on rm etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  if (!std::experimental::filesystem::exists(path)) {
+  if (!std::filesystem::exists(path)) {
     return;
   }
-  std::experimental::filesystem::remove_all(std::experimental::filesystem::path(path));
+  std::filesystem::remove_all(std::filesystem::path(path));
 #else
-  // No support on this system for std::experimental::filesystem.
+  // No support on this system for std::filesystem.
   RELEASE_ASSERT(::system(("rm -rf " + path).c_str()) == 0, "");
 #endif
 }

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -91,8 +91,7 @@ void TestEnvironment::createParentPath(const std::string& path) {
 #ifdef __cpp_lib_experimental_filesystem
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  std::filesystem::create_directories(
-      std::filesystem::path(path).parent_path());
+  std::filesystem::create_directories(std::filesystem::path(path).parent_path());
 #else
   // No support on this system for std::filesystem.
   RELEASE_ASSERT(::system(("mkdir -p $(dirname " + path + ")").c_str()) == 0, "");


### PR DESCRIPTION
OSS-Fuzz builds fail due to std::experimental::filesystem being deprecated in favor of std::filesystem. 

Risk Level: Low
Fixes Issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15303#c1