### PR TITLE
quiche: pass Dispatcher to EnvoyQuicClock/Alarm instead of TimeSystem

### DIFF
--- a/source/extensions/quic_listeners/quiche/BUILD
+++ b/source/extensions/quic_listeners/quiche/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     external_deps = ["quiche_quic_platform"],
     tags = ["nofips"],
     deps = [
+        "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:timer_interface",
         "@com_googlesource_quiche//:quic_core_alarm_interface_lib",
     ],

--- a/source/extensions/quic_listeners/quiche/envoy_quic_alarm.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_alarm.cc
@@ -3,10 +3,10 @@
 namespace Envoy {
 namespace Quic {
 
-EnvoyQuicAlarm::EnvoyQuicAlarm(Event::Scheduler& scheduler, quic::QuicClock& clock,
+EnvoyQuicAlarm::EnvoyQuicAlarm(Event::Dispatcher& dispatcher, const quic::QuicClock& clock,
                                quic::QuicArenaScopedPtr<quic::QuicAlarm::Delegate> delegate)
-    : QuicAlarm(std::move(delegate)), scheduler_(scheduler),
-      timer_(scheduler_.createTimer([this]() { Fire(); })), clock_(clock) {}
+    : QuicAlarm(std::move(delegate)), dispatcher_(dispatcher),
+      timer_(dispatcher_.createTimer([this]() { Fire(); })), clock_(clock) {}
 
 void EnvoyQuicAlarm::CancelImpl() { timer_->disableTimer(); }
 

--- a/source/extensions/quic_listeners/quiche/envoy_quic_alarm.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_alarm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 
 #include "common/common/assert.h"
@@ -16,7 +17,7 @@ namespace Quic {
 // wraps an Event::Timer object and provide interface for QUIC to interact with the timer.
 class EnvoyQuicAlarm : public quic::QuicAlarm {
 public:
-  EnvoyQuicAlarm(Event::Scheduler& scheduler, quic::QuicClock& clock,
+  EnvoyQuicAlarm(Event::Dispatcher& dispatcher, const quic::QuicClock& clock,
                  quic::QuicArenaScopedPtr<quic::QuicAlarm::Delegate> delegate);
 
   ~EnvoyQuicAlarm() override { ASSERT(!IsSet()); };
@@ -30,9 +31,9 @@ public:
 private:
   quic::QuicTime::Delta getDurationBeforeDeadline();
 
-  Event::Scheduler& scheduler_;
+  Event::Dispatcher& dispatcher_;
   Event::TimerPtr timer_;
-  quic::QuicClock& clock_;
+  const quic::QuicClock& clock_;
 };
 
 } // namespace Quic

--- a/source/extensions/quic_listeners/quiche/envoy_quic_alarm_factory.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_alarm_factory.cc
@@ -4,7 +4,7 @@ namespace Envoy {
 namespace Quic {
 
 quic::QuicAlarm* EnvoyQuicAlarmFactory::CreateAlarm(quic::QuicAlarm::Delegate* delegate) {
-  return new EnvoyQuicAlarm(scheduler_, clock_,
+  return new EnvoyQuicAlarm(dispatcher_, clock_,
                             quic::QuicArenaScopedPtr<quic::QuicAlarm::Delegate>(delegate));
 }
 
@@ -12,10 +12,10 @@ quic::QuicArenaScopedPtr<quic::QuicAlarm>
 EnvoyQuicAlarmFactory::CreateAlarm(quic::QuicArenaScopedPtr<quic::QuicAlarm::Delegate> delegate,
                                    quic::QuicConnectionArena* arena) {
   if (arena != nullptr) {
-    return arena->New<EnvoyQuicAlarm>(scheduler_, clock_, std::move(delegate));
+    return arena->New<EnvoyQuicAlarm>(dispatcher_, clock_, std::move(delegate));
   }
   return quic::QuicArenaScopedPtr<quic::QuicAlarm>(
-      new EnvoyQuicAlarm(scheduler_, clock_, std::move(delegate)));
+      new EnvoyQuicAlarm(dispatcher_, clock_, std::move(delegate)));
 }
 
 } // namespace Quic

--- a/source/extensions/quic_listeners/quiche/envoy_quic_alarm_factory.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_alarm_factory.h
@@ -19,8 +19,8 @@ namespace Quic {
 
 class EnvoyQuicAlarmFactory : public quic::QuicAlarmFactory, NonCopyable {
 public:
-  EnvoyQuicAlarmFactory(Event::Scheduler& scheduler, quic::QuicClock& clock)
-      : scheduler_(scheduler), clock_(clock) {}
+  EnvoyQuicAlarmFactory(Event::Dispatcher& dispatcher, const quic::QuicClock& clock)
+      : dispatcher_(dispatcher), clock_(clock) {}
 
   ~EnvoyQuicAlarmFactory() override = default;
 
@@ -31,8 +31,8 @@ public:
               quic::QuicConnectionArena* arena) override;
 
 private:
-  Event::Scheduler& scheduler_;
-  quic::QuicClock& clock_;
+  Event::Dispatcher& dispatcher_;
+  const quic::QuicClock& clock_;
 };
 
 } // namespace Quic

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -243,7 +243,7 @@ envoy_cc_library(
     hdrs = ["envoy_quic_clock.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "//include/envoy/event:timer_interface",
+        "//include/envoy/event:dispatcher_interface",
         "@com_googlesource_quiche//:quic_platform",
     ],
 )

--- a/source/extensions/quic_listeners/quiche/platform/envoy_quic_clock.cc
+++ b/source/extensions/quic_listeners/quiche/platform/envoy_quic_clock.cc
@@ -9,13 +9,13 @@ quic::QuicTime EnvoyQuicClock::ApproximateNow() const {
 }
 
 quic::QuicTime EnvoyQuicClock::Now() const {
-  return quic::QuicTime::Zero() + quic::QuicTime::Delta::FromMicroseconds(
-                                      microsecondsSinceEpoch(time_system_.monotonicTime()));
+  return quic::QuicTime::Zero() + quic::QuicTime::Delta::FromMicroseconds(microsecondsSinceEpoch(
+                                      dispatcher_.timeSource().monotonicTime()));
 }
 
 quic::QuicWallTime EnvoyQuicClock::WallNow() const {
   return quic::QuicWallTime::FromUNIXMicroseconds(
-      microsecondsSinceEpoch(time_system_.systemTime()));
+      microsecondsSinceEpoch(dispatcher_.timeSource().systemTime()));
 }
 
 } // namespace Quic

--- a/source/extensions/quic_listeners/quiche/platform/envoy_quic_clock.h
+++ b/source/extensions/quic_listeners/quiche/platform/envoy_quic_clock.h
@@ -2,7 +2,7 @@
 
 #include <chrono>
 
-#include "envoy/event/timer.h"
+#include "envoy/event/dispatcher.h"
 
 #include "quiche/quic/platform/api/quic_clock.h"
 
@@ -11,7 +11,7 @@ namespace Quic {
 
 class EnvoyQuicClock : public quic::QuicClock {
 public:
-  EnvoyQuicClock(Event::TimeSystem& time_system) : time_system_(time_system) {}
+  EnvoyQuicClock(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
 
   // quic::QuicClock
   quic::QuicTime ApproximateNow() const override;
@@ -23,7 +23,7 @@ private:
     return std::chrono::duration_cast<std::chrono::microseconds>(time.time_since_epoch()).count();
   }
 
-  Event::TimeSystem& time_system_;
+  Event::Dispatcher& dispatcher_;
 };
 
 } // namespace Quic

--- a/test/extensions/quic_listeners/quiche/BUILD
+++ b/test/extensions/quic_listeners/quiche/BUILD
@@ -22,6 +22,7 @@ envoy_cc_test(
         "//source/extensions/quic_listeners/quiche:envoy_quic_alarm_lib",
         "//source/extensions/quic_listeners/quiche/platform:envoy_quic_clock_lib",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/extensions/quic_listeners/quiche/envoy_quic_alarm_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_alarm_test.cc
@@ -1,10 +1,9 @@
-#include "common/event/libevent_scheduler.h"
-
 #include "extensions/quic_listeners/quiche/envoy_quic_alarm.h"
 #include "extensions/quic_listeners/quiche/envoy_quic_alarm_factory.h"
 #include "extensions/quic_listeners/quiche/platform/envoy_quic_clock.h"
 
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -32,19 +31,19 @@ private:
 class EnvoyQuicAlarmTest : public ::testing::Test {
 public:
   EnvoyQuicAlarmTest()
-      : clock_(time_system_), scheduler_(time_system_.createScheduler(base_scheduler_)),
-        alarm_factory_(*scheduler_, clock_) {}
+      : api_(Api::createApiForTest(time_system_)), dispatcher_(api_->allocateDispatcher()),
+        clock_(*dispatcher_), alarm_factory_(*dispatcher_, clock_) {}
 
   void advanceMsAndLoop(int64_t delay_ms) {
     time_system_.sleep(std::chrono::milliseconds(delay_ms));
-    base_scheduler_.run(Dispatcher::RunType::NonBlock);
+    dispatcher_->run(Dispatcher::RunType::NonBlock);
   }
 
 protected:
   Event::SimulatedTimeSystemHelper time_system_;
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
   EnvoyQuicClock clock_;
-  Event::LibeventScheduler base_scheduler_;
-  Event::SchedulerPtr scheduler_;
   EnvoyQuicAlarmFactory alarm_factory_;
   quic::QuicConnectionArena arena_;
 };
@@ -157,7 +156,7 @@ TEST_F(EnvoyQuicAlarmTest, SetAlarmToPastTime) {
   // alarm becomes active upon Set().
   alarm->Set(clock_.Now() - QuicTime::Delta::FromMilliseconds(10));
   EXPECT_FALSE(unowned_delegate->fired());
-  base_scheduler_.run(Dispatcher::RunType::NonBlock);
+  dispatcher_->run(Dispatcher::RunType::NonBlock);
   EXPECT_TRUE(unowned_delegate->fired());
 }
 
@@ -170,7 +169,7 @@ TEST_F(EnvoyQuicAlarmTest, UpdateAlarmWithPastDeadline) {
   EXPECT_FALSE(unowned_delegate->fired());
   // alarm becomes active upon Update().
   alarm->Update(clock_.Now() - QuicTime::Delta::FromMilliseconds(1), quic::QuicTime::Delta::Zero());
-  base_scheduler_.run(Dispatcher::RunType::NonBlock);
+  dispatcher_->run(Dispatcher::RunType::NonBlock);
   EXPECT_TRUE(unowned_delegate->fired());
   unowned_delegate->set_fired(false);
   advanceMsAndLoop(1);
@@ -186,7 +185,7 @@ TEST_F(EnvoyQuicAlarmTest, CancelActiveAlarm) {
   // alarm becomes active upon Set().
   alarm->Set(clock_.Now() - QuicTime::Delta::FromMilliseconds(10));
   alarm->Cancel();
-  base_scheduler_.run(Dispatcher::RunType::NonBlock);
+  dispatcher_->run(Dispatcher::RunType::NonBlock);
   EXPECT_FALSE(unowned_delegate->fired());
 }
 

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -221,5 +221,6 @@ envoy_cc_test(
         "//source/extensions/quic_listeners/quiche/platform:envoy_quic_clock_lib",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:test_time_lib",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/quic_listeners/quiche/platform/envoy_quic_clock_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/envoy_quic_clock_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -13,7 +14,9 @@ namespace Quic {
 
 TEST(EnvoyQuicClockTest, TestNow) {
   Event::SimulatedTimeSystemHelper time_system;
-  EnvoyQuicClock clock(time_system);
+  Api::ApiPtr api = Api::createApiForTest(time_system);
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  EnvoyQuicClock clock(*dispatcher);
   uint64_t mono_time = std::chrono::duration_cast<std::chrono::microseconds>(
                            time_system.monotonicTime().time_since_epoch())
                            .count();
@@ -41,7 +44,9 @@ TEST(EnvoyQuicClockTest, TestNow) {
 // Tests that Now() should never go back.
 TEST(EnvoyQuicClockTest, TestMonotonicityWithReadTimeSystem) {
   Event::TestRealTimeSystem time_system;
-  EnvoyQuicClock clock(time_system);
+  Api::ApiPtr api = Api::createApiForTest(time_system);
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  EnvoyQuicClock clock(*dispatcher);
   quic::QuicTime last_now = clock.Now();
   for (int i = 0; i < 1000; ++i) {
     quic::QuicTime now = clock.Now();


### PR DESCRIPTION
Currently EnvoyQuicClock takes a TimeSystem reference. But TimeSystem objects is not accessible within the scope of its creation. Instead, Event::Dispatcher is accessible in most of the code and also provide access to underlying TimeSource and a per-event loop timestamp which can be helpful for #7177.

For same reason also change EnvoyQuicAlarm to take a Dispatcher reference.

Risk Level: low, not in production
Testing: existing tests passed.
Part of #7177 #2557
