### PR TITLE
clang-tidy: enable most abseil checks as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,34 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,readability-container-size-empty'
+Checks:          'abseil-*,
+                  bugprone-*,
+                  clang-analyzer-*,
+                  clang-diagnostic-*,
+                  modernize-*,
+                  performance-*,
+                  readability-braces-around-statements,
+                  readability-container-size-empty'
+                  readability-redundant-*,
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
-WarningsAsErrors: 'bugprone-assert-side-effect,bugprone-use-after-move,modernize-make-shared,modernize-make-unique,modernize-use-using,performance-faster-string-find,performance-for-range-copy,performance-noexcept-move-constructor,performance-unnecessary-copy-initialization,readability-braces-around-statements,readability-container-size-empty,readability-redundant-smartptr-get,readability-redundant-string-cstr'
+WarningsAsErrors: 'abseil-duration-*,
+                   abseil-faster-strsplit-delimiter,
+                   abseil-no-namespace,
+                   abseil-redundant-strcat-calls,
+                   abseil-str-cat-append,
+                   abseil-string-find-startswith,
+                   abseil-upgrade-duration-conversions,
+                   bugprone-assert-side-effect,
+                   bugprone-use-after-move,
+                   modernize-make-shared,
+                   modernize-make-unique,
+                   modernize-use-using,
+                   performance-faster-string-find,
+                   performance-for-range-copy,
+                   performance-noexcept-move-constructor,
+                   performance-unnecessary-copy-initialization,
+                   readability-braces-around-statements,
+                   readability-container-size-empty,
+                   readability-redundant-smartptr-get,
+                   readability-redundant-string-cstr'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -249,7 +249,7 @@ HttpHealthCheckerImpl::HttpActiveHealthCheckSession::healthCheckResult() {
                   response_headers_->EnvoyUpstreamHealthCheckedCluster()->value().getStringView())
             : EMPTY_STRING;
 
-    if (service_cluster_healthchecked.find(parent_.service_name_.value()) == 0) {
+    if (absl::StartsWith(service_cluster_healthchecked, parent_.service_name_.value())) {
       return degraded ? HealthCheckResult::Degraded : HealthCheckResult::Succeeded;
     } else {
       return HealthCheckResult::Failed;

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -24,6 +24,8 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!complete_);
@@ -140,7 +142,7 @@ Network::FilterStatus WaitForPayloadReader::onData(Buffer::Instance& data, bool 
   data_.append(data.toString());
   data.drain(data.length());
   read_end_stream_ = end_stream;
-  if ((!data_to_wait_for_.empty() && data_.find(data_to_wait_for_) == 0) ||
+  if ((!data_to_wait_for_.empty() && absl::StartsWith(data_, data_to_wait_for_)) ||
       (exact_match_ == false && data_.find(data_to_wait_for_) != std::string::npos) || end_stream) {
     data_to_wait_for_.clear();
     dispatcher_.exit();


### PR DESCRIPTION
Description: Enables every abseil clang-tidy check as an error _except_ `abseil-no-internal-dependencies` because there are ~1500 instances of it. Also broke out each check into a newline so that it's easier to inspect and audit.
Risk Level: Low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Relates to #4863 

Signed-off-by: Derek Argueta <dereka@pinterest.com>
