### PR TITLE
Cleanup: fix typo in code comment

### DIFF
--- a/test/common/http/http2/frame_replay_test.cc
+++ b/test/common/http/http2/frame_replay_test.cc
@@ -185,7 +185,7 @@ TEST_F(RequestFrameCommentTest, SingleByteNulCrLfInHeaderFrame) {
 }
 
 // Validate that corrupting any single byte with {NUL, CR, LF} in a HEADERS frame doesn't crash or
-// trigger ASSERTs. This is a litmus test for the HTTP/2 codec (nghttp2) to demonsrate that it
+// trigger ASSERTs. This is a litmus test for the HTTP/2 codec (nghttp2) to demonstrate that it
 // doesn't suffer from the issue reported for http-parser in CVE-2019-9900. See also
 // https://httpwg.org/specs/rfc7540.html#rfc.section.10.3. We use a non-compressed frame with no
 // Huffman encoding to simplify.
@@ -215,7 +215,7 @@ TEST_F(ResponseFrameCommentTest, SingleByteNulCrLfInHeaderFrame) {
 
 // Validate that corrupting any single byte with {NUL, CR, LF} in a HEADERS field name or value
 // yields a CodecProtocolException or stream reset. This is a litmus test for the HTTP/2 codec
-// (nghttp2) to demonsrate that it doesn't suffer from the issue reported for http-parser in
+// (nghttp2) to demonstrate that it doesn't suffer from the issue reported for http-parser in
 // CVE-2019-9900. See also https://httpwg.org/specs/rfc7540.html#rfc.section.10.3. We use a
 // non-compressed frame with no Huffman encoding to simplify.
 TEST_F(RequestFrameCommentTest, SingleByteNulCrLfInHeaderField) {
@@ -250,7 +250,7 @@ TEST_F(RequestFrameCommentTest, SingleByteNulCrLfInHeaderField) {
 
 // Validate that corrupting any single byte with {NUL, CR, LF} in a HEADERS field name or value
 // yields a CodecProtocolException or stream reset. This is a litmus test for the HTTP/2 codec
-// (nghttp2) to demonsrate that it doesn't suffer from the issue reported for http-parser in
+// (nghttp2) to demonstrate that it doesn't suffer from the issue reported for http-parser in
 // CVE-2019-9900. See also https://httpwg.org/specs/rfc7540.html#rfc.section.10.3. We use a
 // non-compressed frame with no Huffman encoding to simplify.
 TEST_F(ResponseFrameCommentTest, SingleByteNulCrLfInHeaderField) {


### PR DESCRIPTION
Signed-off-by: Guangming Wang <guangming.wang@daocloud.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: cleanup codebase
Risk Level: Low
Testing:no need
Docs Changes:N/A
Release Notes:N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
