### PR TITLE
lua: Allow to set header entry as table to httpCall and respond APIs

### DIFF
--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -109,7 +109,8 @@ more details on the supported API.
     {
       [":method"] = "POST",
       [":path"] = "/",
-      [":authority"] = "lua_cluster"
+      [":authority"] = "lua_cluster",
+      ["set-cookie"] = { "lang=lua; Path=/", "type=binding; Path=/" }
     },
     "hello world",
     5000)
@@ -236,9 +237,9 @@ httpCall()
 
 Makes an HTTP call to an upstream host. Envoy will yield the script until the call completes or
 has an error. *cluster* is a string which maps to a configured cluster manager cluster. *headers*
-is a table of key/value pairs to send. Note that the *:method*, *:path*, and *:authority* headers
-must be set. *body* is an optional string of body data to send. *timeout* is an integer that
-specifies the call timeout in milliseconds.
+is a table of key/value pairs to send (the value can be a string or table of strings). Note that
+the *:method*, *:path*, and *:authority* headers must be set. *body* is an optional string of body
+data to send. *timeout* is an integer that specifies the call timeout in milliseconds.
 
 Returns *headers* which is a table of response headers. Returns *body* which is the string response
 body. May be nil if there is no body.
@@ -264,8 +265,9 @@ passed to subsequent filters. Meaning, the following Lua code is invalid:
     end
   end
 
-*headers* is a table of key/value pairs to send. Note that the *:status* header
-must be set. *body* is a string and supplies the optional response body. May be nil.
+*headers* is a table of key/value pairs to send (the value can be a string or table of strings).
+Note that the *:status* header must be set. *body* is a string and supplies the optional response
+body. May be nil.
 
 metadata()
 ^^^^^^^^^^
@@ -316,10 +318,10 @@ importPublicKey()
 ^^^^^^^^^^^^^^^^^
 
 .. code-block:: lua
-  
+
   pubkey = handle:importPublicKey(keyder, keyderLength)
 
-Returns public key which is used by :ref:`verifySignature <verify_signature>` to verify digital signature. 
+Returns public key which is used by :ref:`verifySignature <verify_signature>` to verify digital signature.
 
 .. _verify_signature:
 
@@ -330,13 +332,13 @@ verifySignature()
 
   ok, error = verifySignature(hashFunction, pubkey, signature, signatureLength, data, dataLength)
 
-Verify signature using provided parameters. *hashFunction* is the variable for hash function which be used 
-for verifying signature. *SHA1*, *SHA224*, *SHA256*, *SHA384* and *SHA512* are supported. 
-*pubkey* is the public key. *signature* is the signature to be verified. *signatureLength* is 
+Verify signature using provided parameters. *hashFunction* is the variable for hash function which be used
+for verifying signature. *SHA1*, *SHA224*, *SHA256*, *SHA384* and *SHA512* are supported.
+*pubkey* is the public key. *signature* is the signature to be verified. *signatureLength* is
 the length of the signature. *data* is the content which will be hashed. *dataLength* is the length of data.
 
 The function returns a pair. If the first element is *true*, the second element will be empty
-which means signature is verified; otherwise, the second element will store the error message. 
+which means signature is verified; otherwise, the second element will store the error message.
 
 .. _config_http_filters_lua_header_wrapper:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,7 +16,7 @@ Version history
 * http: added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature `envoy.reloadable_features.strict_header_validation`.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
-* lua: extended `httpCall()` and `respond()` APIs to accept headers with entry value that can be string or table of strings.
+* lua: extended `httpCall()` and `respond()` APIs to accept headers with entry values that can be a string or table of strings.
 * router: added :ref:`rq_retry_skipped_request_not_complete <config_http_filters_router_stats>` counter stat to router stats.
 * router check tool: add coverage reporting & enforcement.
 * tls: added verification of IP address SAN fields in certificates against configured SANs in the

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,6 +16,7 @@ Version history
 * http: added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature `envoy.reloadable_features.strict_header_validation`.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
+* lua: extended `httpCall()` and `respond()` APIs to accept headers with entry value that can be string or table of strings.
 * router: added :ref:`rq_retry_skipped_request_not_complete <config_http_filters_router_stats>` counter stat to router stats.
 * router check tool: add coverage reporting & enforcement.
 * tls: added verification of IP address SAN fields in certificates against configured SANs in the

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -331,6 +331,7 @@ private:
   HEADER_FUNC(RequestId)                                                                           \
   HEADER_FUNC(Scheme)                                                                              \
   HEADER_FUNC(Server)                                                                              \
+  HEADER_FUNC(SetCookie)                                                                           \
   HEADER_FUNC(Status)                                                                              \
   HEADER_FUNC(TE)                                                                                  \
   HEADER_FUNC(TransferEncoding)                                                                    \

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -331,7 +331,6 @@ private:
   HEADER_FUNC(RequestId)                                                                           \
   HEADER_FUNC(Scheme)                                                                              \
   HEADER_FUNC(Server)                                                                              \
-  HEADER_FUNC(SetCookie)                                                                           \
   HEADER_FUNC(Status)                                                                              \
   HEADER_FUNC(TE)                                                                                  \
   HEADER_FUNC(TransferEncoding)                                                                    \

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -772,7 +772,8 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
                           {":path", "/"},
                           {":method", "POST"},
                           {":authority", "foo"},
-                          {"set-cookie", "flavor=chocolate; Path=/,variant=chewy; Path=/"},
+                          {"set-cookie", "flavor=chocolate; Path=/"},
+                          {"set-cookie", "variant=chewy; Path=/"},
                           {"content-length", "11"}}),
                       message->headers());
             callbacks = &cb;
@@ -994,8 +995,9 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
 
   Http::MessagePtr response_message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  Http::TestHeaderMapImpl expected_headers{
-      {":status", "403"}, {"set-cookie", "flavor=chocolate; Path=/,variant=chewy; Path=/"}};
+  Http::TestHeaderMapImpl expected_headers{{":status", "403"},
+                                           {"set-cookie", "flavor=chocolate; Path=/"},
+                                           {"set-cookie", "variant=chewy; Path=/"}};
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
   callbacks->onSuccess(std::move(response_message));
 }

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -768,13 +768,12 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
-                          {":path", "/"},
-                          {":method", "POST"},
-                          {":authority", "foo"},
-                          {"set-cookie", "flavor=chocolate; Path=/"},
-                          {"set-cookie", "variant=chewy; Path=/"},
-                          {"content-length", "11"}}),
+            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
+                                               {":method", "POST"},
+                                               {":authority", "foo"},
+                                               {"set-cookie", "flavor=chocolate; Path=/"},
+                                               {"set-cookie", "variant=chewy; Path=/"},
+                                               {"content-length", "11"}}),
                       message->headers());
             callbacks = &cb;
             return &request;


### PR DESCRIPTION
Description: Extends `httpCall()` and `respond()` APIs to accept headers with values that can be strings or table of strings. 

Risk Level: Low
Testing: Modified the existing unit tests
Docs Changes: Added
Release Notes: Added
Fixes #7742

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
