### PR TITLE
Dependency: update PGV, opencensus-proto, nghttp2, msgpack-c, bazel-gazelle & cleanup

### DIFF
--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -4,11 +4,11 @@ BAZEL_SKYLIB_SHA256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc70
 GOGOPROTO_RELEASE = "1.2.1"
 GOGOPROTO_SHA256 = "99e423905ba8921e86817607a5294ffeedb66fdd4a85efce5eb2848f715fdb3a"
 
-OPENCENSUS_PROTO_GIT_SHA = "d5d80953a8c2ff4633087af6933cd152678434bb"  # Mar 18, 2019
-OPENCENSUS_PROTO_SHA256 = "a4e87a1da21d1b3a16674332c3ee6e2689d52f3532e2ff8cb4a626c8bcdabcfc"
+OPENCENSUS_PROTO_RELEASE = "0.2.1"
+OPENCENSUS_PROTO_SHA256 = "bfcefa6093fc2ecdf5c9effea86e6982d0d6f9a5178b17fcf73a62e0f3fb43d0"
 
-PGV_GIT_SHA = "dd90514d96e35023ed20201f349542b0bc64461d"
-PGV_SHA256 = "f7d67677fbec5b0f561f6ee6788223fb535d3864b53a28b6678e319f5d1f4f25"
+PGV_GIT_SHA = "2feaabb13a5d697b80fcb938c0ce37b24c9381ee"  # Jul 26, 2018
+PGV_SHA256 = "ddefe3dcbb25d68a2e5dfea67d19c060959c2aecc782802bd4c1a5811d44dd45"
 
 GOOGLEAPIS_GIT_SHA = "be480e391cc88a75cf2a81960ef79c80d5012068"  # Jul 24, 2019
 GOOGLEAPIS_SHA = "c1969e5b72eab6d9b6cfcff748e45ba57294aeea1d96fd04cd081995de0605c2"
@@ -46,8 +46,8 @@ REPOSITORY_LOCATIONS = dict(
     ),
     opencensus_proto = dict(
         sha256 = OPENCENSUS_PROTO_SHA256,
-        strip_prefix = "opencensus-proto-" + OPENCENSUS_PROTO_GIT_SHA + "/src",
-        urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/" + OPENCENSUS_PROTO_GIT_SHA + ".tar.gz"],
+        strip_prefix = "opencensus-proto-" + OPENCENSUS_PROTO_RELEASE + "/src",
+        urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/v" + OPENCENSUS_PROTO_RELEASE + ".tar.gz"],
     ),
     kafka_source = dict(
         sha256 = KAFKA_SOURCE_SHA,

--- a/bazel/external/backward.BUILD
+++ b/bazel/external/backward.BUILD
@@ -1,8 +1,0 @@
-licenses(["notice"])  # Apache 2
-
-cc_library(
-    name = "backward",
-    hdrs = ["backward.hpp"],
-    includes = ["."],
-    visibility = ["//visibility:public"],
-)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -217,8 +217,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/64d6ac985360b624d8e95105701b64a3814794cd.tar.gz"],
     ),
     io_bazel_rules_go = dict(
-        sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz"],
+        sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
     ),
     rules_foreign_cc = dict(
         sha256 = "c957e6663094a1478c43330c1bbfa71afeaf1ab86b7565233783301240c7a0ab",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     bazel_gazelle = dict(
-        sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
+        sha256 = "be9296bfd64882e3c08e3283c58fcb461fa6dd3c171764fcc4cf322f60615a9b",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz"],
     ),
     bazel_toolchains = dict(
         sha256 = "68e7678473090542e679ce7e6aa8a3ba5669577dede2b404f9865d556bd99f10",
@@ -105,9 +105,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/nanopb/nanopb/archive/0.3.9.3.tar.gz"],
     ),
     com_github_nghttp2_nghttp2 = dict(
-        sha256 = "fe9a75ec44e3a2e8f7f0cb83ad91e663bbc4c5085baf37b57ee2610846d7cf5d",
-        strip_prefix = "nghttp2-1.38.0",
-        urls = ["https://github.com/nghttp2/nghttp2/releases/download/v1.38.0/nghttp2-1.38.0.tar.gz"],
+        sha256 = "25b623cd04dc6a863ca3b34ed6247844effe1aa5458229590b3f56a6d53cd692",
+        strip_prefix = "nghttp2-1.39.1",
+        urls = ["https://github.com/nghttp2/nghttp2/releases/download/v1.39.1/nghttp2-1.39.1.tar.gz"],
     ),
     io_opentracing_cpp = dict(
         sha256 = "015c4187f7a6426a2b5196f0ccd982aa87f010cf61f507ae3ce5c90523f92301",
@@ -142,9 +142,6 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/libevent/libevent/archive/0d7d85c2083f7a4c9efe01c061486f332b576d28.tar.gz"],
     ),
     net_zlib = dict(
-        # TODO(moderation): revert to com_github_madler_zlib name pending resolution of workaround
-        # in rules_go https://github.com/bazelbuild/rules_go/blob/master/go/private/repositories.bzl#L87-L101
-        # for issue in protocolbuffers/protobuf https://github.com/protocolbuffers/protobuf/issues/5472
         sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
         strip_prefix = "zlib-1.2.11",
         urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
@@ -155,9 +152,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/jbeder/yaml-cpp/archive/0f9a586ca1dc29c2ecb8dd715a315b93e3f40f79.tar.gz"],
     ),
     com_github_msgpack_msgpack_c = dict(
-        sha256 = "bda49f996a73d2c6080ff0523e7b535917cd28c8a79c3a5da54fc29332d61d1e",
-        strip_prefix = "msgpack-c-cpp-3.1.1",
-        urls = ["https://github.com/msgpack/msgpack-c/archive/cpp-3.1.1.tar.gz"],
+        sha256 = "fbaa28c363a316fd7523f31d1745cf03eab0d1e1ea5a1c60aa0dffd4ce551afe",
+        strip_prefix = "msgpack-3.2.0",
+        urls = ["https://github.com/msgpack/msgpack-c/releases/download/cpp-3.2.0/msgpack-3.2.0.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
         sha256 = "8ab9a0b3f8b7eab5f1cd059920e81fdc138cd4ee657c1412af891652929885c5",
@@ -203,6 +200,7 @@ REPOSITORY_LOCATIONS = dict(
     com_google_googletest = dict(
         sha256 = "cbd251a40485fddd44cdf641af6df2953d45695853af6d68aeb11c7efcde6771",
         strip_prefix = "googletest-d7003576dd133856432e2e07340f45926242cc3a",
+        # 2019-07-16
         # TODO(akonradi): Switch this back to a released version later than 1.8.1 once there is
         # one available.
         urls = ["https://github.com/google/googletest/archive/d7003576dd133856432e2e07340f45926242cc3a.tar.gz"],
@@ -219,8 +217,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/64d6ac985360b624d8e95105701b64a3814794cd.tar.gz"],
     ),
     io_bazel_rules_go = dict(
-        sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
+        sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz"],
     ),
     rules_foreign_cc = dict(
         sha256 = "c957e6663094a1478c43330c1bbfa71afeaf1ab86b7565233783301240c7a0ab",
@@ -235,6 +233,7 @@ REPOSITORY_LOCATIONS = dict(
     io_opencensus_cpp = dict(
         sha256 = "9223b4d54af4151910dede03aa58247e90df72167fcc91d5f75e73a141568036",
         strip_prefix = "opencensus-cpp-e292a374fb42c6cb2743f1689234bd409f4fda20",
+        # 2019-07-15
         urls = ["https://github.com/census-instrumentation/opencensus-cpp/archive/e292a374fb42c6cb2743f1689234bd409f4fda20.tar.gz"],
     ),
     com_github_curl = dict(


### PR DESCRIPTION
Description: Update dependencies:
- PGV ([changes](https://github.com/envoyproxy/protoc-gen-validate/compare/dd90514d96e35023ed20201f349542b0bc64461d...master))
- switch opencensus-proto to 0.2.1 release ([changes](https://github.com/census-instrumentation/opencensus-proto/compare/d5d80953a8c2ff4633087af6933cd152678434bb...v0.2.1)) /cc @kyessenov
- nghttp2 1.39.1 (release notes [1.39.0](https://github.com/nghttp2/nghttp2/releases/tag/v1.39.0), [1.39.1](https://github.com/nghttp2/nghttp2/releases/tag/v1.39.1))
- ~~rules_go 0.19.1 (0.19.0 [release notes](https://github.com/bazelbuild/rules_go/releases/tag/0.19.0))~~ this is breaking the API only. Reverting to master and will sort out later.
- msgpack-c 3.2.0 ([release notes](https://github.com/msgpack/msgpack-c/releases/tag/cpp-3.2.0))
- bazel-gazelle 0.18.1 ([0.18.0 release notes](https://github.com/bazelbuild/bazel-gazelle/releases/tag/0.18.0))
- comment cleanup (remove uneccesary todo and add dates to commits)
- removed unused old backward dependency build file

Risk Level: Medium
Testing: `bazel test //test/...`
Docs Changes: None required
Release Notes: None required

Signed-off-by: Michael Payne <michael@sooper.org>
