### PR TITLE
Remove exclusive tag from aws_metadata_fetcher_integration_test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -817,7 +817,6 @@ envoy_cc_test(
     srcs = [
         "aws_metadata_fetcher_integration_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":integration_lib",
         "//source/common/common:fmt_lib",


### PR DESCRIPTION
As pointed out in feedback from @htuch in https://github.com/envoyproxy/envoy/pull/7303#discussion_r302311460. The tag causes unnecessary de-parallelization of this test.

Risk Level: Low
Testing: Re-ran Integ Tests
Docs Changes: n/a
Release Notes: n/a