### PR TITLE
runtime: add proto constraint to require a layer specifier

### DIFF
--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -295,6 +295,8 @@ message RuntimeLayer {
     // This follows the :ref:`runtime protobuf JSON representation encoding
     // <config_runtime_proto_json>`. Unlike static xDS resources, this static
     // layer is overridable by later layers in the runtime virtual filesystem.
+    option (validate.required) = true;
+
     google.protobuf.Struct static_layer = 2;
     DiskLayer disk_layer = 3;
     AdminLayer admin_layer = 4;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -252,6 +252,7 @@ envoy_cc_test(
         ":invalid_bootstrap.yaml",
         ":invalid_layered_runtime_duplicate_name.yaml",
         ":invalid_layered_runtime_missing_name.yaml",
+        ":invalid_layered_runtime_no_layer_specifier.yaml",
         ":invalid_runtime_bootstrap.yaml",
         ":node_bootstrap.yaml",
         ":node_bootstrap_no_admin_port.yaml",

--- a/test/server/invalid_layered_runtime_no_layer_specifier.yaml
+++ b/test/server/invalid_layered_runtime_no_layer_specifier.yaml
@@ -1,0 +1,3 @@
+layered_runtime:
+  layers:
+    - name: "foo"

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5647989147697152
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5647989147697152
@@ -1,0 +1,191 @@
+static_resources {
+  listeners {
+    name: "$"
+    address {
+      pipe {
+        path: "."
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "="
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    name: "\000$&$`%n&#000;NaN0"
+    address {
+      socket_address {
+        address: "0.0.1.0"
+        port_value: 32768
+        resolver_name: "@q"
+      }
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "="
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+        value: true
+      }
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "="
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+        value: true
+      }
+    }
+    listener_filters_timeout {
+    }
+  }
+  listeners {
+    name: "@"
+    address {
+      socket_address {
+        address: "2147483648.0.1.0"
+        named_port: "L"
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    name: "$"
+    address {
+      pipe {
+        path: "."
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    name: "@"
+    address {
+      socket_address {
+        address: "0.0.1.0"
+        port_value: 32768
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    name: "\000$&$`%n&#000;NaN0"
+    address {
+      pipe {
+        path: "1"
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+        value: true
+      }
+    }
+    use_original_dst {
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "="
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+        value: true
+      }
+    }
+  }
+  listeners {
+    name: "@"
+    address {
+      socket_address {
+        address: "@"
+        port_value: 32768
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "="
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+        value: true
+      }
+    }
+    use_original_dst {
+    }
+  }
+  listeners {
+    name: "\000$&$`%n&#000;NaN0"
+    address {
+      pipe {
+        path: "@"
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+      }
+    }
+    use_original_dst {
+    }
+  }
+  listeners {
+    name: "@"
+    address {
+      socket_address {
+        address: "0.0.1.0"
+        port_value: 32768
+      }
+    }
+    filter_chains {
+    }
+  }
+  listeners {
+    address {
+      pipe {
+        path: "="
+      }
+    }
+    filter_chains {
+      use_proxy_proto {
+        value: true
+      }
+    }
+  }
+}
+admin {
+  access_log_path: "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  address {
+    pipe {
+      path: "$"
+    }
+  }
+}
+layered_runtime {
+  layers {
+    name: "preserveExt"
+  }
+}

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -530,6 +530,12 @@ TEST_P(ServerInstanceImplTest, InvalidLayeredBootstrapDuplicateName) {
                           EnvoyException, "Duplicate layer name: some_static_laye");
 }
 
+// Validate invalid layered runtime with no layer specifier is rejected.
+TEST_P(ServerInstanceImplTest, InvalidLayeredBootstrapNoLayerSpecifier) {
+  EXPECT_THROW_WITH_REGEX(initialize("test/server/invalid_layered_runtime_no_layer_specifier.yaml"),
+                          EnvoyException, "BootstrapValidationError.LayeredRuntime");
+}
+
 // Regression test for segfault when server initialization fails prior to
 // ClusterManager initialization.
 TEST_P(ServerInstanceImplTest, BootstrapClusterManagerInitializationFail) {


### PR DESCRIPTION
Adds a proto constraint to require one of the layers to be specified.

OSS-Fuzz reported a crash on server_fuzz_test because of a RuntimeLayer with a name set, and no layer_specifier. 

Risk Level: Low
Testing: Server test added, and crashing corpus entry added.
Fixes OSS-Fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15757

Signed-off-by: Asra Ali <asraa@google.com>

