### PR TITLE
build: fix CentOS build image

### DIFF
--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -12,8 +12,8 @@ yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-
 ln -s /usr/bin/cmake3 /usr/bin/cmake
 ln -s /usr/bin/ninja-build /usr/bin/ninja
 
-BAZEL_VERSION="$(curl -s https://api.github.com/repos/bazelbuild/bazel/releases/latest |
-    python -c "import json, sys; print json.load(sys.stdin)['tag_name']")"
+# Work-around for the bazel 0.27.0 issue: bazelbuild/bazel#8652
+BAZEL_VERSION=0.26.1
 BAZEL_INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
 curl -OL "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${BAZEL_INSTALLER}"
 chmod u+x "./${BAZEL_INSTALLER}"


### PR DESCRIPTION
Description:
Current CentOS build image is broken since bazel 0.27.0 released due to its unintentional incompatible change. While the bazel team tries releasing the fixed one, we can just pin the bazel version in our CentOS image until the fixed version is released. https://github.com/bazelbuild/bazel/issues/8652

Risk Level: Low
Testing: manual testing

```
~/.ghq/github.com/envoyproxy/envoy fix-centos-build-image
✔ docker run -it envoyproxy/envoy-build-centos:`git rev-parse HEAD` bazel version
Extracting Bazel installation...
WARNING: --batch mode is deprecated. Please instead explicitly shut down your Bazel server using the command "bazel shutdown".
Build label: 0.26.1
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Thu Jun 6 11:05:05 2019 (1559819105)
Build timestamp: 1559819105
Build timestamp as int: 1559819105
```

Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]

Signed-off-by: Taiki Ono <taiki@tetrate.io>
