### PR TITLE
test: don't use <experimental/filesystem> on macOS.

### DIFF
--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -8,7 +8,7 @@
 #if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
 #include <filesystem>
 #elif defined __has_include
-#if __has_include(<experimental/filesystem>)
+#if __has_include(<experimental/filesystem>) && !defined(__APPLE__)
 #include <experimental/filesystem>
 #endif
 #endif
@@ -44,7 +44,7 @@ std::string makeTempDir(char* name_template) {
                                                  name_template, strerror(errno)));
 #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 9000 && !defined(__APPLE__)
   std::__fs::filesystem::create_directories(dirname);
-#elif defined __cpp_lib_experimental_filesystem
+#elif defined __cpp_lib_experimental_filesystem && !defined(__APPLE__)
   std::experimental::filesystem::create_directories(dirname);
 #endif
 #else
@@ -102,7 +102,7 @@ void TestEnvironment::createParentPath(const std::string& path) {
   // We don't want to rely on mkdir etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
   std::__fs::filesystem::create_directories(std::__fs::filesystem::path(path).parent_path());
-#elif defined __cpp_lib_experimental_filesystem
+#elif defined __cpp_lib_experimental_filesystem && !defined(__APPLE__)
   std::experimental::filesystem::create_directories(
       std::experimental::filesystem::path(path).parent_path());
 #else
@@ -120,7 +120,7 @@ void TestEnvironment::removePath(const std::string& path) {
     return;
   }
   std::__fs::filesystem::remove_all(std::__fs::filesystem::path(path));
-#elif defined __cpp_lib_experimental_filesystem
+#elif defined __cpp_lib_experimental_filesystem && !defined(__APPLE__)
   if (!std::experimental::filesystem::exists(path)) {
     return;
   }


### PR DESCRIPTION
Xcode 11 requires at least macOS 10.15 (upcoming) in order to use
either <experimental/filesystem> or C++17 <filesystem>.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>