### PR TITLE
cds: fix original_dst cluster creation crash in worker thread callback

### DIFF
--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -291,7 +291,7 @@ private:
         std::unordered_map<Network::ClientConnection*, std::unique_ptr<TcpConnContainer>>;
 
     struct ClusterEntry : public ThreadLocalCluster {
-      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
+      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterSharedPtr cluster,
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry();
 


### PR DESCRIPTION
Description: If a original_dst cluster got deleted right after it's created, on worker thread,
its creation callback may not be able to find its ClusterData in
ClusterManagerImpl::active_clusters_, then it would crash with std::out_of_rang
exception, because it tried to look up its ClusterData in
ClusterManagerImpl::active_clusters_ by std::map::at().

This change makes thread local cluster creation callback to capture ClusterSharedPtr
directly and use it to create OriginalDstCluster which holds it with a weak pointer.
In this way, worker thread needn't to access ClusterManagerImpl::active_clusters_
anymore.

Risk Level: Medium
Testing:Add cds integration test, create/delete original_dst cluster repeatedly.
 Fixes #7500  

Signed-off-by: lhuang8 <lhuang8@ebay.com>
 

