### PR TITLE
common: replace the moveIntoList

### DIFF
--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -36,7 +36,7 @@ AsyncRequest* AsyncClientImpl::sendRaw(absl::string_view service_full_name,
     return nullptr;
   }
 
-  grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(grpc_stream), active_streams_);
   return async_request;
 }
 
@@ -52,7 +52,7 @@ RawAsyncStream* AsyncClientImpl::startRaw(absl::string_view service_full_name,
     return nullptr;
   }
 
-  grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(grpc_stream), active_streams_);
   return active_streams_.front().get();
 }
 

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -41,7 +41,7 @@ private:
 class AsyncStreamImpl : public RawAsyncStream,
                         Http::AsyncClient::StreamCallbacks,
                         public Event::DeferredDeletable,
-                        LinkedObject<AsyncStreamImpl> {
+                        public LinkedObject<AsyncStreamImpl> {
 public:
   AsyncStreamImpl(AsyncClientImpl& parent, absl::string_view service_full_name,
                   absl::string_view method_name, RawAsyncStreamCallbacks& callbacks,

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -109,7 +109,7 @@ GoogleAsyncClientImpl::sendRaw(absl::string_view service_full_name, absl::string
     return nullptr;
   }
 
-  grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(grpc_stream), active_streams_);
   return async_request;
 }
 
@@ -125,7 +125,7 @@ RawAsyncStream* GoogleAsyncClientImpl::startRaw(absl::string_view service_full_n
     return nullptr;
   }
 
-  grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(grpc_stream), active_streams_);
   return active_streams_.front().get();
 }
 

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -194,7 +194,7 @@ private:
 class GoogleAsyncStreamImpl : public RawAsyncStream,
                               public Event::DeferredDeletable,
                               Logger::Loggable<Logger::Id::grpc>,
-                              LinkedObject<GoogleAsyncStreamImpl> {
+                              public LinkedObject<GoogleAsyncStreamImpl> {
 public:
   GoogleAsyncStreamImpl(GoogleAsyncClientImpl& parent, absl::string_view service_full_name,
                         absl::string_view method_name, RawAsyncStreamCallbacks& callbacks,

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -56,7 +56,7 @@ AsyncClient::Request* AsyncClientImpl::send(MessagePtr&& request, AsyncClient::C
 
   // The request may get immediately failed. If so, we will return nullptr.
   if (!new_request->remote_closed_) {
-    new_request->moveIntoList(std::move(new_request), active_streams_);
+    LinkedObjectUtil::moveIntoFront(std::move(new_request), active_streams_);
     return async_request;
   } else {
     new_request->cleanup();
@@ -67,7 +67,7 @@ AsyncClient::Request* AsyncClientImpl::send(MessagePtr&& request, AsyncClient::C
 AsyncClient::Stream* AsyncClientImpl::start(AsyncClient::StreamCallbacks& callbacks,
                                             const AsyncClient::StreamOptions& options) {
   std::unique_ptr<AsyncStreamImpl> new_stream{new AsyncStreamImpl(*this, callbacks, options)};
-  new_stream->moveIntoList(std::move(new_stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(new_stream), active_streams_);
   return active_streams_.front().get();
 }
 

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -73,7 +73,7 @@ class AsyncStreamImpl : public AsyncClient::Stream,
                         public StreamDecoderFilterCallbacks,
                         public Event::DeferredDeletable,
                         Logger::Loggable<Logger::Id::http>,
-                        LinkedObject<AsyncStreamImpl> {
+                        public LinkedObject<AsyncStreamImpl> {
 public:
   AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
                   const AsyncClient::StreamOptions& options);

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -54,7 +54,7 @@ StreamEncoder& CodecClient::newStream(StreamDecoder& response_decoder) {
   ActiveRequestPtr request(new ActiveRequest(*this, response_decoder));
   request->encoder_ = &codec_->newStream(*request);
   request->encoder_->getStream().addCallbacks(*request);
-  request->moveIntoList(std::move(request), active_requests_);
+  LinkedObjectUtil::moveIntoFront(std::move(request), active_requests_);
   disableIdleTimer();
   return *active_requests_.front()->encoder_;
 }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -252,7 +252,7 @@ StreamDecoder& ConnectionManagerImpl::newStream(StreamEncoder& response_encoder,
   // Both HTTP/1.x and HTTP/2 codecs handle this in StreamCallbackHelper::addCallbacks_.
   ASSERT(read_callbacks_->connection().aboveHighWatermark() == false ||
          new_stream->high_watermark_count_ > 0);
-  new_stream->moveIntoList(std::move(new_stream), streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(new_stream), streams_);
   return **streams_.begin();
 }
 
@@ -524,14 +524,14 @@ void ConnectionManagerImpl::ActiveStream::addStreamDecoderFilterWorker(
     StreamDecoderFilterSharedPtr filter, bool dual_filter) {
   ActiveStreamDecoderFilterPtr wrapper(new ActiveStreamDecoderFilter(*this, filter, dual_filter));
   filter->setDecoderFilterCallbacks(*wrapper);
-  wrapper->moveIntoListBack(std::move(wrapper), decoder_filters_);
+  LinkedObjectUtil::moveIntoBack(std::move(wrapper), decoder_filters_);
 }
 
 void ConnectionManagerImpl::ActiveStream::addStreamEncoderFilterWorker(
     StreamEncoderFilterSharedPtr filter, bool dual_filter) {
   ActiveStreamEncoderFilterPtr wrapper(new ActiveStreamEncoderFilter(*this, filter, dual_filter));
   filter->setEncoderFilterCallbacks(*wrapper);
-  wrapper->moveIntoList(std::move(wrapper), encoder_filters_);
+  LinkedObjectUtil::moveIntoFront(std::move(wrapper), encoder_filters_);
 }
 
 void ConnectionManagerImpl::ActiveStream::addAccessLogHandler(

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -19,7 +19,7 @@ ConnectionPool::Cancellable*
 ConnPoolImplBase::newPendingRequest(StreamDecoder& decoder, ConnectionPool::Callbacks& callbacks) {
   ENVOY_LOG(debug, "queueing request due to no available connections");
   PendingRequestPtr pending_request(new PendingRequest(*this, decoder, callbacks));
-  pending_request->moveIntoList(std::move(pending_request), pending_requests_);
+  LinkedObjectUtil::moveIntoFront(std::move(pending_request), pending_requests_);
   return pending_requests_.front().get();
 }
 

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -87,7 +87,7 @@ void ConnPoolImpl::checkForDrained() {
 void ConnPoolImpl::createNewConnection() {
   ENVOY_LOG(debug, "creating a new connection");
   ActiveClientPtr client(new ActiveClient(*this));
-  client->moveIntoList(std::move(client), busy_clients_);
+  LinkedObjectUtil::moveIntoFront(std::move(client), busy_clients_);
 }
 
 ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_decoder,

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -906,7 +906,7 @@ Http::StreamEncoder& ClientConnectionImpl::newStream(StreamDecoder& decoder) {
   if (connection_.aboveHighWatermark()) {
     stream->runHighWatermarkCallbacks();
   }
-  stream->moveIntoList(std::move(stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(stream), active_streams_);
   return *active_streams_.front();
 }
 
@@ -965,7 +965,7 @@ int ServerConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   }
   stream->decoder_ = &callbacks_.newStream(*stream);
   stream->stream_id_ = frame->hd.stream_id;
-  stream->moveIntoList(std::move(stream), active_streams_);
+  LinkedObjectUtil::moveIntoFront(std::move(stream), active_streams_);
   nghttp2_session_set_stream_user_data(session_, frame->hd.stream_id,
                                        active_streams_.front().get());
   return 0;

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -13,7 +13,7 @@ void FilterManagerImpl::addWriteFilter(WriteFilterSharedPtr filter) {
   ASSERT(connection_.state() == Connection::State::Open);
   ActiveWriteFilterPtr new_filter(new ActiveWriteFilter{*this, filter});
   filter->initializeWriteFilterCallbacks(*new_filter);
-  new_filter->moveIntoList(std::move(new_filter), downstream_filters_);
+  LinkedObjectUtil::moveIntoFront(std::move(new_filter), downstream_filters_);
 }
 
 void FilterManagerImpl::addFilter(FilterSharedPtr filter) {
@@ -25,7 +25,7 @@ void FilterManagerImpl::addReadFilter(ReadFilterSharedPtr filter) {
   ASSERT(connection_.state() == Connection::State::Open);
   ActiveReadFilterPtr new_filter(new ActiveReadFilter{*this, filter});
   filter->initializeReadFilterCallbacks(*new_filter);
-  new_filter->moveIntoListBack(std::move(new_filter), upstream_filters_);
+  LinkedObjectUtil::moveIntoBack(std::move(new_filter), upstream_filters_);
 }
 
 bool FilterManagerImpl::initializeReadFilters() {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -480,7 +480,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   modify_headers_ = modify_headers;
 
   UpstreamRequestPtr upstream_request = std::make_unique<UpstreamRequest>(*this, *conn_pool);
-  upstream_request->moveIntoList(std::move(upstream_request), upstream_requests_);
+  LinkedObjectUtil::moveIntoFront(std::move(upstream_request), upstream_requests_);
   upstream_requests_.front()->encodeHeaders(end_stream);
   if (end_stream) {
     onRequestComplete();
@@ -939,7 +939,7 @@ void Filter::resetOtherUpstreams(UpstreamRequest& upstream_request) {
 
   ASSERT(final_upstream_request);
   // Now put the final request back on this list.
-  final_upstream_request->moveIntoList(std::move(final_upstream_request), upstream_requests_);
+  LinkedObjectUtil::moveIntoFront(std::move(final_upstream_request), upstream_requests_);
 }
 
 void Filter::onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& headers,
@@ -1221,7 +1221,7 @@ void Filter::doRetry() {
   ASSERT(response_timeout_ || timeout_.global_timeout_.count() == 0);
   UpstreamRequestPtr upstream_request = std::make_unique<UpstreamRequest>(*this, *conn_pool);
   UpstreamRequest* upstream_request_tmp = upstream_request.get();
-  upstream_request->moveIntoList(std::move(upstream_request), upstream_requests_);
+  LinkedObjectUtil::moveIntoFront(std::move(upstream_request), upstream_requests_);
   upstream_requests_.front()->encodeHeaders(!callbacks_->decodingBuffer() && !downstream_trailers_);
   // It's possible we got immediately reset which means the upstream request we just
   // added to the front of the list might have been removed, so we need to check to make

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -81,7 +81,7 @@ void ConnPoolImpl::checkForDrained() {
 void ConnPoolImpl::createNewConnection() {
   ENVOY_LOG(debug, "creating a new connection");
   ActiveConnPtr conn(new ActiveConn(*this));
-  conn->moveIntoList(std::move(conn), pending_conns_);
+  LinkedObjectUtil::moveIntoFront(std::move(conn), pending_conns_);
 }
 
 ConnectionPool::Cancellable* ConnPoolImpl::newConnection(ConnectionPool::Callbacks& callbacks) {
@@ -107,7 +107,7 @@ ConnectionPool::Cancellable* ConnPoolImpl::newConnection(ConnectionPool::Callbac
 
     ENVOY_LOG(debug, "queueing request due to no available connections");
     PendingRequestPtr pending_request(new PendingRequest(*this, callbacks));
-    pending_request->moveIntoList(std::move(pending_request), pending_requests_);
+    LinkedObjectUtil::moveIntoFront(std::move(pending_request), pending_requests_);
     return pending_requests_.front().get();
   } else {
     ENVOY_LOG(debug, "max pending requests overflow");

--- a/source/extensions/filters/network/dubbo_proxy/active_message.cc
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.cc
@@ -397,7 +397,7 @@ void ActiveMessage::addDecoderFilter(DubboFilters::DecoderFilterSharedPtr filter
   ActiveMessageDecoderFilterPtr wrapper =
       std::make_unique<ActiveMessageDecoderFilter>(*this, filter);
   filter->setDecoderFilterCallbacks(*wrapper);
-  wrapper->moveIntoListBack(std::move(wrapper), decoder_filters_);
+  LinkedObjectUtil::moveIntoBack(std::move(wrapper), decoder_filters_);
 }
 
 void ActiveMessage::onReset() { parent_.deferredMessage(*this); }

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
@@ -84,7 +84,7 @@ DecoderEventHandler* ConnectionManager::newDecoderEventHandler() {
 
   ActiveMessagePtr new_message(std::make_unique<ActiveMessage>(*this));
   new_message->createFilterChain();
-  new_message->moveIntoList(std::move(new_message), active_message_list_);
+  LinkedObjectUtil::moveIntoFront(std::move(new_message), active_message_list_);
   return (*active_message_list_.begin()).get();
 }
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -165,7 +165,7 @@ DecoderEventHandler& ConnectionManager::newDecoderEventHandler() {
 
   ActiveRpcPtr new_rpc(new ActiveRpc(*this));
   new_rpc->createFilterChain();
-  new_rpc->moveIntoList(std::move(new_rpc), rpcs_);
+  LinkedObjectUtil::moveIntoFront(std::move(new_rpc), rpcs_);
 
   return **rpcs_.begin();
 }

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -218,7 +218,7 @@ private:
     void addDecoderFilter(ThriftFilters::DecoderFilterSharedPtr filter) override {
       ActiveRpcDecoderFilterPtr wrapper = std::make_unique<ActiveRpcDecoderFilter>(*this, filter);
       filter->setDecoderFilterCallbacks(*wrapper);
-      wrapper->moveIntoListBack(std::move(wrapper), decoder_filters_);
+      LinkedObjectUtil::moveIntoBack(std::move(wrapper), decoder_filters_);
     }
 
     FilterStatus applyDecoderFilters(ActiveRpcDecoderFilter* filter);

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -242,7 +242,7 @@ void ConnectionHandlerImpl::ActiveTcpListener::onAccept(
   // Otherwise we let active_socket be destructed when it goes out of scope.
   if (active_socket->iter_ != active_socket->accept_filters_.end()) {
     active_socket->startTimer();
-    active_socket->moveIntoListBack(std::move(active_socket), sockets_);
+    LinkedObjectUtil::moveIntoBack(std::move(active_socket), sockets_);
   }
 }
 
@@ -283,7 +283,7 @@ void ConnectionHandlerImpl::ActiveTcpListener::onNewConnection(
   if (new_connection->state() != Network::Connection::State::Closed) {
     ActiveConnectionPtr active_connection(
         new ActiveConnection(*this, std::move(new_connection), parent_.dispatcher_.timeSource()));
-    active_connection->moveIntoList(std::move(active_connection), connections_);
+    LinkedObjectUtil::moveIntoFront(std::move(active_connection), connections_);
     parent_.num_connections_++;
   }
 }

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -404,7 +404,7 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
         }
         auto stream_ptr = pending_streams.front()->removeFromList(pending_streams);
         HttpStream* const stream = stream_ptr.get();
-        stream_ptr->moveIntoListBack(std::move(stream_ptr), streams);
+        LinkedObjectUtil::moveIntoBack(std::move(stream_ptr), streams);
         stream->response_.encoder_ = &encoder;
         encoder.getStream().addCallbacks(stream->response_.stream_callbacks_);
         stream->stream_index_ = streams.size() - 1;
@@ -436,7 +436,7 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
         HttpStreamPtr stream = std::make_unique<HttpStream>(
             *client, fromSanitizedHeaders(action.new_stream().request_headers()),
             action.new_stream().end_stream());
-        stream->moveIntoListBack(std::move(stream), pending_streams);
+        LinkedObjectUtil::moveIntoBack(std::move(stream), pending_streams);
         break;
       }
       case test::common::http::Action::kStreamAction: {

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -411,7 +411,7 @@ bool FakeUpstream::createNetworkFilterChain(Network::Connection& connection,
   connection.readDisable(true);
   auto connection_wrapper =
       std::make_unique<QueuedConnectionWrapper>(connection, allow_unexpected_disconnects_);
-  connection_wrapper->moveIntoListBack(std::move(connection_wrapper), new_connections_);
+  LinkedObjectUtil::moveIntoBack(std::move(connection_wrapper), new_connections_);
   new_connection_event_.notifyOne();
   return true;
 }

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -81,7 +81,7 @@ public:
     TestListener* listener =
         new TestListener(*this, tag, bind_to_port, hand_off_restored_destination_connections, name,
                          socket_type, listener_filters_timeout);
-    listener->moveIntoListBack(TestListenerPtr{listener}, listeners_);
+    LinkedObjectUtil::moveIntoBack(TestListenerPtr{listener}, listeners_);
     return listener;
   }
 


### PR DESCRIPTION
**Description:**

The signature of LinkedObject<T>::moveIntoList is verbose.
I see the below pattern all over the code base.
```
xx_ptr->moveIntoListBack(std::move(xx_ptr), xx_list);
```
The instance is supposed to deduct from the first param.

This PR adds a LinkedObjectUtil to achieve the deduction.
Now it is less error prone: You never have the concern that
the object doesn't match the 1st param.
It doesn't introduce more complexity as the template paramter
is dedcucted.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

**Risk Level:** LOW
**Testing:** existing test
**Docs Changes:** None... 

However, I am pretty sure most of the extensions outside the code base need a tiny fixup.

The below command should work in most of the cases.
```
grep moveIntoList <code_base_dir> -rl |grep -v linked_object.h | xargs sed -i -- 's/[a-zA-Z_]*->moveIntoList(/LinkedObjectUtil::moveIntoFront(/g'


grep moveIntoListBack <code_base_dir> -rl |grep -v linked_object.h | xargs sed -i -- 's/[a-zA-Z_]*->moveIntoListBack(/LinkedObjectUtil::moveIntoBack(/g'
```