### PR TITLE
protobuf: towards unifying PGV, deprecated and unknown field validation.

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -234,6 +234,7 @@ envoy_cc_library(
         ":resource_monitor_interface",
         "//include/envoy/api:api_interface",
         "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/protobuf:message_validator_interface",
     ],
 )
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -269,11 +269,14 @@ public:
    * implementation is unable to produce a factory with the provided parameters, it should throw an
    * EnvoyException.
    * @param config supplies the protobuf configuration for the filter
+   * @param validation_visitor message validation visitor instance.
    * @return Upstream::ProtocolOptionsConfigConstSharedPtr the protocol options
    */
   virtual Upstream::ProtocolOptionsConfigConstSharedPtr
-  createProtocolOptionsConfig(const Protobuf::Message& config) {
+  createProtocolOptionsConfig(const Protobuf::Message& config,
+                              ProtobufMessage::ValidationVisitor& validation_visitor) {
     UNREFERENCED_PARAMETER(config);
+    UNREFERENCED_PARAMETER(validation_visitor);
     return nullptr;
   }
 

--- a/include/envoy/server/resource_monitor_config.h
+++ b/include/envoy/server/resource_monitor_config.h
@@ -3,6 +3,7 @@
 #include "envoy/api/api.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/protobuf/message_validator.h"
 #include "envoy/server/resource_monitor.h"
 
 #include "common/protobuf/protobuf.h"
@@ -25,6 +26,12 @@ public:
    * @return reference to the Api object
    */
   virtual Api::Api& api() PURE;
+
+  /**
+   * @return ProtobufMessage::ValidationVisitor& validation visitor for filter configuration
+   *         messages.
+   */
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
 };
 
 /**

--- a/include/envoy/upstream/retry.h
+++ b/include/envoy/upstream/retry.h
@@ -79,8 +79,10 @@ class RetryPriorityFactory {
 public:
   virtual ~RetryPriorityFactory() = default;
 
-  virtual RetryPrioritySharedPtr createRetryPriority(const Protobuf::Message& config,
-                                                     uint32_t retry_count) PURE;
+  virtual RetryPrioritySharedPtr
+  createRetryPriority(const Protobuf::Message& config,
+                      ProtobufMessage::ValidationVisitor& validation_visitor,
+                      uint32_t retry_count) PURE;
 
   virtual std::string name() const PURE;
 

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -28,7 +28,8 @@ public:
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
   static FilterPtr fromProto(const envoy::config::filter::accesslog::v2::AccessLogFilter& config,
-                             Runtime::Loader& runtime, Runtime::RandomGenerator& random);
+                             Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+                             ProtobufMessage::ValidationVisitor& validation_visitor);
 };
 
 /**
@@ -82,7 +83,8 @@ class OperatorFilter : public Filter {
 public:
   OperatorFilter(const Protobuf::RepeatedPtrField<
                      envoy::config::filter::accesslog::v2::AccessLogFilter>& configs,
-                 Runtime::Loader& runtime, Runtime::RandomGenerator& random);
+                 Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+                 ProtobufMessage::ValidationVisitor& validation_visitor);
 
 protected:
   std::vector<FilterPtr> filters_;
@@ -94,7 +96,8 @@ protected:
 class AndFilter : public OperatorFilter {
 public:
   AndFilter(const envoy::config::filter::accesslog::v2::AndFilter& config, Runtime::Loader& runtime,
-            Runtime::RandomGenerator& random);
+            Runtime::RandomGenerator& random,
+            ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
@@ -108,7 +111,8 @@ public:
 class OrFilter : public OperatorFilter {
 public:
   OrFilter(const envoy::config::filter::accesslog::v2::OrFilter& config, Runtime::Loader& runtime,
-           Runtime::RandomGenerator& random);
+           Runtime::RandomGenerator& random,
+           ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -235,9 +235,12 @@ public:
    * @param message message to validate.
    * @throw ProtoValidationException if the message does not satisfy its type constraints.
    */
-  template <class MessageType> static void validate(const MessageType& message) {
+  template <class MessageType>
+  static void validate(const MessageType& message,
+                       ProtobufMessage::ValidationVisitor& validation_visitor) {
     // Log warnings or throw errors if deprecated fields are in use.
     checkForDeprecation(message);
+    checkUnknownFields(message, validation_visitor);
 
     std::string err;
     if (!Validate(message, &err)) {
@@ -249,14 +252,14 @@ public:
   static void loadFromFileAndValidate(const std::string& path, MessageType& message,
                                       ProtobufMessage::ValidationVisitor& validation_visitor) {
     loadFromFile(path, message, validation_visitor);
-    validate(message);
+    validate(message, validation_visitor);
   }
 
   template <class MessageType>
   static void loadFromYamlAndValidate(const std::string& yaml, MessageType& message,
                                       ProtobufMessage::ValidationVisitor& validation_visitor) {
     loadFromYaml(yaml, message, validation_visitor);
-    validate(message);
+    validate(message, validation_visitor);
   }
 
   /**
@@ -268,9 +271,11 @@ public:
    * @throw ProtoValidationException if the message does not satisfy its type constraints.
    */
   template <class MessageType>
-  static const MessageType& downcastAndValidate(const Protobuf::Message& config) {
+  static const MessageType&
+  downcastAndValidate(const Protobuf::Message& config,
+                      ProtobufMessage::ValidationVisitor& validation_visitor) {
     const auto& typed_config = dynamic_cast<MessageType>(config);
-    validate(typed_config);
+    validate(typed_config, validation_visitor);
     return typed_config;
   }
 
@@ -282,13 +287,11 @@ public:
    * @return MessageType the typed message inside the Any.
    */
   template <class MessageType>
-  static inline MessageType anyConvert(const ProtobufWkt::Any& message,
-                                       ProtobufMessage::ValidationVisitor& validation_visitor) {
+  static inline MessageType anyConvert(const ProtobufWkt::Any& message) {
     MessageType typed_message;
     if (!message.UnpackTo(&typed_message)) {
       throw EnvoyException("Unable to unpack " + message.DebugString());
     }
-    checkUnknownFields(typed_message, validation_visitor);
     return typed_message;
   };
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -66,7 +66,8 @@ HedgePolicyImpl::HedgePolicyImpl()
     : initial_requests_(1), additional_request_chance_({}), hedge_on_per_try_timeout_(false) {}
 
 RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry_policy,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor) {
+                                 ProtobufMessage::ValidationVisitor& validation_visitor)
+    : validation_visitor_(&validation_visitor) {
   per_try_timeout_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_timeout, 0));
   num_retries_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(retry_policy, num_retries, 1);
@@ -141,7 +142,8 @@ Upstream::RetryPrioritySharedPtr RetryPolicyImpl::retryPriority() const {
   auto& factory = Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryPriorityFactory>(
       retry_priority_config_.first);
 
-  return factory.createRetryPriority(*retry_priority_config_.second, num_retries_);
+  return factory.createRetryPriority(*retry_priority_config_.second, *validation_visitor_,
+                                     num_retries_);
 }
 
 CorsPolicyImpl::CorsPolicyImpl(const envoy::api::v2::route::CorsPolicy& config,

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -258,6 +258,7 @@ private:
   std::vector<uint32_t> retriable_status_codes_;
   absl::optional<std::chrono::milliseconds> base_interval_;
   absl::optional<std::chrono::milliseconds> max_interval_;
+  ProtobufMessage::ValidationVisitor* validation_visitor_{};
 };
 
 /**

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -92,9 +92,8 @@ void RdsRouteConfigSubscription::onConfigUpdate(
   if (!validateUpdateSize(resources.size())) {
     return;
   }
-  auto route_config = MessageUtil::anyConvert<envoy::api::v2::RouteConfiguration>(
-      resources[0], validation_visitor_);
-  MessageUtil::validate(route_config);
+  auto route_config = MessageUtil::anyConvert<envoy::api::v2::RouteConfiguration>(resources[0]);
+  MessageUtil::validate(route_config, validation_visitor_);
   if (route_config.name() != route_config_name_) {
     throw EnvoyException(fmt::format("Unexpected RDS configuration (expecting {}): {}",
                                      route_config_name_, route_config.name()));

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -118,9 +118,7 @@ private:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::RouteConfiguration>(resource,
-                                                                       validation_visitor_)
-        .name();
+    return MessageUtil::anyConvert<envoy::api::v2::RouteConfiguration>(resource).name();
   }
 
   RdsRouteConfigSubscription(

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -60,9 +60,8 @@ void RouteConfigUpdateReceiverImpl::updateVhosts(
     const Protobuf::RepeatedPtrField<envoy::api::v2::Resource>& added_resources) {
   for (const auto& resource : added_resources) {
     envoy::api::v2::route::VirtualHost vhost =
-        MessageUtil::anyConvert<envoy::api::v2::route::VirtualHost>(resource.resource(),
-                                                                    validation_visitor_);
-    MessageUtil::validate(vhost);
+        MessageUtil::anyConvert<envoy::api::v2::route::VirtualHost>(resource.resource());
+    MessageUtil::validate(vhost, validation_visitor_);
     auto found = vhosts.find(vhost.name());
     if (found != vhosts.end()) {
       vhosts.erase(found);

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -105,8 +105,8 @@ void ScopedRdsConfigSubscription::onConfigUpdate(
     const std::string& version_info) {
   std::vector<envoy::api::v2::ScopedRouteConfiguration> scoped_routes;
   for (const auto& resource_any : resources) {
-    scoped_routes.emplace_back(MessageUtil::anyConvert<envoy::api::v2::ScopedRouteConfiguration>(
-        resource_any, validation_visitor_));
+    scoped_routes.emplace_back(
+        MessageUtil::anyConvert<envoy::api::v2::ScopedRouteConfiguration>(resource_any));
   }
 
   std::unordered_set<std::string> resource_names;
@@ -117,7 +117,7 @@ void ScopedRdsConfigSubscription::onConfigUpdate(
     }
   }
   for (const auto& scoped_route : scoped_routes) {
-    MessageUtil::validate(scoped_route);
+    MessageUtil::validate(scoped_route, validation_visitor_);
   }
 
   // TODO(AndresGuedez): refactor such that it can be shared with other delta APIs (e.g., CDS).

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -115,9 +115,7 @@ private:
     ConfigSubscriptionCommonBase::onConfigUpdateFailed();
   }
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::ScopedRouteConfiguration>(resource,
-                                                                             validation_visitor_)
-        .name();
+    return MessageUtil::anyConvert<envoy::api::v2::ScopedRouteConfiguration>(resource).name();
   }
 
   const std::string name_;

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -28,8 +28,7 @@ VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
       scope_(factory_context.scope().createScope(stat_prefix + "vhds." +
                                                  config_update_info_->routeConfigName() + ".")),
       stats_({ALL_VHDS_STATS(POOL_COUNTER(*scope_))}),
-      route_config_providers_(route_config_providers),
-      validation_visitor_(factory_context.messageValidationVisitor()) {
+      route_config_providers_(route_config_providers) {
   const auto& config_source = config_update_info_->routeConfiguration()
                                   .vhds()
                                   .config_source()

--- a/source/common/router/vhds.h
+++ b/source/common/router/vhds.h
@@ -59,9 +59,7 @@ private:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::route::VirtualHost>(resource,
-                                                                       validation_visitor_)
-        .name();
+    return MessageUtil::anyConvert<envoy::api::v2::route::VirtualHost>(resource).name();
   }
 
   RouteConfigUpdatePtr& config_update_info_;
@@ -70,7 +68,6 @@ private:
   Stats::ScopePtr scope_;
   VhdsStats stats_;
   std::unordered_set<RouteConfigProvider*>& route_config_providers_;
-  ProtobufMessage::ValidationVisitor& validation_visitor_;
 };
 
 using VhdsSubscriptionPtr = std::unique_ptr<VhdsSubscription>;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -517,9 +517,8 @@ RtdsSubscription::RtdsSubscription(
 void RtdsSubscription::onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,
                                       const std::string&) {
   validateUpdateSize(resources.size());
-  auto runtime = MessageUtil::anyConvert<envoy::service::discovery::v2::Runtime>(
-      resources[0], validation_visitor_);
-  MessageUtil::validate(runtime);
+  auto runtime = MessageUtil::anyConvert<envoy::service::discovery::v2::Runtime>(resources[0]);
+  MessageUtil::validate(runtime, validation_visitor_);
   if (runtime.name() != resource_name_) {
     throw EnvoyException(
         fmt::format("Unexpected RTDS runtime (expecting {}): {}", resource_name_, runtime.name()));

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -209,9 +209,7 @@ struct RtdsSubscription : Config::SubscriptionCallbacks, Logger::Loggable<Logger
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::service::discovery::v2::Runtime>(resource,
-                                                                           validation_visitor_)
-        .name();
+    return MessageUtil::anyConvert<envoy::service::discovery::v2::Runtime>(resource).name();
   }
 
   void start();

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -30,9 +30,8 @@ SdsApi::SdsApi(envoy::api::v2::core::ConfigSource sds_config, absl::string_view 
 void SdsApi::onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,
                             const std::string& version_info) {
   validateUpdateSize(resources.size());
-  auto secret =
-      MessageUtil::anyConvert<envoy::api::v2::auth::Secret>(resources[0], validation_visitor_);
-  MessageUtil::validate(secret);
+  auto secret = MessageUtil::anyConvert<envoy::api::v2::auth::Secret>(resources[0]);
+  MessageUtil::validate(secret, validation_visitor_);
 
   if (secret.name() != sds_config_name_) {
     throw EnvoyException(

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -59,8 +59,7 @@ protected:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::auth::Secret>(resource, validation_visitor_)
-        .name();
+    return MessageUtil::anyConvert<envoy::api::v2::auth::Secret>(resource).name();
   }
 
 private:

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -35,8 +35,7 @@ void CdsApiImpl::onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::An
   ClusterManager::ClusterInfoMap clusters_to_remove = cm_.clusters();
   std::vector<envoy::api::v2::Cluster> clusters;
   for (const auto& cluster_blob : resources) {
-    clusters.push_back(
-        MessageUtil::anyConvert<envoy::api::v2::Cluster>(cluster_blob, validation_visitor_));
+    clusters.push_back(MessageUtil::anyConvert<envoy::api::v2::Cluster>(cluster_blob));
     clusters_to_remove.erase(clusters.back().name());
   }
   Protobuf::RepeatedPtrField<std::string> to_remove_repeated;
@@ -66,9 +65,8 @@ void CdsApiImpl::onConfigUpdate(
   for (const auto& resource : added_resources) {
     envoy::api::v2::Cluster cluster;
     try {
-      cluster = MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource.resource(),
-                                                                 validation_visitor_);
-      MessageUtil::validate(cluster);
+      cluster = MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource.resource());
+      MessageUtil::validate(cluster, validation_visitor_);
       if (!cluster_names.insert(cluster.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully applied.
         throw EnvoyException(fmt::format("duplicate cluster {} found", cluster.name()));

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -43,7 +43,7 @@ private:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource, validation_visitor_).name();
+    return MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource).name();
   }
 
   CdsApiImpl(const envoy::api::v2::core::ConfigSource& cds_config, ClusterManager& cm,

--- a/source/common/upstream/cluster_factory_impl.h
+++ b/source/common/upstream/cluster_factory_impl.h
@@ -178,7 +178,8 @@ private:
         cluster.cluster_type().typed_config(), ProtobufWkt::Struct::default_instance(),
         socket_factory_context.messageValidationVisitor(), *config);
     return createClusterWithConfig(cluster,
-                                   MessageUtil::downcastAndValidate<const ConfigProto&>(*config),
+                                   MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                       *config, context.messageValidationVisitor()),
                                    context, socket_factory_context, std::move(stats_scope));
   }
 

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -101,9 +101,9 @@ void EdsClusterImpl::onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt
   if (!validateUpdateSize(resources.size())) {
     return;
   }
-  auto cluster_load_assignment = MessageUtil::anyConvert<envoy::api::v2::ClusterLoadAssignment>(
-      resources[0], validation_visitor_);
-  MessageUtil::validate(cluster_load_assignment);
+  auto cluster_load_assignment =
+      MessageUtil::anyConvert<envoy::api::v2::ClusterLoadAssignment>(resources[0]);
+  MessageUtil::validate(cluster_load_assignment, validation_visitor_);
   if (cluster_load_assignment.cluster_name() != cluster_name_) {
     throw EnvoyException(fmt::format("Unexpected EDS cluster (expecting {}): {}", cluster_name_,
                                      cluster_load_assignment.cluster_name()));

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -38,9 +38,7 @@ private:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::ClusterLoadAssignment>(resource,
-                                                                          validation_visitor_)
-        .cluster_name();
+    return MessageUtil::anyConvert<envoy::api::v2::ClusterLoadAssignment>(resource).cluster_name();
   }
 
   using LocalityWeightsMap =

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -140,7 +140,7 @@ createProtocolOptionsConfig(const std::string& name, const ProtobufWkt::Any& typ
   Envoy::Config::Utility::translateOpaqueConfig(typed_config, config, validation_visitor,
                                                 *proto_config);
 
-  return factory->createProtocolOptionsConfig(*proto_config);
+  return factory->createProtocolOptionsConfig(*proto_config, validation_visitor);
 }
 
 std::map<std::string, ProtocolOptionsConfigConstSharedPtr>

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -24,7 +24,8 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
                                               AccessLog::FilterPtr&& filter,
                                               Server::Configuration::FactoryContext& context) {
   const auto& fal_config =
-      MessageUtil::downcastAndValidate<const envoy::config::accesslog::v2::FileAccessLog&>(config);
+      MessageUtil::downcastAndValidate<const envoy::config::accesslog::v2::FileAccessLog&>(
+          config, context.messageValidationVisitor());
   AccessLog::FormatterPtr formatter;
 
   if (fal_config.access_log_format_case() == envoy::config::accesslog::v2::FileAccessLog::kFormat ||

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -29,7 +29,8 @@ HttpGrpcAccessLogFactory::createAccessLogInstance(const Protobuf::Message& confi
   validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
-      const envoy::config::accesslog::v2::HttpGrpcAccessLogConfig&>(config);
+      const envoy::config::accesslog::v2::HttpGrpcAccessLogConfig&>(
+      config, context.messageValidationVisitor());
   std::shared_ptr<GrpcCommon::GrpcAccessLoggerCache> grpc_access_logger_cache =
       context.singletonManager().getTyped<GrpcCommon::GrpcAccessLoggerCache>(
           SINGLETON_MANAGER_REGISTERED_NAME(grpc_access_logger_cache), [&context] {

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -25,8 +25,9 @@ public:
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                const std::string& stats_prefix,
                                Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromProtoTyped(
-        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config), stats_prefix, context);
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             stats_prefix, context);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -41,7 +42,9 @@ public:
   createRouteSpecificFilterConfig(const Protobuf::Message& proto_config,
                                   Server::Configuration::FactoryContext& context) override {
     return createRouteSpecificFilterConfigTyped(
-        MessageUtil::downcastAndValidate<const RouteConfigProto&>(proto_config), context);
+        MessageUtil::downcastAndValidate<const RouteConfigProto&>(
+            proto_config, context.messageValidationVisitor()),
+        context);
   }
 
   std::string name() override { return name_; }

--- a/source/extensions/filters/listener/original_src/original_src_config_factory.cc
+++ b/source/extensions/filters/listener/original_src/original_src_config_factory.cc
@@ -14,9 +14,10 @@ namespace ListenerFilters {
 namespace OriginalSrc {
 
 Network::ListenerFilterFactoryCb OriginalSrcConfigFactory::createFilterFactoryFromProto(
-    const Protobuf::Message& message, Server::Configuration::ListenerFactoryContext&) {
+    const Protobuf::Message& message, Server::Configuration::ListenerFactoryContext& context) {
   auto proto_config = MessageUtil::downcastAndValidate<
-      const envoy::config::filter::listener::original_src::v2alpha1::OriginalSrc&>(message);
+      const envoy::config::filter::listener::original_src::v2alpha1::OriginalSrc&>(
+      message, context.messageValidationVisitor());
   Config config(proto_config);
   return [config](Network::ListenerFilterManager& filter_manager) -> void {
     filter_manager.addAcceptFilter(std::make_unique<OriginalSrcFilter>(config));

--- a/source/extensions/filters/network/common/factory_base.h
+++ b/source/extensions/filters/network/common/factory_base.h
@@ -25,8 +25,9 @@ public:
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromProtoTyped(
-        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config), context);
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             context);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -38,9 +39,10 @@ public:
   }
 
   Upstream::ProtocolOptionsConfigConstSharedPtr
-  createProtocolOptionsConfig(const Protobuf::Message& proto_config) override {
-    return createProtocolOptionsTyped(
-        MessageUtil::downcastAndValidate<const ProtocolOptionsProto&>(proto_config));
+  createProtocolOptionsConfig(const Protobuf::Message& proto_config,
+                              ProtobufMessage::ValidationVisitor& validation_visitor) override {
+    return createProtocolOptionsTyped(MessageUtil::downcastAndValidate<const ProtocolOptionsProto&>(
+        proto_config, validation_visitor));
   }
 
   std::string name() override { return name_; }

--- a/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
@@ -21,8 +21,9 @@ public:
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                const std::string& stats_prefix,
                                Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromProtoTyped(
-        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config), stats_prefix, context);
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             stats_prefix, context);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/filters/network/thrift_proxy/filters/factory_base.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/factory_base.h
@@ -16,8 +16,9 @@ public:
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                const std::string& stats_prefix,
                                Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromProtoTyped(
-        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config), stats_prefix, context);
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             stats_prefix, context);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -34,6 +34,8 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
     case envoy::api::v2::core::GrpcService::GoogleGrpc::CallCredentials::kFromPlugin: {
       if (credential.from_plugin().name() == GrpcCredentialsNames::get().AwsIam) {
         AwsIamGrpcCredentialsFactory credentials_factory;
+        // We don't deal with validation failures here at runtime today, see
+        // https://github.com/envoyproxy/envoy/issues/8010.
         const Envoy::ProtobufTypes::MessagePtr config_message =
             Envoy::Config::Utility::translateToFactoryConfig(
                 credential.from_plugin(), ProtobufMessage::getNullValidationVisitor(),

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -39,7 +39,8 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
                 credential.from_plugin(), ProtobufMessage::getNullValidationVisitor(),
                 credentials_factory);
         const auto& config = Envoy::MessageUtil::downcastAndValidate<
-            const envoy::config::grpc_credential::v2alpha::AwsIamConfig&>(*config_message);
+            const envoy::config::grpc_credential::v2alpha::AwsIamConfig&>(
+            *config_message, ProtobufMessage::getNullValidationVisitor());
         auto credentials_provider =
             std::make_shared<HttpFilters::Common::Aws::DefaultCredentialsProviderChain>(
                 api, HttpFilters::Common::Aws::Utility::metadataFetcher);

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -28,9 +28,8 @@ FileBasedMetadataGrpcCredentialsFactory::getChannelCredentials(
     case envoy::api::v2::core::GrpcService::GoogleGrpc::CallCredentials::kFromPlugin: {
       if (credential.from_plugin().name() == GrpcCredentialsNames::get().FileBasedMetadata) {
         FileBasedMetadataGrpcCredentialsFactory file_based_metadata_credentials_factory;
-        // TODO(htuch): This should probably follow the standard metadata validation pattern, but
-        // needs error handling, since this happens at runtime, not config time, and we need to
-        // catch any validation exceptions.
+        // We don't deal with validation failures here at runtime today, see
+        // https://github.com/envoyproxy/envoy/issues/8010.
         const Envoy::ProtobufTypes::MessagePtr file_based_metadata_config_message =
             Envoy::Config::Utility::translateToFactoryConfig(
                 credential.from_plugin(), ProtobufMessage::getNullValidationVisitor(),

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -37,7 +37,7 @@ FileBasedMetadataGrpcCredentialsFactory::getChannelCredentials(
                 file_based_metadata_credentials_factory);
         const auto& file_based_metadata_config = Envoy::MessageUtil::downcastAndValidate<
             const envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig&>(
-            *file_based_metadata_config_message);
+            *file_based_metadata_config_message, ProtobufMessage::getNullValidationVisitor());
         std::shared_ptr<grpc::CallCredentials> new_call_creds = grpc::MetadataCredentialsFromPlugin(
             std::make_unique<FileBasedMetadataAuthenticator>(file_based_metadata_config, api));
         if (call_creds == nullptr) {

--- a/source/extensions/health_checkers/redis/utility.h
+++ b/source/extensions/health_checkers/redis/utility.h
@@ -21,7 +21,7 @@ getRedisHealthCheckConfig(const envoy::api::v2::core::HealthCheck& health_check_
   MessageUtil::jsonConvert(health_check_config.custom_health_check().config(), validation_visitor,
                            *config);
   return MessageUtil::downcastAndValidate<const envoy::config::health_checker::redis::v2::Redis&>(
-      *config);
+      *config, validation_visitor);
 }
 
 } // namespace

--- a/source/extensions/resource_monitors/common/factory_base.h
+++ b/source/extensions/resource_monitors/common/factory_base.h
@@ -15,8 +15,9 @@ public:
   Server::ResourceMonitorPtr
   createResourceMonitor(const Protobuf::Message& config,
                         Server::Configuration::ResourceMonitorFactoryContext& context) override {
-    return createResourceMonitorFromProtoTyped(
-        MessageUtil::downcastAndValidate<const ConfigProto&>(config), context);
+    return createResourceMonitorFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                   config, context.messageValidationVisitor()),
+                                               context);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/retry/priority/previous_priorities/config.cc
+++ b/source/extensions/retry/priority/previous_priorities/config.cc
@@ -9,12 +9,14 @@ namespace Extensions {
 namespace Retry {
 namespace Priority {
 
-Upstream::RetryPrioritySharedPtr
-PreviousPrioritiesRetryPriorityFactory::createRetryPriority(const Protobuf::Message& config,
-                                                            uint32_t max_retries) {
+Upstream::RetryPrioritySharedPtr PreviousPrioritiesRetryPriorityFactory::createRetryPriority(
+    const Protobuf::Message& config, ProtobufMessage::ValidationVisitor& validation_visitor,
+
+    uint32_t max_retries) {
   return std::make_shared<PreviousPrioritiesRetryPriority>(
       MessageUtil::downcastAndValidate<
-          const envoy::config::retry::previous_priorities::PreviousPrioritiesConfig&>(config)
+          const envoy::config::retry::previous_priorities::PreviousPrioritiesConfig&>(
+          config, validation_visitor)
           .update_frequency(),
       max_retries);
 }

--- a/source/extensions/retry/priority/previous_priorities/config.h
+++ b/source/extensions/retry/priority/previous_priorities/config.h
@@ -15,8 +15,10 @@ namespace Priority {
 
 class PreviousPrioritiesRetryPriorityFactory : public Upstream::RetryPriorityFactory {
 public:
-  Upstream::RetryPrioritySharedPtr createRetryPriority(const Protobuf::Message& config,
-                                                       uint32_t max_retries) override;
+  Upstream::RetryPrioritySharedPtr
+  createRetryPriority(const Protobuf::Message& config,
+                      ProtobufMessage::ValidationVisitor& validation_visitor,
+                      uint32_t max_retries) override;
 
   std::string name() const override {
     return RetryPriorityValues::get().PreviousPrioritiesRetryPriority;

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -19,7 +19,8 @@ namespace DogStatsd {
 Stats::SinkPtr DogStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
                                                      Server::Instance& server) {
   const auto& sink_config =
-      MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::DogStatsdSink&>(config);
+      MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::DogStatsdSink&>(
+          config, server.messageValidationContext().staticValidationVisitor());
   Network::Address::InstanceConstSharedPtr address =
       Network::Address::resolveProtoAddress(sink_config.address());
   ENVOY_LOG(debug, "dog_statsd UDP ip address: {}", address->asString());

--- a/source/extensions/stat_sinks/hystrix/config.cc
+++ b/source/extensions/stat_sinks/hystrix/config.cc
@@ -19,7 +19,8 @@ namespace Hystrix {
 Stats::SinkPtr HystrixSinkFactory::createStatsSink(const Protobuf::Message& config,
                                                    Server::Instance& server) {
   const auto& hystrix_sink =
-      MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::HystrixSink&>(config);
+      MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::HystrixSink&>(
+          config, server.messageValidationContext().staticValidationVisitor());
   return std::make_unique<Hystrix::HystrixSink>(server, hystrix_sink.num_buckets());
 }
 

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -23,7 +23,7 @@ Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Messag
 
   const auto& sink_config =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::MetricsServiceConfig&>(
-          config);
+          config, server.messageValidationContext().staticValidationVisitor());
   const auto& grpc_service = sink_config.grpc_service();
   ENVOY_LOG(debug, "Metrics Service gRPC service configuration: {}", grpc_service.DebugString());
 

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -20,7 +20,8 @@ Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& confi
                                                   Server::Instance& server) {
 
   const auto& statsd_sink =
-      MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::StatsdSink&>(config);
+      MessageUtil::downcastAndValidate<const envoy::config::metrics::v2::StatsdSink&>(
+          config, server.messageValidationContext().staticValidationVisitor());
   switch (statsd_sink.statsd_specifier_case()) {
   case envoy::config::metrics::v2::StatsdSink::kAddress: {
     Network::Address::InstanceConstSharedPtr address =

--- a/source/extensions/tracers/common/factory_base.h
+++ b/source/extensions/tracers/common/factory_base.h
@@ -17,8 +17,10 @@ public:
   // Server::Configuration::TracerFactory
   Tracing::HttpTracerPtr createHttpTracer(const Protobuf::Message& config,
                                           Server::Instance& server) override {
-    return createHttpTracerTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(config),
-                                 server);
+    return createHttpTracerTyped(
+        MessageUtil::downcastAndValidate<const ConfigProto&>(
+            config, server.messageValidationContext().staticValidationVisitor()),
+        server);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -79,7 +79,7 @@ Network::TransportSocketFactoryPtr createTransportSocketFactoryHelper(
       [] { return std::make_shared<AltsSharedState>(); });
   auto config =
       MessageUtil::downcastAndValidate<const envoy::config::transport_socket::alts::v2alpha::Alts&>(
-          message);
+          message, factory_ctxt.messageValidationVisitor());
   HandshakeValidator validator = createHandshakeValidator(config);
 
   const std::string& handshaker_service = config.handshaker_service();

--- a/source/extensions/transport_sockets/tap/config.cc
+++ b/source/extensions/transport_sockets/tap/config.cc
@@ -36,7 +36,7 @@ Network::TransportSocketFactoryPtr UpstreamTapSocketConfigFactory::createTranspo
     Server::Configuration::TransportSocketFactoryContext& context) {
   const auto& outer_config =
       MessageUtil::downcastAndValidate<const envoy::config::transport_socket::tap::v2alpha::Tap&>(
-          message);
+          message, context.messageValidationVisitor());
   auto& inner_config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::UpstreamTransportSocketConfigFactory>(
       outer_config.transport_socket().name());
@@ -55,7 +55,7 @@ Network::TransportSocketFactoryPtr DownstreamTapSocketConfigFactory::createTrans
     const std::vector<std::string>& server_names) {
   const auto& outer_config =
       MessageUtil::downcastAndValidate<const envoy::config::transport_socket::tap::v2alpha::Tap&>(
-          message);
+          message, context.messageValidationVisitor());
   auto& inner_config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::DownstreamTransportSocketConfigFactory>(
       outer_config.transport_socket().name());

--- a/source/extensions/transport_sockets/tls/config.cc
+++ b/source/extensions/transport_sockets/tls/config.cc
@@ -17,7 +17,8 @@ Network::TransportSocketFactoryPtr UpstreamSslSocketFactory::createTransportSock
     const Protobuf::Message& message,
     Server::Configuration::TransportSocketFactoryContext& context) {
   auto client_config = std::make_unique<ClientContextConfigImpl>(
-      MessageUtil::downcastAndValidate<const envoy::api::v2::auth::UpstreamTlsContext&>(message),
+      MessageUtil::downcastAndValidate<const envoy::api::v2::auth::UpstreamTlsContext&>(
+          message, context.messageValidationVisitor()),
       context);
   return std::make_unique<ClientSslSocketFactory>(
       std::move(client_config), context.sslContextManager(), context.statsScope());
@@ -34,7 +35,8 @@ Network::TransportSocketFactoryPtr DownstreamSslSocketFactory::createTransportSo
     const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext& context,
     const std::vector<std::string>& server_names) {
   auto server_config = std::make_unique<ServerContextConfigImpl>(
-      MessageUtil::downcastAndValidate<const envoy::api::v2::auth::DownstreamTlsContext&>(message),
+      MessageUtil::downcastAndValidate<const envoy::api::v2::auth::DownstreamTlsContext&>(
+          message, context.messageValidationVisitor()),
       context);
   return std::make_unique<ServerSslSocketFactory>(
       std::move(server_config), context.sslContextManager(), context.statsScope(), server_names);

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -49,9 +49,8 @@ void LdsApiImpl::onConfigUpdate(
   for (const auto& resource : added_resources) {
     envoy::api::v2::Listener listener;
     try {
-      listener = MessageUtil::anyConvert<envoy::api::v2::Listener>(resource.resource(),
-                                                                   validation_visitor_);
-      MessageUtil::validate(listener);
+      listener = MessageUtil::anyConvert<envoy::api::v2::Listener>(resource.resource());
+      MessageUtil::validate(listener, validation_visitor_);
       if (!listener_names.insert(listener.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully applied.
         throw EnvoyException(fmt::format("duplicate listener {} found", listener.name()));
@@ -91,8 +90,7 @@ void LdsApiImpl::onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::An
     // Add this resource to our delta added/updated pile...
     envoy::api::v2::Resource* to_add = to_add_repeated.Add();
     const std::string listener_name =
-        MessageUtil::anyConvert<envoy::api::v2::Listener>(listener_blob, validation_visitor_)
-            .name();
+        MessageUtil::anyConvert<envoy::api::v2::Listener>(listener_blob).name();
     to_add->set_name(listener_name);
     to_add->set_version(version_info);
     to_add->mutable_resource()->MergeFrom(listener_blob);

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -39,7 +39,7 @@ private:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
   std::string resourceName(const ProtobufWkt::Any& resource) override {
-    return MessageUtil::anyConvert<envoy::api::v2::Listener>(resource, validation_visitor_).name();
+    return MessageUtil::anyConvert<envoy::api::v2::Listener>(resource).name();
   }
 
   std::unique_ptr<Config::Subscription> subscription_;

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -93,7 +93,7 @@ OverloadManagerImpl::OverloadManagerImpl(
     : started_(false), dispatcher_(dispatcher), tls_(slot_allocator.allocateSlot()),
       refresh_interval_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, refresh_interval, 1000))) {
-  Configuration::ResourceMonitorFactoryContextImpl context(dispatcher, api);
+  Configuration::ResourceMonitorFactoryContextImpl context(dispatcher, api, validation_visitor);
   for (const auto& resource : config.resource_monitors()) {
     const auto& name = resource.name();
     ENVOY_LOG(debug, "Adding resource monitor for {}", name);

--- a/source/server/resource_monitor_config_impl.h
+++ b/source/server/resource_monitor_config_impl.h
@@ -8,16 +8,22 @@ namespace Configuration {
 
 class ResourceMonitorFactoryContextImpl : public ResourceMonitorFactoryContext {
 public:
-  ResourceMonitorFactoryContextImpl(Event::Dispatcher& dispatcher, Api::Api& api)
-      : dispatcher_(dispatcher), api_(api) {}
+  ResourceMonitorFactoryContextImpl(Event::Dispatcher& dispatcher, Api::Api& api,
+                                    ProtobufMessage::ValidationVisitor& validation_visitor)
+      : dispatcher_(dispatcher), api_(api), validation_visitor_(validation_visitor) {}
 
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
 
   Api::Api& api() override { return api_; }
 
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    return validation_visitor_;
+  }
+
 private:
   Event::Dispatcher& dispatcher_;
   Api::Api& api_;
+  ProtobufMessage::ValidationVisitor& validation_visitor_;
 };
 
 } // namespace Configuration

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -231,7 +231,7 @@ InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
   if (config_proto.ByteSize() != 0) {
     bootstrap.MergeFrom(config_proto);
   }
-  MessageUtil::validate(bootstrap);
+  MessageUtil::validate(bootstrap, validation_visitor);
   return BootstrapVersion::V2;
 }
 

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1143,7 +1143,7 @@ public:
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, Envoy::ProtobufMessage::getNullValidationVisitor(), *this);
     const auto& header_config =
-        MessageUtil::downcastAndValidate<const envoy::config::filter::accesslog::v2::HeaderFilter&>(
+        TestUtility::downcastAndValidate<const envoy::config::filter::accesslog::v2::HeaderFilter&>(
             *factory_config);
     return std::make_unique<HeaderFilter>(header_config);
   }

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -506,7 +506,7 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
 DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
   try {
     // Validate input early.
-    MessageUtil::validate(input);
+    TestUtility::validate(input);
     codecFuzz(input, HttpVersion::Http1);
     codecFuzz(input, HttpVersion::Http2);
   } catch (const EnvoyException& e) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -123,13 +123,26 @@ TEST_F(ProtobufUtilityTest, RepeatedPtrUtilDebugString) {
   EXPECT_EQ("[value: 10\n, value: 20\n]", RepeatedPtrUtil::debugString(repeated));
 }
 
-TEST_F(ProtobufUtilityTest, DowncastAndValidate) {
+// Validated exception thrown when downcastAndValidate observes a PGV failures.
+TEST_F(ProtobufUtilityTest, DowncastAndValidateFailedValidation) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
   bootstrap.mutable_static_resources()->add_clusters();
-  EXPECT_THROW(MessageUtil::validate(bootstrap), ProtoValidationException);
+  EXPECT_THROW(TestUtility::validate(bootstrap), ProtoValidationException);
   EXPECT_THROW(
-      MessageUtil::downcastAndValidate<const envoy::config::bootstrap::v2::Bootstrap&>(bootstrap),
+      TestUtility::downcastAndValidate<const envoy::config::bootstrap::v2::Bootstrap&>(bootstrap),
       ProtoValidationException);
+}
+
+// Validated exception thrown when downcastAndValidate observes a unknown field.
+TEST_F(ProtobufUtilityTest, DowncastAndValidateUnknownFields) {
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  bootstrap.GetReflection()->MutableUnknownFields(&bootstrap)->AddVarint(1, 0);
+  EXPECT_THROW_WITH_MESSAGE(TestUtility::validate(bootstrap), EnvoyException,
+                            "Protobuf message (type envoy.config.bootstrap.v2.Bootstrap with "
+                            "unknown field set {1}) has unknown fields");
+  EXPECT_THROW_WITH_MESSAGE(TestUtility::validate(bootstrap), EnvoyException,
+                            "Protobuf message (type envoy.config.bootstrap.v2.Bootstrap with "
+                            "unknown field set {1}) has unknown fields");
 }
 
 TEST_F(ProtobufUtilityTest, LoadBinaryProtoFromFile) {
@@ -340,17 +353,6 @@ TEST_F(ProtobufUtilityTest, AnyConvertWrongType) {
   source_any.PackFrom(source_duration);
   EXPECT_THROW_WITH_REGEX(TestUtility::anyConvert<ProtobufWkt::Timestamp>(source_any),
                           EnvoyException, "Unable to unpack .*");
-}
-
-TEST_F(ProtobufUtilityTest, AnyConvertWrongFields) {
-  const ProtobufWkt::Struct obj = MessageUtil::keyValueStruct("test_key", "test_value");
-  ProtobufWkt::Any source_any;
-  source_any.PackFrom(obj);
-  source_any.set_type_url("type.google.com/google.protobuf.Timestamp");
-  EXPECT_THROW_WITH_MESSAGE(TestUtility::anyConvert<ProtobufWkt::Timestamp>(source_any),
-                            EnvoyException,
-                            "Protobuf message (type google.protobuf.Timestamp with unknown "
-                            "field set {1}) has unknown fields");
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertSuccess) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -89,7 +89,7 @@ Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::string& p
 envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
   envoy::api::v2::RouteConfiguration route_config;
   TestUtility::loadFromYaml(yaml, route_config);
-  MessageUtil::validate(route_config);
+  TestUtility::validate(route_config);
   return route_config;
 }
 

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -505,7 +505,7 @@ TEST_F(StreamInfoHeaderFormatterTest, ValidateLimitsOnUserDefinedHeaders) {
     header->mutable_header()->set_key("header_name");
     header->mutable_header()->set_value(long_string);
     header->mutable_append()->set_value(true);
-    EXPECT_THROW_WITH_REGEX(MessageUtil::validate(route), ProtoValidationException,
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(route), ProtoValidationException,
                             "Proto constraint validation failed.*");
   }
   {
@@ -516,7 +516,7 @@ TEST_F(StreamInfoHeaderFormatterTest, ValidateLimitsOnUserDefinedHeaders) {
       header->mutable_header()->set_key("header_name");
       header->mutable_header()->set_value("value");
     }
-    EXPECT_THROW_WITH_REGEX(MessageUtil::validate(route), ProtoValidationException,
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(route), ProtoValidationException,
                             "Proto constraint validation failed.*");
   }
 }

--- a/test/common/router/header_parser_fuzz_test.cc
+++ b/test/common/router/header_parser_fuzz_test.cc
@@ -11,7 +11,7 @@ namespace {
 
 DEFINE_PROTO_FUZZER(const test::common::router::TestCase& input) {
   try {
-    MessageUtil::validate(input);
+    TestUtility::validate(input);
     auto headers_to_add = replaceInvalidHeaders(input.headers_to_add());
     Protobuf::RepeatedPtrField<std::string> headers_to_remove;
     for (const auto& s : input.headers_to_remove()) {

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -295,7 +295,7 @@ envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::
 TEST_F(RouteConfigProviderManagerImplTest, ConfigDump) {
   auto message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["routes"]();
   const auto& route_config_dump =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
           *message_ptr);
 
   // No routes at all, no last_updated timestamp
@@ -325,7 +325,7 @@ virtual_hosts:
           parseRouteConfigurationFromV2Yaml(config_yaml), factory_context_);
   message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["routes"]();
   const auto& route_config_dump2 =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
           *message_ptr);
   TestUtility::loadFromYaml(R"EOF(
 static_route_configs:
@@ -368,7 +368,7 @@ dynamic_route_configs:
   rds_callbacks_->onConfigUpdate(response1.resources(), response1.version_info());
   message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["routes"]();
   const auto& route_config_dump3 =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
           *message_ptr);
   TestUtility::loadFromYaml(R"EOF(
 static_route_configs:
@@ -497,7 +497,7 @@ TEST_F(RouteConfigProviderManagerImplTest, onConfigUpdateWrongSize) {
 TEST_F(RouteConfigProviderManagerImplTest, ConfigDumpAfterConfigRejected) {
   auto message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["routes"]();
   const auto& route_config_dump =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
           *message_ptr);
 
   // No routes at all, no last_updated timestamp
@@ -549,7 +549,7 @@ resources:
 
   message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["routes"]();
   const auto& route_config_dump3 =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::RoutesConfigDump&>(
           *message_ptr);
   TestUtility::loadFromYaml(R"EOF(
 static_route_configs:

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -72,7 +72,7 @@ DEFINE_PROTO_FUZZER(const test::common::router::RouteTestCase& input) {
   try {
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
     NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-    MessageUtil::validate(input.config());
+    TestUtility::validate(input.config());
     ConfigImpl config(cleanRouteConfig(input.config()), factory_context, true);
     Http::TestHeaderMapImpl headers = Fuzz::fromHeaders(input.headers());
     // It's a precondition of routing that {:authority, :path, x-forwarded-proto} headers exists,

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -31,7 +31,7 @@ namespace {
 envoy::api::v2::route::RateLimit parseRateLimitFromV2Yaml(const std::string& yaml_string) {
   envoy::api::v2::route::RateLimit rate_limit;
   TestUtility::loadFromYaml(yaml_string, rate_limit);
-  MessageUtil::validate(rate_limit);
+  TestUtility::validate(rate_limit);
   return rate_limit;
 }
 

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -191,7 +191,7 @@ TEST_F(ScopedRoutesConfigProviderManagerTest, ConfigDump) {
   auto message_ptr =
       factory_context_.admin_.config_tracker_.config_tracker_callbacks_["route_scopes"]();
   const auto& scoped_routes_config_dump =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
           *message_ptr);
 
   // No routes at all, no last_updated timestamp
@@ -237,7 +237,7 @@ $1
       factory_context_, "foo.", *config_provider_manager_);
   message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["route_scopes"]();
   const auto& scoped_routes_config_dump2 =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
           *message_ptr);
   TestUtility::loadFromYaml(R"EOF(
 inline_scoped_route_configs:
@@ -310,7 +310,7 @@ dynamic_scoped_route_configs:
                             expected_config_dump);
   message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["route_scopes"]();
   const auto& scoped_routes_config_dump3 =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
           *message_ptr);
   EXPECT_EQ(expected_config_dump.DebugString(), scoped_routes_config_dump3.DebugString());
 
@@ -342,7 +342,7 @@ dynamic_scoped_route_configs:
                             expected_config_dump);
   message_ptr = factory_context_.admin_.config_tracker_.config_tracker_callbacks_["route_scopes"]();
   const auto& scoped_routes_config_dump4 =
-      MessageUtil::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
+      TestUtility::downcastAndValidate<const envoy::admin::v2alpha::ScopedRoutesConfigDump&>(
           *message_ptr);
   EXPECT_EQ(expected_config_dump.DebugString(), scoped_routes_config_dump4.DebugString());
 }

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -4070,7 +4070,7 @@ TEST(HealthCheckProto, Validation) {
       service_name: locations
       path: /healthcheck
     )EOF";
-    EXPECT_THROW_WITH_REGEX(MessageUtil::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
                             "Proto constraint validation failed.*value must be greater than.*");
   }
   {
@@ -4082,7 +4082,7 @@ TEST(HealthCheckProto, Validation) {
       service_name: locations
       path: /healthcheck
     )EOF";
-    EXPECT_THROW_WITH_REGEX(MessageUtil::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
                             "Proto constraint validation failed.*value must be greater than.*");
   }
   {
@@ -4094,7 +4094,7 @@ TEST(HealthCheckProto, Validation) {
       service_name: locations
       path: /healthcheck
     )EOF";
-    EXPECT_THROW_WITH_REGEX(MessageUtil::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
                             "Proto constraint validation failed.*value must be greater than.*");
   }
   {
@@ -4106,7 +4106,7 @@ TEST(HealthCheckProto, Validation) {
       service_name: locations
       path: /healthcheck
     )EOF";
-    EXPECT_THROW_WITH_REGEX(MessageUtil::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
                             "Proto constraint validation failed.*value must be greater than.*");
   }
 }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2094,7 +2094,8 @@ public:
     return parent_.createEmptyProtocolOptionsProto();
   }
   Upstream::ProtocolOptionsConfigConstSharedPtr
-  createProtocolOptionsConfig(const Protobuf::Message& msg) override {
+  createProtocolOptionsConfig(const Protobuf::Message& msg,
+                              ProtobufMessage::ValidationVisitor&) override {
     return parent_.createProtocolOptionsConfig(msg);
   }
   std::string name() override { CONSTRUCT_ON_FIRST_USE(std::string, "envoy.test.filter"); }
@@ -2130,7 +2131,8 @@ public:
     return parent_.createEmptyProtocolOptionsProto();
   }
   Upstream::ProtocolOptionsConfigConstSharedPtr
-  createProtocolOptionsConfig(const Protobuf::Message& msg) override {
+  createProtocolOptionsConfig(const Protobuf::Message& msg,
+                              ProtobufMessage::ValidationVisitor&) override {
     return parent_.createProtocolOptionsConfig(msg);
   }
   std::string name() override { CONSTRUCT_ON_FIRST_USE(std::string, "envoy.test.filter"); }

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -101,7 +101,7 @@ protected:
     cluster_callback_ = std::make_shared<NiceMock<MockClusterSlotUpdateCallBack>>();
     cluster_.reset(new RedisCluster(
         cluster_config,
-        MessageUtil::downcastAndValidate<const envoy::config::cluster::redis::RedisClusterConfig&>(
+        TestUtility::downcastAndValidate<const envoy::config::cluster::redis::RedisClusterConfig&>(
             config),
         *this, cm, runtime_, *api_, dns_resolver_, factory_context, std::move(scope), false,
         cluster_callback_));

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -31,6 +31,7 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoGrpc) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::StrictMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor()).Times(1);
   EXPECT_CALL(context, localInfo()).Times(1);
   EXPECT_CALL(context, clusterManager()).Times(1);
   EXPECT_CALL(context, runtime()).Times(1);
@@ -85,6 +86,7 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
   TestUtility::loadFromYaml(yaml, *proto_config);
   testing::StrictMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor()).Times(1);
   EXPECT_CALL(context, localInfo()).Times(1);
   EXPECT_CALL(context, clusterManager()).Times(1);
   EXPECT_CALL(context, runtime()).Times(1);

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -306,7 +306,7 @@ TEST_F(HttpFilterTest, BadConfig) {
   envoy::config::filter::http::ext_authz::v2::ExtAuthz proto_config{};
   TestUtility::loadFromYaml(filter_config, proto_config);
   EXPECT_THROW(
-      MessageUtil::downcastAndValidate<const envoy::config::filter::http::ext_authz::v2::ExtAuthz&>(
+      TestUtility::downcastAndValidate<const envoy::config::filter::http::ext_authz::v2::ExtAuthz&>(
           proto_config),
       ProtoValidationException);
 }

--- a/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 
 using testing::Invoke;
+using testing::NiceMock;
 
 namespace Envoy {
 namespace Extensions {
@@ -27,7 +28,7 @@ TEST(OriginalSrcHttpConfigFactoryTest, TestCreateFactory) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
   TestUtility::loadFromYaml(yaml, *proto_config);
 
-  Server::Configuration::MockFactoryContext context;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
 
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "", context);
 

--- a/test/extensions/filters/listener/original_src/original_src_config_factory_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_config_factory_test.cc
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 
 using testing::Invoke;
+using testing::NiceMock;
 
 namespace Envoy {
 namespace Extensions {
@@ -28,7 +29,7 @@ TEST(OriginalSrcConfigFactoryTest, TestCreateFactory) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
   TestUtility::loadFromYaml(yaml, *proto_config);
 
-  Server::Configuration::MockListenerFactoryContext context;
+  NiceMock<Server::Configuration::MockListenerFactoryContext> context;
 
   Network::ListenerFilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*proto_config, context);

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -134,7 +134,7 @@ public:
 
     if (!yaml.empty()) {
       TestUtility::loadFromYaml(yaml, proto_config_);
-      MessageUtil::validate(proto_config_);
+      TestUtility::validate(proto_config_);
     }
 
     proto_config_.set_stat_prefix("test");

--- a/test/extensions/filters/network/dubbo_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/route_matcher_test.cc
@@ -24,7 +24,7 @@ envoy::config::filter::network::dubbo_proxy::v2alpha1::RouteConfiguration
 parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
   envoy::config::filter::network::dubbo_proxy::v2alpha1::RouteConfiguration route_config;
   TestUtility::loadFromYaml(yaml, route_config);
-  MessageUtil::validate(route_config);
+  TestUtility::validate(route_config);
   return route_config;
 }
 
@@ -32,7 +32,7 @@ envoy::config::filter::network::dubbo_proxy::v2alpha1::DubboProxy
 parseDubboProxyFromV2Yaml(const std::string& yaml) {
   envoy::config::filter::network::dubbo_proxy::v2alpha1::DubboProxy config;
   TestUtility::loadFromYaml(yaml, config);
-  MessageUtil::validate(config);
+  TestUtility::validate(config);
   return config;
 }
 

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -95,7 +95,7 @@ TEST_F(ExtAuthzFilterTest, BadExtAuthzConfig) {
   envoy::config::filter::network::ext_authz::v2::ExtAuthz proto_config{};
   TestUtility::loadFromJson(json_string, proto_config);
 
-  EXPECT_THROW(MessageUtil::downcastAndValidate<
+  EXPECT_THROW(TestUtility::downcastAndValidate<
                    const envoy::config::filter::network::ext_authz::v2::ExtAuthz&>(proto_config),
                ProtoValidationException);
 }

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -91,7 +91,7 @@ public:
       proto_config_.set_stat_prefix("test");
     } else {
       TestUtility::loadFromYaml(yaml, proto_config_);
-      MessageUtil::validate(proto_config_);
+      TestUtility::validate(proto_config_);
     }
 
     proto_config_.set_stat_prefix("test");

--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -12,7 +12,8 @@ using testing::ReturnRef;
 namespace Envoy {
 
 // Provide a specialization for ProtobufWkt::Struct (for MockFilterConfigFactory)
-template <> void MessageUtil::validate(const ProtobufWkt::Struct&) {}
+template <>
+void MessageUtil::validate(const ProtobufWkt::Struct&, ProtobufMessage::ValidationVisitor&) {}
 
 namespace Extensions {
 namespace NetworkFilters {

--- a/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
@@ -22,7 +22,7 @@ envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration
 parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
   envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration route_config;
   TestUtility::loadFromYaml(yaml, route_config);
-  MessageUtil::validate(route_config);
+  TestUtility::validate(route_config);
   return route_config;
 }
 

--- a/test/extensions/resource_monitors/fixed_heap/config_test.cc
+++ b/test/extensions/resource_monitors/fixed_heap/config_test.cc
@@ -25,7 +25,8 @@ TEST(FixedHeapMonitorFactoryTest, CreateMonitor) {
   config.set_max_heap_size_bytes(std::numeric_limits<uint64_t>::max());
   Event::MockDispatcher dispatcher;
   Api::ApiPtr api = Api::createApiForTest();
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(dispatcher, *api);
+  Server::Configuration::ResourceMonitorFactoryContextImpl context(
+      dispatcher, *api, ProtobufMessage::getStrictValidationVisitor());
   auto monitor = factory->createResourceMonitor(config, context);
   EXPECT_NE(monitor, nullptr);
 }

--- a/test/extensions/resource_monitors/injected_resource/config_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/config_test.cc
@@ -28,7 +28,8 @@ TEST(InjectedResourceMonitorFactoryTest, CreateMonitor) {
   config.set_filename(TestEnvironment::temporaryPath("injected_resource"));
   Api::ApiPtr api = Api::createApiForTest();
   Event::DispatcherPtr dispatcher(api->allocateDispatcher());
-  Server::Configuration::ResourceMonitorFactoryContextImpl context(*dispatcher, *api);
+  Server::Configuration::ResourceMonitorFactoryContextImpl context(
+      *dispatcher, *api, ProtobufMessage::getStrictValidationVisitor());
   Server::ResourceMonitorPtr monitor = factory->createResourceMonitor(config, context);
   EXPECT_NE(monitor, nullptr);
 }

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -61,7 +61,8 @@ protected:
   std::unique_ptr<InjectedResourceMonitor> createMonitor() {
     envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig config;
     config.set_filename(resource_filename_);
-    Server::Configuration::ResourceMonitorFactoryContextImpl context(*dispatcher_, *api_);
+    Server::Configuration::ResourceMonitorFactoryContextImpl context(
+        *dispatcher_, *api_, ProtobufMessage::getStrictValidationVisitor());
     return std::make_unique<TestableInjectedResourceMonitor>(config, context);
   }
 

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -31,7 +31,8 @@ public:
     // by that method is compatible with the downcast in createRetryPriority.
     auto empty = factory->createEmptyConfigProto();
     empty->MergeFrom(config);
-    retry_priority_ = factory->createRetryPriority(*empty, 3);
+    retry_priority_ =
+        factory->createRetryPriority(*empty, ProtobufMessage::getStrictValidationVisitor(), 3);
     original_priority_load_ = Upstream::HealthyAndDegradedLoad{original_healthy_priority_load,
                                                                original_degraded_priority_load};
   }

--- a/test/extensions/transport_sockets/alts/config_test.cc
+++ b/test/extensions/transport_sockets/alts/config_test.cc
@@ -23,7 +23,7 @@ namespace Alts {
 namespace {
 
 TEST(UpstreamAltsConfigTest, CreateSocketFactory) {
-  MockTransportSocketFactoryContext factory_context;
+  NiceMock<MockTransportSocketFactoryContext> factory_context;
   Singleton::ManagerImpl singleton_manager{Thread::threadFactoryForTest()};
   EXPECT_CALL(factory_context, singletonManager()).WillRepeatedly(ReturnRef(singleton_manager));
   UpstreamAltsTransportSocketConfigFactory factory;
@@ -43,7 +43,7 @@ TEST(UpstreamAltsConfigTest, CreateSocketFactory) {
 }
 
 TEST(DownstreamAltsConfigTest, CreateSocketFactory) {
-  MockTransportSocketFactoryContext factory_context;
+  NiceMock<MockTransportSocketFactoryContext> factory_context;
   Singleton::ManagerImpl singleton_manager{Thread::threadFactoryForTest()};
   EXPECT_CALL(factory_context, singletonManager()).WillRepeatedly(ReturnRef(singleton_manager));
   DownstreamAltsTransportSocketConfigFactory factory;

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -1074,7 +1074,7 @@ TEST_F(ServerContextConfigImplTest, MultiSdsConfig) {
   tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
   tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
   EXPECT_THROW_WITH_REGEX(
-      MessageUtil::validate<envoy::api::v2::auth::DownstreamTlsContext>(tls_context),
+      TestUtility::validate<envoy::api::v2::auth::DownstreamTlsContext>(tls_context),
       EnvoyException, "Proto constraint validation failed");
 }
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -142,7 +142,9 @@ class MockRetryPriorityFactory : public RetryPriorityFactory {
 public:
   MockRetryPriorityFactory(const MockRetryPriority& retry_priority)
       : retry_priority_(retry_priority) {}
-  RetryPrioritySharedPtr createRetryPriority(const Protobuf::Message&, uint32_t) override {
+  RetryPrioritySharedPtr createRetryPriority(const Protobuf::Message&,
+                                             ProtobufMessage::ValidationVisitor&,
+                                             uint32_t) override {
     return std::make_shared<NiceMock<MockRetryPriority>>(retry_priority_);
   }
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -499,8 +499,7 @@ public:
 
   template <class MessageType>
   static inline MessageType anyConvert(const ProtobufWkt::Any& message) {
-    return MessageUtil::anyConvert<MessageType>(message,
-                                                ProtobufMessage::getStrictValidationVisitor());
+    return MessageUtil::anyConvert<MessageType>(message);
   }
 
   template <class MessageType>
@@ -513,6 +512,16 @@ public:
   static void loadFromYamlAndValidate(const std::string& yaml, MessageType& message) {
     return MessageUtil::loadFromYamlAndValidate(yaml, message,
                                                 ProtobufMessage::getStrictValidationVisitor());
+  }
+
+  template <class MessageType> static void validate(const MessageType& message) {
+    return MessageUtil::validate(message, ProtobufMessage::getStrictValidationVisitor());
+  }
+
+  template <class MessageType>
+  static const MessageType& downcastAndValidate(const Protobuf::Message& config) {
+    return MessageUtil::downcastAndValidate<MessageType>(
+        config, ProtobufMessage::getStrictValidationVisitor());
   }
 
   static void jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest) {

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -165,7 +165,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
   auto api = Api::createApiForTest(*stats);
   const std::string contents = api->fileSystem().fileReadToEnd(expected_routes);
   TestUtility::loadFromFile(expected_routes, validation_config, *api);
-  MessageUtil::validate(validation_config);
+  TestUtility::validate(validation_config);
 
   bool no_failures = true;
   for (const envoy::RouterCheckToolSchema::ValidationItem& check_config :

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -59,13 +59,13 @@ void Validator::validate(const std::string& config_path, Schema::Type schema_typ
   case Schema::Type::DiscoveryResponse: {
     envoy::api::v2::DiscoveryResponse discovery_response_config;
     TestUtility::loadFromFile(config_path, discovery_response_config, *api_);
-    MessageUtil::validate(discovery_response_config);
+    TestUtility::validate(discovery_response_config);
     break;
   }
   case Schema::Type::Route: {
     envoy::api::v2::RouteConfiguration route_config;
     TestUtility::loadFromFile(config_path, route_config, *api_);
-    MessageUtil::validate(route_config);
+    TestUtility::validate(route_config);
     break;
   }
   default:


### PR DESCRIPTION
This is part of #7980; basically, we want to leverage the recursive pass
that already exists for the deprecated check. This PR does not implement
the recursive behavior yet for unknown fields though, because there is a
ton of churn, so this PR just has the mechanical bits. We switch
plumbing of validation visitor into places such as anyConvert() and
instead pass this to MessageUtil::validate.

There are a bunch of future followups planned in additional PRs:
* Combine the recursive pass for unknown/deprecated check in
  MessageUtil::validate().
* Add mitigation for #5965 by copying to a temporary before recursive
  expansion.
* [Future] consider moving deprecated reporting into a message
  validation visitor handler.

Risk level: Low
Testing: Some new //test/common/protobuf::utility_test unit test.

Signed-off-by: Harvey Tuch <htuch@google.com>