### PR TITLE
http: add onComplete to AsyncClient::StreamCallbacks

### DIFF
--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -76,6 +76,13 @@ public:
     virtual void onTrailers(HeaderMapPtr&& trailers) PURE;
 
     /**
+     * Called when both the local and remote have gracefully closed the stream.
+     * Useful for asymmetric cases where end_stream may not be bidirectionally observable.
+     * Note this is NOT called on stream reset.
+     */
+    virtual void onClosure() PURE;
+
+    /**
      * Called when the async HTTP stream is reset.
      */
     virtual void onReset() PURE;

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -80,7 +80,7 @@ public:
      * Useful for asymmetric cases where end_stream may not be bidirectionally observable.
      * Note this is NOT called on stream reset.
      */
-    virtual void onClosure() PURE;
+    virtual void onComplete() PURE;
 
     /**
      * Called when the async HTTP stream is reset.

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -166,8 +166,8 @@ void AsyncStreamImpl::streamError(Status::GrpcStatus grpc_status, const std::str
   resetStream();
 }
 
-void AsyncStreamImpl::onClosure() {
-  // No-op since stream closure is handled within other callbacks.
+void AsyncStreamImpl::onComplete() {
+  // No-op since stream completion is handled within other callbacks.
 }
 
 void AsyncStreamImpl::onReset() {

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -166,6 +166,10 @@ void AsyncStreamImpl::streamError(Status::GrpcStatus grpc_status, const std::str
   resetStream();
 }
 
+void AsyncStreamImpl::onClosure() {
+  // No-op since stream closure is handled within other callbacks.
+}
+
 void AsyncStreamImpl::onReset() {
   if (http_reset_) {
     return;

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -55,7 +55,7 @@ public:
   void onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
   void onData(Buffer::Instance& data, bool end_stream) override;
   void onTrailers(Http::HeaderMapPtr&& trailers) override;
-  void onClosure() override;
+  void onComplete() override;
   void onReset() override;
 
   // Grpc::AsyncStream

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -55,6 +55,7 @@ public:
   void onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
   void onData(Buffer::Instance& data, bool end_stream) override;
   void onTrailers(Http::HeaderMapPtr&& trailers) override;
+  void onClosure() override;
   void onReset() override;
 
   // Grpc::AsyncStream

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -194,11 +194,11 @@ void AsyncRequestImpl::initialize() {
 
 void AsyncRequestImpl::onComplete() { callbacks_.onSuccess(std::move(response_)); }
 
-void AsyncRequestImpl::onHeaders(HeaderMapPtr&& headers, bool end_stream) {
+void AsyncRequestImpl::onHeaders(HeaderMapPtr&& headers, bool) {
   response_ = std::make_unique<ResponseMessageImpl>(std::move(headers));
 }
 
-void AsyncRequestImpl::onData(Buffer::Instance& data, bool end_stream) {
+void AsyncRequestImpl::onData(Buffer::Instance& data, bool) {
   if (!response_->body()) {
     response_->body() = std::make_unique<Buffer::OwnedImpl>();
   }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -196,10 +196,6 @@ void AsyncRequestImpl::onComplete() { callbacks_.onSuccess(std::move(response_))
 
 void AsyncRequestImpl::onHeaders(HeaderMapPtr&& headers, bool end_stream) {
   response_ = std::make_unique<ResponseMessageImpl>(std::move(headers));
-
-  if (end_stream) {
-    onComplete();
-  }
 }
 
 void AsyncRequestImpl::onData(Buffer::Instance& data, bool end_stream) {
@@ -207,14 +203,13 @@ void AsyncRequestImpl::onData(Buffer::Instance& data, bool end_stream) {
     response_->body() = std::make_unique<Buffer::OwnedImpl>();
   }
   response_->body()->move(data);
-
-  if (end_stream) {
-    onComplete();
-  }
 }
 
 void AsyncRequestImpl::onTrailers(HeaderMapPtr&& trailers) {
   response_->trailers(std::move(trailers));
+}
+
+void AsyncRequestImpl::onClosure() {
   onComplete();
 }
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -202,6 +202,9 @@ void AsyncRequestImpl::initialize() {
     // sendHeaders can result in synchronous stream closure in certain cases (e.g. connection pool
     // failure).
     if (remoteClosed()) {
+      // In the case that we had a locally-generated response, we manually close the stream locally
+      // to fire the completion callback. This is a no-op if we had a locally-generated reset
+      // instead.
       closeLocal(true);
     } else {
       sendData(*request_->body(), true);

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -209,9 +209,7 @@ void AsyncRequestImpl::onTrailers(HeaderMapPtr&& trailers) {
   response_->trailers(std::move(trailers));
 }
 
-void AsyncRequestImpl::onClosure() {
-  onComplete();
-}
+void AsyncRequestImpl::onClosure() { onComplete(); }
 
 void AsyncRequestImpl::onReset() {
   if (!cancelled_) {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -146,6 +146,7 @@ void AsyncStreamImpl::closeLocal(bool end_stream) {
 
   local_closed_ |= end_stream;
   if (complete()) {
+    stream_callbacks_.onClosure();
     cleanup();
   }
 }
@@ -153,6 +154,7 @@ void AsyncStreamImpl::closeLocal(bool end_stream) {
 void AsyncStreamImpl::closeRemote(bool end_stream) {
   remote_closed_ |= end_stream;
   if (complete()) {
+    stream_callbacks_.onClosure();
     cleanup();
   }
 }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -143,7 +143,8 @@ void AsyncStreamImpl::sendTrailers(HeaderMap& trailers) {
 
 void AsyncStreamImpl::closeLocal(bool end_stream) {
   ASSERT(!(local_closed_ && end_stream));
-  // Due to the fact that send calls can synchronously result in stream closure, it's possible for this to be called after the local side is already closed.
+  // Due to the fact that send calls can synchronously result in stream closure, it's possible for
+  // this to be called after the local side is already closed.
   if (local_closed_) {
     return;
   }
@@ -156,7 +157,9 @@ void AsyncStreamImpl::closeLocal(bool end_stream) {
 }
 
 void AsyncStreamImpl::closeRemote(bool end_stream) {
-  // Due to the fact that callbacks can synchronously result in stream closure, it's possible for this to get called after the remote is already closed (e.g. if the the stream is reset in the callback itself).
+  // Due to the fact that callbacks can synchronously result in stream closure, it's possible for
+  // this to get called after the remote is already closed (e.g. if the the stream is reset in the
+  // callback itself).
   if (remote_closed_) {
     return;
   }
@@ -195,10 +198,14 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
 
 void AsyncRequestImpl::initialize() {
   sendHeaders(request_->headers(), !request_->body());
-  if (!remoteClosed() && request_->body()) {
-    sendData(*request_->body(), true);
-  } else if (remoteClosed() && request_->body()) {
-    closeLocal(true);
+  if (request_->body()) {
+    // sendHeaders can result in synchronous stream closure in certain cases (e.g. connection pool
+    // failure).
+    if (remoteClosed()) {
+      closeLocal(true);
+    } else {
+      sendData(*request_->body(), true);
+    }
   }
   // TODO(mattklein123): Support request trailers.
 }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -389,6 +389,7 @@ private:
   void onHeaders(HeaderMapPtr&& headers, bool end_stream) override;
   void onData(Buffer::Instance& data, bool end_stream) override;
   void onTrailers(HeaderMapPtr&& trailers) override;
+  void onClosure() override;
   void onReset() override;
 
   // Http::StreamDecoderFilterCallbacks

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -88,6 +88,7 @@ public:
 
 protected:
   bool remoteClosed() { return remote_closed_; }
+  void closeLocal(bool end_stream);
 
   AsyncClientImpl& parent_;
 
@@ -281,7 +282,6 @@ private:
   };
 
   void cleanup();
-  void closeLocal(bool end_stream);
   void closeRemote(bool end_stream);
   bool complete() { return local_closed_ && remote_closed_; }
 
@@ -383,13 +383,12 @@ public:
 
 private:
   void initialize();
-  void onComplete();
 
   // AsyncClient::StreamCallbacks
   void onHeaders(HeaderMapPtr&& headers, bool end_stream) override;
   void onData(Buffer::Instance& data, bool end_stream) override;
   void onTrailers(HeaderMapPtr&& trailers) override;
-  void onClosure() override;
+  void onComplete() override;
   void onReset() override;
 
   // Http::StreamDecoderFilterCallbacks

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -100,6 +100,7 @@ TEST_F(AsyncClientImplTest, BasicStream) {
 
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -265,6 +266,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
 
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -388,6 +390,7 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
 
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -427,6 +430,7 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), false));
   TestHeaderMapImpl expected_trailers{{"some", "trailer"}};
   EXPECT_CALL(stream_callbacks_, onTrailers_(HeaderMapEqualRef(&expected_trailers)));
+  EXPECT_CALL(stream_callbacks_, onClosure_());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -720,6 +724,7 @@ TEST_F(AsyncClientImplTest, StreamTimeout) {
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), false));
   EXPECT_CALL(stream_callbacks_, onData(_, true));
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream = client_.start(
       stream_callbacks_, AsyncClient::StreamOptions().setTimeout(std::chrono::milliseconds(40)));
@@ -860,6 +865,7 @@ TEST_F(AsyncClientImplTest, MultipleDataStream) {
 
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body2.get()), true));
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body2.get()), true));
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   stream->sendData(*body2, true);
   response_decoder_->decodeData(*body2, true);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -100,7 +100,7 @@ TEST_F(AsyncClientImplTest, BasicStream) {
 
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -244,7 +244,7 @@ TEST_F(AsyncClientImplTest, RetryWithStream) {
 
   // Normal response.
   expectResponseHeaders(stream_callbacks_, 200, true);
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
   HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers2), true);
 }
@@ -267,7 +267,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
 
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -292,7 +292,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
   EXPECT_CALL(stream_encoder2, encodeData(BufferEqual(body2.get()), true));
 
   expectResponseHeaders(stream_callbacks2, 503, true);
-  EXPECT_CALL(stream_callbacks2, onClosure());
+  EXPECT_CALL(stream_callbacks2, onComplete());
 
   AsyncClient::Stream* stream2 = client_.start(stream_callbacks2, AsyncClient::StreamOptions());
   stream2->sendHeaders(headers2, false);
@@ -392,7 +392,7 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
 
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -432,7 +432,7 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), false));
   TestHeaderMapImpl expected_trailers{{"some", "trailer"}};
   EXPECT_CALL(stream_callbacks_, onTrailers_(HeaderMapEqualRef(&expected_trailers)));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
@@ -550,7 +550,7 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
       .WillOnce(Invoke([&stream](HeaderMap&, bool) { stream->reset(); }));
   EXPECT_CALL(stream_callbacks_, onData(_, _)).Times(0);
   EXPECT_CALL(stream_callbacks_, onReset());
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
@@ -727,7 +727,7 @@ TEST_F(AsyncClientImplTest, StreamTimeout) {
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), false));
   EXPECT_CALL(stream_callbacks_, onData(_, true));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   AsyncClient::Stream* stream = client_.start(
       stream_callbacks_, AsyncClient::StreamOptions().setTimeout(std::chrono::milliseconds(40)));
@@ -761,7 +761,7 @@ TEST_F(AsyncClientImplTest, StreamTimeoutHeadReply) {
   TestHeaderMapImpl expected_timeout{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), true));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   AsyncClient::Stream* stream = client_.start(
       stream_callbacks_, AsyncClient::StreamOptions().setTimeout(std::chrono::milliseconds(40)));
@@ -869,7 +869,7 @@ TEST_F(AsyncClientImplTest, MultipleDataStream) {
 
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body2.get()), true));
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body2.get()), true));
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks_, onComplete());
 
   stream->sendData(*body2, true);
   response_decoder_->decodeData(*body2, true);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -550,6 +550,7 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
       .WillOnce(Invoke([&stream](HeaderMap&, bool) { stream->reset(); }));
   EXPECT_CALL(stream_callbacks_, onData(_, _)).Times(0);
   EXPECT_CALL(stream_callbacks_, onReset());
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -430,7 +430,7 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), false));
   TestHeaderMapImpl expected_trailers{{"some", "trailer"}};
   EXPECT_CALL(stream_callbacks_, onTrailers_(HeaderMapEqualRef(&expected_trailers)));
-  EXPECT_CALL(stream_callbacks_, onClosure_());
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -244,6 +244,7 @@ TEST_F(AsyncClientImplTest, RetryWithStream) {
 
   // Normal response.
   expectResponseHeaders(stream_callbacks_, 200, true);
+  EXPECT_CALL(stream_callbacks_, onClosure());
   HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers2), true);
 }
@@ -291,6 +292,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
   EXPECT_CALL(stream_encoder2, encodeData(BufferEqual(body2.get()), true));
 
   expectResponseHeaders(stream_callbacks2, 503, true);
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream2 = client_.start(stream_callbacks2, AsyncClient::StreamOptions());
   stream2->sendHeaders(headers2, false);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -292,7 +292,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
   EXPECT_CALL(stream_encoder2, encodeData(BufferEqual(body2.get()), true));
 
   expectResponseHeaders(stream_callbacks2, 503, true);
-  EXPECT_CALL(stream_callbacks_, onClosure());
+  EXPECT_CALL(stream_callbacks2, onClosure());
 
   AsyncClient::Stream* stream2 = client_.start(stream_callbacks2, AsyncClient::StreamOptions());
   stream2->sendHeaders(headers2, false);
@@ -760,6 +760,7 @@ TEST_F(AsyncClientImplTest, StreamTimeoutHeadReply) {
   TestHeaderMapImpl expected_timeout{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), true));
+  EXPECT_CALL(stream_callbacks_, onClosure());
 
   AsyncClient::Stream* stream = client_.start(
       stream_callbacks_, AsyncClient::StreamOptions().setTimeout(std::chrono::milliseconds(40)));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -550,7 +550,6 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
       .WillOnce(Invoke([&stream](HeaderMap&, bool) { stream->reset(); }));
   EXPECT_CALL(stream_callbacks_, onData(_, _)).Times(0);
   EXPECT_CALL(stream_callbacks_, onReset());
-  EXPECT_CALL(stream_callbacks_, onComplete());
 
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -347,7 +347,7 @@ public:
   MOCK_METHOD2(onHeaders_, void(HeaderMap& headers, bool end_stream));
   MOCK_METHOD2(onData, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(onTrailers_, void(HeaderMap& headers));
-  MOCK_METHOD0(onClosure, void());
+  MOCK_METHOD0(onComplete, void());
   MOCK_METHOD0(onReset, void());
 };
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -347,6 +347,7 @@ public:
   MOCK_METHOD2(onHeaders_, void(HeaderMap& headers, bool end_stream));
   MOCK_METHOD2(onData, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(onTrailers_, void(HeaderMap& headers));
+  MOCK_METHOD0(onClosure, void());
   MOCK_METHOD0(onReset, void());
 };
 


### PR DESCRIPTION
Description: Add onComplete callback for asymmetric cases where end_stream may not be bidirectionally observable.
Risk Level: Medium
Testing: Updated unit tests

Co-authored-by: Jose Ulises Nino Rivera <jnino@lyft.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>