### PR TITLE
config: Specify Bootstrap as proto object to Envoy::OptionsImpl

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -119,6 +119,7 @@ envoy_cc_library(
         "//include/envoy/network:address_interface",
         "//include/envoy/stats:stats_interface",
         "@envoy_api//envoy/admin/v2alpha:server_info_cc",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],
 )
 

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -80,7 +80,8 @@ public:
   virtual const std::string& configYaml() const PURE;
 
   /**
-   * @return const envoy::config::bootstrap::v2::Bootstrap& a bootstrap proto object.
+   * @return const envoy::config::bootstrap::v2::Bootstrap& a bootstrap proto object
+   * that merges into the config last, after configYaml and configPath.
    */
   virtual const envoy::config::bootstrap::v2::Bootstrap& configProto() const PURE;
 

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -79,6 +79,11 @@ public:
   virtual const std::string& configYaml() const PURE;
 
   /**
+   * @return const envoy::config::bootstrap::v2::Bootstrap& a botstrap proto object.
+   */
+  virtual const envoy::config::bootstrap::v2::Bootstrap& configProto() const PURE;
+
+  /**
    * @return bool allow unknown fields in the configuration?
    */
   virtual bool allowUnknownFields() const PURE;

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -6,6 +6,7 @@
 
 #include "envoy/admin/v2alpha/server_info.pb.h"
 #include "envoy/common/pure.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 #include "envoy/network/address.h"
 
 #include "spdlog/spdlog.h"

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -80,7 +80,7 @@ public:
   virtual const std::string& configYaml() const PURE;
 
   /**
-   * @return const envoy::config::bootstrap::v2::Bootstrap& a botstrap proto object.
+   * @return const envoy::config::bootstrap::v2::Bootstrap& a bootstrap proto object.
    */
   virtual const envoy::config::bootstrap::v2::Bootstrap& configProto() const PURE;
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -211,6 +211,7 @@ envoy_cc_library(
         "//source/common/common:version_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/stats:stats_lib",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],
 )
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -179,6 +179,13 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     concurrency_ = std::max(1U, concurrency.getValue());
   }
 
+  // Exactly one of config_path and config_yaml should be specified.
+  if (!config_path.isSet() && !config_yaml.isSet()) {
+    const std::string message =
+        "At least one of --config-path and --config-yaml should be non-empty";
+    throw MalformedArgvException(message);
+  }
+
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   allow_unknown_fields_ = allow_unknown_fields.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -280,8 +280,7 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
 
 OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,
                          const std::string& service_zone, spdlog::level::level_enum log_level)
-    : base_id_(0u), concurrency_(1u), config_path_(""),
-      config_proto_(envoy::config::bootstrap::v2::Bootstrap()), config_yaml_(""),
+    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""),
       local_address_ip_version_(Network::Address::IpVersion::v4), log_level_(log_level),
       log_format_(Logger::Logger::DEFAULT_LOG_FORMAT), restart_epoch_(0u),
       service_cluster_(service_cluster), service_node_(service_node), service_zone_(service_zone),

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -180,6 +180,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   }
 
   config_path_ = config_path.getValue();
+  config_proto_ = config_proto.getValue();
   config_yaml_ = config_yaml.getValue();
   allow_unknown_fields_ = allow_unknown_fields.getValue();
   admin_address_path_ = admin_address_path.getValue();
@@ -280,7 +281,8 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
 
 OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,
                          const std::string& service_zone, spdlog::level::level_enum log_level)
-    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""),
+    : base_id_(0u), concurrency_(1u), config_path_(""),
+      config_proto_(envoy::config::bootstrap::v2::Bootstrap()), config_yaml_(""),
       local_address_ip_version_(Network::Address::IpVersion::v4), log_level_(log_level),
       log_format_(Logger::Logger::DEFAULT_LOG_FORMAT), restart_epoch_(0u),
       service_cluster_(service_cluster), service_node_(service_node), service_zone_(service_zone),

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -180,7 +180,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   }
 
   config_path_ = config_path.getValue();
-  config_proto_ = config_proto.getValue();
   config_yaml_ = config_yaml.getValue();
   allow_unknown_fields_ = allow_unknown_fields.getValue();
   admin_address_path_ = admin_address_path.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -179,13 +179,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     concurrency_ = std::max(1U, concurrency.getValue());
   }
 
-  // Exactly one of config_path and config_yaml should be specified.
-  if (!config_path.isSet() && !config_yaml.isSet()) {
-    const std::string message =
-        "At least one of --config-path and --config-yaml should be non-empty";
-    throw MalformedArgvException(message);
-  }
-
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   allow_unknown_fields_ = allow_unknown_fields.getValue();

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "envoy/common/exception.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 #include "envoy/server/options.h"
 
 #include "common/common/logger.h"
@@ -40,6 +41,9 @@ public:
   void setBaseId(uint64_t base_id) { base_id_ = base_id; };
   void setConcurrency(uint32_t concurrency) { concurrency_ = concurrency; }
   void setConfigPath(const std::string& config_path) { config_path_ = config_path; }
+  void setConfigProto(const envoy::config::bootstrap::v2::Bootstrap& config_proto) {
+    config_proto_ = config_proto;
+  }
   void setConfigYaml(const std::string& config_yaml) { config_yaml_ = config_yaml; }
   void setAdminAddressPath(const std::string& admin_address_path) {
     admin_address_path_ = admin_address_path;
@@ -76,6 +80,9 @@ public:
   uint64_t baseId() const override { return base_id_; }
   uint32_t concurrency() const override { return concurrency_; }
   const std::string& configPath() const override { return config_path_; }
+  const envoy::config::bootstrap::v2::Bootstrap& configProto() const override {
+    return config_proto_;
+  }
   const std::string& configYaml() const override { return config_yaml_; }
   bool allowUnknownFields() const override { return allow_unknown_fields_; }
   const std::string& adminAddressPath() const override { return admin_address_path_; }
@@ -114,6 +121,7 @@ private:
   uint64_t base_id_;
   uint32_t concurrency_;
   std::string config_path_;
+  envoy::config::bootstrap::v2::Bootstrap config_proto_;
   std::string config_yaml_;
   bool allow_unknown_fields_{false};
   std::string admin_address_path_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -214,8 +214,8 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
 
   // Exactly one of config_path and config_yaml should be specified.
   if (config_path.empty() && config_yaml.empty() && config_proto.ByteSize() == 0) {
-    const std::string message =
-        "At least one of --config-path and --config-yaml should be non-empty";
+    const std::string message = "At least one of --config-path, --config-yaml or "
+                                "Options::configProto() should be non-empty";
     throw EnvoyException(message);
   }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -210,9 +210,10 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
     ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api) {
   const std::string& config_path = options.configPath();
   const std::string& config_yaml = options.configYaml();
+  const envoy::config::bootstrap::v2::Bootstrap& config_proto = options.configProto();
 
   // Exactly one of config_path and config_yaml should be specified.
-  if (config_path.empty() && config_yaml.empty()) {
+  if (config_path.empty() && config_yaml.empty() && config_proto.ByteSize() == 0) {
     const std::string message =
         "At least one of --config-path and --config-yaml should be non-empty";
     throw EnvoyException(message);
@@ -225,6 +226,9 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
     envoy::config::bootstrap::v2::Bootstrap bootstrap_override;
     MessageUtil::loadFromYaml(config_yaml, bootstrap_override, validation_visitor);
     bootstrap.MergeFrom(bootstrap_override);
+  }
+  if (!config_proto.ByteSize() != 0) {
+    bootstrap.MergeFrom(config_proto);
   }
   MessageUtil::validate(bootstrap);
   return BootstrapVersion::V2;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -214,7 +214,7 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
 
   // Exactly one of config_path and config_yaml should be specified.
   if (config_path.empty() && config_yaml.empty() && config_proto.ByteSize() == 0) {
-    const std::string message = "At least one of --config-path, --config-yaml or "
+    const std::string message = "At least one of Options::configPath, Options::configYaml or "
                                 "Options::configProto() should be non-empty";
     throw EnvoyException(message);
   }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -214,9 +214,8 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
 
   // Exactly one of config_path and config_yaml should be specified.
   if (config_path.empty() && config_yaml.empty() && config_proto.ByteSize() == 0) {
-    const std::string message = "At least one of Options::configPath, Options::configYaml or "
-                                "Options::configProto() should be non-empty";
-    throw EnvoyException(message);
+    throw EnvoyException("At least one of --config-path or --config-yaml or Options::configProto() "
+                         "should be non-empty");
   }
 
   if (!config_path.empty()) {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -227,7 +227,7 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
     MessageUtil::loadFromYaml(config_yaml, bootstrap_override, validation_visitor);
     bootstrap.MergeFrom(bootstrap_override);
   }
-  if (!config_proto.ByteSize() != 0) {
+  if (config_proto.ByteSize() != 0) {
     bootstrap.MergeFrom(config_proto);
   }
   MessageUtil::validate(bootstrap);

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -19,10 +19,6 @@ function expect_fail_with_error() {
 start_test Launching envoy with a bogus command line flag.
 expect_fail_with_error "PARSE ERROR: Argument: --bogus-flag" --bogus-flag
 
-start_test Launching envoy without --config-path or --config-yaml fails.
-expect_fail_with_error \
-  "At least one of --config-path and --config-yaml should be non-empty"
-
 start_test Launching envoy with unknown IP address.
 expect_fail_with_error "error: unknown IP address version" --local-address-ip-version foo
 

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -19,6 +19,10 @@ function expect_fail_with_error() {
 start_test Launching envoy with a bogus command line flag.
 expect_fail_with_error "PARSE ERROR: Argument: --bogus-flag" --bogus-flag
 
+start_test Launching envoy without --config-path or --config-yaml fails.
+expect_fail_with_error \
+  "At least one of --config-path or --config-yaml or Options::configProto() should be non-empty"
+
 start_test Launching envoy with unknown IP address.
 expect_fail_with_error "error: unknown IP address version" --local-address-ip-version foo
 

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -19,6 +19,10 @@ function expect_fail_with_error() {
 start_test Launching envoy with a bogus command line flag.
 expect_fail_with_error "PARSE ERROR: Argument: --bogus-flag" --bogus-flag
 
+start_test Launching envoy without --config-path or --config-yaml fails.
+expect_fail_with_error \
+  "At least one of --config-path and --config-yaml should be non-empty"
+
 start_test Launching envoy with unknown IP address.
 expect_fail_with_error "error: unknown IP address version" --local-address-ip-version foo
 

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -45,5 +45,6 @@ envoy_cc_mock(
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:test_time_lib",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],
 )

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -21,6 +21,7 @@ namespace Server {
 MockOptions::MockOptions(const std::string& config_path) : config_path_(config_path) {
   ON_CALL(*this, concurrency()).WillByDefault(ReturnPointee(&concurrency_));
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
+  ON_CALL(*this, configProto()).WillByDefault(ReturnRef(config_proto_));
   ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(config_yaml_));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "envoy/common/mutex_tracer.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 #include "envoy/server/admin.h"
 #include "envoy/server/configuration.h"
 #include "envoy/server/drain_manager.h"
@@ -59,6 +60,7 @@ public:
   MOCK_CONST_METHOD0(baseId, uint64_t());
   MOCK_CONST_METHOD0(concurrency, uint32_t());
   MOCK_CONST_METHOD0(configPath, const std::string&());
+  MOCK_CONST_METHOD0(configProto, const envoy::config::bootstrap::v2::Bootstrap&());
   MOCK_CONST_METHOD0(configYaml, const std::string&());
   MOCK_CONST_METHOD0(allowUnknownFields, bool());
   MOCK_CONST_METHOD0(adminAddressPath, const std::string&());
@@ -84,6 +86,7 @@ public:
   MOCK_CONST_METHOD0(toCommandLineOptions, Server::CommandLineOptionsPtr());
 
   std::string config_path_;
+  envoy::config::bootstrap::v2::Bootstrap config_proto_;
   std::string config_yaml_;
   std::string admin_address_path_;
   std::string service_cluster_name_;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -122,6 +122,7 @@ envoy_cc_test(
         "//test/test_common:logging_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],
 )
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "envoy/common/exception.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 
 #include "common/common/utility.h"
 
@@ -109,6 +110,9 @@ TEST_F(OptionsImplTest, SetAll) {
   options->setBaseId(109876);
   options->setConcurrency(42);
   options->setConfigPath("foo");
+  envoy::config::bootstrap::v2::Bootstrap bootstrap_foo{};
+  bootstrap_foo.mutable_node()->set_id("foo");
+  options->setConfigProto(bootstrap_foo);
   options->setConfigYaml("bogus:");
   options->setAdminAddressPath("path");
   options->setLocalAddressIpVersion(Network::Address::IpVersion::v6);
@@ -130,6 +134,9 @@ TEST_F(OptionsImplTest, SetAll) {
   EXPECT_EQ(109876, options->baseId());
   EXPECT_EQ(42U, options->concurrency());
   EXPECT_EQ("foo", options->configPath());
+  envoy::config::bootstrap::v2::Bootstrap bootstrap_bar{};
+  bootstrap_bar.mutable_node()->set_id("foo");
+  EXPECT_TRUE(TestUtility::protoEqual(bootstrap_bar, options->configProto()));
   EXPECT_EQ("bogus:", options->configYaml());
   EXPECT_EQ("path", options->adminAddressPath());
   EXPECT_EQ(Network::Address::IpVersion::v6, options->localAddressIpVersion());
@@ -278,6 +285,8 @@ TEST_F(OptionsImplTest, SaneTestConstructor) {
 
   EXPECT_EQ(regular_options_impl->baseId(), test_options_impl.baseId());
   EXPECT_EQ(regular_options_impl->configPath(), test_options_impl.configPath());
+  EXPECT_TRUE(TestUtility::protoEqual(regular_options_impl->configProto(),
+                                      test_options_impl.configProto()));
   EXPECT_EQ(regular_options_impl->configYaml(), test_options_impl.configYaml());
   EXPECT_EQ(regular_options_impl->adminAddressPath(), test_options_impl.adminAddressPath());
   EXPECT_EQ(regular_options_impl->localAddressIpVersion(),

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -671,7 +671,9 @@ TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
           hooks_, restart_, stats_store_, fakelock_, component_factory_,
           std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), *thread_local_,
           Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr)),
-      EnvoyException, "At least one of --config-path and --config-yaml should be non-empty");
+      EnvoyException,
+      "At least one of Options::configPath, Options::configYaml or Options::configProto() should "
+      "be non-empty");
 }
 
 // Validate that when std::exception is unexpectedly thrown, we exit safely.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -672,8 +672,8 @@ TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
           std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), *thread_local_,
           Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr)),
       EnvoyException,
-      "At least one of Options::configPath, Options::configYaml or Options::configProto() should "
-      "be non-empty");
+      "At least one of --config-path or --config-yaml or Options::configProto() should be "
+      "non-empty");
 }
 
 // Validate that when std::exception is unexpectedly thrown, we exit safely.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -452,6 +452,25 @@ TEST_P(ServerInstanceImplTest, BootstrapNode) {
   EXPECT_EQ(VersionInfo::version(), server_->localInfo().node().build_version());
 }
 
+TEST_P(ServerInstanceImplTest, LoadsBootstrapFromConfigProtoOptions) {
+  options_.config_proto_.mutable_node()->set_id("foo");
+  initialize("test/server/node_bootstrap.yaml");
+  EXPECT_EQ("foo", server_->localInfo().node().id());
+}
+
+TEST_P(ServerInstanceImplTest, LoadsBootstrapFromConfigYamlAfterConfigPath) {
+  options_.config_yaml_ = "node:\n  id: 'bar'";
+  initialize("test/server/node_bootstrap.yaml");
+  EXPECT_EQ("bar", server_->localInfo().node().id());
+}
+
+TEST_P(ServerInstanceImplTest, LoadsBootstrapFromConfigProtoOptionsLast) {
+  options_.config_yaml_ = "node:\n  id: 'bar'";
+  options_.config_proto_.mutable_node()->set_id("foo");
+  initialize("test/server/node_bootstrap.yaml");
+  EXPECT_EQ("foo", server_->localInfo().node().id());
+}
+
 // Validate server localInfo() from bootstrap Node with CLI overrides.
 TEST_P(ServerInstanceImplTest, BootstrapNodeWithOptionsOverride) {
   options_.service_cluster_name_ = "some_cluster_name";


### PR DESCRIPTION
Description: Adds a method to Envoy::OptionsImpl to allow specifying the bootstrap configuration as a proto `Bootstrap` object directly rather than using the `configYaml` or `configPath` options.

This would allow clients to directly specify a Bootstrap proto object without having to deal with yaml serialization and would simplify our configuration process since we construct the Bootstrap proto programmatically as a protocol buffer.

This is not a command line flag like `configYaml` or `configPath` since this is not a serialized attribute of the options and we don't want to allow for a separate configuration path that isn't YAML.

I moved the validation of the config flags to `source/server/options_impl.cc` so that `test/integration:run_envoy_test` would pass, since we now have a config source that isn't specified on the command line.

Risk Level: Low
Testing: Ran `bazel test test/common/... test/exe/... test/integration/... test/mocks/... test/config_test/... test/server:options_impl_test`
Docs Changes: N/A
Release Notes: N/A
Fixes #7713 
