### PR TITLE
build: remove -lc++fs from linkopts

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -60,7 +60,7 @@ def _envoy_test_linkopts():
         # TODO(mattklein123): It's not great that we universally link against the following libs.
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
-    }) + envoy_select_force_libcpp(["-lc++fs"], ["-lstdc++fs", "-latomic"])
+    }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"])
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -5,7 +5,7 @@
 
 // TODO(asraa): Remove <experimental/filesystem> and rely only on <filesystem> when Envoy requires
 // Clang >= 9.
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
 #include <filesystem>
 #elif defined __has_include
 #if __has_include(<experimental/filesystem>)

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -5,7 +5,7 @@
 
 // TODO(asraa): Remove <experimental/filesystem> and rely only on <filesystem> when Envoy requires
 // Clang >= 9.
-#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
 #include <filesystem>
 #elif defined __has_include
 #if __has_include(<experimental/filesystem>)
@@ -42,7 +42,7 @@ std::string makeTempDir(char* name_template) {
   char* dirname = ::_mktemp(name_template);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, strerror(errno)));
-#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
   std::__fs::filesystem::create_directories(dirname);
 #elif defined __cpp_lib_experimental_filesystem
   std::experimental::filesystem::create_directories(dirname);
@@ -85,7 +85,7 @@ char** argv_;
 } // namespace
 
 void TestEnvironment::createPath(const std::string& path) {
-#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path));
@@ -98,7 +98,7 @@ void TestEnvironment::createPath(const std::string& path) {
 }
 
 void TestEnvironment::createParentPath(const std::string& path) {
-#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path).parent_path());
@@ -113,7 +113,7 @@ void TestEnvironment::createParentPath(const std::string& path) {
 
 void TestEnvironment::removePath(const std::string& path) {
   RELEASE_ASSERT(absl::StartsWith(path, TestEnvironment::temporaryDirectory()), "");
-#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   if (!std::__fs::filesystem::exists(path)) {


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Cherry-picking latest commit of #7329 before release. To unbreak fuzz build. Address #7507 that bring real c++fs dependency.

Risk Level: Low
Testing: local fuzz, CI
Docs Changes:
Release Notes:
