### PR TITLE
docs: fix minor style issue in tracing.rst

### DIFF
--- a/docs/root/intro/arch_overview/observability/tracing.rst
+++ b/docs/root/intro/arch_overview/observability/tracing.rst
@@ -107,7 +107,5 @@ Envoy automatically sends spans to tracing collectors. Depending on the tracing 
 multiple spans are stitched together using common information such as the globally unique
 request ID :ref:`config_http_conn_man_headers_x-request-id` (LightStep) or
 the trace ID configuration (Zipkin and Datadog). See
-
-* :ref:`v2 API reference <envoy_api_msg_config.trace.v2.Tracing>`
-
+:ref:`v2 API reference <envoy_api_msg_config.trace.v2.Tracing>`
 for more information on how to setup tracing in Envoy.


### PR DESCRIPTION
Remove an unnecessary bullet list to make the link to the v2 API
reference inlined.

Risk Level: Low
Testing: N/A
Docs Changes: tracing.rst
Release Notes: N/A

Signed-off-by: Tal Nordan <github@talnordan.com>
