### PR TITLE
test: Use an env-var rather than compile define to control exact memory comparisons.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -97,7 +97,7 @@ if [[ "$CI_TARGET" == "bazel.release" ]]; then
   # toolchain is kept consistent. This ifdef is checked in
   # test/common/stats/stat_test_utility.cc when computing
   # Stats::TestUtil::MemoryTest::mode().
-  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --action_env=ENVOY_MEMORY_TEST_EXACT=true"
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=ENVOY_MEMORY_TEST_EXACT=true"
 
   setup_clang_toolchain
   echo "bazel release build with tests..."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -97,7 +97,7 @@ if [[ "$CI_TARGET" == "bazel.release" ]]; then
   # toolchain is kept consistent. This ifdef is checked in
   # test/common/stats/stat_test_utility.cc when computing
   # Stats::TestUtil::MemoryTest::mode().
-  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --cxxopt=-DMEMORY_TEST_EXACT=1"
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --action_env=ENVOY_MEMORY_TEST_EXACT=true"
 
   setup_clang_toolchain
   echo "bazel release build with tests..."

--- a/test/common/stats/stat_test_utility.cc
+++ b/test/common/stats/stat_test_utility.cc
@@ -118,18 +118,19 @@ MemoryTest::Mode MemoryTest::mode() {
   const size_t end_mem = Memory::Stats::totalCurrentlyAllocated();
   bool can_measure_memory = end_mem > start_mem;
 
-#if defined(MEMORY_TEST_EXACT) // Set in "ci/do_ci.sh" for 'release' tests.
-  RELEASE_ASSERT(can_measure_memory, "Compilation is set up for canonical memory measurements, "
-                                     "but memory measurement looks broken");
-  return Mode::Canonical;
-#else
-  // Different versions of STL and other compiler/architecture differences may
-  // also impact memory usage, so when not compiling with MEMORY_TEST_EXACT,
-  // memory comparisons must be given some slack. There have recently emerged
-  // some memory-allocation differences between development and Envoy CI and
-  // Bazel CI (which compiles Envoy as a test of Bazel).
-  return can_measure_memory ? Mode::Approximate : Mode::Disabled;
-#endif
+  if (getenv("ENVOY_MEMORY_TEST_EXACT") != nullptr) { // Set in "ci/do_ci.sh" for 'release' tests.
+    RELEASE_ASSERT(can_measure_memory,
+                   "$ENVOY_MEMORY_TEST_EXACT is set for canonical memory measurements, "
+                   "but memory measurement looks broken");
+    return Mode::Canonical;
+  } else {
+    // Different versions of STL and other compiler/architecture differences may
+    // also impact memory usage, so when not compiling with MEMORY_TEST_EXACT,
+    // memory comparisons must be given some slack. There have recently emerged
+    // some memory-allocation differences between development and Envoy CI and
+    // Bazel CI (which compiles Envoy as a test of Bazel).
+    return can_measure_memory ? Mode::Approximate : Mode::Disabled;
+  }
 #endif
 }
 


### PR DESCRIPTION
Description: Currently exact memory comparisons occur only when enabled via build-time define, sent via cxxopt. This PR changes the exact comparisons to depend instead on an environment variable, and updates CI to set that environment variable via bazel.
Risk Level: low
Testing: //test/integration:stats_integration_test with the env-var enabled in an opt build
Docs Changes:
Release Notes:
Fixes: #7588
