### PR TITLE
tracing: add grpc-status and grpc-message to spans

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -502,8 +502,9 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
   }
 
   if (active_span_) {
-    Tracing::HttpTracerUtility::finalizeSpan(*active_span_, request_headers_.get(), stream_info_,
-                                             *this);
+    Tracing::HttpTracerUtility::finalizeSpan(*active_span_, request_headers_.get(),
+                                             response_headers_.get(), response_trailers_.get(),
+                                             stream_info_, *this);
   }
   if (state_.successful_upgrade_) {
     connection_manager_.stats_.named_.downstream_cx_upgrades_active_.dec();

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -41,6 +41,7 @@ public:
   // Non-standard tag names.
   const std::string DownstreamCluster = "downstream_cluster";
   const std::string GrpcStatusCode = "grpc.status_code";
+  const std::string GrpcMessage = "grpc.message";
   const std::string GuidXClientTraceId = "guid:x-client-trace-id";
   const std::string GuidXRequestId = "guid:x-request-id";
   const std::string HttpProtocol = "http.protocol";
@@ -101,6 +102,8 @@ public:
    * 2) Finish active span.
    */
   static void finalizeSpan(Span& span, const Http::HeaderMap* request_headers,
+                           const Http::HeaderMap* response_headers,
+                           const Http::HeaderMap* response_trailers,
                            const StreamInfo::StreamInfo& stream_info, const Config& tracing_config);
 
   static const std::string IngressOperation;

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -122,12 +122,14 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
                                           {"x-envoy-original-path", path},
                                           {":method", "GET"},
                                           {"x-forwarded-proto", "http"}};
+  Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
@@ -137,7 +139,8 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, &response_headers, &response_trailers,
+                                  stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
@@ -148,12 +151,14 @@ TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
 
   Http::TestHeaderMapImpl request_headers{
       {"x-envoy-original-path", path}, {":method", "GET"}, {"x-forwarded-proto", "http"}};
+  Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
@@ -163,7 +168,8 @@ TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, &response_headers, &response_trailers,
+                                  stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
@@ -184,7 +190,7 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, StreamInfoLogs) {
@@ -222,7 +228,7 @@ TEST(HttpConnManFinalizerImpl, StreamInfoLogs) {
 
   NiceMock<MockConfig> config;
   EXPECT_CALL(config, verbose).WillOnce(Return(true));
-  HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
@@ -244,7 +250,7 @@ TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
@@ -254,11 +260,13 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
                                           {":path", "/test"},
                                           {":method", "GET"},
                                           {"x-forwarded-proto", "https"}};
+  Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
@@ -282,7 +290,8 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, &response_headers, &response_trailers,
+                                  stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
@@ -291,6 +300,8 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
                                           {":path", "/test"},
                                           {":method", "GET"},
                                           {"x-forwarded-proto", "http"}};
+  Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   request_headers.insertHost().value(std::string("api"));
@@ -299,7 +310,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   request_headers.insertClientTraceId().value(std::string("client_trace_id"));
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   const std::string service_node = "i-453";
 
@@ -339,7 +350,43 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("UT")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
 
-  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, &response_headers, &response_trailers,
+                                  stream_info, config);
+}
+
+TEST(HttpConnManFinalizerImpl, Grpc) {
+  const std::string path_prefix = "http://";
+  NiceMock<MockSpan> span;
+
+  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
+                                          {":scheme", "http"},
+                                          {":path", "/pb.Foo/Bar"},
+                                          {":authority", "example.com:80"},
+                                          {"content-type", "application/grpc"},
+                                          {"te", "trailers"}};
+
+  Http::TestHeaderMapImpl response_headers{{":status", "200"},
+                                           {"content-type", "application/grpc"}};
+  Http::TestHeaderMapImpl response_trailers{{"grpc-status", "0"}, {"grpc-message", ""}};
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
+  absl::optional<uint32_t> response_code(200);
+  EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
+  EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
+  EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+
+  EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("POST")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("0")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("")));
+
+  NiceMock<MockConfig> config;
+  HttpTracerUtility::finalizeSpan(span, &request_headers, &response_headers, &response_trailers,
+                                  stream_info, config);
 }
 
 TEST(HttpTracerUtilityTest, operationTypeToString) {
@@ -352,6 +399,8 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
   MockConfig config;
   StreamInfo::MockStreamInfo stream_info;
   Http::TestHeaderMapImpl request_headers;
+  Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
 
   SpanPtr span_ptr =
       null_tracer.startSpan(config, request_headers, stream_info, {Reason::Sampling, true});
@@ -374,6 +423,8 @@ public:
 
   Http::TestHeaderMapImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}, {":authority", "test"}};
+  Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
   StreamInfo::MockStreamInfo stream_info_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   MockConfig config_;


### PR DESCRIPTION
Description: Adds tags to tracing spans for GRPC responses.
This is done only when the protocol is HTTP2 and the content-type matches for grpc.

Risk Level: Low
Testing: Unit test added. E2E test with datadog tracing.
Docs Changes / Release Notes: let me know if this is needed.

Fixes #7944 
