### PR TITLE
api filter http: add build rules for go protobufs

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/BUILD
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 api_proto_library_internal(
     name = "jwt_authn",
@@ -9,5 +9,15 @@ api_proto_library_internal(
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/core:http_uri",
         "//envoy/api/v2/route",
+    ],
+)
+
+api_go_proto_library(
+    name = "jwt_authn",
+    proto = ":jwt_authn",
+    deps = [
+        "//envoy/api/v2/core:base_go_proto",
+        "//envoy/api/v2/core:http_uri_go_proto",
+        "//envoy/api/v2/route_go_proto",
     ],
 )

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/BUILD
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/BUILD
@@ -18,6 +18,6 @@ api_go_proto_library(
     deps = [
         "//envoy/api/v2/core:base_go_proto",
         "//envoy/api/v2/core:http_uri_go_proto",
-        "//envoy/api/v2/route_go_proto",
+        "//envoy/api/v2/route:route_go_proto",
     ],
 )

--- a/api/envoy/config/filter/http/router/v2/BUILD
+++ b/api/envoy/config/filter/http/router/v2/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
@@ -6,4 +6,10 @@ api_proto_library_internal(
     name = "router",
     srcs = ["router.proto"],
     deps = ["//envoy/config/filter/accesslog/v2:accesslog"],
+)
+
+api_go_proto_library(
+    name = "router",
+    proto = ":router",
+    deps = ["//envoy/config/filter/accesslog/v2:accesslog_go_proto"],
 )

--- a/api/envoy/config/filter/http/transcoder/v2/BUILD
+++ b/api/envoy/config/filter/http/transcoder/v2/BUILD
@@ -1,8 +1,13 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
 api_proto_library_internal(
     name = "transcoder",
     srcs = ["transcoder.proto"],
+)
+
+api_go_proto_library(
+    name = "transcoder",
+    proto = ":transcoder",
 )


### PR DESCRIPTION
Description: All http filters have build rules to generate cc protobufs, but not go protobufs. Added build rules (to a few filters) to generate go protobuf files. Emulates the rules in the `health_check` http filter.

Risk Level: Low

Testing: These rules were copied to google3 and tested internally. Unfortunately, I am having a bit of trouble with `bazel build` directly on these targets ("Package is considered deleted due to --deleted_packages"). Please let me know if there is a better way to test this change.

Docs Changes: N/A

Release Notes: N/A