### PR TITLE
stats: Add type nicknames for the absl::optional types for various stats for their find*() functions.

### DIFF
--- a/include/envoy/stats/scope.h
+++ b/include/envoy/stats/scope.h
@@ -19,6 +19,9 @@ class Histogram;
 class Scope;
 class NullGaugeImpl;
 
+using OptionalCounter = absl::optional<std::reference_wrapper<const Counter>>;
+using OptionalGauge = absl::optional<std::reference_wrapper<const Gauge>>;
+using OptionalHistogram = absl::optional<std::reference_wrapper<const Histogram>>;
 using ScopePtr = std::unique_ptr<Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
 
@@ -93,22 +96,20 @@ public:
    * @param The name of the stat, obtained from the SymbolTable.
    * @return a reference to a counter within the scope's namespace, if it exists.
    */
-  virtual absl::optional<std::reference_wrapper<const Counter>>
-  findCounter(StatName name) const PURE;
+  virtual OptionalCounter findCounter(StatName name) const PURE;
 
   /**
    * @param The name of the stat, obtained from the SymbolTable.
    * @return a reference to a gauge within the scope's namespace, if it exists.
    */
-  virtual absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const PURE;
+  virtual OptionalGauge findGauge(StatName name) const PURE;
 
   /**
    * @param The name of the stat, obtained from the SymbolTable.
    * @return a reference to a histogram within the scope's namespace, if it
    * exists.
    */
-  virtual absl::optional<std::reference_wrapper<const Histogram>>
-  findHistogram(StatName name) const PURE;
+  virtual OptionalHistogram findHistogram(StatName name) const PURE;
 
   /**
    * @return a reference to the symbol table.

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -10,7 +10,6 @@
 #include "envoy/stats/symbol_table.h"
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Stats {

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -99,16 +99,9 @@ public:
     Histogram& histogram = histograms_.get(name);
     return histogram;
   }
-  absl::optional<std::reference_wrapper<const Counter>> findCounter(StatName name) const override {
-    return counters_.find(name);
-  }
-  absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const override {
-    return gauges_.find(name);
-  }
-  absl::optional<std::reference_wrapper<const Histogram>>
-  findHistogram(StatName name) const override {
-    return histograms_.find(name);
-  }
+  OptionalCounter findCounter(StatName name) const override { return counters_.find(name); }
+  OptionalGauge findGauge(StatName name) const override { return gauges_.find(name); }
+  OptionalHistogram findHistogram(StatName name) const override { return histograms_.find(name); }
 
   // Stats::Store
   std::vector<CounterSharedPtr> counters() const override { return counters_.toVector(); }

--- a/source/common/stats/scope_prefixer.cc
+++ b/source/common/stats/scope_prefixer.cc
@@ -44,17 +44,11 @@ Histogram& ScopePrefixer::histogramFromStatName(StatName name) {
   return scope_.histogramFromStatName(StatName(stat_name_storage.get()));
 }
 
-absl::optional<std::reference_wrapper<const Counter>>
-ScopePrefixer::findCounter(StatName name) const {
-  return scope_.findCounter(name);
-}
+OptionalCounter ScopePrefixer::findCounter(StatName name) const { return scope_.findCounter(name); }
 
-absl::optional<std::reference_wrapper<const Gauge>> ScopePrefixer::findGauge(StatName name) const {
-  return scope_.findGauge(name);
-}
+OptionalGauge ScopePrefixer::findGauge(StatName name) const { return scope_.findGauge(name); }
 
-absl::optional<std::reference_wrapper<const Histogram>>
-ScopePrefixer::findHistogram(StatName name) const {
+OptionalHistogram ScopePrefixer::findHistogram(StatName name) const {
   return scope_.findHistogram(name);
 }
 

--- a/source/common/stats/scope_prefixer.h
+++ b/source/common/stats/scope_prefixer.h
@@ -35,10 +35,9 @@ public:
     return histogramFromStatName(storage.statName());
   }
 
-  absl::optional<std::reference_wrapper<const Counter>> findCounter(StatName name) const override;
-  absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const override;
-  absl::optional<std::reference_wrapper<const Histogram>>
-  findHistogram(StatName name) const override;
+  OptionalCounter findCounter(StatName name) const override;
+  OptionalGauge findGauge(StatName name) const override;
+  OptionalHistogram findHistogram(StatName name) const override;
 
   const SymbolTable& constSymbolTable() const override { return scope_.constSymbolTable(); }
   virtual SymbolTable& symbolTable() override { return scope_.symbolTable(); }

--- a/source/common/stats/stat_merger.cc
+++ b/source/common/stats/stat_merger.cc
@@ -35,8 +35,7 @@ void StatMerger::mergeGauges(const Protobuf::Map<std::string, uint64_t>& gauges)
 
     StatNameManagedStorage storage(gauge.first, temp_scope_->symbolTable());
     StatName stat_name = storage.statName();
-    absl::optional<std::reference_wrapper<const Gauge>> gauge_opt =
-        temp_scope_->findGauge(stat_name);
+    OptionalGauge gauge_opt = temp_scope_->findGauge(stat_name);
 
     Gauge::ImportMode import_mode = Gauge::ImportMode::Uninitialized;
     if (gauge_opt) {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -513,18 +513,15 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogramFromStatName(StatName name)
   return **central_ref;
 }
 
-absl::optional<std::reference_wrapper<const Counter>>
-ThreadLocalStoreImpl::ScopeImpl::findCounter(StatName name) const {
+OptionalCounter ThreadLocalStoreImpl::ScopeImpl::findCounter(StatName name) const {
   return findStatLockHeld<Counter>(name, central_cache_.counters_);
 }
 
-absl::optional<std::reference_wrapper<const Gauge>>
-ThreadLocalStoreImpl::ScopeImpl::findGauge(StatName name) const {
+OptionalGauge ThreadLocalStoreImpl::ScopeImpl::findGauge(StatName name) const {
   return findStatLockHeld<Gauge>(name, central_cache_.gauges_);
 }
 
-absl::optional<std::reference_wrapper<const Histogram>>
-ThreadLocalStoreImpl::ScopeImpl::findHistogram(StatName name) const {
+OptionalHistogram ThreadLocalStoreImpl::ScopeImpl::findHistogram(StatName name) const {
   auto iter = central_cache_.histograms_.find(name);
   if (iter == central_cache_.histograms_.end()) {
     return absl::nullopt;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -166,8 +166,8 @@ public:
   const SymbolTable& constSymbolTable() const override { return alloc_.constSymbolTable(); }
   SymbolTable& symbolTable() override { return alloc_.symbolTable(); }
   const TagProducer& tagProducer() const { return *tag_producer_; }
-  absl::optional<std::reference_wrapper<const Counter>> findCounter(StatName name) const override {
-    absl::optional<std::reference_wrapper<const Counter>> found_counter;
+  OptionalCounter findCounter(StatName name) const override {
+    OptionalCounter found_counter;
     Thread::LockGuard lock(lock_);
     for (ScopeImpl* scope : scopes_) {
       found_counter = scope->findCounter(name);
@@ -177,8 +177,8 @@ public:
     }
     return absl::nullopt;
   }
-  absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const override {
-    absl::optional<std::reference_wrapper<const Gauge>> found_gauge;
+  OptionalGauge findGauge(StatName name) const override {
+    OptionalGauge found_gauge;
     Thread::LockGuard lock(lock_);
     for (ScopeImpl* scope : scopes_) {
       found_gauge = scope->findGauge(name);
@@ -188,9 +188,8 @@ public:
     }
     return absl::nullopt;
   }
-  absl::optional<std::reference_wrapper<const Histogram>>
-  findHistogram(StatName name) const override {
-    absl::optional<std::reference_wrapper<const Histogram>> found_histogram;
+  OptionalHistogram findHistogram(StatName name) const override {
+    OptionalHistogram found_histogram;
     Thread::LockGuard lock(lock_);
     for (ScopeImpl* scope : scopes_) {
       found_histogram = scope->findHistogram(name);
@@ -274,10 +273,9 @@ private:
 
     // NOTE: The find methods assume that `name` is fully-qualified.
     // Implementations will not add the scope prefix.
-    absl::optional<std::reference_wrapper<const Counter>> findCounter(StatName name) const override;
-    absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const override;
-    absl::optional<std::reference_wrapper<const Histogram>>
-    findHistogram(StatName name) const override;
+    OptionalCounter findCounter(StatName name) const override;
+    OptionalGauge findGauge(StatName name) const override;
+    OptionalHistogram findHistogram(StatName name) const override;
 
     template <class StatType>
     using MakeStatFn = std::function<RefcountPtr<StatType>(Allocator&, StatName name,

--- a/test/common/stats/stat_merger_test.cc
+++ b/test/common/stats/stat_merger_test.cc
@@ -196,7 +196,7 @@ TEST_F(StatMergerThreadLocalTest, filterOutUninitializedGauges) {
 
   // We don't get "newgauge1" in the aggregated list, but we *do* get it if we try to
   // find it by name.
-  absl::optional<std::reference_wrapper<const Gauge>> find = store_.findGauge(g1.statName());
+  OptionalGauge find = store_.findGauge(g1.statName());
   ASSERT_TRUE(find);
   EXPECT_EQ(&g1, &(find->get()));
 }

--- a/test/integration/filters/eds_ready_filter.cc
+++ b/test/integration/filters/eds_ready_filter.cc
@@ -20,8 +20,7 @@ public:
   EdsReadyFilter(const Stats::Scope& root_scope, Stats::SymbolTable& symbol_table)
       : root_scope_(root_scope), stat_name_("cluster.cluster_0.membership_healthy", symbol_table) {}
   Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
-    absl::optional<std::reference_wrapper<const Stats::Gauge>> gauge =
-        root_scope_.findGauge(stat_name_.statName());
+    Stats::OptionalGauge gauge = root_scope_.findGauge(stat_name_.statName());
     if (!gauge.has_value()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,
                                          "Couldn't find stat", nullptr, absl::nullopt, "");

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -109,16 +109,15 @@ public:
     return histogramFromStatName(storage.statName());
   }
 
-  absl::optional<std::reference_wrapper<const Counter>> findCounter(StatName name) const override {
+  OptionalCounter findCounter(StatName name) const override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->findCounter(name);
   }
-  absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const override {
+  OptionalGauge findGauge(StatName name) const override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->findGauge(name);
   }
-  absl::optional<std::reference_wrapper<const Histogram>>
-  findHistogram(StatName name) const override {
+  OptionalHistogram findHistogram(StatName name) const override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->findHistogram(name);
   }
@@ -170,16 +169,15 @@ public:
     Thread::LockGuard lock(lock_);
     return store_.histogram(name);
   }
-  absl::optional<std::reference_wrapper<const Counter>> findCounter(StatName name) const override {
+  OptionalCounter findCounter(StatName name) const override {
     Thread::LockGuard lock(lock_);
     return store_.findCounter(name);
   }
-  absl::optional<std::reference_wrapper<const Gauge>> findGauge(StatName name) const override {
+  OptionalGauge findGauge(StatName name) const override {
     Thread::LockGuard lock(lock_);
     return store_.findGauge(name);
   }
-  absl::optional<std::reference_wrapper<const Histogram>>
-  findHistogram(StatName name) const override {
+  OptionalHistogram findHistogram(StatName name) const override {
     Thread::LockGuard lock(lock_);
     return store_.findHistogram(name);
   }

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -271,10 +271,9 @@ public:
   MOCK_METHOD1(histogram, Histogram&(const std::string& name));
   MOCK_CONST_METHOD0(histograms, std::vector<ParentHistogramSharedPtr>());
 
-  MOCK_CONST_METHOD1(findCounter, absl::optional<std::reference_wrapper<const Counter>>(StatName));
-  MOCK_CONST_METHOD1(findGauge, absl::optional<std::reference_wrapper<const Gauge>>(StatName));
-  MOCK_CONST_METHOD1(findHistogram,
-                     absl::optional<std::reference_wrapper<const Histogram>>(StatName));
+  MOCK_CONST_METHOD1(findCounter, OptionalCounter(StatName));
+  MOCK_CONST_METHOD1(findGauge, OptionalGauge(StatName));
+  MOCK_CONST_METHOD1(findHistogram, OptionalHistogram(StatName));
 
   Counter& counterFromStatName(StatName name) override {
     return counter(symbol_table_->toString(name));


### PR DESCRIPTION
Description: The types for the findCounter() and sibling methods are quite awkward to type and read. Moreover https://google.github.io/styleguide/cppguide.html#auto discourages use of 'auto' for temp variables to receive the return value. These new type names are in the spirit of CounterSharedPtr et al.
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a

