### PR TITLE
tap: remove unused dependency.

### DIFF
--- a/api/envoy/service/tap/v2alpha/BUILD
+++ b/api/envoy/service/tap/v2alpha/BUILD
@@ -10,7 +10,6 @@ api_proto_library_internal(
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/core:grpc_service",
         "//envoy/api/v2/route",
-        "//envoy/type/matcher:string",
     ],
 )
 

--- a/api/envoy/service/tap/v2alpha/common.proto
+++ b/api/envoy/service/tap/v2alpha/common.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 import "envoy/api/v2/route/route.proto";
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/grpc_service.proto";
-import "envoy/type/matcher/string.proto";
 
 import "google/protobuf/wrappers.proto";
 


### PR DESCRIPTION
Description: Remove an unused dependency from `tap`. This makes a build warning go away.
Risk Level: low
Testing: build
Docs Changes: N/A
Release Notes: N/A
