### PR TITLE
cleanup: move test utility methods in ScopedRdsIntegrationTest to base class HttpIntegrationTest

### DIFF
--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -138,6 +138,20 @@ protected:
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();
 
+  // Verifie the response_headers contains the expected_headers, and response body matches given
+  // body string.
+  void verifyResponse(IntegrationStreamDecoderPtr response, const std::string& response_code,
+                      const Http::TestHeaderMapImpl& expected_headers,
+                      const std::string& expected_body);
+
+  // Helper that sends a request to Envoy, and verifies if Envoy response headers and body size is
+  // the same as the expected headers map.
+  // Requires the "http" port has been registered.
+  void sendRequestAndVerifyResponse(const Http::TestHeaderMapImpl& request_headers,
+                                    const int request_size,
+                                    const Http::TestHeaderMapImpl& response_headers,
+                                    const int response_size, const int backend_idx);
+
   // Check for completion of upstream_request_, and a simple "200" response.
   void checkSimpleRequestSuccess(uint64_t expected_request_size, uint64_t expected_response_size,
                                  IntegrationStreamDecoder* response);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -138,7 +138,7 @@ protected:
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();
 
-  // Verifie the response_headers contains the expected_headers, and response body matches given
+  // Verifies the response_headers contains the expected_headers, and response body matches given
   // body string.
   void verifyResponse(IntegrationStreamDecoderPtr response, const std::string& response_code,
                       const Http::TestHeaderMapImpl& expected_headers,

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -94,41 +94,6 @@ fragments:
     HttpIntegrationTest::initialize();
   }
 
-  // TODO(stevenzzzz): move these utility methods to base classes to share with other tests.
-  // Helper that verifies if given headers are in the response header map.
-  void verifyResponse(IntegrationStreamDecoderPtr response, const std::string& response_code,
-                      const Http::TestHeaderMapImpl& expected_headers,
-                      const std::string& expected_body) {
-    EXPECT_TRUE(response->complete());
-    EXPECT_EQ(response_code, response->headers().Status()->value().getStringView());
-    expected_headers.iterate(
-        [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-          auto response_headers = static_cast<Http::HeaderMap*>(context);
-          const Http::HeaderEntry* entry = response_headers->get(
-              Http::LowerCaseString{std::string(header.key().getStringView())});
-          EXPECT_NE(entry, nullptr);
-          EXPECT_EQ(header.value().getStringView(), entry->value().getStringView());
-          return Http::HeaderMap::Iterate::Continue;
-        },
-        const_cast<void*>(static_cast<const void*>(&response->headers())));
-    EXPECT_EQ(response->body(), expected_body);
-  }
-
-  // Helper that sends a request to Envoy, and verifies if Envoy response headers and body size is
-  // the same as the expected headers map.
-  void sendRequestAndVerifyResponse(const Http::TestHeaderMapImpl& request_headers,
-                                    const int request_size,
-                                    const Http::TestHeaderMapImpl& response_headers,
-                                    const int response_size, const int backend_idx) {
-    codec_client_ = makeHttpConnection(lookupPort("http"));
-    auto response = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
-                                                  response_size, backend_idx);
-    verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
-    EXPECT_TRUE(upstream_request_->complete());
-    EXPECT_EQ(request_size, upstream_request_->bodyLength());
-    cleanupUpstreamAndDownstream();
-  }
-
   void createUpstreams() override {
     HttpIntegrationTest::createUpstreams();
     // Create the SRDS upstream.


### PR DESCRIPTION
Signed-off-by: Xin Zhuang <stevenzzz@google.com>

Description: cleanup tracked by #8050 
Risk Level: LOW [refactor only]
Testing: no
Docs Changes: N/A 
Release Notes: N/A 
[Optional Fixes #Issue] #8050 