### PR TITLE
bazel: change cfg of rule to exec

### DIFF
--- a/tools/protodoc/protodoc.bzl
+++ b/tools/protodoc/protodoc.bzl
@@ -82,12 +82,12 @@ proto_doc_aspect = aspect(
         "_protoc": attr.label(
             default = Label("@com_google_protobuf//:protoc"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_protodoc": attr.label(
             default = Label("//tools/protodoc"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     implementation = _proto_doc_aspect_impl,


### PR DESCRIPTION
The host environment isn't what you want when using remote execution, instead we should use the exec environment