### PR TITLE
admin: fix server state stat

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -195,7 +195,7 @@ void InstanceImpl::flushStatsInternal() {
   server_stats_->days_until_first_cert_expiring_.set(
       sslContextManager().daysUntilFirstCertExpires());
   server_stats_->state_.set(
-      enumToInt(Utility::serverState(initManager().state(), !healthCheckFailed())));
+      enumToInt(Utility::serverState(initManager().state(), healthCheckFailed())));
   InstanceUtil::flushMetricsToSinks(config_.statsSinks(), stats_store_);
   // TODO(ramaraochavali): consider adding different flush interval for histograms.
   if (stat_flush_timer_ != nullptr) {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -315,6 +315,7 @@ TEST_P(ServerInstanceImplTest, EmptyShutdownLifecycleNotifications) {
   server_thread->join();
   // Validate that initialization_time histogram value has been set.
   EXPECT_TRUE(stats_store_.histogram("server.initialization_time").used());
+  EXPECT_EQ(0L, TestUtility::findGauge(stats_store_, "server.state")->value());
 }
 
 TEST_P(ServerInstanceImplTest, LifecycleNotifications) {


### PR DESCRIPTION
Description: The server state stat incorrectly sets to 1 (Draininig) when the server is actually Live(0) because of some incorrect boolean check. This PR fixes it.
Risk Level: Low
Testing: Added
Docs Changes: N/A
Release Notes: N/A

