### PR TITLE
header_to_metadata: support coping metadata to header

### DIFF
--- a/api/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.proto
+++ b/api/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.proto
@@ -11,8 +11,8 @@ import "validate/validate.proto";
 
 // [#protodoc-title: Header-To-Metadata Filter]
 //
-// The configuration for transforming headers into metadata. This is useful
-// for matching load balancer subsets, logging, etc.
+// The configuration for transforming between headers and metadata. This is useful
+// for matching load balancer subsets, logging, sharing metadata across Envoys, etc.
 //
 // Header to Metadata :ref:`configuration overview <config_http_filters_header_to_metadata>`.
 
@@ -84,9 +84,99 @@ message Config {
     bool remove = 4;
   }
 
-  // The list of rules to apply to requests.
-  repeated Rule request_rules = 1;
+  // The list of rules to apply to requests. Use request_rules_v2 instead.
+  repeated Rule request_rules = 1 [deprecated = true];
 
-  // The list of rules to apply to responses.
-  repeated Rule response_rules = 2;
+  // The list of rules to apply to responses. Use response_rules_v2 instead.
+  repeated Rule response_rules = 2 [deprecated = true];
+
+  // A Header defines where to find a HTTP header.
+  message Header {
+    // The name of the HTTP header.
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Whether or not to remove the header after a rule is applied. This only
+    // has effect when used in source.
+    //
+    // This prevents headers from leaking.
+    bool remove = 2;
+  }
+
+  // A Metadata defines where to find a metadata value.
+  message Metadata {
+    // The namespace of the Metadata.
+    // - if this is empty, the filter's namespace will be used.
+    // - if this is "node", the envoy node metadata will be used.
+    string namespace = 1;
+
+    // The key to use within the namespace.
+    string key = 2 [(validate.rules).string.min_bytes = 1];
+
+    // The metadata value's type — defaults to string.
+    ValueType type = 3;
+  }
+
+  // A ToDestination defines how to copy a value to the destination.
+  message ToDestination {
+    // The destination that the value should be copied to.
+    oneof destination {
+      option (validate.required) = true;
+
+      // Destination in HTTP header.
+      Header header = 1;
+
+      // Destination in metadata.
+      // Note: node metadata in destination is not supported.
+      Metadata metadata = 2;
+    }
+
+    // A constant value to copy to the destination.
+    //
+    // When used for a `on_source_present` case, if value is non-empty it'll be used
+    // instead of the source. If both are empty, nothing will be copied to the destination.
+    //
+    // When used for a `on_source_missing` case, a non-empty value must be provided
+    // otherwise nothing will be copied to the destination.
+    string value = 3;
+
+    // Decode the value before copying to the destination, default is NONE (not decoded).
+    // This happens before encode (if present).
+    ValueEncode decode = 4;
+
+    // Encode the value before copying to the destination, default is NONE (not encoded).
+    // This happens after decode (if present).
+    ValueEncode encode = 5;
+  }
+
+  // A RuleV2 defines what ToDestination to apply when a source is present or missing.
+  message RuleV2 {
+    // The source that triggers this rule - required.
+    oneof source {
+      option (validate.required) = true;
+
+      // Source value from the HTTP header.
+      Header header = 1;
+
+      // Source value from metadata.
+      Metadata metadata = 2;
+    }
+
+    // If the source is present, apply the ToDestination.
+    //
+    // If the value in the ToDestination is non-empty, it'll be used instead
+    // of the source.
+    ToDestination on_source_present = 3;
+
+    // If the source is not present, apply the ToDestination.
+    //
+    // The value in the ToDestination must be set, since it'll be used in lieu
+    // of the missing source.
+    ToDestination on_source_missing = 4;
+  }
+
+  // The list of V2 rules to apply to requests.
+  repeated RuleV2 request_rules_v2 = 3;
+
+  // The list of V2 rules to apply to responses.
+  repeated RuleV2 response_rules_v2 = 4;
 }

--- a/api/envoy/config/filter/http/metadata_to_header/v2alpha/BUILD
+++ b/api/envoy/config/filter/http/metadata_to_header/v2alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "metadata_to_header",
+    srcs = ["metadata_to_header.proto"],
+    deps = [],
+)

--- a/api/envoy/config/filter/http/metadata_to_header/v2alpha/metadata_to_header.proto
+++ b/api/envoy/config/filter/http/metadata_to_header/v2alpha/metadata_to_header.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.metadata_to_header.v2alpha;
+
+option java_outer_classname = "MetadataToHeaderProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.metadata_to_header.v2alpha";
+option go_package = "v2alpha";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Metadata-To-Header Filter]
+//
+// The configuration for transforming metadata into header. This is useful for
+// exchanging metadata across Envoys.
+
+message Config {
+  // ValueType defines the type of the metadata value.
+  enum ValueType {
+    STRING = 0;
+    NUMBER = 1;
+
+    // The value is a serialized `protobuf.Value
+    // <https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto#L62>`_.
+    PROTOBUF_VALUE = 2;
+  }
+
+  // ValueEncode defines the encoding algorithm.
+  enum ValueEncode {
+    // The value is not encoded.
+    NONE = 0;
+
+    // The value is encoded in `Base64 <https://tools.ietf.org/html/rfc4648#section-4>`_.
+    // Note: this is mostly used for STRING and PROTOBUF_VALUE to escape the
+    // non-ASCII characters in the header.
+    BASE64 = 1;
+  }
+
+  // A HeaderValuePair defines the header and metadata value pair.
+  message HeaderValuePair {
+    // The header to store the value.
+    string header = 1 [(validate.rules).string.min_bytes = 1];
+
+    // The value to pair with the given key.
+    //
+    // When used for a `on_metadata_present` case, if value is non-empty it'll be used
+    // instead of the metadata value. If both are empty, no header is added.
+    //
+    // When used for a `on_metadata_missing` case, a non-empty value must be provided
+    // otherwise no header is added.
+    string value = 2;
+
+    // The metadata value's type — defaults to string.
+    ValueType type = 3;
+
+    // How is the value encoded, default is NONE (not encoded).
+    // The value will be encoded accordingly before storing to header.
+    ValueEncode encode = 4;
+  }
+
+  // A Metadata defines where to find the metadata value.
+  message Metadata {
+    // The namespace of the dynamic metadata - if this is empty, the node metadata
+    // will be used.
+    string namespace = 1;
+
+    // The key to use within the namespace.
+    string key = 2 [(validate.rules).string.min_bytes = 1];
+  }
+
+  // A Rule defines what header to add when a metadata is present or missing.
+  message Rule {
+    // The metadata to be copied to the header.
+    Metadata metadata = 1;
+
+    // If the metadata is present, apply this HeaderValuePair.
+    //
+    // If the value in the HeaderValuePair is non-empty, it'll be used instead
+    // of the metadata value.
+    HeaderValuePair on_metadata_present = 2;
+
+    // If the metadata is not present, apply this HeaderValuePair.
+    //
+    // The value in the HeaderValuePair must be set, since it'll be used in lieu
+    // of the missing metadata value.
+    HeaderValuePair on_metadata_missing = 3;
+
+    // Whether or not to remove the metadata after a rule is applied.
+    // Only supports dynamic metadata and has no effect on node metadata.
+    bool remove = 4;
+  }
+
+  // The list of rules to apply to requests.
+  repeated Rule request_rules = 1;
+
+  // The list of rules to apply to responses.
+  repeated Rule response_rules = 2;
+}


### PR DESCRIPTION
For the 2nd point in https://github.com/envoyproxy/envoy/issues/7771

@lizan @kyessenov @rgs1 @zuercher @mattklein123 @htuch 
Before working on the actual code change, I would like to get agreements on the API for this. PTAL and let me know what do you think, thank you.

- Option 1
  The [commit](https://github.com/envoyproxy/envoy/commit/81aa376d943dfc836e62f27a0116615180ccb98c) adds a new standalone metadata_to_header filter
  - Pros
    - Cleaner, we don't need to deprecate any thing in the header_to_metadata filter.
  - Cons
    - Duplicate the current filter API and implementation.

- Option 2
  The [commit](https://github.com/envoyproxy/envoy/commit/bdc9dfab6979d5ad979259e5497ba477781bc621) incrementally change the header_to_metadata API by deprecating the old fields.
  - Pros
    - Reuse the current filter API and implementation
    - More powerful as we can support the case for header-to-header and metadata-to-metadata, but not sure if this will be useful.
  - Cons
    - Need to deprecate the current header_to_metadata API.

- Other options
  Please let me know if you have suggestions for other options, thank you.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level: Low
Testing: N/A (will add after API approved)
Docs Changes: N/A (will add after API approved)
Release Notes: N/A (will add after API approved)
[Optional Fixes #Issue]
[Optional Deprecated:]
