### PR TITLE
buffer filter: Populate content-length header

### DIFF
--- a/docs/root/configuration/http_filters/buffer_filter.rst
+++ b/docs/root/configuration/http_filters/buffer_filter.rst
@@ -7,6 +7,9 @@ The buffer filter is used to stop filter iteration and wait for a fully buffered
 This is useful in different situations including protecting some applications from having to deal
 with partial requests and high network latency.
 
+If enabled the buffer filter populates content-length header if it is not present in the request
+already.
+
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.buffer.v2.Buffer>`
 * This filter should be configured with the name *envoy.buffer*.
 

--- a/docs/root/configuration/http_filters/buffer_filter.rst
+++ b/docs/root/configuration/http_filters/buffer_filter.rst
@@ -8,7 +8,8 @@ This is useful in different situations including protecting some applications fr
 with partial requests and high network latency.
 
 If enabled the buffer filter populates content-length header if it is not present in the request
-already.
+already. The behavior can be disabled using the runtime feature
+`envoy.reloadable_features.buffer_filter_populate_content_length`.
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.buffer.v2.Buffer>`
 * This filter should be configured with the name *envoy.buffer*.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,7 +6,7 @@ Version history
 * access log: added :ref:`buffering <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_size_bytes>` and :ref:`periodical flushing <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_flush_interval>` support to gRPC access logger. Defaults to 16KB buffer and flushing every 1 second.
 * admin: added ability to configure listener :ref:`socket options <envoy_api_field_config.bootstrap.v2.Admin.socket_options>`.
 * admin: added config dump support for Secret Discovery Service :ref:`SecretConfigDump <envoy_api_msg_admin.v2alpha.SecretsConfigDump>`.
-* buffer filter: the buffer filter populates content-length header if not present, behavior can be disabled using the runtime feature `envoy.reloadable_features.buffer_populate_content_length`.
+* buffer filter: the buffer filter populates content-length header if not present, behavior can be disabled using the runtime feature `envoy.reloadable_features.buffer_filter_populate_content_length`.
 * config: added access log :ref:`extension filter<envoy_api_field_config.filter.accesslog.v2.AccessLogFilter.extension_filter>`.
 * config: async data access for local and remote data source.
 * config: changed the default value of :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>` from 0s to 15s. This is a change in behaviour in the sense that Envoy will move to the next initialization phase, even if the first config is not delivered in 15s. Refer to :ref:`initialization process <arch_overview_initialization>` for more details.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,7 @@ Version history
 * access log: added :ref:`buffering <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_size_bytes>` and :ref:`periodical flushing <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_flush_interval>` support to gRPC access logger. Defaults to 16KB buffer and flushing every 1 second.
 * admin: added ability to configure listener :ref:`socket options <envoy_api_field_config.bootstrap.v2.Admin.socket_options>`.
 * admin: added config dump support for Secret Discovery Service :ref:`SecretConfigDump <envoy_api_msg_admin.v2alpha.SecretsConfigDump>`.
+* buffer filter: the buffer filter populates content-length header if not present, behavior can be disabled using the runtime feature `envoy.reloadable_features.buffer_populate_content_length`.
 * config: added access log :ref:`extension filter<envoy_api_field_config.filter.accesslog.v2.AccessLogFilter.extension_filter>`.
 * config: async data access for local and remote data source.
 * config: changed the default value of :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>` from 0s to 15s. This is a change in behaviour in the sense that Envoy will move to the next initialization phase, even if the first config is not delivered in 15s. Refer to :ref:`initialization process <arch_overview_initialization>` for more details.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -25,6 +25,7 @@ namespace Runtime {
 constexpr const char* runtime_features[] = {
     // Enabled
     "envoy.reloadable_features.test_feature_true",
+    "envoy.reloadable_features.buffer_populate_content_length",
 };
 
 // This is a list of configuration fields which are disallowed by default in Envoy

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -25,7 +25,7 @@ namespace Runtime {
 constexpr const char* runtime_features[] = {
     // Enabled
     "envoy.reloadable_features.test_feature_true",
-    "envoy.reloadable_features.buffer_populate_content_length",
+    "envoy.reloadable_features.buffer_filter_populate_content_length",
 };
 
 // This is a list of configuration fields which are disallowed by default in Envoy

--- a/source/extensions/filters/http/buffer/BUILD
+++ b/source/extensions/filters/http/buffer/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/runtime:runtime_lib",
         "//source/extensions/filters/http:well_known_names",
         "@envoy_api//envoy/config/filter/http/buffer/v2:buffer_cc",
     ],

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -79,9 +79,11 @@ Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap& headers, 
 Http::FilterDataStatus BufferFilter::decodeData(Buffer::Instance& data, bool end_stream) {
   content_length_ += data.length();
   if (end_stream || settings_->disabled()) {
+    // request_headers_ is initialized iff plugin is enabled.
     if (request_headers_ != nullptr && request_headers_->ContentLength() == nullptr) {
+      ASSERT(!settings_->disabled());
       if (Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.buffer_populate_content_length")) {
+              "envoy.reloadable_features.buffer_filter_populate_content_length")) {
         request_headers_->insertContentLength().value(content_length_);
       }
     }

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -9,6 +9,7 @@
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
+#include "common/runtime/runtime_impl.h"
 
 #include "extensions/filters/http/well_known_names.h"
 
@@ -57,7 +58,7 @@ void BufferFilter::initConfig() {
   settings_ = route_local ? route_local : settings_;
 }
 
-Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap&, bool end_stream) {
+Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap& headers, bool end_stream) {
   if (end_stream) {
     // If this is a header-only request, we don't need to do any buffering.
     return Http::FilterHeadersStatus::Continue;
@@ -70,12 +71,20 @@ Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap&, bool end
   }
 
   callbacks_->setDecoderBufferLimit(settings_->maxRequestBytes());
+  request_headers_ = &headers;
 
   return Http::FilterHeadersStatus::StopIteration;
 }
 
-Http::FilterDataStatus BufferFilter::decodeData(Buffer::Instance&, bool end_stream) {
+Http::FilterDataStatus BufferFilter::decodeData(Buffer::Instance& data, bool end_stream) {
+  content_length_ += data.length();
   if (end_stream || settings_->disabled()) {
+    if (request_headers_ != nullptr && request_headers_->ContentLength() == nullptr) {
+      if (Runtime::runtimeFeatureEnabled(
+              "envoy.reloadable_features.buffer_populate_content_length")) {
+        request_headers_->insertContentLength().value(content_length_);
+      }
+    }
     return Http::FilterDataStatus::Continue;
   }
 

--- a/source/extensions/filters/http/buffer/buffer_filter.h
+++ b/source/extensions/filters/http/buffer/buffer_filter.h
@@ -65,6 +65,8 @@ private:
   BufferFilterConfigSharedPtr config_;
   const BufferFilterSettings* settings_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
+  Http::HeaderMap* request_headers_{};
+  uint64_t content_length_{};
   bool config_initialized_{};
 };
 

--- a/test/extensions/filters/http/buffer/BUILD
+++ b/test/extensions/filters/http/buffer/BUILD
@@ -22,6 +22,10 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/buffer:buffer_filter_lib",
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/init:init_mocks",
+        "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/protobuf:protobuf_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
     ],
 )

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -36,6 +36,27 @@ TEST_P(BufferIntegrationTest, RouterRequestAndResponseWithZeroByteBodyBuffer) {
   testRouterRequestAndResponseWithBody(0, 0, false);
 }
 
+TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
+  config_helper_.addFilter(ConfigHelper::DEFAULT_BUFFER_FILTER);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(Http::TestHeaderMapImpl{
+      {":method", "POST"}, {":scheme", "http"}, {":path", "/shelf"}, {":authority", "host"}});
+  request_encoder_ = &encoder_decoder.first;
+  IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
+  codec_client_->sendData(*request_encoder_, "123", false);
+  codec_client_->sendData(*request_encoder_, "456", false);
+  codec_client_->sendData(*request_encoder_, "789", true);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  auto* content_length = upstream_request_->headers().ContentLength();
+  ASSERT_NE(content_length, nullptr);
+  EXPECT_EQ(atoi(std::string(content_length->value().getStringView()).c_str()), 9);
+}
+
 TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
   config_helper_.addFilter(ConfigHelper::SMALL_BUFFER_FILTER);
   initialize();

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -54,7 +54,9 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
   auto* content_length = upstream_request_->headers().ContentLength();
   ASSERT_NE(content_length, nullptr);
-  EXPECT_EQ(atoi(std::string(content_length->value().getStringView()).c_str()), 9);
+  EXPECT_EQ(content_length->value().getStringView(), "9");
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
 }
 
 TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -147,7 +147,7 @@ TEST_F(BufferFilterTest, ContentLengthPopulationAlreadyPresent) {
 TEST_F(BufferFilterTest, ContentLengthPopulationRuntimeGuard) {
   InSequence s;
   Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.reloadable_features.buffer_populate_content_length", "false"}});
+      {{"envoy.reloadable_features.buffer_filter_populate_content_length", "false"}});
 
   Http::TestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -5,12 +5,18 @@
 #include "envoy/event/dispatcher.h"
 
 #include "common/http/header_map_impl.h"
+#include "common/runtime/runtime_impl.h"
 
 #include "extensions/filters/http/buffer/buffer_filter.h"
 #include "extensions/filters/http/well_known_names.h"
 
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/init/mocks.h"
+#include "test/mocks/local_info/mocks.h"
+#include "test/mocks/protobuf/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/printers.h"
 
 #include "gmock/gmock.h"
@@ -38,6 +44,14 @@ public:
 
   BufferFilterTest() : config_(setupConfig()), filter_(config_) {
     filter_.setDecoderFilterCallbacks(callbacks_);
+
+    // Create a runtime loader, so that tests can manually manipulate runtime
+    // guarded features.
+    envoy::config::bootstrap::v2::LayeredRuntime config;
+    config.add_layers()->mutable_admin_layer();
+    loader_ = std::make_unique<Runtime::ScopedLoaderSingleton>(Runtime::LoaderPtr{
+        new Runtime::LoaderImpl(dispatcher_, tls_, config, local_info_, init_manager_, store_,
+                                generator_, validation_visitor_, *api_)});
   }
 
   void routeLocalConfig(const Router::RouteSpecificFilterConfig* route_settings,
@@ -52,6 +66,15 @@ public:
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   BufferFilterConfigSharedPtr config_;
   BufferFilter filter_;
+  Event::MockDispatcher dispatcher_;
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  Stats::IsolatedStoreImpl store_;
+  Runtime::MockRandomGenerator generator_;
+  Api::ApiPtr api_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  Init::MockManager init_manager_;
+  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
+  std::unique_ptr<Runtime::ScopedLoaderSingleton> loader_;
 };
 
 TEST_F(BufferFilterTest, HeaderOnlyRequest) {
@@ -92,6 +115,46 @@ TEST_F(BufferFilterTest, TxResetAfterEndStream) {
   // It's possible that the stream will be reset on the TX side even after RX end stream. Mimic
   // that here.
   filter_.onDestroy();
+}
+
+TEST_F(BufferFilterTest, ContentLengthPopulation) {
+  InSequence s;
+
+  Http::TestHeaderMapImpl headers;
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data1("hello");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.decodeData(data1, false));
+
+  Buffer::OwnedImpl data2(" world");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data2, true));
+  ASSERT_NE(headers.ContentLength(), nullptr);
+  EXPECT_EQ(headers.ContentLength()->value().getStringView(), "11");
+}
+
+TEST_F(BufferFilterTest, ContentLengthPopulationAlreadyPresent) {
+  InSequence s;
+
+  Http::TestHeaderMapImpl headers{{"content-length", "3"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data("foo");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, true));
+  ASSERT_NE(headers.ContentLength(), nullptr);
+  EXPECT_EQ(headers.ContentLength()->value().getStringView(), "3");
+}
+
+TEST_F(BufferFilterTest, ContentLengthPopulationRuntimeGuard) {
+  InSequence s;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.buffer_populate_content_length", "false"}});
+
+  Http::TestHeaderMapImpl headers;
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data("foo");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, true));
+  EXPECT_EQ(headers.ContentLength(), nullptr);
 }
 
 TEST_F(BufferFilterTest, RouteConfigOverride) {

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -42,7 +42,7 @@ public:
     return std::make_shared<BufferFilterConfig>(proto_config);
   }
 
-  BufferFilterTest() : config_(setupConfig()), filter_(config_) {
+  BufferFilterTest() : config_(setupConfig()), filter_(config_), api_(Api::createApiForTest()) {
     filter_.setDecoderFilterCallbacks(callbacks_);
 
     // Create a runtime loader, so that tests can manually manipulate runtime


### PR DESCRIPTION
Description: Make buffer filter populate `content-length` header if it is not present in the request already. As buffer has to fetch the whole request in order to proceed, calculation of the header value involves mostly no extra cost.
Risk Level: MEDIUM
Testing: added unit and integration tests
Docs Changes: added section about new behavior around `content-length` header
Release Notes: updated
Fixes #7844
