### PR TITLE
Read_policy is not set correctly.

### DIFF
--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -31,14 +31,14 @@ ConfigImpl::ConfigImpl(
     break;
   case envoy::config::filter::network::redis_proxy::v2::
       RedisProxy_ConnPoolSettings_ReadPolicy_REPLICA:
-    read_policy_ = ReadPolicy::PreferMaster;
+    read_policy_ = ReadPolicy::Replica;
     break;
   case envoy::config::filter::network::redis_proxy::v2::
       RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_REPLICA:
-    read_policy_ = ReadPolicy::PreferMaster;
+    read_policy_ = ReadPolicy::PreferReplica;
     break;
   case envoy::config::filter::network::redis_proxy::v2::RedisProxy_ConnPoolSettings_ReadPolicy_ANY:
-    read_policy_ = ReadPolicy::PreferMaster;
+    read_policy_ = ReadPolicy::Any;
     break;
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -225,8 +225,8 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key,
   }
 
   const bool use_crc16 = is_redis_cluster_;
-  Clusters::Redis::RedisLoadBalancerContextImpl lb_context(key, parent_.config_.enableHashtagging(),
-                                                           use_crc16, request);
+  Clusters::Redis::RedisLoadBalancerContextImpl lb_context(
+      key, parent_.config_.enableHashtagging(), use_crc16, request, parent_.config_.readPolicy());
   Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
   if (!host) {
     return nullptr;


### PR DESCRIPTION
Add more integration test and additional checks in the unit tests.

Signed-off-by: Henry Yang <hyang@lyft.com>

Description: The read_policy for redis cluster is not correctly set in the conn_pool_impl.  Also some of the setting are not correctly map from the protos.
Risk Level: Low
Testing: Tests added and updated.
Docs Changes:
Release Notes:
