### PR TITLE
ci: run tsan in RBE

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -4,6 +4,8 @@ jobs:
     matrix:
       release:
         CI_TARGET: 'bazel.release'
+      tsan:
+        CI_TARGET: 'bazel.tsan'
   dependsOn: [] # this removes the implicit dependency on previous stage and causes this to run in parallel.
   timeoutInMinutes: 360
   pool:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,15 +53,6 @@ jobs:
        - store_artifacts:
            path: /build/envoy/generated
            destination: /
-   tsan:
-     executor: ubuntu-build
-     steps:
-       - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
-       - checkout
-       - run: ci/do_circle_ci.sh bazel.tsan
-       - store_artifacts:
-           path: /build/envoy/generated
-           destination: /
 
    compile_time_options:
      executor: ubuntu-build
@@ -169,7 +160,6 @@ workflows:
             tags:
               only: /^v.*/
       - asan
-      - tsan
       - compile_time_options
       - api
       - filter_example_mirror

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
         "//test/extensions/transport_sockets/tls/test_data:certs",
     ],
     external_deps = ["ssl"],
+    shard_count = 4,
     deps = [
         "//include/envoy/network:transport_socket_interface",
         "//source/common/buffer:buffer_lib",


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
add shard_count for ssl_socket_test to avoid OOM in TSAN, as now we run more tests (including IPv6) in RBE.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
