### PR TITLE
build: avoid referring to //source/...

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -483,7 +483,7 @@ resources, you can override Bazel's default job parallelism determination with
 `--jobs=N` to restrict the build to at most `N` simultaneous jobs, e.g.:
 
 ```
-bazel build --jobs=2 //source/...
+bazel build --jobs=2 //source/exe:envoy-static
 ```
 
 # Debugging the Bazel build
@@ -492,19 +492,19 @@ When trying to understand what Bazel is doing, the `-s` and `--explain` options
 are useful. To have Bazel provide verbose output on which commands it is executing:
 
 ```
-bazel build -s //source/...
+bazel build -s //source/exe:envoy-static
 ```
 
 To have Bazel emit to a text file the rationale for rebuilding a target:
 
 ```
-bazel build --explain=file.txt //source/...
+bazel build --explain=file.txt //source/exe:envoy-static
 ```
 
 To get more verbose explanations:
 
 ```
-bazel build --explain=file.txt --verbose_explanations //source/...
+bazel build --explain=file.txt --verbose_explanations //source/exe:envoy-static
 ```
 
 # Resolving paths in bazel build output

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -107,7 +107,7 @@ if [[ "$CI_TARGET" == "bazel.release" ]]; then
   if [[ "$TEST_TARGETS" == "//test/..." ]]; then
     # We have various test binaries in the test directory such as tools, benchmarks, etc. We
     # run a build pass to make sure they compile.
-    bazel build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/... //test/...
+    bazel build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/exe:envoy-static //test/...
   fi
   # Now run all of the tests which should already be compiled.
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} -c opt ${TEST_TARGETS}

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -29,5 +29,5 @@ else
   TEST_TARGETS=//test/...
 fi
 
-bazel build ${BAZEL_BUILD_OPTIONS} //source/... ${TEST_TARGETS}
+bazel build ${BAZEL_BUILD_OPTIONS} //source/exe:envoy-static ${TEST_TARGETS}
 bazel test ${BAZEL_BUILD_OPTIONS} ${TEST_TARGETS}


### PR DESCRIPTION
Using //source/... instead of //source/exe:envoy-static results in
all targets under //source/... and their dependencies being built,
even when disabled on a given platform and/or using various flags.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>