### PR TITLE
utilize new address type in pgv for better errors

### DIFF
--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -44,7 +44,7 @@ message SocketAddress {
   // address must be an IP (*STATIC* or *EDS* clusters) or a hostname resolved by DNS
   // (*STRICT_DNS* or *LOGICAL_DNS* clusters). Address resolution can be customized
   // via :ref:`resolver_name <envoy_api_field_core.SocketAddress.resolver_name>`.
-  string address = 2 [(validate.rules).string.min_bytes = 1];
+  string address = 2 [(validate.rules).string.address = true];
   oneof port_specifier {
     option (validate.required) = true;
     uint32 port_value = 3 [(validate.rules).uint32.lte = 65535];

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -398,11 +398,11 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: main_website.com
+                address: main.website.com
                 port_value: 443
                 protocol: TCP
     tls_context:
-      sni: www.main_website.com
+      sni: www.main.website.com
   - name: local_service
     connect_timeout: 0.25s
     type: STATIC

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -52,7 +52,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: web_service
+                address: web.service.com
                 port_value: 80
 admin:
   access_log_path: "/dev/null"


### PR DESCRIPTION
Description:

Utilize the "address" type string validation that has been added to newer versions of protoc-gen-validate. This can help fix error messages that are poor (stoi), and give you an actual: "this is an invalid address" type flag.

Risk Level: Medium.

This should cover all the same address types. I set the risk level to medium though because the chance is always there. PGV doesn't check unix domain sockets, but my understanding is those use a seperate protobuf: `Pipe` type.

It'd be nice if people were able to run their configs through it too though.

Testing:

I've prepared some example configs (using the original config we found the issue with, which uses some deprecated fields, as well as a config that isn't deprecated): [HERE](https://gist.github.com/SecurityInsanity/b371effff79095ba0f853cac411844a0).

If you run these configs through `--mode validate`. You will see before this patchset they unhelpfully give an error message of: `stoi` (this is because it tries to split: `https://google.com`, and turn: `//google.com` into a port, which fails).

Now with this patch included you will instead see a _more_ reasonable message of:

```
[2019-08-03 17:24:08.665][3767][critical][main] [source/server/config_validation/server.cc:58] error initializing configuration '/tmp/new-example.yaml': Proto constraint validation failed (BootstrapValidationError.StaticResources: ["embedded message failed validation"] | caused by StaticResourcesValidationError.Clusters[i]: ["embedded message failed validation"] | caused by ClusterValidationError.LoadAssignment: ["embedded message failed validation"] | caused by ClusterLoadAssignmentValidationError.Endpoints[i]: ["embedded message failed validation"] | caused by LocalityLbEndpointsValidationError.LbEndpoints[i]: ["embedded message failed validation"] | caused by LbEndpointValidationError.Endpoint: ["embedded message failed validation"] | caused by EndpointValidationError.Address: ["embedded message failed validation"] | caused by AddressValidationError.SocketAddress: ["embedded message failed validation"] | caused by SocketAddressValidationError.Address: ["value must be an ip address, or a hostname."]): static_resources {
```

The end containing the actual error message (`value must be an ip address, or a hostname`).

Ideally you have some configs you can run through to ensure no false positives if tests don't cover those.

Docs Changes: None should be needed since it's the same field, just a better error message.
Release Notes: N/A
