### PR TITLE
dispatcher: surface isThreadSafe() check

### DIFF
--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -211,6 +211,12 @@ public:
    * @return The previously tracked object or nullptr if there was none.
    */
   virtual const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) PURE;
+
+  /**
+   * Validates that an operation is thread-safe with respect to this dispatcher; i.e. that the 
+   * current thread of execution is on the same thread upon which the dispatcher loop is running.
+   */
+  virtual bool isThreadSafe() const PURE;
 };
 
 using DispatcherPtr = std::unique_ptr<Dispatcher>;

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -213,7 +213,7 @@ public:
   virtual const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) PURE;
 
   /**
-   * Validates that an operation is thread-safe with respect to this dispatcher; i.e. that the 
+   * Validates that an operation is thread-safe with respect to this dispatcher; i.e. that the
    * current thread of execution is on the same thread upon which the dispatcher loop is running.
    */
   virtual bool isThreadSafe() const PURE;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -93,7 +93,7 @@ private:
   // Validate that an operation is thread safe, i.e. it's invoked on the same thread that the
   // dispatcher run loop is executing on. We allow run_tid_ to be empty for tests where we don't
   // invoke run().
-  bool isThreadSafe() const {
+  bool isThreadSafe() const override {
     return run_tid_.isEmpty() || run_tid_ == api_.threadFactory().currentThreadId();
   }
 

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -206,17 +206,18 @@ TEST_F(DispatcherImplTest, IsThreadSafe) {
   EXPECT_FALSE(dispatcher_->isThreadSafe());
 }
 
-class NotRanDispatcherImplTest : public testing::Test {
+class NotStartedDispatcherImplTest : public testing::Test {
 protected:
-  NotRanDispatcherImplTest()
+  NotStartedDispatcherImplTest()
       : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
 
   Api::ApiPtr api_;
   DispatcherPtr dispatcher_;
 };
 
-TEST_F(NotRanDispatcherImplTest, IsThreadSafe) {
-  // Thread safe because the dispatcher has not ran. Therefore, no thread id has been assigned.
+TEST_F(NotStartedDispatcherImplTest, IsThreadSafe) {
+  // Thread safe because the dispatcher has not started.
+  // Therefore, no thread id has been assigned.
   EXPECT_TRUE(dispatcher_->isThreadSafe());
 }
 

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -257,4 +257,3 @@ TEST(TimerImplTest, TimerValueConversion) {
 } // namespace
 } // namespace Event
 } // namespace Envoy
-

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -114,6 +114,7 @@ public:
   MOCK_METHOD1(post, void(std::function<void()> callback));
   MOCK_METHOD1(run, void(RunType type));
   MOCK_METHOD1(setTrackedObject, const ScopeTrackedObject*(const ScopeTrackedObject* object));
+  MOCK_METHOD0(isThreadSafe, bool());
   Buffer::WatermarkFactory& getWatermarkFactory() override { return buffer_factory_; }
 
   GlobalTimeSystem time_system_;

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -114,7 +114,7 @@ public:
   MOCK_METHOD1(post, void(std::function<void()> callback));
   MOCK_METHOD1(run, void(RunType type));
   MOCK_METHOD1(setTrackedObject, const ScopeTrackedObject*(const ScopeTrackedObject* object));
-  MOCK_METHOD0(isThreadSafe, bool());
+  MOCK_CONST_METHOD0(isThreadSafe, bool());
   Buffer::WatermarkFactory& getWatermarkFactory() override { return buffer_factory_; }
 
   GlobalTimeSystem time_system_;


### PR DESCRIPTION
Description: Makes this check available for external code to leverage. Provided one has a handle to an event dispatcher, one can check to if the execution context belongs to the dispatcher.
Risk Level: Low
Testing: CI

Co-authored-by: Jose Ulises Nino Rivera <jnino@lyft.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>
