### PR TITLE
grpc: Make Envoy::Grpc::AsyncClient class mock friendly

### DIFF
--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -95,16 +95,17 @@ template <typename Request, typename Response> class AsyncClient /* : public Raw
 public:
   AsyncClient() {}
   AsyncClient(RawAsyncClientPtr&& client) : client_(std::move(client)) {}
+  virtual ~AsyncClient() = default;
 
-  AsyncRequest* send(const Protobuf::MethodDescriptor& service_method,
-                     const Protobuf::Message& request, AsyncRequestCallbacks<Response>& callbacks,
-                     Tracing::Span& parent_span,
-                     const absl::optional<std::chrono::milliseconds>& timeout) {
+  virtual AsyncRequest* send(const Protobuf::MethodDescriptor& service_method,
+                             const Protobuf::Message& request,
+                             AsyncRequestCallbacks<Response>& callbacks, Tracing::Span& parent_span,
+                             const absl::optional<std::chrono::milliseconds>& timeout) {
     return Internal::sendUntyped(client_.get(), service_method, request, callbacks, parent_span,
                                  timeout);
   }
-  AsyncStream<Request> start(const Protobuf::MethodDescriptor& service_method,
-                             AsyncStreamCallbacks<Response>& callbacks) {
+  virtual AsyncStream<Request> start(const Protobuf::MethodDescriptor& service_method,
+                                     AsyncStreamCallbacks<Response>& callbacks) {
     return AsyncStream<Request>(Internal::startUntyped(client_.get(), service_method, callbacks));
   }
 


### PR DESCRIPTION
Envoy::Grpc::AsyncClient template class is currently not very mock friendly since its interface is not virtual. There is no downside for making it virtual and allowing mocking of gRPC clients that use this class.

Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Fixes #7346

Signed-off-by: Yan Avlasov <yavlasov@google.com>
