### PR TITLE
redis: remove redundant move

### DIFF
--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -31,7 +31,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
   client->connection_->addReadFilter(Network::ReadFilterSharedPtr{new UpstreamReadFilter(*client)});
   client->connection_->connect();
   client->connection_->noDelay(true);
-  return std::move(client);
+  return client;
 }
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,


### PR DESCRIPTION
Description: gcc9 reports the used `std::move()` as redundant.

Risk Level: low
Testing: unit tests
Release Notes: N/A
Documentation: N/A