### PR TITLE
clang-tidy: modernize-use-using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,readability-container-size-empty'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
-WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move,readability-container-size-empty,performance-faster-string-find,performance-for-range-copy'
+WarningsAsErrors: 'bugprone-assert-side-effect,bugprone-use-after-move,modernize-make-shared,modernize-make-unique,modernize-use-using,performance-faster-string-find,performance-for-range-copy,readability-braces-around-statements,readability-container-size-empty,readability-redundant-smartptr-get,readability-redundant-string-cstr'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -111,7 +111,7 @@ protected:
     const LowerCaseString* key_;
   };
 
-  using EntryCb = StaticLookupResponse (*)(HeaderMapImpl &);
+  using EntryCb = StaticLookupResponse (*)(HeaderMapImpl&);
 
   /**
    * This is the static lookup table that is used to determine whether a header is one of the O(1)

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -111,7 +111,7 @@ protected:
     const LowerCaseString* key_;
   };
 
-  typedef StaticLookupResponse (*EntryCb)(HeaderMapImpl&);
+  using EntryCb = StaticLookupResponse (*)(HeaderMapImpl &);
 
   /**
    * This is the static lookup table that is used to determine whether a header is one of the O(1)

--- a/source/extensions/filters/http/common/aws/region_provider.h
+++ b/source/extensions/filters/http/common/aws/region_provider.h
@@ -24,7 +24,7 @@ public:
   virtual absl::optional<std::string> getRegion() PURE;
 };
 
-typedef std::shared_ptr<RegionProvider> RegionProviderSharedPtr;
+using RegionProviderSharedPtr = std::shared_ptr<RegionProvider>;
 
 } // namespace Aws
 } // namespace Common

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -42,8 +42,10 @@ public:
   bool onDestroyLog() override;
 
 private:
-  using MutableBodyChunk = envoy::data::tap::v2alpha::Body *(envoy::data::tap::v2alpha::HttpStreamedTraceSegment::*)();
-  using MutableMessage = envoy::data::tap::v2alpha::HttpBufferedTrace::Message *(envoy::data::tap::v2alpha::HttpBufferedTrace::*)();
+  using MutableBodyChunk =
+      envoy::data::tap::v2alpha::Body* (envoy::data::tap::v2alpha::HttpStreamedTraceSegment::*)();
+  using MutableMessage = envoy::data::tap::v2alpha::HttpBufferedTrace::Message* (
+      envoy::data::tap::v2alpha::HttpBufferedTrace::*)();
 
   void onBody(const Buffer::Instance& data,
               Extensions::Common::Tap::TraceWrapperPtr& buffered_streamed_body,

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -42,10 +42,8 @@ public:
   bool onDestroyLog() override;
 
 private:
-  typedef envoy::data::tap::v2alpha::Body* (
-      envoy::data::tap::v2alpha::HttpStreamedTraceSegment::*MutableBodyChunk)();
-  typedef envoy::data::tap::v2alpha::HttpBufferedTrace::Message* (
-      envoy::data::tap::v2alpha::HttpBufferedTrace::*MutableMessage)();
+  using MutableBodyChunk = envoy::data::tap::v2alpha::Body *(envoy::data::tap::v2alpha::HttpStreamedTraceSegment::*)();
+  using MutableMessage = envoy::data::tap::v2alpha::HttpBufferedTrace::Message *(envoy::data::tap::v2alpha::HttpBufferedTrace::*)();
 
   void onBody(const Buffer::Instance& data,
               Extensions::Common::Tap::TraceWrapperPtr& buffered_streamed_body,

--- a/test/common/http/http2/metadata_encoder_decoder_test.cc
+++ b/test/common/http/http2/metadata_encoder_decoder_test.cc
@@ -20,18 +20,18 @@ namespace {
 static const uint64_t STREAM_ID = 1;
 
 // The buffer stores data sent by encoder and received by decoder.
-typedef struct {
+struct TestBuffer {
   uint8_t buf[1024 * 1024] = {0};
   size_t length = 0;
-} TestBuffer;
+};
 
 // The application data structure passes to nghttp2 session.
-typedef struct {
+struct UserData {
   MetadataEncoder* encoder;
   MetadataDecoder* decoder;
   // Stores data sent by encoder and received by the decoder.
   TestBuffer* output_buffer;
-} UserData;
+};
 
 // Nghttp2 callback function for sending extension frame.
 static ssize_t pack_extension_callback(nghttp2_session* session, uint8_t* buf, size_t len,

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -286,7 +286,7 @@ public:
 
       return true;
     }
-    typedef std::list<std::unique_ptr<const Protobuf::Message>> ProtoList;
+    using ProtoList = std::list<std::unique_ptr<const Protobuf::Message>>;
     // Iterate through using protoEqual as ignore_ordering is true, and fields
     // in the sub-protos may also be out of order.
     ProtoList lhs_list =


### PR DESCRIPTION
Description: Enables a clang-tidy error (`modernize-use-using`) for ensuring that `using` is used instead of `typedef`. There've been a few large diffs to standardize on that, I believe one from @fredlas - this clang check will prevent regressing on this style.
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rt-using

Also alphabetized the `WarningsAsErrors` in `.clang-tidy`.

Relates to #4863 
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>