### PR TITLE
Update route.proto

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -1139,7 +1139,7 @@ message RateLimit {
     //
     // .. code-block:: cpp
     //
-    //   ("<descriptor_key>", "<header_value_queried_from_header>")
+    //   ("request_headers", "<header_value_queried_from_header>")
     message RequestHeaders {
       // The header name to be queried from the request headers. The header’s
       // value is used to populate the value of the descriptor entry for the


### PR DESCRIPTION
Fix missing descriptor_key for request headers for rate limit actions

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
