### PR TITLE
libevent: update to include patch on master

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -135,7 +135,7 @@ REPOSITORY_LOCATIONS = dict(
         # and https://github.com/lyft/envoy-mobile/issues/215.
         # TODO(mergeconflict): Update to v2.2 when it is released.
         strip_prefix = "libevent-0d7d85c2083f7a4c9efe01c061486f332b576d28",
-        # 2019-05-16
+        # 2019-07-02
         urls = ["https://github.com/libevent/libevent/archive/0d7d85c2083f7a4c9efe01c061486f332b576d28.tar.gz"],
     ),
     net_zlib = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -127,7 +127,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/benchmark/archive/v1.5.0.tar.gz"],
     ),
     com_github_libevent_libevent = dict(
-        sha256 = "6f799dd920aab9487cb04cd40627a5d4104fbbd246ebb5c8fd5e520055af2ef5",
+        sha256 = "549d34065eb2485dfad6c8de638caaa6616ed130eec36dd978f73b6bdd5af113",
         # This SHA includes the new "prepare" and "check" watchers, used for event loop performance
         # stats (see https://github.com/libevent/libevent/pull/793) and the fix for a race condition
         # in the watchers (see https://github.com/libevent/libevent/pull/802).

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -131,11 +131,12 @@ REPOSITORY_LOCATIONS = dict(
         # This SHA includes the new "prepare" and "check" watchers, used for event loop performance
         # stats (see https://github.com/libevent/libevent/pull/793) and the fix for a race condition
         # in the watchers (see https://github.com/libevent/libevent/pull/802).
-        # This also includes the fix for https://github.com/libevent/libevent/issues/806
+        # This also includes the fixes for https://github.com/libevent/libevent/issues/806
+        # and https://github.com/lyft/envoy-mobile/issues/215.
         # TODO(mergeconflict): Update to v2.2 when it is released.
-        strip_prefix = "libevent-3b1864b625ec37c3051512845982f347f4cc5621",
+        strip_prefix = "libevent-0d7d85c2083f7a4c9efe01c061486f332b576d28",
         # 2019-05-16
-        urls = ["https://github.com/libevent/libevent/archive/3b1864b625ec37c3051512845982f347f4cc5621.tar.gz"],
+        urls = ["https://github.com/libevent/libevent/archive/0d7d85c2083f7a4c9efe01c061486f332b576d28.tar.gz"],
     ),
     net_zlib = dict(
         # TODO(moderation): revert to com_github_madler_zlib name pending resolution of workaround


### PR DESCRIPTION
Pulls in the change added by https://github.com/libevent/libevent/pull/849 to address https://github.com/lyft/envoy-mobile/issues/215.

Signed-off-by: Michael Rebello <mrebello@lyft.com>