### PR TITLE
Fix RuntimeFromNonWorkerThreads

### DIFF
--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -628,22 +628,32 @@ TEST_F(StaticLoaderImplTest, RuntimeFromNonWorkerThreads) {
   Thread::CondVar foo_changed;
   const Snapshot* original_thread_snapshot_pointer = nullptr;
   auto thread = Thread::threadFactoryForTest().createThread([&]() {
-    Thread::LockGuard lock(mutex);
-    EXPECT_EQ("bar", loader_->threadsafeSnapshot()->get("foo"));
-    original_thread_snapshot_pointer = loader_->threadsafeSnapshot().get();
-    EXPECT_EQ(original_thread_snapshot_pointer, loader_->threadsafeSnapshot().get());
-    foo_read.notifyOne();
+    {
+      Thread::LockGuard lock(mutex);
+      EXPECT_EQ("bar", loader_->threadsafeSnapshot()->get("foo"));
+      original_thread_snapshot_pointer = loader_->threadsafeSnapshot().get();
+      EXPECT_EQ(original_thread_snapshot_pointer, loader_->threadsafeSnapshot().get());
+      foo_read.notifyOne();
+    }
 
-    foo_changed.wait(mutex);
-    EXPECT_EQ("eep", loader_->threadsafeSnapshot()->get("foo"));
+    {
+      Thread::LockGuard lock(mutex);
+      foo_changed.wait(mutex);
+      EXPECT_EQ("eep", loader_->threadsafeSnapshot()->get("foo"));
+    }
   });
 
   {
-    Thread::LockGuard lock(mutex);
-    foo_read.wait(mutex);
-    loader_->mergeValues({{"foo", "eep"}});
-    foo_changed.notifyOne();
-    EXPECT_EQ("eep", loader_->threadsafeSnapshot()->get("foo"));
+    {
+      Thread::LockGuard lock(mutex);
+      foo_read.wait(mutex);
+      loader_->mergeValues({{"foo", "eep"}});
+    }
+    {
+      Thread::LockGuard lock(mutex);
+      foo_changed.notifyOne();
+      EXPECT_EQ("eep", loader_->threadsafeSnapshot()->get("foo"));
+    }
   }
 
   thread->join();

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -633,7 +633,7 @@ TEST_F(StaticLoaderImplTest, RuntimeFromNonWorkerThreads) {
     {
       Thread::LockGuard lock(mutex);
       EXPECT_EQ("bar", loader_->threadsafeSnapshot()->get("foo"));
-      read_bar  = true;
+      read_bar = true;
       original_thread_snapshot_pointer = loader_->threadsafeSnapshot().get();
       EXPECT_EQ(original_thread_snapshot_pointer, loader_->threadsafeSnapshot().get());
       foo_read.notifyOne();


### PR DESCRIPTION
This is a follow-up to e61681d. While working on #7574, I am getting
consistent timeouts for this test.

I think it happens because the code on the main thread runs slower
than the code on the reader thread.

My fix is to properly acquire and release the lock on each step,
to ensure they are properly sequenced. That is:

1) read from reader
2) write from writer
3) read new value from reader
4) read new value from writer

To repro the timeout, I added a sleep before step 2. After this change,
I can't repro anymore.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
