### PR TITLE
bazel: use lld when linking for host with RBE and libc++.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -101,6 +101,7 @@ build:rbe-toolchain-clang --crosstool_top=@rbe_ubuntu_clang//cc:toolchain
 build:rbe-toolchain-clang --extra_toolchains=@rbe_ubuntu_clang//config:cc-toolchain
 build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-8/bin
 
+build:rbe-toolchain-clang-libc++ --config=libc++
 build:rbe-toolchain-clang-libc++ --config=rbe-toolchain
 build:rbe-toolchain-clang-libc++ --crosstool_top=@rbe_ubuntu_clang_libcxx//cc:toolchain
 build:rbe-toolchain-clang-libc++ --extra_toolchains=@rbe_ubuntu_clang_libcxx//config:cc-toolchain


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>