### PR TITLE
fuzz: xDS fuzzer skeleton code

### DIFF
--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])  # Apache 2
 
-load("//bazel:envoy_build_system.bzl", "envoy_cc_fuzz_test", "envoy_cc_test", "envoy_package")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_fuzz_test", "envoy_cc_test", "envoy_cc_test_library", "envoy_package", "envoy_proto_library")
 load(
     "//source/extensions:all_extensions.bzl",
     "envoy_all_extensions",
@@ -95,4 +95,33 @@ envoy_cc_fuzz_test(
         "//test/mocks/server:server_mocks",
         "//test/test_common:environment_lib",
     ] + envoy_all_extensions(),
+)
+
+envoy_proto_library(
+    name = "xds_fuzz_proto",
+    srcs = ["xds_fuzz.proto"],
+    deps = [],
+)
+
+envoy_cc_test_library(
+    name = "xds_fuzz_lib",
+    srcs = ["xds_fuzz.cc"],
+    hdrs = ["xds_fuzz.h"],
+    deps = [
+        "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
+        "//test/integration:http_integration_lib",
+        ":xds_fuzz_proto_cc",
+        "//test/integration:integration_lib",
+        "//include/envoy/event:dispatcher_interface",
+        "//test/fuzz:fuzz_runner_lib",
+    ] + envoy_all_extensions(),
+)
+
+envoy_cc_fuzz_test(
+    name = "xds_fuzz_test",
+    srcs = ["xds_fuzz_test.cc"],
+    corpus = "//test/server/config_validation:xds_corpus",
+    deps = [
+        ":xds_fuzz_lib",
+    ],
 )

--- a/test/server/config_validation/xds_corpus/example
+++ b/test/server/config_validation/xds_corpus/example
@@ -1,4 +1,11 @@
 actions {
+  add_listener {
+    version : "1"
+    name : "listener_0"
+    route_config : "route_config_0"
+  }
+}
+actions {
   add_route {
     name : "route_config_0"
     cluster : "cluster_0"
@@ -6,44 +13,15 @@ actions {
 }
 
 actions {
-  add_listener {
-    version : "1"
-    name : "listener_0"
-    route_config : "route_config_0"
-  }
-}
-actions {
-  remove_listener {
-    name : "listener_0"
-    version : "1"
-  }
-}
-actions {
-  add_listener {
-    version: "1"
-    name : "listener_1"
-    route_config : "route_config_0"
- }
-}
-actions {
   add_route {
-    name : "route_config_3"
+    name : "route_config_1"
     cluster : "cluster_0"
-  } 
+  }
 }
 actions {
   add_listener {
-    version: "1"
+    version : "1"
     name : "listener_1"
-    route_config : "route_config_2"
+    route_config : "route_config_1"
   }
 }
-
-#actions {
-#  add_listener {
-#    version : "2"
-#    name : "listener_1"
-#    route_config : "route_config_0"
-#  }
-#
-#}

--- a/test/server/config_validation/xds_corpus/example
+++ b/test/server/config_validation/xds_corpus/example
@@ -1,0 +1,49 @@
+actions {
+  add_route {
+    name : "route_config_0"
+    cluster : "cluster_0"
+  }
+}
+
+actions {
+  add_listener {
+    version : "1"
+    name : "listener_0"
+    route_config : "route_config_0"
+  }
+}
+actions {
+  remove_listener {
+    name : "listener_0"
+    version : "1"
+  }
+}
+actions {
+  add_listener {
+    version: "1"
+    name : "listener_1"
+    route_config : "route_config_0"
+ }
+}
+actions {
+  add_route {
+    name : "route_config_3"
+    cluster : "cluster_0"
+  } 
+}
+actions {
+  add_listener {
+    version: "1"
+    name : "listener_1"
+    route_config : "route_config_2"
+  }
+}
+
+#actions {
+#  add_listener {
+#    version : "2"
+#    name : "listener_1"
+#    route_config : "route_config_0"
+#  }
+#
+#}

--- a/test/server/config_validation/xds_corpus/example1
+++ b/test/server/config_validation/xds_corpus/example1
@@ -11,15 +11,11 @@ actions {
     cluster : "cluster_0"
   }
 }
-
 actions {
-  add_listener {
-    version : "1"
-    name : "listener_1"
-    route_config : "route_config_1"
+  remove_route {
+    name : "route_config_0"
   }
 }
-
 actions {
   add_route {
     name : "route_config_1"
@@ -29,7 +25,7 @@ actions {
 actions {
   add_listener {
     version : "1"
-    name : "listener_2"
+    name : "listener_1"
     route_config : "route_config_1"
   }
 }

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -1,0 +1,244 @@
+#include "test/server/config_validation/xds_fuzz.h"
+
+#include <fstream>
+
+#include "envoy/event/dispatcher.h"
+
+#include "test/integration/fake_upstream.h"
+
+namespace Envoy {
+namespace Server {
+
+const std::string config = R"EOF(
+dynamic_resources:
+  lds_config: {ads: {}}
+  cds_config: {ads: {}}
+  ads_config:
+    api_type: GRPC
+static_resources:
+  clusters:
+    name: dummy_cluster
+    connect_timeout: { seconds: 5 }
+    type: STATIC
+    hosts:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 0
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 0
+)EOF";
+
+XdsFuzzTest::XdsFuzzTest(Network::Address::IpVersion version,
+                         const test::server::config_validation::XdsTestCase& input)
+    : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, version, config),
+      actions_(input.actions()), num_lds_updates_(0) {
+  use_lds_ = false;
+  create_xds_upstream_ = true;
+  tls_xds_upstream_ = false;
+}
+
+void XdsFuzzTest::initialize() {
+  // Add ADS config with gRPC.
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+    auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
+    auto* grpc_service = ads_config->add_grpc_services();
+    grpc_service->mutable_envoy_grpc()->set_cluster_name("ads_cluster");
+    auto* ads_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ads_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ads_cluster->set_name("ads_cluster");
+  });
+  HttpIntegrationTest::initialize();
+  setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
+  if (xds_stream_ == nullptr) {
+    createXdsConnection();
+    AssertionResult result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    xds_stream_->startGrpcStream();
+  }
+}
+
+envoy::api::v2::Listener XdsFuzzTest::buildListener(const std::string& name,
+                                                    const std::string& route_config,
+                                                    const std::string& stat_prefix) {
+  return TestUtility::parseYaml<envoy::api::v2::Listener>(fmt::format(
+      R"EOF(
+      name: {}
+      address:
+        socket_address:
+          address: {}
+          port_value: 0
+      filter_chains:
+        filters:
+        - name: envoy.http_connection_manager
+          config:
+            stat_prefix: {}
+            codec_type: HTTP1
+            rds:
+              route_config_name: {}
+              config_source: {{ ads: {{}} }}
+            http_filters: [{{ name: envoy.router }}]
+    )EOF",
+      name, Network::Test::getLoopbackAddressString(version_), stat_prefix, route_config));
+}
+
+envoy::api::v2::Cluster XdsFuzzTest::buildCluster(const std::string& name) {
+  return TestUtility::parseYaml<envoy::api::v2::Cluster>(fmt::format(R"EOF(
+      name: {}
+      connect_timeout: 5s
+      type: EDS
+      eds_cluster_config: {{ eds_config: {{ ads: {{}} }} }}
+      lb_policy: ROUND_ROBIN
+      http2_protocol_options: {{}}
+    )EOF",
+                                                                     name));
+}
+
+envoy::api::v2::ClusterLoadAssignment
+XdsFuzzTest::buildClusterLoadAssignment(const std::string& name) {
+  return TestUtility::parseYaml<envoy::api::v2::ClusterLoadAssignment>(
+      fmt::format(R"EOF(
+      cluster_name: {}
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: {}
+                port_value: {}
+    )EOF",
+                  name, Network::Test::getLoopbackAddressString(version_),
+                  fake_upstreams_[0]->localAddress()->ip()->port()));
+}
+
+envoy::api::v2::RouteConfiguration XdsFuzzTest::buildRouteConfig(const std::string& name,
+                                                                 const std::string& cluster) {
+  return TestUtility::parseYaml<envoy::api::v2::RouteConfiguration>(fmt::format(R"EOF(
+      name: {}
+      virtual_hosts:
+      - name: integration
+        domains: ["*"]
+        routes:
+        - match: {{ prefix: "/" }}
+          route: {{ cluster: {} }}
+    )EOF",
+                                                                                name, cluster));
+}
+
+void XdsFuzzTest::addListener(const std::vector<envoy::api::v2::Listener>& listeners,
+                              const std::string& version) {
+  // Parse action and state into a DiscoveryResponse.
+  sendDiscoveryResponse<envoy::api::v2::Listener>(Config::TypeUrl::get().Listener, listeners, {},
+                                                  {}, version);
+}
+
+void XdsFuzzTest::addRoute(const std::vector<envoy::api::v2::RouteConfiguration> routes,
+                           const std::string& version) {
+  // Parse action and state into a DiscoveryResponse.
+  sendDiscoveryResponse<envoy::api::v2::RouteConfiguration>(
+      Config::TypeUrl::get().RouteConfiguration, routes, {}, {}, version);
+}
+
+void XdsFuzzTest::close() {
+  cleanUpXdsConnection();
+  test_server_.reset();
+  fake_upstreams_.clear();
+}
+
+void XdsFuzzTest::replay() {
+  // QUESTION: sanity check -- doesn't this init after each test case input?
+  // Maybe the upstream connection is only initialized if it's not set.. check...
+  // Go through actions.
+  initialize();
+
+  sendDiscoveryResponse<envoy::api::v2::Cluster>(Config::TypeUrl::get().Cluster,
+                                                 {buildCluster("cluster_0")},
+                                                 {buildCluster("cluster_0")}, {}, "1");
+  sendDiscoveryResponse<envoy::api::v2::ClusterLoadAssignment>(
+      Config::TypeUrl::get().ClusterLoadAssignment, {buildClusterLoadAssignment("cluster_0")},
+      {buildClusterLoadAssignment("cluster_0")}, {}, "1");
+
+  for (const auto& action : actions_) {
+    switch (action.action_selector_case()) {
+    case test::server::config_validation::Action::kAddListener: {
+      // First remove listener if it already exists.
+      listeners.erase(std::remove_if(listeners.begin(), listeners.end(),
+                                     [&action](const envoy::api::v2::Listener& listener) {
+                                       return listener.name() == action.add_listener().name();
+                                     }),
+                      listeners.end());
+
+      // Add / updated listener.
+      listeners.push_back(
+          buildListener(action.add_listener().name(), action.add_listener().route_config()));
+
+      // Send DiscoveryResponse to add / update listener.
+      addListener(listeners, action.add_listener().version());
+      num_lds_updates_++;
+
+      // compareDiscoveryRequest (move to addListener?)
+      std::vector<std::string> names;
+      for (const auto& listener : listeners) {
+        names.push_back(listener.name());
+      }
+      // Causes a pure virtual method call error
+      // ASSERT_TRUE(compareDiscoveryRequest(Envoy::Config::TypeUrl::get().Listener,
+      // action.add_listener().version(), names, {}, {}));
+
+      break;
+    }
+    case test::server::config_validation::Action::kAddRoute: {
+      routes.push_back(buildRouteConfig(action.add_route().name(), action.add_route().cluster()));
+      addRoute(routes, action.add_route().version());
+      break;
+    }
+    case test::server::config_validation::Action::kRemoveListener: {
+      // Check if listener with this name is in the list of listeners, and if so, remove.
+      listeners.erase(std::remove_if(listeners.begin(), listeners.end(),
+                                     [&action](const envoy::api::v2::Listener& listener) {
+                                       return listener.name() == action.remove_listener().name();
+                                     }),
+                      listeners.end());
+      // Draining listener -> assert_failure.
+      addListener(listeners, action.add_listener().version());
+      num_lds_updates_++; // Move this in to addListener
+      break;
+    }
+    case test::server::config_validation::Action::kRemoveRoute: {
+      // Check if route with this name is in the list of routes, and if so, remove.
+      std::remove_if(routes.begin(), routes.end(),
+                     [&](const envoy::api::v2::RouteConfiguration& route) {
+                       return route.name() == action.remove_route().name();
+                     });
+      addRoute(routes, action.add_route().version());
+      break;
+    }
+    default:
+      break;
+    }
+  }
+  // Disconnect and close.
+  verifyState();
+  close();
+}
+
+void XdsFuzzTest::verifyState() {
+  // Verify listeners.
+  // Wait to receive all the gRPC versions....?
+  // test_server_->waitForCounterGe("listener_manager.lds.update_attempt", num_lds_updates_);
+  // ENVOY_LOG_MISC(debug, "updates {} {}", num_lds_updates_,
+  // test_server_->counter("listener_manager.lds.update_attempt")->value());
+  // RELEASE_ASSERT( test_server_->counter("listener_manager.lds.update_attempt")->value() ==
+  // num_lds_updates_, ""); ENVOY_LOG_MISC(debug, "WARMING {}",
+  // test_server_->gauge("listener_manager.total_listeners_warming")->value());
+  // TODO: Keep track of update_rejected (duplicate listeners).
+  // Check draining states based on action record.
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -4,8 +4,8 @@
 
 #include "envoy/event/dispatcher.h"
 
-#include "test/integration/fake_upstream.h"
 #include "test/common/grpc/grpc_client_integration.h"
+#include "test/integration/fake_upstream.h"
 
 namespace Envoy {
 namespace Server {
@@ -46,24 +46,14 @@ XdsFuzzTest::XdsFuzzTest(Network::Address::IpVersion version,
 
 void XdsFuzzTest::initialize() {
   // Add ADS config with gRPC.
-  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
     auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
     auto* grpc_service = ads_config->add_grpc_services();
     grpc_service->mutable_envoy_grpc()->set_cluster_name("ads_cluster");
     auto* ads_cluster = bootstrap.mutable_static_resources()->add_clusters();
     ads_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
     ads_cluster->set_name("ads_cluster");
-    // auto* context = ads_cluster->mutable_tls_context();
-    // auto* validation_context = context->mutable_common_tls_context()->mutable_validation_context();
-    // validation_context->mutable_trusted_ca()->set_filename(
-    //     TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
-    // validation_context->add_verify_subject_alt_name("foo.lyft.com");
-    // if (clientType() == Grpc::ClientType::GoogleGrpc) {
-    //   auto* google_grpc = grpc_service->mutable_google_grpc();
-    //   auto* ssl_creds = google_grpc->mutable_channel_credentials()->mutable_ssl_credentials();
-    //   ssl_creds->mutable_root_certs()->set_filename(
-    //       TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
-    });
+  });
   HttpIntegrationTest::initialize();
   setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
   if (xds_stream_ == nullptr) {
@@ -141,16 +131,16 @@ envoy::api::v2::RouteConfiguration XdsFuzzTest::buildRouteConfig(const std::stri
                                                                                 name, cluster));
 }
 
-void XdsFuzzTest::addListener(const std::vector<envoy::api::v2::Listener>& listeners,
-                              const std::string& version) {
+void XdsFuzzTest::updateListener(const std::vector<envoy::api::v2::Listener>& listeners,
+                                 const std::string& version) {
   // Parse action and state into a DiscoveryResponse.
   ENVOY_LOG_MISC(debug, "Sending Listener DiscoveryResponse version {}", version);
   sendDiscoveryResponse<envoy::api::v2::Listener>(Config::TypeUrl::get().Listener, listeners, {},
                                                   {}, version);
 }
 
-void XdsFuzzTest::addRoute(const std::vector<envoy::api::v2::RouteConfiguration> routes,
-                           const std::string& version) {
+void XdsFuzzTest::updateRoute(const std::vector<envoy::api::v2::RouteConfiguration> routes,
+                              const std::string& version) {
   // Parse action and state into a DiscoveryResponse.
   sendDiscoveryResponse<envoy::api::v2::RouteConfiguration>(
       Config::TypeUrl::get().RouteConfiguration, routes, {}, {}, version);
@@ -163,11 +153,9 @@ void XdsFuzzTest::close() {
 }
 
 void XdsFuzzTest::replay() {
-  // QUESTION: sanity check -- doesn't this init after each test case input?
-  // Maybe the upstream connection is only initialized if it's not set.. check...
-  // Go through actions.
   initialize();
 
+  // Set up an initial cluster.
   sendDiscoveryResponse<envoy::api::v2::Cluster>(Config::TypeUrl::get().Cluster,
                                                  {buildCluster("cluster_0")},
                                                  {buildCluster("cluster_0")}, {}, "1");
@@ -176,50 +164,46 @@ void XdsFuzzTest::replay() {
       {buildClusterLoadAssignment("cluster_0")}, {}, "1");
 
   for (const auto& action : actions_) {
-    ENVOY_LOG_MISC(debug, "Action: {}", action.DebugString());
+    ENVOY_LOG_MISC(trace, "Action: {}", action.DebugString());
     switch (action.action_selector_case()) {
     case test::server::config_validation::Action::kAddListener: {
-      // First remove listener if it already exists.
+      // Update the listener list.
       listeners.erase(std::remove_if(listeners.begin(), listeners.end(),
                                      [&action](const envoy::api::v2::Listener& listener) {
                                        return listener.name() == action.add_listener().name();
                                      }),
                       listeners.end());
-
-      // Add / updated listener.
       listeners.push_back(
           buildListener(action.add_listener().name(), action.add_listener().route_config()));
 
-      // Send DiscoveryResponse to add / update listener.
-      addListener(listeners, action.add_listener().version());
+      // Send Listener DiscoveryResponse and update count.
+      updateListener(listeners, action.add_listener().version());
       num_lds_updates_++;
-
-      // compareDiscoveryRequest (move to addListener?)
-      std::vector<std::string> names;
-      for (const auto& listener : listeners) {
-        names.push_back(listener.name());
-      }
-      // Causes a pure virtual method call error
-      // ASSERT_TRUE(compareDiscoveryRequest(Envoy::Config::TypeUrl::get().Listener,
-      // action.add_listener().version(), names, {}, {}));
-
+      test_server_->waitForCounterGe("listener_manager.lds.update_attempt", num_lds_updates_);
       break;
     }
     case test::server::config_validation::Action::kAddRoute: {
+      // Update the route list.
+      std::remove_if(routes.begin(), routes.end(),
+                     [&](const envoy::api::v2::RouteConfiguration& route) {
+                       return route.name() == action.remove_route().name();
+                     });
+
       routes.push_back(buildRouteConfig(action.add_route().name(), action.add_route().cluster()));
-      addRoute(routes, action.add_route().version());
+      updateRoute(routes, action.add_route().version());
       break;
     }
     case test::server::config_validation::Action::kRemoveListener: {
-      // Check if listener with this name is in the list of listeners, and if so, remove.
+      // Remove listener from list.
       listeners.erase(std::remove_if(listeners.begin(), listeners.end(),
                                      [&action](const envoy::api::v2::Listener& listener) {
                                        return listener.name() == action.remove_listener().name();
                                      }),
                       listeners.end());
-      // Draining listener -> assert_failure.
-      addListener(listeners, action.add_listener().version());
-      num_lds_updates_++; // Move this in to addListener
+      // Send state of the world listener DiscoveryResponse.
+      updateListener(listeners, action.add_listener().version());
+      num_lds_updates_++;
+      test_server_->waitForCounterGe("listener_manager.lds.update_attempt", num_lds_updates_);
       break;
     }
     case test::server::config_validation::Action::kRemoveRoute: {
@@ -228,29 +212,23 @@ void XdsFuzzTest::replay() {
                      [&](const envoy::api::v2::RouteConfiguration& route) {
                        return route.name() == action.remove_route().name();
                      });
-      addRoute(routes, action.add_route().version());
+      updateRoute(routes, action.add_route().version());
       break;
     }
     default:
       break;
     }
   }
-  // Disconnect and close.
+  // Verify and disconnect.
   verifyState();
   close();
 }
 
 void XdsFuzzTest::verifyState() {
-  // Verify listeners.
-  // Wait to receive all the gRPC versions....?
-  // test_server_->waitForCounterGe("listener_manager.lds.update_attempt", num_lds_updates_);
-  // ENVOY_LOG_MISC(debug, "updates {} {}", num_lds_updates_,
-  // test_server_->counter("listener_manager.lds.update_attempt")->value());
-  // RELEASE_ASSERT( test_server_->counter("listener_manager.lds.update_attempt")->value() ==
-  // num_lds_updates_, ""); ENVOY_LOG_MISC(debug, "WARMING {}",
-  // test_server_->gauge("listener_manager.total_listeners_warming")->value());
-  // TODO: Keep track of update_rejected (duplicate listeners).
-  // Check draining states based on action record.
+  // Verify listener states.
+  EXPECT_EQ(test_server_->counter("listener_manager.lds.update_attempt")->value(),
+            num_lds_updates_);
+  // Check listener success.
 }
 
 } // namespace Server

--- a/test/server/config_validation/xds_fuzz.h
+++ b/test/server/config_validation/xds_fuzz.h
@@ -11,27 +11,26 @@ namespace Envoy {
 namespace Server {
 
 class XdsFuzzTest : public HttpIntegrationTest {
-  // Holds on to the list of actions / state
-  // Reference to the XdsFuzzTest, which configures the
 public:
   XdsFuzzTest(Network::Address::IpVersion version,
               const test::server::config_validation::XdsTestCase& input);
 
   void initialize();
 
-  envoy::api::v2::Listener buildListener(const std::string& name, const std::string& route_config,
-                                         const std::string& stat_prefix = "ads_test");
   envoy::api::v2::Cluster buildCluster(const std::string& name);
   envoy::api::v2::ClusterLoadAssignment buildClusterLoadAssignment(const std::string& name);
+  envoy::api::v2::Listener buildListener(const std::string& name, const std::string& route_config,
+                                         const std::string& stat_prefix = "ads_test");
   envoy::api::v2::RouteConfiguration buildRouteConfig(const std::string& name,
                                                       const std::string& cluster);
 
-  void addListener(const std::vector<envoy::api::v2::Listener>& listeners,
+  void updateListener(const std::vector<envoy::api::v2::Listener>& listeners,
+                      const std::string& version);
+  void updateRoute(const std::vector<envoy::api::v2::RouteConfiguration> routes,
                    const std::string& version);
-  void addRoute(const std::vector<envoy::api::v2::RouteConfiguration> routes,
-                const std::string& version);
 
   void replay();
+  // Currently empty.
   void verifyState();
   void close();
 
@@ -39,10 +38,9 @@ public:
 
 private:
   Protobuf::RepeatedPtrField<test::server::config_validation::Action> actions_;
-  // Un-ordered map these (name : Listener)?
-  // Attach state (warming|draining|active)?
   std::vector<envoy::api::v2::Cluster> clusters;
   std::vector<envoy::api::v2::RouteConfiguration> routes;
+  // TODO: Attach warming / active label.
   std::vector<envoy::api::v2::Listener> listeners;
   uint64_t num_lds_updates_;
 };

--- a/test/server/config_validation/xds_fuzz.h
+++ b/test/server/config_validation/xds_fuzz.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "test/fuzz/fuzz_runner.h"
+#include "test/integration/http_integration.h"
+#include "test/integration/integration.h"
+#include "test/integration/utility.h"
+#include "test/server/config_validation/xds_fuzz.pb.h"
+#include "test/test_common/network_utility.h"
+
+namespace Envoy {
+namespace Server {
+
+class XdsFuzzTest : public HttpIntegrationTest {
+  // Holds on to the list of actions / state
+  // Reference to the XdsFuzzTest, which configures the
+public:
+  XdsFuzzTest(Network::Address::IpVersion version,
+              const test::server::config_validation::XdsTestCase& input);
+
+  void initialize();
+
+  envoy::api::v2::Listener buildListener(const std::string& name, const std::string& route_config,
+                                         const std::string& stat_prefix = "ads_test");
+  envoy::api::v2::Cluster buildCluster(const std::string& name);
+  envoy::api::v2::ClusterLoadAssignment buildClusterLoadAssignment(const std::string& name);
+  envoy::api::v2::RouteConfiguration buildRouteConfig(const std::string& name,
+                                                      const std::string& cluster);
+
+  void addListener(const std::vector<envoy::api::v2::Listener>& listeners,
+                   const std::string& version);
+  void addRoute(const std::vector<envoy::api::v2::RouteConfiguration> routes,
+                const std::string& version);
+
+  void replay();
+  void verifyState();
+  void close();
+
+  const std::chrono::milliseconds max_wait_ms_{10};
+
+private:
+  Protobuf::RepeatedPtrField<test::server::config_validation::Action> actions_;
+  // Un-ordered map these (name : Listener)?
+  // Attach state (warming|draining|active)?
+  std::vector<envoy::api::v2::Cluster> clusters;
+  std::vector<envoy::api::v2::RouteConfiguration> routes;
+  std::vector<envoy::api::v2::Listener> listeners;
+  uint64_t num_lds_updates_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/test/server/config_validation/xds_fuzz.proto
+++ b/test/server/config_validation/xds_fuzz.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package test.server.config_validation;
+
+// Structured input for xds_fuzz_test.
+message AddListener {
+  string name = 1;
+  string route_config = 2;
+  string version = 3;
+}
+
+message AddRoute {
+  string name = 1;
+  string cluster = 2;
+  string version = 3;
+}
+
+message RemoveListener {
+  string name = 1;
+  string version = 2;
+}
+
+message RemoveRoute {
+  string name = 1;
+}
+
+message Action {
+  oneof action_selector {
+    AddListener add_listener = 1;
+    AddRoute add_route = 2;
+    RemoveListener remove_listener = 3;
+    RemoveRoute remove_route = 4;
+  }
+}
+
+message XdsTestCase {
+  repeated Action actions = 1;
+}

--- a/test/server/config_validation/xds_fuzz_test.cc
+++ b/test/server/config_validation/xds_fuzz_test.cc
@@ -1,0 +1,15 @@
+#include "test/server/config_validation/xds_fuzz.h"
+#include "test/server/config_validation/xds_fuzz.pb.h"
+
+namespace Envoy {
+namespace Server {
+
+DEFINE_PROTO_FUZZER(const test::server::config_validation::XdsTestCase& input) {
+  RELEASE_ASSERT(!TestEnvironment::getIpVersionsForTest().empty(), "");
+  const auto ip_version = TestEnvironment::getIpVersionsForTest()[0];
+  XdsFuzzTest test(ip_version, input);
+  test.replay();
+}
+
+} // namespace Server
+} // namespace Envoy


### PR DESCRIPTION
This is a skeleton for an xDS fuzzer. The setup is very similar to ads_integration_test. The fuzzer tests against corpus files, which consist of sequences of xDS updates, currently just restricted to LDS/RDS (the test setup includes building a single cluster, and I might make route configurations only reference this cluster, or expand the possible xDS updates to include CDS actions). 

Right now, the fuzzer just checks for crashes and verifies the number of lds updates is what we expect. I'd like the fuzzer to check:
* expected listener states: active/warming/draining listeners
* listener manager update attempts/failures
* ...?

If you have any feedback or things you'd like to see, please let me know. I'll update as I work.