### PR TITLE
jwt: improve the JWT filter logging

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -41,6 +41,7 @@ namespace Logger {
   FUNCTION(hystrix)              \
   FUNCTION(init)                 \
   FUNCTION(io)                   \
+  FUNCTION(jwt)                  \
   FUNCTION(kafka)                \
   FUNCTION(lua)                  \
   FUNCTION(main)                 \

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -51,6 +51,9 @@ envoy_cc_library(
     name = "filter_lib",
     srcs = ["filter.cc"],
     hdrs = ["filter.h"],
+    external_deps = [
+        "jwt_verify_lib",
+    ],
     deps = [
         ":filter_config_interface",
         ":matchers_lib",

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -4,6 +4,8 @@
 
 #include "extensions/filters/http/well_known_names.h"
 
+#include "jwt_verify_lib/status.h"
+
 using ::google::jwt_verify::Status;
 
 namespace Envoy {
@@ -55,7 +57,8 @@ void Filter::setPayload(const ProtobufWkt::Struct& payload) {
 }
 
 void Filter::onComplete(const Status& status) {
-  ENVOY_LOG(debug, "Called Filter : check complete {}", int(status));
+  ENVOY_LOG(debug, "Called Filter : check complete {}",
+            ::google::jwt_verify::getStatusString(status));
   // This stream has been reset, abort the callback.
   if (state_ == Responded) {
     return;

--- a/source/extensions/filters/http/jwt_authn/filter.h
+++ b/source/extensions/filters/http/jwt_authn/filter.h
@@ -17,7 +17,7 @@ namespace JwtAuthn {
 // The Envoy filter to process JWT auth.
 class Filter : public Http::StreamDecoderFilter,
                public Verifier::Callbacks,
-               public Logger::Loggable<Logger::Id::filter> {
+               public Logger::Loggable<Logger::Id::jwt> {
 public:
   Filter(FilterConfigSharedPtr config);
 

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -59,7 +59,7 @@ struct JwtAuthnFilterStats {
 /**
  * The filter config object to hold config and relevant objects.
  */
-class FilterConfig : public Logger::Loggable<Logger::Id::config>, public AuthFactory {
+class FilterConfig : public Logger::Loggable<Logger::Id::jwt>, public AuthFactory {
 public:
   ~FilterConfig() override = default;
 
@@ -92,12 +92,6 @@ public:
   }
 
   JwtAuthnFilterStats& stats() { return stats_; }
-
-  // Get the Config.
-  const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication&
-  getProtoConfig() const {
-    return proto_config_;
-  }
 
   // Get per-thread cache object.
   ThreadLocalCache& getCache() const { return tls_->getTyped<ThreadLocalCache>(); }

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -25,7 +25,7 @@ namespace {
 // Default cache expiration time in 5 minutes.
 constexpr int PubkeyCacheExpirationSec = 600;
 
-class JwksDataImpl : public JwksCache::JwksData, public Logger::Loggable<Logger::Id::filter> {
+class JwksDataImpl : public JwksCache::JwksData, public Logger::Loggable<Logger::Id::jwt> {
 public:
   JwksDataImpl(const JwtProvider& jwt_provider, TimeSource& time_source, Api::Api& api)
       : jwt_provider_(jwt_provider), time_source_(time_source) {

--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -19,7 +19,7 @@ namespace {
 /**
  * Perform a match against any HTTP header or pseudo-header.
  */
-class BaseMatcherImpl : public Matcher, public Logger::Loggable<Logger::Id::filter> {
+class BaseMatcherImpl : public Matcher, public Logger::Loggable<Logger::Id::jwt> {
 public:
   BaseMatcherImpl(const RequirementRule& rule)
       : case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(rule.match(), case_sensitive, true)) {


### PR DESCRIPTION
Description:
Refactor the JWT filter logging for better debugging experience:
- Add logger ID `jwt`
- Log JWT verification result when multiple tokens are used
- Remove never used function `getProtoConfig()`

@qiwzhang @lizan 

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yangmin Zhu <ymzhu@google.com>