### PR TITLE
Set INCLUDE_DIRECTORIES so libcurl can find local urlapi.h

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -75,6 +75,7 @@ envoy_cmake_external(
         "CURL_HIDDEN_SYMBOLS": "off",
         "CMAKE_USE_LIBSSH2": "off",
         "CMAKE_INSTALL_LIBDIR": "lib",
+        "INCLUDE_DIRECTORIES": "include/curl",
     },
     lib_source = "@com_github_curl//:all",
     static_libraries = select({


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/8112

Signed-off-by: John Millikin <jmillikin@stripe.com>