### PR TITLE
admin: fix /server_info hot restart version

### DIFF
--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -36,6 +36,9 @@ message ServerInfo {
   // Uptime since the start of the first epoch.
   google.protobuf.Duration uptime_all_epochs = 4;
 
+  // Hot restart version.
+  string hot_restart_version = 5;
+
   // Command line options the server is currently running with.
   CommandLineOptions command_line_options = 6;
 }
@@ -82,8 +85,7 @@ message CommandLineOptions {
   // See :option:`--log-path` for details.
   string log_path = 11;
 
-  // See :option:`--hot-restart-version` for details.
-  bool hot_restart_version = 12;
+  reserved 12;
 
   // See :option:`--service-cluster` for details.
   string service_cluster = 13;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -719,6 +719,7 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap& head
   time_t current_time = time(nullptr);
   envoy::admin::v2alpha::ServerInfo server_info;
   server_info.set_version(VersionInfo::version());
+  server_info.set_hot_restart_version(server_.hotRestart().version());
   server_info.set_state(
       Utility::serverState(server_.initManager().state(), server_.healthCheckFailed()));
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1239,6 +1239,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
   }));
   NiceMock<Init::MockManager> initManager;
   ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
+  ON_CALL(server_.hot_restart_, version()).WillByDefault(Return("foo_version"));
 
   {
     Http::HeaderMapImpl response_headers;
@@ -1254,6 +1255,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
     // values such as timestamps + Envoy version are tricky to test for.
     TestUtility::loadFromJson(body, server_info_proto);
     EXPECT_EQ(server_info_proto.state(), envoy::admin::v2alpha::ServerInfo::LIVE);
+    EXPECT_EQ(server_info_proto.hot_restart_version(), "foo_version");
     EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
     EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
   }


### PR DESCRIPTION
The existing output was never populated / did not make sense.

Risk Level: Low
Testing: New UT
Docs Changes: N/A
Release Notes: N/A
