### PR TITLE
Fix redis_cluster_test for multiple DNS resolution scenario.

### DIFF
--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -425,22 +425,6 @@ protected:
     EXPECT_CALL(active_dns_query_, cancel());
   }
 
-  void testRedisResolve() {
-    EXPECT_CALL(dispatcher_, createTimer_(_));
-    RedisCluster::RedisDiscoverySession discovery_session(*cluster_, *this);
-    auto dns_response =
-        TestUtility::makeDnsResponse(std::list<std::string>({"127.0.0.1", "127.0.0.2"}));
-    discovery_session.registerDiscoveryAddress(std::move(dns_response), 22120);
-    expectRedisResolve(true);
-    discovery_session.startResolveRedis();
-
-    // 2nd startResolveRedis() call will be a no-opt until the first startResolve is done.
-    discovery_session.startResolveRedis();
-
-    // Make sure cancel is called.
-    EXPECT_CALL(pool_request_, cancel());
-  }
-
   Stats::IsolatedStoreImpl stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
   std::shared_ptr<NiceMock<Network::MockDnsResolver>> dns_resolver_{
@@ -722,9 +706,53 @@ TEST_F(RedisClusterTest, DnsDiscoveryResolverBasic) {
   testDnsResolve("foo.bar.com", 22120);
 }
 
-TEST_F(RedisClusterTest, RedisDiscoveryResolverBasic) {
-  setupFromV2Yaml(BasicConfig);
-  testRedisResolve();
+TEST_F(RedisClusterTest, MultipleDnsDiscovery) {
+  const std::string config = R"EOF(
+  name: name
+  connect_timeout: 0.25s
+  dns_lookup_family: V4_ONLY
+  hosts:
+  - socket_address:
+      address: foo.bar.com
+      port_value: 22120
+  - socket_address:
+      address: foo1.bar.com
+      port_value: 22120
+  cluster_type:
+    name: envoy.clusters.redis
+    typed_config:
+      "@type": type.googleapis.com/google.protobuf.Struct
+      value:
+        cluster_refresh_rate: 4s
+        cluster_refresh_timeout: 0.25s
+  )EOF";
+
+  setupFromV2Yaml(config);
+
+  // Only single in-flight "cluster slots" call.
+  expectRedisResolve(true);
+
+  ReadyWatcher dns_resolve_1;
+  ReadyWatcher dns_resolve_2;
+
+  EXPECT_CALL(*dns_resolver_, resolve("foo.bar.com", _, _))
+      .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
+                           Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
+        cb(TestUtility::makeDnsResponse(std::list<std::string>({"127.0.0.1", "127.0.0.2"})));
+        return nullptr;
+      }));
+
+  EXPECT_CALL(*dns_resolver_, resolve("foo1.bar.com", _, _))
+      .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
+                           Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
+        cb(TestUtility::makeDnsResponse(std::list<std::string>({"127.0.0.3", "127.0.0.4"})));
+        return nullptr;
+      }));
+
+  cluster_->initialize([&]() -> void { initialized_.ready(); });
+
+  // Pending RedisResolve will call cancel in the destructor.
+  EXPECT_CALL(pool_request_, cancel());
 }
 
 } // namespace Redis


### PR DESCRIPTION
Description: Minor clean up of the redis cluster test for multiple DNS resolution scenario as discussed in previous PR.
Risk Level: Low
Testing: Updated unit test
Docs Changes: No
Release Notes: No