### PR TITLE
tests: remove redundant std::move()

### DIFF
--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -48,7 +48,7 @@ public:
           Buffer::OwnedImpl("Lorem ipsum dolor sit amet, consectetuer adipiscing elit.");
       buffer->add(new_buffer);
     }
-    return std::move(buffer);
+    return buffer;
   }
 
   Network::Address::InstanceConstSharedPtr addr_;

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -64,7 +64,7 @@ public:
       Server::Configuration::ResourceMonitorFactoryContext& context) override {
     auto monitor = std::make_unique<FakeResourceMonitor>(context.dispatcher());
     monitor_ = monitor.get();
-    return std::move(monitor);
+    return monitor;
   }
 
   FakeResourceMonitor* monitor_; // not owned


### PR DESCRIPTION
Description: gcc9 reports the uses of std::move() redundant.

Risk Level: low
Testing: unit tests
Release Notes: N/A
Documentation: N/A