### PR TITLE
api: clarify non-empty LDS/CDS resource hints.

### DIFF
--- a/api/envoy/api/v2/discovery.proto
+++ b/api/envoy/api/v2/discovery.proto
@@ -35,10 +35,10 @@ message DiscoveryRequest {
 
   // List of resources to subscribe to, e.g. list of cluster names or a route
   // configuration name. If this is empty, all resources for the API are
-  // returned. LDS/CDS expect empty resource_names, since this is global
-  // discovery for the Envoy instance. The LDS and CDS responses will then imply
-  // a number of resources that need to be fetched via EDS/RDS, which will be
-  // explicitly enumerated in resource_names.
+  // returned. LDS/CDS may have empty resource_names, which will cause all
+  // resources for the Envoy instance to be returned. The LDS and CDS responses
+  // will then imply a number of resources that need to be fetched via EDS/RDS,
+  // which will be explicitly enumerated in resource_names.
   repeated string resource_names = 3;
 
   // Type of the resource that is being requested, e.g.

--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -160,8 +160,8 @@ Resource hints
 ^^^^^^^^^^^^^^
 
 The :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` specified in the :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` are a hint.
-Some resource types, e.g. `Clusters` and `Listeners` will
-specify an empty :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` list, since Envoy is interested in
+Some resource types, e.g. `Clusters` and `Listeners` may
+specify an empty :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` list, since a client such as Envoy is interested in
 learning about all the :ref:`Clusters (CDS) <envoy_api_msg_Cluster>` and :ref:`Listeners (LDS) <envoy_api_msg_Listener>`
 that the management server(s) know about corresponding to its node
 identification. Other resource types, e.g. :ref:`RouteConfiguration (RDS) <envoy_api_msg_RouteConfiguration>`
@@ -169,10 +169,11 @@ and :ref:`ClusterLoadAssignment (EDS) <envoy_api_msg_ClusterLoadAssignment>`, fo
 CDS/LDS updates and Envoy is able to explicitly enumerate these
 resources.
 
-LDS/CDS resource hints will always be empty and it is expected that the
-management server will provide the complete state of the LDS/CDS
-resources in each response. An absent `Listener` or `Cluster` will
-be deleted.
+Envoy will always set the LDS/CDS resource hints to empty and it is expected that the management
+server will provide the complete state of the LDS/CDS resources in each response. An absent
+`Listener` or `Cluster` will be deleted. Other xDS clients may specify explicit LDS/CDS resources as
+resource hints, for example if they only have a singleton listener and already know its name from
+some out-of-band configuration.
 
 For EDS/RDS, the management server does not need to supply every
 requested resource and may also supply additional, unrequested


### PR DESCRIPTION
In order to better support clients such as gRPC-LB that want to access
only a single listener/cluster, provide the scope in the xDS
specification to specify explicit resource hints.

Signed-off-by: Harvey Tuch <htuch@google.com>