### PR TITLE
fuzz: fix filesystem bug, use std::__fs::filesystem

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ envoy_api_dependencies()
 load("//bazel:repositories.bzl", "GO_VERSION", "envoy_dependencies")
 load("//bazel:cc_configure.bzl", "cc_configure")
 
-envoy_dependencies()
+envoy_dependencies(skip_targets=["tcmalloc_and_profiler","tcmalloc_debug"])
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ envoy_api_dependencies()
 load("//bazel:repositories.bzl", "GO_VERSION", "envoy_dependencies")
 load("//bazel:cc_configure.bzl", "cc_configure")
 
-envoy_dependencies(skip_targets=["tcmalloc_and_profiler","tcmalloc_debug"])
+envoy_dependencies()
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -41,7 +41,7 @@ std::string makeTempDir(char* name_template) {
   char* dirname = ::_mktemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, strerror(errno)));
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
   std::__fs::filesystem::create_directories(dirname);
 #elif defined __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(dirname);
@@ -84,7 +84,7 @@ char** argv_;
 } // namespace
 
 void TestEnvironment::createPath(const std::string& path) {
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path));
@@ -97,7 +97,7 @@ void TestEnvironment::createPath(const std::string& path) {
 }
 
 void TestEnvironment::createParentPath(const std::string& path) {
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path).parent_path());
@@ -112,7 +112,7 @@ void TestEnvironment::createParentPath(const std::string& path) {
 
 void TestEnvironment::removePath(const std::string& path) {
   RELEASE_ASSERT(absl::StartsWith(path, TestEnvironment::temporaryDirectory()), "");
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   if (!std::__fs::filesystem::exists(path)) {

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -3,7 +3,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
 #include <filesystem>
 #elif defined __has_include
 // TODO(asraa): Remove this when Envoy requires Clang >= 9.

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -3,10 +3,11 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
+// TODO(asraa): Remove <experimental/filesystem> and rely only on <filesystem> when Envoy requires
+// Clang >= 9.
+#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
 #include <filesystem>
 #elif defined __has_include
-// TODO(asraa): Remove this when Envoy requires Clang >= 9.
 #if __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 #endif
@@ -41,7 +42,7 @@ std::string makeTempDir(char* name_template) {
   char* dirname = ::_mktemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, strerror(errno)));
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
   std::__fs::filesystem::create_directories(dirname);
 #elif defined __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(dirname);
@@ -84,7 +85,7 @@ char** argv_;
 } // namespace
 
 void TestEnvironment::createPath(const std::string& path) {
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path));
@@ -97,7 +98,7 @@ void TestEnvironment::createPath(const std::string& path) {
 }
 
 void TestEnvironment::createParentPath(const std::string& path) {
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path).parent_path());
@@ -112,7 +113,7 @@ void TestEnvironment::createParentPath(const std::string& path) {
 
 void TestEnvironment::removePath(const std::string& path) {
   RELEASE_ASSERT(absl::StartsWith(path, TestEnvironment::temporaryDirectory()), "");
-#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   if (!std::__fs::filesystem::exists(path)) {

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -3,11 +3,11 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#ifdef __has_include
-#if __has_include(<filesystem>)
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
 #include <filesystem>
+#elif defined __has_include
 // TODO(asraa): Remove this when Envoy requires Clang >= 9.
-#elif __has_include(<experimental/filesystem>)
+#if __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 #endif
 #endif
@@ -41,8 +41,8 @@ std::string makeTempDir(char* name_template) {
   char* dirname = ::_mktemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, strerror(errno)));
-#ifdef __cpp_lib_filesystem
-  std::filesystem::create_directories(dirname);
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
+  std::__fs::filesystem::create_directories(dirname);
 #elif defined __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(dirname);
 #endif
@@ -84,10 +84,10 @@ char** argv_;
 } // namespace
 
 void TestEnvironment::createPath(const std::string& path) {
-#ifdef __cpp_lib_filesystem
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  std::filesystem::create_directories(std::filesystem::path(path));
+  std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path));
 #elif defined __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(std::experimental::filesystem::path(path));
 #else
@@ -97,10 +97,10 @@ void TestEnvironment::createPath(const std::string& path) {
 }
 
 void TestEnvironment::createParentPath(const std::string& path) {
-#ifdef __cpp_lib_filesystem
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+  std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path).parent_path());
 #elif defined __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(
       std::experimental::filesystem::path(path).parent_path());
@@ -112,13 +112,13 @@ void TestEnvironment::createParentPath(const std::string& path) {
 
 void TestEnvironment::removePath(const std::string& path) {
   RELEASE_ASSERT(absl::StartsWith(path, TestEnvironment::temporaryDirectory()), "");
-#ifdef __cpp_lib_filesystem
+#if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
-  if (!std::filesystem::exists(path)) {
+  if (!std::__fs::filesystem::exists(path)) {
     return;
   }
-  std::filesystem::remove_all(std::filesystem::path(path));
+  std::__fs::filesystem::remove_all(std::__fs::filesystem::path(path));
 #elif defined __cpp_lib_experimental_filesystem
   if (!std::experimental::filesystem::exists(path)) {
     return;


### PR DESCRIPTION
Since OSS-Fuzz minijail prohibits mkdir calls, we use std::__fs::filesystem namespace which implements filesystem. 

The OSS-Fuzz image was taking the mkdir branch, since neither filesystem nor experimental/filesystem was found. However, we are able to use std::__fs::filesystem branch in the OSS-Fuzz image and the std::experimental::filesystem branch locally.

Risk Level: Low
Testing: Add RELEASE_ASSERT(1==0, "") under the #if defined(_LIBCPP_VERSION) && TEST_STD_VER < 17 branch to verify that branch is taken in oss-fuzz docker. run_fuzzer with oss-fuzz docker is successful.
Fixes OSS-Fuzz issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15414

Signed-off-by: Asra Ali <asraa@google.com>


