### PR TITLE
ci: speed up release and mac run

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -104,12 +104,6 @@ if [[ "$CI_TARGET" == "bazel.release" ]]; then
   bazel_binary_build release
 
   echo "Testing ${TEST_TARGETS}"
-  if [[ "$TEST_TARGETS" == "//test/..." ]]; then
-    # We have various test binaries in the test directory such as tools, benchmarks, etc. We
-    # run a build pass to make sure they compile.
-    bazel build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/exe:envoy-static //test/...
-  fi
-  # Now run all of the tests which should already be compiled.
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} -c opt ${TEST_TARGETS}
   exit 0
 elif [[ "$CI_TARGET" == "bazel.release.server_only" ]]; then

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -29,5 +29,7 @@ else
   TEST_TARGETS=//test/...
 fi
 
-bazel build ${BAZEL_BUILD_OPTIONS} //source/exe:envoy-static ${TEST_TARGETS}
+if [[ "$TEST_TARGETS" == "//test/..." ]]; then
+  bazel build ${BAZEL_BUILD_OPTIONS} //source/exe:envoy-static
+fi
 bazel test ${BAZEL_BUILD_OPTIONS} ${TEST_TARGETS}


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Pulling out from #7536, allowing RBE not download test binaries. Let bazel schedule test runs at same time at build proceeds to speed up. Also let us collect Bazel profile on release compiles with test.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
