### PR TITLE
rds: validate config in depth before update config dump

### DIFF
--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -48,6 +48,11 @@ public:
    * Callback used to notify RouteConfigProvider about configuration changes.
    */
   virtual void onConfigUpdate() PURE;
+
+  /**
+   * Validate if the route configuration can be applied to the context of the route config provider.
+   */
+  virtual void validateConfig(const envoy::api::v2::RouteConfiguration& config) const PURE;
 };
 
 using RouteConfigProviderPtr = std::unique_ptr<RouteConfigProvider>;

--- a/include/envoy/router/route_config_update_receiver.h
+++ b/include/envoy/router/route_config_update_receiver.h
@@ -28,6 +28,7 @@ public:
    */
   virtual bool onRdsUpdate(const envoy::api::v2::RouteConfiguration& rc,
                            const std::string& version_info) PURE;
+
   /**
    * Called on updates via VHDS.
    * @param added_resources supplies Resources (each containing a VirtualHost) that have been

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -99,6 +99,11 @@ void RdsRouteConfigSubscription::onConfigUpdate(
     throw EnvoyException(fmt::format("Unexpected RDS configuration (expecting {}): {}",
                                      route_config_name_, route_config.name()));
   }
+  for (auto* provider : route_config_providers_) {
+    // This seems inefficient, though it is neccessary to validate config in each context,
+    // especially when it comes with per_filter_config,
+    provider->validateConfig(route_config);
+  }
 
   if (config_update_info_->onRdsUpdate(route_config, version_info)) {
     stats_.config_reload_.inc();
@@ -196,6 +201,12 @@ void RdsRouteConfigProviderImpl::onConfigUpdate() {
       new ConfigImpl(config_update_info_->routeConfiguration(), factory_context_, false));
   tls_->runOnAllThreads(
       [this, new_config]() -> void { tls_->getTyped<ThreadLocalConfig>().config_ = new_config; });
+}
+
+void RdsRouteConfigProviderImpl::validateConfig(
+    const envoy::api::v2::RouteConfiguration& config) const {
+  // TODO(lizan): consider cache the config here until onConfigUpdate.
+  ConfigImpl validation_config(config, factory_context_, false);
 }
 
 RouteConfigProviderManagerImpl::RouteConfigProviderManagerImpl(Server::Admin& admin) {

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -100,7 +100,7 @@ void RdsRouteConfigSubscription::onConfigUpdate(
                                      route_config_name_, route_config.name()));
   }
   for (auto* provider : route_config_providers_) {
-    // This seems inefficient, though it is neccessary to validate config in each context,
+    // This seems inefficient, though it is necessary to validate config in each context,
     // especially when it comes with per_filter_config,
     provider->validateConfig(route_config);
   }

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -66,6 +66,7 @@ public:
   }
   SystemTime lastUpdated() const override { return last_updated_; }
   void onConfigUpdate() override {}
+  void validateConfig(const envoy::api::v2::RouteConfiguration&) const override {}
 
 private:
   ConfigConstSharedPtr config_;
@@ -159,7 +160,6 @@ public:
   ~RdsRouteConfigProviderImpl() override;
 
   RdsRouteConfigSubscription& subscription() { return *subscription_; }
-  void onConfigUpdate() override;
 
   // Router::RouteConfigProvider
   Router::ConfigConstSharedPtr config() override;
@@ -167,6 +167,8 @@ public:
     return config_update_info_->configInfo();
   }
   SystemTime lastUpdated() const override { return config_update_info_->lastUpdated(); }
+  void onConfigUpdate() override;
+  void validateConfig(const envoy::api::v2::RouteConfiguration& config) const override;
 
 private:
   struct ThreadLocalConfig : public ThreadLocal::ThreadLocalObject {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -172,6 +172,7 @@ private:
     absl::optional<ConfigInfo> configInfo() const override { return {}; }
     SystemTime lastUpdated() const override { return time_source_.systemTime(); }
     void onConfigUpdate() override {}
+    void validateConfig(const envoy::api::v2::RouteConfiguration&) const override {}
 
     Router::ConfigConstSharedPtr config_;
     TimeSource& time_source_;

--- a/test/common/http/conn_manager_impl_common.h
+++ b/test/common/http/conn_manager_impl_common.h
@@ -25,6 +25,7 @@ struct RouteConfigProvider : public Router::RouteConfigProvider {
   absl::optional<ConfigInfo> configInfo() const override { return {}; }
   SystemTime lastUpdated() const override { return time_source_.systemTime(); }
   void onConfigUpdate() override {}
+  void validateConfig(const envoy::api::v2::RouteConfiguration&) const override {}
 
   TimeSource& time_source_;
   std::shared_ptr<Router::MockConfig> route_config_{new NiceMock<Router::MockConfig>()};


### PR DESCRIPTION
Description:
Route config need deep validation for virtual host duplication check, regex check, per filter config validation etc, which PGV wasn't enough.

Risk Level: Low
Testing: regression test
Docs Changes: N/A
Release Notes: N/A
Fixes #7939