### PR TITLE
Introduce --features=compiler_param_file option for windows

### DIFF
--- a/ci/build_setup.ps1
+++ b/ci/build_setup.ps1
@@ -18,4 +18,4 @@ echo "ENVOY_BAZEL_ROOT: $env:ENVOY_BAZEL_ROOT"
 echo "ENVOY_SRCDIR: $env:ENVOY_SRCDIR"
 
 $env:BAZEL_BASE_OPTIONS="--noworkspace_rc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\tools\bazel.rc"
-$env:BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --jobs=$env:NUM_CPUS --show_task_finish --cache_test_results=no --test_output=all $env:BAZEL_BUILD_EXTRA_OPTIONS $env:BAZEL_EXTRA_TEST_OPTIONS"
+$env:BAZEL_BUILD_OPTIONS="--features=compiler_param_file --strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --jobs=$env:NUM_CPUS --show_task_finish --cache_test_results=no --test_output=all $env:BAZEL_BUILD_EXTRA_OPTIONS $env:BAZEL_EXTRA_TEST_OPTIONS"


### PR DESCRIPTION
This resolves compile line length issues by triggering a command args file.

This will allow us to use bazel as is without resorting to hacks.

Signed-off-by: @wrowe

Description:
This resolves compile line length issues by triggering a command args file
https://github.com/bazelbuild/bazel/issues/5163

Risk Level: Low

Testing: Tested locally on Windows

Docs Changes: N/A

Release Notes:

Fixes: https://github.com/bazelbuild/bazel/issues/5163

