### PR TITLE
update filter example with what we use for tests

### DIFF
--- a/ci/filter_example_mirror.sh
+++ b/ci/filter_example_mirror.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+ENVOY_SRCDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 CHECKOUT_DIR=../envoy-filter-example
 
 if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" == "master" ]
@@ -14,13 +15,17 @@ then
   git -C "$CHECKOUT_DIR" fetch
   git -C "$CHECKOUT_DIR" checkout -B master origin/master
 
+  echo "Updating Submodule..."
   # Update submodule to latest Envoy SHA
   ENVOY_SHA=$(git rev-parse HEAD)
   git -C "$CHECKOUT_DIR" submodule update --init
   git -C "$CHECKOUT_DIR/envoy" checkout "$ENVOY_SHA"
-  git -C "$CHECKOUT_DIR" commit -a -m "Update Envoy submodule to $ENVOY_SHA"
 
-  echo "Pushing..."
+  echo "Updating Workspace file."
+  sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${CHECKOUT_DIR}"/WORKSPACE
+
+  echo "Commiting, and Pushing..."
+  git -C "$CHECKOUT_DIR" commit -a -m "Update Envoy submodule to $ENVOY_SHA"
   git -C "$CHECKOUT_DIR" push origin master
   echo "Done"
 fi

--- a/ci/filter_example_mirror.sh
+++ b/ci/filter_example_mirror.sh
@@ -22,7 +22,7 @@ then
   git -C "$CHECKOUT_DIR/envoy" checkout "$ENVOY_SHA"
 
   echo "Updating Workspace file."
-  sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${CHECKOUT_DIR}"/WORKSPACE
+  sed -e "s|{ENVOY_SRCDIR}|envoy|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${CHECKOUT_DIR}"/WORKSPACE
 
   echo "Committing, and Pushing..."
   git -C "$CHECKOUT_DIR" commit -a -m "Update Envoy submodule to $ENVOY_SHA"

--- a/ci/filter_example_mirror.sh
+++ b/ci/filter_example_mirror.sh
@@ -24,7 +24,7 @@ then
   echo "Updating Workspace file."
   sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${CHECKOUT_DIR}"/WORKSPACE
 
-  echo "Commiting, and Pushing..."
+  echo "Committing, and Pushing..."
   git -C "$CHECKOUT_DIR" commit -a -m "Update Envoy submodule to $ENVOY_SHA"
   git -C "$CHECKOUT_DIR" push origin master
   echo "Done"


### PR DESCRIPTION
Description:

this forces the same workspace file we use for tests:
  - https://github.com/envoyproxy/envoy/blob/14c5371/ci/build_setup.sh#L75

to be pushed to the envoy-filter-example. this will allow not having
to file a manual PR to fix the build, such as:

- https://github.com/envoyproxy/envoy-filter-example/pull/95

Risk Level: Low
Testing: Not sure how I can test this manually. Perhaps someone as part of the envoy org can run the script manually?
Docs Changes: None
Release Notes: None

