### PR TITLE
test: hopefully deflaking lua test

### DIFF
--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1264,7 +1264,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
   num_loops = 200
 #endif
 
-  for (uint64_t i = 0; i < num_loops; i++) {
+      for (uint64_t i = 0; i < num_loops; i++) {
     Http::TestHeaderMapImpl request_headers{{":path", "/"}};
     Http::TestHeaderMapImpl expected_headers{{":status", "503"}, {"content-length", "4"}};
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1264,7 +1264,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
   num_loops = 200;
 #endif
 
-      for (uint64_t i = 0; i < num_loops; i++) {
+  for (uint64_t i = 0; i < num_loops; i++) {
     Http::TestHeaderMapImpl request_headers{{":path", "/"}};
     Http::TestHeaderMapImpl expected_headers{{":status", "503"}, {"content-length", "4"}};
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1257,7 +1257,14 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
   config_->runtimeGC();
   const uint64_t mem_use_at_start = config_->runtimeBytesUsed();
 
-  for (uint64_t i = 0; i < 2000; i++) {
+  uint64_t num_loops = 2000;
+#if defined(__has_feature) && (__has_feature(thread_sanitizer))
+  // per https://github.com/envoyproxy/envoy/issues/7374 this test is causing
+  // problems on tsan
+  num_loops = 200
+#endif
+
+  for (uint64_t i = 0; i < num_loops; i++) {
     Http::TestHeaderMapImpl request_headers{{":path", "/"}};
     Http::TestHeaderMapImpl expected_headers{{":status", "503"}, {"content-length", "4"}};
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1261,7 +1261,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
 #if defined(__has_feature) && (__has_feature(thread_sanitizer))
   // per https://github.com/envoyproxy/envoy/issues/7374 this test is causing
   // problems on tsan
-  num_loops = 200
+  num_loops = 200;
 #endif
 
       for (uint64_t i = 0; i < num_loops; i++) {


### PR DESCRIPTION
As discussed on slack I think this is hitting timeout/OOM due to the large loop factor.
Toning it down for tsan to get CI to stop flaking while we figure out why it wasn't logging

Risk Level: n/a (test only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
mitigating #7374
