### PR TITLE
http inspector: multiple reads for http inspector

### DIFF
--- a/source/extensions/filters/listener/http_inspector/BUILD
+++ b/source/extensions/filters/listener/http_inspector/BUILD
@@ -13,7 +13,10 @@ envoy_package()
 envoy_cc_library(
     name = "http_inspector_lib",
     srcs = ["http_inspector.cc"],
-    hdrs = ["http_inspector.h"],
+    hdrs = [
+        "http_inspector.h",
+        "http_protocol_header.h",
+    ],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:timer_interface",

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -72,7 +72,7 @@ void Filter::onRead() {
 }
 
 void Filter::parseHttpHeader(absl::string_view data) {
-  size_t len = std::min(data.length(), Filter::HTTP2_CONNECTION_PREFACE.length());
+  const size_t len = std::min(data.length(), Filter::HTTP2_CONNECTION_PREFACE.length());
   if (Filter::HTTP2_CONNECTION_PREFACE.compare(0, len, data, 0, len) == 0) {
     if (data.length() < Filter::HTTP2_CONNECTION_PREFACE.length()) {
       return;
@@ -84,7 +84,8 @@ void Filter::parseHttpHeader(absl::string_view data) {
     const size_t pos = data.find_first_of("\r\n");
     if (pos != absl::string_view::npos) {
       const absl::string_view request_line = data.substr(0, pos);
-      std::vector<absl::string_view> fields = absl::StrSplit(request_line, absl::MaxSplits(' ', 4));
+      const std::vector<absl::string_view> fields =
+          absl::StrSplit(request_line, absl::MaxSplits(' ', 4));
 
       // Method SP Request-URI SP HTTP-Version
       if (fields.size() != 3) {
@@ -107,7 +108,7 @@ void Filter::parseHttpHeader(absl::string_view data) {
 
     // Cannot find \r or \n
     ENVOY_LOG(trace, "http inspector: no request line detected");
-    std::vector<absl::string_view> fields = absl::StrSplit(data, absl::MaxSplits(' ', 4));
+    const std::vector<absl::string_view> fields = absl::StrSplit(data, absl::MaxSplits(' ', 4));
 
     // Check if inspect partial of HTTP 1.x packet.
     switch (fields.size()) {
@@ -144,7 +145,7 @@ void Filter::parseHttpHeader(absl::string_view data) {
   }
 }
 
-bool Filter::checkPrefix(absl::string_view prefix,
+bool Filter::checkPrefix(const absl::string_view prefix,
                          const absl::flat_hash_set<std::string>& hash_set) {
   for (const auto& value : hash_set) {
     if (value.length() < prefix.length()) {

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -72,18 +72,15 @@ void Filter::onRead() {
 }
 
 void Filter::parseHttpHeader(absl::string_view data) {
-  if (absl::StartsWith(data, Filter::HTTP2_CONNECTION_PREFACE)) {
+  size_t len = std::min(data.length(), Filter::HTTP2_CONNECTION_PREFACE.length());
+  if (Filter::HTTP2_CONNECTION_PREFACE.compare(0, len, data, 0, len) == 0) {
+    if (data.length() < Filter::HTTP2_CONNECTION_PREFACE.length()) {
+      return;
+    }
     ENVOY_LOG(trace, "http inspector: http2 connection preface found");
     protocol_ = "HTTP/2";
     done(true);
   } else {
-    if (data.length() < Filter::HTTP2_CONNECTION_PREFACE.length()) {
-      // Inspect partial HTTP2 connection preface
-      if (Filter::HTTP2_CONNECTION_PREFACE.substr(0, data.length()) == data) {
-        return;
-      }
-    }
-
     const size_t pos = data.find_first_of("\r\n");
     if (pos != absl::string_view::npos) {
       const absl::string_view request_line = data.substr(0, pos);
@@ -196,13 +193,46 @@ const absl::flat_hash_set<std::string>& Filter::httpProtocols() const {
 }
 
 const absl::flat_hash_set<std::string>& Filter::httpMethods() const {
-  CONSTRUCT_ON_FIRST_USE(
-      absl::flat_hash_set<std::string>,
-      {Http::Headers::get().MethodValues.Connect, Http::Headers::get().MethodValues.Delete,
-       Http::Headers::get().MethodValues.Get, Http::Headers::get().MethodValues.Head,
-       Http::Headers::get().MethodValues.Post, Http::Headers::get().MethodValues.Put,
-       Http::Headers::get().MethodValues.Options, Http::Headers::get().MethodValues.Trace,
-       HttpInspector::ExtendedHeader::get().MethodValues.Patch});
+  CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>,
+                         {HttpInspector::ExtendedHeader::get().MethodValues.Acl,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Baseline_Control,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Bind,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Checkin,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Checkout,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Connect,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Copy,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Delete,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Get,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Head,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Label,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Link,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Lock,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Merge,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Mkactivity,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Mkcalendar,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Mkcol,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Mkredirectref,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Mkworkspace,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Move,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Options,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Orderpatch,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Patch,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Post,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Pri,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Proppatch,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Purge,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Put,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Rebind,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Report,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Search,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Trace,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Unbind,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Uncheckout,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Unlink,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Unlock,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Update,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Updateredirectref,
+                          HttpInspector::ExtendedHeader::get().MethodValues.Version_Control});
 }
 
 } // namespace HttpInspector

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -108,21 +108,6 @@ void Filter::parseHttpHeader(absl::string_view data) {
   }
 }
 
-bool Filter::checkPrefix(const absl::string_view prefix,
-                         const absl::flat_hash_set<std::string>& hash_set) {
-  for (const auto& value : hash_set) {
-    if (value.length() < prefix.length()) {
-      continue;
-    }
-
-    if (value.substr(0, prefix.length()) == prefix) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 void Filter::done(bool success) {
   ENVOY_LOG(trace, "http inspector: done: {}", success);
 

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -68,7 +68,7 @@ private:
   bool checkPrefix(absl::string_view prefix, const absl::flat_hash_set<std::string>& hash_set);
 
   const absl::flat_hash_set<std::string>& httpProtocols() const;
-  const absl::flat_hash_set<std::string>& httpMethods() const;
+  const absl::flat_hash_set<std::string>& http1xMethods() const;
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_{nullptr};

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -65,8 +65,10 @@ private:
   void onRead();
   void done(bool success);
   void parseHttpHeader(absl::string_view data);
+  bool checkPrefix(absl::string_view prefix, const absl::flat_hash_set<std::string>& hash_set);
 
   const absl::flat_hash_set<std::string>& httpProtocols() const;
+  const absl::flat_hash_set<std::string>& httpMethods() const;
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_{nullptr};

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -65,7 +65,8 @@ private:
   void onRead();
   void done(bool success);
   void parseHttpHeader(absl::string_view data);
-  bool checkPrefix(absl::string_view prefix, const absl::flat_hash_set<std::string>& hash_set);
+  bool checkPrefix(const absl::string_view prefix,
+                   const absl::flat_hash_set<std::string>& hash_set);
 
   const absl::flat_hash_set<std::string>& httpProtocols() const;
   const absl::flat_hash_set<std::string>& httpMethods() const;

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -65,7 +65,6 @@ private:
   void onRead();
   void done(bool success);
   void parseHttpHeader(absl::string_view data);
-  bool checkPrefix(absl::string_view prefix, const absl::flat_hash_set<std::string>& hash_set);
 
   const absl::flat_hash_set<std::string>& httpProtocols() const;
   const absl::flat_hash_set<std::string>& http1xMethods() const;

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -65,8 +65,7 @@ private:
   void onRead();
   void done(bool success);
   void parseHttpHeader(absl::string_view data);
-  bool checkPrefix(const absl::string_view prefix,
-                   const absl::flat_hash_set<std::string>& hash_set);
+  bool checkPrefix(absl::string_view prefix, const absl::flat_hash_set<std::string>& hash_set);
 
   const absl::flat_hash_set<std::string>& httpProtocols() const;
   const absl::flat_hash_set<std::string>& httpMethods() const;

--- a/source/extensions/filters/listener/http_inspector/http_protocol_header.h
+++ b/source/extensions/filters/listener/http_inspector/http_protocol_header.h
@@ -15,7 +15,45 @@ namespace HttpInspector {
 class ExtendedHeaderValues {
 public:
   struct {
+    const std::string Acl{"ACL"};
+    const std::string Baseline_Control{"BASELINE-CONTROL"};
+    const std::string Bind{"BIND"};
+    const std::string Checkin{"CHECKIN"};
+    const std::string Checkout{"CHECKOUT"};
+    const std::string Connect{"CONNECT"};
+    const std::string Copy{"COPY"};
+    const std::string Delete{"DELETE"};
+    const std::string Get{"GET"};
+    const std::string Head{"HEAD"};
+    const std::string Label{"LABEL"};
+    const std::string Link{"LINK"};
+    const std::string Lock{"LOCK"};
+    const std::string Merge{"Merge"};
+    const std::string Mkactivity{"MKACTIVITY"};
+    const std::string Mkcalendar{"MKCALENDAR"};
+    const std::string Mkcol{"MKCOL"};
+    const std::string Mkredirectref{"MKREDIRECTREF"};
+    const std::string Mkworkspace{"MKWORKSPACE"};
+    const std::string Move{"MOVE"};
+    const std::string Options{"OPTIONS"};
+    const std::string Orderpatch{"ORDERPATCH"};
     const std::string Patch{"PATCH"};
+    const std::string Post{"POST"};
+    const std::string Pri{"PRI"};
+    const std::string Proppatch{"PROPPATCH"};
+    const std::string Purge{"PURGE"};
+    const std::string Put{"PUT"};
+    const std::string Rebind{"REBIND"};
+    const std::string Report{"REPORT"};
+    const std::string Search{"SEARCH"};
+    const std::string Trace{"TRACE"};
+    const std::string Unbind{"UNBIND"};
+    const std::string Uncheckout{"UNCHECKOUT"};
+    const std::string Unlink{"UNLINK"};
+    const std::string Unlock{"UNLOCK"};
+    const std::string Update{"UPDATE"};
+    const std::string Updateredirectref{"UPDATEREDIRECTREF"};
+    const std::string Version_Control{"VERSION-CONTROL"};
   } MethodValues;
 };
 

--- a/source/extensions/filters/listener/http_inspector/http_protocol_header.h
+++ b/source/extensions/filters/listener/http_inspector/http_protocol_header.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+#include "common/singleton/const_singleton.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ListenerFilters {
+namespace HttpInspector {
+
+/**
+ * Class including extended methods.
+ */
+class ExtendedHeaderValues {
+public:
+  struct {
+    const std::string Patch{"PATCH"};
+  } MethodValues;
+};
+
+using ExtendedHeader = ConstSingleton<ExtendedHeaderValues>;
+
+} // namespace HttpInspector
+} // namespace ListenerFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -127,12 +127,10 @@ TEST_F(HttpInspectorTest, InvalidHttpMethod) {
         return Api::SysCallSizeResult{ssize_t(header.size()), 0};
       }));
 
-  const std::vector<absl::string_view> alpn_protos{absl::string_view("http/1.1")};
-
-  EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(cb_, continueFilterChain(true));
   file_event_callback_(Event::FileReadyType::Read);
-  EXPECT_EQ(1, cfg_->stats().http11_found_.value());
+  EXPECT_EQ(0, cfg_->stats().http11_found_.value());
 }
 
 TEST_F(HttpInspectorTest, InvalidHttpRequestLine) {
@@ -226,9 +224,9 @@ TEST_F(HttpInspectorTest, InvalidConnectionPreface) {
       }));
 
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
-  EXPECT_CALL(cb_, continueFilterChain(true));
+  EXPECT_CALL(cb_, continueFilterChain(true)).Times(0);
   file_event_callback_(Event::FileReadyType::Read);
-  EXPECT_EQ(1, cfg_->stats().http_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().http_not_found_.value());
 }
 
 TEST_F(HttpInspectorTest, ReadError) {
@@ -242,7 +240,7 @@ TEST_F(HttpInspectorTest, ReadError) {
   EXPECT_EQ(1, cfg_->stats().read_error_.value());
 }
 
-TEST_F(HttpInspectorTest, MultipleReads) {
+TEST_F(HttpInspectorTest, MultipleReadsHttp2) {
 
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
@@ -260,12 +258,16 @@ TEST_F(HttpInspectorTest, MultipleReads) {
     EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
       return Api::SysCallSizeResult{ssize_t(-1), EAGAIN};
     }));
-    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
-        .WillOnce(Invoke([&data](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
-          ASSERT(length >= data.size());
-          memcpy(buffer, data.data(), data.size());
-          return Api::SysCallSizeResult{ssize_t(data.size()), 0};
-        }));
+
+    for (size_t i = 1; i <= 24; i++) {
+      EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+          .WillOnce(
+              Invoke([&data, i](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+                ASSERT(length >= data.size());
+                memcpy(buffer, data.data(), data.size());
+                return Api::SysCallSizeResult{ssize_t(i), 0};
+              }));
+    }
   }
 
   bool got_continue = false;
@@ -277,6 +279,143 @@ TEST_F(HttpInspectorTest, MultipleReads) {
     file_event_callback_(Event::FileReadyType::Read);
   }
   EXPECT_EQ(1, cfg_->stats().http2_found_.value());
+}
+
+TEST_F(HttpInspectorTest, MultipleReadsHttp2BadPreface) {
+
+  init();
+  const std::string header = "505249202a20485454502f322e300d0a0d0c";
+  const std::vector<uint8_t> data = Hex::decode(header);
+  {
+    InSequence s;
+
+    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
+      return Api::SysCallSizeResult{ssize_t(-1), EAGAIN};
+    }));
+
+    for (size_t i = 1; i <= data.size(); i++) {
+      EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+          .WillOnce(
+              Invoke([&data, i](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+                ASSERT(length >= data.size());
+                memcpy(buffer, data.data(), data.size());
+                return Api::SysCallSizeResult{ssize_t(i), 0};
+              }));
+    }
+  }
+
+  bool got_continue = false;
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
+  EXPECT_CALL(cb_, continueFilterChain(true)).WillOnce(InvokeWithoutArgs([&got_continue]() {
+    got_continue = true;
+  }));
+  while (!got_continue) {
+    file_event_callback_(Event::FileReadyType::Read);
+  }
+  EXPECT_EQ(1, cfg_->stats().http_not_found_.value());
+}
+
+TEST_F(HttpInspectorTest, MultipleReadsHttp1) {
+
+  init();
+
+  const absl::string_view data = "GET /anything HTTP/1.0\r";
+  {
+    InSequence s;
+
+    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
+      return Api::SysCallSizeResult{ssize_t(-1), EAGAIN};
+    }));
+
+    for (size_t i = 1; i <= data.length(); i++) {
+      EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+          .WillOnce(
+              Invoke([&data, i](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+                ASSERT(length >= data.size());
+                memcpy(buffer, data.data(), data.size());
+                return Api::SysCallSizeResult{ssize_t(i), 0};
+              }));
+    }
+  }
+
+  bool got_continue = false;
+  const std::vector<absl::string_view> alpn_protos = {absl::string_view("http/1.0")};
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
+  EXPECT_CALL(cb_, continueFilterChain(true)).WillOnce(InvokeWithoutArgs([&got_continue]() {
+    got_continue = true;
+  }));
+  while (!got_continue) {
+    file_event_callback_(Event::FileReadyType::Read);
+  }
+  EXPECT_EQ(1, cfg_->stats().http10_found_.value());
+}
+
+TEST_F(HttpInspectorTest, MultipleReadsHttp1BadMethod) {
+
+  init();
+
+  const absl::string_view data = "GE ";
+  {
+    InSequence s;
+
+    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
+      return Api::SysCallSizeResult{ssize_t(-1), EAGAIN};
+    }));
+
+    for (size_t i = 1; i <= data.length(); i++) {
+      EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+          .WillOnce(
+              Invoke([&data, i](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+                ASSERT(length >= data.size());
+                memcpy(buffer, data.data(), data.size());
+                return Api::SysCallSizeResult{ssize_t(i), 0};
+              }));
+    }
+  }
+
+  bool got_continue = false;
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
+  EXPECT_CALL(cb_, continueFilterChain(true)).WillOnce(InvokeWithoutArgs([&got_continue]() {
+    got_continue = true;
+  }));
+  while (!got_continue) {
+    file_event_callback_(Event::FileReadyType::Read);
+  }
+  EXPECT_EQ(1, cfg_->stats().http_not_found_.value());
+}
+
+TEST_F(HttpInspectorTest, MultipleReadsHttp1BadProtocol) {
+
+  init();
+
+  const absl::string_view data = "GET /index HTT\r";
+  {
+    InSequence s;
+
+    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
+      return Api::SysCallSizeResult{ssize_t(-1), EAGAIN};
+    }));
+
+    for (size_t i = 1; i <= data.length(); i++) {
+      EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+          .WillOnce(
+              Invoke([&data, i](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+                ASSERT(length >= data.size());
+                memcpy(buffer, data.data(), data.size());
+                return Api::SysCallSizeResult{ssize_t(i), 0};
+              }));
+    }
+  }
+
+  bool got_continue = false;
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
+  EXPECT_CALL(cb_, continueFilterChain(true)).WillOnce(InvokeWithoutArgs([&got_continue]() {
+    got_continue = true;
+  }));
+  while (!got_continue) {
+    file_event_callback_(Event::FileReadyType::Read);
+  }
+  EXPECT_EQ(1, cfg_->stats().http_not_found_.value());
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: crazyxy <yxyan@google.com>

Description: multiple reads when inspecting http protocol
Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
