### PR TITLE
Fix URL building in AWS metadata fetching utility

### DIFF
--- a/source/extensions/filters/http/common/aws/utility.h
+++ b/source/extensions/filters/http/common/aws/utility.h
@@ -48,8 +48,6 @@ public:
    * @auth_token authentication token to pass in the request, empty string indicates no auth.
    * @return Metadata document or nullopt in case if unable to fetch it.
    *
-   * @note In case of an error, function will log ENVOY_LOG_MISC(debug) message.
-   *
    * @note This is not main loop safe method as it is blocking. It is intended to be used from the
    * gRPC auth plugins that are able to schedule blocking plugins on a different thread.
    */

--- a/test/integration/aws_metadata_fetcher_integration_test.cc
+++ b/test/integration/aws_metadata_fetcher_integration_test.cc
@@ -45,7 +45,7 @@ public:
                     body:
                       inline_string: METADATA_VALUE_WITH_AUTH
                   match:
-                    prefix: "/"
+                    prefix: "/v2/metadata"
                     headers:
                       - name: Authorization
                         exact_match: AUTH_TOKEN
@@ -55,7 +55,7 @@ public:
                     body:
                       inline_string: METADATA_VALUE
                   match:
-                    prefix: "/"
+                    prefix: "/v2/metadata"
               domains: "*"
             name: route_config_0
       )EOF",
@@ -78,7 +78,7 @@ public:
 TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
   const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
                                     lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::metadataFetcher(endpoint, "/v2/metadata", "");
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE", *response);
@@ -90,7 +90,7 @@ TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
 TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
   const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
                                     lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "", "AUTH_TOKEN");
+  const auto response = Utility::metadataFetcher(endpoint, "/v2/metadata", "AUTH_TOKEN");
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -109,7 +109,7 @@ TEST_F(AwsMetadataIntegrationTestFailure, Failure) {
                                     lookupPort("listener_0"));
 
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::metadataFetcher(endpoint, "/v2/metadata", "");
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
@@ -133,7 +133,7 @@ TEST_F(AwsMetadataIntegrationTestTimeout, Timeout) {
                                     lookupPort("listener_0"));
 
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::metadataFetcher(endpoint, "/v2/metadata", "");
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());


### PR DESCRIPTION
Description: While resolving the AWS App Mesh fork of envoy with envoy/master I found that the metadata fetcher (Envoy::Extensions::HttpFilters::Common::Aws::Utility::metadataFetcher) did not properly handle paths with extraneous leading slashes.

For example, we were building URLs like so: `http://169.254.170.2:80//v2/foo`.

Extra leading slashes are actually supposed to be handled by the Amazon ECS agent: aws/amazon-ecs-agent/issues/1839 since this is a really common paper-cut. But we should not rely on that behavior.

Risk Level: low
Testing: Updated integration test to use a path with a leading slash. Also manually tested by connecting Envoy to the App Mesh control-plane.
Docs Changes: None
Release Notes: None