### PR TITLE
server: add initialization time stat

### DIFF
--- a/docs/root/configuration/statistics.rst
+++ b/docs/root/configuration/statistics.rst
@@ -23,6 +23,7 @@ Server related statistics are rooted at *server.* with following statistics:
   version, Gauge, Integer represented version number based on SCM revision
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
   hot_restart_epoch, Gauge, Current hot restart epoch
+  initialization_time_ms, Histogram, Total time taken for Envoy initialization in milliseconds
   debug_assertion_failures, Counter, Number of debug assertion failures detected in a release build if compiled with `--define log_debug_assert_in_release=enabled` or zero otherwise
 
 File system

--- a/docs/root/configuration/statistics.rst
+++ b/docs/root/configuration/statistics.rst
@@ -23,7 +23,7 @@ Server related statistics are rooted at *server.* with following statistics:
   version, Gauge, Integer represented version number based on SCM revision
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
   hot_restart_epoch, Gauge, Current hot restart epoch
-  initialization_time_ms, Histogram, Total time taken for Envoy initialization in milliseconds
+  initialization_time_ms, Histogram, Total time taken for Envoy initialization in milliseconds. This is the time from server start-up until the worker threads are ready to accept new connections
   debug_assertion_failures, Counter, Number of debug assertion failures detected in a release build if compiled with `--define log_debug_assert_in_release=enabled` or zero otherwise
 
 File system

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -79,10 +79,11 @@ Version history
 * sandbox: added :ref:`CSRF sandbox <install_sandboxes_csrf>`.
 * server: ``--define manual_stamp=manual_stamp`` was added to allow server stamping outside of binary rules.
   more info in the `bazel docs <https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#enabling-optional-features>`_.
+* server: added :ref:`Server State <statistics>` statistic.
+* server: added :ref:`initialization_time_ms<statistics>` statistic.
 * subset: added :ref:`list_as_any<envoy_api_field_Cluster.LbSubsetConfig.list_as_any>` option to
   the subset lb which allows matching metadata against any of the values in a list value
   on the endpoints.
-* server: added :ref:`Server State <statistics>` statistic.
 * tool: added :repo:`proto <test/tools/router_check/validation.proto>` support for :ref:`router check tool <install_tools_route_table_check_tool>` tests.
 * tracing: add trace sampling configuration to the route, to override the route level.
 * upstream: added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -278,8 +278,11 @@ void InstanceImpl::initialize(const Options& options,
   const std::string server_stats_prefix = "server.";
   server_stats_ = std::make_unique<ServerStats>(
       ServerStats{ALL_SERVER_STATS(POOL_COUNTER_PREFIX(stats_store_, server_stats_prefix),
-                                   POOL_GAUGE_PREFIX(stats_store_, server_stats_prefix))});
+                                   POOL_GAUGE_PREFIX(stats_store_, server_stats_prefix),
+                                   POOL_HISTOGRAM_PREFIX(stats_store_, server_stats_prefix))});
 
+  initialization_timer_ =
+      std::make_unique<Stats::Timespan>(server_stats_->initialization_time_ms_, timeSource());
   server_stats_->concurrency_.set(options_.concurrency());
   server_stats_->hot_restart_epoch_.set(options_.restartEpoch());
 
@@ -410,7 +413,7 @@ void InstanceImpl::initialize(const Options& options,
 
 void InstanceImpl::startWorkers() {
   listener_manager_->startWorkers(*guard_dog_);
-
+  initialization_timer_->complete();
   // At this point we are ready to take traffic and all listening ports are up. Notify our parent
   // if applicable that they can stop listening and drain.
   restarter_.drainParentListeners();

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -277,6 +277,8 @@ private:
   std::unique_ptr<ProcessContext> process_context_;
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
   const std::thread::id main_thread_id_;
+  // initialization_time is a histogram for tracking the initialization time across hot restarts
+  // whenever we have support for histogram merge across hot restarts.
   Stats::TimespanPtr initialization_timer_;
 
   using LifecycleNotifierCallbacks = std::list<StageCallback>;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -48,7 +48,6 @@ namespace Server {
 /**
  * All server wide stats. @see stats_macros.h
  */
-// clang-format off
 #define ALL_SERVER_STATS(COUNTER, GAUGE, HISTOGRAM)                                                \
   COUNTER(debug_assertion_failures)                                                                \
   GAUGE(concurrency, NeverImport)                                                                  \
@@ -63,7 +62,6 @@ namespace Server {
   GAUGE(uptime, Accumulate)                                                                        \
   GAUGE(version, NeverImport)                                                                      \
   HISTOGRAM(initialization_time_ms)
-// clang-format on
 
 struct ServerStats {
   ALL_SERVER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -15,6 +15,7 @@
 #include "envoy/server/tracer_config.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/stats/stats_macros.h"
+#include "envoy/stats/timespan.h"
 #include "envoy/tracing/http_tracer.h"
 
 #include "common/access_log/access_log_manager_impl.h"
@@ -47,7 +48,8 @@ namespace Server {
 /**
  * All server wide stats. @see stats_macros.h
  */
-#define ALL_SERVER_STATS(COUNTER, GAUGE)                                                           \
+// clang-format off
+#define ALL_SERVER_STATS(COUNTER, GAUGE, HISTOGRAM)                                                \
   COUNTER(debug_assertion_failures)                                                                \
   GAUGE(concurrency, NeverImport)                                                                  \
   GAUGE(days_until_first_cert_expiring, Accumulate)                                                \
@@ -59,10 +61,12 @@ namespace Server {
   GAUGE(state, NeverImport)                                                                        \
   GAUGE(total_connections, Accumulate)                                                             \
   GAUGE(uptime, Accumulate)                                                                        \
-  GAUGE(version, NeverImport)
+  GAUGE(version, NeverImport)                                                                      \
+  HISTOGRAM(initialization_time_ms)
+// clang-format on
 
 struct ServerStats {
-  ALL_SERVER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+  ALL_SERVER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 /**
@@ -275,6 +279,7 @@ private:
   std::unique_ptr<ProcessContext> process_context_;
   std::unique_ptr<Memory::HeapShrinker> heap_shrinker_;
   const std::thread::id main_thread_id_;
+  Stats::TimespanPtr initialization_timer_;
 
   using LifecycleNotifierCallbacks = std::list<StageCallback>;
   using LifecycleNotifierCompletionCallbacks = std::list<StageCallbackWithCompletion>;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -314,6 +314,8 @@ TEST_P(ServerInstanceImplTest, EmptyShutdownLifecycleNotifications) {
   auto server_thread = startTestServer("test/server/node_bootstrap.yaml", false);
   server_->dispatcher().post([&] { server_->shutdown(); });
   server_thread->join();
+  // Validate that initialization_time histogram value has been set.
+  EXPECT_TRUE(stats_store_.histogram("server.initialization_time").used());
 }
 
 TEST_P(ServerInstanceImplTest, LifecycleNotifications) {


### PR DESCRIPTION
Description: Adds a server stat to capture the initialization time of Envoy.
Risk Level: Low
Testing: Added automated test
Docs Changes: Updated
Release Notes: Added

