### PR TITLE
Fix onHostHealthUpdate got called before the cluster is resolved.

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -75,6 +75,11 @@ void RedisClusterLoadBalancerFactory::onHostHealthUpdate() {
     current_shard_vector = shard_vector_;
   }
 
+  // This can get called by cluster initialization before the Redis Cluster topology is resolved.
+  if (!current_shard_vector) {
+    return;
+  }
+
   auto shard_vector = std::make_shared<std::vector<RedisShardSharedPtr>>();
 
   for (auto const& shard : *current_shard_vector) {

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -44,6 +44,7 @@ public:
     factory_ = std::make_shared<RedisClusterLoadBalancerFactory>(random_);
     lb_ = std::make_unique<RedisClusterThreadAwareLoadBalancer>(factory_);
     lb_->initialize();
+    factory_->onHostHealthUpdate();
   }
 
   void validateAssignment(Upstream::HostVector& hosts,


### PR DESCRIPTION
Signed-off-by: Henry Yang <hyang@lyft.com>

Description: onHostHealthUpdate got called before the cluster is resolved, in our particular case this cluster was never created so it's an empty cluster.  Here's the call stack:
> #2  Envoy::Extensions::Clusters::Redis::RedisClusterLoadBalancerFactory::onHostHealthUpdate (this=<optimized out>) at external/envoy/source/extensions/clusters/redis/redis_cluster_lb.cc:80 
#3  0x00000000004ae8cf in Envoy::Extensions::Clusters::Redis::RedisCluster::reloadHealthyHostsHelper (this=0x30e1510, host=...) at external/envoy/source/extensions/clusters/redis/redis_cluster.cc:119 
#4  0x00000000007e9d61 in reloadHealthyHosts (this=<optimized out>, host=...) at external/envoy/source/common/upstream/upstream_impl.cc:919 
#5  Envoy::Upstream::ClusterImplBase::finishInitialization (this=0x30e1510) at external/envoy/source/common/upstream/upstream_impl.cc:877 
#6  0x00000000007e9c62 in Envoy::Upstream::ClusterImplBase::onInitDone (this=0x30e1510) at external/envoy/source/common/upstream/upstream_impl.cc:863 

Risk Level: Low
Testing: Test updated to reflect this case.
Docs Changes: N/A
Release Notes: N/A
