### PR TITLE
io: reduce unknown error code log level

### DIFF
--- a/source/common/network/io_socket_error_impl.cc
+++ b/source/common/network/io_socket_error_impl.cc
@@ -26,7 +26,7 @@ Api::IoError::IoErrorCode IoSocketError::getErrorCode() const {
   case EADDRNOTAVAIL:
     return IoErrorCode::AddressNotAvailable;
   default:
-    ENVOY_LOG_MISC(error, "Unknown error code {} details {}", errno_, ::strerror(errno_));
+    ENVOY_LOG_MISC(debug, "Unknown error code {} details {}", errno_, ::strerror(errno_));
     return IoErrorCode::UnknownError;
   }
 }


### PR DESCRIPTION
```
2019-07-29T17:11:16.00568 [2019-07-29 17:11:16.005][26039][error][misc] [external/envoy/source/common/network/io_socket_error_impl.cc:29] Unknown error code 111 details Connection refused
```

I saw the previous log line on a production box and I think this should
be a debug log condition.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
