### PR TITLE
build/test: Fix msan use-of-unitialized-value in transport_sockets/tls/context_impl.cc

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -518,6 +518,7 @@ bool ContextImpl::verifySubjectAltName(X509* cert,
     case GEN_IPADD: {
       if (san->d.ip->length == 4) {
         sockaddr_in sin;
+        sin.sin_port = 0;
         sin.sin_family = AF_INET;
         memcpy(&sin.sin_addr, san->d.ip->data, sizeof(sin.sin_addr));
         Network::Address::Ipv4Instance addr(&sin);
@@ -528,6 +529,7 @@ bool ContextImpl::verifySubjectAltName(X509* cert,
         }
       } else if (san->d.ip->length == 16) {
         sockaddr_in6 sin6;
+        sin6.sin6_port = 0;
         sin6.sin6_family = AF_INET6;
         memcpy(&sin6.sin6_addr, san->d.ip->data, sizeof(sin6.sin6_addr));
         Network::Address::Ipv6Instance addr(sin6);


### PR DESCRIPTION
Signed-off-by: Ashley Hedberg <ahedberg@google.com>

Description: The sin_port/sin6_port fields were not initialized, causing msan to warn on use-of-uninitialized-value in ssl_socket_test:

[ RUN      ] IpVersions/SslSocketTest.Ipv4San/IPv6
==5456==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55cfb4ae6a9b in Envoy::Network::Address::Ipv4Instance::Ipv4Instance(sockaddr_in const*) source/common/network/address_impl.cc:178:24
    #1 0x55cfaf715886 in Envoy::Extensions::TransportSockets::Tls::ContextImpl::verifySubjectAltName(x509_st*, std::__msan::vector<std::__msan::basic_string<char, std::__msan::char_traits<char>, std::__msan::allocator<char> >, std::__msan::allocator<std::__msan::basic_string<char, std::__msan::char_traits<char>, std::__msan::allocator<char> > > > const&) source/extensions/transport_sockets/tls/context_impl.cc:523:40

This was detected during google's import.

Risk Level: none (test-only fix)
Testing: internal testing to confirm that this change fixes the msan warnings, plus bazel test test/extensions/transport_sockets/...
Docs Changes: n/a
Release Notes: n/a