### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/deprecate_features/deprecate_features.py
+++ b/tools/deprecate_features/deprecate_features.py
@@ -1,5 +1,6 @@
 # A simple script to snag deprecated proto fields and add them to runtime_features.h
 
+from __future__ import print_function
 import re
 import subprocess
 import fileinput
@@ -19,7 +20,7 @@ def deprecate_proto():
     if match:
       filenames_and_fields.add(tuple([match.group(1), match.group(2)]))
     else:
-      print 'no match in ' + line + ' please address manually!'
+      print('no match in ' + line + ' please address manually!')
 
   # Now discard any deprecated features already listed in runtime_features
   exiting_deprecated_regex = re.compile(r'.*"envoy.deprecated_features.(.*):(.*)",.*')
@@ -59,7 +60,7 @@ def flip_runtime_features():
     if match:
       features_to_flip.add(match.group(1))
     else:
-      print 'no match in ' + line + ' please address manually!'
+      print('no match in ' + line + ' please address manually!')
 
   # Exempt the two test flags.
   features_to_flip.remove('envoy.reloadable_features.my_feature_name')
@@ -85,8 +86,8 @@ deprecate_email, deprecate_code = deprecate_proto()
 email = ('The Envoy maintainer team is cutting the next Envoy release.  In the new release ' +
          runtime_email + deprecate_email)
 
-print '\n\nSuggested envoy-announce email: \n'
-print email
+print('\n\nSuggested envoy-announce email: \n')
+print(email)
 
 if not raw_input('Apply relevant runtime changes? [yN] ').strip().lower() in ('y', 'yes'):
   exit(1)
@@ -96,6 +97,6 @@ for line in fileinput.FileInput('source/common/runtime/runtime_features.cc', inp
     line = line.replace(line, line + runtime_features_code)
   if 'envoy.deprecated_features.deprecated.proto:is_deprecated_fatal' in line:
     line = line.replace(line, line + deprecate_code)
-  print line,
+  print(line, end='')
 
-print '\nChanges applied.  Please send the email above to envoy-announce.\n'
+print('\nChanges applied.  Please send the email above to envoy-announce.\n')


### PR DESCRIPTION
Related to #4552

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
