### PR TITLE
redis: fix multi-key eval/evalsha commands when prefix removal enabled

### DIFF
--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -56,7 +56,7 @@ envoy_cc_library(
     hdrs = ["command_splitter_impl.h"],
     deps = [
         ":command_splitter_interface",
-        ":router_interface",
+        ":router_lib",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/stats:timespan",
         "//source/common/common:assert_lib",

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -206,10 +206,9 @@ SplitRequestPtr EvalRequest::create(Router& router, Common::Redis::RespValuePtr&
           // A prefix router modified the first key, and its logic will now be applied to the
           // other keys. eval and evalsha have the same offsets for num_keys and the keys
           // themselves.
-          for (uint32_t key_index = 4; key_index <= (3 + num_keys); key_index++) {
-            bool prefix_found = (incoming_request->asArray()[key_index].asString().find(
-                                     prefix_route->prefix()) == 0);
-            if (prefix_found) {
+          for (uint64_t key_index = 4; key_index <= (3 + num_keys); key_index++) {
+            if (absl::StartsWith(incoming_request->asArray()[key_index].asString(),
+                                 prefix_route->prefix())) {
               // The prefix has been found as part of this key; remove it. This logic assumes that
               // the prefix route that matches the first key either applies to the other keys or NO
               // prefix does. Other prefixes from other routes are not checked against these other

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -17,7 +17,7 @@
 #include "extensions/filters/network/common/redis/client_impl.h"
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
-#include "extensions/filters/network/redis_proxy/router.h"
+#include "extensions/filters/network/redis_proxy/router_impl.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/redis_proxy/router.h
+++ b/source/extensions/filters/network/redis_proxy/router.h
@@ -64,6 +64,16 @@ public:
    * Returns a connection pool that matches a given route. When no match is found, the catch all
    * pool is used. When remove prefix is set to true, the prefix will be removed from the key.
    * @param key mutable reference to the key of the current command.
+   * @param key_modified mutable reference to boolean that is true if the key is modified, false
+   * otherwise.
+   * @return a handle to the connection pool.
+   */
+  virtual RouteSharedPtr upstreamPool(std::string& key, bool& key_modified) PURE;
+
+  /**
+   * Returns a connection pool that matches a given route. When no match is found, the catch all
+   * pool is used. When remove prefix is set to true, the prefix will be removed from the key.
+   * @param key mutable reference to the key of the current command.
    * @return a handle to the connection pool.
    */
   virtual RouteSharedPtr upstreamPool(std::string& key) PURE;

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -65,7 +65,8 @@ PrefixRoutes::PrefixRoutes(
   }
 }
 
-RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
+RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key, bool& key_modified) {
+  key_modified = false;
   PrefixSharedPtr value = nullptr;
   if (case_insensitive_) {
     std::string copy(key);
@@ -78,6 +79,7 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
   if (value != nullptr) {
     if (value->removePrefix()) {
       key.erase(0, value->prefix().length());
+      key_modified = true;
     }
     return value;
   }

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -69,7 +69,12 @@ public:
                    prefix_routes,
                Upstreams&& upstreams, Runtime::Loader& runtime);
 
-  RouteSharedPtr upstreamPool(std::string& key) override;
+  RouteSharedPtr upstreamPool(std::string& key, bool& key_modified) override;
+
+  RouteSharedPtr upstreamPool(std::string& key) override {
+    bool key_modified;
+    return upstreamPool(key, key_modified);
+  }
 
 private:
   TrieLookupTable<PrefixSharedPtr> prefix_lookup_table_;

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -33,6 +33,7 @@ public:
 
 class NullRouterImpl : public Router {
   RouteSharedPtr upstreamPool(std::string&) override { return nullptr; }
+  RouteSharedPtr upstreamPool(std::string&, bool&) override { return nullptr; }
 };
 
 class CommandLookUpSpeedTest {

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -39,6 +39,7 @@ public:
   PassthruRouter(ConnPool::InstanceSharedPtr conn_pool)
       : route_(std::make_shared<testing::NiceMock<MockRoute>>(conn_pool)) {}
 
+  RouteSharedPtr upstreamPool(std::string&, bool&) override { return route_; }
   RouteSharedPtr upstreamPool(std::string&) override { return route_; }
 
 private:

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -24,6 +24,7 @@ public:
   MockRouter();
   ~MockRouter();
 
+  MOCK_METHOD2(upstreamPool, RouteSharedPtr(std::string& key, bool& key_modified));
   MOCK_METHOD1(upstreamPool, RouteSharedPtr(std::string& key));
 };
 


### PR DESCRIPTION
Signed-off-by: Mitch Sukalski <mitch.sukalski@workday.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:

This PR addresses prefix removal on eval/evalssh command keys when 1) there are multiple keys (numkeys > 1), 2) prefix routes are configured, and 3) remove_prefix is true for selected prefix routes. Currently, only the first key is modified properly. A new variant of Router::upstreamPool() has been added that passes a mutable reference to a boolean (key_modified) that indicates whether the key has been modified. For most of the command splitter code, there is only a single key of interest in each Redis command, and this new variant is not needed. For commands that might have more than one key, this upstreamPool() provides a low overhead mechanism to determine whether further key modification is necessary.

Risk Level: low
Testing: additional integration test
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
