### PR TITLE
Fix documentation about load balancer subsets

### DIFF
--- a/docs/root/intro/arch_overview/upstream/load_balancing/locality_weight.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/locality_weight.rst
@@ -64,7 +64,14 @@ cluster configuration and providing weights in :ref:`LocalityLbEndpoints
 <envoy_api_msg_endpoint.LocalityLbEndpoints>` via :ref:`load_balancing_weight
 <envoy_api_field_endpoint.LocalityLbEndpoints.load_balancing_weight>`.
 
-This feature is not compatible with :ref:`load balancer subsetting
-<arch_overview_load_balancer_subsets>`, since it is not straightforward to
-reconcile locality level weighting with sensible weights for individual subsets.
+By setting :ref:`locality_weight_aware
+<Cluster.LbSubsetConfig.locality_weight_aware>`, this feature can be made
+compatible with :ref:`load balancer subsetting
+<arch_overview_load_balancer_subsets>`. Take care when enabling both load
+balancer subsetting and locality weighted load balancing as the resulting
+traffic split may be undesirable.
 
+It's possible to smooth out the weighting of a given locality when using
+subsets by setting :ref:`scale_locality_weight
+<Cluster.LbSubsetConfig.scale_locality_weight>`, which scales the weights by
+proportionally to the number of hosts in the subset predicate.


### PR DESCRIPTION
Fix the docs describing the interaction between load balancer subsets and the locality weighted load balancer.

This is a product of my discussion in slack with @snowp. Currently, the documentation for the Locality Weighted LB claims that it is entirely not compatible with subset selectors but this is no longer true with the `locality_weight_aware` flag on the Cluster subset config.

This PR updates the docs to reflect that.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level: None
Testing: Not applicable
Docs Changes: This is exclusively a documentation change
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
