### PR TITLE
Fuzz reuse

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -90,9 +90,9 @@ def envoy_cc_fuzz_test(
         name = test_lib_name,
         deps = deps + [
             repository + "//test/fuzz:fuzz_runner_lib",
-            repository + "//bazel:dynamic_stdlib"
+            repository + "//bazel:dynamic_stdlib",
         ],
-        repository=repository,
+        repository = repository,
         **kwargs
     )
     native.cc_test(
@@ -110,7 +110,7 @@ def envoy_cc_fuzz_test(
                 repository + "//test/fuzz:main",
             ],
         }),
-        size=size,
+        size = size,
         tags = tags,
     )
 

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -63,7 +63,14 @@ def _envoy_test_linkopts():
     }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"])
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
-def envoy_cc_fuzz_test(name, corpus, repository = "", size = "medium", deps = [], tags = [], **kwargs):
+def envoy_cc_fuzz_test(
+        name,
+        corpus,
+        repository = "",
+        size = "medium",
+        deps = [],
+        tags = [],
+        **kwargs):
     if not (corpus.startswith("//") or corpus.startswith(":") or corpus.startswith("@")):
         corpus_name = name + "_corpus"
         corpus = native.glob([corpus + "/**"])
@@ -81,7 +88,10 @@ def envoy_cc_fuzz_test(name, corpus, repository = "", size = "medium", deps = []
     test_lib_name = name + "_lib"
     envoy_cc_test_library(
         name = test_lib_name,
-        deps = deps + [repository + "//test/fuzz:fuzz_runner_lib", repository + "//bazel:dynamic_stdlib"],
+        deps = deps + [
+            repository + "//test/fuzz:fuzz_runner_lib",
+            repository + "//bazel:dynamic_stdlib"
+        ],
         repository=repository,
         **kwargs
     )

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -63,8 +63,8 @@ def _envoy_test_linkopts():
     }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"])
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
-def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
-    if not (corpus.startswith("//") or corpus.startswith(":")):
+def envoy_cc_fuzz_test(name, corpus, repository = "", size = "medium", deps = [], tags = [], **kwargs):
+    if not (corpus.startswith("//") or corpus.startswith(":") or corpus.startswith("@")):
         corpus_name = name + "_corpus"
         corpus = native.glob([corpus + "/**"])
         native.filegroup(
@@ -81,7 +81,8 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     test_lib_name = name + "_lib"
     envoy_cc_test_library(
         name = test_lib_name,
-        deps = deps + ["//test/fuzz:fuzz_runner_lib", "//bazel:dynamic_stdlib"],
+        deps = deps + [repository + "//test/fuzz:fuzz_runner_lib", repository + "//bazel:dynamic_stdlib"],
+        repository=repository,
         **kwargs
     )
     native.cc_test(
@@ -93,12 +94,13 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         data = [corpus_name],
         # No fuzzing on macOS.
         deps = select({
-            "@envoy//bazel:apple": ["//test:dummy_main"],
+            "@envoy//bazel:apple": [repository + "//test:dummy_main"],
             "//conditions:default": [
                 ":" + test_lib_name,
-                "//test/fuzz:main",
+                repository + "//test/fuzz:main",
             ],
         }),
+        size=size,
         tags = tags,
     )
 


### PR DESCRIPTION
Description:

this PR allows the `envoy_cc_fuzz_test` rule to be used when pulling in envoy. which can be useful when you're writing filters for envoy, and want to reuse the fuzzing architecture envoy has already built. other rules already allow for this (see envoy_cc_test in this same file for example).

Risk Level: Low

Testing:

*Testing the Old Rule Still Works*

It is possible to test the old rules still work (even without specifying a repository), by simply choosing your favorite fuzz test, and choosing to run bazel test on it. For example: `bazel test //test/common/router:header_parser_fuzz_test`. Any envoy_cc_fuzz_test rule should do.

*Testing New Rules Work*

I've done testing inside my own repository, but if you want to create your own test rule you can probably do the following in envoy-filter-example:

1. Checkout envoy-filter-example, and update the envoy submodule to this pr.
2. Follow the directions in: `test/fuzz/README.md` to define a envoy_cc_fuzz_test rule. Make sure to add a line for: `repository = "@envoy"` which is the new argument being added.
3. You should be able to run the fuzz test.

Docs Changes: N/A
Release Notes: N/A
