### PR TITLE
cluster: remove unused proto import

### DIFF
--- a/api/envoy/api/v2/cluster/filter.proto
+++ b/api/envoy/api/v2/cluster/filter.proto
@@ -9,7 +9,6 @@ option csharp_namespace = "Envoy.Api.V2.ClusterNS";
 option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";


### PR DESCRIPTION
This warms when building:

> envoy/api/v2/cluster/filter.proto:12:1: warning: Import google/protobuf/struct.proto but not used.

Signed-off-by: Michael Rebello <me@michaelrebello.com>

Risk Level: Noe
Testing: CI