### PR TITLE
test: cleaning up test runtime

### DIFF
--- a/test/common/http/http1/BUILD
+++ b/test/common/http/http1/BUILD
@@ -28,6 +28,7 @@ envoy_cc_test(
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:logging_lib",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -12,15 +12,10 @@
 
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
-#include "test/mocks/init/mocks.h"
-#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
-#include "test/mocks/protobuf/mocks.h"
-#include "test/mocks/runtime/mocks.h"
-#include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
-#include "test/test_common/utility.h"
+#include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -38,17 +33,6 @@ namespace Http1 {
 
 class Http1ServerConnectionImplTest : public testing::Test {
 public:
-  Http1ServerConnectionImplTest() : api_(Api::createApiForTest()) {
-    envoy::config::bootstrap::v2::LayeredRuntime config;
-    config.add_layers()->mutable_admin_layer();
-
-    // Create a runtime loader, so that tests can manually manipulate runtime
-    // guarded features.
-    loader_ = std::make_unique<Runtime::ScopedLoaderSingleton>(Runtime::LoaderPtr{
-        new Runtime::LoaderImpl(dispatcher_, tls_, config, local_info_, init_manager_, store_,
-                                generator_, validation_visitor_, *api_)});
-  }
-
   void initialize() {
     codec_ = std::make_unique<ServerConnectionImpl>(connection_, store_, callbacks_,
                                                     codec_settings_, max_request_headers_kb_);
@@ -65,15 +49,7 @@ public:
 
 protected:
   uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
-  Event::MockDispatcher dispatcher_;
-  NiceMock<ThreadLocal::MockInstance> tls_;
   Stats::IsolatedStoreImpl store_;
-  Runtime::MockRandomGenerator generator_;
-  Api::ApiPtr api_;
-  NiceMock<LocalInfo::MockLocalInfo> local_info_;
-  Init::MockManager init_manager_;
-  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
-  std::unique_ptr<Runtime::ScopedLoaderSingleton> loader_;
 };
 
 void Http1ServerConnectionImplTest::expect400(Protocol p, bool allow_absolute_url,
@@ -366,6 +342,7 @@ TEST_F(Http1ServerConnectionImplTest, HostHeaderTranslation) {
 // Ensures that requests with invalid HTTP header values are not rejected
 // when the runtime guard is not enabled for the feature.
 TEST_F(Http1ServerConnectionImplTest, HeaderInvalidCharsRuntimeGuard) {
+  TestScopedRuntime scoped_runtime;
   // When the runtime-guarded feature is NOT enabled, invalid header values
   // should be accepted by the codec.
   Runtime::LoaderSingleton::getExisting()->mergeValues(
@@ -384,6 +361,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderInvalidCharsRuntimeGuard) {
 // Ensures that requests with invalid HTTP header values are properly rejected
 // when the runtime guard is enabled for the feature.
 TEST_F(Http1ServerConnectionImplTest, HeaderInvalidCharsRejection) {
+  TestScopedRuntime scoped_runtime;
   // When the runtime-guarded feature is enabled, invalid header values
   // should result in a rejection.
   Runtime::LoaderSingleton::getExisting()->mergeValues(
@@ -850,16 +828,6 @@ TEST_F(Http1ServerConnectionImplTest, WatermarkTest) {
 
 class Http1ClientConnectionImplTest : public testing::Test {
 public:
-  Http1ClientConnectionImplTest() : api_(Api::createApiForTest()) {
-    envoy::config::bootstrap::v2::LayeredRuntime config;
-
-    // Create a runtime loader, so that tests can manually manipulate runtime
-    // guarded features.
-    loader_ = std::make_unique<Runtime::ScopedLoaderSingleton>(Runtime::LoaderPtr{
-        new Runtime::LoaderImpl(dispatcher_, tls_, config, local_info_, init_manager_, store_,
-                                generator_, validation_visitor_, *api_)});
-  }
-
   void initialize() {
     codec_ = std::make_unique<ClientConnectionImpl>(connection_, store_, callbacks_);
   }
@@ -869,15 +837,7 @@ public:
   std::unique_ptr<ClientConnectionImpl> codec_;
 
 protected:
-  Event::MockDispatcher dispatcher_;
-  NiceMock<ThreadLocal::MockInstance> tls_;
   Stats::IsolatedStoreImpl store_;
-  Runtime::MockRandomGenerator generator_;
-  Api::ApiPtr api_;
-  NiceMock<LocalInfo::MockLocalInfo> local_info_;
-  Init::MockManager init_manager_;
-  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
-  std::unique_ptr<Runtime::ScopedLoaderSingleton> loader_;
 };
 
 TEST_F(Http1ClientConnectionImplTest, SimpleGet) {

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -30,6 +30,7 @@ envoy_cc_test(
         "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/buffer/BUILD
+++ b/test/extensions/filters/http/buffer/BUILD
@@ -27,6 +27,7 @@ envoy_extension_cc_test(
         "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/test_common/test_runtime.h
+++ b/test/test_common/test_runtime.h
@@ -25,7 +25,6 @@
 
 namespace Envoy {
 
-// TODO(alyssawilk) move existing runtime tests over to using this.
 class TestScopedRuntime {
 public:
   TestScopedRuntime() : api_(Api::createApiForTest()) {


### PR DESCRIPTION
Using the new runtime utility to clean up a bunch of test gorp.  Yay utils!

Risk Level: n/a (test only)
Testing: tests pass
Docs Changes: n/a
Release Notes: n/a
