### PR TITLE
Wip: Add multi-connection support in H2 conn pool.

### DIFF
--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -36,6 +36,8 @@ public:
   bool hasActiveConnections() const override;
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; };
   const Upstream::ResourcePriority& resourcePriority() const { return priority_; };
+  ConnectionPool::Cancellable* newStream(Http::StreamDecoder& response_decoder,
+                                         ConnectionPool::Callbacks& callbacks) override;
 
 protected:
   struct ActiveClient : LinkedObject<ActiveClient>,
@@ -103,9 +105,6 @@ protected:
                              ConnectionPool::Callbacks& callbacks);
   void createNewConnection();
   void onUpstreamReady(ActiveClient& client);
-  ConnectionPool::Cancellable* newStream(Http::StreamDecoder& response_decoder,
-                                         ConnectionPool::Callbacks& callbacks) override;
-
   void applyToEachClient(std::list<ActiveClientPtr>& client_list,
                          const std::function<void(const ActiveClientPtr&)>& fn);
   Stats::TimespanPtr conn_connect_ms_;

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -151,8 +151,6 @@ protected:
   // Connections remain in this list till:
   //  - Connection is closed.
   std::list<ActiveClientPtr> to_close_clients_;
-  ActiveClientPtr primary_client_;
-  ActiveClientPtr draining_client_;
   std::list<DrainedCb> drained_callbacks_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
 };

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -34,10 +34,6 @@ public:
   void addDrainedCallback(DrainedCb cb) override;
   void drainConnections() override;
   bool hasActiveConnections() const override;
-  /*
-  ConnectionPool::Cancellable* newStream(Http::StreamDecoder& response_decoder,
-                                         ConnectionPool::Callbacks& callbacks) override;
-                                         */
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; };
   const Upstream::ResourcePriority& resourcePriority() const { return priority_; };
 
@@ -108,7 +104,7 @@ protected:
   void createNewConnection();
   void onUpstreamReady(ActiveClient& client);
   ConnectionPool::Cancellable* newStream(Http::StreamDecoder& response_decoder,
-                                         ConnectionPool::Callbacks& callbacks);
+                                         ConnectionPool::Callbacks& callbacks) override;
 
   void applyToEachClient(std::list<ActiveClientPtr>& client_list,
                          const std::function<void(const ActiveClientPtr&)>& fn);

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -501,6 +501,10 @@ private:
   };
 };
 
+/*
+ * An implementation of `ConnectionRequestPolicy` that is based on the aggregate
+ * count of streams(requests) for its policies.
+ */
 class AggregateRequestsConnectionPolicy : public ConnectionRequestPolicy {
 public:
   using State = ConnectionRequestPolicy::State;
@@ -594,6 +598,11 @@ public:
 
   void createNetworkFilterChain(Network::Connection&) const override;
 
+  /**
+   * Returns instance of connection policy for the cluster.
+   * TODO(conqerAtApple): Currently returns `AggregateRequestsConnectionPolicy`
+   * In actual implementation, will be injected into this object.
+   */
   const ConnectionRequestPolicy& connectionPolicy() const override;
 
 private:

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -501,6 +501,20 @@ private:
   };
 };
 
+class AggregateRequestsConnectionPolicy : public ConnectionRequestPolicy {
+public:
+  using State = ConnectionRequestPolicy::State;
+
+  AggregateRequestsConnectionPolicy(const ClusterInfo&);
+
+  virtual State onNewStream(const ConnectionRequestPolicySubscriber&) const override;
+  virtual State onStreamReset(const ConnectionRequestPolicySubscriber&,
+                              const State&) const override;
+
+private:
+  const ClusterInfo& cluster_;
+};
+
 /**
  * Implementation of ClusterInfo that reads from JSON.
  */
@@ -580,6 +594,8 @@ public:
 
   void createNetworkFilterChain(Network::Connection&) const override;
 
+  const ConnectionRequestPolicy& connectionPolicy() const override;
+
 private:
   struct ResourceManagers {
     ResourceManagers(const envoy::api::v2::Cluster& config, Runtime::Loader& runtime,
@@ -627,6 +643,7 @@ private:
   const absl::optional<envoy::api::v2::Cluster::CustomClusterType> cluster_type_;
   const std::unique_ptr<Server::Configuration::CommonFactoryContext> factory_context_;
   std::vector<Network::FilterFactoryCb> filter_factories_;
+  mutable std::unique_ptr<ConnectionRequestPolicy> connection_policy_;
 };
 
 /**

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -41,7 +41,8 @@ MockClusterInfo::MockClusterInfo()
           ClusterInfoImpl::generateCircuitBreakersStats(stats_store_, "default", true)),
       resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1,
                                                           std::numeric_limits<uint64_t>::max(),
-                                                          circuit_breakers_stats_)) {
+                                                          circuit_breakers_stats_)),
+      connection_policy_(*this) {
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
   ON_CALL(*this, idleTimeout()).WillByDefault(Return(absl::optional<std::chrono::milliseconds>()));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
@@ -80,6 +81,7 @@ MockClusterInfo::MockClusterInfo()
         return *typed_metadata_;
       }));
   ON_CALL(*this, clusterType()).WillByDefault(ReturnRef(cluster_type_));
+  ON_CALL(*this, connectionPolicy()).WillByDefault(ReturnRef(connection_policy_));
 }
 
 MockClusterInfo::~MockClusterInfo() = default;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -106,6 +106,7 @@ public:
   MOCK_CONST_METHOD0(warmHosts, bool());
   MOCK_CONST_METHOD0(eds_service_name, absl::optional<std::string>());
   MOCK_CONST_METHOD1(createNetworkFilterChain, void(Network::Connection&));
+  MOCK_CONST_METHOD0(connectionPolicy, const ConnectionRequestPolicy&());
 
   std::string name_{"fake_cluster"};
   absl::optional<std::string> eds_service_name_;
@@ -131,6 +132,7 @@ public:
   envoy::api::v2::Cluster::CommonLbConfig lb_config_;
   envoy::api::v2::core::Metadata metadata_;
   std::unique_ptr<Envoy::Config::TypedMetadata> typed_metadata_;
+  AggregateRequestsConnectionPolicy connection_policy_;
 };
 
 class MockIdleTimeEnabledClusterInfo : public MockClusterInfo {


### PR DESCRIPTION
Signed-off-by: Jojy G Varghese <jojy_varghese@apple.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Currently H2 connection pool can create only ONE upstream connection. There are use cases that demand a policy based approach to connections in the H2 pool More background can be found at:
 `https://github.com/envoyproxy/envoy/issues/7403`

The policy could be described as below example :

```
 clusters:                                                                      
    - name: cluster-name                                                   
      connect_timeout: 0.25s       
      connection_policy:
           max_requests_per_connection: 1  
           drain_on_overflow: yes // Should drain or keep in overflow list
           idle_timeout: 500ms     // Time after which the connection can be closed.                   
                                                  
      ...
      ...                

```

Risk Level: High
Testing: Unit tests, Integration tests to be added
Docs Changes: This change will require new configuration for describing the policy.
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
