### PR TITLE
common: fix illegal path check

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -130,12 +130,14 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // instances poking in bad places. We may have to consider conditioning on
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
-  // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (absl::StartsWith(canonical_path.rc_, "/dev") ||
-      absl::StartsWith(canonical_path.rc_, "/sys") ||
-      absl::StartsWith(canonical_path.rc_, "/proc")) {
-    return true;
+  static std::vector<std::string> paths = {"/dev", "/sys", "/proc"};
+  auto offset = canonical_path.rc_.find('/', 1);
+  for (const auto& p : paths) {
+    if (canonical_path.rc_.compare(0, offset, p) == 0) {
+      return true;
+    }
   }
+
   return false;
 }
 

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -130,10 +130,11 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // instances poking in bad places. We may have to consider conditioning on
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
-  static std::vector<std::string> paths = {"/dev", "/sys", "/proc"};
-  auto offset = canonical_path.rc_.find('/', 1);
-  for (const auto& p : paths) {
-    if (canonical_path.rc_.compare(0, offset, p) == 0) {
+  static const char* const paths[] = {"/dev", "/sys", "/proc"};
+  absl::string_view canonical(canonical_path.rc_);
+  const auto offset = canonical.find('/', 1);
+  for (const auto& path : paths) {
+    if (canonical.compare(0, offset, path) == 0) {
       return true;
     }
   }

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -7,6 +7,8 @@
 
 #include "common/filesystem/file_shared_impl.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Filesystem {
 
@@ -42,7 +44,9 @@ public:
   bool illegalPath(const std::string& path) override;
 
 private:
+  bool illegalCanonicalPath(const absl::string_view& path);
   Api::SysCallStringResult canonicalPath(const std::string& path);
+
   friend class FileSystemImplTest;
 };
 

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -148,6 +148,7 @@ TEST_F(FileSystemImplTest, IllegalPath) {
 #endif
 }
 
+#ifndef WIN32
 TEST_F(FileSystemImplTest, illegalCanonicalPath) {
   EXPECT_FALSE(illegalCanonicalPath("/develop"));
   EXPECT_FALSE(illegalCanonicalPath("/develop/"));
@@ -156,6 +157,7 @@ TEST_F(FileSystemImplTest, illegalCanonicalPath) {
   EXPECT_FALSE(illegalCanonicalPath("/procedure"));
   EXPECT_FALSE(illegalCanonicalPath("/procedure/"));
 }
+#endif
 
 TEST_F(FileSystemImplTest, ConstructedFileNotOpen) {
   const std::string new_file_path = TestEnvironment::temporaryPath("envoy_this_not_exist");

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -33,6 +33,9 @@ protected:
   Api::SysCallStringResult canonicalPath(const std::string& path) {
     return file_system_.canonicalPath(path);
   }
+  bool illegalCanonicalPath(const absl::string_view& canonical) {
+    return file_system_.illegalCanonicalPath(canonical);
+  }
   InstanceImplPosix file_system_;
 #endif
 };
@@ -143,6 +146,15 @@ TEST_F(FileSystemImplTest, IllegalPath) {
   EXPECT_TRUE(file_system_.illegalPath("/sys/"));
   EXPECT_TRUE(file_system_.illegalPath("/_some_non_existent_file"));
 #endif
+}
+
+TEST_F(FileSystemImplTest, illegalCanonicalPath) {
+  EXPECT_FALSE(illegalCanonicalPath("/develop"));
+  EXPECT_FALSE(illegalCanonicalPath("/develop/"));
+  EXPECT_FALSE(illegalCanonicalPath("/system"));
+  EXPECT_FALSE(illegalCanonicalPath("/system/"));
+  EXPECT_FALSE(illegalCanonicalPath("/procedure"));
+  EXPECT_FALSE(illegalCanonicalPath("/procedure/"));
 }
 
 TEST_F(FileSystemImplTest, ConstructedFileNotOpen) {


### PR DESCRIPTION
common: fix illegal path check

Description:
`InstanceImplPosix::illegalPath()` checks if a path illegal by comparing whether
it begins with "/dev", "/sys" or "/proc". Unfortunately, I build and run Envoy
test cases in "/develop" folder, which is totally legal, but because it begins
with '/dev' it is considered illegal. This fix makes the check more robust.

Testing: `InstanceImplPosix::canonicalPath()` is not mock-able right now, no new test case added.
 
Signed-off-by: lhuang8 <lhuang8@ebay.com>
