### PR TITLE
buffer: add "overflow" watermark

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -372,10 +372,13 @@ public:
    *   low watermark.
    * @param above_high_watermark supplies a function to call if the buffer goes over a configured
    *   high watermark.
+   * @param above_overflow_watermark supplies a function to call if the buffer goes over a
+   *   configured "overflow" watermark.
    * @return a newly created InstancePtr.
    */
   virtual InstancePtr create(std::function<void()> below_low_watermark,
-                             std::function<void()> above_high_watermark) PURE;
+                             std::function<void()> above_high_watermark,
+                             std::function<void()> above_overflow_watermark) PURE;
 };
 
 using WatermarkFactoryPtr = std::unique_ptr<WatermarkFactory>;

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -140,6 +140,12 @@ public:
                              absl::string_view transport_failure_reason) PURE;
 
   /**
+   * Fires when a stream, or the connection the stream is sending to, goes over its "overflow"
+   * watermark.
+   */
+  virtual void onAboveWriteBufferOverflowWatermark() PURE;
+
+  /**
    * Fires when a stream, or the connection the stream is sending to, goes over its high watermark.
    */
   virtual void onAboveWriteBufferHighWatermark() PURE;
@@ -311,6 +317,11 @@ public:
   virtual bool wantsToWrite() PURE;
 
   /**
+   * Called when the underlying Network::Connection goes over its "overflow" watermark.
+   */
+  virtual void onUnderlyingConnectionAboveWriteBufferOverflowWatermark() PURE;
+
+  /**
    * Called when the underlying Network::Connection goes over its high watermark.
    */
   virtual void onUnderlyingConnectionAboveWriteBufferHighWatermark() PURE;
@@ -328,6 +339,13 @@ public:
 class DownstreamWatermarkCallbacks {
 public:
   virtual ~DownstreamWatermarkCallbacks() = default;
+
+  /**
+   * Called when the downstream connection or stream goes over its "overflow" watermark. Note that
+   * this may be called separately for both the stream going over and the connection going over.
+   * The implementation should close the stream.
+   */
+  virtual void onAboveWriteBufferOverflowWatermark() PURE;
 
   /**
    * Called when the downstream connection or stream goes over its high watermark. Note that this

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -354,7 +354,14 @@ public:
   virtual void encodeMetadata(MetadataMapPtr&& metadata_map) PURE;
 
   /**
-   * Called when the buffer for a decoder filter or any buffers the filter sends data to go over
+   * Called when the buffer for a decoder filter, or any buffers the filter sends data to, go over
+   * their "overflow" watermark. Implementations should close/reset any streams that overflow their
+   * write buffers.
+   */
+  virtual void onDecoderFilterAboveWriteBufferOverflowWatermark() PURE;
+
+  /**
+   * Called when the buffer for a decoder filter, or any buffers the filter sends data to, go over
    * their high watermark.
    *
    * In the case of a filter such as the router filter, which spills into multiple buffers (codec,
@@ -602,6 +609,12 @@ public:
    * @return a reference to the newly created trailers map.
    */
   virtual HeaderMap& addEncodedTrailers() PURE;
+
+  /**
+   * Called when an encoder filter goes over its "overflow" watermark. The stream should be closed
+   * in response to overflows.
+   */
+  virtual void onEncoderFilterAboveWriteBufferOverflowWatermark() PURE;
 
   /**
    * Called when an encoder filter goes over its high watermark.

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -48,6 +48,12 @@ public:
   virtual void onEvent(ConnectionEvent event) PURE;
 
   /**
+   * Called when the write buffer for a connection goes over its "overflow"
+   * watermark.
+   */
+  virtual void onAboveWriteBufferOverflowWatermark() PURE;
+
+  /**
    * Called when the write buffer for a connection goes over its high watermark.
    */
   virtual void onAboveWriteBufferHighWatermark() PURE;

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -7,32 +7,32 @@ namespace Buffer {
 
 void WatermarkBuffer::add(const void* data, uint64_t size) {
   OwnedImpl::add(data, size);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::add(absl::string_view data) {
   OwnedImpl::add(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::add(const Instance& data) {
   OwnedImpl::add(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::prepend(absl::string_view data) {
   OwnedImpl::prepend(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::prepend(Instance& data) {
   OwnedImpl::prepend(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::commit(RawSlice* iovecs, uint64_t num_iovecs) {
   OwnedImpl::commit(iovecs, num_iovecs);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::drain(uint64_t size) {
@@ -42,23 +42,23 @@ void WatermarkBuffer::drain(uint64_t size) {
 
 void WatermarkBuffer::move(Instance& rhs) {
   OwnedImpl::move(rhs);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::move(Instance& rhs, uint64_t length) {
   OwnedImpl::move(rhs, length);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 Api::IoCallUint64Result WatermarkBuffer::read(Network::IoHandle& io_handle, uint64_t max_length) {
   Api::IoCallUint64Result result = OwnedImpl::read(io_handle, max_length);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
   return result;
 }
 
 uint64_t WatermarkBuffer::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) {
   uint64_t bytes_reserved = OwnedImpl::reserve(length, iovecs, num_iovecs);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
   return bytes_reserved;
 }
 
@@ -68,11 +68,14 @@ Api::IoCallUint64Result WatermarkBuffer::write(Network::IoHandle& io_handle) {
   return result;
 }
 
-void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_watermark) {
-  ASSERT(low_watermark < high_watermark || (high_watermark == 0 && low_watermark == 0));
+void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_watermark,
+                                    uint32_t overflow_watermark) {
+  ASSERT((low_watermark < high_watermark && high_watermark < overflow_watermark) ||
+         (overflow_watermark == 0 && high_watermark == 0 && low_watermark == 0));
   low_watermark_ = low_watermark;
   high_watermark_ = high_watermark;
-  checkHighWatermark();
+  overflow_watermark_ = overflow_watermark;
+  checkHighAndOverflowWatermarks();
   checkLowWatermark();
 }
 
@@ -86,14 +89,19 @@ void WatermarkBuffer::checkLowWatermark() {
   below_low_watermark_();
 }
 
-void WatermarkBuffer::checkHighWatermark() {
-  if (above_high_watermark_called_ || high_watermark_ == 0 ||
-      OwnedImpl::length() <= high_watermark_) {
+void WatermarkBuffer::checkHighAndOverflowWatermarks() {
+  if (!above_overflow_watermark_called_ && overflow_watermark_ != 0 &&
+      OwnedImpl::length() > overflow_watermark_) {
+    above_overflow_watermark_called_ = true;
+    above_overflow_watermark_();
     return;
   }
 
-  above_high_watermark_called_ = true;
-  above_high_watermark_();
+  if (!above_high_watermark_called_ && high_watermark_ != 0 &&
+      OwnedImpl::length() > high_watermark_) {
+    above_high_watermark_called_ = true;
+    above_high_watermark_();
+  }
 }
 
 } // namespace Buffer

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -333,6 +333,7 @@ private:
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(HeaderMapPtr&& trailers) override;
   void encodeMetadata(MetadataMapPtr&&) override {}
+  void onDecoderFilterAboveWriteBufferOverflowWatermark() override {}
   void onDecoderFilterAboveWriteBufferHighWatermark() override {}
   void onDecoderFilterBelowWriteBufferLowWatermark() override {}
   void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -192,6 +192,7 @@ private:
     void onResetStream(StreamResetReason reason, absl::string_view) override {
       parent_.onReset(*this, reason);
     }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -219,6 +220,9 @@ private:
   void onEvent(Network::ConnectionEvent event) override;
   // Pass watermark events from the connection on to the codec which will pass it to the underlying
   // streams.
+  void onAboveWriteBufferOverflowWatermark() override {
+    codec_->onUnderlyingConnectionAboveWriteBufferOverflowWatermark();
+  }
   void onAboveWriteBufferHighWatermark() override {
     codec_->onUnderlyingConnectionAboveWriteBufferHighWatermark();
   }

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -36,6 +36,17 @@ public:
     }
   }
 
+  void runOverflowWatermarkCallbacks() {
+    if (reset_callbacks_started_ || local_end_stream_) {
+      return;
+    }
+    for (StreamCallbacks* callbacks : callbacks_) {
+      if (callbacks) {
+        callbacks->onAboveWriteBufferOverflowWatermark();
+      }
+    }
+  }
+
   void runResetCallbacks(StreamResetReason reason) {
     // Reset callbacks are a special case, and the only StreamCallbacks allowed
     // to run after local_end_stream_.

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -81,6 +81,9 @@ public:
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
   // Pass connection watermark events on to all the streams associated with that connection.
+  void onAboveWriteBufferOverflowWatermark() override {
+    codec_->onUnderlyingConnectionAboveWriteBufferOverflowWatermark();
+  }
   void onAboveWriteBufferHighWatermark() override {
     codec_->onUnderlyingConnectionAboveWriteBufferHighWatermark();
   }
@@ -274,6 +277,7 @@ private:
     void encodeData(Buffer::Instance& data, bool end_stream) override;
     void encodeTrailers(HeaderMapPtr&& trailers) override;
     void encodeMetadata(MetadataMapPtr&& metadata_map_ptr) override;
+    void onDecoderFilterAboveWriteBufferOverflowWatermark() override;
     void onDecoderFilterAboveWriteBufferHighWatermark() override;
     void onDecoderFilterBelowWriteBufferLowWatermark() override;
     void
@@ -358,6 +362,7 @@ private:
     void addEncodedData(Buffer::Instance& data, bool streaming) override;
     void injectEncodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
     HeaderMap& addEncodedTrailers() override;
+    void onEncoderFilterAboveWriteBufferOverflowWatermark() override;
     void onEncoderFilterAboveWriteBufferHighWatermark() override;
     void onEncoderFilterBelowWriteBufferLowWatermark() override;
     void setEncoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
@@ -448,6 +453,7 @@ private:
     // Http::StreamCallbacks
     void onResetStream(StreamResetReason reason,
                        absl::string_view transport_failure_reason) override;
+    void onAboveWriteBufferOverflowWatermark() override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
 
@@ -496,6 +502,7 @@ private:
 
     // Pass on watermark callbacks to watermark subscribers. This boils down to passing watermark
     // events for this stream and the downstream connection to the router filter.
+    void callOverflowWatermarkCallbacks();
     void callHighWatermarkCallbacks();
     void callLowWatermarkCallbacks();
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -162,6 +162,9 @@ public:
   Protocol protocol() override { return protocol_; }
   void shutdownNotice() override {} // Called during connection manager drain flow
   bool wantsToWrite() override { return false; }
+  void onUnderlyingConnectionAboveWriteBufferOverflowWatermark() override {
+    onAboveOverflowWatermark();
+  }
   void onUnderlyingConnectionAboveWriteBufferHighWatermark() override { onAboveHighWatermark(); }
   void onUnderlyingConnectionBelowWriteBufferLowWatermark() override { onBelowLowWatermark(); }
 
@@ -260,6 +263,11 @@ private:
   virtual void sendProtocolError() PURE;
 
   /**
+   * Called when output_buffer_ or the underlying connection exceed the "overflow" watermark.
+   */
+  virtual void onAboveOverflowWatermark() PURE;
+
+  /**
    * Called when output_buffer_ or the underlying connection go from below a low watermark to over
    * a high watermark.
    */
@@ -335,6 +343,7 @@ private:
   void onMessageComplete() override;
   void onResetStream(StreamResetReason reason) override;
   void sendProtocolError() override;
+  void onAboveOverflowWatermark() override;
   void onAboveHighWatermark() override;
   void onBelowLowWatermark() override;
 
@@ -376,6 +385,7 @@ private:
   void onMessageComplete() override;
   void onResetStream(StreamResetReason reason) override;
   void sendProtocolError() override {}
+  void onAboveOverflowWatermark() override;
   void onAboveHighWatermark() override;
   void onBelowLowWatermark() override;
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -69,6 +69,7 @@ protected:
     void onResetStream(StreamResetReason, absl::string_view) override {
       parent_.parent_.onDownstreamReset(parent_);
     }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -92,6 +93,7 @@ protected:
     void onEvent(Network::ConnectionEvent event) override {
       parent_.onConnectionEvent(*this, event);
     }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -52,6 +52,7 @@ protected:
     void onEvent(Network::ConnectionEvent event) override {
       parent_.onConnectionEvent(*this, event);
     }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -137,6 +137,7 @@ protected:
 
   void onLowWatermark();
   void onHighWatermark();
+  void onOverflowWatermark();
 
   TransportSocketPtr transport_socket_;
   ConnectionSocketPtr socket_;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -388,6 +388,10 @@ private:
     // Http::StreamCallbacks
     void onResetStream(Http::StreamResetReason reason,
                        absl::string_view transport_failure_reason) override;
+    void onAboveWriteBufferOverflowWatermark() override {
+      // TODO(mergeconflict): Does it make sense to log or stat this?
+      resetStream();
+    }
     void onAboveWriteBufferHighWatermark() override { disableDataFromDownstream(); }
     void onBelowWriteBufferLowWatermark() override { enableDataFromDownstream(); }
 
@@ -437,6 +441,7 @@ private:
       // Http::DownstreamWatermarkCallbacks
       void onBelowWriteBufferLowWatermark() override;
       void onAboveWriteBufferHighWatermark() override;
+      void onAboveWriteBufferOverflowWatermark() override;
 
       UpstreamRequest& parent_;
     };

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -430,6 +430,12 @@ void ConnPoolImpl::ActiveConn::onEvent(Network::ConnectionEvent event) {
   }
 }
 
+void ConnPoolImpl::ActiveConn::onAboveWriteBufferOverflowWatermark() {
+  if (wrapper_ != nullptr && wrapper_->callbacks_ != nullptr) {
+    wrapper_->callbacks_->onAboveWriteBufferOverflowWatermark();
+  }
+}
+
 void ConnPoolImpl::ActiveConn::onAboveWriteBufferHighWatermark() {
   if (wrapper_ != nullptr && wrapper_->callbacks_ != nullptr) {
     wrapper_->callbacks_->onAboveWriteBufferHighWatermark();

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -99,6 +99,7 @@ protected:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -260,6 +260,12 @@ void Filter::readDisableDownstream(bool disable) {
   }
 }
 
+void Filter::DownstreamCallbacks::onAboveWriteBufferOverflowWatermark() {
+  // TODO(mergeconflict): Do we want this to appear as a local or remote close?
+  // Also, we probably want to log when this happens.
+  onEvent(Network::ConnectionEvent::RemoteClose);
+}
+
 void Filter::DownstreamCallbacks::onAboveWriteBufferHighWatermark() {
   ASSERT(!on_high_watermark_called_);
   on_high_watermark_called_ = true;
@@ -280,6 +286,11 @@ void Filter::UpstreamCallbacks::onEvent(Network::ConnectionEvent event) {
   } else {
     drainer_->onEvent(event);
   }
+}
+
+void Filter::UpstreamCallbacks::onAboveWriteBufferOverflowWatermark() {
+  // TODO(mergeconflict): Same as above in DownstreamCallbacks.
+  onEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 void Filter::UpstreamCallbacks::onAboveWriteBufferHighWatermark() {

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -211,6 +211,7 @@ public:
     // Tcp::ConnectionPool::UpstreamCallbacks
     void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
 
@@ -237,6 +238,7 @@ protected:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override { parent_.onDownstreamEvent(event); }
+    void onAboveWriteBufferOverflowWatermark() override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -280,6 +280,7 @@ private:
           parent_.removeTcpConn(host_, connection_);
         }
       }
+      void onAboveWriteBufferOverflowWatermark() override {}
       void onAboveWriteBufferHighWatermark() override {}
       void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -94,6 +94,7 @@ private:
     // Http::StreamCallbacks
     void onResetStream(Http::StreamResetReason reason,
                        absl::string_view transport_failure_reason) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -104,6 +105,7 @@ private:
       ConnectionCallbackImpl(HttpActiveHealthCheckSession& parent) : parent_(parent) {}
       // Network::ConnectionCallbacks
       void onEvent(Network::ConnectionEvent event) override { parent_.onEvent(event); }
+      void onAboveWriteBufferOverflowWatermark() override {}
       void onAboveWriteBufferHighWatermark() override {}
       void onBelowWriteBufferLowWatermark() override {}
 
@@ -226,6 +228,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override { parent_.onEvent(event); }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -311,6 +314,7 @@ private:
     // Http::StreamCallbacks
     void onResetStream(Http::StreamResetReason reason,
                        absl::string_view transport_failure_reason) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -322,6 +326,7 @@ private:
       ConnectionCallbackImpl(GrpcActiveHealthCheckSession& parent) : parent_(parent) {}
       // Network::ConnectionCallbacks
       void onEvent(Network::ConnectionEvent event) override { parent_.onEvent(event); }
+      void onAboveWriteBufferOverflowWatermark() override {}
       void onAboveWriteBufferHighWatermark() override {}
       void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -178,6 +178,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -173,6 +173,7 @@ void FaultFilter::maybeSetupResponseRateLimit(const Http::HeaderMap& request_hea
 
   response_limiter_ = std::make_unique<StreamRateLimiter>(
       rate_kbps.value(), encoder_callbacks_->encoderBufferLimit(),
+      [this] { encoder_callbacks_->onEncoderFilterAboveWriteBufferOverflowWatermark(); },
       [this] { encoder_callbacks_->onEncoderFilterAboveWriteBufferHighWatermark(); },
       [this] { encoder_callbacks_->onEncoderFilterBelowWriteBufferLowWatermark(); },
       [this](Buffer::Instance& data, bool end_stream) {
@@ -406,6 +407,7 @@ Http::FilterTrailersStatus FaultFilter::encodeTrailers(Http::HeaderMap&) {
 }
 
 StreamRateLimiter::StreamRateLimiter(uint64_t max_kbps, uint64_t max_buffered_data,
+                                     std::function<void()> overflow_cb,
                                      std::function<void()> pause_data_cb,
                                      std::function<void()> resume_data_cb,
                                      std::function<void(Buffer::Instance&, bool)> write_data_cb,
@@ -419,7 +421,7 @@ StreamRateLimiter::StreamRateLimiter(uint64_t max_kbps, uint64_t max_buffered_da
       // ~63ms intervals.
       token_bucket_(SecondDivisor, time_source, SecondDivisor),
       token_timer_(dispatcher.createTimer([this] { onTokenTimer(); })),
-      buffer_(resume_data_cb, pause_data_cb) {
+      buffer_(resume_data_cb, pause_data_cb, overflow_cb) {
   ASSERT(bytes_per_time_slice_ > 0);
   ASSERT(max_buffered_data > 0);
   buffer_.setWatermarks(max_buffered_data);

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -111,7 +111,10 @@ public:
   /**
    * @param max_kbps maximum rate in KiB/s.
    * @param max_buffered_data maximum data to buffer before invoking the pause callback.
-   * @param pause_data_cb callback invoked when the limiter has buffered too much data.
+   * @param overflow_cb callback invoked when the limiter has buffered too much data despite
+   *                    previous backpressure.
+   * @param pause_data_cb callback invoked when the limiter has buffered enough data to necessitate
+   *                      backpressure.
    * @param resume_data_cb callback invoked when the limiter has gone under the buffer limit.
    * @param write_data_cb callback invoked to write data to the stream.
    * @param continue_cb callback invoked to continue the stream. This is only used to continue
@@ -120,7 +123,8 @@ public:
    * @param dispatcher the stream's dispatcher to use for creating timers.
    */
   StreamRateLimiter(uint64_t max_kbps, uint64_t max_buffered_data,
-                    std::function<void()> pause_data_cb, std::function<void()> resume_data_cb,
+                    std::function<void()> overflow_cb, std::function<void()> pause_data_cb,
+                    std::function<void()> resume_data_cb,
                     std::function<void(Buffer::Instance&, bool)> write_data_cb,
                     std::function<void()> continue_cb, TimeSource& time_source,
                     Event::Dispatcher& dispatcher);

--- a/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.h
+++ b/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.h
@@ -118,6 +118,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -114,6 +114,7 @@ private:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
@@ -68,6 +68,11 @@ void ConnectionManager::onEvent(Network::ConnectionEvent event) {
   resetAllMessages(event == Network::ConnectionEvent::LocalClose);
 }
 
+void ConnectionManager::onAboveWriteBufferOverflowWatermark() {
+  ENVOY_CONN_LOG(debug, "onAboveWriteBufferOverflowWatermark", read_callbacks_->connection());
+  read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+}
+
 void ConnectionManager::onAboveWriteBufferHighWatermark() {
   ENVOY_CONN_LOG(debug, "onAboveWriteBufferHighWatermark", read_callbacks_->connection());
   read_callbacks_->connection().readDisable(true);

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.h
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.h
@@ -59,6 +59,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent) override;
+  void onAboveWriteBufferOverflowWatermark() override;
   void onAboveWriteBufferHighWatermark() override;
   void onBelowWriteBufferLowWatermark() override;
 

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
@@ -39,6 +39,7 @@ public:
   // Tcp::ConnectionPool::UpstreamCallbacks
   void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/ext_authz/ext_authz.h
+++ b/source/extensions/filters/network/ext_authz/ext_authz.h
@@ -85,6 +85,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -137,6 +137,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -87,6 +87,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -71,6 +71,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -84,6 +84,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -70,6 +70,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -166,6 +166,7 @@ public:
   // Tcp::ConnectionPool::UpstreamCallbacks
   void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -86,6 +86,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -112,6 +112,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -170,6 +170,7 @@ private:
         listener_.removeConnection(*this);
       }
     }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -720,7 +720,7 @@ TEST_P(Http2CodecImplFlowControlTest, FlowControlPendingRecvData) {
   // the recv buffer can be overrun by a client which negotiates a larger
   // SETTINGS_MAX_FRAME_SIZE but there's no current easy way to tweak that in
   // envoy (without sending raw HTTP/2 frames) so we lower the buffer limit instead.
-  server_->getStream(1)->setWriteBufferWatermarks(10, 20);
+  server_->getStream(1)->setWriteBufferWatermarks(10, 20, 40);
 
   EXPECT_CALL(request_decoder_, decodeData(_, false));
   Buffer::OwnedImpl data(std::string(40, 'a'));

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -161,16 +161,16 @@ protected:
     dispatcher_ = api_->allocateDispatcher(Buffer::WatermarkFactoryPtr{factory});
     // The first call to create a client session will get a MockBuffer.
     // Other calls for server sessions will by default get a normal OwnedImpl.
-    EXPECT_CALL(*factory, create_(_, _))
+    EXPECT_CALL(*factory, create_(_, _, _))
         .Times(AnyNumber())
-        .WillOnce(Invoke([&](std::function<void()> below_low,
-                             std::function<void()> above_high) -> Buffer::Instance* {
-          client_write_buffer_ = new MockWatermarkBuffer(below_low, above_high);
+        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                             std::function<void()> above_overflow) -> Buffer::Instance* {
+          client_write_buffer_ = new MockWatermarkBuffer(below_low, above_high, above_overflow);
           return client_write_buffer_;
         }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
   }
 
@@ -185,12 +185,12 @@ protected:
 
   ConnectionMocks createConnectionMocks() {
     auto dispatcher = std::make_unique<NiceMock<Event::MockDispatcher>>();
-    EXPECT_CALL(dispatcher->buffer_factory_, create_(_, _))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
+    EXPECT_CALL(dispatcher->buffer_factory_, create_(_, _, _))
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
           // ConnectionImpl calls Envoy::MockBufferFactory::create(), which calls create_() and
           // wraps the returned raw pointer below with a unique_ptr.
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
     // This timer will be returned (transferring ownership) to the ConnectionImpl when createTimer()
@@ -1166,10 +1166,10 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayConfigDisabledTest) {
 
   NiceMock<MockConnectionCallbacks> callbacks;
   NiceMock<Event::MockDispatcher> dispatcher;
-  EXPECT_CALL(dispatcher.buffer_factory_, create_(_, _))
-      .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                std::function<void()> above_high) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high);
+  EXPECT_CALL(dispatcher.buffer_factory_, create_(_, _, _))
+      .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                std::function<void()> above_overflow) -> Buffer::Instance* {
+        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
   IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>(0);
   std::unique_ptr<Network::ConnectionImpl> server_connection(new Network::ConnectionImpl(
@@ -1359,10 +1359,10 @@ private:
 class MockTransportConnectionImplTest : public testing::Test {
 public:
   MockTransportConnectionImplTest() {
-    EXPECT_CALL(dispatcher_.buffer_factory_, create_(_, _))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+    EXPECT_CALL(dispatcher_.buffer_factory_, create_(_, _, _))
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
     file_event_ = new Event::MockFileEvent;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -3869,16 +3869,16 @@ protected:
     dispatcher_ = api_->allocateDispatcher(Buffer::WatermarkFactoryPtr{factory});
 
     // By default, expect 4 buffers to be created - the client and server read and write buffers.
-    EXPECT_CALL(*factory, create_(_, _))
+    EXPECT_CALL(*factory, create_(_, _, _))
         .Times(2)
-        .WillOnce(Invoke([&](std::function<void()> below_low,
-                             std::function<void()> above_high) -> Buffer::Instance* {
-          client_write_buffer = new MockWatermarkBuffer(below_low, above_high);
+        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                             std::function<void()> above_overflow) -> Buffer::Instance* {
+          client_write_buffer = new MockWatermarkBuffer(below_low, above_high, above_overflow);
           return client_write_buffer;
         }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
     initialize();

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -156,6 +156,7 @@ public:
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,
                      absl::string_view transport_failure_reason) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
@@ -233,6 +234,7 @@ public:
     }
   }
 
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/integration/filter_manager_integration_test.h
+++ b/test/integration/filter_manager_integration_test.h
@@ -111,6 +111,7 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -50,6 +50,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -146,10 +146,11 @@ IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
                                            bool enable_half_close)
     : payload_reader_(new WaitForPayloadReader(dispatcher)),
       callbacks_(new ConnectionCallbacks(*this)) {
-  EXPECT_CALL(factory, create_(_, _))
-      .WillOnce(Invoke([&](std::function<void()> below_low,
-                           std::function<void()> above_high) -> Buffer::Instance* {
-        client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(below_low, above_high);
+  EXPECT_CALL(factory, create_(_, _, _))
+      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                           std::function<void()> above_overflow) -> Buffer::Instance* {
+        client_write_buffer_ =
+            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
         return client_write_buffer_;
       }));
 
@@ -243,10 +244,10 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
   // complex test hooks to the server and/or spin waiting on stats, neither of which I think are
   // necessary right now.
   timeSystem().sleep(std::chrono::milliseconds(10));
-  ON_CALL(*mock_buffer_factory_, create_(_, _))
-      .WillByDefault(Invoke([](std::function<void()> below_low,
-                               std::function<void()> above_high) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high);
+  ON_CALL(*mock_buffer_factory_, create_(_, _, _))
+      .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                               std::function<void()> above_overflow) -> Buffer::Instance* {
+        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
   ON_CALL(factory_context_, api()).WillByDefault(ReturnRef(*api_));
 }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -62,6 +62,7 @@ public:
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,
                      absl::string_view transport_failure_reason) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
@@ -109,6 +110,7 @@ private:
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -70,6 +70,7 @@ private:
       upstream_.reset();
     }
     void onEvent(Network::ConnectionEvent) override {}
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -377,11 +377,12 @@ void TcpProxySslIntegrationTest::setupConnections() {
   // Set up the mock buffer factory so the newly created SSL client will have a mock write
   // buffer. This allows us to track the bytes actually written to the socket.
 
-  EXPECT_CALL(*mock_buffer_factory_, create_(_, _))
+  EXPECT_CALL(*mock_buffer_factory_, create_(_, _, _))
       .Times(1)
-      .WillOnce(Invoke([&](std::function<void()> below_low,
-                           std::function<void()> above_high) -> Buffer::Instance* {
-        client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(below_low, above_high);
+      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                           std::function<void()> above_overflow) -> Buffer::Instance* {
+        client_write_buffer_ =
+            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
         ON_CALL(*client_write_buffer_, move(_))
             .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
         ON_CALL(*client_write_buffer_, drain(_))

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -40,6 +40,7 @@ public:
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,
                      absl::string_view transport_failure_reason) override;
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
@@ -93,6 +94,7 @@ private:
       last_connection_event_ = event;
       connecting_ = false;
     }
+    void onAboveWriteBufferOverflowWatermark() override {}
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -161,6 +163,7 @@ public:
                 event == Network::ConnectionEvent::LocalClose);
     connected_ |= (event == Network::ConnectionEvent::Connected);
   }
+  void onAboveWriteBufferOverflowWatermark() override {}
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 

--- a/test/mocks/buffer/mocks.cc
+++ b/test/mocks/buffer/mocks.cc
@@ -6,16 +6,18 @@ namespace Envoy {
 
 template <>
 MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(std::function<void()> below_low,
-                                                        std::function<void()> above_high)
-    : Buffer::WatermarkBuffer(below_low, above_high) {}
+                                                        std::function<void()> above_high,
+                                                        std::function<void()> above_overflow)
+    : Buffer::WatermarkBuffer(below_low, above_high, above_overflow) {}
 
 template <>
 MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase()
-    : Buffer::WatermarkBuffer([&]() -> void {}, [&]() -> void {}) {
+    : Buffer::WatermarkBuffer([&]() -> void {}, [&]() -> void {}, [&]() -> void {}) {
   ASSERT(0); // This constructor is not supported for WatermarkBuffer.
 }
 template <>
-MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()>, std::function<void()>)
+MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()>, std::function<void()>,
+                                                  std::function<void()>)
     : Buffer::OwnedImpl() {
   ASSERT(0); // This constructor is not supported for OwnedImpl.
 }

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -65,6 +65,7 @@ public:
 
   // Http::StreamCallbacks
   MOCK_METHOD2(onResetStream, void(StreamResetReason reason, absl::string_view));
+  MOCK_METHOD0(onAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
 };
@@ -80,6 +81,7 @@ public:
   MOCK_METHOD0(protocol, Protocol());
   MOCK_METHOD0(shutdownNotice, void());
   MOCK_METHOD0(wantsToWrite, bool());
+  MOCK_METHOD0(onUnderlyingConnectionAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onUnderlyingConnectionAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onUnderlyingConnectionBelowWriteBufferLowWatermark, void());
 
@@ -97,6 +99,7 @@ public:
   MOCK_METHOD0(protocol, Protocol());
   MOCK_METHOD0(shutdownNotice, void());
   MOCK_METHOD0(wantsToWrite, bool());
+  MOCK_METHOD0(onUnderlyingConnectionAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onUnderlyingConnectionAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onUnderlyingConnectionBelowWriteBufferLowWatermark, void());
 
@@ -141,6 +144,7 @@ public:
   MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
   MOCK_METHOD0(activeSpan, Tracing::Span&());
   MOCK_METHOD0(tracingConfig, Tracing::Config&());
+  MOCK_METHOD0(onDecoderFilterAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onDecoderFilterAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onDecoderFilterBelowWriteBufferLowWatermark, void());
   MOCK_METHOD1(addDownstreamWatermarkCallbacks, void(DownstreamWatermarkCallbacks&));
@@ -212,6 +216,7 @@ public:
   MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
   MOCK_METHOD0(activeSpan, Tracing::Span&());
   MOCK_METHOD0(tracingConfig, Tracing::Config&());
+  MOCK_METHOD0(onEncoderFilterAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onEncoderFilterAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onEncoderFilterBelowWriteBufferLowWatermark, void());
   MOCK_METHOD1(setEncoderBufferLimit, void(uint32_t));
@@ -380,6 +385,7 @@ public:
 
 class MockDownstreamWatermarkCallbacks : public DownstreamWatermarkCallbacks {
 public:
+  MOCK_METHOD0(onAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
 };

--- a/test/mocks/network/connection.cc
+++ b/test/mocks/network/connection.cc
@@ -35,6 +35,12 @@ void MockConnectionBase::raiseBytesSentCallbacks(uint64_t num_bytes) {
   }
 }
 
+void MockConnectionBase::runOverflowWatermarkCallbacks() {
+  for (auto* callback : callbacks_) {
+    callback->onAboveWriteBufferOverflowWatermark();
+  }
+}
+
 void MockConnectionBase::runHighWatermarkCallbacks() {
   for (auto* callback : callbacks_) {
     callback->onAboveWriteBufferHighWatermark();

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -21,6 +21,7 @@ public:
 
   // Network::ConnectionCallbacks
   MOCK_METHOD1(onEvent, void(Network::ConnectionEvent event));
+  MOCK_METHOD0(onAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
 };
@@ -29,6 +30,7 @@ class MockConnectionBase {
 public:
   void raiseEvent(Network::ConnectionEvent event);
   void raiseBytesSentCallbacks(uint64_t num_bytes);
+  void runOverflowWatermarkCallbacks();
   void runHighWatermarkCallbacks();
   void runLowWatermarkCallbacks();
 

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -32,6 +32,7 @@ public:
   // Tcp::ConnectionPool::UpstreamCallbacks
   MOCK_METHOD2(onUpstreamData, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(onEvent, void(Network::ConnectionEvent event));
+  MOCK_METHOD0(onAboveWriteBufferOverflowWatermark, void());
   MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
 };


### PR DESCRIPTION
WIP: Add a new "overflow" watermark to watermark buffers. Intended usage: if a buffer continues to be written to after exceeding its high watermark, Envoy should protect itself by closing the associated stream.

Risk Level: Medium
Testing: Only unit tests so far; needs integration tests.
Docs Changes: TBD
Release Notes: TBD

Signed-off-by: Dan Rosen <mergeconflict@google.com>
