### PR TITLE
ci: bring JVM heap limit back

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,15 @@
 # Envoy specific Bazel build/test options.
+
+# Bazel doesn't need more than 200MB of memory for local build based on memory profiling:
+# https://docs.bazel.build/versions/master/skylark/performance.html#memory-profiling
+# The default JVM max heapsize is 1/4 of physical memory up to 32GB which could be large
+# enough to consume all memory constrained by cgroup in large host, which is the case in CircleCI.
+# Limiting JVM heapsize here to let it do GC more when approaching the limit to
+# leave room for compiler/linker.
+# The number 2G is choosed heuristically to both support in CircleCI and large enough for RBE.
+# Startup options cannot be selected via config.
+startup --host_jvm_args=-Xmx2g
+
 build --workspace_status_command=bazel/get_workspace_status
 build --experimental_remap_main_repo
 build --experimental_local_memory_estimate


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Fixes some CI flakes in ASAN/TSAN caused by #7558.

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:

