### PR TITLE
include: add log dependency header to connection_handler.h

### DIFF
--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -9,6 +9,8 @@
 #include "envoy/network/listener.h"
 #include "envoy/ssl/context.h"
 
+#include "spdlog/spdlog.h"
+
 namespace Envoy {
 namespace Network {
 


### PR DESCRIPTION
Description: The connection_handler.h uses spdlog but is missing a header. Causes problems when compiling internally. cc. @htuch. 

Risk Level: Low
Testing: Let the CI run
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Teju Nareddy <nareddyt@google.com>