### PR TITLE
Add missing initialization of the Http11AbsolutePathWithPort test

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -241,6 +241,8 @@ TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePath2) {
 }
 
 TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePathWithPort) {
+  initialize();
+
   TestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com:4532"}, {":path", "/foo/bar"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer(


### PR DESCRIPTION
Add missing initialization of the Http1ServerConnectionImplTest.Http11AbsolutePathWithPort test

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
