### PR TITLE
bazel: set strict action env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,7 @@ startup --host_jvm_args=-Xmx2g
 build --workspace_status_command=bazel/get_workspace_status
 build --experimental_remap_main_repo
 build --experimental_local_memory_estimate
+build --experimental_strict_action_env=true
 build --host_force_python=PY2
 build --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
 build --action_env=BAZEL_LINKOPTS=-lm:-static-libgcc


### PR DESCRIPTION
We pass all environment variables we care about explicitly and should
not pass any other not set variables.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
