### PR TITLE
Fix heartbeat packet parsing error

### DIFF
--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -306,7 +306,8 @@ public:
     buffer.add(static_cast<void*>(&msg_type), 1);
     buffer.add(std::string{0x14});
     addInt64(buffer, request_id);                    // Request Id
-    buffer.add(std::string{0x00, 0x00, 0x00, 0x00}); // Body Length
+    buffer.add(std::string{0x00, 0x00, 0x00, 0x01}); // Body Length
+    buffer.add(std::string{0x01});                   // Body
   }
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
@@ -377,6 +378,7 @@ TEST_F(ConnectionManagerTest, OnDataHandlesHeartbeatEvent) {
       }));
 
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0U, buffer_.length());
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 
   EXPECT_EQ(0U, store_.counter("test.request").value());
@@ -1156,8 +1158,7 @@ TEST_F(ConnectionManagerTest, PendingMessageEnd) {
   EXPECT_EQ(1U, store_.gauge("test.request_active", Stats::Gauge::ImportMode::Accumulate).value());
 }
 
-// TODO(alyssawilk) update.
-TEST_F(ConnectionManagerTest, DEPRECATED_FEATURE_TEST(Routing)) {
+TEST_F(ConnectionManagerTest, Routing) {
   const std::string yaml = R"EOF(
 stat_prefix: test
 protocol_type: Dubbo
@@ -1169,7 +1170,9 @@ route_config:
       - match:
           method:
             name:
-              regex: "(.*?)"
+              safe_regex:
+                google_re2: {}
+                regex: "(.*?)"
         route:
             cluster: user_service_dubbo_server
 )EOF";


### PR DESCRIPTION
Description: 
The heartbeat packet may carry data, and it is treated as null data when processing the heartbeat packet, causing some data to remain in the buffer.

Risk Level: low 
Testing: Existing unit test
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] #7970 
[Optional Deprecated:]
