### PR TITLE
Ondestroy

### DIFF
--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -146,7 +146,6 @@ MockConnectionSocket::MockConnectionSocket()
 }
 
 MockListener::MockListener() {}
-MockListener::~MockListener() { onDestroy(); }
 
 MockConnectionHandler::MockConnectionHandler() {}
 MockConnectionHandler::~MockConnectionHandler() {}
@@ -171,7 +170,6 @@ MockTransportSocketCallbacks::MockTransportSocketCallbacks() {
 MockTransportSocketCallbacks::~MockTransportSocketCallbacks() {}
 
 MockUdpListener::MockUdpListener() {}
-MockUdpListener::~MockUdpListener() { onDestroy(); }
 
 MockUdpReadFilterCallbacks::MockUdpReadFilterCallbacks() {
   ON_CALL(*this, udpListener()).WillByDefault(ReturnRef(udp_listener_));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -322,7 +322,6 @@ public:
   MockListener();
   ~MockListener();
 
-  MOCK_METHOD0(onDestroy, void());
   MOCK_METHOD0(enable, void());
   MOCK_METHOD0(disable, void());
 };
@@ -429,7 +428,6 @@ public:
   MockUdpListener();
   ~MockUdpListener();
 
-  MOCK_METHOD0(onDestroy, void());
   MOCK_METHOD0(enable, void());
   MOCK_METHOD0(disable, void());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -117,7 +117,6 @@ TEST_F(ConnectionHandlerTest, RemoveListener) {
   handler_->stopListeners(0);
   handler_->removeListeners(0);
 
-  EXPECT_CALL(*listener, onDestroy());
   handler_->stopListeners(1);
 
   EXPECT_CALL(*connection, close(Network::ConnectionCloseType::NoFlush));
@@ -146,7 +145,6 @@ TEST_F(ConnectionHandlerTest, DisableListener) {
   handler_->addListener(*test_listener);
 
   EXPECT_CALL(*listener, disable());
-  EXPECT_CALL(*listener, onDestroy());
 
   handler_->disableListeners();
 }
@@ -165,7 +163,6 @@ TEST_F(ConnectionHandlerTest, AddDisabledListener) {
           }));
   EXPECT_CALL(*listener, disable());
   EXPECT_CALL(test_listener->socket_, localAddress());
-  EXPECT_CALL(*listener, onDestroy());
 
   handler_->disableListeners();
   handler_->addListener(*test_listener);
@@ -192,7 +189,6 @@ TEST_F(ConnectionHandlerTest, DestroyCloseConnections) {
 
   EXPECT_CALL(*connection, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
-  EXPECT_CALL(*listener, onDestroy());
   handler_.reset();
 }
 
@@ -220,8 +216,6 @@ TEST_F(ConnectionHandlerTest, CloseDuringFilterChainCreate) {
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
   EXPECT_EQ(0UL, handler_->numConnections());
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
@@ -248,8 +242,6 @@ TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
   EXPECT_EQ(0UL, handler_->numConnections());
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
@@ -283,11 +275,9 @@ TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
   EXPECT_EQ(listener2, handler_->findListenerByAddress(ByRef(*alt_address2)));
   EXPECT_EQ(listener2, handler_->findListenerByAddress(ByRef(*alt_address3)));
 
-  EXPECT_CALL(*listener, onDestroy());
   handler_->stopListeners(1);
   EXPECT_EQ(listener2, handler_->findListenerByAddress(ByRef(*alt_address)));
 
-  EXPECT_CALL(*listener2, onDestroy());
   handler_->stopListeners(2);
 
   Network::MockListener* listener3 = new Network::MockListener();
@@ -300,8 +290,6 @@ TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
 
   EXPECT_EQ(listener3, handler_->findListenerByAddress(ByRef(*alt_address2)));
   EXPECT_EQ(listener3, handler_->findListenerByAddress(ByRef(*alt_address3)));
-
-  EXPECT_CALL(*listener3, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, NormalRedirect) {
@@ -359,9 +347,6 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   listener_callbacks1->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
   EXPECT_EQ(1UL, handler_->numConnections());
-
-  EXPECT_CALL(*listener2, onDestroy());
-  EXPECT_CALL(*listener1, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
@@ -421,9 +406,6 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   listener_callbacks1->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
   EXPECT_EQ(1UL, handler_->numConnections());
-
-  EXPECT_CALL(*listener2, onDestroy());
-  EXPECT_CALL(*listener1, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
@@ -468,8 +450,6 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   listener_callbacks1->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
   EXPECT_EQ(1UL, handler_->numConnections());
-
-  EXPECT_CALL(*listener1, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
@@ -506,8 +486,6 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   listener_callbacks1->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
   EXPECT_EQ(1UL, handler_->numConnections());
-
-  EXPECT_CALL(*listener1, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
@@ -529,8 +507,6 @@ TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
   EXPECT_CALL(*accepted_socket, setDetectedTransportProtocol(absl::string_view("raw_buffer")));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
@@ -563,8 +539,6 @@ TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
   EXPECT_CALL(*accepted_socket, detectedTransportProtocol()).WillOnce(Return(dummy));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 // Timeout during listener filter stop iteration.
@@ -606,8 +580,6 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
   dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0UL, downstream_pre_cx_active.value());
   EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 // Timeout is disabled once the listener filters complete.
@@ -646,8 +618,6 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(*timeout, disableTimer());
   listener_filter_cb->continueFilterChain(true);
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 // Ensure there is no timeout when the timeout is disabled with 0s.
@@ -681,8 +651,6 @@ TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
   EXPECT_CALL(dispatcher_, createTimer_(_)).Times(0);
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
-
-  EXPECT_CALL(*listener, onDestroy());
 }
 
 // Ensure an exception is thrown if there are no filters registered for a UDP listener
@@ -700,7 +668,6 @@ TEST_F(ConnectionHandlerTest, UdpListenerNoFilterThrowsException) {
   EXPECT_CALL(factory_, createUdpListenerFilterChain(_, _))
       .WillOnce(Invoke([&](Network::UdpListenerFilterManager&,
                            Network::UdpReadFilterCallbacks&) -> bool { return true; }));
-  EXPECT_CALL(*listener, onDestroy());
 
   try {
     handler_->addListener(*test_listener);


### PR DESCRIPTION
Mock(Udp)Listener mocks onDestroy() which is not in its base class. It is called in destructor, but there is no point of checking the destruction of a mock class anyway.

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
