### PR TITLE
Update jwt_verify_lib to 2019-07-01

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -156,10 +156,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/archive/cpp-3.1.1.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "700be26170c1917e83d1319b88a2112dccd1179cd78c5672940483e7c45ca6ae",
-        strip_prefix = "jwt_verify_lib-85cf0edf1f1bc507ff7d96a8d6a9bc20307b0fcf",
-        # 2018-12-01
-        urls = ["https://github.com/google/jwt_verify_lib/archive/85cf0edf1f1bc507ff7d96a8d6a9bc20307b0fcf.tar.gz"],
+        sha256 = "8ab9a0b3f8b7eab5f1cd059920e81fdc138cd4ee657c1412af891652929885c5",
+        strip_prefix = "jwt_verify_lib-6356535ae83a3f1820b6b06dae80cd6a0a03e7f2",
+        # 2019-07-01
+        urls = ["https://github.com/google/jwt_verify_lib/archive/6356535ae83a3f1820b6b06dae80cd6a0a03e7f2.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "ef26268c54c8084d17654ba2ed5140bffeffd2a040a895ffb22a6cca3f6c613f",


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

The [change](https://github.com/google/jwt_verify_lib/commit/5b76bc8a40d5756fe1c1b850091407779bc13e8e) in  jwt_verify_lib: hardend the JWT verification code when calling openssl code. 


Description:
If EVP_DigestVerifyInit fails, don't call EVP_DigestVerifyUpdate
If EVP_DigestVerifyUpdate fails, don't call EVP_DigestVerifyFinal

Risk Level:  Low
Testing: None
Docs Changes: None
Release Notes: None
