### PR TITLE
ci: install glib2 and update ninja to version 1.8.2.

### DIFF
--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -6,11 +6,10 @@ set -e
 yum install -y centos-release-scl epel-release
 yum update -y
 yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-1.8.0-openjdk-headless rsync \
-    rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
-    libtool autoconf tcpdump
+    rh-git218 wget unzip which make cmake3 patch devtoolset-7-libatomic-devel openssl python27 \
+    libtool autoconf tcpdump glib2-devel
 
 ln -s /usr/bin/cmake3 /usr/bin/cmake
-ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 # SLES 11 has older glibc than CentOS 7, so pre-built binary for it works on CentOS 7
 LLVM_VERSION=8.0.0

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -14,4 +14,12 @@ if [[ "$(uname -m)" == "x86_64" ]]; then
   curl --location --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION}/bazelisk-linux-amd64 \
     && echo "$SHA256  /usr/local/bin/bazel" | sha256sum --check \
     && chmod +x /usr/local/bin/bazel
+
+  # ninja
+  VERSION=1.8.2
+  SHA256=d2fea9ff33b3ef353161ed906f260d565ca55b8ca0568fa07b1d2cab90a84a07
+  curl -sLo ninja-"$VERSION".zip https://github.com/ninja-build/ninja/releases/download/v"$VERSION"/ninja-linux.zip \
+    && echo "$SHA256" ninja-"$VERSION".zip | sha256sum --check \
+    && unzip ninja-"$VERSION".zip \
+    && mv ninja /usr/bin
 fi

--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -19,7 +19,7 @@ update-alternatives --config gcc
 update-alternatives --config g++
 
 apt-get install -y --no-install-recommends curl wget make cmake git python python-pip python-setuptools python3 python3-pip \
-  unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client
+  unzip bc libtool automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client libglib2.0-dev
 
 # clang 8.
 case $ARCH in


### PR DESCRIPTION
Needed for the upcoming V8-based Wasm VM.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>