### PR TITLE
ci: less invasive surgery in Bazel cache when cleaning .gcno.

### DIFF
--- a/test/common/runtime/filesystem_setup.sh
+++ b/test/common/runtime/filesystem_setup.sh
@@ -6,6 +6,7 @@ TEST_DATA=test/common/runtime/test_data
 
 # Regular runtime tests.
 cd "${TEST_RUNDIR}"
+rm -rf "${TEST_TMPDIR}/${TEST_DATA}"
 mkdir -p "${TEST_TMPDIR}/${TEST_DATA}"
 cp -RfL "${TEST_DATA}"/* "${TEST_TMPDIR}/${TEST_DATA}"
 chmod -R u+rwX "${TEST_TMPDIR}/${TEST_DATA}"

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -104,12 +104,12 @@ protected:
 
 class DiskLoaderImplTest : public LoaderImplTest {
 public:
-  static void SetUpTestSuite() {
+  void SetUp() override {
     TestEnvironment::exec(
         {TestEnvironment::runfilesPath("test/common/runtime/filesystem_setup.sh")});
   }
 
-  static void TearDownTestSuite() {
+  void TearDown() override {
     TestEnvironment::removePath(TestEnvironment::temporaryPath("test/common/runtime/test_data"));
   }
 

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -451,7 +451,7 @@
   },
 
   "runtime": {
-    "symlink_root": "{{ test_rundir }}/test/common/runtime/test_data/current",
+    "symlink_root": "{{ test_tmpdir }}/test/common/runtime/test_data/current",
     "subdirectory": "envoy",
     "override_subdirectory": "envoy_override"
   },

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -416,7 +416,7 @@ stats_sinks:
     tcp_cluster_name: statsd
 watchdog: {}
 runtime:
-  symlink_root: "{{ test_rundir }}/test/common/runtime/test_data/current"
+  symlink_root: "{{ test_tmpdir }}/test/common/runtime/test_data/current"
   subdirectory: envoy
   override_subdirectory: envoy_override
 admin:

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -165,8 +165,6 @@ envoy_sh_test(
     data = [
         "test_utility.sh",
         "//source/exe:envoy-static",
-        "//test/common/runtime:filesystem_setup.sh",
-        "//test/common/runtime:filesystem_test_data",
         "//test/config/integration:server_config_files",
         "//tools:socket_passing",
     ],
@@ -178,8 +176,6 @@ envoy_sh_test(
     data = [
         "test_utility.sh",
         "//source/exe:envoy-static",
-        "//test/common/runtime:filesystem_setup.sh",
-        "//test/common/runtime:filesystem_test_data",
         "//test/config/integration:server_config_files",
     ],
 )

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -8,8 +8,8 @@ source "$TEST_RUNDIR/test/integration/test_utility.sh"
 JSON_TEST_ARRAY=()
 
 # Ensure that the runtime watch root exist.
-mkdir -p "${TEST_RUNDIR}"/test/common/runtime/test_data/current/envoy
-mkdir -p "${TEST_RUNDIR}"/test/common/runtime/test_data/current/envoy_override
+mkdir -p "${TEST_TMPDIR}"/test/common/runtime/test_data/current/envoy
+mkdir -p "${TEST_TMPDIR}"/test/common/runtime/test_data/current/envoy_override
 
 # Parameterize IPv4 and IPv6 testing.
 if [[ -z "${ENVOY_IP_TEST_VERSIONS}" ]] || [[ "${ENVOY_IP_TEST_VERSIONS}" == "all" ]] \

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -34,7 +34,15 @@ fi
 # This is where we are going to copy the .gcno files into.
 GCNO_ROOT=bazel-out/k8-dbg/bin/test/coverage/coverage_tests.runfiles/"${WORKSPACE}"
 echo "    GCNO_ROOT=${GCNO_ROOT}"
-rm -rf ${GCNO_ROOT}
+
+echo "Cleaning .gcno from previous coverage runs..."
+NUM_PREVIOUS_GCNO_FILES=0
+for f in $(find -L "${GCNO_ROOT}" -name "*.gcno")
+do
+  rm -f "${f}"
+  let NUM_PREVIOUS_GCNO_FILES=NUM_PREVIOUS_GCNO_FILES+1
+done
+echo "Cleanup completed. ${NUM_PREVIOUS_GCNO_FILES} files deleted."
 
 # Make sure //test/coverage:coverage_tests is up-to-date.
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"


### PR DESCRIPTION
Today, we nuke the runfiles directory to cleanup on a previous run's .gcno files, which are unknown
to Bazel but copied there for the gcovr run. This is fine in CI, which always does a clean build,
but for local developer flow, it breaks coverage when we re-run tests a second time, since Bazel
doesn't like you nuking random files in the cache that it owns. This PR limits the removed files to
just .gcno.

Risk level: Low
Testing: Local CI Docker rebuilds.

Signed-off-by: Harvey Tuch <htuch@google.com>
