### PR TITLE
use new buffers by default

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -22,6 +22,7 @@ Version history
 * listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * lua: extended `httpCall()` and `respond()` APIs to accept headers with entry values that can be a string or table of strings.
+* performance: new buffer implementation enabled by default (to disable add "--use-libevent-buffers 1" to the command-line arguments when starting Envoy).
 * router: added :ref:`rq_retry_skipped_request_not_complete <config_http_filters_router_stats>` counter stat to router stats.
 * router check tool: add coverage reporting & enforcement.
 * router check tool: add comprehensive coverage reporting.

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -104,7 +104,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
 
   TCLAP::ValueArg<bool> use_libevent_buffer("", "use-libevent-buffers",
                                             "Use the original libevent buffer implementation",
-                                            false, true, "bool", cmd);
+                                            false, false, "bool", cmd);
 
   cmd.setExceptionHandling(false);
   try {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -94,7 +94,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(std::chrono::seconds(60), options->drainTime());
   EXPECT_EQ(std::chrono::seconds(90), options->parentShutdownTime());
   EXPECT_EQ(true, options->hotRestartDisabled());
-  EXPECT_EQ(true, options->libeventBufferEnabled());
+  EXPECT_EQ(false, options->libeventBufferEnabled());
   EXPECT_EQ(true, options->cpusetThreadsEnabled());
 
   options = createOptionsImpl("envoy --mode init_only");


### PR DESCRIPTION
Description:

switch Envoy::Buffer to Brian Pane's implementation (aka "new buffers") by default. 

Risk Level: Medium 
  - There's been decent testing on this, but it's still a pretty massive change.

Testing:

Ran through the following test plan locally:

```
1. Build envoy on this PR.
2. Spin up a server with no CLI Args: `./bazel-bin/source/exe/envoy-static -c /tmp/config.yaml` validate that: `[2019-08-09 10:11:52.900][6365][info][main] [source/server/server.cc:269] buffer implementation: new` gets logged
3. Ensure new buffers can be turned off by running: `./bazel-bin/source/exe/envoy-static --use-libevent-buffers 1 -c /tmp/config.yaml` validate that: `[2019-08-09 10:12:14.247][6431][info][main] [source/server/server.cc:269] buffer implementation: old (libevent)` got logged
```

There's also be some testers in actual environments see #7314 , and [Envoy Meeting Minutes](https://docs.google.com/document/d/1Yc4zkV-A_cC_R3C0u6D15WQAsRSxADs8p2l8UMMa4P4/edit).

Docs Changes: None
Release Notes: Added a line about how it's the default, including how to turn it off.

fixes #7314 
