### PR TITLE
http: preserve empty header values for inlined headers

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -297,9 +297,6 @@ struct HeaderMapImpl::StaticLookupTable : public TrieLookupTable<EntryCb> {
 };
 
 void HeaderMapImpl::appendToHeader(HeaderString& header, absl::string_view data) {
-  if (data.empty()) {
-    return;
-  }
   if (!header.empty()) {
     header.append(",", 1);
   }

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -646,11 +646,11 @@ TEST(HeaderMapImplTest, AddCopy) {
   headers.addCopy(cache_control, "public");
   EXPECT_EQ("max-age=1345,public", headers.get(cache_control)->value().getStringView());
   headers.addCopy(cache_control, "");
-  EXPECT_EQ("max-age=1345,public", headers.get(cache_control)->value().getStringView());
+  EXPECT_EQ("max-age=1345,public,", headers.get(cache_control)->value().getStringView());
   headers.addCopy(cache_control, 123);
-  EXPECT_EQ("max-age=1345,public,123", headers.get(cache_control)->value().getStringView());
+  EXPECT_EQ("max-age=1345,public,,123", headers.get(cache_control)->value().getStringView());
   headers.addCopy(cache_control, std::numeric_limits<uint64_t>::max());
-  EXPECT_EQ("max-age=1345,public,123,18446744073709551615",
+  EXPECT_EQ("max-age=1345,public,,123,18446744073709551615",
             headers.get(cache_control)->value().getStringView());
 }
 
@@ -790,8 +790,9 @@ TEST(HeaderMapImplTest, TestAppendHeader) {
   {
     HeaderString value3;
     value3.setCopy("empty", 5);
-    HeaderMapImpl::appendToHeader(value3, "");
     EXPECT_EQ(value3, "empty");
+    HeaderMapImpl::appendToHeader(value3, "");
+    EXPECT_EQ(value3, "empty,");
   }
   // Regression test for appending to an empty string with a short string, then
   // setting integer.


### PR DESCRIPTION
Description:
This PR changes the headermap impl. to preserve empty headers, even for inlined headers. Since inlined headers are comma-concatenated, this means a list like ("a", "", "b") is now comma-concatenated as "a,,b".

Risk Level: 
 - Low.
Testing:
 - I needed to modify :header_map_impl_test to expect the new behavior.

Docs Changes: n/a
Release Notes: n/a

Fixes #7521