### PR TITLE
sds: add ability to reload TLS session ticket keys

### DIFF
--- a/include/envoy/secret/secret_manager.h
+++ b/include/envoy/secret/secret_manager.h
@@ -45,6 +45,14 @@ public:
   findStaticCertificateValidationContextProvider(const std::string& name) const PURE;
 
   /**
+   * @param name a name of the static TlsSessionTicketKeysConfigProviderSharedPtr.
+   * @return the TlsSessionTicketKeysConfigProviderSharedPtr. Returns nullptr
+   * if the static tls session ticket keys are not found.
+   */
+  virtual TlsSessionTicketKeysConfigProviderSharedPtr
+  findStaticTlsSessionTicketKeysContextProvider(const std::string& name) const PURE;
+
+  /**
    * @param tls_certificate the protobuf config of the TLS certificate.
    * @return a TlsCertificateConfigProviderSharedPtr created from tls_certificate.
    */
@@ -61,6 +69,13 @@ public:
   createInlineCertificateValidationContextProvider(
       const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context)
       PURE;
+
+  /**
+   * @param tls_certificate the protobuf config of the TLS session ticket keys.
+   * @return a TlsSessionTicketKeysConfigProviderSharedPtr created from session_ticket_keys.
+   */
+  virtual TlsSessionTicketKeysConfigProviderSharedPtr createInlineTlsSessionTicketKeysProvider(
+      const envoy::api::v2::auth::TlsSessionTicketKeys& tls_certificate) PURE;
 
   /**
    * Finds and returns a dynamic secret provider associated to SDS config. Create
@@ -89,6 +104,22 @@ public:
    */
   virtual CertificateValidationContextConfigProviderSharedPtr
   findOrCreateCertificateValidationContextProvider(
+      const envoy::api::v2::core::ConfigSource& config_source, const std::string& config_name,
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) PURE;
+
+  /**
+   * Finds and returns a dynamic secret provider associated to SDS config. Create
+   * a new one if such provider does not exist.
+   *
+   * @param config_source a protobuf message object containing a SDS config source.
+   * @param config_name a name that uniquely refers to the SDS config source.
+   * @param secret_provider_context context that provides components for creating and initializing
+   * secret provider.
+   * @return TlsSessionTicketKeysConfigProviderSharedPtr the dynamic tls session ticket keys secret
+   * provider.
+   */
+  virtual TlsSessionTicketKeysConfigProviderSharedPtr
+  findOrCreateTlsSessionTicketKeysContextProvider(
       const envoy::api::v2::core::ConfigSource& config_source, const std::string& config_name,
       Server::Configuration::TransportSocketFactoryContext& secret_provider_context) PURE;
 };

--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -36,6 +36,7 @@ public:
 using TlsCertificatePtr = std::unique_ptr<envoy::api::v2::auth::TlsCertificate>;
 using CertificateValidationContextPtr =
     std::unique_ptr<envoy::api::v2::auth::CertificateValidationContext>;
+using TlsSessionTicketKeysPtr = std::unique_ptr<envoy::api::v2::auth::TlsSessionTicketKeys>;
 
 using TlsCertificateConfigProvider = SecretProvider<envoy::api::v2::auth::TlsCertificate>;
 using TlsCertificateConfigProviderSharedPtr = std::shared_ptr<TlsCertificateConfigProvider>;
@@ -44,6 +45,11 @@ using CertificateValidationContextConfigProvider =
     SecretProvider<envoy::api::v2::auth::CertificateValidationContext>;
 using CertificateValidationContextConfigProviderSharedPtr =
     std::shared_ptr<CertificateValidationContextConfigProvider>;
+
+using TlsSessionTicketKeysConfigProvider =
+    SecretProvider<envoy::api::v2::auth::TlsSessionTicketKeys>;
+using TlsSessionTicketKeysConfigProviderSharedPtr =
+    std::shared_ptr<TlsSessionTicketKeysConfigProvider>;
 
 } // namespace Secret
 } // namespace Envoy

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -72,9 +72,11 @@ private:
 
 class TlsCertificateSdsApi;
 class CertificateValidationContextSdsApi;
+class TlsSessionTicketKeysSdsApi;
 using TlsCertificateSdsApiSharedPtr = std::shared_ptr<TlsCertificateSdsApi>;
 using CertificateValidationContextSdsApiSharedPtr =
     std::shared_ptr<CertificateValidationContextSdsApi>;
+using TlsSessionTicketKeysSdsApiSharedPtr = std::shared_ptr<TlsSessionTicketKeysSdsApi>;
 
 /**
  * TlsCertificateSdsApi implementation maintains and updates dynamic TLS certificate secrets.
@@ -177,6 +179,65 @@ protected:
 private:
   CertificateValidationContextPtr certificate_validation_context_secrets_;
   Common::CallbackManager<const envoy::api::v2::auth::CertificateValidationContext&>
+      validation_callback_manager_;
+};
+
+/**
+ * TlsSessionTicketKeysSdsApi implementation maintains and updates dynamic tls session ticket keys
+ * secrets.
+ */
+class TlsSessionTicketKeysSdsApi : public SdsApi, public TlsSessionTicketKeysConfigProvider {
+public:
+  static TlsSessionTicketKeysSdsApiSharedPtr
+  create(Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+         const envoy::api::v2::core::ConfigSource& sds_config, const std::string& sds_config_name,
+         std::function<void()> destructor_cb) {
+    // We need to do this early as we invoke the subscription factory during initialization, which
+    // is too late to throw.
+    Config::Utility::checkLocalInfo("TlsSessionTicketKeysSdsApi",
+                                    secret_provider_context.localInfo());
+    return std::make_shared<TlsSessionTicketKeysSdsApi>(
+        sds_config, sds_config_name, secret_provider_context.clusterManager().subscriptionFactory(),
+        secret_provider_context.messageValidationVisitor(), secret_provider_context.stats(),
+        *secret_provider_context.initManager(), destructor_cb);
+  }
+
+  TlsSessionTicketKeysSdsApi(const envoy::api::v2::core::ConfigSource& sds_config,
+                             const std::string& sds_config_name,
+                             Config::SubscriptionFactory& subscription_factory,
+                             ProtobufMessage::ValidationVisitor& validation_visitor,
+                             Stats::Store& stats, Init::Manager& init_manager,
+                             std::function<void()> destructor_cb)
+      : SdsApi(sds_config, sds_config_name, subscription_factory, validation_visitor, stats,
+               init_manager, std::move(destructor_cb)) {}
+
+  // SecretProvider
+  const envoy::api::v2::auth::TlsSessionTicketKeys* secret() const override {
+    return tls_session_ticket_keys_.get();
+  }
+
+  Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+    return update_callback_manager_.add(callback);
+  }
+
+  Common::CallbackHandle* addValidationCallback(
+      std::function<void(const envoy::api::v2::auth::TlsSessionTicketKeys&)> callback) {
+    return validation_callback_manager_.add(callback);
+  }
+
+protected:
+  void setSecret(const envoy::api::v2::auth::Secret& secret) override {
+    tls_session_ticket_keys_ =
+        std::make_unique<envoy::api::v2::auth::TlsSessionTicketKeys>(secret.session_ticket_keys());
+  }
+
+  void validateConfig(const envoy::api::v2::auth::Secret& secret) override {
+    validation_callback_manager_.runCallbacks(secret.session_ticket_keys());
+  }
+
+private:
+  Secret::TlsSessionTicketKeysPtr tls_session_ticket_keys_;
+  Common::CallbackManager<const envoy::api::v2::auth::TlsSessionTicketKeys&>
       validation_callback_manager_;
 };
 

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -24,6 +24,9 @@ public:
   CertificateValidationContextConfigProviderSharedPtr
   findStaticCertificateValidationContextProvider(const std::string& name) const override;
 
+  TlsSessionTicketKeysConfigProviderSharedPtr
+  findStaticTlsSessionTicketKeysContextProvider(const std::string& name) const override;
+
   TlsCertificateConfigProviderSharedPtr createInlineTlsCertificateProvider(
       const envoy::api::v2::auth::TlsCertificate& tls_certificate) override;
 
@@ -32,12 +35,19 @@ public:
       const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context)
       override;
 
+  TlsSessionTicketKeysConfigProviderSharedPtr createInlineTlsSessionTicketKeysProvider(
+      const envoy::api::v2::auth::TlsSessionTicketKeys& tls_session_ticket_keys) override;
+
   TlsCertificateConfigProviderSharedPtr findOrCreateTlsCertificateProvider(
       const envoy::api::v2::core::ConfigSource& config_source, const std::string& config_name,
       Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
 
   CertificateValidationContextConfigProviderSharedPtr
   findOrCreateCertificateValidationContextProvider(
+      const envoy::api::v2::core::ConfigSource& config_source, const std::string& config_name,
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
+
+  TlsSessionTicketKeysConfigProviderSharedPtr findOrCreateTlsSessionTicketKeysContextProvider(
       const envoy::api::v2::core::ConfigSource& config_source, const std::string& config_name,
       Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
 
@@ -88,9 +98,13 @@ private:
   std::unordered_map<std::string, CertificateValidationContextConfigProviderSharedPtr>
       static_certificate_validation_context_providers_;
 
+  std::unordered_map<std::string, TlsSessionTicketKeysConfigProviderSharedPtr>
+      static_session_ticket_keys_providers_;
+
   // map hash code of SDS config source and SdsApi object.
   DynamicSecretProviders<TlsCertificateSdsApi> certificate_providers_;
   DynamicSecretProviders<CertificateValidationContextSdsApi> validation_context_providers_;
+  DynamicSecretProviders<TlsSessionTicketKeysSdsApi> session_ticket_keys_providers_;
 };
 
 } // namespace Secret

--- a/source/common/secret/secret_provider_impl.cc
+++ b/source/common/secret/secret_provider_impl.cc
@@ -17,5 +17,10 @@ CertificateValidationContextConfigProviderImpl::CertificateValidationContextConf
           std::make_unique<envoy::api::v2::auth::CertificateValidationContext>(
               certificate_validation_context)) {}
 
+TlsSessionTicketKeysConfigProviderImpl::TlsSessionTicketKeysConfigProviderImpl(
+    const envoy::api::v2::auth::TlsSessionTicketKeys& tls_session_ticket_keys)
+    : tls_session_ticket_keys_(
+          std::make_unique<envoy::api::v2::auth::TlsSessionTicketKeys>(tls_session_ticket_keys)) {}
+
 } // namespace Secret
 } // namespace Envoy

--- a/source/common/secret/secret_provider_impl.h
+++ b/source/common/secret/secret_provider_impl.h
@@ -40,5 +40,20 @@ private:
   Secret::CertificateValidationContextPtr certificate_validation_context_;
 };
 
+class TlsSessionTicketKeysConfigProviderImpl : public TlsSessionTicketKeysConfigProvider {
+public:
+  TlsSessionTicketKeysConfigProviderImpl(
+      const envoy::api::v2::auth::TlsSessionTicketKeys& tls_session_ticket_keys);
+
+  const envoy::api::v2::auth::TlsSessionTicketKeys* secret() const override {
+    return tls_session_ticket_keys_.get();
+  }
+
+  Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
+
+private:
+  Secret::TlsSessionTicketKeysPtr tls_session_ticket_keys_;
+};
+
 } // namespace Secret
 } // namespace Envoy

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -104,6 +104,40 @@ getCertificateValidationContextConfigProvider(
   }
 }
 
+Secret::TlsSessionTicketKeysConfigProviderSharedPtr getTlsSessionTicketKeysConfigProvider(
+    Server::Configuration::TransportSocketFactoryContext& factory_context,
+    const envoy::api::v2::auth::DownstreamTlsContext& config) {
+
+  switch (config.session_ticket_keys_type_case()) {
+  case envoy::api::v2::auth::DownstreamTlsContext::kSessionTicketKeys:
+    return factory_context.secretManager().createInlineTlsSessionTicketKeysProvider(
+        config.session_ticket_keys());
+  case envoy::api::v2::auth::DownstreamTlsContext::kSessionTicketKeysSdsSecretConfig: {
+    const auto& sds_secret_config = config.session_ticket_keys_sds_secret_config();
+    if (sds_secret_config.has_sds_config()) {
+      // Fetch dynamic secret.
+      return factory_context.secretManager().findOrCreateTlsSessionTicketKeysContextProvider(
+          sds_secret_config.sds_config(), sds_secret_config.name(), factory_context);
+    } else {
+      // Load static secret.
+      auto secret_provider =
+          factory_context.secretManager().findStaticTlsSessionTicketKeysContextProvider(
+              sds_secret_config.name());
+      if (!secret_provider) {
+        throw EnvoyException(
+            fmt::format("Unknown tls session ticket keys: {}", sds_secret_config.name()));
+      }
+      return secret_provider;
+    }
+  }
+  case envoy::api::v2::auth::DownstreamTlsContext::SESSION_TICKET_KEYS_TYPE_NOT_SET:
+    return nullptr;
+  default:
+    throw EnvoyException(fmt::format("Unexpected case for oneof session_ticket_keys: {}",
+                                     config.session_ticket_keys_type_case()));
+  }
+}
+
 } // namespace
 
 ContextConfigImpl::ContextConfigImpl(
@@ -339,27 +373,23 @@ ServerContextConfigImpl::ServerContextConfigImpl(
                         DEFAULT_CIPHER_SUITES, DEFAULT_CURVES, factory_context),
       require_client_certificate_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, false)),
-      session_ticket_keys_([&config, &api = api_] {
-        std::vector<SessionTicketKey> ret;
+      session_ticket_keys_provider_(
+          getTlsSessionTicketKeysConfigProvider(factory_context, config)) {
+  if (session_ticket_keys_provider_ != nullptr) {
+    // Validate tls session ticket keys early to reject bad sds updates.
+    stk_validation_callback_handle_ =
+        dynamic_cast<Secret::TlsSessionTicketKeysSdsApi*>(session_ticket_keys_provider_.get())
+            ->addValidationCallback([this](const envoy::api::v2::auth::TlsSessionTicketKeys& keys) {
+              getSessionTicketKeys(keys);
+            });
+  }
 
-        switch (config.session_ticket_keys_type_case()) {
-        case envoy::api::v2::auth::DownstreamTlsContext::kSessionTicketKeys:
-          for (const auto& datasource : config.session_ticket_keys().keys()) {
-            validateAndAppendKey(ret, Config::DataSource::read(datasource, false, api));
-          }
-          break;
-        case envoy::api::v2::auth::DownstreamTlsContext::kSessionTicketKeysSdsSecretConfig:
-          throw EnvoyException("SDS not supported yet");
-          break;
-        case envoy::api::v2::auth::DownstreamTlsContext::SESSION_TICKET_KEYS_TYPE_NOT_SET:
-          break;
-        default:
-          throw EnvoyException(fmt::format("Unexpected case for oneof session_ticket_keys: {}",
-                                           config.session_ticket_keys_type_case()));
-        }
+  // Load inline or static secrets.
+  if (session_ticket_keys_provider_ != nullptr &&
+      session_ticket_keys_provider_->secret() != nullptr) {
+    session_ticket_keys_ = getSessionTicketKeys(*session_ticket_keys_provider_->secret());
+  }
 
-        return ret;
-      }()) {
   if ((config.common_tls_context().tls_certificates().size() +
        config.common_tls_context().tls_certificate_sds_secret_configs().size()) == 0) {
     throw EnvoyException("No TLS certificates found for server context");
@@ -369,10 +399,45 @@ ServerContextConfigImpl::ServerContextConfigImpl(
   }
 }
 
-// Append a SessionTicketKey to keys, initializing it with key_data.
+ServerContextConfigImpl::~ServerContextConfigImpl() {
+  if (stk_update_callback_handle_ != nullptr) {
+    stk_update_callback_handle_->remove();
+  }
+  if (stk_validation_callback_handle_ != nullptr) {
+    stk_validation_callback_handle_->remove();
+  }
+}
+
+void ServerContextConfigImpl::setSecretUpdateCallback(std::function<void()> callback) {
+  ContextConfigImpl::setSecretUpdateCallback(callback);
+  if (session_ticket_keys_provider_) {
+    if (stk_update_callback_handle_) {
+      stk_update_callback_handle_->remove();
+    }
+    // Once session_ticket_keys_ receives new secret, this callback updates
+    // ContextConfigImpl::session_ticket_keys_ with new session ticket keys.
+    stk_update_callback_handle_ =
+        session_ticket_keys_provider_->addUpdateCallback([this, callback]() {
+          session_ticket_keys_ = getSessionTicketKeys(*session_ticket_keys_provider_->secret());
+          callback();
+        });
+  }
+}
+
+std::vector<Ssl::ServerContextConfig::SessionTicketKey>
+ServerContextConfigImpl::getSessionTicketKeys(
+    const envoy::api::v2::auth::TlsSessionTicketKeys& keys) {
+  std::vector<Ssl::ServerContextConfig::SessionTicketKey> result;
+  for (const auto& datasource : keys.keys()) {
+    result.emplace_back(getSessionTicketKey(Config::DataSource::read(datasource, false, api_)));
+  }
+  return result;
+}
+
+// Extracts a SessionTicketKey from raw binary data.
 // Throws if key_data is invalid.
-void ServerContextConfigImpl::validateAndAppendKey(
-    std::vector<ServerContextConfig::SessionTicketKey>& keys, const std::string& key_data) {
+Ssl::ServerContextConfig::SessionTicketKey
+ServerContextConfigImpl::getSessionTicketKey(const std::string& key_data) {
   // If this changes, need to figure out how to deal with key files
   // that previously worked. For now, just assert so we'll notice that
   // it changed if it does.
@@ -384,8 +449,7 @@ void ServerContextConfigImpl::validateAndAppendKey(
                                      key_data.size(), sizeof(SessionTicketKey)));
   }
 
-  keys.emplace_back();
-  SessionTicketKey& dst_key = keys.back();
+  SessionTicketKey dst_key;
 
   std::copy_n(key_data.begin(), dst_key.name_.size(), dst_key.name_.begin());
   size_t pos = dst_key.name_.size();
@@ -394,6 +458,8 @@ void ServerContextConfigImpl::validateAndAppendKey(
   std::copy_n(key_data.begin() + pos, dst_key.aes_key_.size(), dst_key.aes_key_.begin());
   pos += dst_key.aes_key_.size();
   ASSERT(key_data.begin() + pos == key_data.end());
+
+  return dst_key;
 }
 
 } // namespace Tls

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -130,12 +130,22 @@ public:
   ServerContextConfigImpl(
       const envoy::api::v2::auth::DownstreamTlsContext& config,
       Server::Configuration::TransportSocketFactoryContext& secret_provider_context);
+  ~ServerContextConfigImpl() override;
 
   // Ssl::ServerContextConfig
   bool requireClientCertificate() const override { return require_client_certificate_; }
   const std::vector<SessionTicketKey>& sessionTicketKeys() const override {
     return session_ticket_keys_;
   }
+
+  bool isReady() const override {
+    const bool parent_is_ready = ContextConfigImpl::isReady();
+    const bool session_ticket_keys_are_ready =
+        (session_ticket_keys_provider_ == nullptr || !session_ticket_keys_.empty());
+    return parent_is_ready && session_ticket_keys_are_ready;
+  }
+
+  void setSecretUpdateCallback(std::function<void()> callback) override;
 
 private:
   static const unsigned DEFAULT_MIN_VERSION;
@@ -144,10 +154,14 @@ private:
   static const std::string DEFAULT_CURVES;
 
   const bool require_client_certificate_;
-  const std::vector<SessionTicketKey> session_ticket_keys_;
+  std::vector<SessionTicketKey> session_ticket_keys_;
+  Secret::TlsSessionTicketKeysConfigProviderSharedPtr session_ticket_keys_provider_;
+  Common::CallbackHandle* stk_update_callback_handle_{};
+  Common::CallbackHandle* stk_validation_callback_handle_{};
 
-  static void validateAndAppendKey(std::vector<ServerContextConfig::SessionTicketKey>& keys,
-                                   const std::string& key_data);
+  std::vector<ServerContextConfig::SessionTicketKey>
+  getSessionTicketKeys(const envoy::api::v2::auth::TlsSessionTicketKeys& keys);
+  ServerContextConfig::SessionTicketKey getSessionTicketKey(const std::string& key_data);
 };
 
 } // namespace Tls

--- a/test/mocks/secret/mocks.h
+++ b/test/mocks/secret/mocks.h
@@ -21,6 +21,8 @@ public:
                      TlsCertificateConfigProviderSharedPtr(const std::string& name));
   MOCK_CONST_METHOD1(findStaticCertificateValidationContextProvider,
                      CertificateValidationContextConfigProviderSharedPtr(const std::string& name));
+  MOCK_CONST_METHOD1(findStaticTlsSessionTicketKeysContextProvider,
+                     TlsSessionTicketKeysConfigProviderSharedPtr(const std::string& name));
   MOCK_METHOD1(createInlineTlsCertificateProvider,
                TlsCertificateConfigProviderSharedPtr(
                    const envoy::api::v2::auth::TlsCertificate& tls_certificate));
@@ -28,6 +30,9 @@ public:
                CertificateValidationContextConfigProviderSharedPtr(
                    const envoy::api::v2::auth::CertificateValidationContext&
                        certificate_validation_context));
+  MOCK_METHOD1(createInlineTlsSessionTicketKeysProvider,
+               TlsSessionTicketKeysConfigProviderSharedPtr(
+                   const envoy::api::v2::auth::TlsSessionTicketKeys& tls_session_ticket_keys));
   MOCK_METHOD3(findOrCreateTlsCertificateProvider,
                TlsCertificateConfigProviderSharedPtr(
                    const envoy::api::v2::core::ConfigSource&, const std::string&,
@@ -37,6 +42,10 @@ public:
                    const envoy::api::v2::core::ConfigSource& config_source,
                    const std::string& config_name,
                    Server::Configuration::TransportSocketFactoryContext& secret_provider_context));
+  MOCK_METHOD3(findOrCreateTlsSessionTicketKeysContextProvider,
+               TlsSessionTicketKeysConfigProviderSharedPtr(
+                   const envoy::api::v2::core::ConfigSource&, const std::string&,
+                   Server::Configuration::TransportSocketFactoryContext&));
 };
 
 class MockSecretCallbacks : public SecretCallbacks {


### PR DESCRIPTION
Description: Finish migration of TLS session ticket keys to provider-based API.
Risk Level: Medium
Testing: TODO
Docs Changes: TODO
Release Notes: TODO
Fixes #7397
