### PR TITLE
admin: call listen in tests to verify behavior of SO_REUSEPORT

### DIFF
--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -589,12 +589,8 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithSocketOptions) {
 
   // First attempt to bind and listen socket should fail due to the lack of SO_REUSEPORT socket
   // options.
-  try {
-    bindAndListenTcpSocket(address, nullptr);
-    ADD_FAILURE() << "expected bind or listen to fail, but got success instead.";
-  } catch (Network::SocketBindException& exc) {
-    EXPECT_EQ(exc.errorNumber(), EADDRINUSE) << "unexpected exception: " << exc.what();
-  }
+  EXPECT_THAT_THROWS_MESSAGE(bindAndListenTcpSocket(address, nullptr), EnvoyException,
+                             HasSubstr(strerror(EADDRINUSE)));
 
   // Second attempt should succeed as kernel allows multiple sockets to listen the same address iff
   // both of them use SO_REUSEPORT socket option.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -575,7 +575,7 @@ void bindAndListenTcpSocket(const Network::Address::InstanceConstSharedPtr& addr
   // Some kernels erroneously allow `bind` without SO_REUSEPORT for addresses
   // with some other socket already listening on it, see #7636.
   if (::listen(socket->ioHandle().fd(), 1) != 0) {
-    throw EnvoyException("Address already in use");
+    throw EnvoyException(fmt::format("cannot listen:{}", strerror(errno)));
   }
 }
 } // namespace

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -575,7 +575,7 @@ void bindAndListenTcpSocket(const Network::Address::InstanceConstSharedPtr& addr
   // Some kernels erroneously allow `bind` without SO_REUSEPORT for addresses
   // with some other socket already listening on it, see #7636.
   if (::listen(socket->ioHandle().fd(), 1) != 0) {
-    // Mimick bind exception for the test simplicity.
+    // Mimic bind exception for the test simplicity.
     throw Network::SocketBindException(fmt::format("cannot listen: {}", strerror(errno)), errno);
   }
 }

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -568,17 +568,28 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithoutAccessLog) {
                             "An admin access log path is required for a listening server.");
 }
 
+namespace {
+void bindAndListenTcpSocket(const Network::Address::InstanceConstSharedPtr& address, const Network::Socket::OptionsSharedPtr& options) {
+    auto socket = std::make_unique<Network::TcpListenSocket>(address, options, true);
+    // Some kernels erroneously allow `bind` without SO_REUSEPORT for addresses
+    // with some other socket already listening on it, see #7636.
+    if (::listen(socket->ioHandle().fd(), 1) != 0) {
+        throw EnvoyException("Address already in use");
+    }
+}
+}
+
 // Test that `socket_options` field in an Admin proto is honored.
 TEST_P(ServerInstanceImplTest, BootstrapNodeWithSocketOptions) {
   ASSERT_NO_THROW(initialize("test/server/node_bootstrap_with_admin_socket_options.yaml"));
   const auto address = server_->admin().socket().localAddress();
-  EXPECT_THAT_THROWS_MESSAGE(std::make_unique<Network::TcpListenSocket>(address, nullptr, true),
+  EXPECT_THAT_THROWS_MESSAGE(bindAndListenTcpSocket(address, nullptr),
                              EnvoyException, HasSubstr("Address already in use"));
   auto options = std::make_shared<Network::Socket::Options>();
   options->emplace_back(std::make_shared<Network::SocketOptionImpl>(
       envoy::api::v2::core::SocketOption::STATE_PREBIND,
       ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_REUSEPORT), 1));
-  EXPECT_NO_THROW(std::make_unique<Network::TcpListenSocket>(address, options, true));
+  EXPECT_NO_THROW(bindAndListenTcpSocket(address, options));
 }
 
 // Empty bootstrap succeeds.


### PR DESCRIPTION
Description: In some cases `bind` call may succeed, so verify by calling `listen` as well.
Risk Level: LOW
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #7636
