### PR TITLE
router: remove implicit cast of lambda to bool

### DIFF
--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -225,7 +225,7 @@ RetryStatus RetryStateImpl::shouldHedgeRetryPerTryTimeout(DoRetryCallback callba
   // retries are associated with a stream reset which is analogous to a gateway
   // error. When hedging on per try timeout is enabled, however, there is no
   // stream reset.
-  return shouldRetry([]() -> bool { return true; }, callback);
+  return shouldRetry(true, callback);
 }
 
 bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_headers) {


### PR DESCRIPTION
Per #7736, we're inadvertently casting a lambda expression to
bool. Fortunately, the code is attempting to pass true, so it
works.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes: #7736

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
