### PR TITLE
bazelci: fix again

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,8 +1,11 @@
 ---
 tasks:
   release:
-    platform: ubuntu1604
+    platform: ubuntu1804
     build_targets:
       - "//source/exe:envoy-static"
     test_targets:
       - "//test/..."
+    test_flags:
+    # Workaround for https://github.com/envoyproxy/envoy/issues/7647
+      - "--deleted_packages=//test/extensions/tracers/dynamic_ot"


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Bazel CI image for 16.04 contains too old toolchain to compile Envoy. Let's just add a workaround for now.

Risk Level:
Testing:
Docs Changes:
Release Notes:
