### PR TITLE
admin: fix compilation error

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -673,22 +673,16 @@ Http::Code AdminImpl::handlerResetCounters(absl::string_view, Http::HeaderMap&,
 }
 
 envoy::admin::v2alpha::ServerInfo::State AdminImpl::serverState() {
-  envoy::admin::v2alpha::ServerInfo::State state;
-
   switch (server_.initManager().state()) {
   case Init::Manager::State::Uninitialized:
-    state = envoy::admin::v2alpha::ServerInfo::PRE_INITIALIZING;
-    break;
+    return envoy::admin::v2alpha::ServerInfo::PRE_INITIALIZING;
   case Init::Manager::State::Initializing:
-    state = envoy::admin::v2alpha::ServerInfo::INITIALIZING;
-    break;
+    return envoy::admin::v2alpha::ServerInfo::INITIALIZING;
   case Init::Manager::State::Initialized:
-    state = server_.healthCheckFailed() ? envoy::admin::v2alpha::ServerInfo::DRAINING
-                                        : envoy::admin::v2alpha::ServerInfo::LIVE;
-    break;
+    return server_.healthCheckFailed() ? envoy::admin::v2alpha::ServerInfo::DRAINING
+                                       : envoy::admin::v2alpha::ServerInfo::LIVE;
   }
-
-  return state;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap& headers,


### PR DESCRIPTION
Description: Fix compilation error in `envoy/source/server/http/admin.cc` for gcc-8.2.0 `opt` compilation mode:
```
external/envoy/source/server/http/admin.cc: In member function 'envoy::admin::v2alpha::ServerInfo::State Envoy::Server::AdminImpl::serverState()':
external/envoy/source/server/http/admin.cc:691:10: error: 'state' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   return state;
          ^~~~~
```

* Restructure switch to directly return from case branches.
* Hint gcc that outer branch is inaccessible.

Risk Level: Low
Testing: Compile envoy using gcc-8.2.0 to verify the fix
Docs Changes: N/A
Release Notes: N/A
