### PR TITLE
release: un-deprecate "use_original_dst".

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -44,7 +44,6 @@ constexpr const char* disallowed_features[] = {
     "envoy.deprecated_features.deprecated.proto:is_deprecated_fatal",
     "envoy.deprecated_features.bootstrap.proto:runtime",
     "envoy.deprecated_features.redis_proxy.proto:catch_all_cluster",
-    "envoy.deprecated_features.lds.proto:use_original_dst",
     "envoy.deprecated_features.server_info.proto:max_stats",
     "envoy.deprecated_features.redis_proxy.proto:cluster",
     "envoy.deprecated_features.server_info.proto:max_obj_name_len",


### PR DESCRIPTION
"use_original_dst" and "bind_to_port" are two complementary parts
of the "virtual listeners" feature, and they should be deprecated
together.

However, they are both currently exempted (see: #5355), so revert
the change from #7549.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>