### PR TITLE
HCM: save 8 or 16 bytes for each http filter

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -96,9 +96,9 @@ private:
    */
   struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks {
     ActiveStreamFilterBase(ActiveStream& parent, bool dual_filter)
-        : iteration_state_(IterationState::Continue), iterate_from_current_filter_(false),
-          parent_(parent), headers_continued_(false), continue_headers_continued_(false),
-          end_stream_(false), dual_filter_(dual_filter) {}
+        : parent_(parent), iteration_state_(IterationState::Continue),
+          iterate_from_current_filter_(false), headers_continued_(false),
+          continue_headers_continued_(false), end_stream_(false), dual_filter_(dual_filter) {}
 
     // Functions in the following block are called after the filter finishes processing
     // corresponding data. Those functions handle state updates and data storage (if needed)
@@ -159,13 +159,13 @@ private:
       StopAllWatermark,    // Iteration has stopped for all frame types, and following data should
                            // be buffered until high watermark is reached.
     };
+    ActiveStream& parent_;
     IterationState iteration_state_;
     // If the filter resumes iteration from a StopAllBuffer/Watermark state, the current filter
     // hasn't parsed data and trailers. As a result, the filter iteration should start with the
     // current filter instead of the next one. If true, filter iteration starts with the current
     // filter. Otherwise, starts with the next filter in the chain.
-    bool iterate_from_current_filter_;
-    ActiveStream& parent_;
+    bool iterate_from_current_filter_ : 1;
     bool headers_continued_ : 1;
     bool continue_headers_continued_ : 1;
     // If true, end_stream is called for this filter.


### PR DESCRIPTION
**Description:** 
Use bit field and adjust member order.

was
```
source/common/http/conn_manager_impl.cc:118:88: note: in instantiation of template class 'Envoy::Http::check_size<0, 80>' requested here
        check_size<0, sizeof(struct ConnectionManagerImpl::ActiveStreamDecoderFilter)> dummy1_;
source/common/http/conn_manager_impl.cc:119:88: note: in instantiation of template class 'Envoy::Http::check_size<0, 72>' requested here
        check_size<0, sizeof(struct ConnectionManagerImpl::ActiveStreamEncoderFilter)> dummy2_;
```

With this PR

```
source/common/http/conn_manager_impl.cc:118:88: note: in instantiation of template class 'Envoy::Http::check_size<0, 72>' requested here
        check_size<0, sizeof(struct ConnectionManagerImpl::ActiveStreamDecoderFilter)> dummy1_;
source/common/http/conn_manager_impl.cc:119:88: note: in instantiation of template class 'Envoy::Http::check_size<0, 64>' requested here
        check_size<0, sizeof(struct ConnectionManagerImpl::ActiveStreamEncoderFilter)> dummy2_;
```

Below is is the calculator that I run with but reverted. See
https://stackoverflow.com/questions/11526526/how-to-combine-static-assert-with-sizeof-and-stringify

```
+template <int s, int t> struct check_size { static_assert(s == t, "wrong size"); };
+
 ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
                                              const Network::DrainDecision& drain_close,
                                              Runtime::RandomGenerator& random_generator,
@@ -110,7 +112,10 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
           overload_manager ? overload_manager->getThreadLocalOverloadState().getState(
                                  Server::OverloadActionNames::get().DisableHttpKeepAlive)
                            : Server::OverloadManager::getInactiveState()),
-      time_source_(time_source) {}
+      time_source_(time_source) {
+  check_size<0, sizeof(struct ConnectionManagerImpl::ActiveStreamDecoderFilter)> dummy1_;
+  check_size<0, sizeof(struct ConnectionManagerImpl::ActiveStreamEncoderFilter)> dummy2_;
+}
```

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

**Risk Level:**
 LOW
**Testing:**
 Existing test
