### PR TITLE
[test] convert Outlier Detection test stubs to v2 YAML

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -271,6 +271,7 @@ envoy_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 


### PR DESCRIPTION
Description: Convert calls of `translateOutlierDetection` (there was only 1) to v2.
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>