### PR TITLE
stats: fix clang-tidy errors in null stats

### DIFF
--- a/source/common/stats/null_counter.h
+++ b/source/common/stats/null_counter.h
@@ -20,7 +20,7 @@ public:
     // will not be able to access the SymbolTable& to free the symbols. An RAII
     // alternative would be to store the SymbolTable reference in the
     // MetricImpl, costing 8 bytes per stat.
-    MetricImpl::clear(symbolTable());
+    MetricImpl::clear(symbol_table_);
   }
 
   void add(uint64_t) override {}

--- a/source/common/stats/null_gauge.h
+++ b/source/common/stats/null_gauge.h
@@ -20,7 +20,7 @@ public:
     // will not be able to access the SymbolTable& to free the symbols. An RAII
     // alternative would be to store the SymbolTable reference in the
     // MetricImpl, costing 8 bytes per stat.
-    MetricImpl::clear(symbolTable());
+    MetricImpl::clear(symbol_table_);
   }
 
   void add(uint64_t) override {}


### PR DESCRIPTION
Description: for some reason I was able to check in this code that called a virtual function during destruction, which clang-tidy doesn't like. Fortunately it's easy to fix.
Risk Level: low
Testing: //test/common/stats/...
Docs Changes: n/a
Release Notes: n/a

