### PR TITLE
stats: Remove field from GaugeImpl that was not used, by moving it to the counter-specific section.

### DIFF
--- a/source/common/stats/heap_stat_data.cc
+++ b/source/common/stats/heap_stat_data.cc
@@ -110,9 +110,7 @@ public:
   uint32_t use_count() const override { return ref_count_; }
 
 private:
-  // Holds backing store for both CounterImpl and GaugeImpl. This provides a level
-  // of indirection needed to enable stats created with the same name from
-  // different scopes to share the same value.
+  // All counter state is held in individual atomics.
   std::atomic<uint64_t> value_{0};
   std::atomic<uint64_t> pending_increment_{0};
   std::atomic<uint16_t> flags_{0};

--- a/source/common/stats/heap_stat_data.cc
+++ b/source/common/stats/heap_stat_data.cc
@@ -73,26 +73,9 @@ public:
 
   // Metric
   SymbolTable& symbolTable() override { return alloc_.symbolTable(); }
-  bool used() const override { return flags_ & Metric::Flags::Used; }
-
-  // RefcountInterface
-  void incRefCount() override { ++ref_count_; }
-  bool decRefCount() override {
-    ASSERT(ref_count_ >= 1);
-    return --ref_count_ == 0;
-  }
-  uint32_t use_count() const override { return ref_count_; }
 
 protected:
   HeapStatDataAllocator& alloc_;
-
-  // Holds backing store for both CounterImpl and GaugeImpl. This provides a level
-  // of indirection needed to enable stats created with the same name from
-  // different scopes to share the same value.
-  std::atomic<uint64_t> value_{0};
-  std::atomic<uint64_t> pending_increment_{0};
-  std::atomic<uint16_t> flags_{0};
-  std::atomic<uint16_t> ref_count_{0};
 };
 
 class CounterImpl : public StatsSharedImpl<Counter> {
@@ -113,15 +96,34 @@ public:
   void inc() override { add(1); }
   uint64_t latch() override { return pending_increment_.exchange(0); }
   void reset() override { value_ = 0; }
-  bool used() const override { return flags_ & Flags::Used; }
   uint64_t value() const override { return value_; }
+
+  // Metric
+  bool used() const override { return flags_ & Metric::Flags::Used; }
+
+  // RefcountInterface
+  void incRefCount() override { ++ref_count_; }
+  bool decRefCount() override {
+    ASSERT(ref_count_ >= 1);
+    return --ref_count_ == 0;
+  }
+  uint32_t use_count() const override { return ref_count_; }
+
+private:
+  // Holds backing store for both CounterImpl and GaugeImpl. This provides a level
+  // of indirection needed to enable stats created with the same name from
+  // different scopes to share the same value.
+  std::atomic<uint64_t> value_{0};
+  std::atomic<uint64_t> pending_increment_{0};
+  std::atomic<uint16_t> flags_{0};
+  std::atomic<uint16_t> ref_count_{0};
 };
 
 class GaugeImpl : public StatsSharedImpl<Gauge> {
 public:
   GaugeImpl(StatName name, HeapStatDataAllocator& alloc, absl::string_view tag_extracted_name,
             const std::vector<Tag>& tags, ImportMode import_mode)
-      : StatsSharedImpl(name, alloc, tag_extracted_name, tags) {
+      : StatsSharedImpl(name, alloc, tag_extracted_name, tags), value_(0), flags_(0) {
     switch (import_mode) {
     case ImportMode::Accumulate:
       flags_ |= Flags::LogicAccumulate;
@@ -141,23 +143,34 @@ public:
 
   // Stats::Gauge
   void add(uint64_t amount) override {
+    Thread::LockGuard lock(mutex_);
     value_ += amount;
     flags_ |= Flags::Used;
   }
   void dec() override { sub(1); }
   void inc() override { add(1); }
   void set(uint64_t value) override {
+    Thread::LockGuard lock(mutex_);
     value_ = value;
     flags_ |= Flags::Used;
   }
   void sub(uint64_t amount) override {
+    Thread::LockGuard lock(mutex_);
     ASSERT(value_ >= amount);
-    ASSERT(used() || amount == 0);
+    ASSERT(usedLockHeld() || amount == 0);
     value_ -= amount;
   }
-  uint64_t value() const override { return value_; }
+  uint64_t value() const override {
+    Thread::LockGuard lock(mutex_);
+    return value_;
+  }
 
   ImportMode importMode() const override {
+    Thread::LockGuard lock(mutex_);
+    return importModeLockHeld();
+  }
+
+  ImportMode importModeLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
     if (flags_ & Flags::NeverImport) {
       return ImportMode::NeverImport;
     } else if (flags_ & Flags::LogicAccumulate) {
@@ -167,7 +180,8 @@ public:
   }
 
   void mergeImportMode(ImportMode import_mode) override {
-    ImportMode current = importMode();
+    Thread::LockGuard lock(mutex_);
+    ImportMode current = importModeLockHeld();
     if (current == import_mode) {
       return;
     }
@@ -192,6 +206,33 @@ public:
       break;
     }
   }
+
+  // Metric
+  bool used() const override {
+    Thread::LockGuard lock(mutex_);
+    return usedLockHeld();
+  }
+
+  // RefcountInterface
+  void incRefCount() override { ++ref_count_; }
+  bool decRefCount() override {
+    ASSERT(ref_count_ >= 1);
+    return --ref_count_ == 0;
+  }
+  uint32_t use_count() const override { return ref_count_; }
+
+  bool usedLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
+    return flags_ & Metric::Flags::Used;
+  }
+
+private:
+  // Holds backing store for both CounterImpl and GaugeImpl. This provides a level
+  // of indirection needed to enable stats created with the same name from
+  // different scopes to share the same value.
+  mutable Thread::MutexBasicLockable mutex_;
+  uint64_t value_ GUARDED_BY(mutex_);
+  uint16_t flags_ GUARDED_BY(mutex_);
+  std::atomic<uint16_t> ref_count_{0};
 };
 
 CounterSharedPtr HeapStatDataAllocator::makeCounter(StatName name,

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -209,6 +209,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithStats) {
   // 2019/06/17  7243     49412       49700   macros for exact/upper-bound memory checks
   // 2019/06/29  7364     45685       46000   combine 2 levels of stat ref-counting into 1
   // 2019/06/30  7428     42742       43000   remove stats multiple inheritance, inline HeapStatData
+  // 2019/07/06  7477     42574       43000   fork gauge representation to drop pending_increment_
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -218,7 +219,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithStats) {
   // On a local clang8/libstdc++/linux flow, the memory usage was observed in
   // June 2019 to be 64 bytes higher than it is in CI/release. Your mileage may
   // vary.
-  EXPECT_MEMORY_EQ(m_per_cluster, 42742);
+  EXPECT_MEMORY_EQ(m_per_cluster, 42574);
   EXPECT_MEMORY_LE(m_per_cluster, 43000);
 }
 

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -209,7 +209,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithStats) {
   // 2019/06/17  7243     49412       49700   macros for exact/upper-bound memory checks
   // 2019/06/29  7364     45685       46000   combine 2 levels of stat ref-counting into 1
   // 2019/06/30  7428     42742       43000   remove stats multiple inheritance, inline HeapStatData
-  // 2019/07/06  7477     42574       43000   fork gauge representation to drop pending_increment_
+  // 2019/07/06  7477     42742       43000   fork gauge representation to drop pending_increment_
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -219,7 +219,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithStats) {
   // On a local clang8/libstdc++/linux flow, the memory usage was observed in
   // June 2019 to be 64 bytes higher than it is in CI/release. Your mileage may
   // vary.
-  EXPECT_MEMORY_EQ(m_per_cluster, 42574);
+  EXPECT_MEMORY_EQ(m_per_cluster, 42742); // 104 bytes higher than a debug build.
   EXPECT_MEMORY_LE(m_per_cluster, 43000);
 }
 


### PR DESCRIPTION
Description: forks more of the implementations between Counters and Gauges. Counters remain effectively as they were. For Gauges, we get to drop the `pending_increment_` field which was not used, but to resolve this bug we need to add a mutex, so this saves a little memory.

The need for this is mentioned in #7109 but this does not fully resolve that bug.

This is WiP because I need to verify that it passes 'release' test now, having tweaked the expected memory value, but no way to check it on my system.
Risk Level: medium
Testing: //test/common/stats/...
Docs Changes: n/a
Release Notes: n/a