### PR TITLE
api config: add build rules for go protos

### DIFF
--- a/api/envoy/config/accesslog/v2/BUILD
+++ b/api/envoy/config/accesslog/v2/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal", "api_go_proto_library")
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 

--- a/api/envoy/config/accesslog/v2/BUILD
+++ b/api/envoy/config/accesslog/v2/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal", "api_go_proto_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -13,4 +13,10 @@ api_proto_library_internal(
 api_proto_library_internal(
     name = "file",
     srcs = ["file.proto"],
+)
+
+api_go_proto_library(
+    name = "als",
+    proto = ":als",
+    deps = ["//envoy/api/v2/core:grpc_service_go_proto"],
 )

--- a/api/envoy/config/filter/network/tcp_proxy/v2/BUILD
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal", "api_go_proto_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -9,5 +9,15 @@ api_proto_library_internal(
         "//envoy/api/v2/core:address",
         "//envoy/api/v2/core:base",
         "//envoy/config/filter/accesslog/v2:accesslog",
+    ],
+)
+
+api_go_proto_library(
+    name = "tcp_proxy",
+    proto = ":tcp_proxy",
+    deps = [
+        "//envoy/api/v2/core:address_go_proto",
+        "//envoy/api/v2/core:base_go_proto",
+        "//envoy/config/filter/accesslog/v2:accesslog_go_proto",
     ],
 )

--- a/api/envoy/config/filter/network/tcp_proxy/v2/BUILD
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal", "api_go_proto_library")
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 


### PR DESCRIPTION
Description: Some BUILD files are missing build rules to generate go protos. `envoyproxy/go-control-plane` depends on these protos, so they should be exposed publicly. Added build rules to generate *.pb.go files.

Risk Level: Low

Testing: These rules were copied to google3 and tested internally. Unfortunately, I am having a bit of trouble with bazel build directly on these targets ("Package is considered deleted due to --deleted_packages"). Please let me know if there is a better way to test this change.

Docs Changes: N/A

Release Notes: N/A

Signed-off-by: Teju Nareddy <nareddyt@google.com>