### PR TITLE
eds: avoid send too many ClusterLoadAssignment requests 

### DIFF
--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -125,7 +125,7 @@ public:
   }
   void pause(const std::string&) override {}
   void resume(const std::string&) override {}
-  bool paused(const std::string&) const override { NOT_REACHED_GCOVR_EXCL_LINE; }
+  bool paused(const std::string&) const override { return false; }
 };
 
 } // namespace Config

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -60,6 +60,9 @@ void CdsApiImpl::onConfigUpdate(
   cm_.adsMux().pause(Config::TypeUrl::get().ClusterLoadAssignment);
   Cleanup eds_resume([this] { cm_.adsMux().resume(Config::TypeUrl::get().ClusterLoadAssignment); });
 
+  ENVOY_LOG(info, "cds: add {} cluster(s), remove {} cluster(s)", added_resources.size(),
+            removed_resources.size());
+
   std::vector<std::string> exception_msgs;
   std::unordered_set<std::string> cluster_names;
   bool any_applied = false;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -129,6 +129,7 @@ public:
   State state() const { return state_; }
 
 private:
+  void initializeSecondaryClusters();
   void maybeFinishInitialize();
   void onClusterInit(Cluster& cluster);
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -31,8 +31,6 @@
 namespace Envoy {
 namespace Upstream {
 
-class ClusterManagerImpl;
-
 /**
  * Production implementation of ClusterManagerFactory.
  */
@@ -102,7 +100,7 @@ public:
    * @param per_cluster_init_callback supplies the callback to call when a cluster has itself
    *        initialized. The cluster manager can use this for post-init processing.
    */
-  ClusterManagerInitHelper(ClusterManagerImpl& cm,
+  ClusterManagerInitHelper(ClusterManager& cm,
                            const std::function<void(Cluster&)>& per_cluster_init_callback)
       : cm_(cm), per_cluster_init_callback_(per_cluster_init_callback) {}
 
@@ -134,7 +132,7 @@ private:
   void maybeFinishInitialize();
   void onClusterInit(Cluster& cluster);
 
-  ClusterManagerImpl& cm_;
+  ClusterManager& cm_;
   std::function<void(Cluster& cluster)> per_cluster_init_callback_;
   CdsApi* cds_{};
   std::function<void()> initialized_callback_;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -31,6 +31,8 @@
 namespace Envoy {
 namespace Upstream {
 
+class ClusterManagerImpl;
+
 /**
  * Production implementation of ClusterManagerFactory.
  */
@@ -100,8 +102,9 @@ public:
    * @param per_cluster_init_callback supplies the callback to call when a cluster has itself
    *        initialized. The cluster manager can use this for post-init processing.
    */
-  ClusterManagerInitHelper(const std::function<void(Cluster&)>& per_cluster_init_callback)
-      : per_cluster_init_callback_(per_cluster_init_callback) {}
+  ClusterManagerInitHelper(ClusterManagerImpl& cm,
+                           const std::function<void(Cluster&)>& per_cluster_init_callback)
+      : cm_(cm), per_cluster_init_callback_(per_cluster_init_callback) {}
 
   enum class State {
     // Initial state. During this state all static clusters are loaded. Any phase 1 clusters
@@ -131,6 +134,7 @@ private:
   void maybeFinishInitialize();
   void onClusterInit(Cluster& cluster);
 
+  ClusterManagerImpl& cm_;
   std::function<void(Cluster& cluster)> per_cluster_init_callback_;
   CdsApi* cds_{};
   std::function<void()> initialized_callback_;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -42,6 +42,8 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::ByRef;
+using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
 using testing::Mock;
@@ -2823,6 +2825,52 @@ TEST_F(ClusterManagerInitHelperTest, UpdateAlreadyInitialized) {
   EXPECT_CALL(*this, onClusterInit(Ref(cluster2)));
   EXPECT_CALL(cm_initialized, ready());
   cluster2.initialize_callback_();
+}
+
+TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithoutEdsPaused) {
+  InSequence s;
+
+  ReadyWatcher cm_initialized;
+  init_helper_.setInitializedCb([&]() -> void { cm_initialized.ready(); });
+
+  NiceMock<MockClusterMockPrioritySet> cluster1;
+  ON_CALL(cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
+  init_helper_.addCluster(cluster1);
+
+  const auto& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
+  EXPECT_CALL(cm_.ads_mux_, paused(Eq(ByRef(type_url)))).Times(1).WillRepeatedly(Return(false));
+  EXPECT_CALL(cm_.ads_mux_, pause(Eq(ByRef(type_url)))).Times(1);
+  EXPECT_CALL(cluster1, initialize(_));
+  EXPECT_CALL(cm_.ads_mux_, resume(Eq(ByRef(type_url)))).Times(1);
+
+  init_helper_.onStaticLoadComplete();
+
+  EXPECT_CALL(*this, onClusterInit(Ref(cluster1)));
+  EXPECT_CALL(cm_initialized, ready());
+  cluster1.initialize_callback_();
+}
+
+TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithEdsPaused) {
+  InSequence s;
+
+  ReadyWatcher cm_initialized;
+  init_helper_.setInitializedCb([&]() -> void { cm_initialized.ready(); });
+
+  NiceMock<MockClusterMockPrioritySet> cluster1;
+  ON_CALL(cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
+  init_helper_.addCluster(cluster1);
+
+  const auto& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
+  EXPECT_CALL(cm_.ads_mux_, paused(Eq(ByRef(type_url)))).Times(1).WillRepeatedly(Return(true));
+  EXPECT_CALL(cm_.ads_mux_, pause(Eq(ByRef(type_url)))).Times(0);
+  EXPECT_CALL(cluster1, initialize(_));
+  EXPECT_CALL(cm_.ads_mux_, resume(Eq(ByRef(type_url)))).Times(0);
+
+  init_helper_.onStaticLoadComplete();
+
+  EXPECT_CALL(*this, onClusterInit(Ref(cluster1)));
+  EXPECT_CALL(cm_initialized, ready());
+  cluster1.initialize_callback_();
 }
 
 TEST_F(ClusterManagerInitHelperTest, AddSecondaryAfterSecondaryInit) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2842,10 +2842,10 @@ TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithoutEdsPaused) {
   init_helper_.addCluster(cluster1);
 
   const auto& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
-  EXPECT_CALL(cm_.ads_mux_, paused(Eq(ByRef(type_url)))).Times(1).WillRepeatedly(Return(false));
-  EXPECT_CALL(cm_.ads_mux_, pause(Eq(ByRef(type_url)))).Times(1);
+  EXPECT_CALL(cm_.ads_mux_, paused(Eq(ByRef(type_url)))).WillRepeatedly(Return(false));
+  EXPECT_CALL(cm_.ads_mux_, pause(Eq(ByRef(type_url))));
   EXPECT_CALL(cluster1, initialize(_));
-  EXPECT_CALL(cm_.ads_mux_, resume(Eq(ByRef(type_url)))).Times(1);
+  EXPECT_CALL(cm_.ads_mux_, resume(Eq(ByRef(type_url))));
 
   init_helper_.onStaticLoadComplete();
 
@@ -2869,7 +2869,7 @@ TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithEdsPaused) {
   init_helper_.addCluster(cluster1);
 
   const auto& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
-  EXPECT_CALL(cm_.ads_mux_, paused(Eq(ByRef(type_url)))).Times(1).WillRepeatedly(Return(true));
+  EXPECT_CALL(cm_.ads_mux_, paused(Eq(ByRef(type_url)))).WillRepeatedly(Return(true));
   EXPECT_CALL(cm_.ads_mux_, pause(Eq(ByRef(type_url)))).Times(0);
   EXPECT_CALL(cluster1, initialize(_));
   EXPECT_CALL(cm_.ads_mux_, resume(Eq(ByRef(type_url)))).Times(0);

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2827,6 +2827,10 @@ TEST_F(ClusterManagerInitHelperTest, UpdateAlreadyInitialized) {
   cluster2.initialize_callback_();
 }
 
+// If secondary clusters initialization triggered outside of CdsApiImpl::onConfigUpdate()'s
+// callback flows, sending ClusterLoadAssignment should not be paused before calling
+// ClusterManagerInitHelper::maybeFinishInitialize(). This case tests that
+// ClusterLoadAssignment request is paused and resumed properly.
 TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithoutEdsPaused) {
   InSequence s;
 
@@ -2850,6 +2854,10 @@ TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithoutEdsPaused) {
   cluster1.initialize_callback_();
 }
 
+// If secondary clusters initialization triggered inside of CdsApiImpl::onConfigUpdate()'s
+// callback flows, that's, the CDS response didn't have any primary cluster, sending
+// ClusterLoadAssignment should be already paused by CdsApiImpl::onConfigUpdate().
+// This case tests that ClusterLoadAssignment request isn't paused again.
 TEST_F(ClusterManagerInitHelperTest, InitSecondaryWithEdsPaused) {
   InSequence s;
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2752,7 +2752,8 @@ class ClusterManagerInitHelperTest : public testing::Test {
 public:
   MOCK_METHOD1(onClusterInit, void(Cluster& cluster));
 
-  ClusterManagerInitHelper init_helper_{[this](Cluster& cluster) { onClusterInit(cluster); }};
+  NiceMock<MockClusterManager> cm_;
+  ClusterManagerInitHelper init_helper_{cm_, [this](Cluster& cluster) { onClusterInit(cluster); }};
 };
 
 TEST_F(ClusterManagerInitHelperTest, ImmediateInitialize) {


### PR DESCRIPTION
eds: avoid send too many ClusterLoadAssignment requests while initializing secondary clusters

Description:
During initializing secondary clusters, for each initialized cluster, a ClusterLoadAssignment
request is sent to istio pilot with the cluster's name appended into request's resource_names
list. With a huge number of clusters(e.g 10k clusters), this behavior slows down Envoy's
initialization and consumes ton of memory. This change pauses ADS mux for ClusterLoadAssignment to avoid that.

Risk Level: Medium
Testing: tiny change, no test case added
Fixes #7955
 
Signed-off-by: lhuang8 <lhuang8@ebay.com>

 



