### PR TITLE
docs: add more info about the admin logging endpoint

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -179,10 +179,15 @@ modify different aspects of the server:
 
 .. http:post:: /logging
 
-  Enable/disable different logging levels on a particular logger or all loggers. Generally only used during
-  development. To change a particular logger's level, set the query parameter like so, <logger_name>=<desired_level>.
-  To change the logging level across all loggers, set the query parameter as level=<desired_level>. To list the loggers,
-  send a POST request to the /logging endpoint without a query parameter.
+  Enable/disable different logging levels on a particular logger or all loggers.
+
+  - To change the logging level across all loggers, set the query parameter as level=<desired_level>.
+  - To change a particular logger's level, set the query parameter like so, <logger_name>=<desired_level>.
+  - To list the loggers, send a POST request to the /logging endpoint without a query parameter.
+
+  .. note::
+
+    Generally only used during development.
 
 .. http:post:: /memory
 

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -179,8 +179,10 @@ modify different aspects of the server:
 
 .. http:post:: /logging
 
-  Enable/disable different logging levels on different subcomponents. Generally only used during
-  development.
+  Enable/disable different logging levels on a particular logger or all loggers. Generally only used during
+  development. To change a particular logger's level, set the query parameter like so, <logger_name>=<desired_level>.
+  To change the logging level across all loggers, set the query parameter as level=<desired_level>. To list the loggers,
+  send a POST request to the /logging endpoint without a query parameter.
 
 .. http:post:: /memory
 


### PR DESCRIPTION
Description:

Add more info about the admin logging endpoint. It was unclear how to interact with the logging endpoint without looking through the [admin IT test](https://github.com/envoyproxy/envoy/blob/139cca5f6f150e4adeed235ac7ab6f9ae5f844ba/test/integration/integration_admin_test.cc#L66-L110).

Risk Level: None
Testing: None
Docs Changes: Added info about the admin logging endpoint.
Release Notes: None