### PR TITLE
runtime: distinct symlink root and subdir in layered runtime.

### DIFF
--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -248,6 +248,11 @@ message RuntimeLayer {
     // treated.
     string symlink_root = 1;
 
+    // Specifies the subdirectory to load within the root directory. This is
+    // useful if multiple systems share the same delivery mechanism. Envoy
+    // configuration elements can be contained in a dedicated subdirectory.
+    string subdirectory = 3;
+
     // :ref:`Append <config_runtime_local_disk_service_cluster_subdirs>` the
     // service cluster to the path under symlink root.
     bool append_service_cluster = 2;

--- a/docs/root/configuration/runtime.rst
+++ b/docs/root/configuration/runtime.rst
@@ -30,8 +30,8 @@ be:
   - static_layer:
       health_check:
         min_interval: 5
-  - disk_layer: { symlink_root: /srv/runtime/current/envoy }
-  - disk_layer: { symlink_root: /srv/runtime/current/envoy_override, append_service_cluster: true }
+  - disk_layer: { symlink_root: /srv/runtime/current, subdirectory: envoy }
+  - disk_layer: { symlink_root: /srv/runtime/current, subdirectory: envoy_override, append_service_cluster: true }
   - admin_layer: {}
 
 In the deprecated :ref:`runtime <envoy_api_msg_config.bootstrap.v2.Runtime>` bootstrap

--- a/source/common/config/runtime_utility.cc
+++ b/source/common/config/runtime_utility.cc
@@ -14,14 +14,14 @@ void translateRuntime(const envoy::config::bootstrap::v2::Runtime& runtime_confi
     {
       auto* layer = layered_runtime_config.add_layers();
       layer->set_name("root");
-      layer->mutable_disk_layer()->set_symlink_root(runtime_config.symlink_root() + "/" +
-                                                    runtime_config.subdirectory());
+      layer->mutable_disk_layer()->set_symlink_root(runtime_config.symlink_root());
+      layer->mutable_disk_layer()->set_subdirectory(runtime_config.subdirectory());
     }
     if (!runtime_config.override_subdirectory().empty()) {
       auto* layer = layered_runtime_config.add_layers();
       layer->set_name("override");
-      layer->mutable_disk_layer()->set_symlink_root(runtime_config.symlink_root() + "/" +
-                                                    runtime_config.override_subdirectory());
+      layer->mutable_disk_layer()->set_symlink_root(runtime_config.symlink_root());
+      layer->mutable_disk_layer()->set_subdirectory(runtime_config.override_subdirectory());
       layer->mutable_disk_layer()->set_append_service_cluster(true);
     }
   }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -585,7 +585,8 @@ std::unique_ptr<SnapshotImpl> LoaderImpl::createNewSnapshot() {
       layers.emplace_back(std::make_unique<const ProtoLayer>(layer.name(), layer.static_layer()));
       break;
     case envoy::config::bootstrap::v2::RuntimeLayer::kDiskLayer: {
-      std::string path = layer.disk_layer().symlink_root();
+      std::string path =
+          layer.disk_layer().symlink_root() + "/" + layer.disk_layer().subdirectory();
       if (layer.disk_layer().append_service_cluster()) {
         path += "/" + service_cluster_;
       }

--- a/test/common/config/runtime_utility_test.cc
+++ b/test/common/config/runtime_utility_test.cc
@@ -41,7 +41,8 @@ TEST(RuntimeUtility, TranslateSubdirOnly) {
   {
     auto* layer = expected_runtime_config.add_layers();
     layer->set_name("root");
-    layer->mutable_disk_layer()->set_symlink_root("foo/bar");
+    layer->mutable_disk_layer()->set_symlink_root("foo");
+    layer->mutable_disk_layer()->set_subdirectory("bar");
   }
   {
     auto* layer = expected_runtime_config.add_layers();
@@ -67,12 +68,14 @@ TEST(RuntimeUtility, TranslateSubdirOverride) {
   {
     auto* layer = expected_runtime_config.add_layers();
     layer->set_name("root");
-    layer->mutable_disk_layer()->set_symlink_root("foo/bar");
+    layer->mutable_disk_layer()->set_symlink_root("foo");
+    layer->mutable_disk_layer()->set_subdirectory("bar");
   }
   {
     auto* layer = expected_runtime_config.add_layers();
     layer->set_name("override");
-    layer->mutable_disk_layer()->set_symlink_root("foo/baz");
+    layer->mutable_disk_layer()->set_symlink_root("foo");
+    layer->mutable_disk_layer()->set_subdirectory("baz");
     layer->mutable_disk_layer()->set_append_service_cluster(true);
   }
   {

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -380,9 +380,9 @@ TEST(InitialImplTest, LayeredRuntime) {
         health_check:
           min_interval: 5
     - name: root
-      disk_layer: { symlink_root: /srv/runtime/current/envoy }
+      disk_layer: { symlink_root: /srv/runtime/current, subdirectory: envoy }
     - name: override
-      disk_layer: { symlink_root: /srv/runtime/current/envoy_override, append_service_cluster: true }
+      disk_layer: { symlink_root: /srv/runtime/current, subdirectory: envoy_override, append_service_cluster: true }
     - name: admin
       admin_layer: {}
   )EOF";
@@ -448,9 +448,9 @@ TEST(InitialImplTest, DeprecatedRuntimeTranslation) {
       health_check:
         min_interval: 5
   - name: root
-    disk_layer: { symlink_root: /srv/runtime/current/envoy }
+    disk_layer: { symlink_root: /srv/runtime/current, subdirectory: envoy }
   - name: override
-    disk_layer: { symlink_root: /srv/runtime/current/envoy_override, append_service_cluster: true }
+    disk_layer: { symlink_root: /srv/runtime/current, subdirectory: envoy_override, append_service_cluster: true }
   - name: admin
     admin_layer: {}
   )EOF";


### PR DESCRIPTION
Without a distinction between the root and subdir, we can't watch for
symlink swaps that cover multiple layers.

Risk level: Low
Testing: additional test expects added.

Signed-off-by: Harvey Tuch <htuch@google.com>