### PR TITLE
Explicitly mark Python binaries with python_version = PY3

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -70,6 +70,7 @@ py_binary(
     name = "capture_fuzz_gen",
     srcs = ["capture_fuzz_gen.py"],
     licenses = ["notice"],  # Apache 2
+    python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":capture_fuzz_proto_py",


### PR DESCRIPTION
Explicitly mark Python binaries with python_version = PY3

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
