### PR TITLE
clang-tidy: remove OSX-specific checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,8 @@
 Checks:          'abseil-*,
                   bugprone-*,
                   clang-analyzer-*,
+                  -clang-analyzer-optin.osx.*,
+                  -clang-analyzer-osx.*,
                   clang-diagnostic-*,
                   modernize-*,
                   performance-*,


### PR DESCRIPTION
Description: This eliminates clang-tidy checks that are specific to Objective-C compatibility & Foundation. Full list of checks that will be disabled:
```
clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker,
clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker,
clang-analyzer-osx.API,
clang-analyzer-osx.NumberObjectConversions,
clang-analyzer-osx.SecKeychainAPI,
clang-analyzer-osx.cocoa.AtSync,
clang-analyzer-osx.cocoa.ClassRelease,
clang-analyzer-osx.cocoa.Dealloc,
clang-analyzer-osx.cocoa.IncompatibleMethodTypes,
clang-analyzer-osx.cocoa.MissingSuperCall,
clang-analyzer-osx.cocoa.NSAutoreleasePool,
clang-analyzer-osx.cocoa.NSError,
clang-analyzer-osx.cocoa.NilArg,
clang-analyzer-osx.cocoa.ObjCGenerics,
clang-analyzer-osx.cocoa.RetainCount,
clang-analyzer-osx.cocoa.SelfInit,
clang-analyzer-osx.SuperDealloc,
clang-analyzer-osx.cocoa.UnusedIvars,
clang-analyzer-osx.cocoa.VariadicMethodTypes,
clang-analyzer-osx.coreFoundation.CFError,
clang-analyzer-osx.coreFoundation.CFNumber,
clang-analyzer-osx.coreFoundation.CFRetainRelease,
clang-analyzer-osx.coreFoundation.containers.OutOfBounds,
clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
```
Risk Level: Low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>