### PR TITLE
zk: remove explicit specifier from multi-parameter constructor

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -111,7 +111,7 @@ using DecoderPtr = std::unique_ptr<Decoder>;
 
 class DecoderImpl : public Decoder, Logger::Loggable<Logger::Id::filter> {
 public:
-  explicit DecoderImpl(DecoderCallbacks& callbacks, uint32_t max_packet_bytes)
+  DecoderImpl(DecoderCallbacks& callbacks, uint32_t max_packet_bytes)
       : callbacks_(callbacks), max_packet_bytes_(max_packet_bytes), helper_(max_packet_bytes) {}
 
   // ZooKeeperProxy::Decoder


### PR DESCRIPTION
Description: `explicit` is only needed for single-parameter constructors to avoid using it for implicit conversions. cc @rgs1 
Risk Level: low
Testing: included
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <darguetap@gmail.com>