### PR TITLE
release: flipping deprecated features to be fatal-by-default

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -103,7 +103,7 @@ or you can subscribe to the iCal feed [here](https://app.opsgenie.com/webcal/get
   following version. E.g., "1.7.0 (pending)".
 * Run the deprecate_versions.py script (e.g. `sh tools/deprecate_version/deprecate_version.sh 1.8.0 1.10.0`)
   to file tracking issues for code which can be removed.
-* Run the deprecate_features.py script (e.g. `sh tools/deprecate_version/deprecate_features.sh`)
+* Run the deprecate_features.py script (e.g. `sh tools/deprecate_features/deprecate_features.sh`)
   to make the last release's deprecated features fatal-by-default. Submit the resultant PR and send
   an email to envoy-announce.
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -188,7 +188,7 @@ message Cluster {
   //   **This field is deprecated**. Set the
   //   :ref:`load_assignment<envoy_api_field_Cluster.load_assignment>` field instead.
   //
-  repeated core.Address hosts = 7 [deprecated = true];
+  repeated core.Address hosts = 7;
 
   // Setting this is required for specifying members of
   // :ref:`STATIC<envoy_api_enum_value_Cluster.DiscoveryType.STATIC>`,

--- a/configs/envoy_double_proxy_v2.template.yaml
+++ b/configs/envoy_double_proxy_v2.template.yaml
@@ -175,9 +175,18 @@ tracing:
       access_token_file: "/etc/envoy/lightstep_access_token"
       collector_cluster: lightstep_saas
 layered_runtime:
-    layers:
+  layers:
     - name: root
-      disk_layer: { symlink_root: /srv/runtime_data/current, subdirectory: envoy }
+      disk_layer:
+        symlink_root: /srv/configset/envoydata/current
+        subdirectory: envoy
+    - name: override
+      disk_layer:
+        symlink_root: /srv/configset/envoydata/current
+        subdirectory: envoy_override
+        append_service_cluster: true
+    - name: admin
+      admin_layer: {}
 admin:
   access_log_path: "/var/log/envoy/admin_access.log"
   address:

--- a/configs/envoy_double_proxy_v2.template.yaml
+++ b/configs/envoy_double_proxy_v2.template.yaml
@@ -174,10 +174,10 @@ tracing:
       "@type": type.googleapis.com/envoy.config.trace.v2.LightstepConfig
       access_token_file: "/etc/envoy/lightstep_access_token"
       collector_cluster: lightstep_saas
-runtime:
-  symlink_root: "/srv/runtime_data/current"
-  subdirectory: envoy
-  override_subdirectory: envoy_override
+layered_runtime:
+    layers:
+    - name: root
+      disk_layer: { symlink_root: /srv/runtime_data/current, subdirectory: envoy }
 admin:
   access_log_path: "/var/log/envoy/admin_access.log"
   address:

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -158,9 +158,18 @@ tracing:
       collector_cluster: lightstep_saas
       access_token_file: "/etc/envoy/lightstep_access_token"
 layered_runtime:
-    layers:
+  layers:
     - name: root
-      disk_layer: { symlink_root: /srv/runtime_data/current, subdirectory: envoy }
+      disk_layer:
+        symlink_root: /srv/configset/envoydata/current
+        subdirectory: envoy
+    - name: override
+      disk_layer:
+        symlink_root: /srv/configset/envoydata/current
+        subdirectory: envoy_override
+        append_service_cluster: true
+    - name: admin
+      admin_layer: {}
 admin:
   access_log_path: /var/log/envoy/admin_access.log
   address:

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -157,10 +157,10 @@ tracing:
       "@type": type.googleapis.com/envoy.config.trace.v2.LightstepConfig
       collector_cluster: lightstep_saas
       access_token_file: "/etc/envoy/lightstep_access_token"
-runtime:
-  symlink_root: /srv/runtime_data/current
-  subdirectory: envoy
-  override_subdirectory: envoy_override
+layered_runtime:
+    layers:
+    - name: root
+      disk_layer: { symlink_root: /srv/runtime_data/current, subdirectory: envoy }
 admin:
   access_log_path: /var/log/envoy/admin_access.log
   address:

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -543,10 +543,14 @@ tracing:
       "@type": type.googleapis.com/envoy.config.trace.v2.LightstepConfig
       access_token_file: "/etc/envoy/lightstep_access_token"
       collector_cluster: lightstep_saas
-runtime:
-  symlink_root: "/srv/runtime_data/current"
-  subdirectory: envoy
-  override_subdirectory: envoy_override
+layered_runtime:
+    layers:
+    - name: base
+      static_layer:
+        health_check:
+          min_interval: 5
+    - name: root
+      disk_layer: { symlink_root: /srv/runtime_data/current, subdirectory: envoy }
 admin:
   access_log_path: /var/log/envoy/admin_access.log
   address:

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -544,13 +544,18 @@ tracing:
       access_token_file: "/etc/envoy/lightstep_access_token"
       collector_cluster: lightstep_saas
 layered_runtime:
-    layers:
-    - name: base
-      static_layer:
-        health_check:
-          min_interval: 5
+  layers:
     - name: root
-      disk_layer: { symlink_root: /srv/runtime_data/current, subdirectory: envoy }
+      disk_layer:
+        symlink_root: /srv/configset/envoydata/current
+        subdirectory: envoy
+    - name: override
+      disk_layer:
+        symlink_root: /srv/configset/envoydata/current
+        subdirectory: envoy_override
+        append_service_cluster: true
+    - name: admin
+      admin_layer: {}
 admin:
   access_log_path: /var/log/envoy/admin_access.log
   address:

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -47,6 +47,12 @@ constexpr const char* disallowed_features[] = {
     // Acts as both a test entry for deprecated.proto and a marker for the Envoy
     // deprecation scripts.
     "envoy.deprecated_features.deprecated.proto:is_deprecated_fatal",
+    "envoy.deprecated_features.bootstrap.proto:runtime",
+    "envoy.deprecated_features.redis_proxy.proto:catch_all_cluster",
+    "envoy.deprecated_features.lds.proto:use_original_dst",
+    "envoy.deprecated_features.server_info.proto:max_stats",
+    "envoy.deprecated_features.redis_proxy.proto:cluster",
+    "envoy.deprecated_features.server_info.proto:max_obj_name_len",
     "envoy.deprecated_features.config_source.proto:UNSUPPORTED_REST_LEGACY",
     "envoy.deprecated_features.ext_authz.proto:use_alpha",
     "envoy.deprecated_features.route.proto:enabled",


### PR DESCRIPTION
Flipping the following deprecated fields to be fatal-by-default

runtime from bootstrap.proto
catch_all_cluster from redis_proxy.proto
use_original_dst from lds.proto
max_stats from server_info.proto
cluster from redis_proxy.proto
max_obj_name_len from server_info.proto

Fixing a typo in release instructions
Undeprecating hosts as we're not going to remove it until v3.
Fixing canonical configs to use legal fields (see #7548 for forward-fixing this)

Risk Level: High (for folks ignoring their deprecation warnings)
Testing: //test/... (fixed canonical configs)
Docs Changes: no (should there be?)
Release Notes: no (should there be?)
