### PR TITLE
cleanup: expose requestedServerName as a string view

### DIFF
--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -467,7 +467,7 @@ public:
   /**
    * @return SNI value for downstream host.
    */
-  virtual const std::string& requestedServerName() const PURE;
+  virtual absl::string_view requestedServerName() const PURE;
 
   /**
    * @param failure_reason the upstream transport failure reason.

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -403,7 +403,7 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
   } else if (field_name == "REQUESTED_SERVER_NAME") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
       if (!stream_info.requestedServerName().empty()) {
-        return stream_info.requestedServerName();
+        return std::string(stream_info.requestedServerName());
       } else {
         return UnspecifiedValueString;
       }

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -199,7 +199,7 @@ struct StreamInfoImpl : public StreamInfo {
     requested_server_name_ = std::string(requested_server_name);
   }
 
-  const std::string& requestedServerName() const override { return requested_server_name_; }
+  absl::string_view requestedServerName() const override { return requested_server_name_; }
 
   void setUpstreamTransportFailureReason(absl::string_view failure_reason) override {
     upstream_transport_failure_reason_ = std::string(failure_reason);

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
@@ -232,7 +232,7 @@ void HttpGrpcAccessLog::emitLog(const Http::HeaderMap& request_headers,
     auto* tls_properties = common_properties->mutable_tls_properties();
     const auto* downstream_ssl_connection = stream_info.downstreamSslConnection();
 
-    tls_properties->set_tls_sni_hostname(stream_info.requestedServerName());
+    tls_properties->set_tls_sni_hostname(std::string(stream_info.requestedServerName()));
 
     auto* local_properties = tls_properties->mutable_local_certificate_properties();
     for (const auto& uri_san : downstream_ssl_connection->uriSanLocalCertificate()) {

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -207,7 +207,7 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
     std::string requested_server_name = "stub_server";
     EXPECT_CALL(stream_info, requestedServerName())
-        .WillRepeatedly(ReturnRef(requested_server_name));
+        .WillRepeatedly(Return(absl::string_view(requested_server_name)));
     EXPECT_EQ("stub_server", upstream_format.format(header, header, header, stream_info));
   }
 
@@ -215,7 +215,7 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
     std::string requested_server_name;
     EXPECT_CALL(stream_info, requestedServerName())
-        .WillRepeatedly(ReturnRef(requested_server_name));
+        .WillRepeatedly(Return(absl::string_view(requested_server_name)));
     EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
   }
   {

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -172,7 +172,7 @@ public:
     requested_server_name_ = std::string(requested_server_name);
   }
 
-  const std::string& requestedServerName() const override { return requested_server_name_; }
+  absl::string_view requestedServerName() const override { return requested_server_name_; }
 
   void setUpstreamTransportFailureReason(absl::string_view failure_reason) override {
     upstream_transport_failure_reason_ = std::string(failure_reason);

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -87,8 +87,9 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
         requested_server_name_ = std::string(requested_server_name);
       }));
-  ON_CALL(*this, requestedServerName())
-      .WillByDefault(Return(absl::string_view(requested_server_name_)));
+  ON_CALL(*this, requestedServerName()).WillByDefault(Invoke([this]() {
+    return absl::string_view(requested_server_name_);
+  }));
   ON_CALL(*this, setRouteName(_)).WillByDefault(Invoke([this](const absl::string_view route_name) {
     route_name_ = std::string(route_name);
   }));

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -87,7 +87,8 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
         requested_server_name_ = std::string(requested_server_name);
       }));
-  ON_CALL(*this, requestedServerName()).WillByDefault(ReturnRef(requested_server_name_));
+  ON_CALL(*this, requestedServerName())
+      .WillByDefault(Return(absl::string_view(requested_server_name_)));
   ON_CALL(*this, setRouteName(_)).WillByDefault(Invoke([this](const absl::string_view route_name) {
     route_name_ = std::string(route_name);
   }));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -76,7 +76,7 @@ public:
   MOCK_METHOD0(filterState, FilterState&());
   MOCK_CONST_METHOD0(filterState, const FilterState&());
   MOCK_METHOD1(setRequestedServerName, void(const absl::string_view));
-  MOCK_CONST_METHOD0(requestedServerName, const std::string&());
+  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
   MOCK_METHOD1(setUpstreamTransportFailureReason, void(absl::string_view));
   MOCK_CONST_METHOD0(upstreamTransportFailureReason, const std::string&());
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: expose stream info method to return a string_view since it owns the string value.
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none

