### PR TITLE
Update references to local scripts to enable using build container for filter repos

### DIFF
--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,2 +1,2 @@
-ENVOY_BUILD_SHA=$(grep envoyproxy/envoy-build .circleci/config.yml | sed -e 's#.*envoyproxy/envoy-build:\(.*\)#\1#' | uniq)
+ENVOY_BUILD_SHA=$(grep envoyproxy/envoy-build $(dirname $0)/../.circleci/config.yml | sed -e 's#.*envoyproxy/envoy-build:\(.*\)#\1#' | uniq)
 [[ $(wc -l <<< "${ENVOY_BUILD_SHA}" | awk '{$1=$1};1') == 1 ]] || (echo ".circleci/config.yml hashes are inconsistent!" && exit 1)

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-. ci/envoy_build_sha.sh
+. $(dirname $0)/envoy_build_sha.sh
 
 # We run as root and later drop permissions. This is requried to setup the USER
 # in useradd below, which is need for correct Python execution in the Docker


### PR DESCRIPTION
Update references to local scripts to enable using build container in filter repos

Signed-off-by: Santosh Kumar Cheler <scheler@arubanetworks.com>


Description: This change enables using run_envoy_docker.sh to build envoy-filter-example
Risk Level: Low
Testing: Manually tested building envoy-filter-example using: envoy/ci/run_envoy_docker.sh './ci/do_ci.sh build'
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]