### PR TITLE
check_format: allow paths to be excluded from build_fixer

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -566,11 +566,6 @@ def fixBuildPath(file_path):
 
   error_messages = []
 
-  run_build_fixer = True
-  for excluded_path in build_fixer_check_excluded_paths:
-    if file_path.startswith(excluded_path):
-      run_build_fixer = False
-
   # TODO(htuch): Add API specific BUILD fixer script.
   if not isBuildFixerExcludedFile(file_path) and not isApiFile(file_path) and not isSkylarkFile(
       file_path) and not isWorkspaceFile(file_path):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -353,11 +353,13 @@ def isSkylarkFile(file_path):
 def isWorkspaceFile(file_path):
   return os.path.basename(file_path) == "WORKSPACE"
 
+
 def isBuildFixerExcludedFile(file_path):
   for excluded_path in build_fixer_check_excluded_paths:
     if file_path.startswith(excluded_path):
       return True
   return False
+
 
 def hasInvalidAngleBracketDirectory(line):
   if not line.startswith(INCLUDE_ANGLE):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -353,6 +353,11 @@ def isSkylarkFile(file_path):
 def isWorkspaceFile(file_path):
   return os.path.basename(file_path) == "WORKSPACE"
 
+def isBuildFixerExcludedFile(file_path):
+  for excluded_path in build_fixer_check_excluded_paths:
+    if file_path.startswith(excluded_path):
+      return True
+  return False
 
 def hasInvalidAngleBracketDirectory(line):
   if not line.startswith(INCLUDE_ANGLE):
@@ -565,7 +570,7 @@ def fixBuildPath(file_path):
       run_build_fixer = False
 
   # TODO(htuch): Add API specific BUILD fixer script.
-  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(
+  if not isBuildFixerExcludedFile(file_path) and not isApiFile(file_path) and not isSkylarkFile(
       file_path) and not isWorkspaceFile(file_path):
     if os.system("%s %s %s" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)) != 0:
       error_messages += ["envoy_build_fixer rewrite failed for file: %s" % file_path]
@@ -578,12 +583,7 @@ def fixBuildPath(file_path):
 def checkBuildPath(file_path):
   error_messages = []
 
-  run_build_fixer = True
-  for excluded_path in build_fixer_check_excluded_paths:
-    if file_path.startswith(excluded_path):
-      run_build_fixer = False
-
-  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(
+  if not isBuildFixerExcludedFile(file_path) and not isApiFile(file_path) and not isSkylarkFile(
       file_path) and not isWorkspaceFile(file_path):
     command = "%s %s | diff %s -" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)
     error_messages += executeCommand(command, "envoy_build_fixer check failed", file_path)

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -565,7 +565,8 @@ def fixBuildPath(file_path):
       run_build_fixer = False
 
   # TODO(htuch): Add API specific BUILD fixer script.
-  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(file_path) and not isWorkspaceFile(file_path):
+  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(
+      file_path) and not isWorkspaceFile(file_path):
     if os.system("%s %s %s" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)) != 0:
       error_messages += ["envoy_build_fixer rewrite failed for file: %s" % file_path]
 
@@ -582,7 +583,8 @@ def checkBuildPath(file_path):
     if file_path.startswith(excluded_path):
       run_build_fixer = False
 
-  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(file_path) and not isWorkspaceFile(file_path):
+  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(
+      file_path) and not isWorkspaceFile(file_path):
     command = "%s %s | diff %s -" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)
     error_messages += executeCommand(command, "envoy_build_fixer check failed", file_path)
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -558,8 +558,14 @@ def fixBuildPath(file_path):
     sys.stdout.write(fixBuildLine(line, file_path))
 
   error_messages = []
+
+  run_build_fixer = True
+  for excluded_path in build_fixer_check_excluded_paths:
+    if file_path.startswith(excluded_path):
+      run_build_fixer = False
+
   # TODO(htuch): Add API specific BUILD fixer script.
-  if not isApiFile(file_path) and not isSkylarkFile(file_path) and not isWorkspaceFile(file_path):
+  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(file_path) and not isWorkspaceFile(file_path):
     if os.system("%s %s %s" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)) != 0:
       error_messages += ["envoy_build_fixer rewrite failed for file: %s" % file_path]
 
@@ -570,7 +576,13 @@ def fixBuildPath(file_path):
 
 def checkBuildPath(file_path):
   error_messages = []
-  if not isApiFile(file_path) and not isSkylarkFile(file_path) and not isWorkspaceFile(file_path):
+
+  run_build_fixer = True
+  for excluded_path in build_fixer_check_excluded_paths:
+    if file_path.startswith(excluded_path):
+      run_build_fixer = False
+
+  if run_build_fixer and not isApiFile(file_path) and not isSkylarkFile(file_path) and not isWorkspaceFile(file_path):
     command = "%s %s | diff %s -" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)
     error_messages += executeCommand(command, "envoy_build_fixer check failed", file_path)
 
@@ -796,6 +808,12 @@ if __name__ == "__main__":
       default=[],
       help="exclude paths from the namespace_check.")
   parser.add_argument(
+      "--build_fixer_check_excluded_paths",
+      type=str,
+      nargs="+",
+      default=[],
+      help="exclude paths from envoy_build_fixer check.")
+  parser.add_argument(
       "--include_dir_order",
       type=str,
       default=",".join(common.includeDirOrder()),
@@ -807,6 +825,7 @@ if __name__ == "__main__":
   envoy_build_rule_check = not args.skip_envoy_build_rule_check
   namespace_check = args.namespace_check
   namespace_check_excluded_paths = args.namespace_check_excluded_paths
+  build_fixer_check_excluded_paths = args.build_fixer_check_excluded_paths
   include_dir_order = args.include_dir_order
   if args.add_excluded_prefixes:
     EXCLUDED_PREFIXES += tuple(args.add_excluded_prefixes)


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

Description: We're use envoy's check_format script on a project that pulls in envoy, but the build_fixer introduces noise in some of our build files. This allows it to be conditionally skipped, similar to namespace checking.
Risk Level: Low
Testing: Local
Docs Changes: Present in script help
