### PR TITLE
Fix clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,8 +5,8 @@ Checks:          'abseil-*,
                   modernize-*,
                   performance-*,
                   readability-braces-around-statements,
-                  readability-container-size-empty'
-                  readability-redundant-*,
+                  readability-container-size-empty,
+                  readability-redundant-*'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
 WarningsAsErrors: 'abseil-duration-*,

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Quick syntax check of .clang-tidy using PyYAML.
+if ! python -c 'import yaml, sys; yaml.safe_load(sys.stdin)' < .clang-tidy > /dev/null; then
+  echo ".clang-tidy has a syntax error"
+  exit 1
+fi
+
 echo "Generating compilation database..."
 
 cp -f .bazelrc .bazelrc.bak

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -54,7 +54,7 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& 
 
   uint64_t grpc_status_code;
   if (!grpc_status_header || grpc_status_header->value().empty()) {
-    return absl::optional<Status::GrpcStatus>();
+    return {};
   }
   if (!absl::SimpleAtoi(grpc_status_header->value().getStringView(), &grpc_status_code) ||
       grpc_status_code > Status::GrpcStatus::MaximumValid) {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -368,7 +368,7 @@ ThreadLocalStoreImpl::ScopeImpl::findStatLockHeld(
     return absl::nullopt;
   }
 
-  return std::cref(*iter->second.get());
+  return std::cref(*iter->second);
 }
 
 Counter& ThreadLocalStoreImpl::ScopeImpl::counterFromStatName(StatName name) {

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -710,7 +710,7 @@ SuccessRateAccumulatorBucket* SuccessRateAccumulator::updateCurrentWriter() {
 absl::optional<double>
 SuccessRateAccumulator::getSuccessRate(uint64_t success_rate_request_volume) {
   if (backup_success_rate_bucket_->total_request_counter_ < success_rate_request_volume) {
-    return absl::optional<double>();
+    return {};
   }
 
   return {backup_success_rate_bucket_->success_request_counter_ * 100.0 /

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -295,7 +295,7 @@ TEST_F(ProtobufUtilityTest, HashedValue) {
   EXPECT_EQ(hv1, hv2);
   EXPECT_NE(hv1, hv3);
 
-  HashedValue copy(hv1);
+  HashedValue copy(hv1);  // NOLINT(performance-unnecessary-copy-initialization)
   EXPECT_EQ(hv1, copy);
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -295,7 +295,7 @@ TEST_F(ProtobufUtilityTest, HashedValue) {
   EXPECT_EQ(hv1, hv2);
   EXPECT_NE(hv1, hv3);
 
-  HashedValue copy(hv1);  // NOLINT(performance-unnecessary-copy-initialization)
+  HashedValue copy(hv1); // NOLINT(performance-unnecessary-copy-initialization)
   EXPECT_EQ(hv1, copy);
 }
 

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -755,7 +755,7 @@ TEST_P(QuicMemSliceTest, ConstructMemSliceFromBuffer) {
   quic::QuicMemSlice slice1{quic::QuicMemSliceImpl(buffer, str2.length())};
   EXPECT_EQ(str.length(), buffer.length());
   EXPECT_EQ(str2, std::string(slice1.data(), slice1.length()));
-  std::string str2_old = str2;
+  std::string str2_old = str2;  // NOLINT(performance-unnecessary-copy-initialization)
   // slice1 is released, but str2 should not be affected.
   slice1.Reset();
   EXPECT_TRUE(slice1.empty());

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -755,7 +755,7 @@ TEST_P(QuicMemSliceTest, ConstructMemSliceFromBuffer) {
   quic::QuicMemSlice slice1{quic::QuicMemSliceImpl(buffer, str2.length())};
   EXPECT_EQ(str.length(), buffer.length());
   EXPECT_EQ(str2, std::string(slice1.data(), slice1.length()));
-  std::string str2_old = str2;  // NOLINT(performance-unnecessary-copy-initialization)
+  std::string str2_old = str2; // NOLINT(performance-unnecessary-copy-initialization)
   // slice1 is released, but str2 should not be affected.
   slice1.Reset();
   EXPECT_TRUE(slice1.empty());


### PR DESCRIPTION
Description: #7442 introduced a regression by breaking the syntax in `.clang-tidy`. For the period of about 3 days, clang-tidy only ran warnings for `clang-analyzer-*`. In one of my recent PRs I noticed the output on CI containing `Invalid Argument`. This PR fixes clang-tidy, and I've done a full run of master to ensure there weren't any regressions.
Risk Level: Low
Testing: Ran clang-tidy locally
Docs Changes: N/A
Release Notes: N/A
