### PR TITLE
http health check: clear response headers on conn close

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -187,6 +187,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onEvent(Network::Conne
     // For the raw disconnect event, we are either between intervals in which case we already have
     // a timer setup, or we did the close or got a reset, in which case we already setup a new
     // timer. There is nothing to do here other than blow away the client.
+    response_headers_.reset();
     parent_.dispatcher_.deferredDelete(std::move(client_));
   }
 }


### PR DESCRIPTION
Satisfy an existing assert by clearing response headers when we
timeout with a partial response. The code worked correctly in
release builds but this will fix the assert from firing.

Fixes https://github.com/envoyproxy/envoy/issues/6557

Risk Level: Low
Testing: New UT
Docs Changes: N/A
Release Notes: N/A
