### PR TITLE
clang-tidy: readability-redundant-member-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ WarningsAsErrors: 'abseil-duration-*,
                    performance-unnecessary-copy-initialization,
                    readability-braces-around-statements,
                    readability-container-size-empty,
+                   readability-redundant-member-init,
                    readability-redundant-smartptr-get,
                    readability-redundant-string-cstr'
 

--- a/source/common/config/metadata.h
+++ b/source/common/config/metadata.h
@@ -54,9 +54,7 @@ template <typename factoryClass> class TypedMetadataImpl : public TypedMetadata 
 public:
   static_assert(std::is_base_of<Config::TypedMetadataFactory, factoryClass>::value,
                 "Factory type must be inherited from Envoy::Config::TypedMetadataFactory.");
-  TypedMetadataImpl(const envoy::api::v2::core::Metadata& metadata) : data_() {
-    populateFrom(metadata);
-  }
+  TypedMetadataImpl(const envoy::api::v2::core::Metadata& metadata) { populateFrom(metadata); }
 
   const TypedMetadata::Object* getData(const std::string& key) const override {
     const auto& it = data_.find(key);

--- a/source/common/filesystem/posix/directory_iterator_impl.h
+++ b/source/common/filesystem/posix/directory_iterator_impl.h
@@ -13,8 +13,7 @@ class DirectoryIteratorImpl : public DirectoryIterator {
 public:
   DirectoryIteratorImpl(const std::string& directory_path);
   DirectoryIteratorImpl()
-      : DirectoryIterator(), directory_path_(""), dir_(nullptr),
-        os_sys_calls_(Api::OsSysCallsSingleton::get()) {}
+      : directory_path_(""), dir_(nullptr), os_sys_calls_(Api::OsSysCallsSingleton::get()) {}
 
   ~DirectoryIteratorImpl();
 

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -615,9 +615,8 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
                                                            HostPredicate predicate,
                                                            bool locality_weight_aware,
                                                            bool scale_locality_weight)
-    : PrioritySetImpl(), original_priority_set_(subset_lb.original_priority_set_),
-      predicate_(predicate), locality_weight_aware_(locality_weight_aware),
-      scale_locality_weight_(scale_locality_weight) {
+    : original_priority_set_(subset_lb.original_priority_set_), predicate_(predicate),
+      locality_weight_aware_(locality_weight_aware), scale_locality_weight_(scale_locality_weight) {
 
   for (size_t i = 0; i < original_priority_set_.hostSetsPerPriority().size(); ++i) {
     empty_ &= getOrCreateHostSet(i).hosts().empty();

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -103,7 +103,7 @@ uint64_t GzipFilterConfig::windowBitsUint(Protobuf::uint32 window_bits) {
 }
 
 GzipFilter::GzipFilter(const GzipFilterConfigSharedPtr& config)
-    : skip_compression_{true}, compressed_data_(), compressor_(), config_(config) {}
+    : skip_compression_{true}, config_(config) {}
 
 Http::FilterHeadersStatus GzipFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   if (config_->runtime().snapshot().featureEnabled("gzip.filter_enabled", 100) &&

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -121,9 +121,8 @@ std::string SquashFilterConfig::replaceEnv(const std::string& attachment_templat
 }
 
 SquashFilter::SquashFilter(SquashFilterConfigSharedPtr config, Upstream::ClusterManager& cm)
-    : config_(config), is_squashing_(false), debug_attachment_path_(),
-      attachment_poll_period_timer_(nullptr), attachment_timeout_timer_(nullptr),
-      in_flight_request_(nullptr),
+    : config_(config), is_squashing_(false), attachment_poll_period_timer_(nullptr),
+      attachment_timeout_timer_(nullptr), in_flight_request_(nullptr),
       create_attachment_callback_(std::bind(&SquashFilter::onCreateAttachmentSuccess, this, _1),
                                   std::bind(&SquashFilter::onCreateAttachmentFailure, this, _1)),
       check_attachment_callback_(std::bind(&SquashFilter::onGetAttachmentSuccess, this, _1),

--- a/source/extensions/filters/network/dubbo_proxy/decoder.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder.h
@@ -77,7 +77,7 @@ public:
 private:
   struct DecoderStatus {
     DecoderStatus() = default;
-    DecoderStatus(ProtocolState next_state) : next_state_(next_state), filter_status_{} {};
+    DecoderStatus(ProtocolState next_state) : next_state_(next_state){};
     DecoderStatus(ProtocolState next_state, Network::FilterStatus filter_status)
         : next_state_(next_state), filter_status_(filter_status){};
 

--- a/source/extensions/filters/network/thrift_proxy/decoder.h
+++ b/source/extensions/filters/network/thrift_proxy/decoder.h
@@ -119,7 +119,7 @@ private:
   };
 
   struct DecoderStatus {
-    DecoderStatus(ProtocolState next_state) : next_state_(next_state), filter_status_{} {};
+    DecoderStatus(ProtocolState next_state) : next_state_(next_state){};
     DecoderStatus(ProtocolState next_state, FilterStatus filter_status)
         : next_state_(next_state), filter_status_(filter_status){};
 

--- a/source/extensions/tracers/zipkin/zipkin_core_types.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.h
@@ -56,7 +56,7 @@ public:
   /**
    * Default constructor. Creates an empty Endpoint.
    */
-  Endpoint() : service_name_(), address_(nullptr) {}
+  Endpoint() : address_(nullptr) {}
 
   /**
    * Constructor that initializes an endpoint with the given attributes.
@@ -118,7 +118,7 @@ public:
   /**
    * Default constructor. Creates an empty annotation.
    */
-  Annotation() : timestamp_(0), value_() {}
+  Annotation() : timestamp_(0) {}
 
   /**
    * Constructor that creates an annotation based on the given parameters.
@@ -217,7 +217,7 @@ public:
   /**
    * Default constructor. Creates an empty binary annotation.
    */
-  BinaryAnnotation() : key_(), value_(), annotation_type_(STRING) {}
+  BinaryAnnotation() : annotation_type_(STRING) {}
 
   /**
    * Constructor that creates a binary annotation based on the given parameters.
@@ -307,7 +307,7 @@ public:
    * Default constructor. Creates an empty span.
    */
   explicit Span(TimeSource& time_source)
-      : trace_id_(0), name_(), id_(0), debug_(false), sampled_(false), monotonic_start_time_(0),
+      : trace_id_(0), id_(0), debug_(false), sampled_(false), monotonic_start_time_(0),
         tracer_(nullptr), time_source_(time_source) {}
 
   /**

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -70,7 +70,7 @@ protected:
 
 class ZlibCompressorImplTester : public ZlibCompressorImpl {
 public:
-  ZlibCompressorImplTester() : ZlibCompressorImpl() {}
+  ZlibCompressorImplTester() {}
   ZlibCompressorImplTester(uint64_t chunk_size) : ZlibCompressorImpl(chunk_size) {}
   void compressThenFlush(Buffer::OwnedImpl& buffer) { compress(buffer, State::Flush); }
   void finish(Buffer::OwnedImpl& buffer) { compress(buffer, State::Finish); }

--- a/test/common/config/delta_subscription_impl_test.cc
+++ b/test/common/config/delta_subscription_impl_test.cc
@@ -8,7 +8,7 @@ namespace {
 
 class DeltaSubscriptionImplTest : public DeltaSubscriptionTestHarness, public testing::Test {
 protected:
-  DeltaSubscriptionImplTest() : DeltaSubscriptionTestHarness() {}
+  DeltaSubscriptionImplTest() {}
 };
 
 TEST_F(DeltaSubscriptionImplTest, UpdateResourcesCausesRequest) {

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -1658,7 +1658,7 @@ TEST_F(EdsTest, MalformedIP) {
 
 class EdsAssignmentTimeoutTest : public EdsTest {
 public:
-  EdsAssignmentTimeoutTest() : EdsTest(), interval_timer_(nullptr) {
+  EdsAssignmentTimeoutTest() : interval_timer_(nullptr) {
     EXPECT_CALL(dispatcher_, createTimer_(_))
         .WillOnce(Invoke([this](Event::TimerCb cb) {
           timer_cb_ = cb;

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -239,8 +239,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, WrongSecretFirst) {
 
 class SdsDynamicDownstreamCertValidationContextTest : public SdsDynamicDownstreamIntegrationTest {
 public:
-  SdsDynamicDownstreamCertValidationContextTest()
-      : SdsDynamicDownstreamIntegrationTest(), use_combined_validation_context_(false) {}
+  SdsDynamicDownstreamCertValidationContextTest() : use_combined_validation_context_(false) {}
 
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {


### PR DESCRIPTION
Description: Clean up existing warnings for `readability-redundant-member-init` and enable as an error.
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A

Relates to #4863 

Signed-off-by: Derek Argueta <dereka@pinterest.com>