### PR TITLE
Kafka codec: refactoring for request&response codecs

### DIFF
--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -23,19 +23,22 @@ public:
   virtual void onData(Buffer::Instance& data) PURE;
 };
 
-/**
- * Kafka message encoder.
- * @param MessageType encoded message type (request or response).
- */
-template <typename MessageType> class MessageEncoder {
+template <typename MessageType, typename ParseFailureType>
+class MessageCallback {
 public:
-  virtual ~MessageEncoder() = default;
+  virtual ~MessageCallback() = default;
 
   /**
-   * Encodes given message.
-   * @param message message to be encoded.
+   * Callback method invoked when message is successfully decoded.
+   * @param message message that has been decoded.
    */
-  virtual void encode(const MessageType& message) PURE;
+  virtual void onMessage(MessageType response) PURE;
+
+  /**
+   * Callback method invoked when message could not be decoded.
+   * Invoked after all message's bytes have been consumed.
+   */
+  virtual void onFailedParse(ParseFailureType failure_data) PURE;
 };
 
 /**
@@ -137,7 +140,21 @@ private:
   const std::vector<CallbackType> callbacks_;
 
   ParserType current_parser_;
+};
 
+/**
+ * Kafka message encoder.
+ * @param MessageType encoded message type (request or response).
+ */
+template <typename MessageType> class MessageEncoder {
+public:
+  virtual ~MessageEncoder() = default;
+
+  /**
+   * Encodes given message.
+   * @param message message to be encoded.
+   */
+  virtual void encode(const MessageType& message) PURE;
 };
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -2,6 +2,7 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
+#include "common/common/stack_array.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -35,6 +36,108 @@ public:
    * @param message message to be encoded.
    */
   virtual void encode(const MessageType& message) PURE;
+};
+
+/**
+ * Abstract message decoder, that resolves messages from Buffer instances provided.
+ * When the message has been parsed, notify the callbacks.
+ */
+template <typename ParserType, typename CallbackType>
+class AbstractMessageDecoder : public MessageDecoder {
+public:
+
+  virtual ~AbstractMessageDecoder() = default;
+
+  /**
+   * Creates a decoder that will invoke given callbacks when a message has been parsed.
+   * @param callbacks callbacks to be invoked (in order).
+   */
+  AbstractMessageDecoder(const std::vector<CallbackType> callbacks): callbacks_{callbacks} {};
+
+  /**
+   * Consumes all data present in a buffer.
+   * If a message can be successfully parsed, then callbacks get notified with parsed response.
+   * Updates decoder state.
+   * Can throw if codec's state does not permit usage, or there there were parse failures.
+   * Impl note: similar to redis codec, which also keeps state.
+   */
+  void onData(Buffer::Instance& data) override {
+    // Convert buffer to slices and pass them to `doParse`.
+    uint64_t num_slices = data.getRawSlices(nullptr, 0);
+    STACK_ARRAY(slices, Buffer::RawSlice, num_slices);
+    data.getRawSlices(slices.begin(), num_slices);
+    for (const Buffer::RawSlice& slice : slices) {
+      doParse(slice);
+    }
+  }
+
+protected:
+
+  /**
+   * Create a start parser for a new message.
+   */
+  virtual ParserType createStartParser() PURE;
+
+private:
+
+  /**
+   * Main parse loop.
+   *
+   * If there is data to process, and the current parser is not present,
+   * create a new one with `createStartParser`.
+   * Feed data to a current parser until it returns a parse result.
+   * If the parse result is a parsed message, notify callbacks and reset current parser.
+   * If the parse result is another parser, update current parser, and keep feeding.
+   */
+  void doParse(const Buffer::RawSlice& slice) {
+    const char* bytes = reinterpret_cast<const char*>(slice.mem_);
+    absl::string_view data = {bytes, slice.len_};
+
+    while (!data.empty()) {
+
+      // Re-initialize the parser.
+      if (!current_parser_) {
+        current_parser_ = createStartParser();
+      }
+
+      // Feed the data to the parser.
+      auto result = current_parser_->parse(data);
+      // This loop guarantees that parsers consuming 0 bytes also get processed in this invocation.
+      while (result.hasData()) {
+        if (!result.next_parser_) {
+
+          // Next parser is not present, so we have finished parsing a message.
+          // Depending on whether the parse was successful, invoke the correct callback.
+          if (result.message_) {
+            for (auto& callback : callbacks_) {
+              callback->onMessage(result.message_);
+            }
+          } else {
+            for (auto& callback : callbacks_) {
+              callback->onFailedParse(result.failure_data_);
+            }
+          }
+
+          // As we finished parsing this response, return to outer loop.
+          // If there is more data, the parser will be re-initialized.
+          current_parser_ = nullptr;
+          break;
+        } else {
+
+          // The next parser that's supposed to consume the rest of payload was given.
+          current_parser_ = result.next_parser_;
+        }
+
+        // Keep parsing the data.
+        result = current_parser_->parse(data);
+      }
+    }
+  }
+
+  const std::vector<CallbackType> callbacks_;
+
+  ParserType current_parser_;
+
 };
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -74,6 +74,8 @@ public:
     }
   }
 
+  ParserType getCurrentParserForTest() const { return current_parser_; }
+
 protected:
 
   /**

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -2,6 +2,7 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
+
 #include "common/common/stack_array.h"
 
 namespace Envoy {
@@ -23,8 +24,7 @@ public:
   virtual void onData(Buffer::Instance& data) PURE;
 };
 
-template <typename MessageType, typename ParseFailureType>
-class MessageCallback {
+template <typename MessageType, typename ParseFailureType> class MessageCallback {
 public:
   virtual ~MessageCallback() = default;
 
@@ -48,14 +48,13 @@ public:
 template <typename ParserType, typename CallbackType>
 class AbstractMessageDecoder : public MessageDecoder {
 public:
-
   virtual ~AbstractMessageDecoder() = default;
 
   /**
    * Creates a decoder that will invoke given callbacks when a message has been parsed.
    * @param callbacks callbacks to be invoked (in order).
    */
-  AbstractMessageDecoder(const std::vector<CallbackType> callbacks): callbacks_{callbacks} {};
+  AbstractMessageDecoder(const std::vector<CallbackType> callbacks) : callbacks_{callbacks} {};
 
   /**
    * Consumes all data present in a buffer.
@@ -77,14 +76,12 @@ public:
   ParserType getCurrentParserForTest() const { return current_parser_; }
 
 protected:
-
   /**
    * Create a start parser for a new message.
    */
   virtual ParserType createStartParser() PURE;
 
 private:
-
   /**
    * Main parse loop.
    *

--- a/source/extensions/filters/network/kafka/kafka_request_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.cc
@@ -44,18 +44,6 @@ RequestParseResponse RequestHeaderParser::parse(absl::string_view& data) {
   }
 }
 
-RequestParseResponse SentinelParser::parse(absl::string_view& data) {
-  const uint32_t min = std::min<uint32_t>(context_->remaining_request_size_, data.size());
-  data = {data.data() + min, data.size() - min};
-  context_->remaining_request_size_ -= min;
-  if (0 == context_->remaining_request_size_) {
-    return RequestParseResponse::parseFailure(
-        std::make_shared<RequestParseFailure>(context_->request_header_));
-  } else {
-    return RequestParseResponse::stillWaiting();
-  }
-}
-
 } // namespace Kafka
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/kafka/kafka_request_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.h
@@ -22,13 +22,13 @@ using RequestParserSharedPtr = std::shared_ptr<RequestParser>;
  * Context that is shared between parsers that are handling the same single message.
  */
 struct RequestContext {
-  int32_t remaining_request_size_{0};
+  uint32_t remaining_request_size_{0};
   RequestHeader request_header_{};
 
   /**
    * Bytes left to consume.
    */
-  int32_t& remaining() { return remaining_request_size_; }
+  uint32_t& remaining() { return remaining_request_size_; }
 
   /**
    * Returns data needed for construction of parse failure message.

--- a/source/extensions/filters/network/kafka/kafka_request_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.h
@@ -24,6 +24,20 @@ using RequestParserSharedPtr = std::shared_ptr<RequestParser>;
 struct RequestContext {
   int32_t remaining_request_size_{0};
   RequestHeader request_header_{};
+
+  /**
+   * Bytes left to consume.
+   */
+  int32_t& remaining() {
+    return remaining_request_size_;
+  }
+
+  /**
+   * Returns data needed for construction of parse failure message.
+   */
+  const RequestHeader asFailureData() const {
+    return request_header_;
+  }
 };
 
 using RequestContextSharedPtr = std::shared_ptr<RequestContext>;
@@ -126,19 +140,13 @@ private:
  * api_key & api_version. It does not attempt to capture any data, just throws it away until end of
  * message.
  */
-class SentinelParser : public RequestParser {
+class SentinelParser : public AbstractSentinelParser<RequestContextSharedPtr, RequestParseResponse>, public RequestParser {
 public:
-  SentinelParser(RequestContextSharedPtr context) : context_{context} {};
+  SentinelParser(RequestContextSharedPtr context) : AbstractSentinelParser{context} {};
 
-  /**
-   * Returns failed parse data. Ignores (jumps over) the data provided.
-   */
-  RequestParseResponse parse(absl::string_view& data) override;
-
-  const RequestContextSharedPtr contextForTest() const { return context_; }
-
-private:
-  const RequestContextSharedPtr context_;
+  RequestParseResponse parse(absl::string_view& data) override {
+    return AbstractSentinelParser::parse(data);
+  }
 };
 
 /**

--- a/source/extensions/filters/network/kafka/kafka_request_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.h
@@ -28,16 +28,12 @@ struct RequestContext {
   /**
    * Bytes left to consume.
    */
-  int32_t& remaining() {
-    return remaining_request_size_;
-  }
+  int32_t& remaining() { return remaining_request_size_; }
 
   /**
    * Returns data needed for construction of parse failure message.
    */
-  const RequestHeader asFailureData() const {
-    return request_header_;
-  }
+  const RequestHeader asFailureData() const { return request_header_; }
 };
 
 using RequestContextSharedPtr = std::shared_ptr<RequestContext>;
@@ -140,7 +136,8 @@ private:
  * api_key & api_version. It does not attempt to capture any data, just throws it away until end of
  * message.
  */
-class SentinelParser : public AbstractSentinelParser<RequestContextSharedPtr, RequestParseResponse>, public RequestParser {
+class SentinelParser : public AbstractSentinelParser<RequestContextSharedPtr, RequestParseResponse>,
+                       public RequestParser {
 public:
   SentinelParser(RequestContextSharedPtr context) : AbstractSentinelParser{context} {};
 

--- a/source/extensions/filters/network/kafka/kafka_response_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.cc
@@ -28,19 +28,6 @@ ResponseParseResponse ResponseHeaderParser::parse(absl::string_view& data) {
   return ResponseParseResponse::nextParser(next_parser);
 }
 
-ResponseParseResponse SentinelResponseParser::parse(absl::string_view& data) {
-  const uint32_t min = std::min<uint32_t>(context_->remaining_response_size_, data.size());
-  data = {data.data() + min, data.size() - min};
-  context_->remaining_response_size_ -= min;
-  if (0 == context_->remaining_response_size_) {
-    const auto failure_data = std::make_shared<ResponseMetadata>(
-        context_->api_key_, context_->api_version_, context_->correlation_id_);
-    return ResponseParseResponse::parseFailure(failure_data);
-  } else {
-    return ResponseParseResponse::stillWaiting();
-  }
-}
-
 } // namespace Kafka
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/kafka/kafka_response_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.h
@@ -49,16 +49,12 @@ struct ResponseContext {
   /**
    * Bytes left to consume.
    */
-  int32_t& remaining() {
-    return remaining_response_size_;
-  }
+  int32_t& remaining() { return remaining_response_size_; }
 
   /**
    * Returns data needed for construction of parse failure message.
    */
-  const ResponseMetadata asFailureData() const {
-    return {api_key_, api_version_, correlation_id_};
-  }
+  const ResponseMetadata asFailureData() const { return {api_key_, api_version_, correlation_id_}; }
 };
 
 using ResponseContextSharedPtr = std::shared_ptr<ResponseContext>;
@@ -121,7 +117,9 @@ private:
  * api_key & api_version. It does not attempt to capture any data, just throws it away until end of
  * message.
  */
-class SentinelResponseParser : public AbstractSentinelParser<ResponseContextSharedPtr, ResponseParseResponse>, public ResponseParser {
+class SentinelResponseParser
+    : public AbstractSentinelParser<ResponseContextSharedPtr, ResponseParseResponse>,
+      public ResponseParser {
 public:
   SentinelResponseParser(ResponseContextSharedPtr context) : AbstractSentinelParser{context} {};
 

--- a/source/extensions/filters/network/kafka/kafka_response_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.h
@@ -39,7 +39,7 @@ struct ResponseContext {
   /**
    * Bytes left to process.
    */
-  int32_t remaining_response_size_;
+  uint32_t remaining_response_size_;
 
   /**
    * Response's correlation id.
@@ -49,7 +49,7 @@ struct ResponseContext {
   /**
    * Bytes left to consume.
    */
-  int32_t& remaining() { return remaining_response_size_; }
+  uint32_t& remaining() { return remaining_response_size_; }
 
   /**
    * Returns data needed for construction of parse failure message.

--- a/source/extensions/filters/network/kafka/parser.h
+++ b/source/extensions/filters/network/kafka/parser.h
@@ -43,6 +43,9 @@ using ParserSharedPtr = std::shared_ptr<Parser<MessageType, FailureDataType>>;
  */
 template <typename MessageType, typename FailureDataType> class ParseResponse {
 public:
+
+  using failure_type = FailureDataType;
+
   /**
    * Constructs a response that states that parser still needs data and should not be replaced.
    */
@@ -86,6 +89,30 @@ public:
   ParserSharedPtr<MessageType, FailureDataType> next_parser_;
   MessageType message_;
   FailureDataType failure_data_;
+};
+
+template <typename ContextType, typename ResponseType>
+class AbstractSentinelParser {
+public:
+
+  AbstractSentinelParser(ContextType context): context_{context} {};
+
+  ResponseType parse(absl::string_view& data) {
+    const uint32_t min = std::min<uint32_t>(context_->remaining(), data.size());
+    data = {data.data() + min, data.size() - min};
+    context_->remaining() -= min;
+    if (0 == context_->remaining()) {
+      using failure_type = typename ResponseType::failure_type::element_type;
+      auto failure_data = std::make_shared<failure_type>(context_->asFailureData());
+      return ResponseType::parseFailure(failure_data);
+    } else {
+      return ResponseType::stillWaiting();
+    }
+  }
+
+  const ContextType contextForTest() const { return context_; }
+private:
+  ContextType context_;
 };
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/parser.h
+++ b/source/extensions/filters/network/kafka/parser.h
@@ -43,7 +43,6 @@ using ParserSharedPtr = std::shared_ptr<Parser<MessageType, FailureDataType>>;
  */
 template <typename MessageType, typename FailureDataType> class ParseResponse {
 public:
-
   using failure_type = FailureDataType;
 
   /**
@@ -91,11 +90,9 @@ public:
   FailureDataType failure_data_;
 };
 
-template <typename ContextType, typename ResponseType>
-class AbstractSentinelParser {
+template <typename ContextType, typename ResponseType> class AbstractSentinelParser {
 public:
-
-  AbstractSentinelParser(ContextType context): context_{context} {};
+  AbstractSentinelParser(ContextType context) : context_{context} {};
 
   ResponseType parse(absl::string_view& data) {
     const uint32_t min = std::min<uint32_t>(context_->remaining(), data.size());
@@ -111,6 +108,7 @@ public:
   }
 
   const ContextType contextForTest() const { return context_; }
+
 private:
   ContextType context_;
 };

--- a/source/extensions/filters/network/kafka/request_codec.cc
+++ b/source/extensions/filters/network/kafka/request_codec.cc
@@ -1,7 +1,6 @@
 #include "extensions/filters/network/kafka/request_codec.h"
 
 #include "common/buffer/buffer_impl.h"
-#include "common/common/stack_array.h"
 
 #include "absl/strings/string_view.h"
 
@@ -20,73 +19,7 @@ const InitialParserFactory& InitialParserFactory::getDefaultInstance() {
   CONSTRUCT_ON_FIRST_USE(RequestStartParserFactory);
 }
 
-void RequestDecoder::onData(Buffer::Instance& data) {
-  // Convert buffer to slices and pass them to `doParse`.
-  uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  STACK_ARRAY(slices, Buffer::RawSlice, num_slices);
-  data.getRawSlices(slices.begin(), num_slices);
-  for (const Buffer::RawSlice& slice : slices) {
-    doParse(slice);
-  }
-}
-
-/**
- * Main parse loop:
- * - forward data to current parser,
- * - receive parser response:
- * -- if still waiting, do nothing (we wait for more data),
- * -- if a parser is given, replace current parser with the new one, and it the rest of the data
- * -- if a message is given:
- * --- notify callbacks,
- * --- replace current parser with new start parser, as we are going to start parsing the next
- *     message.
- */
-void RequestDecoder::doParse(const Buffer::RawSlice& slice) {
-  const char* bytes = reinterpret_cast<const char*>(slice.mem_);
-  absl::string_view data = {bytes, slice.len_};
-
-  while (!data.empty()) {
-
-    // Re-initialize the parser.
-    if (!current_parser_) {
-      current_parser_ = createNextParser();
-    }
-
-    // Feed the data to the parser.
-    RequestParseResponse result = current_parser_->parse(data);
-    // This loop guarantees that parsers consuming 0 bytes also get processed in this invocation.
-    while (result.hasData()) {
-      if (!result.next_parser_) {
-
-        // Next parser is not present, so we have finished parsing a message.
-        // Depending on whether the parse was successful, invoke the correct callback.
-        if (result.message_) {
-          for (auto& callback : callbacks_) {
-            callback->onMessage(result.message_);
-          }
-        } else {
-          for (auto& callback : callbacks_) {
-            callback->onFailedParse(result.failure_data_);
-          }
-        }
-
-        // As we finished parsing this request, return to outer loop.
-        // If there is more data, the parser will be re-initialized again.
-        current_parser_ = nullptr;
-        break;
-      } else {
-
-        // The next parser that's supposed to consume the rest of payload was given.
-        current_parser_ = result.next_parser_;
-      }
-
-      // Keep parsing the data.
-      result = current_parser_->parse(data);
-    }
-  }
-}
-
-RequestParserSharedPtr RequestDecoder::createNextParser() {
+RequestParserSharedPtr RequestDecoder::createStartParser() {
   return factory_.create(parser_resolver_);
 }
 

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -64,18 +64,19 @@ public:
 class RequestDecoder : public MessageDecoder {
 public:
   /**
-   * Creates a decoder that can decode requests specified by RequestParserResolver, notifying
-   * callbacks on successful decoding.
-   * @param parserResolver supported parser resolver.
+   * Creates a decoder that will notify provided callbacks when a message is successfully parsed.
    * @param callbacks callbacks to be invoked (in order).
    */
-  RequestDecoder(const RequestParserResolver& parserResolver,
-                 const std::vector<RequestCallbackSharedPtr> callbacks)
-      : RequestDecoder(InitialParserFactory::getDefaultInstance(), parserResolver, callbacks){};
+  RequestDecoder(const std::vector<RequestCallbackSharedPtr> callbacks)
+      : RequestDecoder(InitialParserFactory::getDefaultInstance(),
+                       RequestParserResolver::getDefaultInstance(), callbacks){};
 
   /**
    * Visible for testing.
-   * Allows injecting initial parser factory.
+   * Allows injecting initial parser factory and parser resolver.
+   * @param factory parser factory to be used when new message is to be processed.
+   * @param parserResolver supported parser resolver.
+   * @param callbacks callbacks to be invoked (in order).
    */
   RequestDecoder(const InitialParserFactory& factory, const RequestParserResolver& parserResolver,
                  const std::vector<RequestCallbackSharedPtr> callbacks)

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -43,7 +43,8 @@ public:
  * Each parser along the line returns the fully parsed message or the next parser.
  * Stores parse state (as large message's payload can be provided through multiple `onData` calls).
  */
-class RequestDecoder : public AbstractMessageDecoder<RequestParserSharedPtr, RequestCallbackSharedPtr> {
+class RequestDecoder
+    : public AbstractMessageDecoder<RequestParserSharedPtr, RequestCallbackSharedPtr> {
 public:
   /**
    * Creates a decoder that will notify provided callbacks when a message is successfully parsed.

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -94,6 +94,8 @@ public:
 private:
   void doParse(const Buffer::RawSlice& slice);
 
+  RequestParserSharedPtr createNextParser();
+
   const InitialParserFactory& factory_;
 
   const RequestParserResolver& parser_resolver_;

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -61,7 +61,7 @@ public:
  * Each parser along the line returns the fully parsed message or the next parser.
  * Stores parse state (as large message's payload can be provided through multiple `onData` calls).
  */
-class RequestDecoder : public MessageDecoder {
+class RequestDecoder : public AbstractMessageDecoder<RequestParserSharedPtr, RequestCallbackSharedPtr> {
 public:
   /**
    * Creates a decoder that will notify provided callbacks when a message is successfully parsed.
@@ -80,29 +80,14 @@ public:
    */
   RequestDecoder(const InitialParserFactory& factory, const RequestParserResolver& parserResolver,
                  const std::vector<RequestCallbackSharedPtr> callbacks)
-      : factory_{factory}, parser_resolver_{parserResolver}, callbacks_{callbacks},
-        current_parser_{factory_.create(parser_resolver_)} {};
+      : AbstractMessageDecoder{callbacks}, factory_{factory}, parser_resolver_{parserResolver} {};
 
-  /**
-   * Consumes all data present in a buffer.
-   * If a request can be successfully parsed, then callbacks get notified with parsed request.
-   * Updates decoder state.
-   * Impl note: similar to redis codec, which also keeps state.
-   */
-  void onData(Buffer::Instance& data) override;
+protected:
+  RequestParserSharedPtr createStartParser() override;
 
 private:
-  void doParse(const Buffer::RawSlice& slice);
-
-  RequestParserSharedPtr createNextParser();
-
   const InitialParserFactory& factory_;
-
   const RequestParserResolver& parser_resolver_;
-
-  const std::vector<RequestCallbackSharedPtr> callbacks_;
-
-  RequestParserSharedPtr current_parser_;
 };
 
 /**

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -13,25 +13,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
-/**
- * Callback invoked when request is successfully decoded.
- */
-class RequestCallback {
-public:
-  virtual ~RequestCallback() = default;
-
-  /**
-   * Callback method invoked when request is successfully decoded.
-   * @param request request that has been decoded.
-   */
-  virtual void onMessage(AbstractRequestSharedPtr request) PURE;
-
-  /**
-   * Callback method invoked when request could not be decoded.
-   * Invoked after all request's bytes have been consumed.
-   */
-  virtual void onFailedParse(RequestParseFailureSharedPtr failure_data) PURE;
-};
+using RequestCallback = MessageCallback<AbstractRequestSharedPtr, RequestParseFailureSharedPtr>;
 
 using RequestCallbackSharedPtr = std::shared_ptr<RequestCallback>;
 

--- a/source/extensions/filters/network/kafka/response_codec.cc
+++ b/source/extensions/filters/network/kafka/response_codec.cc
@@ -1,6 +1,7 @@
 #include "extensions/filters/network/kafka/response_codec.h"
 
 #include "common/common/stack_array.h"
+#include "common/buffer/buffer_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -34,70 +35,8 @@ void ResponseDecoder::expectResponse(const int16_t api_key, const int16_t api_ve
   factory_->expectResponse(api_key, api_version);
 };
 
-void ResponseDecoder::onData(Buffer::Instance& data) {
-  // Convert buffer to slices and pass them to `doParse`.
-  uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  STACK_ARRAY(slices, Buffer::RawSlice, num_slices);
-  data.getRawSlices(slices.begin(), num_slices);
-  for (const Buffer::RawSlice& slice : slices) {
-    doParse(slice);
-  }
-}
-
-/**
- * Main parse loop:
- * - initialize parser, if it is not present (using information stored in `factory_`)
- * - forward data to current parser,
- * - receive parser response:
- * -- if still waiting, do nothing (we wait for more data),
- * -- if a parser is given, replace current parser with the new one, and it the rest of the data
- * -- if a message is given:
- * --- notify callbacks,
- * --- clean current parser.
- */
-void ResponseDecoder::doParse(const Buffer::RawSlice& slice) {
-  const char* bytes = reinterpret_cast<const char*>(slice.mem_);
-  absl::string_view data = {bytes, slice.len_};
-
-  while (!data.empty()) {
-
-    // Re-initialize the parser.
-    if (!current_parser_) {
-      current_parser_ = factory_->create(response_parser_resolver_);
-    }
-
-    // Feed the data to the parser.
-    ResponseParseResponse result = current_parser_->parse(data);
-    // This loop guarantees that parsers consuming 0 bytes also get processed in this invocation.
-    while (result.hasData()) {
-      if (!result.next_parser_) {
-
-        // Next parser is not present, so we have finished parsing a message.
-        // Depending on whether the parse was successful, invoke the correct callback.
-        if (result.message_) {
-          for (auto& callback : callbacks_) {
-            callback->onMessage(result.message_);
-          }
-        } else {
-          for (auto& callback : callbacks_) {
-            callback->onFailedParse(result.failure_data_);
-          }
-        }
-
-        // As we finished parsing this response, return to outer loop.
-        // If there is more data, the parser will be re-initialized.
-        current_parser_ = nullptr;
-        break;
-      } else {
-
-        // The next parser that's supposed to consume the rest of payload was given.
-        current_parser_ = result.next_parser_;
-      }
-
-      // Keep parsing the data.
-      result = current_parser_->parse(data);
-    }
-  }
+ResponseParserSharedPtr ResponseDecoder::createStartParser() {
+  return factory_->create(response_parser_resolver_);
 }
 
 void ResponseEncoder::encode(const AbstractResponse& message) {

--- a/source/extensions/filters/network/kafka/response_codec.cc
+++ b/source/extensions/filters/network/kafka/response_codec.cc
@@ -1,7 +1,7 @@
 #include "extensions/filters/network/kafka/response_codec.h"
 
-#include "common/common/stack_array.h"
 #include "common/buffer/buffer_impl.h"
+#include "common/common/stack_array.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/kafka/response_codec.h
+++ b/source/extensions/filters/network/kafka/response_codec.h
@@ -78,7 +78,7 @@ using ResponseInitialParserFactorySharedPtr = std::shared_ptr<ResponseInitialPar
 class ResponseDecoder : public MessageDecoder, public Logger::Loggable<Logger::Id::kafka> {
 public:
   /**
-   * Creates a decoder that will notify provided callbacks.
+   * Creates a decoder that will notify provided callbacks when a message is successfully parsed.
    * @param callbacks callbacks to be invoked (in order).
    */
   ResponseDecoder(const std::vector<ResponseCallbackSharedPtr> callbacks)
@@ -87,7 +87,10 @@ public:
 
   /**
    * Visible for testing.
-   * Allows injecting parser resolver.
+   * Allows injecting initial parser factory and parser resolver.
+   * @param factory parser factory to be used when new message is to be processed.
+   * @param parserResolver supported parser resolver.
+   * @param callbacks callbacks to be invoked (in order).
    */
   ResponseDecoder(const ResponseInitialParserFactorySharedPtr factory,
                   const ResponseParserResolver& response_parser_resolver,

--- a/source/extensions/filters/network/kafka/response_codec.h
+++ b/source/extensions/filters/network/kafka/response_codec.h
@@ -10,25 +10,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
-/**
- * Callback invoked when response is successfully decoded.
- */
-class ResponseCallback {
-public:
-  virtual ~ResponseCallback() = default;
-
-  /**
-   * Callback method invoked when response is successfully decoded.
-   * @param response response that has been decoded.
-   */
-  virtual void onMessage(AbstractResponseSharedPtr response) PURE;
-
-  /**
-   * Callback method invoked when response could not be decoded.
-   * Invoked after all response's bytes have been consumed.
-   */
-  virtual void onFailedParse(ResponseMetadataSharedPtr failure_data) PURE;
-};
+using ResponseCallback = MessageCallback<AbstractResponseSharedPtr, ResponseMetadataSharedPtr>;
 
 using ResponseCallbackSharedPtr = std::shared_ptr<ResponseCallback>;
 

--- a/source/extensions/filters/network/kafka/response_codec.h
+++ b/source/extensions/filters/network/kafka/response_codec.h
@@ -57,7 +57,9 @@ using ResponseInitialParserFactorySharedPtr = std::shared_ptr<ResponseInitialPar
  * As Kafka protocol does not carry response type data, it is necessary to register expected message
  * type beforehand with `expectResponse`.
  */
-class ResponseDecoder : public AbstractMessageDecoder<ResponseParserSharedPtr, ResponseCallbackSharedPtr>, public Logger::Loggable<Logger::Id::kafka> {
+class ResponseDecoder
+    : public AbstractMessageDecoder<ResponseParserSharedPtr, ResponseCallbackSharedPtr>,
+      public Logger::Loggable<Logger::Id::kafka> {
 public:
   /**
    * Creates a decoder that will notify provided callbacks when a message is successfully parsed.
@@ -77,7 +79,8 @@ public:
   ResponseDecoder(const ResponseInitialParserFactorySharedPtr factory,
                   const ResponseParserResolver& response_parser_resolver,
                   const std::vector<ResponseCallbackSharedPtr> callbacks)
-      : AbstractMessageDecoder{callbacks}, factory_{factory}, response_parser_resolver_{response_parser_resolver} {};
+      : AbstractMessageDecoder{callbacks}, factory_{factory}, response_parser_resolver_{
+                                                                  response_parser_resolver} {};
 
   /**
    * Registers an expected message.

--- a/test/extensions/filters/network/kafka/protocol/requests_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/requests_test_cc.j2
@@ -38,7 +38,7 @@ template <typename T> std::shared_ptr<T> RequestTest::serializeAndDeserialize(T 
   putMessageIntoBuffer(message);
 
   std::shared_ptr<MockMessageListener> mock_listener = std::make_shared<MockMessageListener>();
-  RequestDecoder testee{RequestParserResolver::getDefaultInstance(), {mock_listener}};
+  RequestDecoder testee{ {mock_listener} };
 
   AbstractRequestSharedPtr received_message;
   EXPECT_CALL(*mock_listener, onMessage(testing::_))

--- a/test/extensions/filters/network/kafka/request_codec_unit_test.cc
+++ b/test/extensions/filters/network/kafka/request_codec_unit_test.cc
@@ -50,7 +50,7 @@ class RequestCodecUnitTest : public testing::Test, public BufferBasedTest {
 protected:
   MockParserFactory initial_parser_factory_{};
   MockRequestParserResolver parser_resolver_{};
-  MockRequestCallbackSharedPtr request_callback_{std::make_shared<MockRequestCallback>()};
+  MockRequestCallbackSharedPtr callback_{std::make_shared<MockRequestCallback>()};
 };
 
 RequestParseResponse consumeOneByte(absl::string_view& data) {
@@ -67,16 +67,16 @@ TEST_F(RequestCodecUnitTest, shouldDoNothingIfParserReturnsWaiting) {
 
   EXPECT_CALL(initial_parser_factory_, create(_)).WillOnce(Return(parser));
 
-  EXPECT_CALL(*request_callback_, onMessage(_)).Times(0);
-  EXPECT_CALL(*request_callback_, onFailedParse(_)).Times(0);
+  EXPECT_CALL(*callback_, onMessage(_)).Times(0);
+  EXPECT_CALL(*callback_, onFailedParse(_)).Times(0);
 
-  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {request_callback_}};
+  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {callback_}};
 
   // when
   testee.onData(buffer_);
 
   // then
-  // There were no interactions with `request_callback_`.
+  // There were no interactions with `callback_`.
 }
 
 TEST_F(RequestCodecUnitTest, shouldUseNewParserAsResponse) {
@@ -91,57 +91,61 @@ TEST_F(RequestCodecUnitTest, shouldUseNewParserAsResponse) {
   EXPECT_CALL(*parser3, parse(_)).Times(AnyNumber()).WillRepeatedly(Invoke(consumeOneByte));
 
   EXPECT_CALL(initial_parser_factory_, create(_)).WillOnce(Return(parser1));
+  EXPECT_CALL(parser_resolver_, createParser(_, _, _)).Times(0);
 
-  EXPECT_CALL(*request_callback_, onMessage(_)).Times(0);
-  EXPECT_CALL(*request_callback_, onFailedParse(_)).Times(0);
+  EXPECT_CALL(*callback_, onMessage(_)).Times(0);
+  EXPECT_CALL(*callback_, onFailedParse(_)).Times(0);
 
-  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {request_callback_}};
-
-  // when
-  testee.onData(buffer_);
-
-  // then
-  // There were no interactions with `request_callback_`.
-}
-
-TEST_F(RequestCodecUnitTest, shouldPassParsedMessageToCallbackAndReinitialize) {
-  // given
-  putGarbageIntoBuffer();
-
-  AbstractRequestSharedPtr message = std::make_shared<Request<int32_t>>(RequestHeader(), 0);
-
-  MockParserSharedPtr parser1 = std::make_shared<MockParser>();
-  EXPECT_CALL(*parser1, parse(_)).WillOnce(Return(RequestParseResponse::parsedMessage(message)));
-
-  MockParserSharedPtr parser2 = std::make_shared<MockParser>();
-  EXPECT_CALL(*parser2, parse(_)).Times(AnyNumber()).WillRepeatedly(Invoke(consumeOneByte));
-
-  EXPECT_CALL(initial_parser_factory_, create(_))
-      .WillOnce(Return(parser1))
-      .WillOnce(Return(parser2));
-
-  EXPECT_CALL(*request_callback_, onMessage(message));
-  EXPECT_CALL(*request_callback_, onFailedParse(_)).Times(0);
-
-  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {request_callback_}};
+  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {callback_}};
 
   // when
   testee.onData(buffer_);
 
   // then
-  // `request_callback_` had `onFailedParse` invoked once with matching argument.
+  ASSERT_EQ(testee.getCurrentParserForTest(), parser3);
+  // Also, there were no interactions with `callback_`.
 }
 
-TEST_F(RequestCodecUnitTest, shouldPassParseFailureDataToCallbackAndReinitialize) {
+TEST_F(RequestCodecUnitTest, shouldPassParsedMessageToCallback) {
   // given
   putGarbageIntoBuffer();
 
-  RequestParseFailureSharedPtr failure_data =
-      std::make_shared<RequestParseFailure>(RequestHeader());
+  const AbstractRequestSharedPtr parsed_message =
+      std::make_shared<Request<int32_t>>(RequestHeader{0, 0, 0, ""}, 0);
+
+  MockParserSharedPtr all_consuming_parser = std::make_shared<MockParser>();
+  auto consume_and_return = [&parsed_message](absl::string_view& data) -> RequestParseResponse {
+    data = {data.data() + data.size(), 0};
+    return RequestParseResponse::parsedMessage(parsed_message);
+  };
+  EXPECT_CALL(*all_consuming_parser, parse(_)).WillOnce(Invoke(consume_and_return));
+
+  EXPECT_CALL(initial_parser_factory_, create(_)).WillOnce(Return(all_consuming_parser));
+  EXPECT_CALL(parser_resolver_, createParser(_, _, _)).Times(0);
+
+  EXPECT_CALL(*callback_, onMessage(parsed_message));
+  EXPECT_CALL(*callback_, onFailedParse(_)).Times(0);
+
+  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {callback_}};
+
+  // when
+  testee.onData(buffer_);
+
+  // then
+  ASSERT_EQ(testee.getCurrentParserForTest(), nullptr);
+  // Also, `callback_` had `onMessage` invoked once with matching argument.
+}
+
+TEST_F(RequestCodecUnitTest, shouldPassParsedMessageToCallbackAndInitializeNextParser) {
+  // given
+  putGarbageIntoBuffer();
+
+  const AbstractRequestSharedPtr parsed_message =
+      std::make_shared<Request<int32_t>>(RequestHeader(), 0);
 
   MockParserSharedPtr parser1 = std::make_shared<MockParser>();
   EXPECT_CALL(*parser1, parse(_))
-      .WillOnce(Return(RequestParseResponse::parseFailure(failure_data)));
+      .WillOnce(Return(RequestParseResponse::parsedMessage(parsed_message)));
 
   MockParserSharedPtr parser2 = std::make_shared<MockParser>();
   EXPECT_CALL(*parser2, parse(_)).Times(AnyNumber()).WillRepeatedly(Invoke(consumeOneByte));
@@ -150,16 +154,47 @@ TEST_F(RequestCodecUnitTest, shouldPassParseFailureDataToCallbackAndReinitialize
       .WillOnce(Return(parser1))
       .WillOnce(Return(parser2));
 
-  EXPECT_CALL(*request_callback_, onMessage(_)).Times(0);
-  EXPECT_CALL(*request_callback_, onFailedParse(failure_data));
+  EXPECT_CALL(*callback_, onMessage(parsed_message));
+  EXPECT_CALL(*callback_, onFailedParse(_)).Times(0);
 
-  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {request_callback_}};
+  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {callback_}};
 
   // when
   testee.onData(buffer_);
 
   // then
-  // `request_callback_` had `onFailedParse` invoked once with matching argument.
+  ASSERT_EQ(testee.getCurrentParserForTest(), parser2);
+  // Also, `callback_` had `onMessage` invoked once with matching argument.
+}
+
+TEST_F(RequestCodecUnitTest, shouldPassParseFailureDataToCallback) {
+  // given
+  putGarbageIntoBuffer();
+
+  const RequestParseFailureSharedPtr failure_data =
+      std::make_shared<RequestParseFailure>(RequestHeader());
+
+  MockParserSharedPtr parser = std::make_shared<MockParser>();
+  auto consume_and_return = [&failure_data](absl::string_view& data) -> RequestParseResponse {
+    data = {data.data() + data.size(), 0};
+    return RequestParseResponse::parseFailure(failure_data);
+  };
+  EXPECT_CALL(*parser, parse(_)).WillOnce(Invoke(consume_and_return));
+
+  EXPECT_CALL(initial_parser_factory_, create(_)).WillOnce(Return(parser));
+  EXPECT_CALL(parser_resolver_, createParser(_, _, _)).Times(0);
+
+  EXPECT_CALL(*callback_, onMessage(_)).Times(0);
+  EXPECT_CALL(*callback_, onFailedParse(failure_data));
+
+  RequestDecoder testee{initial_parser_factory_, parser_resolver_, {callback_}};
+
+  // when
+  testee.onData(buffer_);
+
+  // then
+  ASSERT_EQ(testee.getCurrentParserForTest(), nullptr);
+  // Also, `callback_` had `onFailedParse` invoked once with matching argument.
 }
 
 } // namespace RequestCodecUnitTest


### PR DESCRIPTION
Description: Refactoring promised in `impl note` section of https://github.com/envoyproxy/envoy/pull/6993#issuecomment-495696775 . 
Response & request codec are following the same paradigm, they use an outer parse-result driven loop, that finally notifies callbacks. The common code & related stuff have been extracted.

Risk Level: Low (Kafka code is unused right now)
Testing: automated tests, manual testing with real Kafka broker and client (dummy filter that deserializes the buffer, clears it, serializes the parse results into buffer again (what should be equivalent to what was received), and passes the buffer's contents further on - done for both requests & responses)
Docs Changes: n/a
Release Notes: n/a