### PR TITLE
api:Add a flag to disable overprovisioning in ClusterLoadAssignment

### DIFF
--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -119,10 +119,12 @@ message ClusterLoadAssignment {
     google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration.gt.seconds = 0];
 
     // The flag to disable overprovisioning. If it is set to true,
-    // overprovisioning_factor will be ignored and Envoy will not do graceful
-    // failover as certain priority level or locality become unhealthy slowly.
-    // Otherwise Envoy will do graceful failover as overprovisioning_factor
-    // suggests.
+    // :ref:`overprovisioning factor
+    // <arch_overview_load_balancing_overprovisioning_factor>` will be ignored
+    // and Envoy will not perform graceful failover between priority levels or
+    // localities as endpoints become unhealthy. Otherwise Envoy will perform
+    // graceful failover as :ref:`overprovisioning factor
+    // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
     // [#next-major-version: Unify with overprovisioning config as a single message.]
     // [#not-implemented-hide:]
     bool disable_overprovisioning = 5;

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -123,6 +123,8 @@ message ClusterLoadAssignment {
     // failover as certain priority level or locality become unhealthy slowly.
     // Otherwise Envoy will do graceful failover as overprovisioning_factor
     // suggests.
+    // [#next-major-version: Unify with overprovisioning config as a single message.]
+    // [#not-implemented-hide:]
     bool disable_overprovisioning = 5;
   }
 

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -117,6 +117,13 @@ message ClusterLoadAssignment {
     // are considered stale and should be marked unhealthy.
     // Defaults to 0 which means endpoints never go stale.
     google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration.gt.seconds = 0];
+
+    // The flag to disable overprovisioning. If it is set to true,
+    // overprovisioning_factor will be ignored and Envoy will not do graceful
+    // failover as certain priority level or locality become unhealthy slowly.
+    // Otherwise Envoy will do graceful failover as overprovisioning_factor
+    // suggests.
+    bool disable_overprovisioning = 5;
   }
 
   // Load balancing policy settings.


### PR DESCRIPTION
Description: Add a boolean flag in ClusterLoadAssignment to disable overprovisioning_factor and stop Envoy doing graceful fail over as certain priority/locality become unhealthy slowly.
Risk Level: Low
Testing: None
Docs Changes: Inline with API protos
Release Notes: N/A

