### PR TITLE
[envoy] Remove max limit for endpoint/locality weight

### DIFF
--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -74,22 +74,15 @@ message LbEndpoint {
   // to subset the endpoints considered in cluster load balancing.
   core.Metadata metadata = 3;
 
-  // The optional load balancing weight of the upstream host, in the range 1 -
-  // 128. Envoy uses the load balancing weight in some of the built in load
+  // The optional load balancing weight of the upstream host; at least 1.
+  // Envoy uses the load balancing weight in some of the built in load
   // balancers. The load balancing weight for an endpoint is divided by the sum
   // of the weights of all endpoints in the endpoint's locality to produce a
   // percentage of traffic for the endpoint. This percentage is then further
   // weighted by the endpoint's locality's load balancing weight from
   // LocalityLbEndpoints. If unspecified, each host is presumed to have equal
   // weight in a locality.
-  //
-  // .. attention::
-  //
-  //   The limit of 128 is somewhat arbitrary, but is applied due to performance
-  //   concerns with the current implementation and can be removed when
-  //   `this issue <https://github.com/envoyproxy/envoy/issues/1285>`_ is fixed.
-  google.protobuf.UInt32Value load_balancing_weight = 4
-      [(validate.rules).uint32 = {gte: 1, lte: 128}];
+  google.protobuf.UInt32Value load_balancing_weight = 4 [(validate.rules).uint32 = {gte: 1}];
 }
 
 // A group of endpoints belonging to a Locality.
@@ -103,7 +96,7 @@ message LocalityLbEndpoints {
   // The group of endpoints belonging to the locality specified.
   repeated LbEndpoint lb_endpoints = 2 [(gogoproto.nullable) = false];
 
-  // Optional: Per priority/region/zone/sub_zone weight - range 1-128. The load
+  // Optional: Per priority/region/zone/sub_zone weight; at least 1. The load
   // balancing weight for a locality is divided by the sum of the weights of all
   // localities  at the same priority level to produce the effective percentage
   // of traffic for the locality.
@@ -113,14 +106,7 @@ message LocalityLbEndpoints {
   // configured. These weights are ignored otherwise. If no weights are
   // specified when locality weighted load balancing is enabled, the locality is
   // assigned no load.
-  //
-  // .. attention::
-  //
-  //   The limit of 128 is somewhat arbitrary, but is applied due to performance
-  //   concerns with the current implementation and can be removed when
-  //   `this issue <https://github.com/envoyproxy/envoy/issues/1285>`_ is fixed.
-  google.protobuf.UInt32Value load_balancing_weight = 3
-      [(validate.rules).uint32 = {gte: 1, lte: 128}];
+  google.protobuf.UInt32Value load_balancing_weight = 3 [(validate.rules).uint32 = {gte: 1}];
 
   // Optional: the priority for this LocalityLbEndpoints. If unspecified this will
   // default to the highest priority (0).

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -19,6 +19,7 @@ Version history
 * csrf: added support for whitelisting additional source origins.
 * dubbo_proxy: support the :ref:`Dubbo proxy filter <config_network_filters_dubbo_proxy>`.
 * eds: added support to specify max time for which endpoints can be used :ref:`gRPC filter <envoy_api_msg_ClusterLoadAssignment.Policy>`.
+* eds: removed max limit for `load_balancing_weight`.
 * event: added :ref:`loop duration and poll delay statistics <operations_performance>`.
 * ext_authz: added a `x-envoy-auth-partial-body` metadata header set to `false|true` indicating if there is a partial body sent in the authorization request message.
 * ext_authz: added configurable status code that allows customizing HTTP responses on filter check status errors.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -275,7 +275,7 @@ HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& clu
   return connection;
 }
 
-void HostImpl::weight(uint32_t new_weight) { weight_ = std::max(1U, std::min(128U, new_weight)); }
+void HostImpl::weight(uint32_t new_weight) { weight_ = std::max(1U, new_weight); }
 
 std::vector<HostsPerLocalityConstSharedPtr> HostsPerLocalityImpl::filter(
     const std::vector<std::function<bool(const Host&)>>& predicates) const {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -900,7 +900,9 @@ TEST(HostImplTest, Weight) {
 
   EXPECT_EQ(1U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 0)->weight());
   EXPECT_EQ(128U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 128)->weight());
-  EXPECT_EQ(10000U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 10000)->weight());
+  EXPECT_EQ(std::numeric_limits<uint32_t>::max(),
+            makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", std::numeric_limits<uint32_t>::max())
+                ->weight());
 
   HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 50);
   EXPECT_EQ(50U, host->weight());
@@ -908,8 +910,8 @@ TEST(HostImplTest, Weight) {
   EXPECT_EQ(51U, host->weight());
   host->weight(0);
   EXPECT_EQ(1U, host->weight());
-  host->weight(10000);
-  EXPECT_EQ(10000U, host->weight());
+  host->weight(std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(std::numeric_limits<uint32_t>::max(), host->weight());
 }
 
 TEST(HostImplTest, HostnameCanaryAndLocality) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -900,7 +900,7 @@ TEST(HostImplTest, Weight) {
 
   EXPECT_EQ(1U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 0)->weight());
   EXPECT_EQ(128U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 128)->weight());
-  EXPECT_EQ(128U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 129)->weight());
+  EXPECT_EQ(10000U, makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 10000)->weight());
 
   HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 50);
   EXPECT_EQ(50U, host->weight());
@@ -908,8 +908,8 @@ TEST(HostImplTest, Weight) {
   EXPECT_EQ(51U, host->weight());
   host->weight(0);
   EXPECT_EQ(1U, host->weight());
-  host->weight(129);
-  EXPECT_EQ(128U, host->weight());
+  host->weight(10000);
+  EXPECT_EQ(10000U, host->weight());
 }
 
 TEST(HostImplTest, HostnameCanaryAndLocality) {


### PR DESCRIPTION
Description: Remove max limit for `load_balancing_weight` in `LbEndpoint` and `LocalityLbEndpoints`.
Risk Level: Low
Testing: Updated existing tests
Docs Changes: Updated in-place documentation in protobuf definitions.
Release Notes: Updated
Fixes #7425 
