### PR TITLE
Ensure the pending requests are popped before the callback is called.

### DIFF
--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -160,10 +160,10 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
 void ClientImpl::onRespValue(RespValuePtr&& value) {
   ASSERT(!pending_requests_.empty());
   PendingRequest& request = pending_requests_.front();
-  bool canceled = request.canceled_;
+  const bool canceled = request.canceled_;
   PoolCallbacks& callbacks = request.callbacks_;
 
-  // We need to ensure the request is pop before calling the callbacks, since the callbacks might
+  // We need to ensure the request is popped before calling the callback, since the callback might
   // result in closing the connection.
   pending_requests_.pop_front();
   if (canceled) {

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -160,15 +160,20 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
 void ClientImpl::onRespValue(RespValuePtr&& value) {
   ASSERT(!pending_requests_.empty());
   PendingRequest& request = pending_requests_.front();
+  bool canceled = request.canceled_;
+  PoolCallbacks& callbacks = request.callbacks_;
 
-  if (request.canceled_) {
+  // We need to ensure the request is pop before calling the callbacks, since the callbacks might
+  // result in closing the connection.
+  pending_requests_.pop_front();
+  if (canceled) {
     host_->cluster().stats().upstream_rq_cancelled_.inc();
   } else if (config_.enableRedirection() && (value->type() == Common::Redis::RespType::Error)) {
     std::vector<absl::string_view> err = StringUtil::splitToken(value->asString(), " ", false);
     bool redirected = false;
     if (err.size() == 3) {
       if (err[0] == RedirectionResponse::get().MOVED || err[0] == RedirectionResponse::get().ASK) {
-        redirected = request.callbacks_.onRedirection(*value);
+        redirected = callbacks.onRedirection(*value);
         if (redirected) {
           host_->cluster().stats().upstream_internal_redirect_succeeded_total_.inc();
         } else {
@@ -177,13 +182,11 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
       }
     }
     if (!redirected) {
-      request.callbacks_.onResponse(std::move(value));
+      callbacks.onResponse(std::move(value));
     }
   } else {
-    request.callbacks_.onResponse(std::move(value));
+    callbacks.onResponse(std::move(value));
   }
-
-  pending_requests_.pop_front();
 
   // If there are no remaining ops in the pipeline we need to disable the timer.
   // Otherwise we boost the timer since we are receiving responses and there are more to flush

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -811,6 +811,8 @@ TEST_F(RedisClientImplTest, MovedRedirectionNotEnabled) {
 }
 
 TEST_F(RedisClientImplTest, RemoveFailedHealthCheck) {
+  // This test simulates a health check response signaling traffic should be drained from the host.
+  // As a result, the health checker will close the client in the call back.
   InSequence s;
 
   setup();
@@ -840,6 +842,8 @@ TEST_F(RedisClientImplTest, RemoveFailedHealthCheck) {
 }
 
 TEST_F(RedisClientImplTest, RemoveFailedHost) {
+  // This test simulates a health check request failed due to remote host closing the connection.
+  // As a result the health checker will close the client in the call back.
   InSequence s;
 
   setup();

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -810,6 +810,60 @@ TEST_F(RedisClientImplTest, MovedRedirectionNotEnabled) {
   client_->close();
 }
 
+TEST_F(RedisClientImplTest, RemoveFailedHealthCheck) {
+  InSequence s;
+
+  setup();
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  EXPECT_CALL(*flush_timer_, enabled()).WillOnce(Return(false));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  // Each call should result in either onResponse or onFailure, never both.
+  EXPECT_CALL(callbacks1, onFailure()).Times(0);
+  EXPECT_CALL(callbacks1, onResponse_(Ref(response1)))
+      .WillOnce(Invoke([&](Common::Redis::RespValuePtr&) {
+        // The health checker might fail the active health check based on the response content, and
+        // result in removing the host and closing the client.
+        client_->close();
+      }));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer()).Times(2);
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::EXT_ORIGIN_REQUEST_SUCCESS, _));
+  callbacks_->onRespValue(std::move(response1));
+}
+
+TEST_F(RedisClientImplTest, RemoveFailedHost) {
+  InSequence s;
+
+  setup();
+
+  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
+  client_->addConnectionCallbacks(connection_callbacks);
+
+  Common::Redis::RespValue request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  EXPECT_CALL(*flush_timer_, enabled()).WillOnce(Return(false));
+  PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::LOCAL_ORIGIN_CONNECT_FAILED, _));
+  EXPECT_CALL(callbacks1, onFailure()).WillOnce(Invoke([&]() { client_->close(); }));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
 TEST(RedisClientFactoryImplTest, Basic) {
   ClientFactoryImpl factory;
   Upstream::MockHost::MockCreateConnectionData conn_info;


### PR DESCRIPTION
Description: 
When the redis healthcheck failed, the host can be ejected inline of the onRespValue.  Which will result in closing the connection and duplicated call to pop_front(), resulting in the following crash:
> #0  0x0000000000e18d68 in typeinfo for Envoy::Event::TimerImpl ()
> #1  0x000000000058aca0 in destroy<Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientImpl::PendingRequest> (this=0x31702d8, __p=0x31702e8) at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/ext/new_allocator.h:140
> #2  destroy<Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientImpl::PendingRequest> (__a=..., __p=0x31702e8) at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/alloc_traits.h:487
> #3  _M_erase (this=0x31702d8, __position=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_list.h:1815
> #4  pop_front (this=0x31702d8) at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_list.h:1104
> #5  Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientImpl::onRespValue(std::unique_ptr<Envoy::Extensions::NetworkFilters::Common::Redis::RespValue, std::default_delete<Envoy::Extensions::NetworkFilters::Common::Redis::RespValue> >&&) (this=0x3170200,
>     value=<optimized out>) at external/envoy/source/extensions/filters/network/common/redis/client_impl.cc:187
> #6  0x000000000058c00a in Envoy::Extensions::NetworkFilters::Common::Redis::DecoderImpl::parseSlice (this=0x2df6600, slice=...) at external/envoy/source/extensions/filters/network/common/redis/codec_impl.cc:400
> #7  0x000000000058bf6b in Envoy::Extensions::NetworkFilters::Common::Redis::DecoderImpl::decode (this=0x2df6600, data=...) at external/envoy/source/extensions/filters/network/common/redis/codec_impl.cc:201
> #8  0x000000000058a787 in Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientImpl::onData (this=0x3170200, data=...) at external/envoy/source/extensions/filters/network/common/redis/client_impl.cc:109
> #9  0x000000000058b27d in Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientImpl::UpstreamReadFilter::onData (this=<optimized out>, data=...)
>     at bazel-out/k8-opt/bin/external/envoy/source/extensions/filters/network/common/redis/_virtual_includes/client_lib/extensions/filters/network/common/redis/client_impl.h:81
> #10 0x0000000000695ac1 in Envoy::Network::FilterManagerImpl::onContinueReading (this=0x316f428, filter=<optimized out>, buffer_source=...) at external/envoy/source/common/network/filter_manager_impl.cc:65
> #11 0x000000000069258c in onRead (this=<optimized out>, read_buffer_size=<optimized out>) at external/envoy/source/common/network/connection_impl.cc:269
> #12 Envoy::Network::ConnectionImpl::onReadReady (this=0x316f400) at external/envoy/source/common/network/connection_impl.cc:513
> #13 0x0000000000692051 in Envoy::Network::ConnectionImpl::onFileEvent (this=0x316f400, events=<optimized out>) at external/envoy/source/common/network/connection_impl.cc:489
> #14 0x000000000068cd85 in operator() (this=0x31702e8, __args=3) at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/std_function.h:706
> #15 operator() (this=<optimized out>, what=<optimized out>, arg=0x31702d8) at external/envoy/source/common/event/file_event_impl.cc:65
> #16 Envoy::Event::FileEventImpl::assignEvents(unsigned int)::$_0::__invoke(int, short, void*) (what=<optimized out>, arg=0x31702d8) at external/envoy/source/common/event/file_event_impl.cc:49
> #17 0x000000000099590d in event_persist_closure (base=<optimized out>, ev=<optimized out>) at /root/.cache/bazel/_bazel_root/e500e327e6981ab742dbacbb6723d21d/sandbox/processwrapper-sandbox/3/execroot/envoy/external/com_github_libevent_libevent/event.c:1645
> #18 event_process_active_single_queue (base=0x2838000, activeq=0x272e360, max_to_process=2147483647, endtime=0x0)
>     at /root/.cache/bazel/_bazel_root/e500e327e6981ab742dbacbb6723d21d/sandbox/processwrapper-sandbox/3/execroot/envoy/external/com_github_libevent_libevent/event.c:1704
> #19 0x0000000000993ec0 in event_process_active (base=<optimized out>) at /root/.cache/bazel/_bazel_root/e500e327e6981ab742dbacbb6723d21d/sandbox/processwrapper-sandbox/3/execroot/envoy/external/com_github_libevent_libevent/event.c:1805
> #20 event_base_loop (base=0x2838000, flags=<optimized out>) at /root/.cache/bazel/_bazel_root/e500e327e6981ab742dbacbb6723d21d/sandbox/processwrapper-sandbox/3/execroot/envoy/external/com_github_libevent_libevent/event.c:2047
> #21 0x000000000064a431 in Envoy::Server::InstanceImpl::run (this=0x27a7000) at external/envoy/source/server/server.cc:520
> #22 0x0000000000463fa0 in Envoy::MainCommonBase::run (this=0x27960e8) at external/envoy/source/exe/main_common.cc:102
> #23 0x0000000000462ef4 in run (this=0x2796000) at bazel-out/k8-opt/bin/external/envoy/source/exe/_virtual_includes/envoy_main_common_lib/exe/main_common.h:91
> #24 main (argc=<optimized out>, argv=0x7ffffea3dc38) at external/envoy/source/exe/main.cc:39

Risk Level: Medium
Testing: Added unit tests
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
Signed-off-by: Henry Yang <hyang@lyft.com>