### PR TITLE
Bump c-ARES version to include important fixes.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -27,13 +27,13 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://files.pythonhosted.org/packages/c6/b4/510617906f8e0c5660e7d96fbc5585113f83ad547a3989b80297ac72a74c/thrift-0.11.0.tar.gz"],
     ),
     com_github_c_ares_c_ares = dict(
-        sha256 = "96edccdb19d79f6bc48c2c0e5916346c8f0507efa72e76bd146a1b9d05f93c2a",
-        strip_prefix = "c-ares-5dd3629bc93449840c36dd635ea6cce606b8c366",
+        sha256 = "bbaab13d6ad399a278d476f533e4d88a7ec7d729507348bb9c2e3b207ba4c606",
+        strip_prefix = "c-ares-d7e070e7283f822b1d2787903cce3615536c5610",
         # 2019-06-19
-        # 21 new commits from release-1.15.0. Upgrade for commit 7d3591ee8a1a63e7748e68e6d880bd1763a32885 "getaddrinfo enhancements"
+        # 27 new commits from release-1.15.0. Upgrade for commit 7d3591ee8a1a63e7748e68e6d880bd1763a32885 "getaddrinfo enhancements" and follow up fixes.
         # Use getaddrinfo to query DNS record and TTL.
         # TODO(crazyxy): Update to release-1.16.0 when it is released.
-        urls = ["https://github.com/c-ares/c-ares/archive/5dd3629bc93449840c36dd635ea6cce606b8c366.tar.gz"],
+        urls = ["https://github.com/c-ares/c-ares/archive/d7e070e7283f822b1d2787903cce3615536c5610.tar.gz"],
     ),
     com_github_circonus_labs_libcircllhist = dict(
         sha256 = "8165aa25e529d7d4b9ae849d3bf30371255a99d6db0421516abcff23214cdc2c",


### PR DESCRIPTION
In https://github.com/envoyproxy/envoy/pull/7395, the c-ARES dependency
version number was increased to gain access to a new getaddrinfo API by
importing a specific nonrelease SHA from c-ARES.

This specific SHA did not include
https://github.com/c-ares/c-ares/commit/b949cc3ddfbeb1b3fba571fb53b186b645e66e9c
, made subsequently, which contains important security relevant fixes for the getaddrinfo
API.

This PR bumps the c-ARES version number to include them.

Signed-off-by: Dan Noé <dpn@google.com>

Description:
Risk Level: Low - external dependency version update
Testing: `bazel test //test/...`
