### PR TITLE
server: skip lifecycle notifications on early envoy shutdown

### DIFF
--- a/include/envoy/server/lifecycle_notifier.h
+++ b/include/envoy/server/lifecycle_notifier.h
@@ -26,6 +26,9 @@ public:
      * This provides listeners a last chance to run a callback on the main dispatcher.
      * Note: the server will wait for callbacks that registered to take a completion
      * before exiting the dispatcher loop.
+     * Note: callbacks that registered with a completion will only be notified for this
+     * stage if the server did not prematurely shutdown before fully starting up (specifically
+     * if the server shutdown before worker threads were started).
      */
     ShutdownExit
   };

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -57,8 +57,8 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
                            ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory,
                            Filesystem::Instance& file_system,
                            std::unique_ptr<ProcessContext> process_context)
-    : secret_manager_(std::make_unique<Secret::SecretManagerImpl>()), shutdown_(false),
-      options_(options), time_source_(time_system), restarter_(restarter),
+    : secret_manager_(std::make_unique<Secret::SecretManagerImpl>()), workers_started_(false),
+      shutdown_(false), options_(options), time_source_(time_system), restarter_(restarter),
       start_time_(time(nullptr)), original_start_time_(start_time_), stats_store_(store),
       thread_local_(tls), api_(new Api::Impl(thread_factory, store, time_system, file_system)),
       dispatcher_(api_->allocateDispatcher()),
@@ -421,6 +421,7 @@ void InstanceImpl::initialize(const Options& options,
 void InstanceImpl::startWorkers() {
   listener_manager_->startWorkers(*guard_dog_);
   initialization_timer_->complete();
+  workers_started_ = true;
   // At this point we are ready to take traffic and all listening ports are up. Notify our parent
   // if applicable that they can stop listening and drain.
   restarter_.drainParentListeners();
@@ -613,11 +614,17 @@ void InstanceImpl::notifyCallbacksForStage(Stage stage, Event::PostCb completion
                                             delete cb;
                                           });
 
-  auto it2 = stage_completable_callbacks_.find(stage);
-  if (it2 != stage_completable_callbacks_.end()) {
-    ENVOY_LOG(info, "Notifying {} callback(s) with completion.", it2->second.size());
-    for (const StageCallbackWithCompletion& callback : it2->second) {
-      callback([cb_guard] { (*cb_guard)(); });
+  // Registrations which take a completion callback are typically implemented by executing a
+  // callback on all worker threads using Slot::runOnAllThreads which will hang indefinitely if
+  // worker threads have not been started so we need to skip notifications if envoy is shutdown
+  // early before workers have started.
+  if (workers_started_) {
+    auto it2 = stage_completable_callbacks_.find(stage);
+    if (it2 != stage_completable_callbacks_.end()) {
+      ENVOY_LOG(info, "Notifying {} callback(s) with completion.", it2->second.size());
+      for (const StageCallbackWithCompletion& callback : it2->second) {
+        callback([cb_guard] { (*cb_guard)(); });
+      }
     }
   }
 }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -233,6 +233,7 @@ private:
   // - There may be active clusters referencing it in config_.cluster_manager_.
   // - There may be active connections referencing it.
   std::unique_ptr<Secret::SecretManager> secret_manager_;
+  bool workers_started_;
   bool shutdown_;
   const Options& options_;
   TimeSource& time_source_;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -373,6 +373,46 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
   server_thread->join();
 }
 
+// A test target which never signals that it is ready.
+class NeverReadyTarget : public Init::TargetImpl {
+public:
+  NeverReadyTarget(absl::Notification& initialized)
+      : Init::TargetImpl("test", [this] { initialize(); }), initialized_(initialized) {}
+
+private:
+  void initialize() { initialized_.Notify(); }
+
+  absl::Notification& initialized_;
+};
+
+TEST_P(ServerInstanceImplTest, NoLifecycleNotificationOnEarlyShutdown) {
+  absl::Notification initialized;
+
+  auto server_thread = Thread::threadFactoryForTest().createThread([&] {
+    initialize("test/server/node_bootstrap.yaml");
+
+    // This shutdown notification should never be called because we will shutdown
+    // early before the init manager finishes initializing and therefore before
+    // the server starts worker threads.
+    auto shutdown_handle = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
+                                                     [&](Event::PostCb) { FAIL(); });
+    NeverReadyTarget target(initialized);
+    server_->initManager().add(target);
+    server_->run();
+
+    shutdown_handle = nullptr;
+    server_ = nullptr;
+    thread_local_ = nullptr;
+  });
+
+  // Wait until the init manager starts initializing targets...
+  initialized.WaitForNotification();
+
+  // Now shutdown the main dispatcher and trigger server lifecycle notifications.
+  server_->dispatcher().post([&] { server_->shutdown(); });
+  server_thread->join();
+}
+
 TEST_P(ServerInstanceImplTest, V2ConfigOnly) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";


### PR DESCRIPTION
Description: Skip lifecycle notifications which take a completion callback when envoy shuts down early before starting worker threads. This is needed because these registrations are typically implemented using Slot::runOnAllThreads which will not work correctly if worker threads have not been started.
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
