### PR TITLE
tls: maintain a free slot index set in TLS InstanceImpl to allocate in O(1…

### DIFF
--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -30,7 +30,7 @@ SlotPtr InstanceImpl::allocateSlot() {
     slots_.push_back(slot.get());
     return slot;
   }
-  uint32_t idx = free_slot_indexes_.front();
+  const uint32_t idx = free_slot_indexes_.front();
   free_slot_indexes_.pop_front();
   ASSERT(idx < slots_.size());
   std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, idx));

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -9,6 +9,8 @@
 
 #include "common/common/logger.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace ThreadLocal {
 
@@ -57,6 +59,9 @@ private:
 
   static thread_local ThreadLocalData thread_local_data_;
   std::vector<SlotImpl*> slots_;
+  // A set of index of freed slots.
+  absl::flat_hash_set<uint32_t> free_slot_indexes_;
+
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
   std::thread::id main_thread_id_;
   Event::Dispatcher* main_thread_dispatcher_{};

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -59,8 +59,8 @@ private:
 
   static thread_local ThreadLocalData thread_local_data_;
   std::vector<SlotImpl*> slots_;
-  // A set of index of freed slots.
-  absl::flat_hash_set<uint32_t> free_slot_indexes_;
+  // A list of index of freed slots.
+  std::list<uint32_t> free_slot_indexes_;
 
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
   std::thread::id main_thread_id_;

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -9,8 +9,6 @@
 
 #include "common/common/logger.h"
 
-#include "absl/container/flat_hash_set.h"
-
 namespace Envoy {
 namespace ThreadLocal {
 


### PR DESCRIPTION
Description: maintain an index set of freed slots in TLS instance impl to allocate in O(1) time.
Risk Level: LOW
Testing: reuse existing unit test
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] #7975 
