### PR TITLE
http1: remove unimplemented constructor

### DIFF
--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -314,10 +314,6 @@ public:
                        ServerConnectionCallbacks& callbacks, Http1Settings settings,
                        uint32_t max_request_headers_kb);
 
-  ServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
-                       Http1Settings settings, uint32_t max_request_headers_kb,
-                       bool strict_header_validation);
-
   bool supports_http_10() override { return codec_settings_.accept_http_10_; }
 
 private:


### PR DESCRIPTION
Removes a stale, unimplemented constructor definition.

Risk Level: low
Testing: n/a
Doc Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
