### PR TITLE
listener: keep ListenerFactoryContext small

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -174,13 +174,6 @@ public:
 class ListenerFactoryContext : public virtual FactoryContext {
 public:
   /**
-   * Store socket options to be set on the listen socket before listening.
-   */
-  virtual void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) PURE;
-
-  virtual void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) PURE;
-
-  /**
    * Give access to the listener configuration
    */
   virtual const Network::ListenerConfig& listenerConfig() const PURE;

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -275,6 +275,15 @@ public:
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
 
+  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) {
+    ensureSocketOptions();
+    listen_socket_options_->emplace_back(std::move(option));
+  }
+  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
+    ensureSocketOptions();
+    Network::Socket::appendOptions(listen_socket_options_, options);
+  }
+
   // Server::Configuration::ListenerFactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {
     return parent_.server_.accessLogManager();
@@ -304,14 +313,6 @@ public:
       listen_socket_options_ =
           std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
     }
-  }
-  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) override {
-    ensureSocketOptions();
-    listen_socket_options_->emplace_back(std::move(option));
-  }
-  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) override {
-    ensureSocketOptions();
-    Network::Socket::appendOptions(listen_socket_options_, options);
   }
   const Network::ListenerConfig& listenerConfig() const override { return *this; }
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -275,15 +275,6 @@ public:
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
 
-  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) {
-    ensureSocketOptions();
-    listen_socket_options_->emplace_back(std::move(option));
-  }
-  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
-    ensureSocketOptions();
-    Network::Socket::appendOptions(listen_socket_options_, options);
-  }
-
   // Server::Configuration::ListenerFactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {
     return parent_.server_.accessLogManager();
@@ -337,6 +328,15 @@ public:
   SystemTime last_updated_;
 
 private:
+  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) {
+    ensureSocketOptions();
+    listen_socket_options_->emplace_back(std::move(option));
+  }
+  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
+    ensureSocketOptions();
+    Network::Socket::appendOptions(listen_socket_options_, options);
+  }
+
   ListenerManagerImpl& parent_;
   Network::Address::InstanceConstSharedPtr address_;
   FilterChainManagerImpl filter_chain_manager_;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -516,11 +516,11 @@ public:
   MockListenerFactoryContext();
   ~MockListenerFactoryContext() override;
 
-  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) override {
+  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) {
     addListenSocketOption_(option);
   }
   MOCK_METHOD1(addListenSocketOption_, void(const Network::Socket::OptionConstSharedPtr&));
-  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) override {
+  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
     addListenSocketOptions_(options);
   }
   MOCK_METHOD1(addListenSocketOptions_, void(const Network::Socket::OptionsSharedPtr&));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -516,14 +516,6 @@ public:
   MockListenerFactoryContext();
   ~MockListenerFactoryContext() override;
 
-  void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) {
-    addListenSocketOption_(option);
-  }
-  MOCK_METHOD1(addListenSocketOption_, void(const Network::Socket::OptionConstSharedPtr&));
-  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
-    addListenSocketOptions_(options);
-  }
-  MOCK_METHOD1(addListenSocketOptions_, void(const Network::Socket::OptionsSharedPtr&));
   const Network::ListenerConfig& listenerConfig() const override { return _listenerConfig_; }
   MOCK_CONST_METHOD0(listenerConfig_, const Network::ListenerConfig&());
 


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Description:
`ListenerFactoryContext` is mainly used by `NetworkFilter` and `ListenerFilter`to access `Listener`.
Code base evolved and there is no use case to add listen socket options.
Instead, listener options should be added by [Listener config proto](https://github.com/envoyproxy/envoy/blob/40d8b7f68c64591f11d4e62ac429af5e074ed3a7/api/envoy/api/v2/lds.proto#L165)

The existing usage are left in listener test to inject failure, probably fit the code in the past but should never seen in current code flow. 

Risk Level: LOW
Testing: Modified tests

Fixes #7467 