### PR TITLE
lds: fix listener removal crash before server start

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -744,8 +744,8 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
   // If there is an active listener it needs to be moved to draining after workers have started, or
   // destroyed directly.
   if (existing_active_listener != active_listeners_.end()) {
-    // Listeners in active_listeners_ are only added to workers after workers have started.
-    // Listeners are only moved to draining after workers have started.
+    // Listeners in active_listeners_ are added to workers after workers start, so we drain
+    // listeners only after this occurs.
     if (workers_started_) {
       drainListener(std::move(*existing_active_listener));
     }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -741,9 +741,14 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
     warming_listeners_.erase(existing_warming_listener);
   }
 
-  // If there is an active listener it needs to be moved to draining.
+  // If there is an active listener it needs to be moved to draining after workers have started, or
+  // destroyed directly.
   if (existing_active_listener != active_listeners_.end()) {
-    drainListener(std::move(*existing_active_listener));
+    // Listeners in active_listeners_ are only added to workers after workers have started.
+    // Listeners are only moved to draining after workers have started.
+    if (workers_started_) {
+      drainListener(std::move(*existing_active_listener));
+    }
     active_listeners_.erase(existing_active_listener);
   }
 

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -968,9 +968,11 @@ TEST_P(AdsIntegrationTest, ListenerDrainBeforeServerStart) {
   sendDiscoveryResponse<envoy::api::v2::Listener>(
       Config::TypeUrl::get().Listener, {buildListener("listener_0", "route_config_0")},
       {buildListener("listener_0", "route_config_0")}, {}, "1");
+  test_server_->waitForGaugeGe("listener_manager.total_listeners_active", 1);
 
   // Remove listener.
   sendDiscoveryResponse<envoy::api::v2::Listener>(Config::TypeUrl::get().Listener, {}, {}, {}, "1");
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_active", 0);
 }
 
 } // namespace

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -954,5 +954,26 @@ TEST_P(AdsIntegrationTest, XdsBatching) {
   initialize();
 }
 
+TEST_P(AdsIntegrationTest, ListenerDrainBeforeClusterInit) {
+  initialize();
+
+  sendDiscoveryResponse<envoy::api::v2::Cluster>(Config::TypeUrl::get().Cluster,
+                                                 {buildCluster("cluster_0")},
+                                                 {buildCluster("cluster_0")}, {}, "1");
+  sendDiscoveryResponse<envoy::api::v2::ClusterLoadAssignment>(
+      Config::TypeUrl::get().ClusterLoadAssignment, {buildClusterLoadAssignment("cluster_0")},
+      {buildClusterLoadAssignment("cluster_0")}, {}, "1");
+
+  sendDiscoveryResponse<envoy::api::v2::RouteConfiguration>(
+      Config::TypeUrl::get().RouteConfiguration, {buildRouteConfig("route_config_0", "cluster_0")},
+      {buildRouteConfig("route_config_0", "cluster_0")}, {}, "1");
+  sendDiscoveryResponse<envoy::api::v2::Listener>(
+      Config::TypeUrl::get().Listener, {buildListener("listener_0", "route_config_0")},
+      {buildListener("listener_0", "route_config_0")}, {}, "1");
+
+  // Remove listener, causing drain before all owned clusters have been initialized.
+  sendDiscoveryResponse<envoy::api::v2::Listener>(Config::TypeUrl::get().Listener, {}, {}, {}, "1");
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -954,7 +954,8 @@ TEST_P(AdsIntegrationTest, XdsBatching) {
   initialize();
 }
 
-TEST_P(AdsIntegrationTest, ListenerDrainBeforeClusterInit) {
+// Validates that listeners can be removed before server start.
+TEST_P(AdsIntegrationTest, ListenerDrainBeforeServerStart) {
   initialize();
 
   sendDiscoveryResponse<envoy::api::v2::Cluster>(Config::TypeUrl::get().Cluster,
@@ -964,14 +965,11 @@ TEST_P(AdsIntegrationTest, ListenerDrainBeforeClusterInit) {
       Config::TypeUrl::get().ClusterLoadAssignment, {buildClusterLoadAssignment("cluster_0")},
       {buildClusterLoadAssignment("cluster_0")}, {}, "1");
 
-  sendDiscoveryResponse<envoy::api::v2::RouteConfiguration>(
-      Config::TypeUrl::get().RouteConfiguration, {buildRouteConfig("route_config_0", "cluster_0")},
-      {buildRouteConfig("route_config_0", "cluster_0")}, {}, "1");
   sendDiscoveryResponse<envoy::api::v2::Listener>(
       Config::TypeUrl::get().Listener, {buildListener("listener_0", "route_config_0")},
       {buildListener("listener_0", "route_config_0")}, {}, "1");
 
-  // Remove listener, causing drain before all owned clusters have been initialized.
+  // Remove listener.
   sendDiscoveryResponse<envoy::api::v2::Listener>(Config::TypeUrl::get().Listener, {}, {}, {}, "1");
 }
 


### PR DESCRIPTION
Listeners are added to active_listeners before server start. Once the server finishes initialization, the RunHelper callback is invoked to start worker threads. In this call, active listeners are added to workers. 

If a listener is removed before server start, Envoy attempts to drain the listener, causing a crash since worker threads haven't been started. This PR ensures we only drain the listener when workers have started. If workers haven't started, we destroy the listener directly.

Testing: Add ads integration test, removing a listener before server start.
Fixes #Issue #7431

