### PR TITLE
hcm: ensure data added during filter callbacks get propagated

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1861,7 +1861,8 @@ bool ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleAfterDataCallbac
     FilterDataStatus status, Buffer::Instance& provided_data, bool& buffer_was_streaming) {
 
   if (status == FilterDataStatus::Continue) {
-    if (iteration_state_ == IterationState::StopSingleIteration || inline_buffered_data_) {
+    if (iteration_state_ == IterationState::StopSingleIteration ||
+        (inline_buffered_data_ && iteration_state_ == IterationState::Continue)) {
       commonHandleBufferData(provided_data);
       commonContinue();
       return false;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1533,6 +1533,7 @@ void ConnectionManagerImpl::ActiveStream::encodeData(
 
     recordLatestDataFilter(entry, state_.latest_data_encoding_filter_, encoder_filters_);
 
+    (*entry)->inline_buffered_data_ = false;
     (*entry)->end_stream_ = end_stream && !response_trailers_;
     FilterDataStatus status = (*entry)->handle_->encodeData(data, (*entry)->end_stream_);
     if ((*entry)->end_stream_) {
@@ -1741,6 +1742,8 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
                      static_cast<const void*>(this));
     return;
   }
+
+  ASSERT(!canIterate() || inline_buffered_data_);
 
   ENVOY_STREAM_LOG(trace, "continuing filter chain: filter={}", parent_,
                    static_cast<const void*>(this));

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -100,8 +100,8 @@ private:
     ActiveStreamFilterBase(ActiveStream& parent, bool dual_filter)
         : parent_(parent), iteration_state_(IterationState::Continue),
           iterate_from_current_filter_(false), headers_continued_(false),
-          continue_headers_continued_(false), end_stream_(false), dual_filter_(dual_filter),
-          decode_headers_called_(false) {}
+          continue_headers_continued_(false), inline_buffered_data_(false), end_stream_(false),
+          dual_filter_(dual_filter), decode_headers_called_(false) {}
 
     // Functions in the following block are called after the filter finishes processing
     // corresponding data. Those functions handle state updates and data storage (if needed)
@@ -151,10 +151,7 @@ private:
       return iteration_state_ == IterationState::StopAllBuffer ||
              iteration_state_ == IterationState::StopAllWatermark;
     }
-    void allowIteration() {
-      ASSERT(iteration_state_ != IterationState::Continue);
-      iteration_state_ = IterationState::Continue;
-    }
+    void allowIteration() { iteration_state_ = IterationState::Continue; }
     MetadataMapVector* getSavedRequestMetadata() {
       if (saved_request_metadata_ == nullptr) {
         saved_request_metadata_ = std::make_unique<MetadataMapVector>();
@@ -192,6 +189,7 @@ private:
     bool iterate_from_current_filter_ : 1;
     bool headers_continued_ : 1;
     bool continue_headers_continued_ : 1;
+    bool inline_buffered_data_ : 1;
     // If true, end_stream is called for this filter.
     bool end_stream_ : 1;
     const bool dual_filter_ : 1;


### PR DESCRIPTION
Currently, add*Data will write data to the filter buffer, but we only
ever read from said buffer if we ever transition from stopping ->
continuing. This means that if add*Data is called when every callback
returns Continue, the data is never propagated to the next filter.

This change adds a flag that is set whenever data is written to the
buffer, using this to flush the buffer when onData returns Continue even
if filter iteration was never stopped.

Fixes #7579

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Medium
Testing: Added HCM UT
Docs Changes: n/a 
Release Notes: n/a
Fixes #7579

