### PR TITLE
[test] add config test for zookeeper

### DIFF
--- a/test/extensions/filters/network/zookeeper_proxy/BUILD
+++ b/test/extensions/filters/network/zookeeper_proxy/BUILD
@@ -2,14 +2,11 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test_library",
     "envoy_package",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_extension_cc_mock",
     "envoy_extension_cc_test",
-    "envoy_extension_cc_test_library",
 )
 
 envoy_package()
@@ -24,4 +21,17 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/zookeeper_proxy:config",
         "//test/mocks/network:network_mocks",
     ],
+)
+
+envoy_extension_cc_test(
+    name = "config_test",
+    srcs = [
+        "config_test.cc",
+    ],
+    extension_name = "envoy.filters.network.zookeeper_proxy",
+    deps = [
+        "//source/extensions/filters/network/zookeeper_proxy:config",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:utility_lib",
+    ]
 )

--- a/test/extensions/filters/network/zookeeper_proxy/BUILD
+++ b/test/extensions/filters/network/zookeeper_proxy/BUILD
@@ -33,5 +33,5 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/zookeeper_proxy:config",
         "//test/mocks/server:server_mocks",
         "//test/test_common:utility_lib",
-    ]
+    ],
 )

--- a/test/extensions/filters/network/zookeeper_proxy/config_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/config_test.cc
@@ -1,0 +1,65 @@
+#include "envoy/config/filter/network/zookeeper_proxy/v1alpha1/zookeeper_proxy.pb.validate.h"
+
+#include "extensions/filters/network/zookeeper_proxy/config.h"
+
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ZooKeeperProxy {
+
+using ZooKeeperProxyProtoConfig =
+    envoy::config::filter::network::zookeeper_proxy::v1alpha1::ZooKeeperProxy;
+
+TEST(ZookeeperFilterConfigTest, ValidateFail) {
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_THROW(
+      ZooKeeperConfigFactory().createFilterFactoryFromProto(ZooKeeperProxyProtoConfig(), context),
+      ProtoValidationException);
+}
+
+TEST(ZookeeperFilterConfigTest, InvalidStatPrefix) {
+  const std::string yaml = R"EOF(
+stat_prefix: ""
+  )EOF";
+
+  ZooKeeperProxyProtoConfig proto_config;
+  EXPECT_THROW(TestUtility::loadFromYamlAndValidate(yaml, proto_config), ProtoValidationException);
+}
+
+TEST(ZookeeperFilterConfigTest, InvalidMaxPacketBytes) {
+  const std::string yaml = R"EOF(
+stat_prefix: test_prefix
+max_packet_bytes: -1
+  )EOF";
+
+  ZooKeeperProxyProtoConfig proto_config;
+  EXPECT_THROW(TestUtility::loadFromYamlAndValidate(yaml, proto_config), EnvoyException);
+}
+
+TEST(ZookeeperFilterConfigTest, SimpleConfig) {
+  const std::string yaml = R"EOF(
+stat_prefix: test_prefix
+  )EOF";
+
+  ZooKeeperProxyProtoConfig proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  ZooKeeperConfigFactory factory;
+
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
+  Network::MockConnection connection;
+  EXPECT_CALL(connection, addFilter(_));
+  cb(connection);
+}
+
+} // namespace ZooKeeperProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Description: Fills in some missing coverage https://s3.amazonaws.com/lyft-envoy/coverage/report-master/coverage.source_extensions_filters_network_zookeeper_proxy_config.cc.html cc @rgs1 
Risk Level: Low
Testing: Included
Docs Changes: N/A
Release Notes: N/A 

Signed-off-by: Derek Argueta <dereka@pinterest.com>