### PR TITLE
Example: identity healthchecks from front-envoy to service-envoy

### DIFF
--- a/docs/root/intro/arch_overview/upstream/health_checking.rst
+++ b/docs/root/intro/arch_overview/upstream/health_checking.rst
@@ -150,6 +150,8 @@ additionally compares the value of the *x-envoy-upstream-healthchecked-cluster* 
 check filter appends *x-envoy-upstream-healthchecked-cluster* to the response headers. The appended
 value is determined by the :option:`--service-cluster` command line option.
 
+A simple example for this configuration can be found [here](https://github.com/envoyproxy/envoy/blob/master/examples/healthchecks).
+
 .. _arch_overview_health_checking_degraded:
 
 Degraded health
@@ -157,5 +159,3 @@ Degraded health
 When using the HTTP health checker, an upstream host can return ``x-envoy-degraded`` to inform the
 health checker that the host is degraded. See :ref:`here <arch_overview_load_balancing_degraded>` for
 how this affects load balancing.
-
-

--- a/examples/healthchecks/front-envoy.yaml
+++ b/examples/healthchecks/front-envoy.yaml
@@ -1,0 +1,65 @@
+---
+node:
+  id: default
+  cluster: front-envoy
+static_resources:
+  listeners:
+  - name: listener
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 7500
+        protocol: TCP
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          http_filters:
+          - name: envoy.router
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - route:
+                  cluster: sidecar_envoy
+                match:
+                  prefix: "/"
+  clusters:
+  - name: sidecar_envoy
+    type: STATIC
+    connect_timeout:
+      seconds: '5'
+    lb_policy: ROUND_ROBIN
+    health_checks:
+    - event_log_path: active_healthcheck_events.log
+      healthy_threshold: 1
+      http_health_check:
+        path: /healthcheck
+        service_name: test-service
+      interval: 5.0s
+      interval_jitter: 5.0s
+      timeout: 2s
+      unhealthy_threshold: 1
+    load_assignment:
+      cluster_name: sidecar_envoy
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            health_check_config:
+              port_value: 7502
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 7502
+admin:
+  access_log_path: "/dev/stdout"
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 7501

--- a/examples/healthchecks/sidecar.yaml
+++ b/examples/healthchecks/sidecar.yaml
@@ -1,0 +1,59 @@
+---
+node:
+  id: default
+  cluster: test-service
+static_resources:
+  listeners:
+  - name: listerner
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 7502
+        protocol: TCP
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          http_filters:
+          - name: envoy.health_check
+            config:
+              headers:
+              - exact_match: /healthcheck
+                name: ':path'
+              pass_through_mode: 'true'
+          - name: envoy.router
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - route:
+                  cluster: application
+                match:
+                  prefix: "/"
+  clusters:
+  - name: application
+    type: STATIC
+    connect_timeout:
+      seconds: '5'
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: application
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 7504
+admin:
+  access_log_path: "/dev/stdout"
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 7503

--- a/examples/healthchecks/test.sh
+++ b/examples/healthchecks/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o errtrace
+
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[96m'
+CLEAR_COLOR='\033[0m'
+
+FRONT_ENVOY_LISTENER="7500"
+FRONT_ENVOY_ADMIN="7501"
+SIDECAR_ENVOY_LISTENER="7502"
+SIDECAR_ENVOY_ADMIN="7503"
+HTTP_ECHO_PORT="7504"
+
+function kill-processes {
+    # Print color is set above so that when ports are killed, red means failed, green means
+    # we passed tests and are cleaning up
+    kill-envoy-pid "${FRONT_ENVOY_LISTENER}" "front envoy listener"
+    kill-envoy-pid "${FRONT_ENVOY_ADMIN}" "front envoy admin"
+    kill-envoy-pid "${SIDECAR_ENVOY_LISTENER}" "sidecar envoy listener"
+    kill-envoy-pid "${SIDECAR_ENVOY_ADMIN}" "sidecar envoy admin"
+    kill-envoy-pid "${HTTP_ECHO_PORT}" "http echo port"
+
+    echo -e "** Trapped exit. Cleaned ports...${CLEAR_COLOR}"
+}
+
+function kill-envoy-pid {
+    local port="${1}"
+    local name="${2:-}"
+    local portpid=$(lsof -nP -i4TCP:"${port}" -i6TCP:"${port}" | grep LISTEN | awk '{print $2}')
+    if [ -n "${portpid}" ]; then
+        echo -e "**** killing ${name} @ ${portpid} bound to ${port}"
+        kill -9 "$portpid" > /dev/null 2>&1
+    fi
+}
+
+trap kill-processes INT TERM EXIT
+kill-processes
+
+http-echo -listen ":${HTTP_ECHO_PORT}" -text "Hi i'm the server $(date)" > /dev/null 2>&1 &
+
+# Docker version
+# docker run --rm --network host -v $(pwd):/etc/envoy --entrypoint envoy envoyproxy/envoy:v1.11.0 -c /etc/envoy/front-envoy.yaml --mode validate
+# docker run --rm --network host -v $(pwd):/etc/envoy --entrypoint envoy envoyproxy/envoy:v1.11.0 -c /etc/envoy/service.yaml --mode validate
+# docker run --rm --network host -v $(pwd):/etc/envoy --entrypoint envoy envoyproxy/envoy:v1.11.0 -c /etc/envoy/front-envoy.yaml --base-id 100 > /dev/null 2>&1 &
+# docker run --rm --network host -v $(pwd):/etc/envoy --entrypoint envoy envoyproxy/envoy:v1.11.0 -c /etc/envoy/service.yaml --base-id 101 > /dev/null 2>&1 &
+
+envoy -c front-envoy.yaml --mode validate
+envoy -c sidecar.yaml --mode validate
+envoy -c front-envoy.yaml --base-id 100 > /dev/null 2>&1 &
+envoy -c sidecar.yaml --base-id 101 > /dev/null 2>&1 &
+
+sleep 5
+
+echo "localhost:${FRONT_ENVOY_LISTENER} ================================"
+curl -vvvv "localhost:${FRONT_ENVOY_LISTENER}"
+
+echo "localhost:${SIDECAR_ENVOY_LISTENER} ================================"
+curl -vvvv "localhost:${SIDECAR_ENVOY_LISTENER}"
+
+echo "healthy ======================================="
+while true; do
+    echo "$(date): $(curl -sSLq localhost:${FRONT_ENVOY_ADMIN}/clusters | grep health_flags)"
+    sleep 5
+done
+echo -e "ONLINE"
+read -r -p ">>>> Press any key to exit..." -n1 -s


### PR DESCRIPTION
### Description: 
I'm attempting to add an example for configuring identity health checks because I found the documentation pretty hard to navigate. 

_I need help._ I can't seem to get the configuration to work as expected. For a minute after all the services, healthchecks will pass, then they will fail. I could use some help with this from a contributor :pray:. 

### Risk Level: 
Low

### Testing: 
None

### Docs Changes: 
Proposed changes will go [here](https://github.com/envoyproxy/envoy/blob/master/docs/root/intro/arch_overview/upstream/health_checking.rst#L147)

### Release Notes: 
None
