### PR TITLE
access_log: Add %REQ_WITHOUT_QUERY()% formatter

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -296,6 +296,19 @@ The following command operators are supported:
   TCP
     Not implemented ("-").
 
+%REQ_WITHOUT_QUERY(X?Y):Z%
+  HTTP
+    Same as **%REQ(X?Y):Z%** but it removes query string from a header entry value.
+    For example, for the following header entry:
+
+    ``":path" : "/?ok=true"``
+
+    * ``%REQ(:PATH)%`` will log: ``/?ok=true``
+    * ``%REQ_WITHOUT_QUERY(:PATH)%`` will log: ``/``
+
+  TCP
+    Not implemented ("-").
+
 %RESP(X?Y):Z%
   HTTP
     Same as **%REQ(X?Y):Z%** but taken from HTTP response headers.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.12.0 (pending)
 ================
 * access log: added :ref:`buffering <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_size_bytes>` and :ref:`periodical flushing <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_flush_interval>` support to gRPC access logger. Defaults to 16KB buffer and flushing every 1 second.
+* access log: added %REQ_WITHOUT_QUERY(X?Y):Z formatter to remove query string from a header entry value.
 * admin: added ability to configure listener :ref:`socket options <envoy_api_field_config.bootstrap.v2.Admin.socket_options>`.
 * admin: added config dump support for Secret Discovery Service :ref:`SecretConfigDump <envoy_api_msg_admin.v2alpha.SecretsConfigDump>`.
 * config: added access log :ref:`extension filter<envoy_api_field_config.filter.accesslog.v2.AccessLogFilter.extension_filter>`.

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -61,8 +61,10 @@ private:
 
   // the indexes of where the parameters for each directive is expected to begin
   static const size_t ReqParamStart{sizeof("REQ(") - 1};
+  static const size_t ReqWithoutQueryParamStart{sizeof("REQ_WITHOUT_QUERY(") - 1};
   static const size_t RespParamStart{sizeof("RESP(") - 1};
   static const size_t TrailParamStart{sizeof("TRAILER(") - 1};
+  static const size_t DynamicMetadataParamStart{sizeof("DYNAMIC_METADATA(") - 1};
   static const size_t StartTimeParamStart{sizeof("START_TIME(") - 1};
 };
 
@@ -137,7 +139,7 @@ private:
 class HeaderFormatter {
 public:
   HeaderFormatter(const std::string& main_header, const std::string& alternative_header,
-                  absl::optional<size_t> max_length);
+                  absl::optional<size_t> max_length, bool remove_query);
 
   std::string format(const Http::HeaderMap& headers) const;
 
@@ -145,6 +147,7 @@ private:
   Http::LowerCaseString main_header_;
   Http::LowerCaseString alternative_header_;
   absl::optional<size_t> max_length_;
+  const bool remove_query_;
 };
 
 /**
@@ -153,7 +156,7 @@ private:
 class RequestHeaderFormatter : public FormatterProvider, HeaderFormatter {
 public:
   RequestHeaderFormatter(const std::string& main_header, const std::string& alternative_header,
-                         absl::optional<size_t> max_length);
+                         absl::optional<size_t> max_length, bool remove_query);
 
   // Formatter::format
   std::string format(const Http::HeaderMap& request_headers, const Http::HeaderMap&,


### PR DESCRIPTION
Description: 
This patch adds `%REQ_WITHOUT_QUERY(X?Y):Z%` formatter to facilitate removing query string from a request header entry value. This is an attempt to fix #7583.

Also modified the metadata else-if case to match the style with other cases.

Risk Level: Low, newly added
Testing: Added unit tests
Docs Changes: Added
Release Notes: Added
Fixes #7583 

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>