### PR TITLE
ci: Enable bazel limited download flags

### DIFF
--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -17,10 +17,13 @@ if [[ ! -z "${GCP_SERVICE_ACCOUNT_KEY}" ]]; then
   echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_FILE}"
 fi
 
-export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \
-  --experimental_inmemory_dotd_files \
-  --experimental_inmemory_jdeps_files \
-  --experimental_remote_download_outputs=toplevel"
+if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
+  export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \
+    --experimental_inmemory_dotd_files \
+    --experimental_inmemory_jdeps_files \
+    --experimental_remote_download_outputs=toplevel"
+fi
+
 if [[ "${BAZEL_REMOTE_CACHE}" =~ ^http ]]; then
   if [[ ! -z "${GCP_SERVICE_ACCOUNT_KEY}" ]]; then
     export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \

--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -17,6 +17,10 @@ if [[ ! -z "${GCP_SERVICE_ACCOUNT_KEY}" ]]; then
   echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_FILE}"
 fi
 
+export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \
+  --experimental_inmemory_dotd_files \
+  --experimental_inmemory_jdeps_files \
+  --experimental_remote_download_outputs=toplevel"
 if [[ "${BAZEL_REMOTE_CACHE}" =~ ^http ]]; then
   if [[ ! -z "${GCP_SERVICE_ACCOUNT_KEY}" ]]; then
     export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \


### PR DESCRIPTION
This should cause bazel to download fewer artifacts when it gets cache
hits