### PR TITLE
fix misspelled words in client.py help message

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/driver/client.py
+++ b/test/extensions/filters/network/thrift_proxy/driver/client.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
       "--headers",
       dest="headers",
       metavar="KEY=VALUE[,KEY=VALUE]",
-      help="list of comma-delimited, key value pairs to include as tranport headers.",
+      help="list of comma-delimited, key value pairs to include as transport headers.",
   )
 
   cfg = parser.parse_args()


### PR DESCRIPTION
Signed-off-by: Guangming Wang <guangming.wang@daocloud.io>

Description: just fix typos
Risk Level: very low
Testing: no need
Docs Changes: no
Release Notes: no
[Optional Fixes #Issue]
[Optional Deprecated:]
