### PR TITLE
tls: make boringssl implementation of TLS optional

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -163,6 +163,13 @@ config_setting(
     values = {"define": "quiche=enabled"},
 )
 
+config_setting(
+    name = "disable_boringssl",
+    define_values = {
+        "boringssl": "disable",
+    },
+)
+
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -170,17 +170,13 @@ config_setting(
 
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
-# - alternative SSL implementation (not BoringSSL) from @boringssl//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.
-# Note that if BoringSSL is disabled //bazel:boringssl alias still points
-# to @boringssl//:ssl, but in this case @boringssl is supposed to be remapped
-# to an alternative SSL implementation in WORKSPACE of the corresponding third
-# party TLS extension.
+# In case of disabled BoringSSL the @boringssl repository can be remapped to an
+# alternative one in WORKSPACE of the corresponding third party TLS extension.
 alias(
     name = "boringssl",
     actual = select({
         "//bazel:boringssl_fips": "@boringssl_fips//:ssl",
-        "//bazel:boringssl_disabled": "@boringssl//:ssl",
         "//conditions:default": "@boringssl//:ssl",
     }),
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -171,8 +171,6 @@ config_setting(
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.
-# In case of disabled BoringSSL the @boringssl repository can be remapped to an
-# alternative one in WORKSPACE of the corresponding third party TLS extension.
 alias(
     name = "boringssl",
     actual = select({

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -170,13 +170,17 @@ config_setting(
 
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
+# - alternative SSL implementation (not BoringSSL) from @boringssl//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.
-# In case of disabled BoringSSL the @boringssl repository can be remapped to an
-# alternative one in WORKSPACE of the corresponding third party TLS extension.
+# Note that if BoringSSL is disabled //bazel:boringssl alias still points
+# to @boringssl//:ssl, but in this case @boringssl is supposed to be remapped
+# to an alternative SSL implementation in WORKSPACE of the corresponding third
+# party TLS extension.
 alias(
     name = "boringssl",
     actual = select({
         "//bazel:boringssl_fips": "@boringssl_fips//:ssl",
+        "//bazel:boringssl_disabled": "@boringssl//:ssl",
         "//conditions:default": "@boringssl//:ssl",
     }),
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -159,20 +159,20 @@ config_setting(
 )
 
 config_setting(
-    name = "enable_quiche",
-    values = {"define": "quiche=enabled"},
+    name = "boringssl_disabled",
+    values = {"define": "boringssl=disabled"},
 )
 
 config_setting(
-    name = "disable_boringssl",
-    define_values = {
-        "boringssl": "disable",
-    },
+    name = "enable_quiche",
+    values = {"define": "quiche=enabled"},
 )
 
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.
+# In case of disabled BoringSSL the @boringssl repository can be remapped to an
+# alternative one in WORKSPACE of the corresponding third party TLS extension.
 alias(
     name = "boringssl",
     actual = select({

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -11,10 +11,10 @@ def envoy_cc_platform_dep(name):
         "//conditions:default": [name + "_posix"],
     })
 
-def envoy_select_boringssl(if_fips, if_disabled, default = None):
+def envoy_select_boringssl(if_fips, default = None, if_disabled = None):
     return select({
         "@envoy//bazel:boringssl_fips": if_fips,
-        "@envoy//bazel:boringssl_disabled": if_disabled,
+        "@envoy//bazel:boringssl_disabled": if_disabled or [],
         "//conditions:default": default or [],
     })
 

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -11,9 +11,10 @@ def envoy_cc_platform_dep(name):
         "//conditions:default": [name + "_posix"],
     })
 
-def envoy_select_boringssl(if_fips, default = None):
+def envoy_select_boringssl(if_fips, if_disabled, default = None):
     return select({
         "@envoy//bazel:boringssl_fips": if_fips,
+        "@envoy//bazel:boringssl_disabled": if_disabled,
         "//conditions:default": default or [],
     })
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -17,7 +17,7 @@ NOBORINGSSL_SKIP_TARGETS = {
     "lua": "envoy.filters.http.lua",
 
     # These two extensions are supposed to be replaced with alternative extensions.
-    "tls": "envoy.filters.http.tls",
+    "tls": "envoy.transport_sockets.tls",
     "tls_inspector": "envoy.filters.listener.tls_inspector",
 }
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -12,6 +12,14 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 
 # dict of {build recipe name: longform extension name,}
 PPC_SKIP_TARGETS = {"luajit": "envoy.filters.http.lua"}
+NOBORINGSSL_SKIP_TARGETS = {
+    # The lua filter depends on BoringSSL
+    "lua": "envoy.filters.http.lua",
+
+    # These two extensions are supposed to be replaced with alternative extensions.
+    "tls": "envoy.filters.http.tls",
+    "tls_inspector": "envoy.filters.listener.tls_inspector",
+}
 
 # go version for rules_go
 GO_VERSION = "1.12.5"

--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -40,6 +40,7 @@ envoy_cc_library(
     deps = [
         ":context_config_interface",
         ":context_interface",
+        "//include/envoy/common:time_interface",
         "//include/envoy/stats:stats_interface",
     ],
 )

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -40,5 +40,16 @@ public:
   virtual void iterateContexts(std::function<void(const Context&)> callback) PURE;
 };
 
+using ContextManagerPtr = std::unique_ptr<ContextManager>;
+
+class ContextManagerFactory {
+public:
+  virtual ~ContextManagerFactory() = default;
+  virtual ContextManagerPtr createContextManager(TimeSource& time_source) PURE;
+
+  // There could be only one factory thus the name is static.
+  static std::string name() { return "ssl_context_manager"; }
+};
+
 } // namespace Ssl
 } // namespace Envoy

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include "envoy/common/time.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/stats/scope.h"

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -291,6 +291,7 @@ envoy_cc_library(
     }),
     copts = envoy_select_boringssl(
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL-FIPS\\\""],
+        ["-DENVOY_SSL_VERSION=\\\"BoringSSL-DISABLED\\\""],
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     ),
     linkstamp = "version_linkstamp.cc",

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -291,7 +291,6 @@ envoy_cc_library(
     }),
     copts = envoy_select_boringssl(
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL-FIPS\\\""],
-        ["-DENVOY_SSL_VERSION=\\\"BoringSSL-DISABLED\\\""],
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     ),
     linkstamp = "version_linkstamp.cc",

--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -24,6 +24,11 @@ std::string VersionInfo::version() {
 #else
                      "DEBUG",
 #endif
-                     ENVOY_SSL_VERSION);
+#ifdef ENVOY_SSL_VERSION
+                     ENVOY_SSL_VERSION
+#else
+                     "no-ssl"
+#endif
+  );
 }
 } // namespace Envoy

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -44,7 +44,7 @@ envoy_cc_library(
     ] + select({
         "//bazel:windows_x86_64": envoy_windows_extensions(),
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
-        "//bazel:disable_boringssl": envoy_all_extensions(NOBORINGSSL_SKIP_TARGETS),
+        "//bazel:boringssl_disabled": envoy_all_extensions(NOBORINGSSL_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),
 )

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -15,7 +15,7 @@ load(
     "envoy_all_extensions",
     "envoy_windows_extensions",
 )
-load("//bazel:repositories.bzl", "PPC_SKIP_TARGETS")
+load("//bazel:repositories.bzl", "NOBORINGSSL_SKIP_TARGETS", "PPC_SKIP_TARGETS")
 
 envoy_package()
 
@@ -44,6 +44,7 @@ envoy_cc_library(
     ] + select({
         "//bazel:windows_x86_64": envoy_windows_extensions(),
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
+        "//bazel:disable_boringssl": envoy_all_extensions(NOBORINGSSL_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),
 )

--- a/source/extensions/all_extensions.bzl
+++ b/source/extensions/all_extensions.bzl
@@ -6,7 +6,6 @@ def envoy_all_extensions(blacklist = dict()):
     # Envoy build.
     all_extensions = [
         "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:config",
     ]
 
     # These extensions can be removed on a site specific basis.

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -52,7 +52,6 @@ EXTENSIONS = {
     "envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
     "envoy.filters.http.squash":                        "//source/extensions/filters/http/squash:config",
     "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
-    "envoy.filters.http.tls":                           "//source/extensions/transport_sockets/tls:config",
 
     #
     # Listener filters
@@ -131,6 +130,7 @@ EXTENSIONS = {
 
     "envoy.transport_sockets.alts":                     "//source/extensions/transport_sockets/alts:config",
     "envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
+    "envoy.transport_sockets.tls":                      "//source/extensions/transport_sockets/tls:config",
 
     # Retry host predicates
     "envoy.retry_host_predicates.previous_hosts":          "//source/extensions/retry/host/previous_hosts:config",

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -52,6 +52,7 @@ EXTENSIONS = {
     "envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
     "envoy.filters.http.squash":                        "//source/extensions/filters/http/squash:config",
     "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
+    "envoy.filters.http.tls":                           "//source/extensions/transport_sockets/tls:config",
 
     #
     # Listener filters

--- a/source/extensions/transport_sockets/tls/config.cc
+++ b/source/extensions/transport_sockets/tls/config.cc
@@ -47,6 +47,12 @@ ProtobufTypes::MessagePtr DownstreamSslSocketFactory::createEmptyConfigProto() {
 REGISTER_FACTORY(DownstreamSslSocketFactory,
                  Server::Configuration::DownstreamTransportSocketConfigFactory);
 
+Ssl::ContextManagerPtr SslContextManagerFactory::createContextManager(TimeSource& time_source) {
+  return std::make_unique<ContextManagerImpl>(time_source);
+}
+
+REGISTER_FACTORY(SslContextManagerFactory, Ssl::ContextManagerFactory);
+
 } // namespace Tls
 } // namespace TransportSockets
 } // namespace Extensions

--- a/source/extensions/transport_sockets/tls/config.h
+++ b/source/extensions/transport_sockets/tls/config.h
@@ -44,6 +44,13 @@ public:
 
 DECLARE_FACTORY(DownstreamSslSocketFactory);
 
+class SslContextManagerFactory : public Ssl::ContextManagerFactory {
+public:
+  Ssl::ContextManagerPtr createContextManager(TimeSource& time_source) override;
+};
+
+DECLARE_FACTORY(SslContextManagerFactory);
+
 } // namespace Tls
 } // namespace TransportSockets
 } // namespace Extensions

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -336,6 +336,7 @@ envoy_cc_library(
         ":guarddog_lib",
         ":listener_hooks_lib",
         ":listener_manager_lib",
+        ":ssl_context_manager_lib",
         ":worker_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:signal_interface",
@@ -377,6 +378,16 @@ envoy_cc_library(
         "//source/server:overload_manager_lib",
         "//source/server/http:admin_lib",
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
+    ],
+)
+
+envoy_cc_library(
+    name = "ssl_context_manager_lib",
+    srcs = ["ssl_context_manager.cc"],
+    hdrs = ["ssl_context_manager.h"],
+    deps = [
+        "//include/envoy/registry",
+        "//include/envoy/ssl:context_manager_interface",
     ],
 )
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -271,8 +271,6 @@ envoy_cc_library(
         "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/transport_sockets:well_known_names",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
         "@envoy_api//envoy/api/v2:lds_cc",
     ],

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -13,6 +13,8 @@
 #include "common/protobuf/utility.h"
 #include "common/singleton/manager_impl.h"
 
+#include "server/ssl_context_manager.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -91,9 +93,7 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
   runtime_loader_ = component_factory.createRuntime(*this, initial_config);
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>();
-  auto& factory = Envoy::Config::Utility::getAndCheckFactory<Ssl::ContextManagerFactory>(
-      Ssl::ContextManagerFactory::name());
-  ssl_context_manager_ = factory.createContextManager(api_->timeSource());
+  ssl_context_manager_ = createContextManager(api_->timeSource());
   cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       admin(), runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(),
       dispatcher(), localInfo(), *secret_manager_, messageValidationVisitor(), *api_, http_context_,

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -93,7 +93,8 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
   runtime_loader_ = component_factory.createRuntime(*this, initial_config);
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>();
-  ssl_context_manager_ = createContextManager(api_->timeSource());
+  ssl_context_manager_ =
+      createContextManager(Ssl::ContextManagerFactory::name(), api_->timeSource());
   cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       admin(), runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(),
       dispatcher(), localInfo(), *secret_manager_, messageValidationVisitor(), *api_, http_context_,

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -91,8 +91,9 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
   runtime_loader_ = component_factory.createRuntime(*this, initial_config);
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>();
-  ssl_context_manager_ =
-      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(api_->timeSource());
+  auto& factory = Envoy::Config::Utility::getAndCheckFactory<Ssl::ContextManagerFactory>(
+      Ssl::ContextManagerFactory::name());
+  ssl_context_manager_ = factory.createContextManager(api_->timeSource());
   cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       admin(), runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(),
       dispatcher(), localInfo(), *secret_manager_, messageValidationVisitor(), *api_, http_context_,

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -181,7 +181,7 @@ private:
   Singleton::ManagerPtr singleton_manager_;
   Runtime::LoaderPtr runtime_loader_;
   Runtime::RandomGeneratorImpl random_generator_;
-  std::unique_ptr<Extensions::TransportSockets::Tls::ContextManagerImpl> ssl_context_manager_;
+  std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   Configuration::MainImpl config_;
   LocalInfo::LocalInfoPtr local_info_;
   AccessLog::AccessLogManagerImpl access_log_manager_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -42,6 +42,7 @@
 #include "server/connection_handler_impl.h"
 #include "server/guarddog_impl.h"
 #include "server/listener_hooks.h"
+#include "server/ssl_context_manager.h"
 
 namespace Envoy {
 namespace Server {
@@ -351,9 +352,7 @@ void InstanceImpl::initialize(const Options& options,
   hooks.onRuntimeCreated();
 
   // Once we have runtime we can initialize the SSL context manager.
-  auto& factory = Envoy::Config::Utility::getAndCheckFactory<Ssl::ContextManagerFactory>(
-      Ssl::ContextManagerFactory::name());
-  ssl_context_manager_ = factory.createContextManager(time_source_);
+  ssl_context_manager_ = createContextManager(time_source_);
 
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
       *admin_, Runtime::LoaderSingleton::get(), stats_store_, thread_local_, *random_generator_,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -352,7 +352,7 @@ void InstanceImpl::initialize(const Options& options,
   hooks.onRuntimeCreated();
 
   // Once we have runtime we can initialize the SSL context manager.
-  ssl_context_manager_ = createContextManager(time_source_);
+  ssl_context_manager_ = createContextManager(Ssl::ContextManagerFactory::name(), time_source_);
 
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
       *admin_, Runtime::LoaderSingleton::get(), stats_store_, thread_local_, *random_generator_,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -351,8 +351,9 @@ void InstanceImpl::initialize(const Options& options,
   hooks.onRuntimeCreated();
 
   // Once we have runtime we can initialize the SSL context manager.
-  ssl_context_manager_ =
-      std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_source_);
+  auto& factory = Envoy::Config::Utility::getAndCheckFactory<Ssl::ContextManagerFactory>(
+      Ssl::ContextManagerFactory::name());
+  ssl_context_manager_ = factory.createContextManager(time_source_);
 
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
       *admin_, Runtime::LoaderSingleton::get(), stats_store_, thread_local_, *random_generator_,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -38,8 +38,6 @@
 #include "server/overload_manager_impl.h"
 #include "server/worker_impl.h"
 
-#include "extensions/transport_sockets/tls/context_manager_impl.h"
-
 #include "absl/container/node_hash_map.h"
 #include "absl/types/optional.h"
 
@@ -249,7 +247,7 @@ private:
   Network::ConnectionHandlerPtr handler_;
   Runtime::RandomGeneratorPtr random_generator_;
   std::unique_ptr<Runtime::ScopedLoaderSingleton> runtime_singleton_;
-  std::unique_ptr<Extensions::TransportSockets::Tls::ContextManagerImpl> ssl_context_manager_;
+  std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   ProdListenerComponentFactory listener_component_factory_;
   ProdWorkerFactory worker_factory_;
   std::unique_ptr<ListenerManager> listener_manager_;

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -1,0 +1,41 @@
+#include "server/ssl_context_manager.h"
+
+#include "envoy/common/exception.h"
+#include "envoy/registry/registry.h"
+
+namespace Envoy {
+namespace Server {
+
+class SslContextManagerStub final : public Envoy::Ssl::ContextManager {
+  Ssl::ClientContextSharedPtr
+  createSslClientContext(Stats::Scope& /* scope */,
+                         const Envoy::Ssl::ClientContextConfig& /* config */) override {
+    throw EnvoyException("SSL is not supported in this configuration");
+  }
+
+  Ssl::ServerContextSharedPtr
+  createSslServerContext(Stats::Scope& /* scope */,
+                         const Envoy::Ssl::ServerContextConfig& /* config */,
+                         const std::vector<std::string>& /* server_names */) override {
+    throw EnvoyException("SSL is not supported in this configuration");
+  }
+
+  size_t daysUntilFirstCertExpires() const override { return std::numeric_limits<int>::max(); }
+
+  void iterateContexts(std::function<void(const Envoy::Ssl::Context&)> /* callback */) override{};
+};
+
+Ssl::ContextManagerPtr createContextManager(TimeSource& time_source) {
+
+  Ssl::ContextManagerFactory* factory =
+      Registry::FactoryRegistry<Ssl::ContextManagerFactory>::getFactory(
+          Ssl::ContextManagerFactory::name());
+  if (factory != nullptr) {
+    return factory->createContextManager(time_source);
+  }
+
+  return std::make_unique<SslContextManagerStub>();
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -6,7 +6,7 @@
 namespace Envoy {
 namespace Server {
 
-class SslContextManagerStub final : public Envoy::Ssl::ContextManager {
+class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
   Ssl::ClientContextSharedPtr
   createSslClientContext(Stats::Scope& /* scope */,
                          const Envoy::Ssl::ClientContextConfig& /* config */) override {
@@ -33,7 +33,7 @@ Ssl::ContextManagerPtr createContextManager(const std::string& factory_name,
     return factory->createContextManager(time_source);
   }
 
-  return std::make_unique<SslContextManagerStub>();
+  return std::make_unique<SslContextManagerNoTlsStub>();
 }
 
 } // namespace Server

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -16,7 +16,6 @@ class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
   createSslClientContext(Stats::Scope& /* scope */,
                          const Envoy::Ssl::ClientContextConfig& /* config */) override {
     throwException();
-    return nullptr;
   }
 
   Ssl::ServerContextSharedPtr
@@ -24,7 +23,6 @@ class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
                          const Envoy::Ssl::ServerContextConfig& /* config */,
                          const std::vector<std::string>& /* server_names */) override {
     throwException();
-    return nullptr;
   }
 
   size_t daysUntilFirstCertExpires() const override { return std::numeric_limits<int>::max(); }
@@ -32,7 +30,9 @@ class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
   void iterateContexts(std::function<void(const Envoy::Ssl::Context&)> /* callback */) override{};
 
 private:
-  void throwException() { throw EnvoyException("SSL is not supported in this configuration"); }
+  [[noreturn]] void throwException() {
+    throw EnvoyException("SSL is not supported in this configuration");
+  }
 };
 
 Ssl::ContextManagerPtr createContextManager(const std::string& factory_name,

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -6,6 +6,11 @@
 namespace Envoy {
 namespace Server {
 
+/**
+ * A stub that provides a SSL context manager capable of reporting on
+ * certificates' data in case there's no TLS implementation built
+ * into Envoy.
+ */
 class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
   Ssl::ClientContextSharedPtr
   createSslClientContext(Stats::Scope& /* scope */,

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -15,19 +15,24 @@ class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
   Ssl::ClientContextSharedPtr
   createSslClientContext(Stats::Scope& /* scope */,
                          const Envoy::Ssl::ClientContextConfig& /* config */) override {
-    throw EnvoyException("SSL is not supported in this configuration");
+    throwException();
+    return nullptr;
   }
 
   Ssl::ServerContextSharedPtr
   createSslServerContext(Stats::Scope& /* scope */,
                          const Envoy::Ssl::ServerContextConfig& /* config */,
                          const std::vector<std::string>& /* server_names */) override {
-    throw EnvoyException("SSL is not supported in this configuration");
+    throwException();
+    return nullptr;
   }
 
   size_t daysUntilFirstCertExpires() const override { return std::numeric_limits<int>::max(); }
 
   void iterateContexts(std::function<void(const Envoy::Ssl::Context&)> /* callback */) override{};
+
+private:
+  void throwException() { throw EnvoyException("SSL is not supported in this configuration"); }
 };
 
 Ssl::ContextManagerPtr createContextManager(const std::string& factory_name,

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -25,10 +25,10 @@ class SslContextManagerStub final : public Envoy::Ssl::ContextManager {
   void iterateContexts(std::function<void(const Envoy::Ssl::Context&)> /* callback */) override{};
 };
 
-Ssl::ContextManagerPtr createContextManager(TimeSource& time_source) {
+Ssl::ContextManagerPtr createContextManager(const std::string& factory_name,
+                                            TimeSource& time_source) {
   Ssl::ContextManagerFactory* factory =
-      Registry::FactoryRegistry<Ssl::ContextManagerFactory>::getFactory(
-          Ssl::ContextManagerFactory::name());
+      Registry::FactoryRegistry<Ssl::ContextManagerFactory>::getFactory(factory_name);
   if (factory != nullptr) {
     return factory->createContextManager(time_source);
   }

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -26,7 +26,6 @@ class SslContextManagerStub final : public Envoy::Ssl::ContextManager {
 };
 
 Ssl::ContextManagerPtr createContextManager(TimeSource& time_source) {
-
   Ssl::ContextManagerFactory* factory =
       Registry::FactoryRegistry<Ssl::ContextManagerFactory>::getFactory(
           Ssl::ContextManagerFactory::name());

--- a/source/server/ssl_context_manager.h
+++ b/source/server/ssl_context_manager.h
@@ -4,7 +4,8 @@
 namespace Envoy {
 namespace Server {
 
-Ssl::ContextManagerPtr createContextManager(TimeSource& time_source);
+Ssl::ContextManagerPtr createContextManager(const std::string& factory_name,
+                                            TimeSource& time_source);
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/ssl_context_manager.h
+++ b/source/server/ssl_context_manager.h
@@ -1,0 +1,10 @@
+#include "envoy/common/time.h"
+#include "envoy/ssl/context_manager.h"
+
+namespace Envoy {
+namespace Server {
+
+Ssl::ContextManagerPtr createContextManager(TimeSource& time_source);
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/ssl_context_manager.h
+++ b/source/server/ssl_context_manager.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "envoy/common/time.h"
 #include "envoy/ssl/context_manager.h"
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -408,7 +408,7 @@ envoy_cc_test_library(
         "//source/extensions/access_loggers/file:config",
         "//source/extensions/transport_sockets/raw_buffer:config",
         "//source/extensions/transport_sockets/tap:config",
-        "//source/extensions/transport_sockets/tls:ssl_socket_lib",
+        "//source/extensions/transport_sockets/tls:config",
         "//source/server:connection_handler_lib",
         "//source/server:hot_restart_nop_lib",
         "//source/server:listener_hooks_lib",

--- a/test/mocks/ssl/BUILD
+++ b/test/mocks/ssl/BUILD
@@ -13,6 +13,7 @@ envoy_cc_mock(
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
     deps = [
+        "//include/envoy/ssl:certificate_validation_context_config_interface",
         "//include/envoy/ssl:connection_interface",
         "//include/envoy/ssl:context_config_interface",
         "//include/envoy/ssl:context_interface",

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -12,5 +12,11 @@ MockConnectionInfo::~MockConnectionInfo() {}
 MockClientContext::MockClientContext() {}
 MockClientContext::~MockClientContext() {}
 
+MockClientContextConfig::MockClientContextConfig() {}
+MockClientContextConfig::~MockClientContextConfig() {}
+
+MockServerContextConfig::MockServerContextConfig() {}
+MockServerContextConfig::~MockServerContextConfig() {}
+
 } // namespace Ssl
 } // namespace Envoy

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <string>
 
+#include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/connection.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
@@ -63,6 +64,48 @@ public:
   MOCK_CONST_METHOD0(daysUntilFirstCertExpires, size_t());
   MOCK_CONST_METHOD0(getCaCertInformation, CertificateDetailsPtr());
   MOCK_CONST_METHOD0(getCertChainInformation, std::vector<CertificateDetailsPtr>());
+};
+
+class MockClientContextConfig : public ClientContextConfig {
+public:
+  MockClientContextConfig();
+  ~MockClientContextConfig();
+
+  MOCK_CONST_METHOD0(alpnProtocols, const std::string&());
+  MOCK_CONST_METHOD0(cipherSuites, const std::string&());
+  MOCK_CONST_METHOD0(ecdhCurves, const std::string&());
+  MOCK_CONST_METHOD0(tlsCertificates,
+                     std::vector<std::reference_wrapper<const TlsCertificateConfig>>());
+  MOCK_CONST_METHOD0(certificateValidationContext, const CertificateValidationContextConfig*());
+  MOCK_CONST_METHOD0(minProtocolVersion, unsigned());
+  MOCK_CONST_METHOD0(maxProtocolVersion, unsigned());
+  MOCK_CONST_METHOD0(isReady, bool());
+  MOCK_METHOD1(setSecretUpdateCallback, void(std::function<void()> callback));
+
+  MOCK_CONST_METHOD0(serverNameIndication, const std::string&());
+  MOCK_CONST_METHOD0(allowRenegotiation, bool());
+  MOCK_CONST_METHOD0(maxSessionKeys, size_t());
+  MOCK_CONST_METHOD0(signingAlgorithmsForTest, const std::string&());
+};
+
+class MockServerContextConfig : public ServerContextConfig {
+public:
+  MockServerContextConfig();
+  ~MockServerContextConfig();
+
+  MOCK_CONST_METHOD0(alpnProtocols, const std::string&());
+  MOCK_CONST_METHOD0(cipherSuites, const std::string&());
+  MOCK_CONST_METHOD0(ecdhCurves, const std::string&());
+  MOCK_CONST_METHOD0(tlsCertificates,
+                     std::vector<std::reference_wrapper<const TlsCertificateConfig>>());
+  MOCK_CONST_METHOD0(certificateValidationContext, const CertificateValidationContextConfig*());
+  MOCK_CONST_METHOD0(minProtocolVersion, unsigned());
+  MOCK_CONST_METHOD0(maxProtocolVersion, unsigned());
+  MOCK_CONST_METHOD0(isReady, bool());
+  MOCK_METHOD1(setSecretUpdateCallback, void(std::function<void()> callback));
+
+  MOCK_CONST_METHOD0(requireClientCertificate, bool());
+  MOCK_CONST_METHOD0(sessionTicketKeys, const std::vector<SessionTicketKey>&());
 };
 
 } // namespace Ssl

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -260,6 +260,7 @@ envoy_cc_test(
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -252,6 +252,17 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "ssl_context_manager_test",
+    srcs = ["ssl_context_manager_test.cc"],
+    deps = [
+        "//source/server:ssl_context_manager_lib",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:simulated_time_system_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "utility_lib",
     hdrs = ["utility.h"],

--- a/test/server/ssl_context_manager_test.cc
+++ b/test/server/ssl_context_manager_test.cc
@@ -1,0 +1,31 @@
+#include "server/ssl_context_manager.h"
+
+#include "test/mocks/ssl/mocks.h"
+#include "test/mocks/stats/mocks.h"
+#include "test/test_common/simulated_time_system.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Server {
+namespace {
+
+TEST(SslContextManager, createStub) {
+  Event::SimulatedTimeSystem time_system;
+  Stats::MockStore scope;
+  Ssl::MockClientContextConfig client_config;
+  Ssl::MockServerContextConfig server_config;
+  std::vector<std::string> server_names;
+
+  Ssl::ContextManagerPtr manager = createContextManager(time_system);
+
+  // check we've created a stub
+  EXPECT_EQ(manager->daysUntilFirstCertExpires(), std::numeric_limits<int>::max());
+  ASSERT_THROW(manager->createSslClientContext(scope, client_config), EnvoyException);
+  ASSERT_THROW(manager->createSslServerContext(scope, server_config, server_names), EnvoyException);
+  ASSERT_NO_THROW(manager->iterateContexts([](const Envoy::Ssl::Context&) -> void {}));
+}
+
+} // namespace
+} // namespace Server
+} // namespace Envoy

--- a/test/server/ssl_context_manager_test.cc
+++ b/test/server/ssl_context_manager_test.cc
@@ -17,7 +17,7 @@ TEST(SslContextManager, createStub) {
   Ssl::MockServerContextConfig server_config;
   std::vector<std::string> server_names;
 
-  Ssl::ContextManagerPtr manager = createContextManager(time_system);
+  Ssl::ContextManagerPtr manager = createContextManager("fake_factory_name", time_system);
 
   // check we've created a stub
   EXPECT_EQ(manager->daysUntilFirstCertExpires(), std::numeric_limits<int>::max());

--- a/test/server/ssl_context_manager_test.cc
+++ b/test/server/ssl_context_manager_test.cc
@@ -19,11 +19,11 @@ TEST(SslContextManager, createStub) {
 
   Ssl::ContextManagerPtr manager = createContextManager("fake_factory_name", time_system);
 
-  // check we've created a stub
+  // Check we've created a stub, not real manager.
   EXPECT_EQ(manager->daysUntilFirstCertExpires(), std::numeric_limits<int>::max());
-  ASSERT_THROW(manager->createSslClientContext(scope, client_config), EnvoyException);
-  ASSERT_THROW(manager->createSslServerContext(scope, server_config, server_names), EnvoyException);
-  ASSERT_NO_THROW(manager->iterateContexts([](const Envoy::Ssl::Context&) -> void {}));
+  EXPECT_THROW(manager->createSslClientContext(scope, client_config), EnvoyException);
+  EXPECT_THROW(manager->createSslServerContext(scope, server_config, server_names), EnvoyException);
+  EXPECT_NO_THROW(manager->iterateContexts([](const Envoy::Ssl::Context&) -> void {}));
 }
 
 } // namespace

--- a/test/server/ssl_context_manager_test.cc
+++ b/test/server/ssl_context_manager_test.cc
@@ -3,6 +3,7 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -21,8 +22,10 @@ TEST(SslContextManager, createStub) {
 
   // Check we've created a stub, not real manager.
   EXPECT_EQ(manager->daysUntilFirstCertExpires(), std::numeric_limits<int>::max());
-  EXPECT_THROW(manager->createSslClientContext(scope, client_config), EnvoyException);
-  EXPECT_THROW(manager->createSslServerContext(scope, server_config, server_names), EnvoyException);
+  EXPECT_THROW_WITH_MESSAGE(manager->createSslClientContext(scope, client_config), EnvoyException,
+                            "SSL is not supported in this configuration");
+  EXPECT_THROW_WITH_MESSAGE(manager->createSslServerContext(scope, server_config, server_names),
+                            EnvoyException, "SSL is not supported in this configuration");
   EXPECT_NO_THROW(manager->iterateContexts([](const Envoy::Ssl::Context&) -> void {}));
 }
 


### PR DESCRIPTION
Description: make boringssl implementation of TLS optional.
To achieve this instantiate the TLS implementation indirectly via `Envoy::Ssl::ContextManagerFactory` and introduce a new build option `--define boringssl=disable`. A user of this option is supposed to provide an alternative implementation of TLS and TLS inspector as a third party extension.

Also disable the lua http filter when boringssl is disabled since it still depends on boringssl's API.

Risk Level: low
Testing: manual and unit tests
Docs Changes: N/A
Release Notes: A new build option (--define boringssl=disable) introduced which disables the standard BoringSSL-based TLS implementation.

Contributes to #5545