### PR TITLE
clang-tidy: readability-redundant-string-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,8 @@ WarningsAsErrors: 'abseil-duration-*,
                    readability-redundant-control-flow,
                    readability-redundant-member-init,
                    readability-redundant-smartptr-get,
-                   readability-redundant-string-cstr'
+                   readability-redundant-string-cstr,
+                   readability-redundant-string-init'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/source/extensions/filters/network/mysql_proxy/mysql_codec_command.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_codec_command.cc
@@ -31,7 +31,7 @@ int Command::parseMessage(Buffer::Instance& buffer, uint32_t len) {
   case Command::Cmd::COM_INIT_DB:
   case Command::Cmd::COM_CREATE_DB:
   case Command::Cmd::COM_DROP_DB: {
-    std::string db = "";
+    std::string db;
     BufferHelper::readStringBySize(buffer, len - 1, db);
     setDb(db);
     break;

--- a/source/extensions/filters/network/thrift_proxy/app_exception_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/app_exception_impl.cc
@@ -8,7 +8,7 @@ namespace ThriftProxy {
 static const std::string TApplicationException = "TApplicationException";
 static const std::string MessageField = "message";
 static const std::string TypeField = "type";
-static const std::string StopField = "";
+static const std::string StopField;
 
 DirectResponse::ResponseType AppException::encode(MessageMetadata& metadata,
                                                   ThriftProxy::Protocol& proto,

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -470,7 +470,7 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
   {
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_CERT");
     NiceMock<Ssl::MockConnectionInfo> connection_info;
-    std::string expected_cert = "";
+    std::string expected_cert;
     ON_CALL(connection_info, urlEncodedPemEncodedPeerCertificate())
         .WillByDefault(ReturnRef(expected_cert));
     EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(&connection_info));

--- a/test/common/common/perf_annotation_disabled_test.cc
+++ b/test/common/common/perf_annotation_disabled_test.cc
@@ -16,7 +16,7 @@ TEST(PerfAnnotationDisabled, testPerfAnnotation) {
   PERF_RECORD(perf, "beta", "1");
   PERF_RECORD(perf, "alpha", "2");
   PERF_RECORD(perf, "beta", "3");
-  std::string report = PERF_TO_STRING();
+  std::string report;
   EXPECT_TRUE(report.empty());
   PERF_CLEAR();
 }

--- a/test/common/runtime/uuid_util_test.cc
+++ b/test/common/runtime/uuid_util_test.cc
@@ -88,7 +88,7 @@ TEST(UUIDUtilsTest, setAndCheckTraceable) {
   EXPECT_TRUE(UuidUtils::setTraceableUuid(uuid, UuidTraceStatus::NoTrace));
   EXPECT_EQ(UuidTraceStatus::NoTrace, UuidUtils::isTraceableUuid(uuid));
 
-  std::string invalid_uuid = "";
+  std::string invalid_uuid;
   EXPECT_FALSE(UuidUtils::setTraceableUuid(invalid_uuid, UuidTraceStatus::Forced));
 }
 } // namespace Envoy

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -203,7 +203,7 @@ TEST_F(StreamInfoImplTest, DynamicMetadataTest) {
 
 TEST_F(StreamInfoImplTest, DumpStateTest) {
   StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem());
-  std::string prefix = "";
+  std::string prefix;
 
   for (int i = 0; i < 7; ++i) {
     std::stringstream out;

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -198,7 +198,7 @@ using LogicalDnsConfigTuple =
 std::vector<LogicalDnsConfigTuple> generateLogicalDnsParams() {
   std::vector<LogicalDnsConfigTuple> dns_config;
   {
-    std::string family_yaml("");
+    std::string family_yaml;
     Network::DnsLookupFamily family(Network::DnsLookupFamily::Auto);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_yaml, family, dns_response));

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -113,7 +113,7 @@ using StrictDnsConfigTuple =
 std::vector<StrictDnsConfigTuple> generateStrictDnsParams() {
   std::vector<StrictDnsConfigTuple> dns_config;
   {
-    std::string family_yaml("");
+    std::string family_yaml;
     Network::DnsLookupFamily family(Network::DnsLookupFamily::Auto);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_yaml, family, dns_response));

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -458,7 +458,7 @@ using RedisDnsConfigTuple = std::tuple<std::string, Network::DnsLookupFamily,
 std::vector<RedisDnsConfigTuple> generateRedisDnsParams() {
   std::vector<RedisDnsConfigTuple> dns_config;
   {
-    std::string family_yaml("");
+    std::string family_yaml;
     Network::DnsLookupFamily family(Network::DnsLookupFamily::Auto);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     std::list<std::string> resolved_host{"127.0.0.1:22120"};

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -67,7 +67,7 @@ TEST(StringDeserializer, ShouldDeserialize) {
 }
 
 TEST(StringDeserializer, ShouldDeserializeEmptyString) {
-  const std::string value = "";
+  const std::string value;
   serializeThenDeserializeAndCheckEquality<StringDeserializer>(value);
 }
 

--- a/test/extensions/filters/network/mysql_proxy/mysql_codec_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_codec_test.cc
@@ -82,7 +82,7 @@ TEST_F(MySQLCodecTest, MySQLServerChallengeV10EncDec) {
  */
 TEST_F(MySQLCodecTest, MySQLServerChallengeIncompleteProtocol) {
   ServerGreeting mysql_greet_encode{};
-  std::string data = "";
+  std::string data;
 
   Buffer::InstancePtr decode_data(new Buffer::OwnedImpl(data));
   ServerGreeting mysql_greet_decode{};

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -510,7 +510,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersEmptyParentSpanTest) {
                                    ZipkinCoreConstants::get().SAMPLED);
 
   // Set parent span id to empty string, to ensure it is ignored
-  const std::string parent_span_id = "";
+  const std::string parent_span_id;
   request_headers_.addReferenceKey(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID, parent_span_id);
 
   Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -30,7 +30,7 @@ protected:
   TestComponentFactory component_factory_;
 };
 
-std::string ValidationServerTest::directory_ = "";
+std::string ValidationServerTest::directory_;
 
 // ValidationServerTest_1 is created only to run different set of parameterized
 // tests than set of tests for ValidationServerTest.

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -206,7 +206,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
 }
 
 bool RouterCheckTool::compareCluster(ToolConfig& tool_config, const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
 
   if (tool_config.route_->routeEntry() != nullptr) {
     actual = tool_config.route_->routeEntry()->clusterName();
@@ -226,7 +226,7 @@ bool RouterCheckTool::compareCluster(
 }
 
 bool RouterCheckTool::compareVirtualCluster(ToolConfig& tool_config, const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
 
   if (tool_config.route_->routeEntry() != nullptr &&
       tool_config.route_->routeEntry()->virtualCluster(*tool_config.headers_) != nullptr) {
@@ -249,7 +249,7 @@ bool RouterCheckTool::compareVirtualCluster(
 }
 
 bool RouterCheckTool::compareVirtualHost(ToolConfig& tool_config, const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
   if (tool_config.route_->routeEntry() != nullptr) {
     Stats::StatName stat_name = tool_config.route_->routeEntry()->virtualHost().statName();
     actual = tool_config.symbolTable().toString(stat_name);
@@ -269,7 +269,7 @@ bool RouterCheckTool::compareVirtualHost(
 }
 
 bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
@@ -296,7 +296,7 @@ bool RouterCheckTool::compareRewritePath(
 }
 
 bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   if (tool_config.route_->routeEntry() != nullptr) {
@@ -323,7 +323,7 @@ bool RouterCheckTool::compareRewriteHost(
 }
 
 bool RouterCheckTool::compareRedirectPath(ToolConfig& tool_config, const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
   if (tool_config.route_->directResponseEntry() != nullptr) {
     actual = tool_config.route_->directResponseEntry()->newPath(*tool_config.headers_);
   }
@@ -363,7 +363,7 @@ bool RouterCheckTool::compareHeaderField(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareCustomHeaderField(ToolConfig& tool_config, const std::string& field,
                                                const std::string& expected) {
-  std::string actual = "";
+  std::string actual;
   Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                 factory_context_->dispatcher().timeSource());
   stream_info.setDownstreamRemoteAddress(Network::Utility::getCanonicalIpv4LoopbackAddress());


### PR DESCRIPTION
Description: Enable `readability-redundant-string-init` as an error and fix existing warnings. This check flags cases of assigning a `std::string` to an empty string rather than using the default constructor, which also initializes with an empty string.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>
