### PR TITLE
test: fix ups for various deprecated fields

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -29,7 +29,6 @@ Version history
 * http: added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature `envoy.reloadable_features.strict_header_validation`.
 * http: changed Envoy to forward existing x-forwarded-proto from upstream trusted proxies. Guarded by `envoy.reloadable_features.trusted_forwarded_proto` which defaults true.
 * http: added the ability to configure the behavior of the server response header, via the :ref:`server_header_transformation<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.server_header_transformation>` field.
-* http: changed Envoy to forward existing x-forwarded-proto from downstream trusted proxies. Guarded by `envoy.reloadable_features.trusted_forwarded_proto` which defaults true.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
 * listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -116,8 +116,172 @@ protected:
 
 class RouteMatcherTest : public testing::Test, public ConfigImplTestBase {};
 
-// TODO(alyssawilk) go through all these tests and update or duplicate.
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(TestRoutes)) {
+// When removing legacy fields this test can be removed.
+TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(TestLegacyRoutes)) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: regex
+  domains:
+  - bat.com
+  routes:
+  - match:
+      regex: "/t[io]c"
+    route:
+      cluster: clock
+  - match:
+      safe_regex:
+        google_re2: {}
+        regex: "/baa+"
+    route:
+      cluster: sheep
+  - match:
+      regex: ".*/\\d{3}$"
+    route:
+      cluster: three_numbers
+      prefix_rewrite: "/rewrote"
+  - match:
+      regex: ".*"
+    route:
+      cluster: regex_default
+- name: regex2
+  domains:
+  - bat2.com
+  routes:
+  - match:
+      regex: ''
+    route:
+      cluster: nothingness
+  - match:
+      regex: ".*"
+    route:
+      cluster: regex_default
+  virtual_clusters:
+  - pattern: "^/rides$"
+    method: POST
+    name: ride_request
+  - pattern: "^/rides/\\d+$"
+    method: PUT
+    name: update_ride
+  - pattern: "^/users/\\d+/chargeaccounts$"
+    method: POST
+    name: cc_add
+  - pattern: "^/users/\\d+/chargeaccounts/(?!validate)\\w+$"
+    method: PUT
+    name: cc_add
+  - pattern: "^/users$"
+    method: POST
+    name: create_user_login
+  - pattern: "^/users/\\d+$"
+    method: PUT
+    name: update_user
+  - headers:
+    - name: ":path"
+      safe_regex_match:
+        google_re2: {}
+        regex: "^/users/\\d+/location$"
+    - name: ":method"
+      exact_match: POST
+    name: ulu
+  )EOF";
+
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  TestConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true);
+
+  // Regular Expression matching
+  EXPECT_EQ("clock",
+            config.route(genHeaders("bat.com", "/tic", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("clock",
+            config.route(genHeaders("bat.com", "/toc", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat.com", "/tac", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat.com", "", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat.com", "/tick", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat.com", "/tic/toc", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("sheep",
+            config.route(genHeaders("bat.com", "/baa", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ(
+      "sheep",
+      config.route(genHeaders("bat.com", "/baaaaaaaaaaaa", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat.com", "/ba", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("nothingness",
+            config.route(genHeaders("bat2.com", "", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat2.com", "/foo", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("regex_default",
+            config.route(genHeaders("bat2.com", " ", "GET"), 0)->routeEntry()->clusterName());
+
+  // Regular Expression matching with query string params
+  EXPECT_EQ(
+      "clock",
+      config.route(genHeaders("bat.com", "/tic?tac=true", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ(
+      "regex_default",
+      config.route(genHeaders("bat.com", "/tac?tic=true", "GET"), 0)->routeEntry()->clusterName());
+
+  // Virtual cluster testing.
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/rides", "GET");
+    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/rides/blah", "POST");
+    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/rides", "POST");
+    EXPECT_EQ("ride_request", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/rides/123", "PUT");
+    EXPECT_EQ("update_ride", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/rides/123/456", "POST");
+    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers =
+        genHeaders("api.lyft.com", "/users/123/chargeaccounts", "POST");
+    EXPECT_EQ("cc_add", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers =
+        genHeaders("api.lyft.com", "/users/123/chargeaccounts/hello123", "PUT");
+    EXPECT_EQ("cc_add", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers =
+        genHeaders("api.lyft.com", "/users/123/chargeaccounts/validate", "PUT");
+    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/foo/bar", "PUT");
+    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/users", "POST");
+    EXPECT_EQ("create_user_login",
+              virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/users/123", "PUT");
+    EXPECT_EQ("update_user", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/users/123/location", "POST");
+    EXPECT_EQ("ulu", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/something/else", "GET");
+    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
+  }
+}
+
+TEST_F(RouteMatcherTest, TestRoutes) {
   const std::string yaml = R"EOF(
 virtual_hosts:
 - name: www2
@@ -172,7 +336,9 @@ virtual_hosts:
   - bat.com
   routes:
   - match:
-      regex: "/t[io]c"
+      safe_regex:
+        google_re2: {}
+        regex: "/t[io]c"
     route:
       cluster: clock
   - match:
@@ -182,12 +348,16 @@ virtual_hosts:
     route:
       cluster: sheep
   - match:
-      regex: ".*/\\d{3}$"
+      safe_regex:
+        google_re2: {}
+        regex: ".*/\\d{3}$"
     route:
       cluster: three_numbers
       prefix_rewrite: "/rewrote"
   - match:
-      regex: ".*"
+      safe_regex:
+        google_re2: {}
+        regex: ".*"
     route:
       cluster: regex_default
 - name: regex2
@@ -195,11 +365,9 @@ virtual_hosts:
   - bat2.com
   routes:
   - match:
-      regex: ''
-    route:
-      cluster: nothingness
-  - match:
-      regex: ".*"
+      safe_regex:
+        google_re2: {}
+        regex: ".*"
     route:
       cluster: regex_default
 - name: default
@@ -280,23 +448,45 @@ virtual_hosts:
       cluster: instant-server
       timeout: 30s
   virtual_clusters:
-  - pattern: "^/rides$"
-    method: POST
+  - headers:
+    - name: ":path"
+      safe_regex_match:
+        google_re2: {}
+        regex: "^/rides$"
+    - name: ":method"
+      exact_match: POST
     name: ride_request
-  - pattern: "^/rides/\\d+$"
-    method: PUT
+  - headers:
+    - name: ":path"
+      safe_regex_match:
+        google_re2: {}
+        regex: "^/rides/\\d+$"
+    - name: ":method"
+      exact_match: PUT
     name: update_ride
-  - pattern: "^/users/\\d+/chargeaccounts$"
-    method: POST
+  - headers:
+    - name: ":path"
+      safe_regex_match:
+        google_re2: {}
+        regex: "^/users/\\d+/chargeaccounts$"
+    - name: ":method"
+      exact_match: POST
     name: cc_add
-  - pattern: "^/users/\\d+/chargeaccounts/(?!validate)\\w+$"
-    method: PUT
-    name: cc_add
-  - pattern: "^/users$"
-    method: POST
+  - headers:
+    - name: ":path"
+      safe_regex_match:
+        google_re2: {}
+        regex: "^/users$"
+    - name: ":method"
+      exact_match: POST
     name: create_user_login
-  - pattern: "^/users/\\d+$"
-    method: PUT
+  - headers:
+    - name: ":path"
+      safe_regex_match:
+        google_re2: {}
+        regex: "^/users/\\d+$"
+    - name: ":method"
+      exact_match: PUT
     name: update_user
   - headers:
     - name: ":path"
@@ -372,8 +562,6 @@ virtual_hosts:
       config.route(genHeaders("bat.com", "/baaaaaaaaaaaa", "GET"), 0)->routeEntry()->clusterName());
   EXPECT_EQ("regex_default",
             config.route(genHeaders("bat.com", "/ba", "GET"), 0)->routeEntry()->clusterName());
-  EXPECT_EQ("nothingness",
-            config.route(genHeaders("bat2.com", "", "GET"), 0)->routeEntry()->clusterName());
   EXPECT_EQ("regex_default",
             config.route(genHeaders("bat2.com", "/foo", "GET"), 0)->routeEntry()->clusterName());
   EXPECT_EQ("regex_default",
@@ -557,21 +745,6 @@ virtual_hosts:
     EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
   }
   {
-    Http::TestHeaderMapImpl headers =
-        genHeaders("api.lyft.com", "/users/123/chargeaccounts", "POST");
-    EXPECT_EQ("cc_add", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
-  }
-  {
-    Http::TestHeaderMapImpl headers =
-        genHeaders("api.lyft.com", "/users/123/chargeaccounts/hello123", "PUT");
-    EXPECT_EQ("cc_add", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
-  }
-  {
-    Http::TestHeaderMapImpl headers =
-        genHeaders("api.lyft.com", "/users/123/chargeaccounts/validate", "PUT");
-    EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
-  }
-  {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/foo/bar", "PUT");
     EXPECT_EQ("other", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
   }
@@ -618,7 +791,8 @@ virtual_hosts:
             config.route(genHeaders("example.com", "/", "GET"), 0)->routeEntry()->clusterName());
 }
 
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(TestRoutesWithInvalidRegex)) {
+// When deprecating regex: this test can be removed.
+TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(TestRoutesWithInvalidRegexLegacy)) {
   std::string invalid_route = R"EOF(
 virtual_hosts:
   - name: regex
@@ -649,6 +823,46 @@ virtual_hosts:
   EXPECT_THROW_WITH_REGEX(TestConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_virtual_cluster),
                                          factory_context_, true),
                           EnvoyException, "Invalid regex '\\^/\\(\\+invalid\\)':");
+}
+
+TEST_F(RouteMatcherTest, TestRoutesWithInvalidRegex) {
+  std::string invalid_route = R"EOF(
+virtual_hosts:
+  - name: regex
+    domains: ["*"]
+    routes:
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/(+invalid)"
+        route: { cluster: "regex" }
+  )EOF";
+
+  std::string invalid_virtual_cluster = R"EOF(
+virtual_hosts:
+  - name: regex
+    domains: ["*"]
+    routes:
+      - match: { prefix: "/" }
+        route: { cluster: "regex" }
+    virtual_clusters:
+      name: "invalid"
+      headers:
+        name: "invalid"
+        safe_regex_match:
+          google_re2: {}
+          regex: "^/(+invalid)"
+  )EOF";
+
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_route), factory_context_, true),
+      EnvoyException, "no argument for repetition operator:");
+
+  EXPECT_THROW_WITH_REGEX(TestConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_virtual_cluster),
+                                         factory_context_, true),
+                          EnvoyException, "no argument for repetition operator");
 }
 
 // Virtual cluster that contains neither pattern nor regex. This must be checked while pattern is
@@ -1078,7 +1292,7 @@ virtual_hosts:
   }
 }
 
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(Priority)) {
+TEST_F(RouteMatcherTest, Priority) {
   const std::string yaml = R"EOF(
 virtual_hosts:
 - name: local_service
@@ -1094,10 +1308,6 @@ virtual_hosts:
       prefix: "/bar"
     route:
       cluster: local_service_grpc
-  virtual_clusters:
-  - pattern: "^/bar$"
-    method: POST
-    name: foo
   )EOF";
 
   TestConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true);
@@ -1165,7 +1375,7 @@ virtual_hosts:
                EnvoyException);
 }
 
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(HeaderMatchedRouting)) {
+TEST_F(RouteMatcherTest, HeaderMatchedRouting) {
   const std::string yaml = R"EOF(
 virtual_hosts:
 - name: local_service
@@ -1199,7 +1409,9 @@ virtual_hosts:
       prefix: "/"
       headers:
       - name: test_header_pattern
-        regex_match: "^user=test-\\d+$"
+        safe_regex_match:
+          google_re2: {}
+          regex: "^user=test-\\d+$"
     route:
       cluster: local_service_with_header_pattern_set_regex
   - match:
@@ -1289,7 +1501,8 @@ virtual_hosts:
 }
 
 // Verify the fixes for https://github.com/envoyproxy/envoy/issues/2406
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(InvalidHeaderMatchedRoutingConfig)) {
+// When removing regex_match this test can be removed entirely.
+TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(InvalidHeaderMatchedRoutingConfigLegacy)) {
   std::string value_with_regex_chars = R"EOF(
 virtual_hosts:
   - name: local_service
@@ -1324,6 +1537,45 @@ virtual_hosts:
       EnvoyException, "Invalid regex");
 }
 
+// Verify the fixes for https://github.com/envoyproxy/envoy/issues/2406
+TEST_F(RouteMatcherTest, InvalidHeaderMatchedRoutingConfig) {
+  std::string value_with_regex_chars = R"EOF(
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header
+              exact_match: "(+not a regex)"
+        route: { cluster: "local_service" }
+  )EOF";
+
+  std::string invalid_regex = R"EOF(
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header
+              safe_regex_match:
+                google_re2: {}
+                regex: "(+invalid regex)"
+        route: { cluster: "local_service" }
+  )EOF";
+
+  EXPECT_NO_THROW(TestConfigImpl(parseRouteConfigurationFromV2Yaml(value_with_regex_chars),
+                                 factory_context_, true));
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_regex), factory_context_, true),
+      EnvoyException, "no argument for repetition operator");
+}
+
+// When removing value: simply remove that section of the config and the relevant test.
 TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(QueryParamMatchedRouting)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
@@ -1438,7 +1690,7 @@ virtual_hosts:
   }
 }
 
-// Verify the fixes for https://github.com/envoyproxy/envoy/issues/2406
+// When removing value: this test can be removed.
 TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(InvalidQueryParamMatchedRoutingConfig)) {
   std::string value_with_regex_chars = R"EOF(
 virtual_hosts:
@@ -2250,7 +2502,7 @@ virtual_hosts:
             config.route(headers, 0)->routeEntry()->clusterNotFoundResponseCode());
 }
 
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(Shadow)) {
+TEST_F(RouteMatcherTest, Shadow) {
   const std::string yaml = R"EOF(
 virtual_hosts:
 - name: www2
@@ -2268,7 +2520,11 @@ virtual_hosts:
     route:
       request_mirror_policy:
         cluster: some_cluster2
-        runtime_key: foo
+        runtime_fraction:
+           default_value:
+             numerator: 20
+             denominator: HUNDRED
+           runtime_key: foo
       cluster: www2
   - match:
       prefix: "/baz"
@@ -2308,6 +2564,7 @@ virtual_hosts:
 
 class RouteConfigurationV2 : public testing::Test, public ConfigImplTestBase {};
 
+// When removing runtime_key: this test can be removed.
 TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RequestMirrorPolicy)) {
   const std::string yaml = R"EOF(
 name: foo
@@ -4265,6 +4522,8 @@ virtual_hosts:
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 
+// When allow_origin: and allow_origin_regex: are removed, simply remove them
+// and the relevant checks below.
 TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TestVHostCorsConfig)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
@@ -4327,7 +4586,7 @@ virtual_hosts:
   EXPECT_EQ(cors_policy->allowCredentials(), true);
 }
 
-TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TestRouteCorsConfig)) {
+TEST_F(RoutePropertyTest, TestRouteCorsConfig) {
   const std::string yaml = R"EOF(
 virtual_hosts:
   - name: "default"
@@ -4338,7 +4597,8 @@ virtual_hosts:
         route:
           cluster: "ats"
           cors:
-            allow_origin: ["test-origin"]
+            allow_origin_string_match:
+            - exact: "test-origin"
             allow_methods: "test-methods"
             allow_headers: "test-headers"
             expose_headers: "test-expose-headers"
@@ -4380,7 +4640,8 @@ virtual_hosts:
   EXPECT_EQ(cors_policy->allowCredentials(), true);
 }
 
-TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TestVHostCorsLegacyConfig)) {
+// When allow-origin: is removed, this test can be removed.
+TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TTestVHostCorsLegacyConfig)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
 - name: default
@@ -4419,6 +4680,7 @@ virtual_hosts:
   EXPECT_EQ(cors_policy->allowCredentials(), true);
 }
 
+// When allow-origin: is removed, this test can be removed.
 TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TestRouteCorsLegacyConfig)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
@@ -4910,14 +5172,17 @@ virtual_hosts:
       Envoy::EnvoyException, "Cannot create a Baz when metadata is empty.");
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RouteConfigGetters)) {
+TEST_F(RouteConfigurationV2, RouteConfigGetters) {
   const std::string yaml = R"EOF(
 name: foo
 virtual_hosts:
   - name: bar
     domains: ["*"]
     routes:
-      - match: { regex: "/rege[xy]" }
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/rege[xy]"
         route: { cluster: ww2 }
       - match: { path: "/exact-path" }
         route: { cluster: ww2 }
@@ -4949,19 +5214,25 @@ virtual_hosts:
   EXPECT_EQ("foo", route_entry->virtualHost().routeConfig().name());
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RouteTracingConfig)) {
+TEST_F(RouteConfigurationV2, RouteTracingConfig) {
   const std::string yaml = R"EOF(
 name: foo
 virtual_hosts:
   - name: bar
     domains: ["*"]
     routes:
-      - match: { regex: "/first" }
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/first"
         tracing:
           client_sampling:
             numerator: 1
         route: { cluster: ww2 }
-      - match: { regex: "/second" }
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/second"
         tracing:
           overall_sampling:
             numerator: 1
@@ -5004,7 +5275,7 @@ virtual_hosts:
 }
 
 // Test to check Prefix Rewrite for redirects
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RedirectPrefixRewrite)) {
+TEST_F(RouteConfigurationV2, RedirectPrefixRewrite) {
   std::string RedirectPrefixRewrite = R"EOF(
 name: AllRedirects
 virtual_hosts:
@@ -5017,7 +5288,10 @@ virtual_hosts:
         redirect: { prefix_rewrite: "/new/path/" }
       - match: { prefix: "/host/prefix" }
         redirect: { host_redirect: new.lyft.com, prefix_rewrite: "/new/prefix"}
-      - match: { regex: "/[r][e][g][e][x].*"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/[r][e][g][e][x].*"
         redirect: { prefix_rewrite: "/new/regex-prefix/" }
       - match: { prefix: "/http/prefix"}
         redirect: { prefix_rewrite: "/https/prefix" , https_redirect: true }
@@ -5191,7 +5465,7 @@ virtual_hosts:
   }
 }
 
-TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(HeaderMatchedRoutingV2)) {
+TEST_F(RouteMatcherTest, HeaderMatchedRoutingV2) {
   const std::string yaml = R"EOF(
 name: foo
 virtual_hosts:
@@ -5224,7 +5498,9 @@ virtual_hosts:
           prefix: "/"
           headers:
             - name: test_header_pattern
-              regex_match: "^user=test-\\d+$"
+              safe_regex_match:
+                google_re2: {}
+                regex: "^user=test-\\d+$"
         route:
           cluster: local_service_with_header_pattern_set_regex
       - match:
@@ -5366,8 +5642,7 @@ virtual_hosts:
   }
 }
 
-TEST_F(RouteConfigurationV2,
-       DEPRECATED_FEATURE_TEST(RegexPrefixWithNoRewriteWorksWhenPathChanged)) {
+TEST_F(RouteConfigurationV2, RegexPrefixWithNoRewriteWorksWhenPathChanged) {
 
   // Setup regex route entry. the regex is trivial, that's ok as we only want to test that
   // path change works.
@@ -5377,7 +5652,10 @@ virtual_hosts:
   - name: regex
     domains: [regex.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route: { cluster: some-cluster }
   )EOF";
 
@@ -5398,14 +5676,17 @@ virtual_hosts:
   }
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(NoIdleTimeout)) {
+TEST_F(RouteConfigurationV2, NoIdleTimeout) {
   const std::string NoIdleTimeout = R"EOF(
 name: NoIdleTimeout
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
   )EOF";
@@ -5416,14 +5697,17 @@ virtual_hosts:
   EXPECT_EQ(absl::nullopt, route_entry->idleTimeout());
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(ZeroIdleTimeout)) {
+TEST_F(RouteConfigurationV2, ZeroIdleTimeout) {
   const std::string ZeroIdleTimeout = R"EOF(
 name: ZeroIdleTimeout
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
           idle_timeout: 0s
@@ -5435,14 +5719,17 @@ virtual_hosts:
   EXPECT_EQ(0, route_entry->idleTimeout().value().count());
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(ExplicitIdleTimeout)) {
+TEST_F(RouteConfigurationV2, ExplicitIdleTimeout) {
   const std::string ExplicitIdleTimeout = R"EOF(
 name: ExplicitIdleTimeout
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
           idle_timeout: 7s
@@ -5455,14 +5742,17 @@ virtual_hosts:
   EXPECT_EQ(7 * 1000, route_entry->idleTimeout().value().count());
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RetriableStatusCodes)) {
+TEST_F(RouteConfigurationV2, RetriableStatusCodes) {
   const std::string ExplicitIdleTimeout = R"EOF(
 name: RetriableStatusCodes
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
           retry_policy:
@@ -5477,14 +5767,17 @@ virtual_hosts:
   EXPECT_EQ(expected_codes, retry_policy.retriableStatusCodes());
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(UpgradeConfigs)) {
+TEST_F(RouteConfigurationV2, UpgradeConfigs) {
   const std::string UpgradeYaml = R"EOF(
 name: RetriableStatusCodes
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
           upgrade_configs:
@@ -5501,14 +5794,17 @@ virtual_hosts:
   EXPECT_FALSE(upgrade_map.find("disabled")->second);
 }
 
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(DuplicateUpgradeConfigs)) {
+TEST_F(RouteConfigurationV2, DuplicateUpgradeConfigs) {
   const std::string yaml = R"EOF(
 name: RetriableStatusCodes
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
           upgrade_configs:
@@ -5524,14 +5820,17 @@ virtual_hosts:
 
 // Verifies that we're creating a new instance of the retry plugins on each call instead of always
 // returning the same one.
-TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RetryPluginsAreNotReused)) {
+TEST_F(RouteConfigurationV2, RetryPluginsAreNotReused) {
   const std::string ExplicitIdleTimeout = R"EOF(
 name: RetriableStatusCodes
 virtual_hosts:
   - name: regex
     domains: [idle.lyft.com]
     routes:
-      - match: { regex: "/regex"}
+      - match:
+          safe_regex:
+            google_re2: {}
+            regex: "/regex"
         route:
           cluster: some-cluster
           retry_policy:

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -155,6 +155,15 @@ virtual_hosts:
       regex: ".*"
     route:
       cluster: regex_default
+- name: default
+  domains:
+  - "*"
+  routes:
+  - match:
+      prefix: "/"
+    route:
+      cluster: instant-server
+      timeout: 30s
   virtual_clusters:
   - pattern: "^/rides$"
     method: POST
@@ -174,14 +183,6 @@ virtual_hosts:
   - pattern: "^/users/\\d+$"
     method: PUT
     name: update_user
-  - headers:
-    - name: ":path"
-      safe_regex_match:
-        google_re2: {}
-        regex: "^/users/\\d+/location$"
-    - name: ":method"
-      exact_match: POST
-    name: ulu
   )EOF";
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
@@ -270,10 +271,6 @@ virtual_hosts:
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/users/123", "PUT");
     EXPECT_EQ("update_user", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
-  }
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/users/123/location", "POST");
-    EXPECT_EQ("ulu", virtualClusterName(config.route(headers, 0)->routeEntry(), headers));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/something/else", "GET");

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -1156,8 +1156,7 @@ TEST_F(ConnectionManagerTest, PendingMessageEnd) {
   EXPECT_EQ(1U, store_.gauge("test.request_active", Stats::Gauge::ImportMode::Accumulate).value());
 }
 
-// TODO(alyssawilk) update.
-TEST_F(ConnectionManagerTest, DEPRECATED_FEATURE_TEST(Routing)) {
+TEST_F(ConnectionManagerTest, Routing) {
   const std::string yaml = R"EOF(
 stat_prefix: test
 protocol_type: Dubbo
@@ -1169,7 +1168,9 @@ route_config:
       - match:
           method:
             name:
-              regex: "(.*?)"
+              safe_regex:
+                google_re2: {}
+                regex: "(.*?)"
         route:
             cluster: user_service_dubbo_server
 )EOF";

--- a/test/extensions/filters/network/dubbo_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/route_matcher_test.cc
@@ -38,8 +38,7 @@ parseDubboProxyFromV2Yaml(const std::string& yaml) {
 
 } // namespace
 
-// TODO(alyssawilk) update.
-TEST(DubboRouteMatcherTest, DEPRECATED_FEATURE_TEST(RouteByServiceNameWithAnyMethod)) {
+TEST(DubboRouteMatcherTest, RouteByServiceNameWithAnyMethod) {
   {
     const std::string yaml = R"EOF(
 name: local_route
@@ -48,7 +47,9 @@ routes:
   - match:
       method:
         name:
-          regex: "(.*?)"
+          safe_regex:
+            google_re2: {}
+            regex: "(.*?)"
     route:
         cluster: user_service_dubbo_server
 )EOF";
@@ -95,7 +96,9 @@ routes:
   - match:
       method:
         name:
-          regex: "(.*?)"
+          safe_regex:
+            google_re2: {}
+            regex: "(.*?)"
     route:
         cluster: user_service_dubbo_server
 )EOF";
@@ -129,7 +132,9 @@ routes:
   - match:
       method:
         name:
-          regex: "(.*?)"
+          safe_regex:
+            google_re2: {}
+            regex: "(.*?)"
     route:
         cluster: user_service_dubbo_server
 )EOF";
@@ -168,7 +173,9 @@ routes:
   - match:
       method:
         name:
-          regex: "(.*?)"
+          safe_regex:
+            google_re2: {}
+            regex: "(.*?)"
     route:
         cluster: user_service_dubbo_server
 )EOF";
@@ -292,8 +299,7 @@ routes:
   EXPECT_EQ("user_service_dubbo_server", matcher.route(metadata, 0)->routeEntry()->clusterName());
 }
 
-// TODO(alyssawilk) update.
-TEST(DubboRouteMatcherTest, DEPRECATED_FEATURE_TEST(RouteByMethodWithRegexMatch)) {
+TEST(DubboRouteMatcherTest, RouteByMethodWithRegexMatch) {
   const std::string yaml = R"EOF(
 name: local_route
 interface: org.apache.dubbo.demo.DemoService
@@ -301,7 +307,9 @@ routes:
   - match:
       method:
         name:
-          regex: "\\d{3}test"
+          safe_regex:
+            google_re2: {}
+            regex: "\\d{3}test"
     route:
         cluster: user_service_dubbo_server
 )EOF";

--- a/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
@@ -331,8 +331,7 @@ routes:
   EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
 }
 
-// TODO(alyssawilk) update.
-TEST(ThriftRouteMatcherTest, DEPRECATED_FEATURE_TEST(RouteByRegexHeaderMatcher)) {
+TEST(ThriftRouteMatcherTest, RouteByRegexHeaderMatcher) {
   const std::string yaml = R"EOF(
 name: config
 routes:
@@ -340,7 +339,9 @@ routes:
       method_name: "method1"
       headers:
       - name: "x-version"
-        regex_match: "0.[5-9]"
+        safe_regex_match:
+          google_re2: {}
+          regex: "0.[5-9]"
     route:
       cluster: "cluster1"
 )EOF";


### PR DESCRIPTION
Takeaways: we've lost the ability to do empty regex (which was covered in router tests and is proto constraint validated on the new safe regex) as well as negative lookahead  (also covered in tests) along with a host of other things conveniently documented as not supported here: https://github.com/google/re2/wiki/Syntax

Otherwise split up a bunch of tests, duplicated and tagged a bunch of tests, and cleaning up after we finally can remove deprecated fields again will be an order of magnitude easier.

Also fixing a dup relnote from #8014

Risk Level: n/a (test only)
Testing: yes.  yes there is.
Docs Changes: no
Release Notes: no
