### PR TITLE
clang-tidy: performance-unnecessary-copy-initialization

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,readability-container-size-empty'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
-WarningsAsErrors: 'bugprone-assert-side-effect,bugprone-use-after-move,modernize-make-shared,modernize-make-unique,modernize-use-using,performance-faster-string-find,performance-for-range-copy,readability-braces-around-statements,readability-container-size-empty,readability-redundant-smartptr-get,readability-redundant-string-cstr'
+WarningsAsErrors: 'bugprone-assert-side-effect,bugprone-use-after-move,modernize-make-shared,modernize-make-unique,modernize-use-using,performance-faster-string-find,performance-for-range-copy,performance-unnecessary-copy-initialization,readability-braces-around-statements,readability-container-size-empty,readability-redundant-smartptr-get,readability-redundant-string-cstr'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -81,7 +81,7 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry
     retry_host_predicate_configs_.emplace_back(host_predicate.name(), std::move(config));
   }
 
-  const auto retry_priority = retry_policy.retry_priority();
+  const auto& retry_priority = retry_policy.retry_priority();
   if (!retry_priority.name().empty()) {
     auto& factory = Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryPriorityFactory>(
         retry_priority.name());

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -82,7 +82,7 @@ std::string ConfigUtility::parseDirectResponseBody(const envoy::api::v2::route::
     return EMPTY_STRING;
   }
   const auto& body = route.direct_response().body();
-  const std::string filename = body.filename();
+  const std::string& filename = body.filename();
   if (!filename.empty()) {
     if (!api.fileSystem().fileExists(filename)) {
       throw EnvoyException(fmt::format("response body file {} does not exist", filename));

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -450,7 +450,7 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& clust
   // We don't allow updates to statically configured clusters in the main configuration. We check
   // both the warming clusters and the active clusters to see if we need an update or the update
   // should be blocked.
-  const std::string cluster_name = cluster.name();
+  const std::string& cluster_name = cluster.name();
   const auto existing_active_cluster = active_clusters_.find(cluster_name);
   const auto existing_warming_cluster = warming_clusters_.find(cluster_name);
   const uint64_t new_hash = MessageUtil::hash(cluster);

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -40,7 +40,7 @@ void MetadataMapHelper::setValue(lua_State* state, const ProtobufWkt::Value& val
     return lua_pushboolean(state, value.bool_value());
 
   case ProtobufWkt::Value::kStringValue: {
-    const auto string_value = value.string_value();
+    const auto& string_value = value.string_value();
     return lua_pushstring(state, string_value.c_str());
   }
 
@@ -49,7 +49,7 @@ void MetadataMapHelper::setValue(lua_State* state, const ProtobufWkt::Value& val
   }
 
   case ProtobufWkt::Value::kListValue: {
-    const auto list = value.list_value();
+    const auto& list = value.list_value();
     const int values_size = list.values_size();
 
     lua_createtable(state, values_size, 0);

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -154,7 +154,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
       Protobuf::util::NewTypeResolverForDescriptorPool(Grpc::Common::typeUrlPrefix(),
                                                        &descriptor_pool_));
 
-  const auto print_config = proto_config.print_options();
+  const auto& print_config = proto_config.print_options();
   print_options_.add_whitespace = print_config.add_whitespace();
   print_options_.always_print_primitive_fields = print_config.always_print_primitive_fields();
   print_options_.always_print_enums_as_ints = print_config.always_print_enums_as_ints();

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -18,7 +18,7 @@ DynamicOpenTracingTracerFactory::DynamicOpenTracingTracerFactory()
 
 Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v2::DynamicOtConfig& proto_config, Server::Instance& server) {
-  const std::string library = proto_config.library();
+  const std::string& library = proto_config.library();
   const std::string config = MessageUtil::getJsonStringFromMessage(proto_config.config());
   Tracing::DriverPtr dynamic_driver =
       std::make_unique<DynamicOpenTracingDriver>(server.stats(), library, config);

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -82,7 +82,7 @@ Network::TransportSocketFactoryPtr createTransportSocketFactoryHelper(
           message);
   HandshakeValidator validator = createHandshakeValidator(config);
 
-  const std::string handshaker_service = config.handshaker_service();
+  const std::string& handshaker_service = config.handshaker_service();
   HandshakerFactory factory =
       [handshaker_service, is_upstream,
        alts_shared_state](Event::Dispatcher& dispatcher,

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -120,7 +120,7 @@ OverloadManagerImpl::OverloadManagerImpl(
     }
 
     for (const auto& trigger : action.triggers()) {
-      const std::string resource = trigger.name();
+      const std::string& resource = trigger.name();
 
       if (resources_.find(resource) == resources_.end()) {
         throw EnvoyException(

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -451,7 +451,7 @@ protected:
 
 TEST_P(MixedAddressTest, Equality) {
   TestCase lhs_case = ::testing::get<0>(GetParam());
-  TestCase rhs_case = ::testing::get<1>(GetParam());
+  const TestCase& rhs_case = ::testing::get<1>(GetParam());
   InstanceConstSharedPtr lhs = testCaseToInstance(lhs_case);
   InstanceConstSharedPtr rhs = testCaseToInstance(rhs_case);
   if (lhs_case == rhs_case) {

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -85,7 +85,7 @@ class TestResolver : public Resolver {
 public:
   InstanceConstSharedPtr
   resolve(const envoy::api::v2::core::SocketAddress& socket_address) override {
-    const std::string logical = socket_address.address();
+    const std::string& logical = socket_address.address();
     const std::string physical = getPhysicalName(logical);
     const std::string port = getPort(socket_address);
     return InstanceConstSharedPtr{new MockResolvedAddress(fmt::format("{}:{}", logical, port),

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -1175,7 +1175,7 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNoLocalLocality) {
   HostsPerLocalitySharedPtr upstream_hosts_per_locality = makeHostsPerLocality(
       {{makeTestHost(info_, "tcp://127.0.0.1:80")}, {makeTestHost(info_, "tcp://127.0.0.1:81")}},
       true);
-  HostsPerLocalitySharedPtr local_hosts_per_locality = upstream_hosts_per_locality;
+  const HostsPerLocalitySharedPtr& local_hosts_per_locality = upstream_hosts_per_locality;
 
   hostSet().healthy_hosts_ = *upstream_hosts;
   hostSet().hosts_ = *upstream_hosts;

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -38,7 +38,7 @@ public:
   using MetadataVector = std::vector<std::pair<std::string, ProtobufWkt::Value>>;
 
   void test(std::string expected, const MetadataVector& metadata) {
-    SubsetLoadBalancer::SubsetMetadata subset_metadata(metadata);
+    const SubsetLoadBalancer::SubsetMetadata& subset_metadata(metadata);
     EXPECT_EQ(expected, lb_.get()->describeMetadata(subset_metadata));
   }
 

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -173,14 +173,14 @@ public:
       return;
     }
 
-    const auto local_cluster_stats = local_loadstats_request.cluster_stats(0);
+    const auto& local_cluster_stats = local_loadstats_request.cluster_stats(0);
     auto* cluster_stats = loadstats_request.mutable_cluster_stats(0);
 
     cluster_stats->set_total_dropped_requests(cluster_stats->total_dropped_requests() +
                                               local_cluster_stats.total_dropped_requests());
 
     for (int i = 0; i < local_cluster_stats.upstream_locality_stats_size(); ++i) {
-      auto local_upstream_locality_stats = local_cluster_stats.upstream_locality_stats(i);
+      const auto& local_upstream_locality_stats = local_cluster_stats.upstream_locality_stats(i);
       bool copied = false;
       for (int j = 0; j < cluster_stats->upstream_locality_stats_size(); ++j) {
         auto* upstream_locality_stats = cluster_stats->mutable_upstream_locality_stats(j);

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -160,7 +160,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
     Envoy::LogRecordingSink log_recorder(Envoy::Logger::Registry::getSink());                      \
     stmt;                                                                                          \
-    const std::vector<std::string> logs = log_recorder.messages();                                 \
+    const std::vector<std::string>& logs = log_recorder.messages();                                \
     ASSERT_EQ(0, logs.size()) << " Logs:\n   " << absl::StrJoin(logs, "   ");                      \
   } while (false)
 

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -169,11 +169,11 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
 
-    std::string test_name = check_config.test_name();
+    const std::string& test_name = check_config.test_name();
     if (details_) {
       std::cout << test_name << std::endl;
     }
-    envoy::RouterCheckToolSchema::ValidationAssert validate = check_config.validate();
+    const envoy::RouterCheckToolSchema::ValidationAssert& validate = check_config.validate();
 
     using checkerFunc =
         std::function<bool(ToolConfig&, const envoy::RouterCheckToolSchema::ValidationAssert&)>;


### PR DESCRIPTION
Description: `performance-unnecessary-copy-initialization` looks for places where copy-construction is used in an assignment when taking a reference would be more efficient. An example where this can happen is when the value cannot be RVO'd (i.e. a data member).
Risk Level: Low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Relates to #4863.

Signed-off-by: Derek Argueta <dereka@pinterest.com>