### PR TITLE
tools: include .m/.mm files when formatting

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -17,7 +17,8 @@ import traceback
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/", "./bazel-", "./.cache",
                      "./source/extensions/extensions_build_config.bzl",
                      "./tools/testdata/check_format/", "./tools/pyformat/")
-SUFFIXES = (".cc", ".h", "BUILD", "WORKSPACE", ".bzl", ".java", ".md", ".rst", ".proto")
+SUFFIXES = ("BUILD", "WORKSPACE", ".bzl", ".cc", ".h", ".java", ".m", ".md", ".mm", ".proto",
+            ".rst")
 DOCS_SUFFIX = (".md", ".rst")
 PROTO_SUFFIX = (".proto")
 


### PR DESCRIPTION
Including these file types will allow this script to be reused in other repos like Envoy Mobile for linting.

https://github.com/lyft/envoy-mobile/issues/191

Signed-off-by: Michael Rebello <mrebello@lyft.com>

Risk Level: Low
Testing: Locally
Docs Changes: No