### PR TITLE
fix clang reference string in check_format.py

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -191,7 +191,7 @@ def checkTools():
                             "users".format(CLANG_FORMAT_PATH))
   else:
     error_messages.append(
-        "Command {} not found. If you have clang-format in version 7.x.x "
+        "Command {} not found. If you have clang-format in version 8.x.x "
         "installed, but the binary name is different or it's not available in "
         "PATH, please use CLANG_FORMAT environment variable to specify the path. "
         "Examples:\n"


### PR DESCRIPTION
Description: Another stray reference to clang-7. I git-grepped around for lines containing `clang` and `7` and I _think_ this is finally the last of them...
Risk Level: None
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>