### PR TITLE
clang-tidy: performance-noexcept-move-constructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,readability-container-size-empty'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
-WarningsAsErrors: 'bugprone-assert-side-effect,bugprone-use-after-move,modernize-make-shared,modernize-make-unique,modernize-use-using,performance-faster-string-find,performance-for-range-copy,performance-unnecessary-copy-initialization,readability-braces-around-statements,readability-container-size-empty,readability-redundant-smartptr-get,readability-redundant-string-cstr'
+WarningsAsErrors: 'bugprone-assert-side-effect,bugprone-use-after-move,modernize-make-shared,modernize-make-unique,modernize-use-using,performance-faster-string-find,performance-for-range-copy,performance-noexcept-move-constructor,performance-unnecessary-copy-initialization,readability-braces-around-statements,readability-container-size-empty,readability-redundant-smartptr-get,readability-redundant-string-cstr'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -46,7 +46,7 @@ static inline bool validHeaderString(absl::string_view s) {
  */
 class LowerCaseString {
 public:
-  LowerCaseString(LowerCaseString&& rhs) : string_(std::move(rhs.string_)) { ASSERT(valid()); }
+  LowerCaseString(LowerCaseString&& rhs) noexcept : string_(std::move(rhs.string_)) { ASSERT(valid()); }
   LowerCaseString(const LowerCaseString& rhs) : string_(rhs.string_) { ASSERT(valid()); }
   explicit LowerCaseString(const std::string& new_string) : string_(new_string) {
     ASSERT(valid());
@@ -113,7 +113,7 @@ public:
    */
   explicit HeaderString(const std::string& ref_value);
 
-  HeaderString(HeaderString&& move_value);
+  HeaderString(HeaderString&& move_value) noexcept;
   ~HeaderString();
 
   /**

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -46,7 +46,9 @@ static inline bool validHeaderString(absl::string_view s) {
  */
 class LowerCaseString {
 public:
-  LowerCaseString(LowerCaseString&& rhs) noexcept : string_(std::move(rhs.string_)) { ASSERT(valid()); }
+  LowerCaseString(LowerCaseString&& rhs) noexcept : string_(std::move(rhs.string_)) {
+    ASSERT(valid());
+  }
   LowerCaseString(const LowerCaseString& rhs) : string_(rhs.string_) { ASSERT(valid()); }
   explicit LowerCaseString(const std::string& new_string) : string_(new_string) {
     ASSERT(valid());

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -54,7 +54,7 @@ HeaderString::HeaderString(const std::string& ref_value) : type_(Type::Reference
   ASSERT(valid());
 }
 
-HeaderString::HeaderString(HeaderString&& move_value) {
+HeaderString::HeaderString(HeaderString&& move_value) noexcept {
   type_ = move_value.type_;
   string_length_ = move_value.string_length_;
   switch (move_value.type_) {

--- a/source/common/stats/symbol_table_impl.h
+++ b/source/common/stats/symbol_table_impl.h
@@ -261,7 +261,7 @@ public:
 
   // Move constructor; needed for using StatNameStorage as an
   // absl::flat_hash_map value.
-  StatNameStorage(StatNameStorage&& src) : bytes_(std::move(src.bytes_)) {}
+  StatNameStorage(StatNameStorage&& src) noexcept : bytes_(std::move(src.bytes_)) {}
 
   // Obtains new backing storage for an already existing StatName. Used to
   // record a computed StatName held in a temp into a more persistent data

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -489,7 +489,7 @@ public:
   explicit IsSubsetOfHeadersMatcherImpl(const HeaderMap& expected_headers)
       : expected_headers_(expected_headers) {}
 
-  IsSubsetOfHeadersMatcherImpl(IsSubsetOfHeadersMatcherImpl&& other)
+  IsSubsetOfHeadersMatcherImpl(IsSubsetOfHeadersMatcherImpl&& other) noexcept
       : expected_headers_(other.expected_headers_) {}
 
   IsSubsetOfHeadersMatcherImpl(const IsSubsetOfHeadersMatcherImpl& other)
@@ -522,7 +522,7 @@ public:
   IsSubsetOfHeadersMatcher(const HeaderMap& expected_headers)
       : expected_headers_(expected_headers) {}
 
-  IsSubsetOfHeadersMatcher(IsSubsetOfHeadersMatcher&& other)
+  IsSubsetOfHeadersMatcher(IsSubsetOfHeadersMatcher&& other) noexcept
       : expected_headers_(static_cast<const HeaderMap&>(other.expected_headers_)) {}
 
   IsSubsetOfHeadersMatcher(const IsSubsetOfHeadersMatcher& other)
@@ -544,7 +544,7 @@ public:
   explicit IsSupersetOfHeadersMatcherImpl(const HeaderMap& expected_headers)
       : expected_headers_(expected_headers) {}
 
-  IsSupersetOfHeadersMatcherImpl(IsSupersetOfHeadersMatcherImpl&& other)
+  IsSupersetOfHeadersMatcherImpl(IsSupersetOfHeadersMatcherImpl&& other) noexcept
       : expected_headers_(other.expected_headers_) {}
 
   IsSupersetOfHeadersMatcherImpl(const IsSupersetOfHeadersMatcherImpl& other)
@@ -578,7 +578,7 @@ public:
   IsSupersetOfHeadersMatcher(const HeaderMap& expected_headers)
       : expected_headers_(expected_headers) {}
 
-  IsSupersetOfHeadersMatcher(IsSupersetOfHeadersMatcher&& other)
+  IsSupersetOfHeadersMatcher(IsSupersetOfHeadersMatcher&& other) noexcept
       : expected_headers_(static_cast<const HeaderMap&>(other.expected_headers_)) {}
 
   IsSupersetOfHeadersMatcher(const IsSupersetOfHeadersMatcher& other)


### PR DESCRIPTION
Description: `performance-noexcept-move-constructor` checks for move constructors that aren't declared `noexcept`, the reason being that STL containers will use the copy constructor for operations like `emplace_back` if the move constructor is not declared `noexcept` due to exception safety guarantees.
http://www.hlsl.co.uk/blog/2017/12/1/c-noexcept-and-move-constructors-effect-on-performance-in-stl-containers
https://stackoverflow.com/a/32225460
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Relates to #4863 

Signed-off-by: Derek Argueta <dereka@pinterest.com>