### PR TITLE
Define cmp() in Python 3

### DIFF
--- a/tools/check_spelling_pedantic.py
+++ b/tools/check_spelling_pedantic.py
@@ -17,6 +17,14 @@ try:
 except NameError:
   pass
 
+try:
+  cmp
+except NameError:
+
+  def cmp(x, y):
+    return (x > y) - (x < y)
+
+
 TOOLS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 # Single line comments: // comment OR /* comment */


### PR DESCRIPTION
Related to #4552

__cmp()__ was removed in Python 3 so redefine it in accordance with https://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-function

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
