### PR TITLE
clang-tidy: fix existing errors on master branch

### DIFF
--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -85,7 +85,7 @@ public:
     return Network::Address::SocketType::Stream;
   }
   void setLocalAddress(const Network::Address::InstanceConstSharedPtr&) override {}
-  void restoreLocalAddress(const Network::Address::InstanceConstSharedPtr&) override { return; }
+  void restoreLocalAddress(const Network::Address::InstanceConstSharedPtr&) override {}
   void setRemoteAddress(const Network::Address::InstanceConstSharedPtr&) override {}
   bool localAddressRestored() const override { return true; }
   void setDetectedTransportProtocol(absl::string_view) override {}
@@ -152,6 +152,7 @@ public:
   void SetUp(const ::benchmark::State& state) override {
     int64_t input_size = state.range(0);
     std::vector<std::string> port_chains;
+    port_chains.reserve(input_size);
     for (int i = 0; i < input_size; i++) {
       port_chains.push_back(absl::StrCat(YamlSingleDstPortTop, 10000 + i, YamlSingleDstPortBottom));
     }


### PR DESCRIPTION
Description: Fix existing violations of `performance-inefficient-vector-operation` and `readability-redundant-control-flow`.
Risk Level: Low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>