### PR TITLE
listener: add an option to continue on listener filters timeout

### DIFF
--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -133,11 +133,16 @@ message Listener {
 
   // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
   // the accepted socket is closed without a connection being created unless
-  // continue_on_listener_filters_timeout is set to true. Specify 0 to disable the
+   // `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
   // timeout. If not specified, a default timeout of 15s is used.
   google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
 
   // Whether a connection should be created when listener filters timeout. Default is false.
+  //
+  // .. attention::
+  //
+  //   Some of listener_filters such as :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`
+  //   should not be used with this option. It will lead unexpected behavior when a connection is created.
   bool continue_on_listener_filters_timeout = 17;
 
   // Whether the listener should be set as a transparent socket.

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -44,7 +44,7 @@ service ListenerDiscoveryService {
   }
 }
 
-// [#comment:next free field: 17]
+// [#comment:next free field: 18]
 message Listener {
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -132,9 +132,13 @@ message Listener {
   repeated listener.ListenerFilter listener_filters = 9;
 
   // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
-  // the accepted socket is closed without a connection being created. Specify 0 to disable the
+  // the accepted socket is closed without a connection being created unless
+  // continue_on_listener_filters_timeout is set to true. Specify 0 to disable the
   // timeout. If not specified, a default timeout of 15s is used.
   google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
+
+  // Whether a connection should be created when listener filters timeout. Default is false.
+  bool continue_on_listener_filters_timeout = 17;
 
   // Whether the listener should be set as a transparent socket.
   // When this flag is set to true, connections can be redirected to the listener using an

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -141,8 +141,8 @@ message Listener {
   //
   // .. attention::
   //
-  //   Some of listener_filters such as :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`
-  //   should not be used with this option. It will lead unexpected behavior when a connection is created.
+  //   Some of listener_filters, such as :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`,
+  //   should not be used with this option. It will cause unexpected behavior when a connection is created.
   bool continue_on_listener_filters_timeout = 17;
 
   // Whether the listener should be set as a transparent socket.

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -133,7 +133,7 @@ message Listener {
 
   // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
   // the accepted socket is closed without a connection being created unless
-   // `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
+  // `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
   // timeout. If not specified, a default timeout of 15s is used.
   google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
 

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -141,8 +141,9 @@ message Listener {
   //
   // .. attention::
   //
-  //   Some listener filters, such as :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`,
-  //   should not be used with this option. It will cause unexpected behavior when a connection is created.
+  //   Some listener filters, such as :ref:`Proxy Protocol filter
+  //   <config_listener_filters_proxy_protocol>`, should not be used with this option. It will cause
+  //   unexpected behavior when a connection is created.
   bool continue_on_listener_filters_timeout = 17;
 
   // Whether the listener should be set as a transparent socket.

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -141,7 +141,7 @@ message Listener {
   //
   // .. attention::
   //
-  //   Some of listener_filters, such as :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`,
+  //   Some listener filters, such as :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>`,
   //   should not be used with this option. It will cause unexpected behavior when a connection is created.
   bool continue_on_listener_filters_timeout = 17;
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,6 +16,7 @@ Version history
 * header to metadata: added :ref:`PROTOBUF_VALUE <envoy_api_enum_value_config.filter.http.header_to_metadata.v2.Config.ValueType.PROTOBUF_VALUE>` and :ref:`ValueEncode <envoy_api_enum_config.filter.http.header_to_metadata.v2.Config.ValueEncode>` to support protobuf Value and Base64 encoding.
 * http: added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature `envoy.reloadable_features.strict_header_validation`.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
+* listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener to continue to create connection when listener filters timed out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * router: added :ref:`rq_retry_skipped_request_not_complete <config_http_filters_router_stats>` counter stat to router stats.
 * router check tool: add coverage reporting & enforcement.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,7 +16,7 @@ Version history
 * header to metadata: added :ref:`PROTOBUF_VALUE <envoy_api_enum_value_config.filter.http.header_to_metadata.v2.Config.ValueType.PROTOBUF_VALUE>` and :ref:`ValueEncode <envoy_api_enum_config.filter.http.header_to_metadata.v2.Config.ValueEncode>` to support protobuf Value and Base64 encoding.
 * http: added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature `envoy.reloadable_features.strict_header_validation`.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
-* listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener to continue to create connection when listener filters timed out.
+* listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * router: added :ref:`rq_retry_skipped_request_not_complete <config_http_filters_router_stats>` counter stat to router stats.
 * router check tool: add coverage reporting & enforcement.

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -100,6 +100,7 @@ envoy_cc_library(
         ":connection_interface",
         ":listen_socket_interface",
         "//include/envoy/stats:stats_interface",
+        "@envoy_api//envoy/api/v2:lds_cc",
     ],
 )
 

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -68,6 +68,7 @@ public:
    *         connection being created. 0 specifies a disabled timeout.
    */
   virtual std::chrono::milliseconds listenerFiltersTimeout() const PURE;
+  virtual bool continueOnListenerFiltersTimeout() const PURE;
 
   /**
    * @return Stats::Scope& the stats scope to use for all listener specific stats.

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -65,9 +65,15 @@ public:
   /**
    * @return std::chrono::milliseconds the time to wait for all listener filters to complete
    *         operation. If the timeout is reached, the accepted socket is closed without a
-   *         connection being created. 0 specifies a disabled timeout.
+   *         connection being created unless continueOnListenerFiltersTimeout() returns true.
+   *         0 specifies a disabled timeout.
    */
   virtual std::chrono::milliseconds listenerFiltersTimeout() const PURE;
+
+  /**
+   * @return bool whether the listener should try to create a connection when listener filters
+   *         timed out.
+   */
   virtual bool continueOnListenerFiltersTimeout() const PURE;
 
   /**

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -72,7 +72,7 @@ public:
 
   /**
    * @return bool whether the listener should try to create a connection when listener filters
-   *         timed out.
+   *         time out.
    */
   virtual bool continueOnListenerFiltersTimeout() const PURE;
 

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -163,9 +163,8 @@ void ConnectionHandlerImpl::ActiveSocket::onTimeout() {
   ASSERT(inserted());
   if (listener_.continue_on_listener_filters_timeout_) {
     newConnection();
-  } else {
-    unlink();
   }
+  unlink();
 }
 
 void ConnectionHandlerImpl::ActiveSocket::startTimer() {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -90,6 +90,7 @@ ConnectionHandlerImpl::ActiveListenerBase::ActiveListenerBase(ConnectionHandlerI
     : parent_(parent), listener_(std::move(listener)),
       stats_(generateStats(config.listenerScope())),
       listener_filters_timeout_(config.listenerFiltersTimeout()),
+      continue_on_listener_filters_timeout_(config.continueOnListenerFiltersTimeout()),
       listener_tag_(config.listenerTag()), config_(config) {}
 
 ConnectionHandlerImpl::ActiveTcpListener::ActiveTcpListener(ConnectionHandlerImpl& parent,
@@ -160,7 +161,11 @@ ConnectionHandlerImpl::findActiveListenerByAddress(const Network::Address::Insta
 void ConnectionHandlerImpl::ActiveSocket::onTimeout() {
   listener_.stats_.downstream_pre_cx_timeout_.inc();
   ASSERT(inserted());
-  unlink();
+  if (listener_.continue_on_listener_filters_timeout_) {
+    newConnection();
+  } else {
+    unlink();
+  }
 }
 
 void ConnectionHandlerImpl::ActiveSocket::startTimer() {
@@ -195,37 +200,40 @@ void ConnectionHandlerImpl::ActiveSocket::continueFilterChain(bool success) {
       }
     }
     // Successfully ran all the accept filters.
-
-    // Check if the socket may need to be redirected to another listener.
-    ActiveListenerBase* new_listener = nullptr;
-
-    if (hand_off_restored_destination_connections_ && socket_->localAddressRestored()) {
-      // Find a listener associated with the original destination address.
-      new_listener = listener_.parent_.findActiveListenerByAddress(*socket_->localAddress());
-    }
-    if (new_listener != nullptr) {
-      // TODO(sumukhs): Try to avoid dynamic_cast by coming up with a better interface design
-      ActiveTcpListener* tcp_listener = dynamic_cast<ActiveTcpListener*>(new_listener);
-      ASSERT(tcp_listener != nullptr, "ActiveSocket listener is expected to be tcp");
-      // Hands off connections redirected by iptables to the listener associated with the
-      // original destination address. Pass 'hand_off_restored_destination_connections' as false to
-      // prevent further redirection.
-      tcp_listener->onAccept(std::move(socket_),
-                             false /* hand_off_restored_destination_connections */);
-    } else {
-      // Set default transport protocol if none of the listener filters did it.
-      if (socket_->detectedTransportProtocol().empty()) {
-        socket_->setDetectedTransportProtocol(
-            Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
-      }
-      // Create a new connection on this listener.
-      listener_.newConnection(std::move(socket_));
-    }
+    newConnection();
   }
 
   // Filter execution concluded, unlink and delete this ActiveSocket if it was linked.
   if (inserted()) {
     unlink();
+  }
+}
+
+void ConnectionHandlerImpl::ActiveSocket::newConnection() {
+  // Check if the socket may need to be redirected to another listener.
+  ActiveListenerBase* new_listener = nullptr;
+
+  if (hand_off_restored_destination_connections_ && socket_->localAddressRestored()) {
+    // Find a listener associated with the original destination address.
+    new_listener = listener_.parent_.findActiveListenerByAddress(*socket_->localAddress());
+  }
+  if (new_listener != nullptr) {
+    // TODO(sumukhs): Try to avoid dynamic_cast by coming up with a better interface design
+    ActiveTcpListener* tcp_listener = dynamic_cast<ActiveTcpListener*>(new_listener);
+    ASSERT(tcp_listener != nullptr, "ActiveSocket listener is expected to be tcp");
+    // Hands off connections redirected by iptables to the listener associated with the
+    // original destination address. Pass 'hand_off_restored_destination_connections' as false to
+    // prevent further redirection.
+    tcp_listener->onAccept(std::move(socket_),
+                           false /* hand_off_restored_destination_connections */);
+  } else {
+    // Set default transport protocol if none of the listener filters did it.
+    if (socket_->detectedTransportProtocol().empty()) {
+      socket_->setDetectedTransportProtocol(
+          Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
+    }
+    // Create a new connection on this listener.
+    listener_.newConnection(std::move(socket_));
   }
 }
 

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -89,6 +89,7 @@ private:
     Network::ListenerPtr listener_;
     ListenerStats stats_;
     const std::chrono::milliseconds listener_filters_timeout_;
+    const bool continue_on_listener_filters_timeout_;
     const uint64_t listener_tag_;
     Network::ListenerConfig& config_;
   };
@@ -200,6 +201,7 @@ private:
     void onTimeout();
     void startTimer();
     void unlink();
+    void newConnection();
 
     // Network::ListenerFilterManager
     void addAcceptFilter(Network::ListenerFilterPtr&& filter) override {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -315,6 +315,7 @@ private:
     std::chrono::milliseconds listenerFiltersTimeout() const override {
       return std::chrono::milliseconds();
     }
+    bool continueOnListenerFiltersTimeout() const override { return false; }
     Stats::Scope& listenerScope() override { return *scope_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -204,7 +204,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
       local_drain_manager_(parent.factory_.createDrainManager(config.drain_type())),
       config_(config), version_info_(version_info),
       listener_filters_timeout_(
-          PROTOBUF_GET_MS_OR_DEFAULT(config, listener_filters_timeout, 15000)) {
+          PROTOBUF_GET_MS_OR_DEFAULT(config, listener_filters_timeout, 15000)),
+      continue_on_listener_filters_timeout_(config.continue_on_listener_filters_timeout()) {
   if (config.has_transparent()) {
     addListenSocketOptions(Network::SocketOptionFactory::buildIpTransparentOptions());
   }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -271,6 +271,9 @@ public:
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return listener_filters_timeout_;
   }
+  bool continueOnListenerFiltersTimeout() const override {
+    return continue_on_listener_filters_timeout_;
+  }
   Stats::Scope& listenerScope() override { return *listener_scope_; }
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
@@ -372,6 +375,7 @@ private:
   const std::string version_info_;
   Network::Socket::OptionsSharedPtr listen_socket_options_;
   const std::chrono::milliseconds listener_filters_timeout_;
+  const bool continue_on_listener_filters_timeout_;
   // to access ListenerManagerImpl::factory_.
   friend class ListenerFilterChainFactoryBuilder;
 };

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -73,6 +73,7 @@ public:
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return std::chrono::milliseconds();
   }
+  bool continueOnListenerFiltersTimeout() const override { return false; }
   Stats::Scope& listenerScope() override { return stats_store_; }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }
@@ -901,6 +902,7 @@ public:
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return std::chrono::milliseconds();
   }
+  bool continueOnListenerFiltersTimeout() const override { return false; }
   Stats::Scope& listenerScope() override { return stats_store_; }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -601,6 +601,7 @@ private:
     std::chrono::milliseconds listenerFiltersTimeout() const override {
       return std::chrono::milliseconds();
     }
+    bool continueOnListenerFiltersTimeout() const override { return false; }
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -307,6 +307,7 @@ public:
   MOCK_CONST_METHOD0(handOffRestoredDestinationConnections, bool());
   MOCK_CONST_METHOD0(perConnectionBufferLimitBytes, uint32_t());
   MOCK_CONST_METHOD0(listenerFiltersTimeout, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(continueOnListenerFiltersTimeout, bool());
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_CONST_METHOD0(listenerTag, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -79,14 +79,15 @@ public:
 
   using TestListenerPtr = std::unique_ptr<TestListener>;
 
-  TestListener* addListener(
-      uint64_t tag, bool bind_to_port, bool hand_off_restored_destination_connections,
-      const std::string& name,
-      Network::Address::SocketType socket_type = Network::Address::SocketType::Stream,
-      std::chrono::milliseconds listener_filters_timeout = std::chrono::milliseconds(15000)) {
-    TestListener* listener =
-        new TestListener(*this, tag, bind_to_port, hand_off_restored_destination_connections, name,
-                         socket_type, listener_filters_timeout, false);
+  TestListener*
+  addListener(uint64_t tag, bool bind_to_port, bool hand_off_restored_destination_connections,
+              const std::string& name,
+              Network::Address::SocketType socket_type = Network::Address::SocketType::Stream,
+              std::chrono::milliseconds listener_filters_timeout = std::chrono::milliseconds(15000),
+              bool continue_on_listener_filters_timeout = false) {
+    TestListener* listener = new TestListener(
+        *this, tag, bind_to_port, hand_off_restored_destination_connections, name, socket_type,
+        listener_filters_timeout, continue_on_listener_filters_timeout);
     listener->moveIntoListBack(TestListenerPtr{listener}, listeners_);
     return listener;
   }
@@ -612,6 +613,58 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
   dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0UL, downstream_pre_cx_active.value());
   EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());
+
+  // Make sure we didn't continue to try create connection.
+  EXPECT_EQ(0UL, stats_store_.counter("no_filter_chain_match").value());
+
+  EXPECT_CALL(*listener, onDestroy());
+}
+
+// Continue on timeout during listener filter stop iteration.
+TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
+  InSequence s;
+
+  TestListener* test_listener =
+      addListener(1, true, false, "test_listener", Network::Address::SocketType::Stream,
+                  std::chrono::milliseconds(15000), true);
+  Network::MockListener* listener = new Network::MockListener();
+  Network::ListenerCallbacks* listener_callbacks;
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
+            listener_callbacks = &cb;
+            return listener;
+          }));
+  EXPECT_CALL(test_listener->socket_, localAddress());
+  handler_->addListener(*test_listener);
+
+  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(factory_, createListenerFilterChain(_))
+      .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
+        manager.addAcceptFilter(Network::ListenerFilterPtr{test_filter});
+        return true;
+      }));
+  EXPECT_CALL(*test_filter, onAccept(_))
+      .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
+        return Network::FilterStatus::StopIteration;
+      }));
+  Event::MockTimer* timeout = new Event::MockTimer(&dispatcher_);
+  EXPECT_CALL(*timeout, enableTimer(std::chrono::milliseconds(15000)));
+  Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
+  listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
+  Stats::Gauge& downstream_pre_cx_active =
+      stats_store_.gauge("downstream_pre_cx_active", Stats::Gauge::ImportMode::Accumulate);
+  EXPECT_EQ(1UL, downstream_pre_cx_active.value());
+
+  EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*timeout, disableTimer());
+  timeout->callback_();
+  dispatcher_.clearDeferredDeleteList();
+  EXPECT_EQ(0UL, downstream_pre_cx_active.value());
+  EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());
+
+  // Make sure we continued to try create connection.
+  EXPECT_EQ(1UL, stats_store_.counter("no_filter_chain_match").value());
 
   EXPECT_CALL(*listener, onDestroy());
 }

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -38,10 +38,12 @@ public:
     TestListener(ConnectionHandlerTest& parent, uint64_t tag, bool bind_to_port,
                  bool hand_off_restored_destination_connections, const std::string& name,
                  Network::Address::SocketType socket_type,
-                 std::chrono::milliseconds listener_filters_timeout)
+                 std::chrono::milliseconds listener_filters_timeout,
+                 bool continue_on_listener_filters_timeout)
         : parent_(parent), tag_(tag), bind_to_port_(bind_to_port),
           hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
-          name_(name), listener_filters_timeout_(listener_filters_timeout) {
+          name_(name), listener_filters_timeout_(listener_filters_timeout),
+          continue_on_listener_filters_timeout_(continue_on_listener_filters_timeout) {
       EXPECT_CALL(socket_, socketType()).WillOnce(Return(socket_type));
     }
 
@@ -58,6 +60,9 @@ public:
     std::chrono::milliseconds listenerFiltersTimeout() const override {
       return listener_filters_timeout_;
     }
+    bool continueOnListenerFiltersTimeout() const override {
+      return continue_on_listener_filters_timeout_;
+    }
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return tag_; }
     const std::string& name() const override { return name_; }
@@ -69,6 +74,7 @@ public:
     const bool hand_off_restored_destination_connections_;
     const std::string name_;
     const std::chrono::milliseconds listener_filters_timeout_;
+    const bool continue_on_listener_filters_timeout_;
   };
 
   using TestListenerPtr = std::unique_ptr<TestListener>;
@@ -80,7 +86,7 @@ public:
       std::chrono::milliseconds listener_filters_timeout = std::chrono::milliseconds(15000)) {
     TestListener* listener =
         new TestListener(*this, tag, bind_to_port, hand_off_restored_destination_connections, name,
-                         socket_type, listener_filters_timeout);
+                         socket_type, listener_filters_timeout, false);
     listener->moveIntoListBack(TestListenerPtr{listener}, listeners_);
     return listener;
   }


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Add an option to continue on listener filters timeout.

Risk Level: Med (mostly guarded by config)
Testing: unittest
Docs Changes: Added
Release Notes: Added
Fixes #7195 
