### PR TITLE
 fuzz: replace invalid characters in upstream metadata for header parser

### DIFF
--- a/test/common/router/header_parser_corpus/clusterfuzz-testcase-header_parser_fuzz_test-5163306626580480
+++ b/test/common/router/header_parser_corpus/clusterfuzz-testcase-header_parser_fuzz_test-5163306626580480
@@ -1,0 +1,80 @@
+headers_to_add {
+  header {
+    key: "P"
+    value: "%PER_REQUEST_STATE(oB]$T)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(B%444ssa4%s4%>TME(B%128sY$T_)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%PER_REQUEST_STATE(dB]$T)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177"
+    value: "%PER_REQUEST_STATE(dB]$T)%"
+  }
+  append {
+    value: true
+  }
+}
+headers_to_add {
+  header {
+    key: "]"
+    value: "%UPSTREAM_METADATA([\"\", \"\"])%"
+  }
+}
+stream_info {
+  dynamic_metadata {
+    filter_metadata {
+      key: "\000\000{\000+p"
+      value {
+      }
+    }
+    filter_metadata {
+      key: "\000}"
+      value {
+      }
+    }
+    filter_metadata {
+      key: "\000}"
+      value {
+      }
+    }
+    filter_metadata {
+      key: "K"
+      value {
+        fields {
+          key: ""
+          value {
+          }
+        }
+      }
+    }
+  }
+  upstream_metadata {
+    filter_metadata {
+      key: ""
+      value {
+        fields {
+          key: ""
+          value {
+            string_value: "c\000\000\000\000\000\000\000"
+          }
+        }
+      }
+    }
+    filter_metadata {
+      key: "-"
+      value {
+      }
+    }
+  }
+}

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -58,7 +58,7 @@ replaceInvalidStringValues(const envoy::api::v2::core::Metadata& upstream_metada
   for (auto& metadata_struct : *processed.mutable_filter_metadata()) {
     // Metadata fields consist of keyed Structs, which is a map of dynamically typed values. These
     // values can be null, a number, a string, a boolean, a list of values, or a recursive struct.
-    // This clears any invalid characters in string values. It  may not be likely a coverage-driven
+    // This clears any invalid characters in string values. It may not be likely a coverage-driven
     // fuzzer will explore recursive structs, so this case is not handled here.
     for (auto& field : *metadata_struct.second.mutable_fields()) {
       if (field.second.kind_case() == ProtobufWkt::Value::kStringValue) {

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -52,6 +52,19 @@ inline Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValueOption> repla
   return processed;
 }
 
+inline envoy::api::v2::core::Metadata
+replaceInvalidStringValues(const envoy::api::v2::core::Metadata& upstream_metadata) {
+  envoy::api::v2::core::Metadata processed = upstream_metadata;
+  for (auto& metadata_struct : *processed.mutable_filter_metadata()) {
+    for (auto& field : *metadata_struct.second.mutable_fields()) {
+      if (field.second.kind_case() == Protobuf::Value::kStringValue) {
+        field.second.set_string_value(replaceInvalidCharacters(field.second.string_value()));
+      }
+    }
+  }
+  return processed;
+}
+
 // Convert from test proto Headers to TestHeaderMapImpl.
 inline Http::TestHeaderMapImpl fromHeaders(
     const test::fuzz::Headers& headers,
@@ -103,8 +116,8 @@ inline TestStreamInfo fromStreamInfo(const test::fuzz::StreamInfo& stream_info,
     test_stream_info.response_code_ = stream_info.response_code().value();
   }
   auto upstream_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
-  auto upstream_metadata =
-      std::make_shared<envoy::api::v2::core::Metadata>(stream_info.upstream_metadata());
+  auto upstream_metadata = std::make_shared<envoy::api::v2::core::Metadata>(
+      replaceInvalidStringValues(stream_info.upstream_metadata()));
   ON_CALL(*upstream_host, metadata()).WillByDefault(testing::Return(upstream_metadata));
   test_stream_info.upstream_host_ = upstream_host;
   auto address = Network::Utility::resolveUrl("tcp://10.0.0.1:443");

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -56,6 +56,10 @@ inline envoy::api::v2::core::Metadata
 replaceInvalidStringValues(const envoy::api::v2::core::Metadata& upstream_metadata) {
   envoy::api::v2::core::Metadata processed = upstream_metadata;
   for (auto& metadata_struct : *processed.mutable_filter_metadata()) {
+    // Metadata fields consist of keyed Structs, which is a map of dynamically typed values. These
+    // values can be null, a number, a string, a boolean, a list of values, or a recursive struct.
+    // This clears any invalid characters in string values. It  may not be likely a coverage-driven
+    // fuzzer will explore recursive structs, so this case is not handled here.
     for (auto& field : *metadata_struct.second.mutable_fields()) {
       if (field.second.kind_case() == ProtobufWkt::Value::kStringValue) {
         field.second.set_string_value(replaceInvalidCharacters(field.second.string_value()));

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -57,7 +57,7 @@ replaceInvalidStringValues(const envoy::api::v2::core::Metadata& upstream_metada
   envoy::api::v2::core::Metadata processed = upstream_metadata;
   for (auto& metadata_struct : *processed.mutable_filter_metadata()) {
     for (auto& field : *metadata_struct.second.mutable_fields()) {
-      if (field.second.kind_case() == Protobuf::Value::kStringValue) {
+      if (field.second.kind_case() == ProtobufWkt::Value::kStringValue) {
         field.second.set_string_value(replaceInvalidCharacters(field.second.string_value()));
       }
     }


### PR DESCRIPTION
Replace invalid header characters in filter metadata strings.

Risk Level: Low
Testing: Add corpus entry
Fixes OSS-Fuzz issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15555

