### PR TITLE
ci: always publish artifacts in Azure

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -45,3 +45,4 @@ jobs:
     inputs:
       pathtoPublish: "$(Build.StagingDirectory)/envoy"
       artifactName: $(CI_TARGET)
+    condition: always()


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Needed to collect failed testlog.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
