### PR TITLE
api: use unique outer class names for tap proto files

### DIFF
--- a/api/envoy/service/tap/v2alpha/tap.proto
+++ b/api/envoy/service/tap/v2alpha/tap.proto
@@ -7,7 +7,7 @@ package envoy.service.tap.v2alpha;
 
 import "validate/validate.proto";
 
-option java_outer_classname = "CommonProto";
+option java_outer_classname = "TapProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.service.tap.v2alpha";
 

--- a/api/envoy/service/tap/v2alpha/tapds.proto
+++ b/api/envoy/service/tap/v2alpha/tapds.proto
@@ -8,7 +8,7 @@ package envoy.service.tap.v2alpha;
 
 import "google/api/annotations.proto";
 
-option java_outer_classname = "CommonProto";
+option java_outer_classname = "TapDsProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.service.tap.v2alpha";
 


### PR DESCRIPTION
When building protos using the Java protoc, multiple input files mapping
to the same output file causes an errorr. This updates the name of the
generated files for the tap proto files to be unique.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Low
Testing: Built protos using protoc --plugin=java_out
Docs Changes: n/a
Release Notes: n/a
