### PR TITLE
Consuming coverage tests

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -143,8 +143,8 @@ def envoy_cc_test(
         repository = repository,
         tags = test_lib_tags,
         copts = copts,
-        # Restrict only to the code coverage tools.
-        visibility = ["@envoy//test/coverage:__pkg__"],
+        # Allow public visibility so these can be consumed in coverage tests in external projects.
+        visibility = ["//visibility:public"],
     )
     native.cc_test(
         name = name,


### PR DESCRIPTION
In https://github.com/envoyproxy/nighthawk/pull/101 we update coverage to the new methodology. 
For that to work we need to be able to consume `_lib_internal_only` targets which aren't visible externally today.  
This proposes a change so we can make that  happen. 
The naming is fairly clear that these targets shouldn't  be used otherwise.

Description:
Risk Level: low
Testing: N/A
Docs Changes: None
Release Notes: None
