### PR TITLE
Fix missing annotation in http_uri.proto

### DIFF
--- a/api/envoy/api/v2/core/http_uri.proto
+++ b/api/envoy/api/v2/core/http_uri.proto
@@ -11,6 +11,8 @@ import "gogoproto/gogo.proto";
 
 import "validate/validate.proto";
 
+option (gogoproto.equal_all) = true;
+
 // [#protodoc-title: HTTP Service URI ]
 
 // Envoy external URI descriptor


### PR DESCRIPTION
Description: Fix missing gogo annotation. The file-level `equal_all` annotation was missing in one of the files and failed to compile in go-control-plane.
https://github.com/envoyproxy/go-control-plane/pull/201

Risk Level: Low
Testing: go-control-plane
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>