### PR TITLE
Patch in ecf04cc and 49f0fb9 from gRPC.

### DIFF
--- a/bazel/grpc-protoinfo-1.patch
+++ b/bazel/grpc-protoinfo-1.patch
@@ -1,0 +1,56 @@
+commit 49f0fb9035120d0f5b5fa49846324c0b2d59c257
+Author: Marcel Hlopko <hlopko@google.com>
+Date:   Thu Jun 20 18:55:56 2019 +0200
+
+    Migrate from dep.proto to dep[ProtoInfo]
+
+diff --git a/WORKSPACE b/WORKSPACE
+index 2db3c5db2f..60582d1a0f 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -20,7 +20,7 @@ register_toolchains(
+ 
+ git_repository(
+     name = "io_bazel_rules_python",
+-    commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
++    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
+     remote = "https://github.com/bazelbuild/rules_python.git",
+ )
+ 
+diff --git a/bazel/generate_cc.bzl b/bazel/generate_cc.bzl
+index b7edcda702..581165a190 100644
+--- a/bazel/generate_cc.bzl
++++ b/bazel/generate_cc.bzl
+@@ -41,11 +41,11 @@ def _join_directories(directories):
+ 
+ def generate_cc_impl(ctx):
+     """Implementation of the generate_cc rule."""
+-    protos = [f for src in ctx.attr.srcs for f in src.proto.check_deps_sources.to_list()]
++    protos = [f for src in ctx.attr.srcs for f in src[ProtoInfo].check_deps_sources.to_list()]
+     includes = [
+         f
+         for src in ctx.attr.srcs
+-        for f in src.proto.transitive_imports.to_list()
++        for f in src[ProtoInfo].transitive_imports.to_list()
+     ]
+     outs = []
+     proto_root = get_proto_root(
+diff --git a/bazel/python_rules.bzl b/bazel/python_rules.bzl
+index 17004f3474..3df30f8262 100644
+--- a/bazel/python_rules.bzl
++++ b/bazel/python_rules.bzl
+@@ -28,12 +28,12 @@ def _get_staged_proto_file(context, source_file):
+ def _generate_py_impl(context):
+     protos = []
+     for src in context.attr.deps:
+-        for file in src.proto.direct_sources:
++        for file in src[ProtoInfo].direct_sources:
+             protos.append(_get_staged_proto_file(context, file))
+     includes = [
+         file
+         for src in context.attr.deps
+-        for file in src.proto.transitive_imports.to_list()
++        for file in src[ProtoInfo].transitive_imports.to_list()
+     ]
+     proto_root = get_proto_root(context.label.workspace_root)
+     format_str = (_GENERATED_GRPC_PROTO_FORMAT if context.executable.plugin else _GENERATED_PROTO_FORMAT)

--- a/bazel/grpc-protoinfo-2.patch
+++ b/bazel/grpc-protoinfo-2.patch
@@ -1,0 +1,32 @@
+commit ecf04ccf4d8be9378166ec9e0ccf44081e211d11
+Author: Marcel Hlopko <hlopko@google.com>
+Date:   Thu Jun 20 18:57:33 2019 +0200
+
+    Require ProtoInfo in attributes, not "proto"
+
+diff --git a/bazel/generate_cc.bzl b/bazel/generate_cc.bzl
+index 581165a190..87e8b9d329 100644
+--- a/bazel/generate_cc.bzl
++++ b/bazel/generate_cc.bzl
+@@ -146,7 +146,7 @@ _generate_cc = rule(
+         "srcs": attr.label_list(
+             mandatory = True,
+             allow_empty = False,
+-            providers = ["proto"],
++            providers = [ProtoInfo],
+         ),
+         "plugin": attr.label(
+             executable = True,
+diff --git a/bazel/python_rules.bzl b/bazel/python_rules.bzl
+index 3df30f8262..d4ff77094c 100644
+--- a/bazel/python_rules.bzl
++++ b/bazel/python_rules.bzl
+@@ -99,7 +99,7 @@ __generate_py = rule(
+         "deps": attr.label_list(
+             mandatory = True,
+             allow_empty = False,
+-            providers = ["proto"],
++            providers = [ProtoInfo],
+         ),
+         "plugin": attr.label(
+             executable = True,

--- a/bazel/grpc-protoinfo-3.patch
+++ b/bazel/grpc-protoinfo-3.patch
@@ -1,0 +1,31 @@
+commit e2ba3aa07009292617c3cabe734e8e44099b22ac
+Author: Lukacs T. Berki <lberki@google.com>
+Date:   Tue Aug 6 14:00:11 2019 +0200
+
+    Update C++ code generation to work with Bazel 0.29 .
+    
+    The above Bazel version changes proto compilation slightly: some proto
+    files are put into a `_virtual_imports` directory and thus
+    `_get_include_directory` needs to be updated accordingly.
+    
+    Ideally, it would use instead the `ProtoInfo` provider to tease out the
+    proto import directories, but that's a bit more intrusive change.
+
+diff --git a/bazel/protobuf.bzl b/bazel/protobuf.bzl
+index f2df7bd87b..3066e1d550 100644
+--- a/bazel/protobuf.bzl
++++ b/bazel/protobuf.bzl
+@@ -59,6 +59,13 @@ def proto_path_to_generated_filename(proto_path, fmt_str):
+ def _get_include_directory(include):
+     directory = include.path
+     prefix_len = 0
++
++    virtual_imports = "/_virtual_imports/"
++    if not include.is_source and virtual_imports in include.path:
++        root, relative = include.path.split(virtual_imports, 2)
++        result = root + virtual_imports + relative.split("/", 1)[0]
++        return result
++
+     if not include.is_source and directory.startswith(include.root.path):
+         prefix_len = len(include.root.path) + 1
+ 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -596,7 +596,14 @@ def _com_googlesource_quiche():
     )
 
 def _com_github_grpc_grpc():
-    _repository_impl("com_github_grpc_grpc")
+    _repository_impl(
+        "com_github_grpc_grpc",
+        patches = [
+            "@envoy//bazel:grpc-protoinfo-1.patch",
+            "@envoy//bazel:grpc-protoinfo-2.patch",
+        ],
+        patch_args = ["-p1"],
+    )
 
     # Rebind some stuff to match what the gRPC Bazel is expecting.
     native.bind(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -599,6 +599,7 @@ def _com_github_grpc_grpc():
     _repository_impl(
         "com_github_grpc_grpc",
         patches = [
+            # Workaround for https://github.com/envoyproxy/envoy/issues/7863
             "@envoy//bazel:grpc-protoinfo-1.patch",
             "@envoy//bazel:grpc-protoinfo-2.patch",
         ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -602,6 +602,8 @@ def _com_github_grpc_grpc():
             # Workaround for https://github.com/envoyproxy/envoy/issues/7863
             "@envoy//bazel:grpc-protoinfo-1.patch",
             "@envoy//bazel:grpc-protoinfo-2.patch",
+            # Pre-integration of https://github.com/grpc/grpc/pull/19860
+            "@envoy//bazel:grpc-protoinfo-3.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
This is so that Envoy keeps building with the --incompatible_disable_legacy_proto_provider command line option of Bazel which is to be flipped in 1.0 .

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
