### PR TITLE
Auth code

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -64,7 +64,8 @@ void Filter::onComplete(const Status& status) {
     stats_.denied_.inc();
     state_ = Responded;
     // verification failed
-    Http::Code code = Http::Code::Unauthorized;
+    Http::Code code =
+        status == Status::JwtAudienceNotAllowed ? Http::Code::Forbidden : Http::Code::Unauthorized;
     // return failure reason as message body
     decoder_callbacks_->sendLocalReply(code, ::google::jwt_verify::getStatusString(status), nullptr,
                                        absl::nullopt, RcDetails::get().JwtAuthnAccessDenied);

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -104,13 +104,36 @@ TEST_F(FilterTest, TestSetPayloadCall) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(headers));
 }
 
-// This test verifies Verifier::Callback is called inline with a failure status.
+// This test verifies Verifier::Callback is called inline with a failure(401 Unauthorized) status.
 // All functions should return Continue except decodeHeaders(), it returns StopIteration.
-TEST_F(FilterTest, InlineFailure) {
+TEST_F(FilterTest, InlineUnauthorizedFailure) {
   setupMockConfig();
   // A failed authentication completed inline: callback is called inside verify().
+
+  EXPECT_CALL(filter_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
   EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
     context->callback()->onComplete(Status::JwtBadFormat);
+  }));
+
+  auto headers = Http::TestHeaderMapImpl{};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(1U, mock_config_->stats().denied_.value());
+
+  Buffer::OwnedImpl data("");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(headers));
+  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details_);
+}
+
+// This test verifies Verifier::Callback is called inline with a failure(403 Forbidden) status.
+// All functions should return Continue except decodeHeaders(), it returns StopIteration.
+TEST_F(FilterTest, InlineForbiddenFailure) {
+  setupMockConfig();
+  // A failed authentication completed inline: callback is called inside verify().
+
+  EXPECT_CALL(filter_callbacks_, sendLocalReply(Http::Code::Forbidden, _, _, _, _));
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
+    context->callback()->onComplete(Status::JwtAudienceNotAllowed);
   }));
 
   auto headers = Http::TestHeaderMapImpl{};
@@ -140,7 +163,6 @@ TEST_F(FilterTest, OutBoundOK) {
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(headers));
 
   // Callback is called now with OK status.
-  auto context = Verifier::createContext(headers, &verifier_callback_);
   m_cb->onComplete(Status::Ok);
 
   EXPECT_EQ(1U, mock_config_->stats().allowed_.value());
@@ -148,8 +170,9 @@ TEST_F(FilterTest, OutBoundOK) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(headers));
 }
 
-// This test verifies Verifier::Callback is called with a failure after verify().
-TEST_F(FilterTest, OutBoundFailure) {
+// This test verifies Verifier::Callback is called with a failure(401 Unauthorized) after verify()
+// returns any NonOK status except JwtAudienceNotAllowed.
+TEST_F(FilterTest, OutBoundUnauthorizedFailure) {
   setupMockConfig();
   Verifier::Callbacks* m_cb;
   // callback is saved, not called right
@@ -164,8 +187,8 @@ TEST_F(FilterTest, OutBoundFailure) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(headers));
 
-  auto context = Verifier::createContext(headers, &verifier_callback_);
   // Callback is called now with a failure status.
+  EXPECT_CALL(filter_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
   m_cb->onComplete(Status::JwtBadFormat);
 
   EXPECT_EQ(1U, mock_config_->stats().denied_.value());
@@ -174,6 +197,35 @@ TEST_F(FilterTest, OutBoundFailure) {
 
   // Should be OK to call the onComplete() again.
   m_cb->onComplete(Status::JwtBadFormat);
+}
+
+// This test verifies Verifier::Callback is called with a failure(403 Forbidden) after verify()
+// returns JwtAudienceNotAllowed.
+TEST_F(FilterTest, OutBoundForbiddenFailure) {
+  setupMockConfig();
+  Verifier::Callbacks* m_cb;
+  // callback is saved, not called right
+  EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([&m_cb](ContextSharedPtr context) {
+    m_cb = context->callback();
+  }));
+
+  auto headers = Http::TestHeaderMapImpl{};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data("");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(headers));
+
+  // Callback is called now with a failure status.
+  EXPECT_CALL(filter_callbacks_, sendLocalReply(Http::Code::Forbidden, _, _, _, _));
+  m_cb->onComplete(Status::JwtAudienceNotAllowed);
+
+  EXPECT_EQ(1U, mock_config_->stats().denied_.value());
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(headers));
+
+  // Should be OK to call the onComplete() again.
+  m_cb->onComplete(Status::JwtAudienceNotAllowed);
 }
 
 // Test verifies that if no route matched requirement, then request is allowed.


### PR DESCRIPTION
Description:
When the Audience is not allowed, it should be unauthorized(403) to that api
instead of being unauthenticated(401), like ESP
https://github.com/cloudendpoints/esp/blob/bcf6db722d9f611896e12f1e68c7e610a719c415/src/nginx/t/auth_pkey.t#L155

Risk Level: Low
Testing: Added
Docs Changes: None
Release Notes: None

