### PR TITLE
test: mock cleanup

### DIFF
--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -84,7 +84,7 @@ TEST_F(AccessLogManagerImplTest, flushToLogFilePeriodically) {
   // make sure timer is re-enabled on callback call
   log_file->write("test2");
   EXPECT_CALL(*timer, enableTimer(timeout_40ms_));
-  timer->callback_();
+  timer->invokeCallback();
 
   {
     Thread::LockGuard lock(file_->write_mutex_);
@@ -147,7 +147,7 @@ TEST_F(AccessLogManagerImplTest, flushToLogFileOnDemand) {
   // make sure timer is re-enabled on callback call
   log_file->write("test2");
   EXPECT_CALL(*timer, enableTimer(timeout_40ms_));
-  timer->callback_();
+  timer->invokeCallback();
   expected_writes++;
 
   {
@@ -176,7 +176,7 @@ TEST_F(AccessLogManagerImplTest, reopenFile) {
       }));
 
   log_file->write("before");
-  timer->callback_();
+  timer->invokeCallback();
 
   {
     Thread::LockGuard lock(file_->write_mutex_);
@@ -205,7 +205,7 @@ TEST_F(AccessLogManagerImplTest, reopenFile) {
 
   log_file->reopen();
   log_file->write("reopened");
-  timer->callback_();
+  timer->invokeCallback();
 
   {
     Thread::LockGuard lock(file_->write_mutex_);
@@ -237,7 +237,7 @@ TEST_F(AccessLogManagerImplTest, reopenThrows) {
       .WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))));
 
   log_file->write("test write");
-  timer->callback_();
+  timer->invokeCallback();
   {
     Thread::LockGuard lock(file_->write_mutex_);
     while (file_->num_writes_ != 1) {
@@ -247,7 +247,7 @@ TEST_F(AccessLogManagerImplTest, reopenThrows) {
   log_file->reopen();
 
   log_file->write("this is to force reopen");
-  timer->callback_();
+  timer->invokeCallback();
 
   {
     Thread::LockGuard lock(file_->open_mutex_);
@@ -258,7 +258,7 @@ TEST_F(AccessLogManagerImplTest, reopenThrows) {
 
   // write call should not cause any exceptions
   log_file->write("random data");
-  timer->callback_();
+  timer->invokeCallback();
 }
 
 TEST_F(AccessLogManagerImplTest, bigDataChunkShouldBeFlushedWithoutTimer) {

--- a/test/common/config/delta_subscription_test_harness.h
+++ b/test/common/config/delta_subscription_test_harness.h
@@ -164,7 +164,7 @@ public:
     EXPECT_CALL(*init_timeout_timer_, disableTimer());
   }
 
-  void callInitFetchTimeoutCb() override { init_timeout_timer_->callback_(); }
+  void callInitFetchTimeoutCb() override { init_timeout_timer_->invokeCallback(); }
 
   const Protobuf::MethodDescriptor* method_descriptor_;
   Grpc::MockAsyncClient* async_client_;

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -149,7 +149,7 @@ public:
     EXPECT_CALL(*init_timeout_timer_, disableTimer());
   }
 
-  void callInitFetchTimeoutCb() override { init_timeout_timer_->callback_(); }
+  void callInitFetchTimeoutCb() override { init_timeout_timer_->invokeCallback(); }
 
   std::string version_;
   const Protobuf::MethodDescriptor* method_descriptor_;

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -166,7 +166,7 @@ public:
     EXPECT_CALL(*init_timeout_timer_, disableTimer());
   }
 
-  void callInitFetchTimeoutCb() override { init_timeout_timer_->callback_(); }
+  void callInitFetchTimeoutCb() override { init_timeout_timer_->invokeCallback(); }
 
   void timerTick() {
     expectSendMessage(cluster_names_, version_);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -192,7 +192,7 @@ TEST_F(AsyncClientImplTest, Retry) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_copy->headers()), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
-  timer_->callback_();
+  timer_->invokeCallback();
 
   // Normal response.
   expectSuccess(200);
@@ -240,7 +240,7 @@ TEST_F(AsyncClientImplTest, RetryWithStream) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), true));
-  timer_->callback_();
+  timer_->invokeCallback();
 
   // Normal response.
   expectResponseHeaders(stream_callbacks_, 200, true);
@@ -731,7 +731,7 @@ TEST_F(AsyncClientImplTest, StreamTimeout) {
   AsyncClient::Stream* stream = client_.start(
       stream_callbacks_, AsyncClient::StreamOptions().setTimeout(std::chrono::milliseconds(40)));
   stream->sendHeaders(message_->headers(), true);
-  timer_->callback_();
+  timer_->invokeCallback();
 
   EXPECT_EQ(1UL,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_timeout")
@@ -765,7 +765,7 @@ TEST_F(AsyncClientImplTest, StreamTimeoutHeadReply) {
   AsyncClient::Stream* stream = client_.start(
       stream_callbacks_, AsyncClient::StreamOptions().setTimeout(std::chrono::milliseconds(40)));
   stream->sendHeaders(message->headers(), true);
-  timer_->callback_();
+  timer_->invokeCallback();
 }
 
 TEST_F(AsyncClientImplTest, RequestTimeout) {
@@ -783,7 +783,7 @@ TEST_F(AsyncClientImplTest, RequestTimeout) {
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
   client_.send(std::move(message_), callbacks_,
                AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(40)));
-  timer_->callback_();
+  timer_->invokeCallback();
 
   EXPECT_EQ(1UL,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_timeout")

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1410,7 +1410,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutGlobal) {
     // encodeHeaders()/encodeData().
     EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
     EXPECT_CALL(*idle_timer, disableTimer());
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
   }));
 
   // 408 direct response after timeout.
@@ -1449,7 +1449,7 @@ TEST_F(HttpConnectionManagerImplTest, AccessEncoderRouteBeforeHeadersArriveOnIdl
     EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
     EXPECT_CALL(*idle_timer, disableTimer());
     // Simulate and idle timeout so that the filter chain gets created.
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
   }));
 
   // This should not be called as we don't have request headers.
@@ -1489,7 +1489,7 @@ TEST_F(HttpConnectionManagerImplTest, TestStreamIdleAccessLog) {
     // encodeHeaders()/encodeData().
     EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
     EXPECT_CALL(*idle_timer, disableTimer());
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
   }));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
@@ -1597,7 +1597,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterDownstreamHeaders
     // encodeHeaders()/encodeData().
     EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
     EXPECT_CALL(*idle_timer, disableTimer());
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
 
     data.drain(4);
   }));
@@ -1669,7 +1669,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterDownstreamHeaders
     // encodeHeaders()/encodeData().
     EXPECT_CALL(*idle_timer, enableTimer(_)).Times(2);
     EXPECT_CALL(*idle_timer, disableTimer());
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
 
     data.drain(4);
   }));
@@ -1720,7 +1720,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterUpstreamHeaders) 
     filter->callbacks_->encodeHeaders(std::move(response_headers), false);
 
     EXPECT_CALL(*idle_timer, disableTimer());
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
 
     data.drain(4);
   }));
@@ -1784,7 +1784,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterBidiData) {
     filter->callbacks_->encodeData(fake_response, false);
 
     EXPECT_CALL(*idle_timer, disableTimer());
-    idle_timer->callback_();
+    idle_timer->invokeCallback();
 
     data.drain(4);
   }));
@@ -1865,7 +1865,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutCallbackDisarmsAndReturns408
     EXPECT_CALL(response_encoder_, encodeData(_, true)).WillOnce(AddBufferToString(&response_body));
 
     conn_manager_->newStream(response_encoder_);
-    request_timer->callback_();
+    request_timer->invokeCallback();
   }));
 
   Buffer::OwnedImpl fake_input("1234");
@@ -2148,7 +2148,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
   EXPECT_CALL(filter_callbacks_.connection_,
               close(Network::ConnectionCloseType::FlushWriteAndDelay));
   EXPECT_CALL(*drain_timer, disableTimer());
-  drain_timer->callback_();
+  drain_timer->invokeCallback();
 
   EXPECT_EQ(1U, stats_.named_.downstream_cx_drain_close_.value());
   EXPECT_EQ(1U, stats_.named_.downstream_rq_3xx_.value());
@@ -2381,7 +2381,7 @@ TEST_F(HttpConnectionManagerImplTest, IdleTimeoutNoCodec) {
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(*idle_timer, disableTimer());
-  idle_timer->callback_();
+  idle_timer->invokeCallback();
 
   EXPECT_EQ(1U, stats_.named_.downstream_cx_idle_timeout_.value());
 }
@@ -2426,14 +2426,14 @@ TEST_F(HttpConnectionManagerImplTest, IdleTimeout) {
 
   Event::MockTimer* drain_timer = setUpTimer();
   EXPECT_CALL(*drain_timer, enableTimer(_));
-  idle_timer->callback_();
+  idle_timer->invokeCallback();
 
   EXPECT_CALL(*codec_, goAway());
   EXPECT_CALL(filter_callbacks_.connection_,
               close(Network::ConnectionCloseType::FlushWriteAndDelay));
   EXPECT_CALL(*idle_timer, disableTimer());
   EXPECT_CALL(*drain_timer, disableTimer());
-  drain_timer->callback_();
+  drain_timer->invokeCallback();
 
   EXPECT_EQ(1U, stats_.named_.downstream_cx_idle_timeout_.value());
 }

--- a/test/common/http/date_provider_impl_test.cc
+++ b/test/common/http/date_provider_impl_test.cc
@@ -27,7 +27,7 @@ TEST(DateProviderImplTest, All) {
   EXPECT_NE(nullptr, headers.Date());
 
   EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(500)));
-  timer->callback_();
+  timer->invokeCallback();
 
   headers.removeDate();
   provider.setDateHeader(headers);

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -109,7 +109,7 @@ public:
 
   void expectAndRunUpstreamReady() {
     EXPECT_TRUE(upstream_ready_enabled_);
-    mock_upstream_ready_timer_->callback_();
+    mock_upstream_ready_timer_->invokeCallback();
     EXPECT_FALSE(upstream_ready_enabled_);
   }
 
@@ -400,10 +400,10 @@ TEST_F(Http1ConnPoolImplTest, ConnectTimeout) {
     EXPECT_NE(nullptr, conn_pool_.newStream(outer_decoder2, callbacks2));
   }));
 
-  conn_pool_.test_clients_[0].connect_timer_->callback_();
+  conn_pool_.test_clients_[0].connect_timer_->invokeCallback();
 
   EXPECT_CALL(callbacks2.pool_failure_, ready());
-  conn_pool_.test_clients_[1].connect_timer_->callback_();
+  conn_pool_.test_clients_[1].connect_timer_->invokeCallback();
 
   EXPECT_CALL(conn_pool_, onClientDestroy()).Times(2);
   dispatcher_.clearDeferredDeleteList();

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -622,7 +622,7 @@ TEST_F(Http2ConnPoolImplTest, ConnectTimeout) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   EXPECT_CALL(r1.callbacks_.pool_failure_, ready());
-  test_clients_[0].connect_timer_->callback_();
+  test_clients_[0].connect_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1247,7 +1247,7 @@ TEST_P(ConnectionImplTest, DelayedCloseTimerResetWithPendingWriteBufferFlushes) 
   (*mocks.file_ready_cb_)(Event::FileReadyType::Write);
 
   // Force the delayed close timeout to trigger so the connection is cleaned up.
-  mocks.timer_->callback_();
+  mocks.timer_->invokeCallback();
 }
 
 // Test that tearing down the connection will disable the delayed close timer.
@@ -1321,16 +1321,9 @@ TEST_P(ConnectionImplTest, DelayedCloseTimeoutNullStats) {
   EXPECT_CALL(*mocks.timer_, enableTimer(_)).Times(1);
   server_connection->close(ConnectionCloseType::FlushWriteAndDelay);
   EXPECT_CALL(*mocks.timer_, disableTimer()).Times(1);
-  // Copy the callback since mocks.timer will be freed when closeSocket() is called.
-  Event::TimerCb callback = mocks.timer_->callback_;
   // The following close() will call closeSocket() and reset internal data structures such as
   // stats.
   server_connection->close(ConnectionCloseType::NoFlush);
-  // Verify the onDelayedCloseTimeout() callback is resilient to the post closeSocket(), pre
-  // destruction state. This should not actually happen due to the timeout disablement in
-  // closeSocket(), but there is enough complexity in connection handling codepaths that being
-  // extra defensive is valuable.
-  callback();
 }
 
 class FakeReadFilter : public Network::ReadFilter {

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -77,7 +77,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRefusedStream) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_refused_stream_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryReset(remote_refused_stream_reset_, callback_));
@@ -98,7 +98,7 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemoteReset) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
@@ -112,7 +112,7 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote503) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -146,7 +146,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote502) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -161,7 +161,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote503) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -176,7 +176,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote504) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -197,7 +197,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemoteReset) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
@@ -211,7 +211,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -226,7 +226,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcDeadlineExceeded) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -241,7 +241,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -256,7 +256,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcUnavilable) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -271,7 +271,7 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcInternal) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryHeaders(response_headers, callback_));
@@ -314,7 +314,7 @@ TEST_F(RouterRetryStateImplTest, PolicyConnectFailureResetConnectFailure) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxRetry) {
@@ -326,7 +326,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxRetry) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxNoRetry) {
@@ -420,7 +420,7 @@ TEST_F(RouterRetryStateImplTest, PolicyResetRemoteReset) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
 }
@@ -435,7 +435,7 @@ TEST_F(RouterRetryStateImplTest, RouteConfigNoHeaderConfig) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 }
 
 TEST_F(RouterRetryStateImplTest, NoAvailableRetries) {
@@ -464,17 +464,17 @@ TEST_F(RouterRetryStateImplTest, MaxRetriesHeader) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(*retry_timer_, enableTimer(_));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(*retry_timer_, enableTimer(_));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_EQ(1UL, cluster_.circuit_breakers_stats_.rq_retry_open_.value());
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
@@ -496,19 +496,19 @@ TEST_F(RouterRetryStateImplTest, Backoff) {
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(24)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(149));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(74)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(349));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(174)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
@@ -533,25 +533,25 @@ TEST_F(RouterRetryStateImplTest, CustomBackOffInterval) {
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(49)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(350));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(50)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(751));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(51)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(1499));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1200)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 }
 
 // Test the default maximum retry back-off interval.
@@ -568,25 +568,25 @@ TEST_F(RouterRetryStateImplTest, CustomBackOffIntervalDefaultMax) {
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(49)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(350));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(50)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(751));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(51)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(1499));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->callback_();
+  retry_timer_->invokeCallback();
 }
 
 TEST_F(RouterRetryStateImplTest, HostSelectionAttempts) {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -176,7 +176,7 @@ public:
     router_->retry_state_->expectResetRetry();
     EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
                 putResult(Upstream::Outlier::Result::LOCAL_ORIGIN_TIMEOUT, _));
-    per_try_timeout_->callback_();
+    per_try_timeout_->invokeCallback();
 
     // We expect this reset to kick off a new request.
     NiceMock<Http::MockStreamEncoder> encoder2;

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -116,7 +116,7 @@ public:
 
   void expectAndRunUpstreamReady() {
     EXPECT_TRUE(upstream_ready_enabled_);
-    mock_upstream_ready_timer_->callback_();
+    mock_upstream_ready_timer_->invokeCallback();
     EXPECT_FALSE(upstream_ready_enabled_);
   }
 
@@ -576,10 +576,10 @@ TEST_F(TcpConnPoolImplTest, ConnectTimeout) {
     EXPECT_NE(nullptr, conn_pool_.newConnection(callbacks2));
   }));
 
-  conn_pool_.test_conns_[0].connect_timer_->callback_();
+  conn_pool_.test_conns_[0].connect_timer_->invokeCallback();
 
   EXPECT_CALL(callbacks2.pool_failure_, ready());
-  conn_pool_.test_conns_[1].connect_timer_->callback_();
+  conn_pool_.test_conns_[1].connect_timer_->invokeCallback();
 
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest()).Times(2);
   dispatcher_.clearDeferredDeleteList();

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -841,7 +841,7 @@ TEST_F(TcpProxyTest, IdleTimeout) {
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(*idle_timer, disableTimer());
-  idle_timer->callback_();
+  idle_timer->invokeCallback();
 }
 
 // Tests that the idle timer is disabled when the downstream connection is closed.
@@ -918,7 +918,7 @@ TEST_F(TcpProxyTest, IdleTimeoutWithOutstandingDataFlushed) {
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(*idle_timer, disableTimer());
-  idle_timer->callback_();
+  idle_timer->invokeCallback();
 }
 
 // Test that access log fields %UPSTREAM_HOST% and %UPSTREAM_CLUSTER% are correctly logged.
@@ -1089,7 +1089,7 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutExpired) {
   EXPECT_EQ(1U, config_->stats().upstream_flush_active_.value());
 
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
-  idle_timer->callback_();
+  idle_timer->invokeCallback();
   EXPECT_EQ(1U, config_->stats().upstream_flush_total_.value());
   EXPECT_EQ(0U, config_->stats().upstream_flush_active_.value());
   EXPECT_EQ(1U, config_->stats().idle_timeout_.value());

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1793,7 +1793,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   EXPECT_CALL(*tcp1_high, addDrainedCallback(_)).WillOnce(SaveArg<0>(&tcp_drained_cb_high));
 
   // Remove the first host, this should lead to the first cp being drained.
-  dns_timer_->callback_();
+  dns_timer_->invokeCallback();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2"}));
   drained_cb();
   drained_cb = nullptr;
@@ -1826,7 +1826,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
 
   // Now add and remove a host that we never have a conn pool to. This should not lead to any
   // drain callbacks, etc.
-  dns_timer_->callback_();
+  dns_timer_->invokeCallback();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.3"}));
   factory_.tls_.shutdownThread();
 }
@@ -2009,7 +2009,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveWithTls) {
   EXPECT_CALL(*tcp1_ibm_com, addDrainedCallback(_)).WillOnce(SaveArg<0>(&tcp_drained_cb_ibm_com));
 
   // Remove the first host, this should lead to the first cp being drained.
-  dns_timer_->callback_();
+  dns_timer_->invokeCallback();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2"}));
   drained_cb();
   drained_cb = nullptr;
@@ -2056,7 +2056,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveWithTls) {
 
   // Now add and remove a host that we never have a conn pool to. This should not lead to any
   // drain callbacks, etc.
-  dns_timer_->callback_();
+  dns_timer_->invokeCallback();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.3"}));
   factory_.tls_.shutdownThread();
 }
@@ -2123,7 +2123,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveDefaultPriority) {
 
   // Remove the first host, this should lead to the cp being drained, without
   // crash.
-  dns_timer_->callback_();
+  dns_timer_->invokeCallback();
   dns_callback(TestUtility::makeDnsResponse({}));
 
   factory_.tls_.shutdownThread();
@@ -2199,7 +2199,7 @@ TEST_F(ClusterManagerImplTest, ConnPoolDestroyWithDraining) {
   EXPECT_CALL(*cp, addDrainedCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
   Tcp::ConnectionPool::Instance::DrainedCb tcp_drained_cb;
   EXPECT_CALL(*tcp, addDrainedCallback(_)).WillOnce(SaveArg<0>(&tcp_drained_cb));
-  dns_timer_->callback_();
+  dns_timer_->invokeCallback();
   dns_callback(TestUtility::makeDnsResponse({}));
 
   // The drained callback might get called when the CP is being destroyed.
@@ -2327,7 +2327,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
   // Ensure the merged updates were applied.
-  timer->callback_();
+  timer->invokeCallback();
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -559,7 +559,7 @@ public:
 
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
-    test_sessions_[0]->interval_timer_->callback_();
+    test_sessions_[0]->interval_timer_->invokeCallback();
 
     EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
     EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
@@ -572,7 +572,7 @@ public:
 
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
-    test_sessions_[0]->interval_timer_->callback_();
+    test_sessions_[0]->interval_timer_->invokeCallback();
 
     EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
     EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
@@ -646,7 +646,7 @@ TEST_F(HttpHealthCheckerImplTest, Degraded) {
   expectStreamCreate(0);
   EXPECT_CALL(runtime_.snapshot_, getInteger("health_check.max_interval", _));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*event_logger_, logNoLongerDegraded(_, _));
   respond(0, "200", false, false, true, false, {}, false);
@@ -673,7 +673,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitter) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
-    test_sessions_[0]->interval_timer_->callback_();
+    test_sessions_[0]->interval_timer_->invokeCallback();
     // the jitter is 1000ms here
     EXPECT_CALL(*test_sessions_[0]->interval_timer_,
                 enableTimer(std::chrono::milliseconds(5000 + i % 1000)));
@@ -693,7 +693,7 @@ TEST_F(HttpHealthCheckerImplTest, InitialJitterNoTraffic) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   health_checker_->start();
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -704,7 +704,7 @@ TEST_F(HttpHealthCheckerImplTest, InitialJitterNoTraffic) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
-    test_sessions_[0]->interval_timer_->callback_();
+    test_sessions_[0]->interval_timer_->invokeCallback();
     // the jitter is 40% of 5000, so should be 2000
     EXPECT_CALL(*test_sessions_[0]->interval_timer_,
                 enableTimer(std::chrono::milliseconds(5000 + i % 2000)));
@@ -733,7 +733,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercentNoTraffic) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
-    test_sessions_[0]->interval_timer_->callback_();
+    test_sessions_[0]->interval_timer_->invokeCallback();
     // the jitter is 40% of 5000, so should be 2000
     EXPECT_CALL(*test_sessions_[0]->interval_timer_,
                 enableTimer(std::chrono::milliseconds(5000 + i % 2000)));
@@ -763,7 +763,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercent) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
-    test_sessions_[0]->interval_timer_->callback_();
+    test_sessions_[0]->interval_timer_->invokeCallback();
     // the jitter is 40% of 1000, so should be 400
     EXPECT_CALL(*test_sessions_[0]->interval_timer_,
                 enableTimer(std::chrono::milliseconds(1000 + i % 400)));
@@ -1087,7 +1087,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
@@ -1127,7 +1127,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 }
 
 TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
@@ -1339,7 +1339,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
             Host::ActiveHealthFailureType::UNHEALTHY);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
@@ -1352,7 +1352,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
@@ -1386,7 +1386,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
             Host::ActiveHealthFailureType::UNHEALTHY);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // logUnhealthy is called with first_check == false
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1403,7 +1403,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
             Host::ActiveHealthFailureType::UNHEALTHY);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
@@ -1416,7 +1416,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
@@ -1446,7 +1446,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(cluster_->prioritySet().getMockHostSet(0)->hosts_[0],
                                   HealthTransition::Changed));
@@ -1475,7 +1475,7 @@ TEST_F(HttpHealthCheckerImplTest, Timeout) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
   EXPECT_EQ(Host::Health::Unhealthy,
             cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
@@ -1504,13 +1504,13 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutThenSuccess) {
   EXPECT_CALL(*test_sessions_[0]->client_connection_, close(_));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
   EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
@@ -1533,13 +1533,13 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutThenRemoteClose) {
   EXPECT_CALL(*test_sessions_[0]->client_connection_, close(_));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
   EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
@@ -1562,7 +1562,7 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutAfterDisconnect) {
   expectSessionCreate();
   expectStreamCreate(0);
   EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
-  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_)).Times(2);
   health_checker_->start();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending)).Times(1);
@@ -1576,7 +1576,8 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutAfterDisconnect) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
 
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->enableTimer(std::chrono::seconds(10));
+  test_sessions_[0]->timeout_timer_->invokeCallback();
   EXPECT_EQ(Host::Health::Unhealthy,
             cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
@@ -1618,7 +1619,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionClose) {
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 }
 
 TEST_F(HttpHealthCheckerImplTest, ProxyConnectionClose) {
@@ -1640,7 +1641,7 @@ TEST_F(HttpHealthCheckerImplTest, ProxyConnectionClose) {
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 }
 
 TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
@@ -1662,7 +1663,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1673,7 +1674,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1684,7 +1685,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // A logical failure is not considered a network failure, therefore the unhealthy threshold is
   // ignored and health state changes immediately. Since the threshold is ignored, next health
@@ -1698,7 +1699,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1709,7 +1710,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1720,7 +1721,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // When transitioning to a successful state, checks should respect healthy_edge_interval. Health
   // state should be delayed pending healthy threshold.
@@ -1732,7 +1733,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
@@ -1742,7 +1743,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // After the healthy threshold is reached, health state should change while checks should respect
   // the default interval.
@@ -1755,7 +1756,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1766,7 +1767,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // First failed check after a run o successful ones should respect unhealthy_edge_interval. A
   // timeout, being a network type failure, should respect unhealthy threshold before changing the
@@ -1774,26 +1775,26 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a network timeout.
   expectClientCreate(0);
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a network timeout.
   expectClientCreate(0);
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent failing checks should respect unhealthy_interval. As the unhealthy threshold is
   // reached, health state should also change.
@@ -1801,27 +1802,27 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a network timeout.
   expectClientCreate(0);
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Remaining failing checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a network timeout.
   expectClientCreate(0);
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // When transitioning to a successful state, checks should respect healthy_edge_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
@@ -1832,7 +1833,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
@@ -1842,7 +1843,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // After the healthy threshold is reached, health state should change while checks should respect
   // the default interval.
@@ -1855,7 +1856,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -1885,7 +1886,7 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -1916,7 +1917,7 @@ TEST_F(HttpHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   expectClientCreate(0);
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -2506,7 +2507,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutThenRemoteClose) {
   EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  timeout_timer_->callback_();
+  timeout_timer_->invokeCallback();
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::TIMEOUT);
   EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
@@ -2514,7 +2515,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutThenRemoteClose) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -2530,7 +2531,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutThenRemoteClose) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -2567,7 +2568,7 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  timeout_timer_->callback_();
+  timeout_timer_->invokeCallback();
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::TIMEOUT);
   EXPECT_EQ(Host::Health::Unhealthy,
@@ -2600,7 +2601,7 @@ TEST_F(TcpHealthCheckerImplTest, DoubleTimeout) {
   EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  timeout_timer_->callback_();
+  timeout_timer_->invokeCallback();
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::TIMEOUT);
   EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
@@ -2608,7 +2609,7 @@ TEST_F(TcpHealthCheckerImplTest, DoubleTimeout) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -2616,7 +2617,7 @@ TEST_F(TcpHealthCheckerImplTest, DoubleTimeout) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  timeout_timer_->callback_();
+  timeout_timer_->invokeCallback();
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::TIMEOUT);
   EXPECT_EQ(Host::Health::Unhealthy,
@@ -2625,7 +2626,7 @@ TEST_F(TcpHealthCheckerImplTest, DoubleTimeout) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -2666,7 +2667,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -2687,7 +2688,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -2726,7 +2727,7 @@ TEST_F(TcpHealthCheckerImplTest, NoData) {
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _)).Times(0);
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 }
 
 TEST_F(TcpHealthCheckerImplTest, PassiveFailure) {
@@ -3389,7 +3390,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   // Next successful healthcheck does not move host int healthy state (because we configured
   // healthchecker this way).
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Host still unhealthy, need yet another healthcheck.
@@ -3399,7 +3400,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 
   // 2nd successful healthcheck renders host healthy.
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
@@ -3428,7 +3429,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
 
   // Next, we need 2 successful checks for host to become available again.
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Host still considered unhealthy.
@@ -3437,7 +3438,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
   expectHostHealthy(false);
 
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Host should has become healthy.
@@ -3466,7 +3467,7 @@ TEST_F(GrpcHealthCheckerImplTest, Disconnect) {
 
   expectClientCreate(0);
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Now, host should be unhealthy.
@@ -3490,7 +3491,7 @@ TEST_F(GrpcHealthCheckerImplTest, Timeout) {
   // Unhealthy threshold is 1 so first timeout causes unhealthy
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
   expectHostHealthy(false);
 }
 
@@ -3508,11 +3509,11 @@ TEST_F(GrpcHealthCheckerImplTest, DoubleTimeout) {
   expectHealthcheckStop(0);
   // Timeouts are considered network failures and make host unhealthy also after 2nd event.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
   expectHostHealthy(true);
 
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
@@ -3560,7 +3561,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -3571,7 +3572,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -3582,7 +3583,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // A logical failure is not considered a network failure, therefore the unhealthy threshold is
   // ignored and health state changes immediately. Since the threshold is ignored, next health
@@ -3596,7 +3597,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -3607,7 +3608,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -3618,7 +3619,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // When transitioning to a successful state, checks should respect healthy_edge_interval. Health
   // state should be delayed pending healthy threshold.
@@ -3630,7 +3631,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
@@ -3640,7 +3641,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // After the healthy threshold is reached, health state should change while checks should respect
   // the default interval.
@@ -3653,7 +3654,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -3664,7 +3665,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // First failed check after a run o successful ones should respect unhealthy_edge_interval. A
   // timeout, being a network type failure, should respect unhealthy threshold before changing the
@@ -3672,22 +3673,22 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent failing checks should respect unhealthy_interval. As the unhealthy threshold is
   // reached, health state should also change.
@@ -3695,23 +3696,23 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Remaining failing checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
-  test_sessions_[0]->timeout_timer_->callback_();
+  test_sessions_[0]->timeout_timer_->invokeCallback();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // When transitioning to a successful state, checks should respect healthy_edge_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
@@ -3722,7 +3723,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
@@ -3732,7 +3733,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // After the healthy threshold is reached, health state should change while checks should respect
   // the default interval.
@@ -3745,7 +3746,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   // Needed after a response is sent.
   expectStreamCreate(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
@@ -3774,7 +3775,7 @@ TEST_F(GrpcHealthCheckerImplTest, RemoteCloseBetweenChecks) {
 
   expectClientCreate(0);
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Test host state haven't changed.
@@ -3803,7 +3804,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   // closes the connection.
   expectClientCreate(0);
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Test host state haven't changed.
@@ -3863,7 +3864,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayBetweenChecks) {
 
   expectClientCreate(0);
   expectHealthcheckStart(0);
-  test_sessions_[0]->interval_timer_->callback_();
+  test_sessions_[0]->interval_timer_->invokeCallback();
 
   expectHealthcheckStop(0);
   // Test host state haven't changed.

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -101,7 +101,7 @@ protected:
     logical_host->outlierDetector().putHttpResponseCode(200);
 
     expectResolve(Network::DnsLookupFamily::V4Only, expected_address);
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
 
     // Should not cause any changes.
     EXPECT_CALL(*resolve_timer_, enableTimer(_));
@@ -133,7 +133,7 @@ protected:
     data.host_description_->healthChecker().setUnhealthy();
 
     expectResolve(Network::DnsLookupFamily::V4Only, expected_address);
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
 
     // Should cause a change.
     EXPECT_CALL(*resolve_timer_, enableTimer(_));
@@ -151,7 +151,7 @@ protected:
     logical_host->createConnection(dispatcher_, nullptr, nullptr);
 
     expectResolve(Network::DnsLookupFamily::V4Only, expected_address);
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
 
     // Empty should not cause any change.
     EXPECT_CALL(*resolve_timer_, enableTimer(_));
@@ -167,7 +167,7 @@ protected:
     // Make sure we cancel.
     EXPECT_CALL(active_dns_query_, cancel());
     expectResolve(Network::DnsLookupFamily::V4Only, expected_address);
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
 
     tls_.shutdownThread();
   }

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -290,7 +290,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
   ASSERT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(true, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->used());
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
-  cleanup_timer_->callback_();
+  cleanup_timer_->invokeCallback();
   EXPECT_EQ(
       cluster_hosts,
       cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()); // hosts vector remains the same
@@ -301,7 +301,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
 
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   EXPECT_CALL(membership_updated_, ready());
-  cleanup_timer_->callback_();
+  cleanup_timer_->invokeCallback();
   EXPECT_NE(cluster_hosts,
             cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()); // hosts vector changes
 
@@ -392,7 +392,7 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   EXPECT_EQ(true, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->used());
   EXPECT_EQ(true, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]->used());
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
-  cleanup_timer_->callback_();
+  cleanup_timer_->invokeCallback();
   EXPECT_EQ(
       cluster_hosts,
       cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()); // hosts vector remains the same
@@ -404,7 +404,7 @@ TEST_F(OriginalDstClusterTest, Membership2) {
 
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   EXPECT_CALL(membership_updated_, ready());
-  cleanup_timer_->callback_();
+  cleanup_timer_->invokeCallback();
   EXPECT_NE(cluster_hosts,
             cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()); // hosts vector changes
 

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -232,7 +232,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow5xxViaHttpCodes) {
   // Interval that doesn't bring the host back in.
   time_system_.setMonotonicTime(std::chrono::milliseconds(9999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
   // Interval that does bring the host back in.
@@ -241,7 +241,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow5xxViaHttpCodes) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[0])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_TRUE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
@@ -359,7 +359,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow5xxViaNonHttpCodes) {
   // Interval that doesn't bring the host back in.
   time_system_.setMonotonicTime(std::chrono::milliseconds(9999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
   // Interval that does bring the host back in.
@@ -368,7 +368,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow5xxViaNonHttpCodes) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[0])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_TRUE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
@@ -450,7 +450,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowGatewayFailure) {
   // Interval that doesn't bring the host back in.
   time_system_.setMonotonicTime(std::chrono::milliseconds(9999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
   // Interval that does bring the host back in.
@@ -459,7 +459,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowGatewayFailure) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[0])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_TRUE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
@@ -537,7 +537,7 @@ TEST_F(OutlierDetectorImplTest, TimeoutWithHttpCode) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[0])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 
   // Report several LOCAL_ORIGIN_TIMEOUT with HTTP code other that 500. Node should not be ejected.
@@ -611,7 +611,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowLocalOriginFailure) {
   // Wait short time - not enough to be unejected
   time_system_.setMonotonicTime(std::chrono::milliseconds(9999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
   // Interval that does bring the host back in.
@@ -620,7 +620,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowLocalOriginFailure) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[0])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_TRUE(hosts_[0]->outlierDetector().lastUnejectionTime());
   EXPECT_EQ(0UL, outlier_detection_ejections_active_.value());
@@ -699,7 +699,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowGatewayFailureAnd5xx) {
   // Interval that doesn't bring the host back in.
   time_system_.setMonotonicTime(std::chrono::milliseconds(9999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
   // Interval that does bring the host back in.
@@ -708,7 +708,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowGatewayFailureAnd5xx) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[0])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_TRUE(hosts_[0]->outlierDetector().lastUnejectionTime());
 
@@ -848,7 +848,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateExternalOrigin) {
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   ON_CALL(runtime_.snapshot_, getInteger("outlier_detection.success_rate_stdev_factor", 1900))
       .WillByDefault(Return(1900));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_EQ(50, hosts_[4]->outlierDetector().successRate(
                     DetectorHostMonitor::SuccessRateMonitorType::ExternalOrigin));
   EXPECT_EQ(90, detector->successRateAverage(
@@ -868,7 +868,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateExternalOrigin) {
   // Interval that doesn't bring the host back in.
   time_system_.setMonotonicTime(std::chrono::milliseconds(19999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_TRUE(hosts_[4]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_EQ(1UL, outlier_detection_ejections_active_.value());
 
@@ -878,7 +878,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateExternalOrigin) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[4])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[4]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_EQ(0UL, outlier_detection_ejections_active_.value());
 
@@ -901,7 +901,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateExternalOrigin) {
 
   time_system_.setMonotonicTime(std::chrono::milliseconds(60001));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_EQ(0UL, outlier_detection_ejections_active_.value());
   EXPECT_EQ(-1, hosts_[4]->outlierDetector().successRate(
                     DetectorHostMonitor::SuccessRateMonitorType::ExternalOrigin));
@@ -982,7 +982,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateLocalOrigin) {
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   ON_CALL(runtime_.snapshot_, getInteger("outlier_detection.success_rate_stdev_factor", 1900))
       .WillByDefault(Return(1900));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_EQ(50, hosts_[4]->outlierDetector().successRate(
                     DetectorHostMonitor::SuccessRateMonitorType::LocalOrigin));
   EXPECT_EQ(90,
@@ -1002,7 +1002,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateLocalOrigin) {
   // Interval that doesn't bring the host back in.
   time_system_.setMonotonicTime(std::chrono::milliseconds(19999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_TRUE(hosts_[4]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_EQ(1UL, outlier_detection_ejections_active_.value());
 
@@ -1012,7 +1012,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateLocalOrigin) {
   EXPECT_CALL(*event_logger_,
               logUneject(std::static_pointer_cast<const HostDescription>(hosts_[4])));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_FALSE(hosts_[4]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   EXPECT_EQ(0UL, outlier_detection_ejections_active_.value());
 
@@ -1031,7 +1031,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlowSuccessRateLocalOrigin) {
 
   time_system_.setMonotonicTime(std::chrono::milliseconds(60001));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
   EXPECT_EQ(0UL, outlier_detection_ejections_active_.value());
   EXPECT_EQ(-1, hosts_[4]->outlierDetector().successRate(
                     DetectorHostMonitor::SuccessRateMonitorType::LocalOrigin));
@@ -1053,7 +1053,7 @@ TEST_F(OutlierDetectorImplTest, EmptySuccessRate) {
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   ON_CALL(runtime_.snapshot_, getInteger("outlier_detection.success_rate_minimum_hosts", 5))
       .WillByDefault(Return(0));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 }
 
 TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
@@ -1083,7 +1083,7 @@ TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
 
   time_system_.setMonotonicTime(std::chrono::milliseconds(9999));
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 }
 
 TEST_F(OutlierDetectorImplTest, Overflow) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -311,7 +311,7 @@ TEST_F(StrictDnsClusterImplTest, Basic) {
   EXPECT_EQ("localhost1", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->hostname());
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
   EXPECT_THAT(
@@ -319,14 +319,14 @@ TEST_F(StrictDnsClusterImplTest, Basic) {
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
   EXPECT_THAT(
       std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.3"}));
@@ -353,9 +353,9 @@ TEST_F(StrictDnsClusterImplTest, Basic) {
 
   // Make sure we cancel.
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   resolver2.expectResolve(*dns_resolver_);
-  resolver2.timer_->callback_();
+  resolver2.timer_->invokeCallback();
 
   EXPECT_CALL(resolver1.active_dns_query_, cancel());
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
@@ -610,7 +610,7 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   EXPECT_EQ(0UL, stats_.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
   EXPECT_THAT(
@@ -622,7 +622,7 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   EXPECT_EQ(1UL, stats_.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
   EXPECT_THAT(
@@ -641,14 +641,14 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   EXPECT_EQ(2UL, stats_.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
 
   // We again received the same set as before for localhost1. No rebuild this time.
   EXPECT_EQ(3UL, stats_.counter("cluster.name.update_no_rebuild").value());
 
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.3"}));
@@ -717,11 +717,11 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasic) {
 
   // Make sure we cancel.
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   resolver2.expectResolve(*dns_resolver_);
-  resolver2.timer_->callback_();
+  resolver2.timer_->invokeCallback();
   resolver3.expectResolve(*dns_resolver_);
-  resolver3.timer_->callback_();
+  resolver3.timer_->invokeCallback();
 
   EXPECT_CALL(resolver1.active_dns_query_, cancel());
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
@@ -799,7 +799,7 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {
   EXPECT_EQ("localhost1", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->hostname());
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
   EXPECT_THAT(
@@ -807,14 +807,14 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
   EXPECT_THAT(
       std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.3"}));
@@ -850,11 +850,11 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {
 
   // Make sure we cancel.
   resolver1.expectResolve(*dns_resolver_);
-  resolver1.timer_->callback_();
+  resolver1.timer_->invokeCallback();
   resolver2.expectResolve(*dns_resolver_);
-  resolver2.timer_->callback_();
+  resolver2.timer_->invokeCallback();
   resolver3.expectResolve(*dns_resolver_);
-  resolver3.timer_->callback_();
+  resolver3.timer_->invokeCallback();
 
   EXPECT_CALL(resolver1.active_dns_query_, cancel());
   EXPECT_CALL(resolver2.active_dns_query_, cancel());

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -375,14 +375,14 @@ protected:
     // Add new host.
     expectRedisResolve();
     EXPECT_CALL(membership_updated_, ready());
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
     EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
     expectClusterSlotResponse(twoSlotsMasters());
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
 
     // No change.
     expectRedisResolve();
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
     EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1).WillOnce(Return(false));
     expectClusterSlotResponse(twoSlotsMasters());
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
@@ -390,7 +390,7 @@ protected:
     // Remove host.
     expectRedisResolve();
     EXPECT_CALL(membership_updated_, ready());
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
     EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
     expectClusterSlotResponse(singleSlotMasterSlave("127.0.0.1", "127.0.0.2", 22120));
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120"}));
@@ -607,7 +607,7 @@ TEST_F(RedisClusterTest, RedisResolveFailure) {
   EXPECT_EQ(1U, cluster_->info()->stats().update_failure_.value());
 
   expectRedisResolve(true);
-  resolve_timer_->callback_();
+  resolve_timer_->invokeCallback();
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
@@ -616,7 +616,7 @@ TEST_F(RedisClusterTest, RedisResolveFailure) {
 
   // Expect no change if resolve failed.
   expectRedisResolve();
-  resolve_timer_->callback_();
+  resolve_timer_->invokeCallback();
   expectClusterSlotFailure();
   expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120"}));
   EXPECT_EQ(3U, cluster_->info()->stats().update_attempt_.value());
@@ -675,7 +675,7 @@ TEST_F(RedisClusterTest, RedisErrorResponse) {
   EXPECT_EQ(1U, cluster_->info()->stats().update_failure_.value());
 
   expectRedisResolve();
-  resolve_timer_->callback_();
+  resolve_timer_->invokeCallback();
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
@@ -689,7 +689,7 @@ TEST_F(RedisClusterTest, RedisErrorResponse) {
   for (uint64_t i = 0; i < (1 << 10); i++) {
     std::bitset<10> flags(i);
     expectRedisResolve();
-    resolve_timer_->callback_();
+    resolve_timer_->invokeCallback();
     if (flags.all()) {
       EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1).WillOnce(Return(false));
     }

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -360,7 +360,7 @@ TEST_F(HealthCheckFilterCachingTest, All) {
 
   // Fire the timer, this should result in the next request going through.
   EXPECT_CALL(*cache_timer_, enableTimer(_));
-  cache_timer_->callback_();
+  cache_timer_->invokeCallback();
   prepareFilter(true);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
 }
@@ -394,7 +394,7 @@ TEST_F(HealthCheckFilterCachingTest, DegradedHeader) {
 
   // Fire the timer, this should result in the next request going through.
   EXPECT_CALL(*cache_timer_, enableTimer(_));
-  cache_timer_->callback_();
+  cache_timer_->invokeCallback();
   prepareFilter(true);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
 }

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -330,7 +330,7 @@ TEST_F(SquashFilterTest, Timeout) {
   EXPECT_CALL(request_, cancel());
   EXPECT_CALL(filter_callbacks_, continueDecoding());
 
-  attachmentTimeout_timer_->callback_();
+  attachmentTimeout_timer_->invokeCallback();
 
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
 }
@@ -359,7 +359,7 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachment) {
 
   // Expect the second get attachment request
   expectAsyncClientSend();
-  retry_timer->callback_();
+  retry_timer->invokeCallback();
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   completeGetStatusRequest("attached");
 }
@@ -378,7 +378,7 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachmentOnFailure) {
   // Expect the second get attachment request
   expectAsyncClientSend();
 
-  retry_timer->callback_();
+  retry_timer->invokeCallback();
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   completeGetStatusRequest("attached");
@@ -432,8 +432,9 @@ TEST_F(SquashFilterTest, TimerExpiresInline) {
   attachmentTimeout_timer_ = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
   EXPECT_CALL(*attachmentTimeout_timer_, enableTimer(config_->attachmentTimeout()))
       .WillOnce(Invoke([&](const std::chrono::milliseconds&) {
+        attachmentTimeout_timer_->enabled_ = true;
         // timer expires inline
-        attachmentTimeout_timer_->callback_();
+        attachmentTimeout_timer_->invokeCallback();
       }));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -430,6 +430,8 @@ TEST_F(SquashFilterTest, TimerExpiresInline) {
   initFilter();
 
   attachmentTimeout_timer_ = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
+  // TODO: this is a really synthetic test as the callback can't actually be called under the stack
+  // of enableTimer. It'd be good to clean this up.
   EXPECT_CALL(*attachmentTimeout_timer_, enableTimer(config_->attachmentTimeout()))
       .WillOnce(Invoke([&](const std::chrono::milliseconds&) {
         attachmentTimeout_timer_->enabled_ = true;

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -221,7 +221,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Interval timer fires.
   setupRequest();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Error response.
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -231,7 +231,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Interval timer fires.
   setupRequest();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Parsing error
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -242,7 +242,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Interval timer fires.
   setupRequest();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // No response failure.
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -259,7 +259,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
             return nullptr;
           }));
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   EXPECT_EQ(4U, stats_store_.counter("auth.clientssl.vpn.update_failure").value());
 }

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -510,7 +510,7 @@ TEST_F(RedisClientImplTest, ConnectTimeout) {
   EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(callbacks1, onFailure());
   EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  connect_or_op_timer_->callback_();
+  connect_or_op_timer_->invokeCallback();
 
   EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_timeout_.value());
   EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
@@ -553,7 +553,7 @@ TEST_F(RedisClientImplTest, OpTimeout) {
   EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(callbacks1, onFailure());
   EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-  connect_or_op_timer_->callback_();
+  connect_or_op_timer_->invokeCallback();
 
   EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_timeout_.value());
   EXPECT_EQ(1UL, host_->stats_.rq_timeout_.value());

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -178,7 +178,7 @@ TEST_F(MongoProxyFilterTest, DelayFaults) {
   EXPECT_EQ(1U, store_.counter("test.op_kill_cursors").value());
 
   EXPECT_CALL(read_filter_callbacks_, continueReading());
-  delay_timer->callback_();
+  delay_timer->invokeCallback();
   EXPECT_EQ(1U, store_.counter("test.delays_injected").value());
 }
 
@@ -558,7 +558,7 @@ TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
 
   EXPECT_CALL(read_filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(*drain_timer, disableTimer());
-  drain_timer->callback_();
+  drain_timer->invokeCallback();
 
   EXPECT_EQ(0U, store_.gauge("test.op_query_active", Stats::Gauge::ImportMode::Accumulate).value());
   EXPECT_EQ(1U, store_.counter("test.cx_drain_close").value());

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -212,7 +212,7 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Failure
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
@@ -222,7 +222,7 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Redis failure via disconnect
   EXPECT_CALL(*timeout_timer_, disableTimer());
@@ -232,18 +232,18 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Timeout
   EXPECT_CALL(pool_request_, cancel());
   EXPECT_CALL(*client_, close());
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  timeout_timer_->callback_();
+  timeout_timer_->invokeCallback();
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Shutdown with active request.
   EXPECT_CALL(pool_request_, cancel());
@@ -280,7 +280,7 @@ TEST_F(RedisHealthCheckerTest, FailuresLogging) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Failure
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
@@ -291,7 +291,7 @@ TEST_F(RedisHealthCheckerTest, FailuresLogging) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Fail again
   EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, false));
@@ -301,7 +301,7 @@ TEST_F(RedisHealthCheckerTest, FailuresLogging) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Shutdown with active request.
   EXPECT_CALL(pool_request_, cancel());
@@ -338,7 +338,7 @@ TEST_F(RedisHealthCheckerTest, LogInitialFailure) {
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Success
   EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
@@ -351,7 +351,7 @@ TEST_F(RedisHealthCheckerTest, LogInitialFailure) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Shutdown with active request.
   EXPECT_CALL(pool_request_, cancel());
@@ -388,7 +388,7 @@ TEST_F(RedisHealthCheckerTest, Exists) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectExistsRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Failure, exists
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
@@ -400,7 +400,7 @@ TEST_F(RedisHealthCheckerTest, Exists) {
   pool_callbacks_->onResponse(std::move(response));
 
   expectExistsRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Failure, no value
   EXPECT_CALL(*timeout_timer_, disableTimer());
@@ -439,7 +439,7 @@ TEST_F(RedisHealthCheckerTest, ExistsRedirected) {
   pool_callbacks_->onRedirection(moved_response);
 
   expectExistsRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Success with ask redirection
   EXPECT_CALL(*timeout_timer_, disableTimer());
@@ -481,7 +481,7 @@ TEST_F(RedisHealthCheckerTest, NoConnectionReuse) {
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // The connection will close on failure.
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
@@ -493,7 +493,7 @@ TEST_F(RedisHealthCheckerTest, NoConnectionReuse) {
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Redis failure via disconnect, the connection was closed by the other end.
   EXPECT_CALL(*timeout_timer_, disableTimer());
@@ -503,18 +503,18 @@ TEST_F(RedisHealthCheckerTest, NoConnectionReuse) {
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Timeout, the connection will be closed.
   EXPECT_CALL(pool_request_, cancel());
   EXPECT_CALL(*client_, close());
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  timeout_timer_->callback_();
+  timeout_timer_->invokeCallback();
 
   expectClientCreate();
   expectPingRequestCreate();
-  interval_timer_->callback_();
+  interval_timer_->invokeCallback();
 
   // Shutdown with active request.
   EXPECT_CALL(pool_request_, cancel());

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -148,7 +148,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
   // Timer should be re-enabled.
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(900)));
 
-  timer_->callback_();
+  timer_->invokeCallback();
 
   EXPECT_EQ(1U, stats_.counter("tracing.datadog.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.datadog.traces_sent").value());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -342,7 +342,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.flush_interval_ms", 1000U))
       .WillOnce(Return(1000U));
 
-  timer_->callback_();
+  timer_->invokeCallback();
 
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.spans_sent").value());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -246,7 +246,7 @@ TEST_F(ZipkinDriverTest, FlushSpansTimer) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.zipkin.flush_interval_ms", 5000U))
       .WillOnce(Return(5000U));
 
-  timer_->callback_();
+  timer_->invokeCallback();
 
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.spans_sent").value());

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -140,9 +140,9 @@ public:
   MOCK_METHOD0(enabled, bool());
 
   bool enabled_{};
-  Event::TimerCb callback_; // TODO(mattklein123): This should be private and only called via
-                            // invoke callback to clear enabled_, but that will break too many
-                            // tests and can be done later.
+
+private:
+  Event::TimerCb callback_;
 };
 
 class MockSignalEvent : public SignalEvent {

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -609,7 +609,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
   EXPECT_EQ(1UL, downstream_pre_cx_active.value());
 
   EXPECT_CALL(*timeout, disableTimer());
-  timeout->callback_();
+  timeout->invokeCallback();
   dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0UL, downstream_pre_cx_active.value());
   EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());
@@ -658,7 +658,7 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
 
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(*timeout, disableTimer());
-  timeout->callback_();
+  timeout->invokeCallback();
   dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0UL, downstream_pre_cx_active.value());
   EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());

--- a/test/server/drain_manager_impl_test.cc
+++ b/test/server/drain_manager_impl_test.cc
@@ -37,7 +37,7 @@ TEST_F(DrainManagerImplTest, Default) {
   drain_manager.startParentShutdownSequence();
 
   EXPECT_CALL(server_.hot_restart_, sendParentTerminateRequest());
-  shutdown_timer->callback_();
+  shutdown_timer->invokeCallback();
 
   // Verify basic drain close.
   EXPECT_CALL(server_, healthCheckFailed()).WillOnce(Return(false));
@@ -58,7 +58,7 @@ TEST_F(DrainManagerImplTest, Default) {
     } else {
       EXPECT_CALL(drain_complete, ready());
     }
-    drain_timer->callback_();
+    drain_timer->invokeCallback();
   }
 
   EXPECT_CALL(server_, healthCheckFailed()).WillOnce(Return(false));


### PR DESCRIPTION
Cleanup inspired by https://github.com/envoyproxy/envoy/pull/7782 where I had to do a bunch of test cleanup because the tests were calling the callback directly rather than using invokeCallback()

This does lose us a synthetic validation in test/common/network/connection_impl_test.cc which the test admitted could not actually happen and from code inspection has been refactored to no longer look dangerous.

Risk Level: n/a (test only)
Testing: tests pass 
Docs Changes: n/a
Release Notes: n/a
