### PR TITLE
bazel: adapt cc_wraper.py to python3

### DIFF
--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import contextlib
 import os
 import shlex

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -109,7 +109,7 @@ def main():
 
     with closing_fd(new_flagfile_fd):
       for arg in new_driver_args:
-        os.write(new_flagfile_fd, bytes(arg + "\n", "utf-8"))
+        os.write(new_flagfile_fd, bytes(str(arg + "\n").encode("utf-8")))
 
     # Provide new arguments using the temp file containing the args
     new_args = ["@" + new_flagfile_path]

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -109,7 +109,7 @@ def main():
 
     with closing_fd(new_flagfile_fd):
       for arg in new_driver_args:
-        os.write(new_flagfile_fd, arg + "\n")
+        os.write(new_flagfile_fd, bytes(arg + "\n", "utf-8"))
 
     # Provide new arguments using the temp file containing the args
     new_args = ["@" + new_flagfile_path]


### PR DESCRIPTION
Description:
In Arch and Clear Linux `/usr/bin/python` points to `python3` causing build failures due to type mismatch in `os.write()`: string is used where bytestring is expected.
Explicitly convert string to bytestring.

Risk Level: low
Testing: unit tests
Release Notes: N/A
Documentation: N/A