### PR TITLE
bazel: Force socket_passing to use python 2

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -23,6 +23,7 @@ envoy_py_test_binary(
     srcs = [
         "socket_passing.py",
     ],
+    python_version = "PY2",
 )
 
 envoy_cc_binary(


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/7379

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>