### PR TITLE
udp_listener: refactor ActiveUdpListener creation

### DIFF
--- a/api/envoy/api/v2/BUILD
+++ b/api/envoy/api/v2/BUILD
@@ -107,6 +107,7 @@ api_proto_library_internal(
         "//envoy/api/v2/core:address",
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/listener",
+        "//envoy/api/v2/listener:udp_listener_config",
     ],
 )
 
@@ -118,6 +119,7 @@ api_go_grpc_library(
         "//envoy/api/v2/core:address_go_proto",
         "//envoy/api/v2/core:base_go_proto",
         "//envoy/api/v2/listener:listener_go_proto",
+        "//envoy/api/v2/listener:udp_listener_go_proto",
     ],
 )
 

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -12,6 +12,7 @@ import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/discovery.proto";
 import "envoy/api/v2/listener/listener.proto";
+import "envoy/api/v2/listener/udp_listener_config.proto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
@@ -44,7 +45,7 @@ service ListenerDiscoveryService {
   }
 }
 
-// [#comment:next free field: 16]
+// [#comment:next free field: 17]
 message Listener {
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -179,6 +180,11 @@ message Listener {
   // On macOS, only values of 0, 1, and unset are valid; other values may result in an error.
   // To set the queue length on macOS, set the net.inet.tcp.fastopen_backlog kernel parameter.
   google.protobuf.UInt32Value tcp_fast_open_queue_length = 12;
+
+  // If address.socket is a UDP socket, this field specifies the actual
+  // udp listener to create, i.e. "raw_udp_listener" for creating an ActiveUdpListener.
+  // If not present, treate it as "raw_udp_listener".
+  listener.UdpListenerConfig udp_listener_config = 16;
 
   reserved 14;
 }

--- a/api/envoy/api/v2/listener/BUILD
+++ b/api/envoy/api/v2/listener/BUILD
@@ -22,3 +22,20 @@ api_go_proto_library(
         "//envoy/api/v2/core:base_go_proto",
     ],
 )
+
+api_proto_library_internal(
+    name = "udp_listener_config",
+    srcs = ["udp_listener_config.proto"],
+    visibility = ["//envoy/api/v2:friends"],
+    deps = [
+        "//envoy/api/v2/core:base",
+    ],
+)
+
+api_go_proto_library(
+    name = "udp_listener_config",
+    proto = ":udp_listener_config",
+    deps = [
+        "//envoy/api/v2/core:base_go_proto",
+    ],
+)

--- a/api/envoy/api/v2/listener/udp_listener_config.proto
+++ b/api/envoy/api/v2/listener/udp_listener_config.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package envoy.api.v2.listener;
+
+option java_outer_classname = "LdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v2";
+
+option java_generic_services = true;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
+
+message UdpListenerConfig {
+  string udp_listener_name = 1;
+
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -11,6 +11,11 @@
 #include "envoy/stats/scope.h"
 
 namespace Envoy {
+
+namespace Server {
+class ActiveUdpListenerFactory;
+} // namespace Server
+
 namespace Network {
 
 class UdpListenerFilterManager;
@@ -83,6 +88,12 @@ public:
    * @return const std::string& the listener's name.
    */
   virtual const std::string& name() const PURE;
+
+  /**
+   * @return factory pointer if socket_type is DATAGRAM, otherwise return
+   * nullptr.
+   */
+  virtual Server::ActiveUdpListenerFactory* udpListenerFactory() PURE;
 };
 
 /**
@@ -177,6 +188,7 @@ public:
   virtual void onReceiveError(const ErrorCode& error_code, Api::IoError::IoErrorCode err) PURE;
 };
 
+using UdpListenerCallbacksPtr = std::unique_ptr<UdpListenerCallbacks>;
 /**
  * An abstract socket listener. Free the listener to stop listening on the socket.
  */

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -10,6 +10,16 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "active_raw_udp_listener_config",
+    srcs = ["active_raw_udp_listener_config.cc"],
+    hdrs = ["active_raw_udp_listener_config.h"],
+    deps = [
+        "//include/envoy/registry",
+        "//source/server:active_udp_listener_config_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "address_lib",
     srcs = [
         "address_impl.cc",

--- a/source/common/network/active_raw_udp_listener_config.cc
+++ b/source/common/network/active_raw_udp_listener_config.cc
@@ -1,0 +1,16 @@
+#include "common/network/active_raw_udp_listener_config.h"
+
+namespace Envoy {
+namespace Network {
+
+std::unique_ptr<Server::ActiveUdpListenerFactory>
+ActiveRawUdpListenerConfigFactory::createActiveUdpListenerFactory(const Protobuf::Message&) {
+  return std::make_unique<Server::ActiveRawUdpListenerFactory>();
+}
+
+std::string ActiveRawUdpListenerConfigFactory::name() { return "raw_udp_listener"; }
+
+REGISTER_FACTORY(ActiveRawUdpListenerConfigFactory, Server::ActiveUdpListenerConfigFactory);
+
+} // namespace Network
+} // namespace Envoy

--- a/source/common/network/active_raw_udp_listener_config.h
+++ b/source/common/network/active_raw_udp_listener_config.h
@@ -1,0 +1,20 @@
+#include "envoy/registry/registry.h"
+
+#include "server/active_udp_listener_config.h"
+#include "server/connection_handler_impl.h"
+
+namespace Envoy {
+namespace Network {
+
+class ActiveRawUdpListenerConfigFactory : public Server::ActiveUdpListenerConfigFactory {
+
+  std::unique_ptr<Server::ActiveUdpListenerFactory>
+  createActiveUdpListenerFactory(const Protobuf::Message&) override;
+
+  std::string name() override;
+};
+
+DECLARE_FACTORY(ActiveRawUdpListenerConfigFactory);
+
+} // namespace Network
+} // namespace Envoy

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -11,6 +11,12 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "active_udp_listener_config_interface",
+    hdrs = ["active_udp_listener_config.h"],
+    deps = [":connection_handler_lib"],
+)
+
+envoy_cc_library(
     name = "backtrace_lib",
     hdrs = ["backtrace.h"],
     external_deps = [
@@ -254,6 +260,7 @@ envoy_cc_library(
     srcs = ["listener_manager_impl.cc"],
     hdrs = ["listener_manager_impl.h"],
     deps = [
+        ":active_udp_listener_config_interface",
         ":configuration_lib",
         ":drain_manager_lib",
         ":filter_chain_manager_lib",

--- a/source/server/active_udp_listener_config.h
+++ b/source/server/active_udp_listener_config.h
@@ -1,0 +1,18 @@
+#include "server/connection_handler_impl.h"
+
+namespace Envoy {
+namespace Server {
+
+class ActiveUdpListenerConfigFactory {
+public:
+  virtual ~ActiveUdpListenerConfigFactory(){};
+
+  virtual std::unique_ptr<ActiveUdpListenerFactory>
+  createActiveUdpListenerFactory(const Protobuf::Message&) PURE;
+
+  // Used to identify which udp listener to create: quic or raw udp.
+  virtual std::string name() PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -27,8 +27,7 @@ void ConnectionHandlerImpl::addListener(Network::ListenerConfig& config) {
   } else {
     ASSERT(socket_type == Network::Address::SocketType::Datagram,
            "Only datagram/stream listener supported");
-    ActiveUdpListenerPtr udp(new ActiveUdpListener(*this, config));
-    listener = std::move(udp);
+    listener = config.udpListenerFactory()->createActiveUdpListener(*this, config);
   }
 
   if (disable_listeners_) {

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -59,22 +59,13 @@ public:
 
   Network::Listener* findListenerByAddress(const Network::Address::Instance& address) override;
 
-private:
   struct ActiveListenerBase;
   using ActiveListenerBasePtr = std::unique_ptr<ActiveListenerBase>;
-
-  struct ActiveTcpListener;
-  using ActiveTcpListenerPtr = std::unique_ptr<ActiveTcpListener>;
 
   struct ActiveUdpListener;
   using ActiveUdpListenerPtr = std::unique_ptr<ActiveUdpListener>;
 
   ActiveListenerBase* findActiveListenerByAddress(const Network::Address::Instance& address);
-
-  struct ActiveConnection;
-  using ActiveConnectionPtr = std::unique_ptr<ActiveConnection>;
-  struct ActiveSocket;
-  using ActiveSocketPtr = std::unique_ptr<ActiveSocket>;
 
   /**
    * Wrapper for an active listener owned by this handler.
@@ -120,6 +111,14 @@ private:
     Network::UdpListener* udp_listener_;
     Network::UdpListenerReadFilterPtr read_filter_;
   };
+
+private:
+  struct ActiveTcpListener;
+  using ActiveTcpListenerPtr = std::unique_ptr<ActiveTcpListener>;
+  struct ActiveConnection;
+  using ActiveConnectionPtr = std::unique_ptr<ActiveConnection>;
+  struct ActiveSocket;
+  using ActiveSocketPtr = std::unique_ptr<ActiveSocket>;
 
   /**
    * Wrapper for an active tcp listener owned by this handler.
@@ -228,5 +227,19 @@ private:
   bool disable_listeners_;
 };
 
+class ActiveUdpListenerFactory {
+public:
+  virtual ~ActiveUdpListenerFactory() {}
+
+  virtual ConnectionHandlerImpl::ActiveListenerBasePtr
+  createActiveUdpListener(ConnectionHandlerImpl& parent, Network::ListenerConfig& config) PURE;
+};
+
+class ActiveRawUdpListenerFactory : public ActiveUdpListenerFactory {
+  ConnectionHandlerImpl::ActiveListenerBasePtr
+  createActiveUdpListener(ConnectionHandlerImpl& parent, Network::ListenerConfig& config) override {
+    return std::make_unique<ConnectionHandlerImpl::ActiveUdpListener>(parent, config);
+  }
+};
 } // namespace Server
 } // namespace Envoy

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -59,6 +59,7 @@ envoy_cc_library(
         "//source/common/stats:stats_lib",
         "//source/common/upstream:host_utility_lib",
         "//source/extensions/access_loggers/file:file_access_log_lib",
+        "//source/server:connection_handler_lib",
         "@envoy_api//envoy/admin/v2alpha:certs_cc",
         "@envoy_api//envoy/admin/v2alpha:clusters_cc",
         "@envoy_api//envoy/admin/v2alpha:config_dump_cc",

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -31,6 +31,7 @@
 #include "common/router/scoped_config_impl.h"
 #include "common/stats/isolated_store_impl.h"
 
+#include "server/connection_handler_impl.h"
 #include "server/http/config_tracker_impl.h"
 
 #include "absl/strings/string_view.h"
@@ -318,11 +319,15 @@ private:
     Stats::Scope& listenerScope() override { return *scope_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }
+    Server::ActiveUdpListenerFactory* udpListenerFactory() override {
+      return udp_listener_factory_.get();
+    }
 
     AdminImpl& parent_;
     const std::string name_;
     Stats::ScopePtr scope_;
     Http::ConnectionManagerListenerStats stats_;
+    std::unique_ptr<Server::ActiveUdpListenerFactory> udp_listener_factory_;
   };
   using AdminListenerPtr = std::unique_ptr<AdminListener>;
 

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -274,6 +274,7 @@ public:
   Stats::Scope& listenerScope() override { return *listener_scope_; }
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
+  ActiveUdpListenerFactory* udpListenerFactory() override { return udp_listener_factory_.get(); }
 
   // Server::Configuration::ListenerFactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {
@@ -369,6 +370,8 @@ private:
   const std::string version_info_;
   Network::Socket::OptionsSharedPtr listen_socket_options_;
   const std::chrono::milliseconds listener_filters_timeout_;
+  std::unique_ptr<Server::ActiveUdpListenerFactory> udp_listener_factory_;
+
   // to access ListenerManagerImpl::factory_.
   friend class ListenerFilterChainFactoryBuilder;
 };

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -520,6 +520,7 @@ envoy_cc_test(
     ],
     deps = [
         ":integration_lib",
+        "//source/common/network:active_raw_udp_listener_config",
         "//source/common/network:listen_socket_lib",
         "//test/integration/filters:udp_listener_echo_filter_lib",
         "//test/server:utility_lib",

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -18,8 +18,6 @@
 #include "common/network/raw_buffer_socket.h"
 #include "common/network/utility.h"
 
-#include "server/connection_handler_impl.h"
-
 #include "extensions/transport_sockets/tls/ssl_socket.h"
 
 #include "test/integration/utility.h"

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -10,7 +10,6 @@
 #include "envoy/grpc/status.h"
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
-#include "envoy/network/connection_handler.h"
 #include "envoy/network/filter.h"
 #include "envoy/server/configuration.h"
 #include "envoy/server/listener_manager.h"
@@ -27,6 +26,8 @@
 #include "common/network/filter_impl.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/stats/isolated_store_impl.h"
+
+#include "server/connection_handler_impl.h"
 
 #include "test/test_common/printers.h"
 #include "test/test_common/test_time_system.h"
@@ -604,8 +605,12 @@ private:
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }
+    Server::ActiveUdpListenerFactory* udpListenerFactory() override {
+      return udp_listener_factory_.get();
+    }
 
     FakeUpstream& parent_;
+    std::unique_ptr<Server::ActiveUdpListenerFactory> udp_listener_factory_;
     std::string name_;
   };
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -310,6 +310,7 @@ public:
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_CONST_METHOD0(listenerTag, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());
+  MOCK_METHOD0(udpListenerFactory, Server::ActiveUdpListenerFactory*());
 
   testing::NiceMock<MockFilterChainFactory> filter_chain_factory_;
   testing::NiceMock<MockListenSocket> socket_;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -168,6 +168,7 @@ envoy_cc_test(
         ":utility_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/config:metadata_lib",
+        "//source/common/network:active_raw_udp_listener_config",
         "//source/common/network:addr_family_aware_socket_option_lib",
         "//source/common/network:listen_socket_lib",
         "//source/common/network:socket_option_lib",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -51,6 +51,7 @@ envoy_cc_test(
     srcs = ["connection_handler_test.cc"],
     deps = [
         "//source/common/common:utility_lib",
+        "//source/common/network:active_raw_udp_listener_config",
         "//source/common/network:address_lib",
         "//source/common/stats:stats_lib",
         "//source/server:connection_handler_lib",


### PR DESCRIPTION
Modify ListenerConfig to provide a listener factory if the socket is a UDP socket through a new interface udpListenerFactory(). 
Modify ConnectionHandlerImpl to addListener() through the new interface.

Add a new member of type envoy::api::v2::listener::UdpListenerConfig in envoy::api::v2::Listener to take a user specified config for the UDP listener.

Risk Level: medium, bad config can create a UDP listener which is not production-ready.
Testing: re-use existing connection_handler_test, listener_manager_test and udp integration tests.

Part of #7433, #2557
