### PR TITLE
remove unnecessary Heap::forceLink

### DIFF
--- a/bazel/PPROF.md
+++ b/bazel/PPROF.md
@@ -10,7 +10,7 @@ specific place yourself.
 
 Static linking is already available (because of a `HeapProfilerDump()` call
 inside
-[`Envoy::Profiler::Heap::forceLink()`](https://github.com/envoyproxy/envoy/blob/master/source/common/profiler/profiler.cc#L21-L26)).
+[`Envoy::Profiler::Heap::stopProfiler())`](https://github.com/envoyproxy/envoy/blob/master/source/common/profiler/profiler.cc#L32-L39)).
 
 ### Compiling a statically-linked Envoy
 

--- a/source/common/profiler/profiler.cc
+++ b/source/common/profiler/profiler.cc
@@ -38,13 +38,6 @@ bool Heap::stopProfiler() {
   return true;
 }
 
-void Heap::forceLink() {
-  // Currently this is here to force the inclusion of the heap profiler during static linking.
-  // Without this call the heap profiler will not be included and cannot be started via env
-  // variable. In the future we can add admin support.
-  HeapProfilerDump("");
-}
-
 } // namespace Profiler
 } // namespace Envoy
 

--- a/source/common/profiler/profiler.h
+++ b/source/common/profiler/profiler.h
@@ -60,9 +60,6 @@ public:
    * @return bool whether the file is dumped
    */
   static bool stopProfiler();
-
-private:
-  static void forceLink();
 };
 
 } // namespace Profiler


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Heap::forceLink is no longer needed as admin endpoint is added. Improves coverage a bit.

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A

