### PR TITLE
decompress: reset zlib buffer upon updating output buffer

### DIFF
--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -50,6 +50,8 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
     }
   }
 
+  // Flush z_stream and reset its buffer. Otherwise the stale content of the buffer
+  // will polute output upon the next call to decompress().
   updateOutput(output_buffer);
 }
 

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -51,7 +51,7 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
   }
 
   // Flush z_stream and reset its buffer. Otherwise the stale content of the buffer
-  // will polute output upon the next call to decompress().
+  // will pollute output upon the next call to decompress().
   updateOutput(output_buffer);
 }
 

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -45,19 +45,12 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     while (inflateNext()) {
       if (zstream_ptr_->avail_out == 0) {
-        output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()),
-                          chunk_size_ - zstream_ptr_->avail_out);
-        chunk_char_ptr_ = std::make_unique<unsigned char[]>(chunk_size_);
-        zstream_ptr_->avail_out = chunk_size_;
-        zstream_ptr_->next_out = chunk_char_ptr_.get();
+        updateOutput(output_buffer);
       }
     }
   }
 
-  const uint64_t n_output{chunk_size_ - zstream_ptr_->avail_out};
-  if (n_output > 0) {
-    output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()), n_output);
-  }
+  updateOutput(output_buffer);
 }
 
 bool ZlibDecompressorImpl::inflateNext() {
@@ -75,6 +68,16 @@ bool ZlibDecompressorImpl::inflateNext() {
 
   RELEASE_ASSERT(result == Z_OK, "");
   return true;
+}
+
+void ZlibDecompressorImpl::updateOutput(Buffer::Instance& output_buffer) {
+  const uint64_t n_output = chunk_size_ - zstream_ptr_->avail_out;
+  if (n_output > 0) {
+    output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()), n_output);
+  }
+  chunk_char_ptr_ = std::make_unique<unsigned char[]>(chunk_size_);
+  zstream_ptr_->avail_out = chunk_size_;
+  zstream_ptr_->next_out = chunk_char_ptr_.get();
 }
 
 } // namespace Decompressor

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -45,6 +45,7 @@ public:
 
 private:
   bool inflateNext();
+  void updateOutput(Buffer::Instance& output_buffer);
 
   const uint64_t chunk_size_;
   bool initialized_;

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -113,6 +113,7 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
 TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   Buffer::OwnedImpl buffer;
   Buffer::OwnedImpl accumulation_buffer;
+  Buffer::OwnedImpl empty_buffer;
 
   Envoy::Compressor::ZlibCompressorImpl compressor;
   compressor.init(Envoy::Compressor::ZlibCompressorImpl::CompressionLevel::Standard,
@@ -143,6 +144,12 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
 
   decompressor.decompress(accumulation_buffer, buffer);
   std::string decompressed_text{buffer.toString()};
+
+  // Check decompressor's internal state isn't broken.
+  drainBuffer(buffer);
+  ASSERT_EQ(0, buffer.length());
+  decompressor.decompress(empty_buffer, buffer);
+  ASSERT_EQ(0, buffer.length());
 
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());


### PR DESCRIPTION
Description:
Reset zlib's buffer upon updating output buffer, otherwise the
content of zlib's buffer is copied again to output upon flushing HTTP stream.

Risk Level: low
Testing: standard tests
Docs Changes: N/A
Release Notes: N/A
