### PR TITLE
filterchain: use span to avoid construct vector

### DIFF
--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -72,7 +72,6 @@ void FilterChainManagerImpl::addFilterChain(
       }
     }
 
-    // TODO(silentdai): use absl::Span to avoid vector construction at server_names and alpn
     addFilterChainForDestinationPorts(
         destination_ports_map_,
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(filter_chain_match, destination_port, 0), destination_ips,

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -72,19 +72,13 @@ void FilterChainManagerImpl::addFilterChain(
       }
     }
 
-    std::vector<std::string> server_names(filter_chain_match.server_names().begin(),
-                                          filter_chain_match.server_names().end());
-
-    std::vector<std::string> application_protocols(
-        filter_chain_match.application_protocols().begin(),
-        filter_chain_match.application_protocols().end());
-
     // TODO(silentdai): use absl::Span to avoid vector construction at server_names and alpn
     addFilterChainForDestinationPorts(
         destination_ports_map_,
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(filter_chain_match, destination_port, 0), destination_ips,
-        server_names, filter_chain_match.transport_protocol(), application_protocols,
-        filter_chain_match.source_type(), source_ips, filter_chain_match.source_ports(),
+        filter_chain_match.server_names(), filter_chain_match.transport_protocol(),
+        filter_chain_match.application_protocols(), filter_chain_match.source_type(), source_ips,
+        filter_chain_match.source_ports(),
         std::shared_ptr<Network::FilterChain>(
             filter_chain_factory_builder.buildFilterChain(*filter_chain)));
   }
@@ -93,11 +87,12 @@ void FilterChainManagerImpl::addFilterChain(
 
 void FilterChainManagerImpl::addFilterChainForDestinationPorts(
     DestinationPortsMap& destination_ports_map, uint16_t destination_port,
-    const std::vector<std::string>& destination_ips, const std::vector<std::string>& server_names,
-    const std::string& transport_protocol, const std::vector<std::string>& application_protocols,
+    const std::vector<std::string>& destination_ips,
+    const absl::Span<const std::string* const> server_names, const std::string& transport_protocol,
+    const absl::Span<const std::string* const> application_protocols,
     const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
     const std::vector<std::string>& source_ips,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+    const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
   if (destination_ports_map.find(destination_port) == destination_ports_map.end()) {
     destination_ports_map[destination_port] =
@@ -110,11 +105,11 @@ void FilterChainManagerImpl::addFilterChainForDestinationPorts(
 
 void FilterChainManagerImpl::addFilterChainForDestinationIPs(
     DestinationIPsMap& destination_ips_map, const std::vector<std::string>& destination_ips,
-    const std::vector<std::string>& server_names, const std::string& transport_protocol,
-    const std::vector<std::string>& application_protocols,
+    const absl::Span<const std::string* const> server_names, const std::string& transport_protocol,
+    const absl::Span<const std::string* const> application_protocols,
     const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
     const std::vector<std::string>& source_ips,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+    const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
   if (destination_ips.empty()) {
     addFilterChainForServerNames(destination_ips_map[EMPTY_STRING], server_names,
@@ -130,11 +125,12 @@ void FilterChainManagerImpl::addFilterChainForDestinationIPs(
 }
 
 void FilterChainManagerImpl::addFilterChainForServerNames(
-    ServerNamesMapSharedPtr& server_names_map_ptr, const std::vector<std::string>& server_names,
-    const std::string& transport_protocol, const std::vector<std::string>& application_protocols,
+    ServerNamesMapSharedPtr& server_names_map_ptr,
+    const absl::Span<const std::string* const> server_names, const std::string& transport_protocol,
+    const absl::Span<const std::string* const> application_protocols,
     const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
     const std::vector<std::string>& source_ips,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+    const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
   if (server_names_map_ptr == nullptr) {
     server_names_map_ptr = std::make_shared<ServerNamesMap>();
@@ -146,16 +142,16 @@ void FilterChainManagerImpl::addFilterChainForServerNames(
                                           application_protocols, source_type, source_ips,
                                           source_ports, filter_chain);
   } else {
-    for (const auto& server_name : server_names) {
-      if (isWildcardServerName(server_name)) {
+    for (const auto& server_name_ptr : server_names) {
+      if (isWildcardServerName(*server_name_ptr)) {
         // Add mapping for the wildcard domain, i.e. ".example.com" for "*.example.com".
         addFilterChainForApplicationProtocols(
-            server_names_map[server_name.substr(1)][transport_protocol], application_protocols,
+            server_names_map[server_name_ptr->substr(1)][transport_protocol], application_protocols,
             source_type, source_ips, source_ports, filter_chain);
       } else {
-        addFilterChainForApplicationProtocols(server_names_map[server_name][transport_protocol],
-                                              application_protocols, source_type, source_ips,
-                                              source_ports, filter_chain);
+        addFilterChainForApplicationProtocols(
+            server_names_map[*server_name_ptr][transport_protocol], application_protocols,
+            source_type, source_ips, source_ports, filter_chain);
       }
     }
   }
@@ -163,18 +159,18 @@ void FilterChainManagerImpl::addFilterChainForServerNames(
 
 void FilterChainManagerImpl::addFilterChainForApplicationProtocols(
     ApplicationProtocolsMap& application_protocols_map,
-    const std::vector<std::string>& application_protocols,
+    const absl::Span<const std::string* const> application_protocols,
     const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
     const std::vector<std::string>& source_ips,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+    const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
   if (application_protocols.empty()) {
     addFilterChainForSourceTypes(application_protocols_map[EMPTY_STRING], source_type, source_ips,
                                  source_ports, filter_chain);
   } else {
-    for (const auto& application_protocol : application_protocols) {
-      addFilterChainForSourceTypes(application_protocols_map[application_protocol], source_type,
-                                   source_ips, source_ports, filter_chain);
+    for (const auto& application_protocol_ptr : application_protocols) {
+      addFilterChainForSourceTypes(application_protocols_map[*application_protocol_ptr],
+                                   source_type, source_ips, source_ports, filter_chain);
     }
   }
 }
@@ -183,7 +179,7 @@ void FilterChainManagerImpl::addFilterChainForSourceTypes(
     SourceTypesArray& source_types_array,
     const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
     const std::vector<std::string>& source_ips,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+    const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
   if (source_ips.empty()) {
     addFilterChainForSourceIPs(source_types_array[source_type].first, EMPTY_STRING, source_ports,
@@ -198,7 +194,7 @@ void FilterChainManagerImpl::addFilterChainForSourceTypes(
 
 void FilterChainManagerImpl::addFilterChainForSourceIPs(
     SourceIPsMap& source_ips_map, const std::string& source_ip,
-    const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+    const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
   if (source_ports.empty()) {
     addFilterChainForSourcePorts(source_ips_map[source_ip], 0, filter_chain);

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -62,42 +62,47 @@ private:
 
   void addFilterChainForDestinationPorts(
       DestinationPortsMap& destination_ports_map, uint16_t destination_port,
-      const std::vector<std::string>& destination_ips, const std::vector<std::string>& server_names,
-      const std::string& transport_protocol, const std::vector<std::string>& application_protocols,
+      const std::vector<std::string>& destination_ips,
+      const absl::Span<const std::string* const> server_names,
+      const std::string& transport_protocol,
+      const absl::Span<const std::string* const> application_protocols,
       const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
       const std::vector<std::string>& source_ips,
-      const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+      const absl::Span<const Protobuf::uint32> source_ports,
       const Network::FilterChainSharedPtr& filter_chain);
   void addFilterChainForDestinationIPs(
       DestinationIPsMap& destination_ips_map, const std::vector<std::string>& destination_ips,
-      const std::vector<std::string>& server_names, const std::string& transport_protocol,
-      const std::vector<std::string>& application_protocols,
+      const absl::Span<const std::string* const> server_names,
+      const std::string& transport_protocol,
+      const absl::Span<const std::string* const> application_protocols,
       const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
       const std::vector<std::string>& source_ips,
-      const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+      const absl::Span<const Protobuf::uint32> source_ports,
       const Network::FilterChainSharedPtr& filter_chain);
   void addFilterChainForServerNames(
-      ServerNamesMapSharedPtr& server_names_map_ptr, const std::vector<std::string>& server_names,
-      const std::string& transport_protocol, const std::vector<std::string>& application_protocols,
+      ServerNamesMapSharedPtr& server_names_map_ptr,
+      const absl::Span<const std::string* const> server_names,
+      const std::string& transport_protocol,
+      const absl::Span<const std::string* const> application_protocols,
       const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
       const std::vector<std::string>& source_ips,
-      const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+      const absl::Span<const Protobuf::uint32> source_ports,
       const Network::FilterChainSharedPtr& filter_chain);
   void addFilterChainForApplicationProtocols(
       ApplicationProtocolsMap& application_protocol_map,
-      const std::vector<std::string>& application_protocols,
+      const absl::Span<const std::string* const> application_protocols,
       const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
       const std::vector<std::string>& source_ips,
-      const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+      const absl::Span<const Protobuf::uint32> source_ports,
       const Network::FilterChainSharedPtr& filter_chain);
   void addFilterChainForSourceTypes(
       SourceTypesArray& source_types_array,
       const envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType source_type,
       const std::vector<std::string>& source_ips,
-      const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+      const absl::Span<const Protobuf::uint32> source_ports,
       const Network::FilterChainSharedPtr& filter_chain);
   void addFilterChainForSourceIPs(SourceIPsMap& source_ips_map, const std::string& source_ip,
-                                  const Protobuf::RepeatedField<Protobuf::uint32>& source_ports,
+                                  const absl::Span<const Protobuf::uint32> source_ports,
                                   const Network::FilterChainSharedPtr& filter_chain);
   void addFilterChainForSourcePorts(SourcePortsMapSharedPtr& source_ports_map_ptr,
                                     uint32_t source_port,


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Description:
Clean up the TODO
The read-only Protobuf::RepeatedField can be viewed as span in listener/filterchain

Risk Level: LOW. It's internal implementation detail of filter chain.
Testing: 
Existing test.
Filterchain benchmark test doesn't complain in trivial case. But I didn't extend the test to embrace huge server names and protocol set.

