### PR TITLE
clang-tidy: readability-redundant-control-flow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,6 +28,7 @@ WarningsAsErrors: 'abseil-duration-*,
                    performance-unnecessary-copy-initialization,
                    readability-braces-around-statements,
                    readability-container-size-empty,
+                   readability-redundant-control-flow,
                    readability-redundant-member-init,
                    readability-redundant-smartptr-get,
                    readability-redundant-string-cstr'

--- a/source/extensions/filters/network/dubbo_proxy/hessian_utils.cc
+++ b/source/extensions/filters/network/dubbo_proxy/hessian_utils.cc
@@ -458,7 +458,6 @@ void HessianUtils::readNull(Buffer::Instance& buffer) {
   size_t size;
   peekNull(buffer, &size);
   buffer.drain(size);
-  return;
 }
 
 std::chrono::milliseconds HessianUtils::peekDate(Buffer::Instance& buffer, size_t* size,

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -237,7 +237,6 @@ private:
         buffer_.drain(size_);
         size_ = 0;
       }
-      return;
     }
 
     TestDnsServerQuery& parent_;

--- a/test/integration/filters/udp_listener_echo_filter.cc
+++ b/test/integration/filters/udp_listener_echo_filter.cc
@@ -33,8 +33,6 @@ void UdpListenerEchoFilter::onData(Network::UdpRecvData& data) {
   auto send_result = read_callbacks_->udpListener().send(send_data);
 
   ASSERT(send_result.ok());
-
-  return;
 }
 
 /**


### PR DESCRIPTION
Description: Fix all cases of `readability-redundant-control-flow` and enable as an error.
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A

Relates to #4863 

Signed-off-by: Derek Argueta <dereka@pinterest.com>