### PR TITLE
Add socket option names for debugging.

### DIFF
--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <tuple>
 #include <vector>
 
 #include "envoy/api/v2/core/base.pb.h"
@@ -15,9 +16,31 @@
 namespace Envoy {
 namespace Network {
 
-// Optional variant of setsockopt(2) optname. The idea here is that if the option is not supported
-// on a platform, we can make this the empty value. This allows us to avoid proliferation of #ifdef.
-using SocketOptionName = absl::optional<std::pair<int, int>>;
+// SocketOptionName is an optional value that captures the setsockopt(2)
+// arguments. The idea here is that if a socket option is not supported
+// on a platform, we can make this the empty value, which allows us to
+// avoid #ifdef proliferation of #ifdef.
+struct SocketOptionName {
+  SocketOptionName() = default;
+  SocketOptionName(const SocketOptionName&) = default;
+  SocketOptionName(int level, int option, const std::string& name)
+      : value_(std::make_tuple(level, option, name)) {}
+
+  int level() const { return std::get<0>(value_.value()); }
+  int option() const { return std::get<1>(value_.value()); }
+  const std::string& name() const { return std::get<2>(value_.value()); }
+
+  bool has_value() const { return value_.has_value(); }
+  bool operator==(const SocketOptionName& rhs) const { return value_ == rhs.value_; }
+
+private:
+  absl::optional<std::tuple<int, int, std::string>> value_;
+};
+
+// ENVOY_MAKE_SOCKET_OPTION_NAME is a helper macro to generate a
+// SocketOptionName with a descriptive string name.
+#define ENVOY_MAKE_SOCKET_OPTION_NAME(level, option)                                               \
+  Network::SocketOptionName(level, option, #level "/" #option)
 
 /**
  * Base class for Sockets

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -19,7 +19,7 @@ namespace Network {
 // SocketOptionName is an optional value that captures the setsockopt(2)
 // arguments. The idea here is that if a socket option is not supported
 // on a platform, we can make this the empty value, which allows us to
-// avoid #ifdef proliferation of #ifdef.
+// avoid #ifdef proliferation.
 struct SocketOptionName {
   SocketOptionName() = default;
   SocketOptionName(const SocketOptionName&) = default;

--- a/source/common/network/socket_option_factory.cc
+++ b/source/common/network/socket_option_factory.cc
@@ -1,5 +1,6 @@
 #include "common/network/socket_option_factory.h"
 
+#include "common/common/fmt.h"
 #include "common/network/addr_family_aware_socket_option_impl.h"
 #include "common/network/socket_option_impl.h"
 
@@ -73,13 +74,15 @@ std::unique_ptr<Socket::Options> SocketOptionFactory::buildLiteralOptions(
       buf.append(socket_option.buf_value());
       break;
     default:
-      ENVOY_LOG(warn, "Socket option specified with no or uknown value: {}",
+      ENVOY_LOG(warn, "Socket option specified with no or unknown value: {}",
                 socket_option.DebugString());
       continue;
     }
     options->emplace_back(std::make_shared<Network::SocketOptionImpl>(
         socket_option.state(),
-        Network::SocketOptionName(std::make_pair(socket_option.level(), socket_option.name())),
+        Network::SocketOptionName(
+            socket_option.level(), socket_option.name(),
+            fmt::format("{}/{}", socket_option.level(), socket_option.name())),
         buf));
   }
   return options;
@@ -107,7 +110,7 @@ std::unique_ptr<Socket::Options> SocketOptionFactory::buildRxQueueOverFlowOption
 #ifdef SO_RXQ_OVFL
   options->push_back(std::make_shared<Network::SocketOptionImpl>(
       envoy::api::v2::core::SocketOption::STATE_BOUND,
-      Network::SocketOptionName(std::make_pair(SOL_SOCKET, SO_RXQ_OVFL)), 1));
+      ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_RXQ_OVFL), 1));
 #endif
   return options;
 }

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -13,71 +13,63 @@ namespace Envoy {
 namespace Network {
 
 #ifdef IP_TRANSPARENT
-#define ENVOY_SOCKET_IP_TRANSPARENT                                                                \
-  Network::SocketOptionName(std::make_pair(IPPROTO_IP, IP_TRANSPARENT))
+#define ENVOY_SOCKET_IP_TRANSPARENT ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IP, IP_TRANSPARENT)
 #else
 #define ENVOY_SOCKET_IP_TRANSPARENT Network::SocketOptionName()
 #endif
 
 #ifdef IPV6_TRANSPARENT
-#define ENVOY_SOCKET_IPV6_TRANSPARENT                                                              \
-  Network::SocketOptionName(std::make_pair(IPPROTO_IPV6, IPV6_TRANSPARENT))
+#define ENVOY_SOCKET_IPV6_TRANSPARENT ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IPV6, IPV6_TRANSPARENT)
 #else
 #define ENVOY_SOCKET_IPV6_TRANSPARENT Network::SocketOptionName()
 #endif
 
 #ifdef IP_FREEBIND
-#define ENVOY_SOCKET_IP_FREEBIND Network::SocketOptionName(std::make_pair(IPPROTO_IP, IP_FREEBIND))
+#define ENVOY_SOCKET_IP_FREEBIND ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IP, IP_FREEBIND)
 #else
 #define ENVOY_SOCKET_IP_FREEBIND Network::SocketOptionName()
 #endif
 
 #ifdef IPV6_FREEBIND
-#define ENVOY_SOCKET_IPV6_FREEBIND                                                                 \
-  Network::SocketOptionName(std::make_pair(IPPROTO_IPV6, IPV6_FREEBIND))
+#define ENVOY_SOCKET_IPV6_FREEBIND ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IPV6, IPV6_FREEBIND)
 #else
 #define ENVOY_SOCKET_IPV6_FREEBIND Network::SocketOptionName()
 #endif
 
 #ifdef SO_KEEPALIVE
-#define ENVOY_SOCKET_SO_KEEPALIVE                                                                  \
-  Network::SocketOptionName(std::make_pair(SOL_SOCKET, SO_KEEPALIVE))
+#define ENVOY_SOCKET_SO_KEEPALIVE ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_KEEPALIVE)
 #else
 #define ENVOY_SOCKET_SO_KEEPALIVE Network::SocketOptionName()
 #endif
 
 #ifdef SO_MARK
-#define ENVOY_SOCKET_SO_MARK Network::SocketOptionName(std::make_pair(SOL_SOCKET, SO_MARK))
+#define ENVOY_SOCKET_SO_MARK ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_MARK)
 #else
 #define ENVOY_SOCKET_SO_MARK Network::SocketOptionName()
 #endif
 
 #ifdef TCP_KEEPCNT
-#define ENVOY_SOCKET_TCP_KEEPCNT Network::SocketOptionName(std::make_pair(IPPROTO_TCP, TCP_KEEPCNT))
+#define ENVOY_SOCKET_TCP_KEEPCNT ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_TCP, TCP_KEEPCNT)
 #else
 #define ENVOY_SOCKET_TCP_KEEPCNT Network::SocketOptionName()
 #endif
 
 #ifdef TCP_KEEPIDLE
-#define ENVOY_SOCKET_TCP_KEEPIDLE                                                                  \
-  Network::SocketOptionName(std::make_pair(IPPROTO_TCP, TCP_KEEPIDLE))
+#define ENVOY_SOCKET_TCP_KEEPIDLE ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_TCP, TCP_KEEPIDLE)
 #elif TCP_KEEPALIVE // macOS uses a different name from Linux for just this option.
-#define ENVOY_SOCKET_TCP_KEEPIDLE                                                                  \
-  Network::SocketOptionName(std::make_pair(IPPROTO_TCP, TCP_KEEPALIVE))
+#define ENVOY_SOCKET_TCP_KEEPIDLE ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_TCP, TCP_KEEPALIVE)
 #else
 #define ENVOY_SOCKET_TCP_KEEPIDLE Network::SocketOptionName()
 #endif
 
 #ifdef TCP_KEEPINTVL
-#define ENVOY_SOCKET_TCP_KEEPINTVL                                                                 \
-  Network::SocketOptionName(std::make_pair(IPPROTO_TCP, TCP_KEEPINTVL))
+#define ENVOY_SOCKET_TCP_KEEPINTVL ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_TCP, TCP_KEEPINTVL)
 #else
 #define ENVOY_SOCKET_TCP_KEEPINTVL Network::SocketOptionName()
 #endif
 
 #ifdef TCP_FASTOPEN
-#define ENVOY_SOCKET_TCP_FASTOPEN                                                                  \
-  Network::SocketOptionName(std::make_pair(IPPROTO_TCP, TCP_FASTOPEN))
+#define ENVOY_SOCKET_TCP_FASTOPEN ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_TCP, TCP_FASTOPEN)
 #else
 #define ENVOY_SOCKET_TCP_FASTOPEN Network::SocketOptionName()
 #endif
@@ -87,20 +79,22 @@ namespace Network {
 // FreeBSD uses IP_RECVDSTADDR for receiving destination address and IP_SENDSRCADDR for sending
 // source address.
 #ifdef IP_RECVDSTADDR
-#define ENVOY_RECV_IP_PKT_INFO Network::SocketOptionName(std::make_pair(IPPROTO_IP, IP_RECVDSTADDR))
+#define ENVOY_RECV_IP_PKT_INFO ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IP, IP_RECVDSTADDR)
 #elif IP_PKTINFO
-#define ENVOY_RECV_IP_PKT_INFO Network::SocketOptionName(std::make_pair(IPPROTO_IP, IP_PKTINFO))
+#define ENVOY_RECV_IP_PKT_INFO ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IP, IP_PKTINFO)
+#else
+#define ENVOY_RECV_IP_PKT_INFO Network::SocketOptionName()
 #endif
 
 // Both Linux and FreeBSD use IPV6_RECVPKTINFO for both sending source address and
 // receiving destination address.
-#define ENVOY_RECV_IPV6_PKT_INFO                                                                   \
-  Network::SocketOptionName(std::make_pair(IPPROTO_IPV6, IPV6_RECVPKTINFO))
+#define ENVOY_RECV_IPV6_PKT_INFO ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IPV6, IPV6_RECVPKTINFO)
 
 class SocketOptionImpl : public Socket::Option, Logger::Loggable<Logger::Id::connection> {
 public:
   SocketOptionImpl(envoy::api::v2::core::SocketOption::SocketState in_state,
-                   Network::SocketOptionName optname, int value) // Yup, int. See setsockopt(2).
+                   Network::SocketOptionName optname,
+                   int value) // Yup, int. See setsockopt(2).
       : SocketOptionImpl(in_state, optname,
                          absl::string_view(reinterpret_cast<char*>(&value), sizeof(value))) {}
 
@@ -129,7 +123,8 @@ public:
    * @return a Api::SysCallIntResult with rc_ = 0 for success and rc = -1 for failure. If the call
    * is successful, errno_ shouldn't be used.
    */
-  static Api::SysCallIntResult setSocketOption(Socket& socket, Network::SocketOptionName optname,
+  static Api::SysCallIntResult setSocketOption(Socket& socket,
+                                               const Network::SocketOptionName& optname,
                                                absl::string_view value);
 
 private:

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -23,7 +23,7 @@ protected:
 // We fail to set the option when the underlying setsockopt syscall fails.
 TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
                                                 {},
                                                 1};
   EXPECT_LOG_CONTAINS("warning", "Failed to set IP socket option on non-IP socket",
@@ -47,10 +47,10 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionSuccess) {
   EXPECT_CALL(testing::Const(socket_), ioHandle()).WillRepeatedly(testing::ReturnRef(*io_handle));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
                                                 {},
                                                 1};
-  testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1,
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
@@ -62,7 +62,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4EmptyOptionNames) {
   AddrFamilyAwareSocketOptionImpl socket_option{
       envoy::api::v2::core::SocketOption::STATE_PREBIND, {}, {}, 1};
 
-  EXPECT_LOG_CONTAINS("warning", "Setting option on socket failed: Operation not supported",
+  EXPECT_LOG_CONTAINS("warning", "Failed to set unsupported option on socket",
                       EXPECT_FALSE(socket_option.setOption(
                           socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
 }
@@ -75,7 +75,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
   AddrFamilyAwareSocketOptionImpl socket_option{
       envoy::api::v2::core::SocketOption::STATE_PREBIND, {}, {}, 1};
 
-  EXPECT_LOG_CONTAINS("warning", "Setting option on socket failed: Operation not supported",
+  EXPECT_LOG_CONTAINS("warning", "Failed to set unsupported option on socket",
                       EXPECT_FALSE(socket_option.setOption(
                           socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
 }
@@ -88,10 +88,9 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
   EXPECT_CALL(testing::Const(socket_), ioHandle()).WillRepeatedly(testing::ReturnRef(*io_handle));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
-                                                1};
-  testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 1};
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1,
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
@@ -103,9 +102,9 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 {},
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11),
                                                 1};
-  testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(6, 11)), 1,
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 1,
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
@@ -117,10 +116,10 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
   EXPECT_CALL(testing::Const(socket_), ioHandle()).WillRepeatedly(testing::ReturnRef(*io_handle));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
                                                 {},
                                                 1};
-  testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1,
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
@@ -132,10 +131,9 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Precedence) {
   EXPECT_CALL(testing::Const(socket_), ioHandle()).WillRepeatedly(testing::ReturnRef(*io_handle));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
-                                                1};
-  testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(6, 11)), 1,
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 1};
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 1,
                              {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
@@ -144,13 +142,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4GetSocketOptionName) {
   socket_.local_address_ = Utility::parseInternetAddress("1.2.3.4", 5678);
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
-                                                1};
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 1};
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), makeDetails(std::make_pair(5, 10), 1));
+  EXPECT_EQ(result.value(), makeDetails(ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1));
 }
 
 // GetSocketOptionName returns the v4 information for a v6 address
@@ -158,13 +155,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6GetSocketOptionName) {
   socket_.local_address_ = Utility::parseInternetAddress("2::1", 5678);
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
-                                                5};
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 5};
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), makeDetails(std::make_pair(6, 11), 5));
+  EXPECT_EQ(result.value(), makeDetails(ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 5));
 }
 
 // GetSocketOptionName returns nullopt if the state is wrong
@@ -172,9 +168,8 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, GetSocketOptionWrongState) {
   socket_.local_address_ = Utility::parseInternetAddress("2::1", 5678);
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
-                                                5};
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 5};
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_BOUND);
   EXPECT_FALSE(result.has_value());
@@ -183,9 +178,8 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, GetSocketOptionWrongState) {
 // GetSocketOptionName returns nullopt if the version could not be determined
 TEST_F(AddrFamilyAwareSocketOptionImplTest, GetSocketOptionCannotDetermineVersion) {
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                                Network::SocketOptionName(std::make_pair(5, 10)),
-                                                Network::SocketOptionName(std::make_pair(6, 11)),
-                                                5};
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10),
+                                                ENVOY_MAKE_SOCKET_OPTION_NAME(6, 11), 5};
 
   IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>();
   EXPECT_CALL(testing::Const(socket_), ioHandle()).WillOnce(testing::ReturnRef(*io_handle));

--- a/test/common/network/socket_option_factory_test.cc
+++ b/test/common/network/socket_option_factory_test.cc
@@ -55,8 +55,8 @@ TEST_F(SocketOptionFactoryTest, TestBuildSocketMarkOptions) {
   const auto expected_option = ENVOY_SOCKET_SO_MARK;
   CHECK_OPTION_SUPPORTED(expected_option);
 
-  const int type = expected_option.value().first;
-  const int option = expected_option.value().second;
+  const int type = expected_option.level();
+  const int option = expected_option.option();
   EXPECT_CALL(os_sys_calls_mock_, setsockopt_(_, _, _, _, sizeof(int)))
       .WillOnce(Invoke([type, option](int, int input_type, int input_option, const void* optval,
                                       socklen_t) -> int {
@@ -79,8 +79,8 @@ TEST_F(SocketOptionFactoryTest, TestBuildIpv4TransparentOptions) {
   const auto expected_option = ENVOY_SOCKET_IP_TRANSPARENT;
   CHECK_OPTION_SUPPORTED(expected_option);
 
-  const int type = expected_option.value().first;
-  const int option = expected_option.value().second;
+  const int type = expected_option.level();
+  const int option = expected_option.option();
   EXPECT_CALL(os_sys_calls_mock_, setsockopt_(_, _, _, _, sizeof(int)))
       .Times(2)
       .WillRepeatedly(Invoke([type, option](int, int input_type, int input_option,
@@ -106,8 +106,8 @@ TEST_F(SocketOptionFactoryTest, TestBuildIpv6TransparentOptions) {
   const auto expected_option = ENVOY_SOCKET_IPV6_TRANSPARENT;
   CHECK_OPTION_SUPPORTED(expected_option);
 
-  const int type = expected_option.value().first;
-  const int option = expected_option.value().second;
+  const int type = expected_option.level();
+  const int option = expected_option.option();
   EXPECT_CALL(os_sys_calls_mock_, setsockopt_(_, _, _, _, sizeof(int)))
       .Times(2)
       .WillRepeatedly(Invoke([type, option](int, int input_type, int input_option,
@@ -152,8 +152,8 @@ TEST_F(SocketOptionFactoryTest, TestBuildLiteralOptions) {
   auto option_details = socket_options->at(0)->getOptionDetails(
       socket_mock_, envoy::api::v2::core::SocketOption::STATE_PREBIND);
   EXPECT_TRUE(option_details.has_value());
-  EXPECT_EQ(SOL_SOCKET, option_details->name_->first);
-  EXPECT_EQ(SO_LINGER, option_details->name_->second);
+  EXPECT_EQ(SOL_SOCKET, option_details->name_.level());
+  EXPECT_EQ(SO_LINGER, option_details->name_.option());
   EXPECT_EQ(sizeof(struct linger), option_details->value_.size());
   const struct linger* linger_ptr =
       reinterpret_cast<const struct linger*>(option_details->value_.data());
@@ -163,8 +163,8 @@ TEST_F(SocketOptionFactoryTest, TestBuildLiteralOptions) {
   option_details = socket_options->at(1)->getOptionDetails(
       socket_mock_, envoy::api::v2::core::SocketOption::STATE_PREBIND);
   EXPECT_TRUE(option_details.has_value());
-  EXPECT_EQ(SOL_SOCKET, option_details->name_->first);
-  EXPECT_EQ(SO_KEEPALIVE, option_details->name_->second);
+  EXPECT_EQ(SOL_SOCKET, option_details->name_.level());
+  EXPECT_EQ(SO_KEEPALIVE, option_details->name_.option());
   EXPECT_EQ(sizeof(int), option_details->value_.size());
   const int* flag_ptr = reinterpret_cast<const int*>(option_details->value_.data());
   EXPECT_EQ(1, *flag_ptr);

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -13,9 +13,36 @@ TEST_F(SocketOptionImplTest, BadFd) {
   EXPECT_EQ(ENOTSUP, result.errno_);
 }
 
+TEST_F(SocketOptionImplTest, HasName) {
+  auto optname = ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_SNDBUF);
+
+  // Verify that the constructor macro sets all the fields correctly.
+  EXPECT_TRUE(optname.has_value());
+  EXPECT_EQ(SOL_SOCKET, optname.level());
+  EXPECT_EQ(SO_SNDBUF, optname.option());
+  EXPECT_EQ("SOL_SOCKET/SO_SNDBUF", optname.name());
+
+  // The default constructor should not have a value, i.e. should
+  // be unsupported.
+  EXPECT_FALSE(SocketOptionName().has_value());
+
+  // If we fail to set an option, verify that the log message
+  // contains the option name so the operator can debug.
+  SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND, optname, 1};
+  EXPECT_CALL(os_sys_calls_, setsockopt_(_, _, _, _, _))
+      .WillOnce(Invoke([](int, int, int, const void* optval, socklen_t) -> int {
+        EXPECT_EQ(1, *static_cast<const int*>(optval));
+        return -1;
+      }));
+
+  EXPECT_LOG_CONTAINS(
+      "warning", "Setting SOL_SOCKET/SO_SNDBUF option on socket failed",
+      socket_option.setOption(socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND));
+}
+
 TEST_F(SocketOptionImplTest, SetOptionSuccessTrue) {
   SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                 Network::SocketOptionName(std::make_pair(5, 10)), 1};
+                                 ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1};
   EXPECT_CALL(os_sys_calls_, setsockopt_(_, 5, 10, _, sizeof(int)))
       .WillOnce(Invoke([](int, int, int, const void* optval, socklen_t) -> int {
         EXPECT_EQ(1, *static_cast<const int*>(optval));
@@ -26,27 +53,27 @@ TEST_F(SocketOptionImplTest, SetOptionSuccessTrue) {
 
 TEST_F(SocketOptionImplTest, GetOptionDetailsCorrectState) {
   SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
-                                 Network::SocketOptionName(std::make_pair(5, 10)), 1};
+                                 ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1};
 
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, makeDetails(std::make_pair(5, 10), 1));
+  EXPECT_EQ(*result, makeDetails(ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1));
 }
 
 TEST_F(SocketOptionImplTest, GetMoreOptionDetailsCorrectState) {
   SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_LISTENING,
-                                 Network::SocketOptionName(std::make_pair(7, 9)), 5};
+                                 ENVOY_MAKE_SOCKET_OPTION_NAME(7, 9), 5};
 
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_LISTENING);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, makeDetails(std::make_pair(7, 9), 5));
+  EXPECT_EQ(*result, makeDetails(ENVOY_MAKE_SOCKET_OPTION_NAME(7, 9), 5));
 }
 
 TEST_F(SocketOptionImplTest, GetOptionDetailsFailureWrongState) {
   SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_LISTENING,
-                                 Network::SocketOptionName(std::make_pair(7, 9)), 5};
+                                 ENVOY_MAKE_SOCKET_OPTION_NAME(7, 9), 5};
 
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_BOUND);
@@ -55,7 +82,7 @@ TEST_F(SocketOptionImplTest, GetOptionDetailsFailureWrongState) {
 
 TEST_F(SocketOptionImplTest, GetUnsupportedOptReturnsNullopt) {
   SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_LISTENING,
-                                 Network::SocketOptionName(absl::nullopt), 5};
+                                 Network::SocketOptionName(), 5};
 
   auto result =
       socket_option.getOptionDetails(socket_, envoy::api::v2::core::SocketOption::STATE_LISTENING);

--- a/test/common/network/socket_option_test.h
+++ b/test/common/network/socket_option_test.h
@@ -39,8 +39,8 @@ public:
       const std::set<envoy::api::v2::core::SocketOption::SocketState>& when) {
     for (auto state : when) {
       if (option_name.has_value()) {
-        EXPECT_CALL(os_sys_calls_, setsockopt_(_, option_name.value().first,
-                                               option_name.value().second, _, sizeof(int)))
+        EXPECT_CALL(os_sys_calls_,
+                    setsockopt_(_, option_name.level(), option_name.option(), _, sizeof(int)))
             .WillOnce(Invoke([option_val](int, int, int, const void* optval, socklen_t) -> int {
               EXPECT_EQ(option_val, *static_cast<const int*>(optval));
               return 0;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2838,8 +2838,8 @@ public:
         expect_success = false;
         continue;
       }
-      EXPECT_CALL(os_sys_calls, setsockopt_(_, name_val.first.value().first,
-                                            name_val.first.value().second, _, sizeof(int)))
+      EXPECT_CALL(os_sys_calls,
+                  setsockopt_(_, name_val.first.level(), name_val.first.option(), _, sizeof(int)))
           .WillOnce(Invoke([&name_val](int, int, int, const void* optval, socklen_t) -> int {
             EXPECT_EQ(name_val.second, *static_cast<const int*>(optval));
             return 0;
@@ -3009,7 +3009,7 @@ TEST_F(SockoptsTest, SockoptsClusterOnly) {
   )EOF";
   initialize(yaml);
   std::vector<std::pair<Network::SocketOptionName, int>> names_vals{
-      {Network::SocketOptionName({1, 2}), 3}, {Network::SocketOptionName({4, 5}), 6}};
+      {ENVOY_MAKE_SOCKET_OPTION_NAME(1, 2), 3}, {ENVOY_MAKE_SOCKET_OPTION_NAME(4, 5), 6}};
   expectSetsockopts(names_vals);
 }
 
@@ -3037,7 +3037,7 @@ TEST_F(SockoptsTest, SockoptsClusterManagerOnly) {
   )EOF";
   initialize(yaml);
   std::vector<std::pair<Network::SocketOptionName, int>> names_vals{
-      {Network::SocketOptionName({1, 2}), 3}, {Network::SocketOptionName({4, 5}), 6}};
+      {ENVOY_MAKE_SOCKET_OPTION_NAME(1, 2), 3}, {ENVOY_MAKE_SOCKET_OPTION_NAME(4, 5), 6}};
   expectSetsockopts(names_vals);
 }
 
@@ -3067,7 +3067,7 @@ TEST_F(SockoptsTest, SockoptsClusterOverride) {
   )EOF";
   initialize(yaml);
   std::vector<std::pair<Network::SocketOptionName, int>> names_vals{
-      {Network::SocketOptionName({1, 2}), 3}, {Network::SocketOptionName({4, 5}), 6}};
+      {ENVOY_MAKE_SOCKET_OPTION_NAME(1, 2), 3}, {ENVOY_MAKE_SOCKET_OPTION_NAME(4, 5), 6}};
   expectSetsockopts(names_vals);
 }
 
@@ -3116,16 +3116,15 @@ public:
                   options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
               return connection_;
             }));
-    EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_SO_KEEPALIVE.value().first,
-                                          ENVOY_SOCKET_SO_KEEPALIVE.value().second, _, sizeof(int)))
+    EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_SO_KEEPALIVE.level(),
+                                          ENVOY_SOCKET_SO_KEEPALIVE.option(), _, sizeof(int)))
         .WillOnce(Invoke([](int, int, int, const void* optval, socklen_t) -> int {
           EXPECT_EQ(1, *static_cast<const int*>(optval));
           return 0;
         }));
     if (keepalive_probes.has_value()) {
-      EXPECT_CALL(os_sys_calls,
-                  setsockopt_(_, ENVOY_SOCKET_TCP_KEEPCNT.value().first,
-                              ENVOY_SOCKET_TCP_KEEPCNT.value().second, _, sizeof(int)))
+      EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_TCP_KEEPCNT.level(),
+                                            ENVOY_SOCKET_TCP_KEEPCNT.option(), _, sizeof(int)))
           .WillOnce(
               Invoke([&keepalive_probes](int, int, int, const void* optval, socklen_t) -> int {
                 EXPECT_EQ(keepalive_probes.value(), *static_cast<const int*>(optval));
@@ -3133,18 +3132,16 @@ public:
               }));
     }
     if (keepalive_time.has_value()) {
-      EXPECT_CALL(os_sys_calls,
-                  setsockopt_(_, ENVOY_SOCKET_TCP_KEEPIDLE.value().first,
-                              ENVOY_SOCKET_TCP_KEEPIDLE.value().second, _, sizeof(int)))
+      EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_TCP_KEEPIDLE.level(),
+                                            ENVOY_SOCKET_TCP_KEEPIDLE.option(), _, sizeof(int)))
           .WillOnce(Invoke([&keepalive_time](int, int, int, const void* optval, socklen_t) -> int {
             EXPECT_EQ(keepalive_time.value(), *static_cast<const int*>(optval));
             return 0;
           }));
     }
     if (keepalive_interval.has_value()) {
-      EXPECT_CALL(os_sys_calls,
-                  setsockopt_(_, ENVOY_SOCKET_TCP_KEEPINTVL.value().first,
-                              ENVOY_SOCKET_TCP_KEEPINTVL.value().second, _, sizeof(int)))
+      EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_TCP_KEEPINTVL.level(),
+                                            ENVOY_SOCKET_TCP_KEEPINTVL.option(), _, sizeof(int)))
           .WillOnce(
               Invoke([&keepalive_interval](int, int, int, const void* optval, socklen_t) -> int {
                 EXPECT_EQ(keepalive_interval.value(), *static_cast<const int*>(optval));

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -261,7 +261,7 @@ public:
     TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls(&os_sys_calls);
     if (expected_option.has_value()) {
       expectCreateListenSocket(expected_state, expected_num_options);
-      expectSetsockopt(os_sys_calls, expected_option.value().first, expected_option.value().second,
+      expectSetsockopt(os_sys_calls, expected_option.level(), expected_option.option(),
                        expected_value, expected_num_options);
       manager_->addOrUpdateListener(listener, "", true);
       EXPECT_EQ(1U, manager_->listeners().size());


### PR DESCRIPTION
Description:

Capture a human-readable name for a socket option so that if setting
it fails, the log message can indicate which option was problematic.

Risk Level:

Low

Testing:

Verified that trying to set the TCP fast open socket option to 15 on macOS logs which socket option failed.

Docs Changes:

None.

Release Notes:

None.