### PR TITLE
Fix segfault in grpc upstream log reporting

### DIFF
--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -243,7 +243,7 @@ private:
   Network::Address::InstanceConstSharedPtr downstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_direct_remote_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
-  const Ssl::ConnectionInfo* downstream_ssl_info_;
+  const Ssl::ConnectionInfo* downstream_ssl_info_{};
   std::string requested_server_name_;
   UpstreamTiming upstream_timing_;
   std::string upstream_transport_failure_reason_;


### PR DESCRIPTION
Fix segfault in grpc upstream log reporting

Signed-off-by: Alexey Baranov <me@kotiki.cc>

Description:
`StreamInfoImpl::downstream_ssl_info_` was left uninitilaized in `UpstreamRequest::stream_info_`, and null check incorrectly passed for a pointer pointing to nowhere. Not quite sure how that worked before.
[object construction](https://github.com/envoyproxy/envoy/blob/master/source/common/router/router.cc#L1296). Note, that no one calls `StreamInfoImpl::setDownstreamSslConnection`
[logging itself](https://github.com/envoyproxy/envoy/blob/master/source/common/router/router.cc#L1326)
[here is the check](https://github.com/envoyproxy/envoy/blob/master/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc#L227)

Risk Level: Low
Testing: Surprisingly, all tests use `NiceMock` for `StreamInfo` which returns initialized null pointer :)
Docs Changes: N/A
Release Notes: N/A
