### PR TITLE
fix portFromUrl when double protocol is provided

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -90,6 +90,11 @@ uint32_t portFromUrl(const std::string& url, const std::string& scheme,
     throw EnvoyException(fmt::format("malformed url: {}", url));
   }
 
+  size_t rcolon_index = url.rfind(':');
+  if (colon_index != rcolon_index) {
+    throw EnvoyException(fmt::format("malformed url: {}", url));
+  }
+
   try {
     return std::stoi(url.substr(colon_index + 1));
   } catch (const std::invalid_argument& e) {

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -29,6 +29,7 @@ TEST(NetworkUtility, Url) {
   EXPECT_THROW(Utility::hostFromTcpUrl("tcp://foo"), EnvoyException);
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo"), EnvoyException);
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:bar"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://https://foo:1234"), EnvoyException);
   EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:999999999999"), EnvoyException);
 }
@@ -40,6 +41,7 @@ TEST(NetworkUtility, udpUrl) {
   EXPECT_THROW(Utility::portFromUdpUrl("bogus://foo:1234"), EnvoyException);
   EXPECT_THROW(Utility::hostFromUdpUrl("tcp://foo"), EnvoyException);
   EXPECT_THROW(Utility::portFromUdpUrl("tcp://foo:1234"), EnvoyException);
+  EXPECT_THROW(Utility::portFromUdpUrl("udp://https://foo:1234"), EnvoyException);
   EXPECT_THROW(Utility::hostFromUdpUrl(""), EnvoyException);
   EXPECT_THROW(Utility::portFromUdpUrl("udp://foo:999999999999"), EnvoyException);
 }


### PR DESCRIPTION
revival of #7823 

Description:

this fixes a particular exception case where an end-user configures
a socket address to point at: `https://google.com` instead of just
the hostname: `google.com`.

instead of throwing an (stoi) error. because it can't turn:
`//google.com` into a port. we now through a slightly more sane:
`malformed url`. it isn't as good as a protoc-gen-validate message
since it's not clear why: `tcp://` gets prepended, but I think it's
digestable enough to know, you shouldn't be putting https there.
not to mention it is a step forward from: `stoi`.

Risk Level: Low

Testing:

Not only are there unit tests, but you can run through the [following configurations](https://gist.github.com/SecurityInsanity/b371effff79095ba0f853cac411844a0) and
see the new error messages.

Docs Changes: None
Release Notes: None
