### PR TITLE
Update Datadog tracer version to v1.0.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -120,9 +120,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/lightstep/lightstep-tracer-cpp/archive/v0.8.0.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "a3d1c03e7af570fa64c01df259e6e9bb78637a6bd9c65c6bf7e8703e466dc22f",
-        strip_prefix = "dd-opentracing-cpp-0.4.2",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.4.2.tar.gz"],
+        sha256 = "705b0faedc8bf0a4a1619ed6d43fed5ea6313633178098c315bbfe1945105632",
+        strip_prefix = "dd-opentracing-cpp-1.0.0",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v1.0.0.tar.gz"],
     ),
     com_github_google_benchmark = dict(
         sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -120,9 +120,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/lightstep/lightstep-tracer-cpp/archive/v0.8.0.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "705b0faedc8bf0a4a1619ed6d43fed5ea6313633178098c315bbfe1945105632",
-        strip_prefix = "dd-opentracing-cpp-1.0.0",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v1.0.0.tar.gz"],
+        sha256 = "5996ec077c637feb159ed0297cdb35f0de5713123f22796341965d3551fd55f8",
+        strip_prefix = "dd-opentracing-cpp-886d45bfa9cb08e1b2c5229a92b3aabe90a6eca5",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/886d45bfa9cb08e1b2c5229a92b3aabe90a6eca5.tar.gz"],
     ),
     com_github_google_benchmark = dict(
         sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -120,9 +120,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/lightstep/lightstep-tracer-cpp/archive/v0.8.0.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "5996ec077c637feb159ed0297cdb35f0de5713123f22796341965d3551fd55f8",
-        strip_prefix = "dd-opentracing-cpp-886d45bfa9cb08e1b2c5229a92b3aabe90a6eca5",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/886d45bfa9cb08e1b2c5229a92b3aabe90a6eca5.tar.gz"],
+        sha256 = "f7fb2ad541f812c36fd78f9a38e4582d87dadb563ab80bee3f7c3a2132a425c5",
+        strip_prefix = "dd-opentracing-cpp-1.0.1",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v1.0.1.tar.gz"],
     ),
     com_github_google_benchmark = dict(
         sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -80,8 +80,8 @@ void TraceReporter::enableTimer() {
 
 void TraceReporter::flushTraces() {
   auto pendingTraces = encoder_->pendingTraces();
-  ENVOY_LOG(debug, "flushing traces: {} traces", pendingTraces);
   if (pendingTraces) {
+    ENVOY_LOG(debug, "flushing traces: {} traces", pendingTraces);
     driver_.tracerStats().traces_sent_.add(pendingTraces);
 
     Http::MessagePtr message(new Http::RequestMessageImpl());
@@ -95,7 +95,7 @@ void TraceReporter::flushTraces() {
     Buffer::InstancePtr body(new Buffer::OwnedImpl());
     body->add(encoder_->payload());
     message->body() = std::move(body);
-    ENVOY_LOG(debug, "submitting {} trace(s) to {} with payload {}", pendingTraces,
+    ENVOY_LOG(debug, "submitting {} trace(s) to {} with payload size {}", pendingTraces,
               encoder_->path(), encoder_->payload().size());
 
     driver_.clusterManager()


### PR DESCRIPTION
Signed-off-by: Caleb Gilmour <caleb.gilmour@datadoghq.com>

Description: Updates dd-opentracing-cpp from v0.4.2 to v1.0.0
Fairly minor changes/fixes/features under the hood.
Tiny update to the datadog tracer code in envoy, because it made too much noise with debug enabled.

Risk Level: Low.
Testing: No changes. Passed unit tests and manual E2E tests.
Docs Changes: N/A
Release Notes: N/A
