### PR TITLE
owners: add @asraa and @lambdai to OWNERS.

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -39,6 +39,7 @@ routing PRs, questions, etc. to the right place.
 * All maintainers
 * Piotr Sikora ([PiotrSikora](https://github.com/PiotrSikora)) (piotrsikora@google.com)
 * Yan Avlasov ([yanavlasov](https://github.com/yanavlasov)) (yavlasov@google.com)
+* Asra Ali ([asraa](https://github.com/asraa)) (asraa@google.com)
 
 # Emeritus maintainers
 
@@ -60,3 +61,5 @@ matter expert reviews. Feel free to loop them in as needed.
   * Bazel/build.
 * Daniel Hochman ([danielhochman](https://github.com/danielhochman)) (dhochman@lyft.com)
   * Redis, Python, configuration/operational questions.
+* Yuchen Dai ([lambdai](https://github.com/lambdai)) (lambdai@google.com)
+  * v2 xDS, listeners, filter chain discovery service.


### PR DESCRIPTION
* @asraa is joining Envoy OSS security team.

* @lambdai is joining Friends of Envoy as v2 xDS point.

Signed-off-by: Harvey Tuch <htuch@google.com>