### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -11,6 +11,7 @@
 # In each case this script will add file and line information to any backtrace log
 # lines found and echo back all non-Backtrace lines untouched.
 
+from __future__ import print_function
 import collections
 import re
 import subprocess
@@ -73,6 +74,6 @@ if __name__ == "__main__":
     rununder.wait()
     sys.exit(rununder.returncode)  # Pass back test pass/fail result
   else:
-    print "Usage (execute subprocess): stack_decode.py executable_file [additional args]"
-    print "Usage (read from stdin): stack_decode.py -s executable_file"
+    print("Usage (execute subprocess): stack_decode.py executable_file [additional args]")
+    print("Usage (read from stdin): stack_decode.py -s executable_file")
     sys.exit(1)


### PR DESCRIPTION
Related to #4552

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Signed-off-by: Christian Clauss cclauss@me.com

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
