### PR TITLE
clang-tidy: use empty()

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -344,7 +344,7 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
     const auto merge_timeout =
         PROTOBUF_GET_MS_OR_DEFAULT(cluster.info()->lbConfig(), update_merge_window, 1000);
     // Remember: we only merge updates with no adds/removes — just hc/weight/metadata changes.
-    const bool is_mergeable = !hosts_added.size() && !hosts_removed.size();
+    const bool is_mergeable = hosts_added.empty() && hosts_removed.empty();
 
     if (merge_timeout > 0) {
       // If this is not mergeable, we should cancel any scheduled updates since

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -71,7 +71,7 @@ SubsetLoadBalancer::SubsetLoadBalancer(
   // Configure future updates.
   original_priority_set_callback_handle_ = priority_set.addPriorityUpdateCb(
       [this](uint32_t priority, const HostVector& hosts_added, const HostVector& hosts_removed) {
-        if (!hosts_added.size() && !hosts_removed.size()) {
+        if (hosts_added.empty() && hosts_removed.empty()) {
           // It's possible that metadata changed, without hosts being added nor removed.
           // If so we need to add any new subsets, remove unused ones, and regroup hosts into
           // the right subsets.

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -74,7 +74,7 @@ TapConfigBaseImpl::TapConfigBaseImpl(envoy::service::tap::v2alpha::TapConfig&& p
 }
 
 const Matcher& TapConfigBaseImpl::rootMatcher() const {
-  ASSERT(matchers_.size() >= 1);
+  ASSERT(!matchers_.empty());
   return *matchers_[0];
 }
 

--- a/source/extensions/filters/network/thrift_proxy/header_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/header_transport_impl.cc
@@ -198,7 +198,7 @@ void HeaderTransportImpl::encodeFrame(Buffer::Instance& buffer, const MessageMet
   }
 
   BufferHelper::writeVarIntI32(header_buffer, 0); // num transforms
-  if (headers.size() > 0) {
+  if (!headers.empty()) {
     // Info ID 1
     header_buffer.writeByte(1);
 

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -895,7 +895,7 @@ int ServerContextImpl::sessionTicketProcess(SSL*, uint8_t* key_name, uint8_t* iv
 
   if (encrypt == 1) {
     // Encrypt
-    RELEASE_ASSERT(session_ticket_keys_.size() >= 1, "");
+    RELEASE_ASSERT(!session_ticket_keys_.empty(), "");
     // TODO(ggreenway): validate in SDS that session_ticket_keys_ cannot be empty,
     // or if we allow it to be emptied, reconfigure the context so this callback
     // isn't set.

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -396,8 +396,8 @@ public:
     AssertionResult result = fake_stream.waitForHeadersComplete();
     RELEASE_ASSERT(result, result.message());
     Http::TestHeaderMapImpl stream_headers(fake_stream.headers());
-    if (access_token_value_ != "") {
-      if (access_token_value_2_ == "") {
+    if (!access_token_value_.empty()) {
+      if (access_token_value_2_.empty()) {
         EXPECT_EQ("Bearer " + access_token_value_, stream_headers.get_("authorization"));
       } else {
         EXPECT_EQ("Bearer " + access_token_value_ + ",Bearer " + access_token_value_2_,
@@ -414,10 +414,10 @@ public:
     ssl_creds->mutable_root_certs()->set_filename(
         TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
     google_grpc->add_call_credentials()->set_access_token(access_token_value_);
-    if (access_token_value_2_ != "") {
+    if (!access_token_value_2_.empty()) {
       google_grpc->add_call_credentials()->set_access_token(access_token_value_2_);
     }
-    if (refresh_token_value_ != "") {
+    if (!refresh_token_value_.empty()) {
       google_grpc->add_call_credentials()->set_google_refresh_token(refresh_token_value_);
     }
     return config;

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -431,7 +431,7 @@ public:
 protected:
   InstanceConstSharedPtr testCaseToInstance(const struct TestCase& test_case) {
     // Catch default construction.
-    if (test_case.address_ == "") {
+    if (test_case.address_.empty()) {
       return nullptr;
     }
     switch (test_case.type_) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1448,7 +1448,7 @@ virtual_hosts:
                              ->mutable_routes(0)
                              ->mutable_route()
                              ->mutable_hash_policy();
-    if (hash_policies->size() > 0) {
+    if (!hash_policies->empty()) {
       return hash_policies->Mutable(0);
     } else {
       return hash_policies->Add();

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -290,7 +290,7 @@ public:
   envoy::api::v2::core::Metadata buildMetadata(const std::string& version) const {
     envoy::api::v2::core::Metadata metadata;
 
-    if (version != "") {
+    if (!version.empty()) {
       Envoy::Config::Metadata::mutableMetadataValue(
           metadata, Config::MetadataFilters::get().ENVOY_LB, "version")
           .set_string_value(version);

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -381,7 +381,7 @@ public:
                                                bool is_default = false) const {
     envoy::api::v2::core::Metadata metadata;
 
-    if (version != "") {
+    if (!version.empty()) {
       Envoy::Config::Metadata::mutableMetadataValue(
           metadata, Config::MetadataFilters::get().ENVOY_LB, "version")
           .set_string_value(version);

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -244,7 +244,7 @@ protected:
   }
 
   Envoy::Http::AsyncClient::Callbacks* popPendingCallback() {
-    if (0 == callbacks_.size()) {
+    if (callbacks_.empty()) {
       // Can't use ASSERT_* as this is not a test function
       throw std::underflow_error("empty deque");
     }

--- a/test/extensions/filters/network/mysql_proxy/mysql_command_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_command_test.cc
@@ -71,7 +71,7 @@ public:
   std::string buildCreate(enum TestResource res, std::string option, bool if_not_exists,
                           std::string res_name, std::string value) {
     std::string command("CREATE ");
-    if (option != "") {
+    if (!option.empty()) {
       command.append(option);
       command.append(SPACE);
     }
@@ -159,7 +159,7 @@ public:
   //"INSERT INTO <table> ...
   std::string buildInsert(std::string option, bool into, std::string table, std::string values) {
     std::string command("INSERT ");
-    if (option != "") {
+    if (!option.empty()) {
       command.append(option);
       command.append(SPACE);
     }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -126,7 +126,7 @@ public:
                << "Couldn't decode gRPC data frame: " << body().toString();
       }
     }
-    if (decoded_grpc_frames_.size() < 1) {
+    if (decoded_grpc_frames_.empty()) {
       timeout = std::chrono::duration_cast<std::chrono::milliseconds>(end_time -
                                                                       timeSystem().monotonicTime());
       if (!waitForData(client_dispatcher, grpc_decoder_.length(), timeout)) {


### PR DESCRIPTION
Description: `readability-container-size-empty` is already enabled as an error in clang-tidy, this diff just cleans up the existing errors.
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A

Relates to #4863 
