### PR TITLE
Add _GNU_SOURCE to libevent build for Android builds

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -99,6 +99,13 @@ envoy_cmake_external(
         # doesn't respect custom toolchains such as the Android NDK,
         # see https://github.com/bazelbuild/rules_foreign_cc/issues/252
         "CMAKE_RANLIB": "",
+        # Force _GNU_SOURCE on for Android builds. This would be contained in
+        # a 'select' but the downstream macro uses a select on all of these
+        # options, and they cannot be nested.
+        # If https://github.com/bazelbuild/rules_foreign_cc/issues/289 is fixed
+        # this can be removed.
+        # More details https://github.com/lyft/envoy-mobile/issues/116
+        "_GNU_SOURCE": "on",
     },
     copy_pdb = True,
     lib_source = "@com_github_libevent_libevent//:all",


### PR DESCRIPTION
The Android NDK doesn't assume `_GNU_SOURCE`, clang only assumes it for
C++ builds, not C builds. libevent uses `pipe2` which in the NDK is only
exposed in the header when these variables are set. In bazel 0.27.0
these implicit use became an error.

More details:

- https://github.com/lyft/envoy-mobile/issues/116
- https://github.com/libevent/libevent/pull/850

Risk Level: Low