### PR TITLE
api: Fix duplicate java_outer_classname declarations

### DIFF
--- a/api/envoy/api/v2/listener/udp_listener_config.proto
+++ b/api/envoy/api/v2/listener/udp_listener_config.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2.listener;
 
-option java_outer_classname = "ListenerProto";
+option java_outer_classname = "UdpListenerConfigProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
 option go_package = "listener";

--- a/api/envoy/type/matcher/regex.proto
+++ b/api/envoy/type/matcher/regex.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher;
 
-option java_outer_classname = "StringProto";
+option java_outer_classname = "RegexProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type.matcher";
 option go_package = "matcher";


### PR DESCRIPTION
Description:
The java_outer_classname is unintentionally duplicated in the new
udp_listener_config and regex proto files. This changes them to unique
names that match the predominant naming scheme.

Risk Level: Low
