### PR TITLE
cleanup: expose address string_view accessor

### DIFF
--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -13,6 +13,7 @@
 #include "envoy/network/io_handle.h"
 
 #include "absl/numeric/int128.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Network {
@@ -116,6 +117,11 @@ public:
    * For pipe addresses: "/foo"
    */
   virtual const std::string& asString() const PURE;
+
+  /**
+   * @return Similar to asString but returns a string view.
+   */
+  virtual absl::string_view asStringView() const PURE;
 
   /**
    * @return a human readable string for the address that represents the

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -56,6 +56,7 @@ class InstanceBase : public Instance {
 public:
   // Network::Address::Instance
   const std::string& asString() const override { return friendly_name_; }
+  absl::string_view asStringView() const override { return friendly_name_; }
   // Default logical name is the human-readable name.
   const std::string& logicalName() const override { return asString(); }
   Type type() const override { return type_; }

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -144,6 +144,7 @@ TEST(Ipv4InstanceTest, SocketAddress) {
 
   Ipv4Instance address(&addr4);
   EXPECT_EQ("1.2.3.4:6502", address.asString());
+  EXPECT_EQ("1.2.3.4:6502", address.asStringView());
   EXPECT_EQ("1.2.3.4:6502", address.logicalName());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("1.2.3.4", address.ip()->addressAsString());
@@ -157,6 +158,7 @@ TEST(Ipv4InstanceTest, SocketAddress) {
 TEST(Ipv4InstanceTest, AddressOnly) {
   Ipv4Instance address("3.4.5.6");
   EXPECT_EQ("3.4.5.6:0", address.asString());
+  EXPECT_EQ("3.4.5.6:0", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("3.4.5.6", address.ip()->addressAsString());
   EXPECT_EQ(0U, address.ip()->port());
@@ -168,6 +170,7 @@ TEST(Ipv4InstanceTest, AddressOnly) {
 TEST(Ipv4InstanceTest, AddressAndPort) {
   Ipv4Instance address("127.0.0.1", 80);
   EXPECT_EQ("127.0.0.1:80", address.asString());
+  EXPECT_EQ("127.0.0.1:80", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("127.0.0.1", address.ip()->addressAsString());
   EXPECT_FALSE(address.ip()->isAnyAddress());
@@ -180,6 +183,7 @@ TEST(Ipv4InstanceTest, AddressAndPort) {
 TEST(Ipv4InstanceTest, PortOnly) {
   Ipv4Instance address(443);
   EXPECT_EQ("0.0.0.0:443", address.asString());
+  EXPECT_EQ("0.0.0.0:443", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("0.0.0.0", address.ip()->addressAsString());
   EXPECT_TRUE(address.ip()->isAnyAddress());
@@ -192,6 +196,7 @@ TEST(Ipv4InstanceTest, PortOnly) {
 TEST(Ipv4InstanceTest, Multicast) {
   Ipv4Instance address("230.0.0.1");
   EXPECT_EQ("230.0.0.1:0", address.asString());
+  EXPECT_EQ("230.0.0.1:0", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("230.0.0.1", address.ip()->addressAsString());
   EXPECT_FALSE(address.ip()->isAnyAddress());
@@ -204,6 +209,7 @@ TEST(Ipv4InstanceTest, Multicast) {
 TEST(Ipv4InstanceTest, Broadcast) {
   Ipv4Instance address("255.255.255.255");
   EXPECT_EQ("255.255.255.255:0", address.asString());
+  EXPECT_EQ("255.255.255.255:0", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("255.255.255.255", address.ip()->addressAsString());
   EXPECT_EQ(0U, address.ip()->port());
@@ -225,6 +231,7 @@ TEST(Ipv6InstanceTest, SocketAddress) {
 
   Ipv6Instance address(addr6);
   EXPECT_EQ("[1:23::ef]:32000", address.asString());
+  EXPECT_EQ("[1:23::ef]:32000", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("1:23::ef", address.ip()->addressAsString());
   EXPECT_FALSE(address.ip()->isAnyAddress());
@@ -238,6 +245,7 @@ TEST(Ipv6InstanceTest, SocketAddress) {
 TEST(Ipv6InstanceTest, AddressOnly) {
   Ipv6Instance address("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
   EXPECT_EQ("[2001:db8:85a3::8a2e:370:7334]:0", address.asString());
+  EXPECT_EQ("[2001:db8:85a3::8a2e:370:7334]:0", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("2001:db8:85a3::8a2e:370:7334", address.ip()->addressAsString());
   EXPECT_EQ(0U, address.ip()->port());
@@ -250,6 +258,7 @@ TEST(Ipv6InstanceTest, AddressOnly) {
 TEST(Ipv6InstanceTest, AddressAndPort) {
   Ipv6Instance address("::0001", 80);
   EXPECT_EQ("[::1]:80", address.asString());
+  EXPECT_EQ("[::1]:80", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("::1", address.ip()->addressAsString());
   EXPECT_EQ(80U, address.ip()->port());
@@ -261,6 +270,7 @@ TEST(Ipv6InstanceTest, AddressAndPort) {
 TEST(Ipv6InstanceTest, PortOnly) {
   Ipv6Instance address(443);
   EXPECT_EQ("[::]:443", address.asString());
+  EXPECT_EQ("[::]:443", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("::", address.ip()->addressAsString());
   EXPECT_TRUE(address.ip()->isAnyAddress());
@@ -273,6 +283,7 @@ TEST(Ipv6InstanceTest, PortOnly) {
 TEST(Ipv6InstanceTest, Multicast) {
   Ipv6Instance address("FF00::");
   EXPECT_EQ("[ff00::]:0", address.asString());
+  EXPECT_EQ("[ff00::]:0", address.asStringView());
   EXPECT_EQ(Type::Ip, address.type());
   EXPECT_EQ("ff00::", address.ip()->addressAsString());
   EXPECT_FALSE(address.ip()->isAnyAddress());
@@ -311,6 +322,7 @@ TEST(PipeInstanceTest, AbstractNamespace) {
 #if defined(__linux__)
   PipeInstance address("@/foo");
   EXPECT_EQ("@/foo", address.asString());
+  EXPECT_EQ("@/foo", address.asStringView());
   EXPECT_EQ(Type::Pipe, address.type());
   EXPECT_EQ(nullptr, address.ip());
 #else

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -369,6 +369,7 @@ public:
     return asString() == rhs.asString();
   }
   const std::string& asString() const override { return antagonistic_name_; }
+  absl::string_view asStringView() const override { return antagonistic_name_; }
   const std::string& logicalName() const override { return antagonistic_name_; }
   Api::SysCallIntResult bind(int fd) const override { return instance_.bind(fd); }
   Api::SysCallIntResult connect(int fd) const override { return instance_.connect(fd); }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -376,6 +376,7 @@ public:
   MOCK_CONST_METHOD0(sockAddrLen, socklen_t());
 
   const std::string& asString() const override { return physical_; }
+  absl::string_view asStringView() const override { return physical_; }
   const std::string& logicalName() const override { return logical_; }
 
   const std::string logical_;


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>
Description: expose address instance string_view accessor. It already owns the string, so we can avoid the copy.
Risk Level: low
Testing: unit tests
Docs Changes:
Release Notes:

