### PR TITLE
http: check parent address before use (oss-fuzz #11036).

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -117,7 +117,7 @@ void AsyncStreamImpl::sendHeaders(HeaderMap& headers, bool end_stream) {
   is_grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
   headers.insertEnvoyInternalRequest().value().setReference(
       Headers::get().EnvoyInternalRequestValues.True);
-  if (send_xff_) {
+  if (send_xff_ && parent_.config_.local_info_.address()) {
     Utility::appendXff(headers, *parent_.config_.local_info_.address());
   }
   router_.decodeHeaders(headers, end_stream);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -908,6 +908,18 @@ TEST_F(AsyncClientImplTest, RdsGettersTest) {
   EXPECT_CALL(stream_callbacks_, onReset());
 }
 
+// Test oss-fuzz issue #11036, where a crash happened in sendHeaders() if local address wasn't set
+// and XFF was used.
+TEST_F(AsyncClientImplTest, XffTest) {
+  TestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  AsyncClient::Stream* stream =
+      client_.start(stream_callbacks_, AsyncClient::StreamOptions().setSendXff(true));
+  ON_CALL(local_info_, address()).WillByDefault(Return(nullptr));
+  stream->sendHeaders(headers, true);
+  EXPECT_CALL(stream_callbacks_, onReset());
+}
+
 } // namespace
 
 // Must not be in anonymous namespace for friend to work.

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5653036932792320
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5653036932792320
@@ -1,0 +1,234 @@
+static_resources {   listeners {     name: "                                   "     address {       socket_address {         address: "       "         port_value: 2048         resolver_name: " "         ipv4_compat: true       }     }     filter_chains {       filter_chain_match {         transport_protocol: "         "         server_names: " "         server_names: " "       }     }     filter_chains {       filter_chain_match {         transport_protocol: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: ""         server_names: " "         server_names: " "         server_names: " "       }     }     filter_chains {       filter_chain_match {         transport_protocol: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: " "         server_names: ")"
+        server_names: ""
+        server_names: "l"
+        server_names: "?"
+        server_names: "l"
+      }
+    }
+    filter_chains {
+    }
+  }
+  clusters {
+    name: "%"
+    connect_timeout {
+      seconds: 2304
+    }
+    per_connection_buffer_limit_bytes {
+      value: 16
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "zz"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: "p  t\000\000"
+      }
+    }
+    hosts {
+      pipe {
+        path: "&"
+      }
+    }
+    hosts {
+      pipe {
+        path: "("
+      }
+    }
+    hosts {
+      pipe {
+        path: "5"
+      }
+    }
+    hosts {
+      pipe {
+        path: "?"
+      }
+    }
+    hosts {
+      pipe {
+        path: "P"
+      }
+    }
+    hosts {
+      pipe {
+        path: "p"
+      }
+    }
+    hosts {
+      pipe {
+        path: "d"
+      }
+    }
+    hosts {
+      pipe {
+        path: "#"
+      }
+    }
+    hosts {
+      pipe {
+        path: "]"
+      }
+    }
+    hosts {
+      pipe {
+        path: "/"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: " "
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: "#"
+      }
+    }
+    hosts {
+      pipe {
+        path: " "
+      }
+    }
+    hosts {
+      pipe {
+        path: "5"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: "p"
+      }
+    }
+    hosts {
+      pipe {
+        path: "9"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: ")"
+      }
+    }
+    hosts {
+      pipe {
+        path: ";"
+      }
+    }
+    hosts {
+      pipe {
+        path: "#"
+      }
+    }
+    hosts {
+      pipe {
+        path: "log_\000\000\000202"
+      }
+    }
+    hosts {
+      pipe {
+        path: "("
+      }
+    }
+    hosts {
+      pipe {
+        path: "#"
+      }
+    }
+    hosts {
+      pipe {
+        path: "v"
+      }
+    }
+    hosts {
+      pipe {
+        path: "#"
+      }
+    }
+    hosts {
+      pipe {
+        path: "2"
+      }
+    }
+    hosts {
+      pipe {
+        path: "1"
+      }
+    }
+    hosts {
+      pipe {
+        path: "("
+      }
+    }
+    hosts {
+      pipe {
+        path: "("
+      }
+    }
+    tls_context {
+      sni: "mane"
+      allow_renegotiation: true
+    }
+    dns_lookup_family: V4_ONLY
+    outlier_detection {
+    }
+    metadata {
+      filter_metadata {
+        key: ""
+        value {
+        }
+      }
+    }
+    upstream_connection_options {
+    }
+  }
+}
+cluster_manager {
+  load_stats_config {
+    api_type: GRPC
+    grpc_services {
+      envoy_grpc {
+        cluster_name: "%"
+      }
+      initial_metadata {
+        key: "routu_c"
+      }
+    }
+  }
+}
+admin {
+  access_log_path: "1"
+  profile_path: "2"
+  address {
+    pipe {
+      path: ";"
+    }
+  }
+}


### PR DESCRIPTION
Description: Fix oss-fuzz issue 11036. If the address in local_info_ was `nullptr`, a crash happened in
`sendHeaders()` function whenever XFF was used. The issue is marked fixed in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11036 even though the testcase attached in the bug report (and this PR) seems to always trigger the crash.
Risk Level: low
Testing: fuzzing and one unit test
Docs Changes: N/A
Release Notes: N/A
