### PR TITLE
bazelci: fix failures in ubuntu 18.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,8 +1,8 @@
 ---
 tasks:
-  ubuntu_1804:
-    platform: ubuntu1804
+  release:
+    platform: ubuntu1604
     build_targets:
-      - "//source/..."
+      - "//source/exe:envoy-static"
     test_targets:
       - "//test/..."


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Using ubuntu 18.04 caught #7647 while it is not good to block Bazel CI.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
