### PR TITLE
fuzz: fix oss-fuzz build failure 

### DIFF
--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -45,6 +45,7 @@ std::string makeTempDir(char* name_template) {
   std::filesystem::create_directories(dirname);
 #elifdef __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(dirname);
+#endif
 #else
   char* dirname = ::mkdtemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -4,7 +4,10 @@
 #include <unistd.h>
 
 #ifdef __has_include
-#if __has_include(<experimental/filesystem>)
+#if __has_include(<filesystem>)
+#include <filesystem>
+// TODO(asraa): Remove this when Envoy requires Clang >= 9.
+#elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 #endif
 #endif
@@ -38,6 +41,9 @@ std::string makeTempDir(char* name_template) {
   char* dirname = ::_mktemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, strerror(errno)));
+#ifdef __cpp_lib_filesystem
+  std::filesystem::create_directories(dirname);
+#elifdef __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(dirname);
 #else
   char* dirname = ::mkdtemp(name_template);
@@ -77,39 +83,48 @@ char** argv_;
 } // namespace
 
 void TestEnvironment::createPath(const std::string& path) {
-#ifdef __cpp_lib_experimental_filesystem
+#ifdef __cpp_lib_filesystem
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
+  std::filesystem::create_directories(std::filesystem::path(path));
+#elifdef __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(std::experimental::filesystem::path(path));
 #else
-  // No support on this system for std::experimental::filesystem.
+  // No support on this system for std::filesystem or std::experimental::filesystem.
   RELEASE_ASSERT(::system(("mkdir -p " + path).c_str()) == 0, "");
 #endif
 }
 
 void TestEnvironment::createParentPath(const std::string& path) {
-#ifdef __cpp_lib_experimental_filesystem
+#ifdef __cpp_lib_filesystem
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
+  std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+#elifdef __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(
       std::experimental::filesystem::path(path).parent_path());
 #else
-  // No support on this system for std::experimental::filesystem.
+  // No support on this system for std::filesystem or std::experimental::filesystem.
   RELEASE_ASSERT(::system(("mkdir -p $(dirname " + path + ")").c_str()) == 0, "");
 #endif
 }
 
 void TestEnvironment::removePath(const std::string& path) {
   RELEASE_ASSERT(absl::StartsWith(path, TestEnvironment::temporaryDirectory()), "");
-#ifdef __cpp_lib_experimental_filesystem
-  // We don't want to rely on rm etc. if we can avoid it, since it might not
+#ifdef __cpp_lib_filesystem
+  // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
+  if (!std::filesystem::exists(path)) {
+    return;
+  }
+  std::filesystem::remove_all(std::filesystem::path(path));
+#elifdef __cpp_lib_experimental_filesystem
   if (!std::experimental::filesystem::exists(path)) {
     return;
   }
   std::experimental::filesystem::remove_all(std::experimental::filesystem::path(path));
 #else
-  // No support on this system for std::experimental::filesystem.
+  // No support on this system for std::filesystem or std::experimental::filesystem.
   RELEASE_ASSERT(::system(("rm -rf " + path).c_str()) == 0, "");
 #endif
 }


### PR DESCRIPTION
OSS-Fuzz (using Clang version 9) builds fail due to std::experimental::filesystem being deprecated in favor of std::filesystem. This resolves the build failure until Envoy requires Clang >= 9.

Risk Level: Low
Testing: Fuzzers build successfully.

Fixes #Issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15303#c1
