### PR TITLE
accesslog: don't open log file with read flag

### DIFF
--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -42,9 +42,9 @@ AccessLogFileImpl::AccessLogFileImpl(Filesystem::FilePtr&& file, Event::Dispatch
 }
 
 Filesystem::FlagSet AccessLogFileImpl::defaultFlags() {
-  static constexpr Filesystem::FlagSet default_flags{
-      1 << Filesystem::File::Operation::Read | 1 << Filesystem::File::Operation::Write |
-      1 << Filesystem::File::Operation::Create | 1 << Filesystem::File::Operation::Append};
+  static constexpr Filesystem::FlagSet default_flags{1 << Filesystem::File::Operation::Write |
+                                                     1 << Filesystem::File::Operation::Create |
+                                                     1 << Filesystem::File::Operation::Append};
 
   return default_flags;
 }

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -14,6 +14,7 @@
 
 using testing::_;
 using testing::ByMove;
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnNew;
@@ -49,14 +50,28 @@ protected:
 
 TEST_F(AccessLogManagerImplTest, BadFile) {
   EXPECT_CALL(dispatcher_, createTimer_(_));
-  EXPECT_CALL(*file_, open_()).WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))));
+  EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))));
   EXPECT_THROW(access_log_manager_.createAccessLog("foo"), EnvoyException);
+}
+
+TEST_F(AccessLogManagerImplTest, OpenFileWithRightFlags) {
+  EXPECT_CALL(dispatcher_, createTimer_(_));
+  EXPECT_CALL(*file_, open_(_))
+      .WillOnce(Invoke([](Filesystem::FlagSet flags) -> Api::IoCallBoolResult {
+        EXPECT_FALSE(flags[Filesystem::File::Operation::Read]);
+        EXPECT_TRUE(flags[Filesystem::File::Operation::Write]);
+        EXPECT_TRUE(flags[Filesystem::File::Operation::Append]);
+        EXPECT_TRUE(flags[Filesystem::File::Operation::Create]);
+        return Filesystem::resultSuccess<bool>(true);
+      }));
+  EXPECT_NE(nullptr, access_log_manager_.createAccessLog("foo"));
+  EXPECT_CALL(*file_, close_()).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 }
 
 TEST_F(AccessLogManagerImplTest, flushToLogFilePeriodically) {
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
 
-  EXPECT_CALL(*file_, open_()).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
+  EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
 
   EXPECT_CALL(*timer, enableTimer(timeout_40ms_));
@@ -98,7 +113,7 @@ TEST_F(AccessLogManagerImplTest, flushToLogFilePeriodically) {
 TEST_F(AccessLogManagerImplTest, flushToLogFileOnDemand) {
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
 
-  EXPECT_CALL(*file_, open_()).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
+  EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
 
   EXPECT_CALL(*timer, enableTimer(timeout_40ms_));
@@ -163,7 +178,7 @@ TEST_F(AccessLogManagerImplTest, reopenFile) {
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
 
   Sequence sq;
-  EXPECT_CALL(*file_, open_())
+  EXPECT_CALL(*file_, open_(_))
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
@@ -188,7 +203,7 @@ TEST_F(AccessLogManagerImplTest, reopenFile) {
   EXPECT_CALL(*file_, close_())
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
-  EXPECT_CALL(*file_, open_())
+  EXPECT_CALL(*file_, open_(_))
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 
@@ -224,7 +239,7 @@ TEST_F(AccessLogManagerImplTest, reopenThrows) {
       }));
 
   Sequence sq;
-  EXPECT_CALL(*file_, open_())
+  EXPECT_CALL(*file_, open_(_))
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 
@@ -232,7 +247,7 @@ TEST_F(AccessLogManagerImplTest, reopenThrows) {
   EXPECT_CALL(*file_, close_())
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
-  EXPECT_CALL(*file_, open_())
+  EXPECT_CALL(*file_, open_(_))
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))));
 
@@ -262,7 +277,7 @@ TEST_F(AccessLogManagerImplTest, reopenThrows) {
 }
 
 TEST_F(AccessLogManagerImplTest, bigDataChunkShouldBeFlushedWithoutTimer) {
-  EXPECT_CALL(*file_, open_()).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
+  EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
 
   EXPECT_CALL(*file_, write_(_))
@@ -305,7 +320,7 @@ TEST_F(AccessLogManagerImplTest, reopenAllFiles) {
   EXPECT_CALL(dispatcher_, createTimer_(_)).WillRepeatedly(ReturnNew<NiceMock<Event::MockTimer>>());
 
   Sequence sq;
-  EXPECT_CALL(*file_, open_())
+  EXPECT_CALL(*file_, open_(_))
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
   AccessLogFileSharedPtr log = access_log_manager_.createAccessLog("foo");
@@ -315,7 +330,7 @@ TEST_F(AccessLogManagerImplTest, reopenAllFiles) {
       .WillOnce(Return(ByMove(std::unique_ptr<NiceMock<Filesystem::MockFile>>(file2))));
 
   Sequence sq2;
-  EXPECT_CALL(*file2, open_())
+  EXPECT_CALL(*file2, open_(_))
       .InSequence(sq2)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
   AccessLogFileSharedPtr log2 = access_log_manager_.createAccessLog("bar");
@@ -342,10 +357,10 @@ TEST_F(AccessLogManagerImplTest, reopenAllFiles) {
       .InSequence(sq2)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 
-  EXPECT_CALL(*file_, open_())
+  EXPECT_CALL(*file_, open_(_))
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
-  EXPECT_CALL(*file2, open_())
+  EXPECT_CALL(*file2, open_(_))
       .InSequence(sq2)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 

--- a/test/extensions/access_loggers/file/BUILD
+++ b/test/extensions/access_loggers/file/BUILD
@@ -18,5 +18,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/access_loggers/file:config",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:environment_lib",
     ],
 )

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -9,6 +9,7 @@
 #include "extensions/access_loggers/well_known_names.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/environment.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -18,6 +19,8 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace File {
 namespace {
+
+using testing::ReturnRef;
 
 TEST(FileAccessLogConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
@@ -154,6 +157,34 @@ TEST(FileAccessLogConfigTest, FileAccessLogJsonWithNestedKeyTest) {
                               EnvoyException,
                               "Only string values are supported in the JSON access log format.");
   }
+}
+
+TEST(FileAccessLogConfigTest, FileAccessPermissionTest) {
+  auto factory =
+      Registry::FactoryRegistry<Server::Configuration::AccessLogInstanceFactory>::getFactory(
+          AccessLogNames::get().File);
+  ASSERT_NE(nullptr, factory);
+
+  ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
+  ASSERT_NE(nullptr, message);
+
+  std::string log_file =
+      absl::StrCat(TestEnvironment::temporaryDirectory(), "/log_file_permission_test.txt");
+
+  TestEnvironment::exec({"touch", log_file});
+  TestEnvironment::exec({"chmod", "000", log_file});
+
+  auto& fs = Filesystem::fileSystemForTest();
+  auto& file_access_log = dynamic_cast<envoy::config::accesslog::v2::FileAccessLog&>(*message);
+  file_access_log.set_path("log_file");
+  file_access_log.set_format("%START_TIME%");
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  ON_CALL(context.api_, fileSystem()).WillByDefault(ReturnRef(fs));
+  AccessLog::InstanceSharedPtr instance =
+      factory->createAccessLogInstance(*message, nullptr, context);
+  EXPECT_NE(nullptr, instance);
+  EXPECT_NE(nullptr, dynamic_cast<FileAccessLog*>(instance.get()));
 }
 
 } // namespace

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -9,10 +9,10 @@ namespace Filesystem {
 MockFile::MockFile() : num_opens_(0), num_writes_(0), is_open_(false) {}
 MockFile::~MockFile() = default;
 
-Api::IoCallBoolResult MockFile::open(FlagSet) {
+Api::IoCallBoolResult MockFile::open(FlagSet flag) {
   Thread::LockGuard lock(open_mutex_);
 
-  Api::IoCallBoolResult result = open_();
+  Api::IoCallBoolResult result = open_(flag);
   is_open_ = result.rc_;
   num_opens_++;
   open_event_.notifyOne();

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -25,7 +25,7 @@ public:
   bool isOpen() const override { return is_open_; };
   MOCK_CONST_METHOD0(path, std::string());
 
-  MOCK_METHOD0(open_, Api::IoCallBoolResult());
+  MOCK_METHOD1(open_, Api::IoCallBoolResult(FlagSet flag));
   MOCK_METHOD1(write_, Api::IoCallSizeResult(absl::string_view buffer));
   MOCK_METHOD0(close_, Api::IoCallBoolResult());
 

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -25,7 +25,8 @@ public:
   bool isOpen() const override { return is_open_; };
   MOCK_CONST_METHOD0(path, std::string());
 
-  MOCK_METHOD1(open_, Api::IoCallBoolResult(FlagSet flag));
+  // The first parameter here must be `const FlagSet&` otherwise it doesn't compile with libstdc++
+  MOCK_METHOD1(open_, Api::IoCallBoolResult(const FlagSet& flag));
   MOCK_METHOD1(write_, Api::IoCallSizeResult(absl::string_view buffer));
   MOCK_METHOD0(close_, Api::IoCallBoolResult());
 


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
File access log shouldn't need read access for a file.

Risk Level: Low
Testing: local in mac, CI
Docs Changes:
Release Notes:
Fixes #7997 