### PR TITLE
(timer) Clarify lifetime requirements on Envoy::Event::Timer

### DIFF
--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -16,7 +16,8 @@ namespace Event {
 using TimerCb = std::function<void()>;
 
 /**
- * An abstract timer event. Free the timer to unregister any pending timeouts.
+ * An abstract timer event. Free the timer to unregister any pending timeouts. Must be freed before
+ * the dispatcher is torn down.
  */
 class Timer {
 public:


### PR DESCRIPTION
I attempted to use a Timer from outside of Envoy in my code, and ran into destructor problems. The Timer was being destroyed after the Envoy server was already destroyed, causing a segfault (partial stack trace below). Is this a bug in the code or a bug in the comments?

Risk Level: N/A (Comment only)

```
(gdb) bt
#0  0x00007ffff7eb9970 in pthread_mutex_lock () from /usr/grte/v4/lib64/libpthread.so.0
#1  0x0000555563d481c0 in evthread_posix_lock (mode=0, lock_=0xcdcdcdcdcdcdcdcd) at libevent/src/evthread_pthread.c:75
#2  0x0000555563d5f356 in event_del_ (ev=0x7fffbd812428, blocking=2) at libevent/src/event.c:2811
#3  0x0000555563d5db9a in event_del (ev=0x7fffbd812428) at libevent/src/event.c:2821
#4  0x0000555563d47ea5 in Envoy::Event::ImplBase::~ImplBase (this=0x7fffbd812428) at envoy/src/source/common/event/event_impl_base.cc:10
#5  0x0000555563d47e17 in Envoy::Event::TimerImpl::~TimerImpl (this=0x7fffbd812420) at envoy/src/source/common/event/timer_impl.h:24
#6  0x0000555563d47e4c in Envoy::Event::TimerImpl::~TimerImpl (this=0x7fffbd812420) at envoy/src/source/common/event/timer_impl.h:24
#7  0x000055555de3a2df in std::__u::default_delete<Envoy::Event::Timer>::operator() (this=0x7fffbdfb6718, __ptr=0x7fffbd812420)
    at crosstool/v18/stable/toolchain/bin/../include/c++/v1/memory:2344
#8  0x000055555de3a043 in std::__u::unique_ptr<Envoy::Event::Timer, std::__u::default_delete<Envoy::Event::Timer> >::~unique_ptr (this=0x7fffbdfb6718)
    at crosstool/v18/stable/toolchain/bin/../include/c++/v1/memory:2560
```