### PR TITLE
protobuf: recursively validate unknown fields.

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -88,21 +88,6 @@ ProtoValidationException::ProtoValidationException(const std::string& validation
   ENVOY_LOG_MISC(debug, "Proto validation error; throwing {}", what());
 }
 
-void MessageUtil::checkUnknownFields(const Protobuf::Message& message,
-                                     ProtobufMessage::ValidationVisitor& validation_visitor) {
-  const auto& unknown_fields = message.GetReflection()->GetUnknownFields(message);
-  // If there are no unknown fields, we're done here.
-  if (unknown_fields.empty()) {
-    return;
-  }
-  std::string error_msg;
-  for (int n = 0; n < unknown_fields.field_count(); ++n) {
-    error_msg += absl::StrCat(n > 0 ? ", " : "", unknown_fields.field(n).number());
-  }
-  validation_visitor.onUnknownField("type " + message.GetTypeName() + " with unknown field set {" +
-                                    error_msg + "}");
-}
-
 void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& message,
                                ProtobufMessage::ValidationVisitor& validation_visitor) {
   Protobuf::util::JsonParseOptions options;
@@ -159,7 +144,7 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
   if (absl::EndsWith(path, FileExtensions::get().ProtoBinary)) {
     // Attempt to parse the binary format.
     if (message.ParseFromString(contents)) {
-      MessageUtil::checkUnknownFields(message, validation_visitor);
+      MessageUtil::checkForUnexpectedFields(message, validation_visitor);
       return;
     }
     throw EnvoyException("Unable to parse file \"" + path + "\" as a binary protobuf (type " +
@@ -180,7 +165,23 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
   }
 }
 
-void MessageUtil::checkForDeprecation(const Protobuf::Message& message, Runtime::Loader* runtime) {
+void MessageUtil::checkForUnexpectedFields(const Protobuf::Message& message,
+                                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                                           Runtime::Loader* runtime) {
+  // Reject unknown fields.
+  const auto& unknown_fields = message.GetReflection()->GetUnknownFields(message);
+  if (!unknown_fields.empty()) {
+    std::string error_msg;
+    for (int n = 0; n < unknown_fields.field_count(); ++n) {
+      error_msg += absl::StrCat(n > 0 ? ", " : "", unknown_fields.field(n).number());
+    }
+    // We use the validation visitor but have hard coded behavior below for deprecated fields.
+    // TODO(htuch): Unify the deprecated and unknown visitor handling behind the validation
+    // visitor pattern. https://github.com/envoyproxy/envoy/issues/8092.
+    validation_visitor.onUnknownField("type " + message.GetTypeName() +
+                                      " with unknown field set {" + error_msg + "}");
+  }
+
   const Protobuf::Descriptor* descriptor = message.GetDescriptor();
   const Protobuf::Reflection* reflection = message.GetReflection();
   for (int i = 0; i < descriptor->field_count(); ++i) {
@@ -231,10 +232,12 @@ void MessageUtil::checkForDeprecation(const Protobuf::Message& message, Runtime:
       if (field->is_repeated()) {
         const int size = reflection->FieldSize(message, field);
         for (int j = 0; j < size; ++j) {
-          checkForDeprecation(reflection->GetRepeatedMessage(message, field, j), runtime);
+          checkForUnexpectedFields(reflection->GetRepeatedMessage(message, field, j),
+                                   validation_visitor, runtime);
         }
       } else {
-        checkForDeprecation(reflection->GetMessage(message, field), runtime);
+        checkForUnexpectedFields(reflection->GetMessage(message, field), validation_visitor,
+                                 runtime);
       }
     }
   }

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -206,9 +206,6 @@ public:
     return HashUtil::xxHash64(text);
   }
 
-  static void checkUnknownFields(const Protobuf::Message& message,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor);
-
   static void loadFromJson(const std::string& json, Protobuf::Message& message,
                            ProtobufMessage::ValidationVisitor& validation_visitor);
   static void loadFromJson(const std::string& json, ProtobufWkt::Struct& message);
@@ -225,8 +222,9 @@ public:
    *    in disallowed_features in runtime_features.h
    */
   static void
-  checkForDeprecation(const Protobuf::Message& message,
-                      Runtime::Loader* loader = Runtime::LoaderSingleton::getExisting());
+  checkForUnexpectedFields(const Protobuf::Message& message,
+                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                           Runtime::Loader* loader = Runtime::LoaderSingleton::getExisting());
 
   /**
    * Validate protoc-gen-validate constraints on a given protobuf.
@@ -238,9 +236,8 @@ public:
   template <class MessageType>
   static void validate(const MessageType& message,
                        ProtobufMessage::ValidationVisitor& validation_visitor) {
-    // Log warnings or throw errors if deprecated fields are in use.
-    checkForDeprecation(message);
-    checkUnknownFields(message, validation_visitor);
+    // Log warnings or throw errors if deprecated fields or unknown fields are in use.
+    checkForUnexpectedFields(message, validation_visitor);
 
     std::string err;
     if (!Validate(message, &err)) {

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "common/network/utility.h"
+#include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/utility.h"
 #include "common/stream_info/stream_info_impl.h"
 
@@ -74,7 +75,9 @@ RouterCheckTool RouterCheckTool::create(const std::string& router_config_file,
   auto factory_context = std::make_unique<NiceMock<Server::Configuration::MockFactoryContext>>();
   auto config = std::make_unique<Router::ConfigImpl>(route_config, *factory_context, false);
   if (!disableDeprecationCheck) {
-    MessageUtil::checkForDeprecation(route_config, &factory_context->runtime_loader_);
+    MessageUtil::checkForUnexpectedFields(route_config,
+                                          ProtobufMessage::getStrictValidationVisitor(),
+                                          &factory_context->runtime_loader_);
   }
 
   return RouterCheckTool(std::move(factory_context), std::move(config), std::move(stats),


### PR DESCRIPTION
This PR unifies the recursive traversal of deprecated fields with that of unknown fields. It doesn't
deal with moving to a validator visitor model for deprecation; this would be a nice cleanup that we
track at https://github.com/envoyproxy/envoy/issues/8092.

Risk level: Low
Testing: New nested unknown field test added.

Fixes #7980

Signed-off-by: Harvey Tuch <htuch@google.com>