### PR TITLE
config dump, listeners are added to warming list if workers are not started yet

### DIFF
--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -969,6 +969,9 @@ TEST_P(AdsIntegrationTest, ListenerDrainBeforeServerStart) {
       Config::TypeUrl::get().Listener, {buildListener("listener_0", "route_config_0")},
       {buildListener("listener_0", "route_config_0")}, {}, "1");
   test_server_->waitForGaugeGe("listener_manager.total_listeners_active", 1);
+  // Before server is started, even though listeners are added to active list
+  // we mark them as "warming" in config dump since they're not initialized yet.
+  EXPECT_EQ(getListenersConfigDump().dynamic_warming_listeners().size(), 1);
 
   // Remove listener.
   sendDiscoveryResponse<envoy::api::v2::Listener>(Config::TypeUrl::get().Listener, {}, {}, {}, "1");

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -766,6 +766,7 @@ filter_chains: {}
 version_info: version1
 static_listeners:
 dynamic_active_listeners:
+dynamic_warming_listeners:
   version_info: "version1"
   listener:
     name: "foo"
@@ -777,7 +778,6 @@ dynamic_active_listeners:
   last_updated:
     seconds: 1001001001
     nanos: 1000000
-dynamic_warming_listeners:
 dynamic_draining_listeners:
 )EOF");
 
@@ -808,6 +808,7 @@ per_connection_buffer_limit_bytes: 10
 version_info: version2
 static_listeners:
 dynamic_active_listeners:
+dynamic_warming_listeners:
   version_info: "version2"
   listener:
     name: "foo"
@@ -820,7 +821,6 @@ dynamic_active_listeners:
   last_updated:
     seconds: 2002002002
     nanos: 2000000
-dynamic_warming_listeners:
 dynamic_draining_listeners:
 )EOF");
 


### PR DESCRIPTION
Signed-off-by: Jianfei Hu <jianfeih@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Listeners config dump changed to warming_listeners if the workers are not started.
Risk Level: Low
Testing: Unit test, (existing unit test is good enough, with workers started before and after)
Docs Changes:
Release Notes: Listeners config dump changed to warming_listeners if the workers are not started.
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/6904
[Optional Deprecated:]
