### PR TITLE
ci: add fuzz test targets to ci

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -10,6 +10,8 @@ jobs:
         CI_TARGET: 'bazel.gcc'
       compile_time_options:
         CI_TARGET: 'bazel.compile_time_options'
+      fuzz:
+        CI_TARGET: 'bazel.fuzz'
   dependsOn: [] # this removes the implicit dependency on previous stage and causes this to run in parallel.
   timeoutInMinutes: 360
   pool:

--- a/.bazelrc
+++ b/.bazelrc
@@ -146,4 +146,5 @@ build:asan-fuzzer --config=asan
 build:asan-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:asan-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 build:asan-fuzzer --copt=-fsanitize-coverage=trace-pc-guard
+# Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -146,3 +146,4 @@ build:asan-fuzzer --config=asan
 build:asan-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:asan-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 build:asan-fuzzer --copt=-fsanitize-coverage=trace-pc-guard
+build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -123,7 +123,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         testonly = 1,
         data = [corpus_name],
         deps = [":" + test_lib_name],
-        tags = ["manual"] + tags,
+        tags = ["manual", "libfuzzer"] + tags,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -123,7 +123,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         testonly = 1,
         data = [corpus_name],
         deps = [":" + test_lib_name],
-        tags = ["manual", "libfuzzer"] + tags,
+        tags = ["manual", "fuzzer"] + tags,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -115,7 +115,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         tags = ["manual"] + tags,
     )
 
-    native.cc_binary(
+    native.cc_test(
         name = name + "_with_libfuzzer",
         copts = envoy_copts("@envoy", test = True),
         linkopts = ["-fsanitize=fuzzer"] + _envoy_test_linkopts(),

--- a/ci/README.md
+++ b/ci/README.md
@@ -98,6 +98,8 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.coverity` &mdash; build Envoy static binary and run Coverity Scan static analysis.
 * `bazel.tsan` &mdash; build and run tests under `-c dbg --config=clang-tsan` with clang.
 * `bazel.tsan <test>` &mdash; build and run a specified test or test dir under `-c dbg --config=clang-tsan` with clang.
+* `bazel.fuzz` &mdash; build and run fuzz tests under `-c dbg --config=asan-fuzzer` with clang.
+* `bazel.fuzz <test>` &mdash; build and run a specified fuzz test or test dir under `-c dbg --config=asan-fuzzer` with clang.
 * `bazel.compile_time_options` &mdash; build Envoy and run tests with various compile-time options toggled to their non-default state, to ensure they still build.
 * `bazel.compile_time_options <test>` &mdash; build Envoy and run a specified test or test dir with various compile-time options toggled to their non-default state, to ensure they still build.
 * `bazel.clang_tidy` &mdash; build and run clang-tidy over all source files.

--- a/ci/README.md
+++ b/ci/README.md
@@ -99,7 +99,7 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.tsan` &mdash; build and run tests under `-c dbg --config=clang-tsan` with clang.
 * `bazel.tsan <test>` &mdash; build and run a specified test or test dir under `-c dbg --config=clang-tsan` with clang.
 * `bazel.fuzz` &mdash; build and run fuzz tests under `-c dbg --config=asan-fuzzer` with clang.
-* `bazel.fuzz <test>` &mdash; build and run a specified fuzz test or test dir under `-c dbg --config=asan-fuzzer` with clang.
+* `bazel.fuzz <test>` &mdash; build and run a specified fuzz test or test dir under `-c dbg --config=asan-fuzzer` with clang. If specifying a single fuzz test, must use the full target name with "_with_libfuzzer" for `<test>`.
 * `bazel.compile_time_options` &mdash; build Envoy and run tests with various compile-time options toggled to their non-default state, to ensure they still build.
 * `bazel.compile_time_options <test>` &mdash; build Envoy and run a specified test or test dir with various compile-time options toggled to their non-default state, to ensure they still build.
 * `bazel.clang_tidy` &mdash; build and run clang-tidy over all source files.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -264,9 +264,7 @@ elif [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
   setup_clang_toolchain
   echo "bazel ASAN libFuzzer build with fuzz tests ${FUZZ_TEST_TARGETS}"
   echo "Building envoy fuzzers and executing 100 fuzz iterations..."
-  for t in ${FUZZ_TEST_TARGETS}; do
-    bazel_with_collection run ${BAZEL_BUILD_OPTIONS} --config=asan-fuzzer $t -- -runs=10
-  done;
+  bazel_with_collection test ${BAZEL_BUILD_OPTIONS} --config=asan-fuzzer ${FUZZ_TEST_TARGETS} --test_arg="-runs=10"
   exit 0
 elif [[ "$CI_TARGET" == "fix_format" ]]; then
   echo "fix_format..."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -93,8 +93,7 @@ if [[ $# -gt 1 ]]; then
 else
   TEST_TARGETS=//test/...
   if [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
-    FUZZER_TARGETS_CC=$(find . -name *_fuzz_test.cc)
-    FUZZ_TEST_TARGETS="$(for t in ${FUZZER_TARGETS_CC}; do echo "${t:2:-3}_with_libfuzzer"; done;)"    
+    FUZZ_TEST_TARGETS="$(for t in $(bazel query "attr('tags','libfuzzer',//test/...)"); do echo $t; done;)"
   fi  
 fi
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -86,12 +86,11 @@ CI_TARGET=$1
 if [[ $# -gt 1 ]]; then
   shift
   TEST_TARGETS=$*
-  FUZZ_TEST_TARGETS=$*"_with_libfuzzer"
 else
   TEST_TARGETS=//test/...
 fi
 
-if [[ ! -z "$FUZZ_TEST_TARGET" && "$CI_TARGET" == "bazel.fuzz" ]]; then
+if [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
   FUZZ_TEST_TARGETS="$(bazel query "attr('tags','fuzzer',${TEST_TARGETS})")"
 fi  
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -90,10 +90,6 @@ else
   TEST_TARGETS=//test/...
 fi
 
-if [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
-  FUZZ_TEST_TARGETS="$(bazel query "attr('tags','fuzzer',${TEST_TARGETS})")"
-fi  
-
 if [[ "$CI_TARGET" == "bazel.release" ]]; then
   # When testing memory consumption, we want to test against exact byte-counts
   # where possible. As these differ between platforms and compile options, we
@@ -258,6 +254,7 @@ elif [[ "$CI_TARGET" == "bazel.coverity" ]]; then
   exit 0
 elif [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
   setup_clang_toolchain
+  FUZZ_TEST_TARGETS="$(bazel query "attr('tags','fuzzer',${TEST_TARGETS})")"
   echo "bazel ASAN libFuzzer build with fuzz tests ${FUZZ_TEST_TARGETS}"
   echo "Building envoy fuzzers and executing 100 fuzz iterations..."
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} --config=asan-fuzzer ${FUZZ_TEST_TARGETS} --test_arg="-runs=10"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -93,7 +93,7 @@ if [[ $# -gt 1 ]]; then
 else
   TEST_TARGETS=//test/...
   if [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
-    FUZZ_TEST_TARGETS="$(for t in $(bazel query "attr('tags','libfuzzer',//test/...)"); do echo $t; done;)"
+    FUZZ_TEST_TARGETS="$(bazel query "attr('tags','fuzzer',//test/...)")"
   fi  
 fi
 
@@ -263,8 +263,10 @@ elif [[ "$CI_TARGET" == "bazel.coverity" ]]; then
 elif [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
   setup_clang_toolchain
   echo "bazel ASAN libFuzzer build with fuzz tests ${FUZZ_TEST_TARGETS}"
-  echo "Building envoy fuzzers and running against corpora"
-  bazel_with_collection test ${BAZEL_BUILD_OPTIONS} -c dbg --config=asan-fuzzer ${FUZZ_TEST_TARGETS}
+  echo "Building envoy fuzzers and executing 100 fuzz iterations..."
+  for t in ${FUZZ_TEST_TARGETS}; do
+    bazel_with_collection run ${BAZEL_BUILD_OPTIONS} --config=asan-fuzzer $t -- -runs=10
+  done;
   exit 0
 elif [[ "$CI_TARGET" == "fix_format" ]]; then
   echo "fix_format..."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -85,18 +85,15 @@ CI_TARGET=$1
 
 if [[ $# -gt 1 ]]; then
   shift
-  # If this is a fuzz test, add _with_libfuzzer
-  if [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
-    FUZZ_TEST_TARGETS=$*"_with_libfuzzer"
-  fi
   TEST_TARGETS=$*
+  FUZZ_TEST_TARGETS=$*"_with_libfuzzer"
 else
   TEST_TARGETS=//test/...
-  if [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
-    FUZZ_TEST_TARGETS="$(bazel query "attr('tags','fuzzer',//test/...)")"
-  fi  
 fi
 
+if [[ ! -z "$FUZZ_TEST_TARGET" && "$CI_TARGET" == "bazel.fuzz" ]]; then
+  FUZZ_TEST_TARGETS="$(bazel query "attr('tags','fuzzer',${TEST_TARGETS})")"
+fi  
 
 if [[ "$CI_TARGET" == "bazel.release" ]]; then
   # When testing memory consumption, we want to test against exact byte-counts


### PR DESCRIPTION
Builds fuzz targets with asan+libfuzzer and runs them against their corpora.  Our native bazel builds work, this PR integrates the asan+libfuzzer builds in to CI. The fuzz target binaries will be in your envoy docker build directory.

Invoke with the following for all fuzz targets, or a specified one.
./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.fuzz'
./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.fuzz //test/common/common:utility_fuzz_test'

@yevgenypats @htuch @lizan 

Risk level: low
Signed-off-by: Asra Ali <asraa@google.com>
