### PR TITLE
config: add fallback timeout to tls_inspector

### DIFF
--- a/api/envoy/config/filter/listener/tls_inspector/v2alpha1/BUILD
+++ b/api/envoy/config/filter/listener/tls_inspector/v2alpha1/BUILD
@@ -1,0 +1,8 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "tls_inspector",
+    srcs = ["tls_inspector.proto"],
+)

--- a/api/envoy/config/filter/listener/tls_inspector/v2alpha1/tls_inspector.proto
+++ b/api/envoy/config/filter/listener/tls_inspector/v2alpha1/tls_inspector.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package envoy.config.filter.listener.tls_inspector.v2alpha1;
+
+option java_outer_classname = "TlsInspectorProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.listener.tls_inspector.v2alpha1";
+
+option go_package = "v2alpha1";
+
+import "google/protobuf/duration.proto";
+import "validate/validate.proto";
+
+// [#protodoc-title: Tls Inspector Listener Filter]
+// Sniff the Tls protocol before filter chain match.
+
+// The Tls Inspector listener filter inspect the initial bytes of the connection and determine if
+// the connection is TLS. The config defines when the listener config should give up.
+message TlsInspector {
+
+  // The timeout to stop sniffing and mark the connection as plain text.
+  google.protobuf.Duration fallback_timeout = 1 [(validate.rules).duration.gt = {}];
+
+  // Mark the connection as plain text if this number of bytes is received but cannot determine as
+  // TLS connection.
+  uint32 max_client_hello_size = 2;
+}

--- a/source/extensions/filters/listener/tls_inspector/BUILD
+++ b/source/extensions/filters/listener/tls_inspector/BUILD
@@ -36,5 +36,6 @@ envoy_cc_library(
         "//include/envoy/server:filter_config_interface",
         "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
+        "@envoy_api//envoy/config/filter/listener/tls_inspector/v2alpha1:tls_inspector_cc",
     ],
 )

--- a/source/extensions/filters/listener/tls_inspector/config.cc
+++ b/source/extensions/filters/listener/tls_inspector/config.cc
@@ -1,5 +1,7 @@
 #include <string>
 
+#include "envoy/config/filter/listener/tls_inspector/v2alpha1/tls_inspector.pb.h"
+#include "envoy/config/filter/listener/tls_inspector/v2alpha1/tls_inspector.pb.validate.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
 
@@ -18,16 +20,25 @@ class TlsInspectorConfigFactory : public Server::Configuration::NamedListenerFil
 public:
   // NamedListenerFilterConfigFactory
   Network::ListenerFilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message&,
+  createFilterFactoryFromProto(const Protobuf::Message& message,
                                Server::Configuration::ListenerFactoryContext& context) override {
-    ConfigSharedPtr config(new Config(context.scope()));
-    return [config](Network::ListenerFilterManager& filter_manager) -> void {
+    const auto& proto_config = MessageUtil::downcastAndValidate<
+        const envoy::config::filter::listener::tls_inspector::v2alpha1::TlsInspector&>(message);
+
+    std::chrono::milliseconds fallback_timeout = std::chrono::milliseconds::max();
+    if (proto_config.has_fallback_timeout()) {
+      fallback_timeout = std::chrono::milliseconds(
+          DurationUtil::durationToMilliseconds(proto_config.fallback_timeout()));
+    }
+    auto config = std::make_shared<Config>(context.scope(), fallback_timeout);
+    return [config = std::move(config)](Network::ListenerFilterManager& filter_manager) -> void {
       filter_manager.addAcceptFilter(std::make_unique<Filter>(config));
     };
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<Envoy::ProtobufWkt::Empty>();
+    return std::make_unique<
+        envoy::config::filter::listener::tls_inspector::v2alpha1::TlsInspector>();
   }
 
   std::string name() override { return ListenerFilterNames::get().TlsInspector; }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -23,9 +23,10 @@ namespace Extensions {
 namespace ListenerFilters {
 namespace TlsInspector {
 
-Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
+Config::Config(Stats::Scope& scope, std::chrono::milliseconds fallback_timeout,
+               uint32_t max_client_hello_size)
     : stats_{ALL_TLS_INSPECTOR_STATS(POOL_COUNTER_PREFIX(scope, "tls_inspector."))},
-      ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())),
+      ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())), fallback_timeout_(fallback_timeout),
       max_client_hello_size_(max_client_hello_size) {
 
   if (max_client_hello_size_ > TLS_MAX_CLIENT_HELLO) {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -41,17 +41,21 @@ struct TlsInspectorStats {
  */
 class Config {
 public:
-  Config(Stats::Scope& scope, uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
+  Config(Stats::Scope& scope,
+         std::chrono::milliseconds fallback_timeout = std::chrono::milliseconds::max(),
+         uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
 
   const TlsInspectorStats& stats() const { return stats_; }
   bssl::UniquePtr<SSL> newSsl();
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
+  std::chrono::milliseconds fallbackTimeout() const { return fallback_timeout_; }
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
 private:
   TlsInspectorStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
+  const std::chrono::milliseconds fallback_timeout_;
   const uint32_t max_client_hello_size_;
 };
 

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -311,7 +311,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
         Config::Utility::getAndCheckFactory<Configuration::NamedListenerFilterConfigFactory>(
             Extensions::ListenerFilters::ListenerFilterNames::get().TlsInspector);
     listener_filter_factories_.push_back(
-        factory.createFilterFactoryFromProto(Envoy::ProtobufWkt::Empty(), *this));
+        factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), *this));
   }
 }
 

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -32,7 +32,7 @@ namespace {
 class TlsInspectorTest : public testing::Test {
 public:
   TlsInspectorTest()
-      : cfg_(std::make_shared<Config>(store_)),
+      : cfg_(std::make_shared<Config>(store_, std::chrono::milliseconds::max())),
         io_handle_(std::make_unique<Network::IoSocketHandleImpl>(42)) {}
   ~TlsInspectorTest() override { io_handle_->close(); }
 
@@ -65,8 +65,9 @@ public:
 
 // Test that an exception is thrown for an invalid value for max_client_hello_size
 TEST_F(TlsInspectorTest, MaxClientHelloSize) {
-  EXPECT_THROW_WITH_MESSAGE(Config(store_, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
-                            "max_client_hello_size of 65537 is greater than maximum of 65536.");
+  EXPECT_THROW_WITH_MESSAGE(
+      Config(store_, std::chrono::milliseconds::max(), Config::TLS_MAX_CLIENT_HELLO + 1),
+      EnvoyException, "max_client_hello_size of 65537 is greater than maximum of 65536.");
 }
 
 // Test that the filter detects Closed events and terminates.
@@ -196,7 +197,7 @@ TEST_F(TlsInspectorTest, NoExtensions) {
 // maximum allowed size.
 TEST_F(TlsInspectorTest, ClientHelloTooBig) {
   const size_t max_size = 50;
-  cfg_ = std::make_shared<Config>(store_, max_size);
+  cfg_ = std::make_shared<Config>(store_, std::chrono::milliseconds::max(), max_size);
   std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("example.com", "");
   ASSERT(client_hello.size() > max_size);
   init();


### PR DESCRIPTION
Description: 

Istio is seeing mysql connection rejected when deprecating bind_to_port=false listeners by migrating to listener with a large amount of filter chains.

tls_inspector always expecting some bytes from client. Otherwise it block the filterchain match.
There are some application protocols that requires server send the handshake packet first. E.g. MySQL. 
That means if there are two filter chains, one requires tls_inpsector listener filter and the other filter chain expecting mysql traffic
can never listed in the same listener. 
If MySQL client connects, the connection is handled by envoy listener and blocked at tls_inspector::onAccept()
before trying to match any filter chain.

One of the solution is to allow tls_inspector fallback to determine it as plain text after a certain timeout (e.g. 10ms).  (Not implemented yet, prototype https://github.com/silentdai/envoy/tree/toimpl)
- The envoy listener may wrongly determine tls connection as TCP, and it's the matched filter chain's responsibility to either reject the connection or survive.
- The MySQL filter chain would see the above fall back timeout (10ms -ish)

Back compatibility: if the tls_inspector config proto is not setting fallback timeout field, the default timeout is infinity.

Fix #7195

Risk Level: LOW
Testing: 
Docs Changes: TODO
Release Notes: TODO