### PR TITLE
api: fix ruby package naming conflicts

### DIFF
--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -7,6 +7,7 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option go_package = "cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "envoy/api/v2/core/base.proto";
 

--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -6,6 +6,7 @@ option java_outer_classname = "OutlierDetectionProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -7,6 +7,7 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
 option go_package = "listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
 
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/auth/cert.proto";


### PR DESCRIPTION
Description: The existing protos yield a ruby module and class with the same name for both cluster and listener. This fixes for ruby what https://github.com/envoyproxy/envoy/pull/3854 fixed for C#.
Risk Level: Low
Testing: I successfully generated valid envoy configurations using the ruby code generated by these updated protos.
Docs Changes: N/A
Release Notes: Ruby module name overrides for data plane api proto definitions.