### PR TITLE
Improve tools/stack_decode.py

### DIFF
--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -72,7 +72,10 @@ if __name__ == "__main__":
     decode_stacktrace_log(sys.argv[2], sys.stdin)
     sys.exit(0)
   elif len(sys.argv) > 1:
-    rununder = subprocess.Popen(sys.argv[1:], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    rununder = subprocess.Popen(sys.argv[1:],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                text=True)
     decode_stacktrace_log(sys.argv[1], rununder.stdout)
     rununder.wait()
     sys.exit(rununder.returncode)  # Pass back test pass/fail result


### PR DESCRIPTION
Description: Adjust `tools/stack_decode.py` to more obviously be Python 2 (not 3), and to work on stack traces that don't include the symbol names.
Risk Level: Low
Testing: Manually tested on a stack trace that one of our users sent us
Docs Changes: None
Release Notes: None