### PR TITLE
api: clone v2[alpha] to v3alpha.

### DIFF
--- a/api/envoy/admin/v3alpha/BUILD
+++ b/api/envoy/admin/v3alpha/BUILD
@@ -1,0 +1,76 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "config_dump",
+    srcs = ["config_dump.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha:cds",
+        "//envoy/api/v3alpha:lds",
+        "//envoy/api/v3alpha:rds",
+        "//envoy/api/v3alpha:srds",
+        "//envoy/api/v3alpha/auth:cert",
+        "//envoy/config/bootstrap/v3alpha:bootstrap",
+    ],
+)
+
+api_proto_library_internal(
+    name = "clusters",
+    srcs = ["clusters.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":metrics",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:health_check",
+        "//envoy/type:percent",
+    ],
+)
+
+api_proto_library_internal(
+    name = "listeners",
+    srcs = ["listeners.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+    ],
+)
+
+api_proto_library_internal(
+    name = "metrics",
+    srcs = ["metrics.proto"],
+    visibility = ["//visibility:public"],
+)
+
+api_proto_library_internal(
+    name = "memory",
+    srcs = ["memory.proto"],
+    visibility = ["//visibility:public"],
+)
+
+api_proto_library_internal(
+    name = "mutex_stats",
+    srcs = ["mutex_stats.proto"],
+    visibility = ["//visibility:public"],
+)
+
+api_proto_library_internal(
+    name = "certs",
+    srcs = ["certs.proto"],
+    visibility = ["//visibility:public"],
+)
+
+api_proto_library_internal(
+    name = "server_info",
+    srcs = ["server_info.proto"],
+    visibility = ["//visibility:public"],
+)
+
+api_proto_library_internal(
+    name = "tap",
+    srcs = ["tap.proto"],
+    deps = [
+        "//envoy/service/tap/v3alpha:common",
+    ],
+)

--- a/api/envoy/admin/v3alpha/certs.proto
+++ b/api/envoy/admin/v3alpha/certs.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "CertsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+import "google/protobuf/timestamp.proto";
+
+// [#protodoc-title: Certificates]
+
+// Proto representation of certificate details. Admin endpoint uses this wrapper for `/certs` to
+// display certificate information. See :ref:`/certs <operations_admin_interface_certs>` for more
+// information.
+message Certificates {
+  // List of certificates known to an Envoy.
+  repeated Certificate certificates = 1;
+}
+
+message Certificate {
+
+  // Details of CA certificate.
+  repeated CertificateDetails ca_cert = 1;
+
+  // Details of Certificate Chain
+  repeated CertificateDetails cert_chain = 2;
+}
+
+message CertificateDetails {
+  // Path of the certificate.
+  string path = 1;
+
+  // Certificate Serial Number.
+  string serial_number = 2;
+
+  // List of Subject Alternate names.
+  repeated SubjectAlternateName subject_alt_names = 3;
+
+  // Minimum of days until expiration of certificate and it's chain.
+  uint64 days_until_expiration = 4;
+
+  // Indicates the time from which the certificate is valid.
+  google.protobuf.Timestamp valid_from = 5;
+
+  // Indicates the time at which the certificate expires.
+  google.protobuf.Timestamp expiration_time = 6;
+}
+
+message SubjectAlternateName {
+
+  // Subject Alternate Name.
+  oneof name {
+    string dns = 1;
+    string uri = 2;
+  }
+}

--- a/api/envoy/admin/v3alpha/clusters.proto
+++ b/api/envoy/admin/v3alpha/clusters.proto
@@ -1,0 +1,143 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "ClustersProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+import "envoy/admin/v3alpha/metrics.proto";
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/health_check.proto";
+import "envoy/type/percent.proto";
+
+// [#protodoc-title: Clusters]
+
+// Admin endpoint uses this wrapper for `/clusters` to display cluster status information.
+// See :ref:`/clusters <operations_admin_interface_clusters>` for more information.
+message Clusters {
+  // Mapping from cluster name to each cluster's status.
+  repeated ClusterStatus cluster_statuses = 1;
+}
+
+// Details an individual cluster's current status.
+message ClusterStatus {
+  // Name of the cluster.
+  string name = 1;
+
+  // Denotes whether this cluster was added via API or configured statically.
+  bool added_via_api = 2;
+
+  // The success rate threshold used in the last interval.
+  // If
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *false*, all errors: externally and locally generated were used to calculate the threshold.
+  // If
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *true*, only externally generated errors were used to calculate the threshold.
+  // The threshold is used to eject hosts based on their success rate. See
+  // :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for details.
+  //
+  // Note: this field may be omitted in any of the three following cases:
+  //
+  // 1. There were not enough hosts with enough request volume to proceed with success rate based
+  //    outlier ejection.
+  // 2. The threshold is computed to be < 0 because a negative value implies that there was no
+  //    threshold for that interval.
+  // 3. Outlier detection is not enabled for this cluster.
+  envoy.type.Percent success_rate_ejection_threshold = 3;
+
+  // Mapping from host address to the host's current status.
+  repeated HostStatus host_statuses = 4;
+
+  // The success rate threshold used in the last interval when only locally originated failures were
+  // taken into account and externally originated errors were treated as success.
+  // This field should be interpretted only when
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *true*. The threshold is used to eject hosts based on their success rate.
+  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
+  // details.
+  //
+  // Note: this field may be omitted in any of the three following cases:
+  //
+  // 1. There were not enough hosts with enough request volume to proceed with success rate based
+  //    outlier ejection.
+  // 2. The threshold is computed to be < 0 because a negative value implies that there was no
+  //    threshold for that interval.
+  // 3. Outlier detection is not enabled for this cluster.
+  envoy.type.Percent local_origin_success_rate_ejection_threshold = 5;
+}
+
+// Current state of a particular host.
+message HostStatus {
+  // Address of this host.
+  envoy.api.v3alpha.core.Address address = 1;
+
+  // List of stats specific to this host.
+  repeated SimpleMetric stats = 2;
+
+  // The host's current health status.
+  HostHealthStatus health_status = 3;
+
+  // Request success rate for this host over the last calculated interval.
+  // If
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *false*, all errors: externally and locally generated were used in success rate
+  // calculation. If
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *true*, only externally generated errors were used in success rate calculation.
+  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
+  // details.
+  //
+  // Note: the message will not be present if host did not have enough request volume to calculate
+  // success rate or the cluster did not have enough hosts to run through success rate outlier
+  // ejection.
+  envoy.type.Percent success_rate = 4;
+
+  // The host's weight. If not configured, the value defaults to 1.
+  uint32 weight = 5;
+
+  // The hostname of the host, if applicable.
+  string hostname = 6;
+
+  // The host's priority. If not configured, the value defaults to 0 (highest priority).
+  uint32 priority = 7;
+
+  // Request success rate for this host over the last calculated
+  // interval when only locally originated errors are taken into account and externally originated
+  // errors were treated as success.
+  // This field should be interpretted only when
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *true*.
+  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
+  // details.
+  //
+  // Note: the message will not be present if host did not have enough request volume to calculate
+  // success rate or the cluster did not have enough hosts to run through success rate outlier
+  // ejection.
+  envoy.type.Percent local_origin_success_rate = 8;
+}
+
+// Health status for a host.
+message HostHealthStatus {
+  // The host is currently failing active health checks.
+  bool failed_active_health_check = 1;
+
+  // The host is currently considered an outlier and has been ejected.
+  bool failed_outlier_check = 2;
+
+  // The host is currently being marked as degraded through active health checking.
+  bool failed_active_degraded_check = 4;
+
+  // The host has been removed from service discovery, but is being stabilized due to active
+  // health checking.
+  bool pending_dynamic_removal = 5;
+
+  // The host has not yet been health checked.
+  bool pending_active_hc = 6;
+
+  // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported
+  // here.
+  // TODO(mrice32): pipe through remaining EDS health status possibilities.
+  envoy.api.v3alpha.core.HealthStatus eds_health_status = 3;
+}

--- a/api/envoy/admin/v3alpha/config_dump.proto
+++ b/api/envoy/admin/v3alpha/config_dump.proto
@@ -1,0 +1,266 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "ConfigDumpProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+import "envoy/api/v3alpha/auth/cert.proto";
+import "envoy/api/v3alpha/cds.proto";
+import "envoy/api/v3alpha/lds.proto";
+import "envoy/api/v3alpha/rds.proto";
+import "envoy/api/v3alpha/srds.proto";
+import "envoy/config/bootstrap/v3alpha/bootstrap.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
+
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: ConfigDump]
+
+// The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper
+// message to maintain and serve arbitrary configuration information from any component in Envoy.
+message ConfigDump {
+  // This list is serialized and dumped in its entirety at the
+  // :ref:`/config_dump <operations_admin_interface_config_dump>` endpoint.
+  //
+  // The following configurations are currently supported and will be dumped in the order given
+  // below:
+  //
+  // * *bootstrap*: :ref:`BootstrapConfigDump <envoy_api_msg_admin.v3alpha.BootstrapConfigDump>`
+  // * *clusters*: :ref:`ClustersConfigDump <envoy_api_msg_admin.v3alpha.ClustersConfigDump>`
+  // * *listeners*: :ref:`ListenersConfigDump <envoy_api_msg_admin.v3alpha.ListenersConfigDump>`
+  // * *routes*:  :ref:`RoutesConfigDump <envoy_api_msg_admin.v3alpha.RoutesConfigDump>`
+  repeated google.protobuf.Any configs = 1;
+}
+
+// This message describes the bootstrap configuration that Envoy was started with. This includes
+// any CLI overrides that were merged. Bootstrap configuration information can be used to recreate
+// the static portions of an Envoy configuration by reusing the output as the bootstrap
+// configuration for another Envoy.
+message BootstrapConfigDump {
+  envoy.config.bootstrap.v3alpha.Bootstrap bootstrap = 1;
+
+  // The timestamp when the BootstrapConfig was last updated.
+  google.protobuf.Timestamp last_updated = 2;
+}
+
+// Envoy's listener manager fills this message with all currently known listeners. Listener
+// configuration information can be used to recreate an Envoy configuration by populating all
+// listeners as static listeners or by returning them in a LDS response.
+message ListenersConfigDump {
+  // This is the :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` in the
+  // last processed LDS discovery response. If there are only static bootstrap listeners, this field
+  // will be "".
+  string version_info = 1;
+
+  // Describes a statically loaded listener.
+  message StaticListener {
+    // The listener config.
+    envoy.api.v3alpha.Listener listener = 1;
+
+    // The timestamp when the Listener was last updated.
+    google.protobuf.Timestamp last_updated = 2;
+  }
+
+  // Describes a dynamically loaded cluster via the LDS API.
+  message DynamicListener {
+    // This is the per-resource version information. This version is currently taken from the
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time
+    // that the listener was loaded. In the future, discrete per-listener versions may be supported
+    // by the API.
+    string version_info = 1;
+
+    // The listener config.
+    envoy.api.v3alpha.Listener listener = 2;
+
+    // The timestamp when the Listener was last updated.
+    google.protobuf.Timestamp last_updated = 3;
+  }
+
+  // The statically loaded listener configs.
+  repeated StaticListener static_listeners = 2;
+
+  // The dynamically loaded active listeners. These are listeners that are available to service
+  // data plane traffic.
+  repeated DynamicListener dynamic_active_listeners = 3;
+
+  // The dynamically loaded warming listeners. These are listeners that are currently undergoing
+  // warming in preparation to service data plane traffic. Note that if attempting to recreate an
+  // Envoy configuration from a configuration dump, the warming listeners should generally be
+  // discarded.
+  repeated DynamicListener dynamic_warming_listeners = 4;
+
+  // The dynamically loaded draining listeners. These are listeners that are currently undergoing
+  // draining in preparation to stop servicing data plane traffic. Note that if attempting to
+  // recreate an Envoy configuration from a configuration dump, the draining listeners should
+  // generally be discarded.
+  repeated DynamicListener dynamic_draining_listeners = 5;
+}
+
+// Envoy's cluster manager fills this message with all currently known clusters. Cluster
+// configuration information can be used to recreate an Envoy configuration by populating all
+// clusters as static clusters or by returning them in a CDS response.
+message ClustersConfigDump {
+  // This is the :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` in the
+  // last processed CDS discovery response. If there are only static bootstrap clusters, this field
+  // will be "".
+  string version_info = 1;
+
+  // Describes a statically loaded cluster.
+  message StaticCluster {
+    // The cluster config.
+    envoy.api.v3alpha.Cluster cluster = 1;
+
+    // The timestamp when the Cluster was last updated.
+    google.protobuf.Timestamp last_updated = 2;
+  }
+
+  // Describes a dynamically loaded cluster via the CDS API.
+  message DynamicCluster {
+    // This is the per-resource version information. This version is currently taken from the
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time
+    // that the cluster was loaded. In the future, discrete per-cluster versions may be supported by
+    // the API.
+    string version_info = 1;
+
+    // The cluster config.
+    envoy.api.v3alpha.Cluster cluster = 2;
+
+    // The timestamp when the Cluster was last updated.
+    google.protobuf.Timestamp last_updated = 3;
+  }
+
+  // The statically loaded cluster configs.
+  repeated StaticCluster static_clusters = 2;
+
+  // The dynamically loaded active clusters. These are clusters that are available to service
+  // data plane traffic.
+  repeated DynamicCluster dynamic_active_clusters = 3;
+
+  // The dynamically loaded warming clusters. These are clusters that are currently undergoing
+  // warming in preparation to service data plane traffic. Note that if attempting to recreate an
+  // Envoy configuration from a configuration dump, the warming clusters should generally be
+  // discarded.
+  repeated DynamicCluster dynamic_warming_clusters = 4;
+}
+
+// Envoy's RDS implementation fills this message with all currently loaded routes, as described by
+// their RouteConfiguration objects. Static routes configured in the bootstrap configuration are
+// separated from those configured dynamically via RDS. Route configuration information can be used
+// to recreate an Envoy configuration by populating all routes as static routes or by returning them
+// in RDS responses.
+message RoutesConfigDump {
+  message StaticRouteConfig {
+    // The route config.
+    envoy.api.v3alpha.RouteConfiguration route_config = 1;
+
+    // The timestamp when the Route was last updated.
+    google.protobuf.Timestamp last_updated = 2;
+  }
+
+  message DynamicRouteConfig {
+    // This is the per-resource version information. This version is currently taken from the
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time that
+    // the route configuration was loaded.
+    string version_info = 1;
+
+    // The route config.
+    envoy.api.v3alpha.RouteConfiguration route_config = 2;
+
+    // The timestamp when the Route was last updated.
+    google.protobuf.Timestamp last_updated = 3;
+  }
+
+  // The statically loaded route configs.
+  repeated StaticRouteConfig static_route_configs = 2;
+
+  // The dynamically loaded route configs.
+  repeated DynamicRouteConfig dynamic_route_configs = 3;
+}
+
+// Envoy's scoped RDS implementation fills this message with all currently loaded route
+// configuration scopes (defined via ScopedRouteConfigurationsSet protos). This message lists both
+// the scopes defined inline with the higher order object (i.e., the HttpConnectionManager) and the
+// dynamically obtained scopes via the SRDS API.
+message ScopedRoutesConfigDump {
+  message InlineScopedRouteConfigs {
+    // The name assigned to the scoped route configurations.
+    string name = 1;
+
+    // The scoped route configurations.
+    repeated envoy.api.v3alpha.ScopedRouteConfiguration scoped_route_configs = 2;
+
+    // The timestamp when the scoped route config set was last updated.
+    google.protobuf.Timestamp last_updated = 3;
+  }
+
+  message DynamicScopedRouteConfigs {
+    // The name assigned to the scoped route configurations.
+    string name = 1;
+
+    // This is the per-resource version information. This version is currently taken from the
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time that
+    // the scoped routes configuration was loaded.
+    string version_info = 2;
+
+    // The scoped route configurations.
+    repeated envoy.api.v3alpha.ScopedRouteConfiguration scoped_route_configs = 3;
+
+    // The timestamp when the scoped route config set was last updated.
+    google.protobuf.Timestamp last_updated = 4;
+  }
+
+  // The statically loaded scoped route configs.
+  repeated InlineScopedRouteConfigs inline_scoped_route_configs = 1;
+
+  // The dynamically loaded scoped route configs.
+  repeated DynamicScopedRouteConfigs dynamic_scoped_route_configs = 2;
+}
+
+// Envoys SDS implementation fills this message with all secrets fetched dynamically via SDS.
+message SecretsConfigDump {
+  // DynamicSecret contains secret information fetched via SDS.
+  message DynamicSecret {
+    // The name assigned to the secret.
+    string name = 1;
+
+    // This is the per-resource version information.
+    string version_info = 2;
+
+    // The timestamp when the secret was last updated.
+    google.protobuf.Timestamp last_updated = 3;
+
+    // The actual secret information.
+    // Security sensitive information is redacted (replaced with "[redacted]") for
+    // private keys and passwords in TLS certificates.
+    envoy.api.v3alpha.auth.Secret secret = 4;
+  }
+
+  // StaticSecret specifies statically loaded secret in bootstrap.
+  message StaticSecret {
+    // The name assigned to the secret.
+    string name = 1;
+
+    // The timestamp when the secret was last updated.
+    google.protobuf.Timestamp last_updated = 2;
+
+    // The actual secret information.
+    // Security sensitive information is redacted (replaced with "[redacted]") for
+    // private keys and passwords in TLS certificates.
+    envoy.api.v3alpha.auth.Secret secret = 3;
+  }
+
+  // The statically loaded secrets.
+  repeated StaticSecret static_secrets = 1;
+
+  // The dynamically loaded active secrets. These are secrets that are available to service
+  // clusters or listeners.
+  repeated DynamicSecret dynamic_active_secrets = 2;
+
+  // The dynamically loaded warming secrets. These are secrets that are currently undergoing
+  // warming in preparation to service clusters or listeners.
+  repeated DynamicSecret dynamic_warming_secrets = 3;
+}

--- a/api/envoy/admin/v3alpha/listeners.proto
+++ b/api/envoy/admin/v3alpha/listeners.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "ListenersProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+import "envoy/api/v3alpha/core/address.proto";
+
+// [#protodoc-title: Listeners]
+
+// Admin endpoint uses this wrapper for `/listeners` to display listener status information.
+// See :ref:`/listeners <operations_admin_interface_listeners>` for more information.
+message Listeners {
+  // List of listener statuses.
+  repeated ListenerStatus listener_statuses = 1;
+}
+
+// Details an individual listener's current status.
+message ListenerStatus {
+  // Name of the listener
+  string name = 1;
+
+  // The actual local address that the listener is listening on. If a listener was configured
+  // to listen on port 0, then this address has the port that was allocated by the OS.
+  envoy.api.v3alpha.core.Address local_address = 2;
+}

--- a/api/envoy/admin/v3alpha/memory.proto
+++ b/api/envoy/admin/v3alpha/memory.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "MemoryProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+// [#protodoc-title: Memory]
+
+// Proto representation of the internal memory consumption of an Envoy instance. These represent
+// values extracted from an internal TCMalloc instance. For more information, see the section of the
+// docs entitled ["Generic Tcmalloc Status"](https://gperftools.github.io/gperftools/tcmalloc.html).
+message Memory {
+
+  // The number of bytes allocated by the heap for Envoy. This is an alias for
+  // `generic.current_allocated_bytes`.
+  uint64 allocated = 1;
+
+  // The number of bytes reserved by the heap but not necessarily allocated. This is an alias for
+  // `generic.heap_size`.
+  uint64 heap_size = 2;
+
+  // The number of bytes in free, unmapped pages in the page heap. These bytes always count towards
+  // virtual memory usage, and depending on the OS, typically do not count towards physical memory
+  // usage. This is an alias for `tcmalloc.pageheap_unmapped_bytes`.
+  uint64 pageheap_unmapped = 3;
+
+  // The number of bytes in free, mapped pages in the page heap. These bytes always count towards
+  // virtual memory usage, and unless the underlying memory is swapped out by the OS, they also
+  // count towards physical memory usage. This is an alias for `tcmalloc.pageheap_free_bytes`.
+  uint64 pageheap_free = 4;
+
+  // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias
+  // for `tcmalloc.current_total_thread_cache_bytes`.
+  uint64 total_thread_cache = 5;
+}

--- a/api/envoy/admin/v3alpha/metrics.proto
+++ b/api/envoy/admin/v3alpha/metrics.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "MetricsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+// [#protodoc-title: Metrics]
+
+// Proto representation of an Envoy Counter or Gauge value.
+message SimpleMetric {
+  enum Type {
+    COUNTER = 0;
+    GAUGE = 1;
+  }
+
+  // Type of the metric represented.
+  Type type = 1;
+
+  // Current metric value.
+  uint64 value = 2;
+
+  // Name of the metric.
+  string name = 3;
+}

--- a/api/envoy/admin/v3alpha/mutex_stats.proto
+++ b/api/envoy/admin/v3alpha/mutex_stats.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "MutexStatsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+// [#protodoc-title: MutexStats]
+
+// Proto representation of the statistics collected upon absl::Mutex contention, if Envoy is run
+// under :option:`--enable-mutex-tracing`. For more information, see the `absl::Mutex`
+// [docs](https://abseil.io/about/design/mutex#extra-features).
+//
+// *NB*: The wait cycles below are measured by `absl::base_internal::CycleClock`, and may not
+// correspond to core clock frequency. For more information, see the `CycleClock`
+// [docs](https://github.com/abseil/abseil-cpp/blob/master/absl/base/internal/cycleclock.h).
+message MutexStats {
+
+  // The number of individual mutex contentions which have occurred since startup.
+  uint64 num_contentions = 1;
+
+  // The length of the current contention wait cycle.
+  uint64 current_wait_cycles = 2;
+
+  // The lifetime total of all contention wait cycles.
+  uint64 lifetime_wait_cycles = 3;
+}

--- a/api/envoy/admin/v3alpha/server_info.proto
+++ b/api/envoy/admin/v3alpha/server_info.proto
@@ -1,0 +1,137 @@
+syntax = "proto3";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "ServerInfoProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+import "google/protobuf/duration.proto";
+
+// [#protodoc-title: Server State]
+
+// Proto representation of the value returned by /server_info, containing
+// server version/server status information.
+message ServerInfo {
+  // Server version.
+  string version = 1;
+
+  enum State {
+    // Server is live and serving traffic.
+    LIVE = 0;
+    // Server is draining listeners in response to external health checks failing.
+    DRAINING = 1;
+    // Server has not yet completed cluster manager initialization.
+    PRE_INITIALIZING = 2;
+    // Server is running the cluster manager initialization callbacks (e.g., RDS).
+    INITIALIZING = 3;
+  }
+
+  // State of the server.
+  State state = 2;
+
+  // Uptime since current epoch was started.
+  google.protobuf.Duration uptime_current_epoch = 3;
+
+  // Uptime since the start of the first epoch.
+  google.protobuf.Duration uptime_all_epochs = 4;
+
+  // Hot restart version.
+  string hot_restart_version = 5;
+
+  // Command line options the server is currently running with.
+  CommandLineOptions command_line_options = 6;
+}
+
+message CommandLineOptions {
+  // See :option:`--base-id` for details.
+  uint64 base_id = 1;
+
+  // See :option:`--concurrency` for details.
+  uint32 concurrency = 2;
+
+  // See :option:`--config-path` for details.
+  string config_path = 3;
+
+  // See :option:`--config-yaml` for details.
+  string config_yaml = 4;
+
+  // See :option:`--allow-unknown-static-fields` for details.
+  bool allow_unknown_static_fields = 5;
+
+  // See :option:`--reject-unknown-dynamic-fields` for details.
+  bool reject_unknown_dynamic_fields = 26;
+
+  // See :option:`--admin-address-path` for details.
+  string admin_address_path = 6;
+
+  enum IpVersion {
+    v4 = 0;
+    v6 = 1;
+  }
+
+  // See :option:`--local-address-ip-version` for details.
+  IpVersion local_address_ip_version = 7;
+
+  // See :option:`--log-level` for details.
+  string log_level = 8;
+
+  // See :option:`--component-log-level` for details.
+  string component_log_level = 9;
+
+  // See :option:`--log-format` for details.
+  string log_format = 10;
+
+  // See :option:`--log-path` for details.
+  string log_path = 11;
+
+  reserved 12;
+
+  // See :option:`--service-cluster` for details.
+  string service_cluster = 13;
+
+  // See :option:`--service-node` for details.
+  string service_node = 14;
+
+  // See :option:`--service-zone` for details.
+  string service_zone = 15;
+
+  // See :option:`--file-flush-interval-msec` for details.
+  google.protobuf.Duration file_flush_interval = 16;
+
+  // See :option:`--drain-time-s` for details.
+  google.protobuf.Duration drain_time = 17;
+
+  // See :option:`--parent-shutdown-time-s` for details.
+  google.protobuf.Duration parent_shutdown_time = 18;
+
+  enum Mode {
+    // Validate configs and then serve traffic normally.
+    Serve = 0;
+
+    // Validate configs and exit.
+    Validate = 1;
+
+    // Completely load and initialize the config, and then exit without running the listener loop.
+    InitOnly = 2;
+  }
+
+  // See :option:`--mode` for details.
+  Mode mode = 19;
+
+  // max_stats and max_obj_name_len are now unused and have no effect.
+  uint64 max_stats = 20 [deprecated = true];
+  uint64 max_obj_name_len = 21 [deprecated = true];
+
+  // See :option:`--disable-hot-restart` for details.
+  bool disable_hot_restart = 22;
+
+  // See :option:`--enable-mutex-tracing` for details.
+  bool enable_mutex_tracing = 23;
+
+  // See :option:`--restart-epoch` for details.
+  uint32 restart_epoch = 24;
+
+  // See :option:`--cpuset-threads` for details.
+  bool cpuset_threads = 25;
+}

--- a/api/envoy/admin/v3alpha/tap.proto
+++ b/api/envoy/admin/v3alpha/tap.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "envoy/service/tap/v3alpha/common.proto";
+import "validate/validate.proto";
+
+package envoy.admin.v3alpha;
+
+option java_outer_classname = "TapProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.admin.v3alpha";
+
+// The /tap admin request body that is used to configure an active tap session.
+message TapRequest {
+  // The opaque configuration ID used to match the configuration to a loaded extension.
+  // A tap extension configures a similar opaque ID that is used to match.
+  string config_id = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The tap configuration to load.
+  service.tap.v3alpha.TapConfig tap_config = 2 [(validate.rules).message.required = true];
+}

--- a/api/envoy/api/v3alpha/BUILD
+++ b/api/envoy/api/v3alpha/BUILD
@@ -1,0 +1,171 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+# Friends of core API packages - filters, services, service configs.
+# Package //envoy/api/v3alpha contains xDS and discovery definitions that should
+# be in //envoy/service/discovery, but remain here for backwards compatibility.
+package_group(
+    name = "friends",
+    packages = [
+        "//envoy/admin/...",
+        "//envoy/api/v3alpha",
+        "//envoy/config/...",
+        "//envoy/data/...",
+        "//envoy/service/...",
+    ],
+)
+
+api_proto_library_internal(
+    name = "discovery",
+    srcs = ["discovery.proto"],
+    visibility = [":friends"],
+    deps = ["//envoy/api/v3alpha/core:base"],
+)
+
+api_go_proto_library(
+    name = "discovery",
+    proto = ":discovery",
+    deps = ["//envoy/api/v3alpha/core:base_go_proto"],
+)
+
+api_proto_library_internal(
+    name = "eds",
+    srcs = ["eds.proto"],
+    has_services = 1,
+    visibility = [":friends"],
+    deps = [
+        ":discovery",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:health_check",
+        "//envoy/api/v3alpha/endpoint",
+        "//envoy/type:percent",
+    ],
+)
+
+api_go_grpc_library(
+    name = "eds",
+    proto = ":eds",
+    deps = [
+        ":discovery_go_proto",
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:health_check_go_proto",
+        "//envoy/api/v3alpha/endpoint:endpoint_go_proto",
+        "//envoy/type:percent_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "cds",
+    srcs = ["cds.proto"],
+    has_services = 1,
+    visibility = [":friends"],
+    deps = [
+        ":discovery",
+        ":eds",
+        "//envoy/api/v3alpha/auth:cert",
+        "//envoy/api/v3alpha/cluster:circuit_breaker",
+        "//envoy/api/v3alpha/cluster:filter",
+        "//envoy/api/v3alpha/cluster:outlier_detection",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:config_source",
+        "//envoy/api/v3alpha/core:health_check",
+        "//envoy/api/v3alpha/core:protocol",
+        "//envoy/api/v3alpha/endpoint",
+        "//envoy/type:percent",
+    ],
+)
+
+api_go_grpc_library(
+    name = "cds",
+    proto = ":cds",
+    deps = [
+        ":discovery_go_proto",
+        ":eds_go_grpc",
+        "//envoy/api/v3alpha/auth:cert_go_proto",
+        "//envoy/api/v3alpha/cluster:circuit_breaker_go_proto",
+        "//envoy/api/v3alpha/cluster:filter_go_proto",
+        "//envoy/api/v3alpha/cluster:outlier_detection_go_proto",
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:config_source_go_proto",
+        "//envoy/api/v3alpha/core:health_check_go_proto",
+        "//envoy/api/v3alpha/core:protocol_go_proto",
+        "//envoy/api/v3alpha/endpoint:endpoint_go_proto",
+        "//envoy/type:percent_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "lds",
+    srcs = ["lds.proto"],
+    has_services = 1,
+    visibility = [":friends"],
+    deps = [
+        ":discovery",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/listener",
+        "//envoy/api/v3alpha/listener:udp_listener_config",
+    ],
+)
+
+api_go_grpc_library(
+    name = "lds",
+    proto = ":lds",
+    deps = [
+        ":discovery_go_proto",
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/listener:listener_go_proto",
+        "//envoy/api/v3alpha/listener:udp_listener_config_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "rds",
+    srcs = ["rds.proto"],
+    has_services = 1,
+    visibility = [":friends"],
+    deps = [
+        ":discovery",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:config_source",
+        "//envoy/api/v3alpha/route",
+    ],
+)
+
+api_go_grpc_library(
+    name = "rds",
+    proto = ":rds",
+    deps = [
+        ":discovery_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:config_source_go_proto",
+        "//envoy/api/v3alpha/route:route_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "srds",
+    srcs = ["srds.proto"],
+    has_services = 1,
+    visibility = [":friends"],
+    deps = [
+        ":discovery",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/route",
+    ],
+)
+
+api_go_grpc_library(
+    name = "srds",
+    proto = ":srds",
+    deps = [
+        ":discovery_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)

--- a/api/envoy/api/v3alpha/README.md
+++ b/api/envoy/api/v3alpha/README.md
@@ -1,0 +1,9 @@
+Protocol buffer definitions for xDS and top-level resource API messages.
+
+Package group `//envoy/api/v2:friends` enumerates all consumers of the shared
+API messages. That includes package envoy.api.v2 itself, which contains several
+xDS definitions. Default visibility for all shared definitions should be set to
+`//envoy/api/v2:friends`.
+
+Additionally, packages envoy.api.v2.core and envoy.api.v2.auth are also
+consumed throughout the subpackages of `//envoy/api/v2`.

--- a/api/envoy/api/v3alpha/auth/BUILD
+++ b/api/envoy/api/v3alpha/auth/BUILD
@@ -1,0 +1,35 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+package_group(
+    name = "friends",
+    includes = [
+        "//envoy/api/v3alpha:friends",
+    ],
+    packages = [
+        "//envoy/api/v3alpha/cluster",
+        "//envoy/api/v3alpha/endpoint",
+        "//envoy/api/v3alpha/listener",
+        "//envoy/api/v3alpha/route",
+    ],
+)
+
+api_proto_library_internal(
+    name = "cert",
+    srcs = ["cert.proto"],
+    visibility = [":friends"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:config_source",
+    ],
+)
+
+api_go_proto_library(
+    name = "cert",
+    proto = ":cert",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:config_source_go_proto",
+    ],
+)

--- a/api/envoy/api/v3alpha/auth/cert.proto
+++ b/api/envoy/api/v3alpha/auth/cert.proto
@@ -1,0 +1,407 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.auth;
+
+option java_outer_classname = "CertProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.auth";
+option go_package = "auth";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/config_source.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Common TLS configuration]
+
+message TlsParameters {
+  enum TlsProtocol {
+    // Envoy will choose the optimal TLS version.
+    TLS_AUTO = 0;
+
+    // TLS 1.0
+    TLSv1_0 = 1;
+
+    // TLS 1.1
+    TLSv1_1 = 2;
+
+    // TLS 1.2
+    TLSv1_2 = 3;
+
+    // TLS 1.3
+    TLSv1_3 = 4;
+  }
+
+  // Minimum TLS protocol version. By default, it's ``TLSv1_0``.
+  TlsProtocol tls_minimum_protocol_version = 1 [(validate.rules).enum.defined_only = true];
+
+  // Maximum TLS protocol version. By default, it's ``TLSv1_3`` for servers in non-FIPS builds, and
+  // ``TLSv1_2`` for clients and for servers using :ref:`BoringSSL FIPS <arch_overview_ssl_fips>`.
+  TlsProtocol tls_maximum_protocol_version = 2 [(validate.rules).enum.defined_only = true];
+
+  // If specified, the TLS listener will only support the specified `cipher list
+  // <https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Cipher-suite-configuration>`_
+  // when negotiating TLS 1.0-1.2 (this setting has no effect when negotiating TLS 1.3). If not
+  // specified, the default list will be used.
+  //
+  // In non-FIPS builds, the default cipher list is:
+  //
+  // .. code-block:: none
+  //
+  //   [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
+  //   [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
+  //   ECDHE-ECDSA-AES128-SHA
+  //   ECDHE-RSA-AES128-SHA
+  //   AES128-GCM-SHA256
+  //   AES128-SHA
+  //   ECDHE-ECDSA-AES256-GCM-SHA384
+  //   ECDHE-RSA-AES256-GCM-SHA384
+  //   ECDHE-ECDSA-AES256-SHA
+  //   ECDHE-RSA-AES256-SHA
+  //   AES256-GCM-SHA384
+  //   AES256-SHA
+  //
+  // In builds using :ref:`BoringSSL FIPS <arch_overview_ssl_fips>`, the default cipher list is:
+  //
+  // .. code-block:: none
+  //
+  //   ECDHE-ECDSA-AES128-GCM-SHA256
+  //   ECDHE-RSA-AES128-GCM-SHA256
+  //   ECDHE-ECDSA-AES128-SHA
+  //   ECDHE-RSA-AES128-SHA
+  //   AES128-GCM-SHA256
+  //   AES128-SHA
+  //   ECDHE-ECDSA-AES256-GCM-SHA384
+  //   ECDHE-RSA-AES256-GCM-SHA384
+  //   ECDHE-ECDSA-AES256-SHA
+  //   ECDHE-RSA-AES256-SHA
+  //   AES256-GCM-SHA384
+  //   AES256-SHA
+  repeated string cipher_suites = 3;
+
+  // If specified, the TLS connection will only support the specified ECDH
+  // curves. If not specified, the default curves will be used.
+  //
+  // In non-FIPS builds, the default curves are:
+  //
+  // .. code-block:: none
+  //
+  //   X25519
+  //   P-256
+  //
+  // In builds using :ref:`BoringSSL FIPS <arch_overview_ssl_fips>`, the default curve is:
+  //
+  // .. code-block:: none
+  //
+  //   P-256
+  repeated string ecdh_curves = 4;
+}
+
+// BoringSSL private key method configuration. The private key methods are used for external
+// (potentially asynchronous) signing and decryption operations. Some use cases for private key
+// methods would be TPM support and TLS acceleration.
+message PrivateKeyProvider {
+  // Private key method provider name. The name must match a
+  // supported private key method provider type.
+  string provider_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Private key method provider specific configuration.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}
+
+message TlsCertificate {
+  // The TLS certificate chain.
+  core.DataSource certificate_chain = 1;
+
+  // The TLS private key.
+  core.DataSource private_key = 2;
+
+  // BoringSSL private key method provider. This is an alternative to :ref:`private_key
+  // <envoy_api_field_auth.TlsCertificate.private_key>` field. This can't be
+  // marked as ``oneof`` due to API compatibility reasons. Setting both :ref:`private_key
+  // <envoy_api_field_auth.TlsCertificate.private_key>` and
+  // :ref:`private_key_provider
+  // <envoy_api_field_auth.TlsCertificate.private_key_provider>` fields will result in an
+  // error.
+  PrivateKeyProvider private_key_provider = 6;
+
+  // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
+  // TLS private key is not password encrypted.
+  core.DataSource password = 3;
+
+  // [#not-implemented-hide:]
+  core.DataSource ocsp_staple = 4;
+
+  // [#not-implemented-hide:]
+  repeated core.DataSource signed_certificate_timestamp = 5;
+}
+
+message TlsSessionTicketKeys {
+  // Keys for encrypting and decrypting TLS session tickets. The
+  // first key in the array contains the key to encrypt all new sessions created by this context.
+  // All keys are candidates for decrypting received tickets. This allows for easy rotation of keys
+  // by, for example, putting the new key first, and the previous key second.
+  //
+  // If :ref:`session_ticket_keys <envoy_api_field_auth.DownstreamTlsContext.session_ticket_keys>`
+  // is not specified, the TLS library will still support resuming sessions via tickets, but it will
+  // use an internally-generated and managed key, so sessions cannot be resumed across hot restarts
+  // or on different hosts.
+  //
+  // Each key must contain exactly 80 bytes of cryptographically-secure random data. For
+  // example, the output of ``openssl rand 80``.
+  //
+  // .. attention::
+  //
+  //   Using this feature has serious security considerations and risks. Improper handling of keys
+  //   may result in loss of secrecy in connections, even if ciphers supporting perfect forward
+  //   secrecy are used. See https://www.imperialviolet.org/2013/06/27/botchingpfs.html for some
+  //   discussion. To minimize the risk, you must:
+  //
+  //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
+  //   * Rotate session ticket keys at least daily, and preferably hourly
+  //   * Always generate keys using a cryptographically-secure random data source
+  repeated core.DataSource keys = 1 [(validate.rules).repeated .min_items = 1];
+}
+
+message CertificateValidationContext {
+  // TLS certificate data containing certificate authority certificates to use in verifying
+  // a presented peer certificate (e.g. server certificate for clusters or client certificate
+  // for listeners). If not specified and a peer certificate is presented it will not be
+  // verified. By default, a client certificate is optional, unless one of the additional
+  // options (:ref:`require_client_certificate
+  // <envoy_api_field_auth.DownstreamTlsContext.require_client_certificate>`,
+  // :ref:`verify_certificate_spki
+  // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>`,
+  // :ref:`verify_certificate_hash
+  // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>`, or
+  // :ref:`verify_subject_alt_name
+  // <envoy_api_field_auth.CertificateValidationContext.verify_subject_alt_name>`) is also
+  // specified.
+  //
+  // It can optionally contain certificate revocation lists, in which case Envoy will verify
+  // that the presented peer certificate has not been revoked by one of the included CRLs.
+  //
+  // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
+  // system CA locations.
+  core.DataSource trusted_ca = 1;
+
+  // An optional list of base64-encoded SHA-256 hashes. If specified, Envoy will verify that the
+  // SHA-256 of the DER-encoded Subject Public Key Information (SPKI) of the presented certificate
+  // matches one of the specified values.
+  //
+  // A base64-encoded SHA-256 of the Subject Public Key Information (SPKI) of the certificate
+  // can be generated with the following command:
+  //
+  // .. code-block:: bash
+  //
+  //   $ openssl x509 -in path/to/client.crt -noout -pubkey \
+  //     | openssl pkey -pubin -outform DER \
+  //     | openssl dgst -sha256 -binary \
+  //     | openssl enc -base64
+  //   NvqYIYSbgK2vCJpQhObf77vv+bQWtc5ek5RIOwPiC9A=
+  //
+  // This is the format used in HTTP Public Key Pinning.
+  //
+  // When both:
+  // :ref:`verify_certificate_hash
+  // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>` and
+  // :ref:`verify_certificate_spki
+  // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>` are specified,
+  // a hash matching value from either of the lists will result in the certificate being accepted.
+  //
+  // .. attention::
+  //
+  //   This option is preferred over :ref:`verify_certificate_hash
+  //   <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>`,
+  //   because SPKI is tied to a private key, so it doesn't change when the certificate
+  //   is renewed using the same private key.
+  repeated string verify_certificate_spki = 3
+      [(validate.rules).repeated .items.string = {min_bytes: 44, max_bytes: 44}];
+
+  // An optional list of hex-encoded SHA-256 hashes. If specified, Envoy will verify that
+  // the SHA-256 of the DER-encoded presented certificate matches one of the specified values.
+  //
+  // A hex-encoded SHA-256 of the certificate can be generated with the following command:
+  //
+  // .. code-block:: bash
+  //
+  //   $ openssl x509 -in path/to/client.crt -outform DER | openssl dgst -sha256 | cut -d" " -f2
+  //   df6ff72fe9116521268f6f2dd4966f51df479883fe7037b39f75916ac3049d1a
+  //
+  // A long hex-encoded and colon-separated SHA-256 (a.k.a. "fingerprint") of the certificate
+  // can be generated with the following command:
+  //
+  // .. code-block:: bash
+  //
+  //   $ openssl x509 -in path/to/client.crt -noout -fingerprint -sha256 | cut -d"=" -f2
+  //   DF:6F:F7:2F:E9:11:65:21:26:8F:6F:2D:D4:96:6F:51:DF:47:98:83:FE:70:37:B3:9F:75:91:6A:C3:04:9D:1A
+  //
+  // Both of those formats are acceptable.
+  //
+  // When both:
+  // :ref:`verify_certificate_hash
+  // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>` and
+  // :ref:`verify_certificate_spki
+  // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>` are specified,
+  // a hash matching value from either of the lists will result in the certificate being accepted.
+  repeated string verify_certificate_hash = 2
+      [(validate.rules).repeated .items.string = {min_bytes: 64, max_bytes: 95}];
+
+  // An optional list of Subject Alternative Names. If specified, Envoy will verify that the
+  // Subject Alternative Name of the presented certificate matches one of the specified values.
+  //
+  // .. attention::
+  //
+  //   Subject Alternative Names are easily spoofable and verifying only them is insecure,
+  //   therefore this option must be used together with :ref:`trusted_ca
+  //   <envoy_api_field_auth.CertificateValidationContext.trusted_ca>`.
+  repeated string verify_subject_alt_name = 4;
+
+  // [#not-implemented-hide:] Must present a signed time-stamped OCSP response.
+  google.protobuf.BoolValue require_ocsp_staple = 5;
+
+  // [#not-implemented-hide:] Must present signed certificate time-stamp.
+  google.protobuf.BoolValue require_signed_certificate_timestamp = 6;
+
+  // An optional `certificate revocation list
+  // <https://en.wikipedia.org/wiki/Certificate_revocation_list>`_
+  // (in PEM format). If specified, Envoy will verify that the presented peer
+  // certificate has not been revoked by this CRL. If this DataSource contains
+  // multiple CRLs, all of them will be used.
+  core.DataSource crl = 7;
+
+  // If specified, Envoy will not reject expired certificates.
+  bool allow_expired_certificate = 8;
+}
+
+// TLS context shared by both client and server TLS contexts.
+message CommonTlsContext {
+  // TLS protocol versions, cipher suites etc.
+  TlsParameters tls_params = 1;
+
+  // :ref:`Multiple TLS certificates <arch_overview_ssl_cert_select>` can be associated with the
+  // same context to allow both RSA and ECDSA certificates.
+  //
+  // Only a single TLS certificate is supported in client contexts. In server contexts, the first
+  // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
+  // used for clients that support ECDSA.
+  repeated TlsCertificate tls_certificates = 2;
+
+  // Configs for fetching TLS certificates via SDS API.
+  repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
+      [(validate.rules).repeated .max_items = 1];
+
+  message CombinedCertificateValidationContext {
+    // How to validate peer certificates.
+    CertificateValidationContext default_validation_context = 1
+        [(validate.rules).message.required = true];
+
+    // Config for fetching validation context via SDS API.
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message.required = true];
+  };
+
+  oneof validation_context_type {
+    // How to validate peer certificates.
+    CertificateValidationContext validation_context = 3;
+
+    // Config for fetching validation context via SDS API.
+    SdsSecretConfig validation_context_sds_secret_config = 7;
+
+    // Combined certificate validation context holds a default CertificateValidationContext
+    // and SDS config. When SDS server returns dynamic CertificateValidationContext, both dynamic
+    // and default CertificateValidationContext are merged into a new CertificateValidationContext
+    // for validation. This merge is done by Message::MergeFrom(), so dynamic
+    // CertificateValidationContext overwrites singular fields in default
+    // CertificateValidationContext, and concatenates repeated fields to default
+    // CertificateValidationContext, and logical OR is applied to boolean fields.
+    CombinedCertificateValidationContext combined_validation_context = 8;
+  }
+
+  // Supplies the list of ALPN protocols that the listener should expose. In
+  // practice this is likely to be set to one of two values (see the
+  // :ref:`codec_type
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.codec_type>`
+  // parameter in the HTTP connection manager for more information):
+  //
+  // * "h2,http/1.1" If the listener is going to support both HTTP/2 and HTTP/1.1.
+  // * "http/1.1" If the listener is only going to support HTTP/1.1.
+  //
+  // There is no default for this parameter. If empty, Envoy will not expose ALPN.
+  repeated string alpn_protocols = 4;
+
+  reserved 5;
+}
+
+message UpstreamTlsContext {
+  // Common TLS context settings.
+  CommonTlsContext common_tls_context = 1;
+
+  // SNI string to use when creating TLS backend connections.
+  string sni = 2 [(validate.rules).string.max_bytes = 255];
+
+  // If true, server-initiated TLS renegotiation will be allowed.
+  //
+  // .. attention::
+  //
+  //   TLS renegotiation is considered insecure and shouldn't be used unless absolutely necessary.
+  bool allow_renegotiation = 3;
+
+  // Maximum number of session keys (Pre-Shared Keys for TLSv1.3+, Session IDs and Session Tickets
+  // for TLSv1.2 and older) to store for the purpose of session resumption.
+  //
+  // Defaults to 1, setting this to 0 disables session resumption.
+  google.protobuf.UInt32Value max_session_keys = 4;
+}
+
+message DownstreamTlsContext {
+  // Common TLS context settings.
+  CommonTlsContext common_tls_context = 1;
+
+  // If specified, Envoy will reject connections without a valid client
+  // certificate.
+  google.protobuf.BoolValue require_client_certificate = 2;
+
+  // If specified, Envoy will reject connections without a valid and matching SNI.
+  // [#not-implemented-hide:]
+  google.protobuf.BoolValue require_sni = 3;
+
+  oneof session_ticket_keys_type {
+    // TLS session ticket key settings.
+    TlsSessionTicketKeys session_ticket_keys = 4;
+
+    // [#not-implemented-hide:]
+    SdsSecretConfig session_ticket_keys_sds_secret_config = 5;
+  }
+}
+
+// [#proto-status: experimental]
+message SdsSecretConfig {
+  // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
+  // When both name and config are specified, then secret can be fetched and/or reloaded via SDS.
+  // When only name is specified, then secret will be loaded from static resources [V2-API-DIFF].
+  string name = 1;
+  core.ConfigSource sds_config = 2;
+}
+
+// [#proto-status: experimental]
+message Secret {
+  // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
+  string name = 1;
+  oneof type {
+    TlsCertificate tls_certificate = 2;
+    TlsSessionTicketKeys session_ticket_keys = 3;
+    CertificateValidationContext validation_context = 4;
+  }
+}

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -1,0 +1,660 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha;
+
+option java_outer_classname = "CdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha";
+
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/auth/cert.proto";
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/config_source.proto";
+import "envoy/api/v3alpha/discovery.proto";
+import "envoy/api/v3alpha/core/health_check.proto";
+import "envoy/api/v3alpha/core/protocol.proto";
+import "envoy/api/v3alpha/cluster/circuit_breaker.proto";
+import "envoy/api/v3alpha/cluster/filter.proto";
+import "envoy/api/v3alpha/cluster/outlier_detection.proto";
+import "envoy/api/v3alpha/eds.proto";
+import "envoy/type/percent.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
+
+// Return list of all clusters this proxy will load balance to.
+service ClusterDiscoveryService {
+  rpc StreamClusters(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaClusters(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchClusters(DiscoveryRequest) returns (DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:clusters"
+      body: "*"
+    };
+  }
+}
+
+// [#protodoc-title: Clusters]
+
+// Configuration for a single upstream cluster.
+// [#comment:next free field: 41]
+message Cluster {
+  // Supplies the name of the cluster which must be unique across all clusters.
+  // The cluster name is used when emitting
+  // :ref:`statistics <config_cluster_manager_cluster_stats>` if :ref:`alt_stat_name
+  // <envoy_api_field_Cluster.alt_stat_name>` is not provided.
+  // Any ``:`` in the cluster name will be converted to ``_`` when emitting statistics.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // An optional alternative to the cluster name to be used while emitting stats.
+  // Any ``:`` in the name will be converted to ``_`` when emitting statistics. This should not be
+  // confused with :ref:`Router Filter Header
+  // <config_http_filters_router_x-envoy-upstream-alt-stat-name>`.
+  string alt_stat_name = 28;
+
+  // Refer to :ref:`service discovery type <arch_overview_service_discovery_types>`
+  // for an explanation on each type.
+  enum DiscoveryType {
+    // Refer to the :ref:`static discovery type<arch_overview_service_discovery_types_static>`
+    // for an explanation.
+    STATIC = 0;
+
+    // Refer to the :ref:`strict DNS discovery
+    // type<arch_overview_service_discovery_types_strict_dns>`
+    // for an explanation.
+    STRICT_DNS = 1;
+
+    // Refer to the :ref:`logical DNS discovery
+    // type<arch_overview_service_discovery_types_logical_dns>`
+    // for an explanation.
+    LOGICAL_DNS = 2;
+
+    // Refer to the :ref:`service discovery type<arch_overview_service_discovery_types_eds>`
+    // for an explanation.
+    EDS = 3;
+
+    // Refer to the :ref:`original destination discovery
+    // type<arch_overview_service_discovery_types_original_destination>`
+    // for an explanation.
+    ORIGINAL_DST = 4;
+  }
+
+  // Extended cluster type.
+  message CustomClusterType {
+    // The type of the cluster to instantiate. The name must match a supported cluster type.
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Cluster specific configuration which depends on the cluster being instantiated.
+    // See the supported cluster for further documentation.
+    google.protobuf.Any typed_config = 2;
+  }
+
+  oneof cluster_discovery_type {
+    // The :ref:`service discovery type <arch_overview_service_discovery_types>`
+    // to use for resolving the cluster.
+    DiscoveryType type = 2 [(validate.rules).enum.defined_only = true];
+
+    // The custom cluster type.
+    CustomClusterType cluster_type = 38;
+  }
+
+  // Only valid when discovery type is EDS.
+  message EdsClusterConfig {
+    // Configuration for the source of EDS updates for this Cluster.
+    core.ConfigSource eds_config = 1;
+
+    // Optional alternative to cluster name to present to EDS. This does not
+    // have the same restrictions as cluster name, i.e. it may be arbitrary
+    // length.
+    string service_name = 2;
+  }
+  // Configuration to use for EDS updates for the Cluster.
+  EdsClusterConfig eds_cluster_config = 3;
+
+  // The timeout for new network connections to hosts in the cluster.
+  google.protobuf.Duration connect_timeout = 4
+      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+
+  // Soft limit on size of the cluster’s connections read and write buffers. If
+  // unspecified, an implementation defined default is applied (1MiB).
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
+
+  // Refer to :ref:`load balancer type <arch_overview_load_balancing_types>` architecture
+  // overview section for information on each type.
+  enum LbPolicy {
+    // Refer to the :ref:`round robin load balancing
+    // policy<arch_overview_load_balancing_types_round_robin>`
+    // for an explanation.
+    ROUND_ROBIN = 0;
+
+    // Refer to the :ref:`least request load balancing
+    // policy<arch_overview_load_balancing_types_least_request>`
+    // for an explanation.
+    LEAST_REQUEST = 1;
+
+    // Refer to the :ref:`ring hash load balancing
+    // policy<arch_overview_load_balancing_types_ring_hash>`
+    // for an explanation.
+    RING_HASH = 2;
+
+    // Refer to the :ref:`random load balancing
+    // policy<arch_overview_load_balancing_types_random>`
+    // for an explanation.
+    RANDOM = 3;
+
+    // Refer to the :ref:`original destination load balancing
+    // policy<arch_overview_load_balancing_types_original_destination>`
+    // for an explanation.
+    //
+    // .. attention::
+    //
+    //   **This load balancing policy is deprecated**. Use CLUSTER_PROVIDED instead.
+    //
+    ORIGINAL_DST_LB = 4 [deprecated = true];
+
+    // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
+    // for an explanation.
+    MAGLEV = 5;
+
+    // This load balancer type must be specified if the configured cluster provides a cluster
+    // specific load balancer. Consult the configured cluster's documentation for whether to set
+    // this option or not.
+    CLUSTER_PROVIDED = 6;
+  }
+  // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
+  // when picking a host in the cluster.
+  LbPolicy lb_policy = 6 [(validate.rules).enum.defined_only = true];
+
+  // If the service discovery type is
+  // :ref:`STATIC<envoy_api_enum_value_Cluster.DiscoveryType.STATIC>`,
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
+  // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
+  // then hosts is required.
+  //
+  // .. attention::
+  //
+  //   **This field is deprecated**. Set the
+  //   :ref:`load_assignment<envoy_api_field_Cluster.load_assignment>` field instead.
+  //
+  repeated core.Address hosts = 7;
+
+  // Setting this is required for specifying members of
+  // :ref:`STATIC<envoy_api_enum_value_Cluster.DiscoveryType.STATIC>`,
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
+  // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>` clusters.
+  // This field supersedes :ref:`hosts<envoy_api_field_Cluster.hosts>` field.
+  // [#comment:TODO(dio): Deprecate the hosts field and add it to :ref:`deprecated log<deprecated>`
+  // once load_assignment is implemented.]
+  //
+  // .. attention::
+  //
+  //   Setting this allows non-EDS cluster types to contain embedded EDS equivalent
+  //   :ref:`endpoint assignments<envoy_api_msg_ClusterLoadAssignment>`.
+  //   Setting this overrides :ref:`hosts<envoy_api_field_Cluster.hosts>` values.
+  //
+  ClusterLoadAssignment load_assignment = 33;
+
+  // Optional :ref:`active health checking <arch_overview_health_checking>`
+  // configuration for the cluster. If no
+  // configuration is specified no health checking will be done and all cluster
+  // members will be considered healthy at all times.
+  repeated core.HealthCheck health_checks = 8;
+
+  // Optional maximum requests for a single upstream connection. This parameter
+  // is respected by both the HTTP/1.1 and HTTP/2 connection pool
+  // implementations. If not specified, there is no limit. Setting this
+  // parameter to 1 will effectively disable keep alive.
+  google.protobuf.UInt32Value max_requests_per_connection = 9;
+
+  // Optional :ref:`circuit breaking <arch_overview_circuit_break>` for the cluster.
+  cluster.CircuitBreakers circuit_breakers = 10;
+
+  // The TLS configuration for connections to the upstream cluster. If no TLS
+  // configuration is specified, TLS will not be used for new connections.
+  //
+  // .. attention::
+  //
+  //   Server certificate verification is not enabled by default. Configure
+  //   :ref:`trusted_ca<envoy_api_field_auth.CertificateValidationContext.trusted_ca>` to enable
+  //   verification.
+  auth.UpstreamTlsContext tls_context = 11;
+
+  reserved 12;
+
+  // Additional options when handling HTTP requests. These options will be applicable to both
+  // HTTP1 and HTTP2 requests.
+  core.HttpProtocolOptions common_http_protocol_options = 29;
+
+  // Additional options when handling HTTP1 requests.
+  core.Http1ProtocolOptions http_protocol_options = 13;
+
+  // Even if default HTTP2 protocol options are desired, this field must be
+  // set so that Envoy will assume that the upstream supports HTTP/2 when
+  // making new HTTP connection pool connections. Currently, Envoy only
+  // supports prior knowledge for upstream connections. Even if TLS is used
+  // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
+  // connections to happen over plain text.
+  core.Http2ProtocolOptions http2_protocol_options = 14;
+
+  // The extension_protocol_options field is used to provide extension-specific protocol options
+  // for upstream connections. The key should match the extension filter name, such as
+  // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
+  // specific options.
+  map<string, google.protobuf.Struct> extension_protocol_options = 35;
+
+  // The extension_protocol_options field is used to provide extension-specific protocol options
+  // for upstream connections. The key should match the extension filter name, such as
+  // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
+  // specific options.
+  map<string, google.protobuf.Any> typed_extension_protocol_options = 36;
+
+  reserved 15;
+
+  // If the DNS refresh rate is specified and the cluster type is either
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
+  // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
+  // this value is used as the cluster’s DNS refresh
+  // rate. If this setting is not specified, the value defaults to 5000ms. For
+  // cluster types other than
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
+  // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`
+  // this setting is ignored.
+  google.protobuf.Duration dns_refresh_rate = 16
+      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+
+  // Optional configuration for setting cluster's DNS refresh rate. If the value is set to true,
+  // cluster's DNS refresh rate will be set to resource record's TTL which comes from DNS
+  // resolution.
+  bool respect_dns_ttl = 39;
+
+  // When V4_ONLY is selected, the DNS resolver will only perform a lookup for
+  // addresses in the IPv4 family. If V6_ONLY is selected, the DNS resolver will
+  // only perform a lookup for addresses in the IPv6 family. If AUTO is
+  // specified, the DNS resolver will first perform a lookup for addresses in
+  // the IPv6 family and fallback to a lookup for addresses in the IPv4 family.
+  // For cluster types other than
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>` and
+  // :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
+  // this setting is
+  // ignored.
+  enum DnsLookupFamily {
+    AUTO = 0;
+    V4_ONLY = 1;
+    V6_ONLY = 2;
+  }
+
+  // The DNS IP address resolution policy. If this setting is not specified, the
+  // value defaults to
+  // :ref:`AUTO<envoy_api_enum_value_Cluster.DnsLookupFamily.AUTO>`.
+  DnsLookupFamily dns_lookup_family = 17 [(validate.rules).enum.defined_only = true];
+
+  // If DNS resolvers are specified and the cluster type is either
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
+  // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
+  // this value is used to specify the cluster’s dns resolvers.
+  // If this setting is not specified, the value defaults to the default
+  // resolver, which uses /etc/resolv.conf for configuration. For cluster types
+  // other than
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
+  // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`
+  // this setting is ignored.
+  repeated core.Address dns_resolvers = 18;
+
+  // If specified, outlier detection will be enabled for this upstream cluster.
+  // Each of the configuration values can be overridden via
+  // :ref:`runtime values <config_cluster_manager_cluster_runtime_outlier_detection>`.
+  cluster.OutlierDetection outlier_detection = 19;
+
+  // The interval for removing stale hosts from a cluster type
+  // :ref:`ORIGINAL_DST<envoy_api_enum_value_Cluster.DiscoveryType.ORIGINAL_DST>`.
+  // Hosts are considered stale if they have not been used
+  // as upstream destinations during this interval. New hosts are added
+  // to original destination clusters on demand as new connections are
+  // redirected to Envoy, causing the number of hosts in the cluster to
+  // grow over time. Hosts that are not stale (they are actively used as
+  // destinations) are kept in the cluster, which allows connections to
+  // them remain open, saving the latency that would otherwise be spent
+  // on opening new connections. If this setting is not specified, the
+  // value defaults to 5000ms. For cluster types other than
+  // :ref:`ORIGINAL_DST<envoy_api_enum_value_Cluster.DiscoveryType.ORIGINAL_DST>`
+  // this setting is ignored.
+  google.protobuf.Duration cleanup_interval = 20
+      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+
+  // Optional configuration used to bind newly established upstream connections.
+  // This overrides any bind_config specified in the bootstrap proto.
+  // If the address and port are empty, no bind will be performed.
+  core.BindConfig upstream_bind_config = 21;
+
+  // Optionally divide the endpoints in this cluster into subsets defined by
+  // endpoint metadata and selected by route and weighted cluster metadata.
+  message LbSubsetConfig {
+
+    // If NO_FALLBACK is selected, a result
+    // equivalent to no healthy hosts is reported. If ANY_ENDPOINT is selected,
+    // any cluster endpoint may be returned (subject to policy, health checks,
+    // etc). If DEFAULT_SUBSET is selected, load balancing is performed over the
+    // endpoints matching the values from the default_subset field.
+    enum LbSubsetFallbackPolicy {
+      NO_FALLBACK = 0;
+      ANY_ENDPOINT = 1;
+      DEFAULT_SUBSET = 2;
+    }
+
+    // The behavior used when no endpoint subset matches the selected route's
+    // metadata. The value defaults to
+    // :ref:`NO_FALLBACK<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetFallbackPolicy.NO_FALLBACK>`.
+    LbSubsetFallbackPolicy fallback_policy = 1 [(validate.rules).enum.defined_only = true];
+
+    // Specifies the default subset of endpoints used during fallback if
+    // fallback_policy is
+    // :ref:`DEFAULT_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetFallbackPolicy.DEFAULT_SUBSET>`.
+    // Each field in default_subset is
+    // compared to the matching LbEndpoint.Metadata under the *envoy.lb*
+    // namespace. It is valid for no hosts to match, in which case the behavior
+    // is the same as a fallback_policy of
+    // :ref:`NO_FALLBACK<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetFallbackPolicy.NO_FALLBACK>`.
+    google.protobuf.Struct default_subset = 2;
+
+    // Specifications for subsets.
+    message LbSubsetSelector {
+      // List of keys to match with the weighted cluster metadata.
+      repeated string keys = 1;
+      // The behavior used when no endpoint subset matches the selected route's
+      // metadata.
+      LbSubsetSelectorFallbackPolicy fallback_policy = 2
+          [(validate.rules).enum.defined_only = true];
+
+      // Allows to override top level fallback policy per selector.
+      enum LbSubsetSelectorFallbackPolicy {
+        // If NOT_DEFINED top level config fallback policy is used instead.
+        NOT_DEFINED = 0;
+        // If NO_FALLBACK is selected, a result equivalent to no healthy hosts is reported.
+        NO_FALLBACK = 1;
+        // If ANY_ENDPOINT is selected, any cluster endpoint may be returned
+        // (subject to policy, health checks, etc).
+        ANY_ENDPOINT = 2;
+        // If DEFAULT_SUBSET is selected, load balancing is performed over the
+        // endpoints matching the values from the default_subset field.
+        DEFAULT_SUBSET = 3;
+      }
+    }
+
+    // For each entry, LbEndpoint.Metadata's
+    // *envoy.lb* namespace is traversed and a subset is created for each unique
+    // combination of key and value. For example:
+    //
+    // .. code-block:: json
+    //
+    //   { "subset_selectors": [
+    //       { "keys": [ "version" ] },
+    //       { "keys": [ "stage", "hardware_type" ] }
+    //   ]}
+    //
+    // A subset is matched when the metadata from the selected route and
+    // weighted cluster contains the same keys and values as the subset's
+    // metadata. The same host may appear in multiple subsets.
+    repeated LbSubsetSelector subset_selectors = 3;
+
+    // If true, routing to subsets will take into account the localities and locality weights of the
+    // endpoints when making the routing decision.
+    //
+    // There are some potential pitfalls associated with enabling this feature, as the resulting
+    // traffic split after applying both a subset match and locality weights might be undesirable.
+    //
+    // Consider for example a situation in which you have 50/50 split across two localities X/Y
+    // which have 100 hosts each without subsetting. If the subset LB results in X having only 1
+    // host selected but Y having 100, then a lot more load is being dumped on the single host in X
+    // than originally anticipated in the load balancing assignment delivered via EDS.
+    bool locality_weight_aware = 4;
+
+    // When used with locality_weight_aware, scales the weight of each locality by the ratio
+    // of hosts in the subset vs hosts in the original subset. This aims to even out the load
+    // going to an individual locality if said locality is disproportionally affected by the
+    // subset predicate.
+    bool scale_locality_weight = 5;
+
+    // If true, when a fallback policy is configured and its corresponding subset fails to find
+    // a host this will cause any host to be selected instead.
+    //
+    // This is useful when using the default subset as the fallback policy, given the default
+    // subset might become empty. With this option enabled, if that happens the LB will attempt
+    // to select a host from the entire cluster.
+    bool panic_mode_any = 6;
+
+    // If true, metadata specified for a metadata key will be matched against the corresponding
+    // endpoint metadata if the endpoint metadata matches the value exactly OR it is a list value
+    // and any of the elements in the list matches the criteria.
+    bool list_as_any = 7;
+  }
+
+  // Configuration for load balancing subsetting.
+  LbSubsetConfig lb_subset_config = 22;
+
+  // Specific configuration for the LeastRequest load balancing policy.
+  message LeastRequestLbConfig {
+    // The number of random healthy hosts from which the host with the fewest active requests will
+    // be chosen. Defaults to 2 so that we perform two-choice selection if the field is not set.
+    google.protobuf.UInt32Value choice_count = 1 [(validate.rules).uint32.gte = 2];
+  }
+
+  // Specific configuration for the :ref:`RingHash<arch_overview_load_balancing_types_ring_hash>`
+  // load balancing policy.
+  message RingHashLbConfig {
+    // Minimum hash ring size. The larger the ring is (that is, the more hashes there are for each
+    // provided host) the better the request distribution will reflect the desired weights. Defaults
+    // to 1024 entries, and limited to 8M entries. See also
+    // :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>`.
+    google.protobuf.UInt64Value minimum_ring_size = 1 [(validate.rules).uint64.lte = 8388608];
+
+    reserved 2;
+
+    // The hash function used to hash hosts onto the ketama ring.
+    enum HashFunction {
+      // Use `xxHash <https://github.com/Cyan4973/xxHash>`_, this is the default hash function.
+      XX_HASH = 0;
+      // Use `MurmurHash2 <https://sites.google.com/site/murmurhash/>`_, this is compatible with
+      // std:hash<string> in GNU libstdc++ 3.4.20 or above. This is typically the case when compiled
+      // on Linux and not macOS.
+      MURMUR_HASH_2 = 1;
+    }
+
+    // The hash function used to hash hosts onto the ketama ring. The value defaults to
+    // :ref:`XX_HASH<envoy_api_enum_value_Cluster.RingHashLbConfig.HashFunction.XX_HASH>`.
+    HashFunction hash_function = 3 [(validate.rules).enum.defined_only = true];
+
+    // Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries, but can be lowered
+    // to further constrain resource use. See also
+    // :ref:`minimum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.minimum_ring_size>`.
+    google.protobuf.UInt64Value maximum_ring_size = 4 [(validate.rules).uint64.lte = 8388608];
+  }
+
+  // Specific configuration for the
+  // :ref:`Original Destination <arch_overview_load_balancing_types_original_destination>`
+  // load balancing policy.
+  message OriginalDstLbConfig {
+    // When true, :ref:`x-envoy-original-dst-host
+    // <config_http_conn_man_headers_x-envoy-original-dst-host>` can be used to override destination
+    // address.
+    //
+    // .. attention::
+    //
+    //   This header isn't sanitized by default, so enabling this feature allows HTTP clients to
+    //   route traffic to arbitrary hosts and/or ports, which may have serious security
+    //   consequences.
+    bool use_http_header = 1;
+  }
+
+  // Optional configuration for the load balancing algorithm selected by
+  // LbPolicy. Currently only
+  // :ref:`RING_HASH<envoy_api_enum_value_Cluster.LbPolicy.RING_HASH>` and
+  // :ref:`LEAST_REQUEST<envoy_api_enum_value_Cluster.LbPolicy.LEAST_REQUEST>`
+  // has additional configuration options.
+  // Specifying ring_hash_lb_config or least_request_lb_config without setting the corresponding
+  // LbPolicy will generate an error at runtime.
+  oneof lb_config {
+    // Optional configuration for the Ring Hash load balancing policy.
+    RingHashLbConfig ring_hash_lb_config = 23;
+    // Optional configuration for the Original Destination load balancing policy.
+    OriginalDstLbConfig original_dst_lb_config = 34;
+    // Optional configuration for the LeastRequest load balancing policy.
+    LeastRequestLbConfig least_request_lb_config = 37;
+  }
+
+  // Common configuration for all load balancer implementations.
+  message CommonLbConfig {
+    // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.
+    // If not specified, the default is 50%.
+    // To disable panic mode, set to 0%.
+    //
+    // .. note::
+    //   The specified percent will be truncated to the nearest 1%.
+    envoy.type.Percent healthy_panic_threshold = 1;
+    // Configuration for :ref:`zone aware routing
+    // <arch_overview_load_balancing_zone_aware_routing>`.
+    message ZoneAwareLbConfig {
+      // Configures percentage of requests that will be considered for zone aware routing
+      // if zone aware routing is configured. If not specified, the default is 100%.
+      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+      envoy.type.Percent routing_enabled = 1;
+      // Configures minimum upstream cluster size required for zone aware routing
+      // If upstream cluster size is less than specified, zone aware routing is not performed
+      // even if zone aware routing is configured. If not specified, the default is 6.
+      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+      google.protobuf.UInt64Value min_cluster_size = 2;
+    }
+    // Configuration for :ref:`locality weighted load balancing
+    // <arch_overview_load_balancing_locality_weighted_lb>`
+    message LocalityWeightedLbConfig {
+    }
+    oneof locality_config_specifier {
+      ZoneAwareLbConfig zone_aware_lb_config = 2;
+      LocalityWeightedLbConfig locality_weighted_lb_config = 3;
+    }
+    // If set, all health check/weight/metadata updates that happen within this duration will be
+    // merged and delivered in one shot when the duration expires. The start of the duration is when
+    // the first update happens. This is useful for big clusters, with potentially noisy deploys
+    // that might trigger excessive CPU usage due to a constant stream of healthcheck state changes
+    // or metadata updates. The first set of updates to be seen apply immediately (e.g.: a new
+    // cluster). Please always keep in mind that the use of sandbox technologies may change this
+    // behavior.
+    //
+    // If this is not set, we default to a merge window of 1000ms. To disable it, set the merge
+    // window to 0.
+    //
+    // Note: merging does not apply to cluster membership changes (e.g.: adds/removes); this is
+    // because merging those updates isn't currently safe. See
+    // https://github.com/envoyproxy/envoy/pull/3941.
+    google.protobuf.Duration update_merge_window = 4;
+
+    // If set to true, Envoy will not consider new hosts when computing load balancing weights until
+    // they have been health checked for the first time. This will have no effect unless
+    // active health checking is also configured.
+    //
+    // Ignoring a host means that for any load balancing calculations that adjust weights based
+    // on the ratio of eligible hosts and total hosts (priority spillover, locality weighting and
+    // panic mode) Envoy will exclude these hosts in the denominator.
+    //
+    // For example, with hosts in two priorities P0 and P1, where P0 looks like
+    // {healthy, unhealthy (new), unhealthy (new)}
+    // and where P1 looks like
+    // {healthy, healthy}
+    // all traffic will still hit P0, as 1 / (3 - 2) = 1.
+    //
+    // Enabling this will allow scaling up the number of hosts for a given cluster without entering
+    // panic mode or triggering priority spillover, assuming the hosts pass the first health check.
+    //
+    // If panic mode is triggered, new hosts are still eligible for traffic; they simply do not
+    // contribute to the calculation when deciding whether panic mode is enabled or not.
+    bool ignore_new_hosts_until_first_hc = 5;
+
+    // If set to `true`, the cluster manager will drain all existing
+    // connections to upstream hosts whenever hosts are added or removed from the cluster.
+    bool close_connections_on_host_set_change = 6;
+  }
+
+  // Common configuration for all load balancer implementations.
+  CommonLbConfig common_lb_config = 27;
+
+  // Optional custom transport socket implementation to use for upstream connections.
+  core.TransportSocket transport_socket = 24;
+
+  // The Metadata field can be used to provide additional information about the
+  // cluster. It can be used for stats, logging, and varying filter behavior.
+  // Fields should use reverse DNS notation to denote which entity within Envoy
+  // will need the information. For instance, if the metadata is intended for
+  // the Router filter, the filter name should be specified as *envoy.router*.
+  core.Metadata metadata = 25;
+
+  enum ClusterProtocolSelection {
+    // Cluster can only operate on one of the possible upstream protocols (HTTP1.1, HTTP2).
+    // If :ref:`http2_protocol_options <envoy_api_field_Cluster.http2_protocol_options>` are
+    // present, HTTP2 will be used, otherwise HTTP1.1 will be used.
+    USE_CONFIGURED_PROTOCOL = 0;
+    // Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
+    USE_DOWNSTREAM_PROTOCOL = 1;
+  }
+
+  // Determines how Envoy selects the protocol used to speak to upstream hosts.
+  ClusterProtocolSelection protocol_selection = 26;
+
+  // Optional options for upstream connections.
+  envoy.api.v3alpha.UpstreamConnectionOptions upstream_connection_options = 30;
+
+  // If an upstream host becomes unhealthy (as determined by the configured health checks
+  // or outlier detection), immediately close all connections to the failed host.
+  //
+  // .. note::
+  //
+  //   This is currently only supported for connections created by tcp_proxy.
+  //
+  // .. note::
+  //
+  //   The current implementation of this feature closes all connections immediately when
+  //   the unhealthy status is detected. If there are a large number of connections open
+  //   to an upstream host that becomes unhealthy, Envoy may spend a substantial amount of
+  //   time exclusively closing these connections, and not processing any other traffic.
+  bool close_connections_on_host_health_failure = 31;
+
+  // If this cluster uses EDS or STRICT_DNS to configure its hosts, immediately drain
+  // connections from any hosts that are removed from service discovery.
+  //
+  // This only affects behavior for hosts that are being actively health checked.
+  // If this flag is not set to true, Envoy will wait until the hosts fail active health
+  // checking before removing it from the cluster.
+  bool drain_connections_on_host_removal = 32;
+
+  // An optional list of network filters that make up the filter chain for
+  // outgoing connections made by the cluster. Order matters as the filters are
+  // processed sequentially as connection events happen.
+  repeated cluster.Filter filters = 40;
+}
+
+// An extensible structure containing the address Envoy should bind to when
+// establishing upstream connections.
+message UpstreamBindConfig {
+  // The address Envoy should bind to when establishing upstream connections.
+  core.Address source_address = 1;
+}
+
+message UpstreamConnectionOptions {
+  // If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+  core.TcpKeepalive tcp_keepalive = 1;
+}

--- a/api/envoy/api/v3alpha/cluster/BUILD
+++ b/api/envoy/api/v3alpha/cluster/BUILD
@@ -1,0 +1,48 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "circuit_breaker",
+    srcs = ["circuit_breaker.proto"],
+    visibility = [
+        "//envoy/api/v3alpha:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_go_proto_library(
+    name = "circuit_breaker",
+    proto = ":circuit_breaker",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "outlier_detection",
+    srcs = ["outlier_detection.proto"],
+    visibility = [
+        "//envoy/api/v3alpha:__pkg__",
+    ],
+)
+
+api_go_proto_library(
+    name = "outlier_detection",
+    proto = ":outlier_detection",
+)
+
+api_proto_library_internal(
+    name = "filter",
+    srcs = ["filter.proto"],
+    visibility = [
+        "//envoy/api/v3alpha:__pkg__",
+    ],
+)
+
+api_go_proto_library(
+    name = "filter",
+    proto = ":filter",
+)

--- a/api/envoy/api/v3alpha/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v3alpha/cluster/circuit_breaker.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.cluster;
+
+option java_outer_classname = "CircuitBreakerProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.cluster";
+option go_package = "cluster";
+option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
+
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Circuit breakers]
+
+// :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be
+// specified individually for each defined priority.
+message CircuitBreakers {
+
+  // A Thresholds defines CircuitBreaker settings for a
+  // :ref:`RoutingPriority<envoy_api_enum_core.RoutingPriority>`.
+  message Thresholds {
+    // The :ref:`RoutingPriority<envoy_api_enum_core.RoutingPriority>`
+    // the specified CircuitBreaker settings apply to.
+    // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+    // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+    core.RoutingPriority priority = 1;
+
+    // The maximum number of connections that Envoy will make to the upstream
+    // cluster. If not specified, the default is 1024.
+    google.protobuf.UInt32Value max_connections = 2;
+
+    // The maximum number of pending requests that Envoy will allow to the
+    // upstream cluster. If not specified, the default is 1024.
+    google.protobuf.UInt32Value max_pending_requests = 3;
+
+    // The maximum number of parallel requests that Envoy will make to the
+    // upstream cluster. If not specified, the default is 1024.
+    google.protobuf.UInt32Value max_requests = 4;
+
+    // The maximum number of parallel retries that Envoy will allow to the
+    // upstream cluster. If not specified, the default is 3.
+    google.protobuf.UInt32Value max_retries = 5;
+
+    // If track_remaining is true, then stats will be published that expose
+    // the number of resources remaining until the circuit breakers open. If
+    // not specified, the default is false.
+    bool track_remaining = 6;
+
+    // The maximum number of connection pools per cluster that Envoy will concurrently support at
+    // once. If not specified, the default is unlimited. Set this for clusters which create a
+    // large number of connection pools. See
+    // :ref:`Circuit Breaking <arch_overview_circuit_break_cluster_maximum_connection_pools>` for
+    // more details.
+    google.protobuf.UInt32Value max_connection_pools = 7;
+  }
+
+  // If multiple :ref:`Thresholds<envoy_api_msg_cluster.CircuitBreakers.Thresholds>`
+  // are defined with the same :ref:`RoutingPriority<envoy_api_enum_core.RoutingPriority>`,
+  // the first one in the list is used. If no Thresholds is defined for a given
+  // :ref:`RoutingPriority<envoy_api_enum_core.RoutingPriority>`, the default values
+  // are used.
+  repeated Thresholds thresholds = 1;
+}

--- a/api/envoy/api/v3alpha/cluster/filter.proto
+++ b/api/envoy/api/v3alpha/cluster/filter.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.cluster;
+
+option java_outer_classname = "FilterProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.cluster";
+option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
+
+import "google/protobuf/any.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Upstream filters]
+//
+// Upstream filters apply to the connections to the upstream cluster hosts.
+message Filter {
+  // The name of the filter to instantiate. The name must match a
+  // :ref:`supported filter <config_network_filters>`.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Filter specific configuration which depends on the filter being
+  // instantiated. See the supported filters for further documentation.
+  google.protobuf.Any typed_config = 2;
+}

--- a/api/envoy/api/v3alpha/cluster/outlier_detection.proto
+++ b/api/envoy/api/v3alpha/cluster/outlier_detection.proto
@@ -1,0 +1,117 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.cluster;
+
+option java_outer_classname = "OutlierDetectionProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.cluster";
+option csharp_namespace = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy.Api.V2.ClusterNS";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Outlier detection]
+
+// See the :ref:`architecture overview <arch_overview_outlier_detection>` for
+// more information on outlier detection.
+message OutlierDetection {
+  // The number of consecutive 5xx responses or local origin errors that are mapped
+  // to 5xx error codes before a consecutive 5xx ejection
+  // occurs. Defaults to 5.
+  google.protobuf.UInt32Value consecutive_5xx = 1;
+
+  // The time interval between ejection analysis sweeps. This can result in
+  // both new ejections as well as hosts being returned to service. Defaults
+  // to 10000ms or 10s.
+  google.protobuf.Duration interval = 2 [(validate.rules).duration.gt = {}];
+
+  // The base time that a host is ejected for. The real time is equal to the
+  // base time multiplied by the number of times the host has been ejected.
+  // Defaults to 30000ms or 30s.
+  google.protobuf.Duration base_ejection_time = 3 [(validate.rules).duration.gt = {}];
+
+  // The maximum % of an upstream cluster that can be ejected due to outlier
+  // detection. Defaults to 10% but will eject at least one host regardless of the value.
+  google.protobuf.UInt32Value max_ejection_percent = 4 [(validate.rules).uint32.lte = 100];
+
+  // The % chance that a host will be actually ejected when an outlier status
+  // is detected through consecutive 5xx. This setting can be used to disable
+  // ejection or to ramp it up slowly. Defaults to 100.
+  google.protobuf.UInt32Value enforcing_consecutive_5xx = 5 [(validate.rules).uint32.lte = 100];
+
+  // The % chance that a host will be actually ejected when an outlier status
+  // is detected through success rate statistics. This setting can be used to
+  // disable ejection or to ramp it up slowly. Defaults to 100.
+  google.protobuf.UInt32Value enforcing_success_rate = 6 [(validate.rules).uint32.lte = 100];
+
+  // The number of hosts in a cluster that must have enough request volume to
+  // detect success rate outliers. If the number of hosts is less than this
+  // setting, outlier detection via success rate statistics is not performed
+  // for any host in the cluster. Defaults to 5.
+  google.protobuf.UInt32Value success_rate_minimum_hosts = 7;
+
+  // The minimum number of total requests that must be collected in one
+  // interval (as defined by the interval duration above) to include this host
+  // in success rate based outlier detection. If the volume is lower than this
+  // setting, outlier detection via success rate statistics is not performed
+  // for that host. Defaults to 100.
+  google.protobuf.UInt32Value success_rate_request_volume = 8;
+
+  // This factor is used to determine the ejection threshold for success rate
+  // outlier ejection. The ejection threshold is the difference between the
+  // mean success rate, and the product of this factor and the standard
+  // deviation of the mean success rate: mean - (stdev *
+  // success_rate_stdev_factor). This factor is divided by a thousand to get a
+  // double. That is, if the desired factor is 1.9, the runtime value should
+  // be 1900. Defaults to 1900.
+  google.protobuf.UInt32Value success_rate_stdev_factor = 9;
+
+  // The number of consecutive gateway failures (502, 503, 504 status codes)
+  // before a consecutive gateway failure ejection occurs. Defaults to 5.
+  google.protobuf.UInt32Value consecutive_gateway_failure = 10;
+
+  // The % chance that a host will be actually ejected when an outlier status
+  // is detected through consecutive gateway failures. This setting can be
+  // used to disable ejection or to ramp it up slowly. Defaults to 0.
+  google.protobuf.UInt32Value enforcing_consecutive_gateway_failure = 11
+      [(validate.rules).uint32.lte = 100];
+
+  // Determines whether to distinguish local origin failures from external errors. If set to true
+  // the following configuration parameters are taken into account:
+  // :ref:`consecutive_local_origin_failure<envoy_api_field_cluster.OutlierDetection.consecutive_local_origin_failure>`,
+  // :ref:`enforcing_consecutive_local_origin_failure<envoy_api_field_cluster.OutlierDetection.enforcing_consecutive_local_origin_failure>`
+  // and
+  // :ref:`enforcing_local_origin_success_rate<envoy_api_field_cluster.OutlierDetection.enforcing_local_origin_success_rate>`.
+  // Defaults to false.
+  bool split_external_local_origin_errors = 12;
+
+  // The number of consecutive locally originated failures before ejection
+  // occurs. Defaults to 5. Parameter takes effect only when
+  // :ref:`split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is set to true.
+  google.protobuf.UInt32Value consecutive_local_origin_failure = 13;
+
+  // The % chance that a host will be actually ejected when an outlier status
+  // is detected through consecutive locally originated failures. This setting can be
+  // used to disable ejection or to ramp it up slowly. Defaults to 100.
+  // Parameter takes effect only when
+  // :ref:`split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is set to true.
+  google.protobuf.UInt32Value enforcing_consecutive_local_origin_failure = 14
+      [(validate.rules).uint32.lte = 100];
+
+  // The % chance that a host will be actually ejected when an outlier status
+  // is detected through success rate statistics for locally originated errors.
+  // This setting can be used to disable ejection or to ramp it up slowly. Defaults to 100.
+  // Parameter takes effect only when
+  // :ref:`split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is set to true.
+  google.protobuf.UInt32Value enforcing_local_origin_success_rate = 15
+      [(validate.rules).uint32.lte = 100];
+}

--- a/api/envoy/api/v3alpha/core/BUILD
+++ b/api/envoy/api/v3alpha/core/BUILD
@@ -1,0 +1,136 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+package_group(
+    name = "friends",
+    includes = [
+        "//envoy/api/v3alpha:friends",
+    ],
+    packages = [
+        "//envoy/api/v3alpha/auth",
+        "//envoy/api/v3alpha/cluster",
+        "//envoy/api/v3alpha/endpoint",
+        "//envoy/api/v3alpha/listener",
+        "//envoy/api/v3alpha/route",
+    ],
+)
+
+api_proto_library_internal(
+    name = "address",
+    srcs = ["address.proto"],
+    visibility = [
+        ":friends",
+    ],
+    deps = [":base"],
+)
+
+api_go_proto_library(
+    name = "address",
+    proto = ":address",
+    deps = [":base_go_proto"],
+)
+
+api_proto_library_internal(
+    name = "base",
+    srcs = ["base.proto"],
+    visibility = [
+        ":friends",
+    ],
+    deps = [
+        ":http_uri",
+        "//envoy/type:percent",
+    ],
+)
+
+api_go_proto_library(
+    name = "base",
+    proto = ":base",
+    deps = [
+        ":http_uri_go_proto",
+        "//envoy/type:percent_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "health_check",
+    srcs = ["health_check.proto"],
+    visibility = [
+        ":friends",
+    ],
+    deps = [
+        ":base",
+        "//envoy/type:range",
+    ],
+)
+
+api_go_proto_library(
+    name = "health_check",
+    proto = ":health_check",
+    deps = [
+        ":base_go_proto",
+        "//envoy/type:range_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "config_source",
+    srcs = ["config_source.proto"],
+    visibility = [
+        ":friends",
+    ],
+    deps = [
+        ":base",
+        ":grpc_service",
+    ],
+)
+
+api_go_proto_library(
+    name = "config_source",
+    proto = ":config_source",
+    deps = [
+        ":base_go_proto",
+        ":grpc_service_go_proto",
+    ],
+)
+
+api_go_proto_library(
+    name = "http_uri",
+    proto = ":http_uri",
+)
+
+api_proto_library_internal(
+    name = "http_uri",
+    srcs = ["http_uri.proto"],
+    visibility = [
+        ":friends",
+    ],
+)
+
+api_proto_library_internal(
+    name = "grpc_service",
+    srcs = ["grpc_service.proto"],
+    visibility = [
+        ":friends",
+    ],
+    deps = [":base"],
+)
+
+api_go_proto_library(
+    name = "grpc_service",
+    proto = ":grpc_service",
+    deps = [":base_go_proto"],
+)
+
+api_proto_library_internal(
+    name = "protocol",
+    srcs = ["protocol.proto"],
+    visibility = [
+        ":friends",
+    ],
+)
+
+api_go_proto_library(
+    name = "protocol",
+    proto = ":protocol",
+)

--- a/api/envoy/api/v3alpha/core/address.proto
+++ b/api/envoy/api/v3alpha/core/address.proto
@@ -1,0 +1,121 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "AddressProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Network addresses]
+
+message Pipe {
+  // Unix Domain Socket path. On Linux, paths starting with '@' will use the
+  // abstract namespace. The starting '@' is replaced by a null byte by Envoy.
+  // Paths starting with '@' will result in an error in environments other than
+  // Linux.
+  string path = 1 [(validate.rules).string.min_bytes = 1];
+}
+
+message SocketAddress {
+  enum Protocol {
+    option (gogoproto.goproto_enum_prefix) = false;
+    TCP = 0;
+    // [#not-implemented-hide:]
+    UDP = 1;
+  }
+  Protocol protocol = 1 [(validate.rules).enum.defined_only = true];
+  // The address for this socket. :ref:`Listeners <config_listeners>` will bind
+  // to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
+  // to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
+  // It is possible to distinguish a Listener address via the prefix/suffix matching
+  // in :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>`.] When used
+  // within an upstream :ref:`BindConfig <envoy_api_msg_core.BindConfig>`, the address
+  // controls the source address of outbound connections. For :ref:`clusters
+  // <envoy_api_msg_Cluster>`, the cluster type determines whether the
+  // address must be an IP (*STATIC* or *EDS* clusters) or a hostname resolved by DNS
+  // (*STRICT_DNS* or *LOGICAL_DNS* clusters). Address resolution can be customized
+  // via :ref:`resolver_name <envoy_api_field_core.SocketAddress.resolver_name>`.
+  string address = 2 [(validate.rules).string.min_bytes = 1];
+  oneof port_specifier {
+    option (validate.required) = true;
+    uint32 port_value = 3 [(validate.rules).uint32.lte = 65535];
+    // This is only valid if :ref:`resolver_name
+    // <envoy_api_field_core.SocketAddress.resolver_name>` is specified below and the
+    // named resolver is capable of named port resolution.
+    string named_port = 4;
+  }
+  // The name of the custom resolver. This must have been registered with Envoy. If
+  // this is empty, a context dependent default applies. If the address is a concrete
+  // IP address, no resolution will occur. If address is a hostname this
+  // should be set for resolution other than DNS. Specifying a custom resolver with
+  // *STRICT_DNS* or *LOGICAL_DNS* will generate an error at runtime.
+  string resolver_name = 5;
+
+  // When binding to an IPv6 address above, this enables `IPv4 compatibility
+  // <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
+  // allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
+  // IPv6 space as ``::FFFF:<IPv4-address>``.
+  bool ipv4_compat = 6;
+}
+
+message TcpKeepalive {
+  // Maximum number of keepalive probes to send without response before deciding
+  // the connection is dead. Default is to use the OS level configuration (unless
+  // overridden, Linux defaults to 9.)
+  google.protobuf.UInt32Value keepalive_probes = 1;
+  // The number of seconds a connection needs to be idle before keep-alive probes
+  // start being sent. Default is to use the OS level configuration (unless
+  // overridden, Linux defaults to 7200s (ie 2 hours.)
+  google.protobuf.UInt32Value keepalive_time = 2;
+  // The number of seconds between keep-alive probes. Default is to use the OS
+  // level configuration (unless overridden, Linux defaults to 75s.)
+  google.protobuf.UInt32Value keepalive_interval = 3;
+}
+
+message BindConfig {
+  // The address to bind to when creating a socket.
+  SocketAddress source_address = 1 [(validate.rules).message.required = true];
+
+  // Whether to set the *IP_FREEBIND* option when creating the socket. When this
+  // flag is set to true, allows the :ref:`source_address
+  // <envoy_api_field_UpstreamBindConfig.source_address>` to be an IP address
+  // that is not configured on the system running Envoy. When this flag is set
+  // to false, the option *IP_FREEBIND* is disabled on the socket. When this
+  // flag is not set (default), the socket is not modified, i.e. the option is
+  // neither enabled nor disabled.
+  google.protobuf.BoolValue freebind = 2;
+
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries.
+  repeated SocketOption socket_options = 3;
+}
+
+// Addresses specify either a logical or physical address and port, which are
+// used to tell Envoy where to bind/listen, connect to upstream and find
+// management servers.
+message Address {
+  oneof address {
+    option (validate.required) = true;
+
+    SocketAddress socket_address = 1;
+    Pipe pipe = 2;
+  }
+}
+
+// CidrRange specifies an IP Address and a prefix length to construct
+// the subnet mask for a `CIDR <https://tools.ietf.org/html/rfc4632>`_ range.
+message CidrRange {
+  // IPv4 or IPv6 address, e.g. ``192.0.0.0`` or ``2001:db8::``.
+  string address_prefix = 1 [(validate.rules).string.min_bytes = 1];
+  // Length of prefix, e.g. 0, 32.
+  google.protobuf.UInt32Value prefix_len = 2 [(validate.rules).uint32.lte = 128];
+}

--- a/api/envoy/api/v3alpha/core/base.proto
+++ b/api/envoy/api/v3alpha/core/base.proto
@@ -1,0 +1,292 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "BaseProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+option go_package = "core";
+
+import "envoy/api/v3alpha/core/http_uri.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+import "envoy/type/percent.proto";
+
+option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: Common types]
+
+// Identifies location of where either Envoy runs or where upstream hosts run.
+message Locality {
+  // Region this :ref:`zone <envoy_api_field_core.Locality.zone>` belongs to.
+  string region = 1;
+
+  // Defines the local service zone where Envoy is running. Though optional, it
+  // should be set if discovery service routing is used and the discovery
+  // service exposes :ref:`zone data <envoy_api_field_endpoint.LocalityLbEndpoints.locality>`,
+  // either in this message or via :option:`--service-zone`. The meaning of zone
+  // is context dependent, e.g. `Availability Zone (AZ)
+  // <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html>`_
+  // on AWS, `Zone <https://cloud.google.com/compute/docs/regions-zones/>`_ on
+  // GCP, etc.
+  string zone = 2;
+
+  // When used for locality of upstream hosts, this field further splits zone
+  // into smaller chunks of sub-zones so they can be load balanced
+  // independently.
+  string sub_zone = 3;
+}
+
+// Identifies a specific Envoy instance. The node identifier is presented to the
+// management server, which may use this identifier to distinguish per Envoy
+// configuration for serving.
+message Node {
+  // An opaque node identifier for the Envoy node. This also provides the local
+  // service node name. It should be set if any of the following features are
+  // used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
+  // <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+  // <arch_overview_tracing>`, either in this message or via
+  // :option:`--service-node`.
+  string id = 1;
+
+  // Defines the local service cluster name where Envoy is running. Though
+  // optional, it should be set if any of the following features are used:
+  // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+  // verification <envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name>`,
+  // :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v3alpha.Runtime>`,
+  // :ref:`user agent addition
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.add_user_agent>`,
+  // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+  // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+  // <arch_overview_tracing>`, either in this message or via
+  // :option:`--service-cluster`.
+  string cluster = 2;
+
+  // Opaque metadata extending the node identifier. Envoy will pass this
+  // directly to the management server.
+  google.protobuf.Struct metadata = 3;
+
+  // Locality specifying where the Envoy instance is running.
+  Locality locality = 4;
+
+  // This is motivated by informing a management server during canary which
+  // version of Envoy is being tested in a heterogeneous fleet. This will be set
+  // by Envoy in management server RPCs.
+  string build_version = 5;
+}
+
+// Metadata provides additional inputs to filters based on matched listeners,
+// filter chains, routes and endpoints. It is structured as a map, usually from
+// filter name (in reverse DNS format) to metadata specific to the filter. Metadata
+// key-values for a filter are merged as connection and request handling occurs,
+// with later values for the same key overriding earlier values.
+//
+// An example use of metadata is providing additional values to
+// http_connection_manager in the envoy.http_connection_manager.access_log
+// namespace.
+//
+// Another example use of metadata is to per service config info in cluster metadata, which may get
+// consumed by multiple filters.
+//
+// For load balancing, Metadata provides a means to subset cluster endpoints.
+// Endpoints have a Metadata object associated and routes contain a Metadata
+// object to match against. There are some well defined metadata used today for
+// this purpose:
+//
+// * ``{"envoy.lb": {"canary": <bool> }}`` This indicates the canary status of an
+//   endpoint and is also used during header processing
+//   (x-envoy-upstream-canary) and for stats purposes.
+message Metadata {
+  // Key is the reverse DNS filter name, e.g. com.acme.widget. The envoy.*
+  // namespace is reserved for Envoy's built-in filters.
+  map<string, google.protobuf.Struct> filter_metadata = 1;
+}
+
+// Runtime derived uint32 with a default when not specified.
+message RuntimeUInt32 {
+  // Default value if runtime value is not available.
+  uint32 default_value = 2;
+
+  // Runtime key to get value for comparison. This value is used if defined.
+  string runtime_key = 3 [(validate.rules).string.min_bytes = 1];
+}
+
+// Envoy supports :ref:`upstream priority routing
+// <arch_overview_http_routing_priority>` both at the route and the virtual
+// cluster level. The current priority implementation uses different connection
+// pool and circuit breaking settings for each priority level. This means that
+// even for HTTP/2 requests, two physical connections will be used to an
+// upstream host. In the future Envoy will likely support true HTTP/2 priority
+// over a single upstream connection.
+enum RoutingPriority {
+  DEFAULT = 0;
+  HIGH = 1;
+}
+
+// HTTP request method.
+enum RequestMethod {
+  option (gogoproto.goproto_enum_prefix) = false;
+  METHOD_UNSPECIFIED = 0;
+  GET = 1;
+  HEAD = 2;
+  POST = 3;
+  PUT = 4;
+  DELETE = 5;
+  CONNECT = 6;
+  OPTIONS = 7;
+  TRACE = 8;
+  PATCH = 9;
+}
+
+// Header name/value pair.
+message HeaderValue {
+  // Header name.
+  string key = 1 [(validate.rules).string = {min_bytes: 1, max_bytes: 16384}];
+
+  // Header value.
+  //
+  // The same :ref:`format specifier <config_access_log_format>` as used for
+  // :ref:`HTTP access logging <config_access_log>` applies here, however
+  // unknown header values are replaced with the empty string instead of `-`.
+  string value = 2 [(validate.rules).string.max_bytes = 16384];
+}
+
+// Header name/value pair plus option to control append behavior.
+message HeaderValueOption {
+  // Header name/value pair that this option applies to.
+  HeaderValue header = 1 [(validate.rules).message.required = true];
+
+  // Should the value be appended? If true (default), the value is appended to
+  // existing values.
+  google.protobuf.BoolValue append = 2;
+}
+
+// Wrapper for a set of headers.
+message HeaderMap {
+  repeated HeaderValue headers = 1;
+}
+
+// Data source consisting of either a file or an inline value.
+message DataSource {
+  oneof specifier {
+    option (validate.required) = true;
+
+    // Local filesystem data source.
+    string filename = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Bytes inlined in the configuration.
+    bytes inline_bytes = 2 [(validate.rules).bytes.min_len = 1];
+
+    // String inlined in the configuration.
+    string inline_string = 3 [(validate.rules).string.min_bytes = 1];
+  }
+}
+
+// The message specifies how to fetch data from remote and how to verify it.
+message RemoteDataSource {
+  // The HTTP URI to fetch the remote data.
+  HttpUri http_uri = 1 [(validate.rules).message.required = true];
+
+  // SHA256 string for verifying data.
+  string sha256 = 2 [(validate.rules).string.min_bytes = 1];
+}
+
+// Async data source which support async data fetch.
+message AsyncDataSource {
+  oneof specifier {
+    option (validate.required) = true;
+
+    // Local async data source.
+    DataSource local = 1;
+
+    // Remote async data source.
+    RemoteDataSource remote = 2;
+  }
+}
+
+// Configuration for transport socket in :ref:`listeners <config_listeners>` and
+// :ref:`clusters <envoy_api_msg_Cluster>`. If the configuration is
+// empty, a default transport socket implementation and configuration will be
+// chosen based on the platform and existence of tls_context.
+message TransportSocket {
+  // The name of the transport socket to instantiate. The name must match a supported transport
+  // socket implementation.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Implementation specific configuration which depends on the implementation being instantiated.
+  // See the supported transport socket implementations for further documentation.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}
+
+// Generic socket option message. This would be used to set socket options that
+// might not exist in upstream kernels or precompiled Envoy binaries.
+message SocketOption {
+  // An optional name to give this socket option for debugging, etc.
+  // Uniqueness is not required and no special meaning is assumed.
+  string description = 1;
+  // Corresponding to the level value passed to setsockopt, such as IPPROTO_TCP
+  int64 level = 2;
+  // The numeric name as passed to setsockopt
+  int64 name = 3;
+  oneof value {
+    option (validate.required) = true;
+
+    // Because many sockopts take an int value.
+    int64 int_value = 4;
+    // Otherwise it's a byte buffer.
+    bytes buf_value = 5;
+  }
+  enum SocketState {
+    option (gogoproto.goproto_enum_prefix) = false;
+    // Socket options are applied after socket creation but before binding the socket to a port
+    STATE_PREBIND = 0;
+    // Socket options are applied after binding the socket to a port but before calling listen()
+    STATE_BOUND = 1;
+    // Socket options are applied after calling listen()
+    STATE_LISTENING = 2;
+  }
+  // The state in which the option will be applied. When used in BindConfig
+  // STATE_PREBIND is currently the only valid value.
+  SocketState state = 6 [(validate.rules).enum.defined_only = true];
+}
+
+// Runtime derived FractionalPercent with defaults for when the numerator or denominator is not
+// specified via a runtime key.
+message RuntimeFractionalPercent {
+  // Default value if the runtime value's for the numerator/denominator keys are not available.
+  envoy.type.FractionalPercent default_value = 1 [(validate.rules).message.required = true];
+
+  // Runtime key for a YAML representation of a FractionalPercent.
+  string runtime_key = 2;
+}
+
+// Identifies a specific ControlPlane instance that Envoy is connected to.
+message ControlPlane {
+  // An opaque control plane identifier that uniquely identifies an instance
+  // of control plane. This can be used to identify which control plane instance,
+  // the Envoy is connected to.
+  string identifier = 1;
+}
+
+// Identifies the direction of the traffic relative to the local Envoy.
+enum TrafficDirection {
+  // Default option is unspecified.
+  UNSPECIFIED = 0;
+
+  // The transport is used for incoming traffic.
+  INBOUND = 1;
+
+  // The transport is used for outgoing traffic.
+  OUTBOUND = 2;
+}

--- a/api/envoy/api/v3alpha/core/config_source.proto
+++ b/api/envoy/api/v3alpha/core/config_source.proto
@@ -1,0 +1,126 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "ConfigSourceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+
+import "envoy/api/v3alpha/core/grpc_service.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Configuration sources]
+
+// API configuration source. This identifies the API type and cluster that Envoy
+// will use to fetch an xDS API.
+message ApiConfigSource {
+  // APIs may be fetched via either REST or gRPC.
+  enum ApiType {
+    // Ideally this would be 'reserved 0' but one can't reserve the default
+    // value. Instead we throw an exception if this is ever used.
+    UNSUPPORTED_REST_LEGACY = 0 [deprecated = true];
+    // REST-JSON v2 API. The `canonical JSON encoding
+    // <https://developers.google.com/protocol-buffers/docs/proto3#json>`_ for
+    // the v2 protos is used.
+    REST = 1;
+    // gRPC v2 API.
+    GRPC = 2;
+    // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
+    // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
+    // with every update, the xDS server only sends what has changed since the last update.
+    //
+    // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
+    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    DELTA_GRPC = 3;
+  }
+  ApiType api_type = 1 [(validate.rules).enum.defined_only = true];
+  // Cluster names should be used only with REST. If > 1
+  // cluster is defined, clusters will be cycled through if any kind of failure
+  // occurs.
+  //
+  // .. note::
+  //
+  //  The cluster with name ``cluster_name`` must be statically defined and its
+  //  type must not be ``EDS``.
+  repeated string cluster_names = 2;
+
+  // Multiple gRPC services be provided for GRPC. If > 1 cluster is defined,
+  // services will be cycled through if any kind of failure occurs.
+  repeated GrpcService grpc_services = 4;
+
+  // For REST APIs, the delay between successive polls.
+  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+
+  // For REST APIs, the request timeout. If not set, a default value of 1s will be used.
+  google.protobuf.Duration request_timeout = 5
+      [(validate.rules).duration.gt.seconds = 0, (gogoproto.stdduration) = true];
+
+  // For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
+  // rate limited.
+  RateLimitSettings rate_limit_settings = 6;
+
+  // Skip the node identifier in subsequent discovery requests for streaming gRPC config types.
+  bool set_node_on_first_message_only = 7;
+}
+
+// Aggregated Discovery Service (ADS) options. This is currently empty, but when
+// set in :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` can be used to
+// specify that ADS is to be used.
+message AggregatedConfigSource {
+}
+
+// Rate Limit settings to be applied for discovery requests made by Envoy.
+message RateLimitSettings {
+  // Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a
+  // default value of 100 will be used.
+  google.protobuf.UInt32Value max_tokens = 1;
+
+  // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
+  // per second will be used.
+  google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double.gt = 0.0];
+}
+
+// Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters
+// <config_cluster_manager>`, :ref:`routes
+// <envoy_api_msg_RouteConfiguration>`, :ref:`endpoints
+// <arch_overview_service_discovery>` etc. may either be sourced from the
+// filesystem or from an xDS API source. Filesystem configs are watched with
+// inotify for updates.
+message ConfigSource {
+  oneof config_source_specifier {
+    option (validate.required) = true;
+    // Path on the filesystem to source and watch for configuration updates.
+    //
+    // .. note::
+    //
+    //  The path to the source must exist at config load time.
+    //
+    // .. note::
+    //
+    //   Envoy will only watch the file path for *moves.* This is because in general only moves
+    //   are atomic. The same method of swapping files as is demonstrated in the
+    //   :ref:`runtime documentation <config_runtime_symbolic_link_swap>` can be used here also.
+    string path = 1;
+    // API configuration source.
+    ApiConfigSource api_config_source = 2;
+    // When set, ADS will be used to fetch resources. The ADS API configuration
+    // source in the bootstrap configuration is used.
+    AggregatedConfigSource ads = 3;
+  }
+
+  // When this timeout is specified, Envoy will wait no longer than the specified time for first
+  // config response on this xDS subscription during the :ref:`initialization process
+  // <arch_overview_initialization>`. After reaching the timeout, Envoy will move to the next
+  // initialization phase, even if the first config is not delivered yet. The timer is activated
+  // when the xDS API subscription starts, and is disarmed on first config update or on error. 0
+  // means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
+  // timeout applies). The default is 15s.
+  google.protobuf.Duration initial_fetch_timeout = 4;
+}

--- a/api/envoy/api/v3alpha/core/grpc_service.proto
+++ b/api/envoy/api/v3alpha/core/grpc_service.proto
@@ -1,0 +1,173 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "GrpcServiceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/empty.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: gRPC services]
+
+// gRPC service configuration. This is used by :ref:`ApiConfigSource
+// <envoy_api_msg_core.ApiConfigSource>` and filter configurations.
+message GrpcService {
+  message EnvoyGrpc {
+    // The name of the upstream gRPC cluster. SSL credentials will be supplied
+    // in the :ref:`Cluster <envoy_api_msg_Cluster>` :ref:`tls_context
+    // <envoy_api_field_Cluster.tls_context>`.
+    string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+  }
+
+  // [#proto-status: draft]
+  message GoogleGrpc {
+    // The target URI when using the `Google C++ gRPC client
+    // <https://github.com/grpc/grpc>`_. SSL credentials will be supplied in
+    // :ref:`channel_credentials <envoy_api_field_core.GrpcService.GoogleGrpc.channel_credentials>`.
+    string target_uri = 1 [(validate.rules).string.min_bytes = 1];
+
+    // See https://grpc.io/grpc/cpp/structgrpc_1_1_ssl_credentials_options.html.
+    message SslCredentials {
+      // PEM encoded server root certificates.
+      DataSource root_certs = 1;
+
+      // PEM encoded client private key.
+      DataSource private_key = 2;
+
+      // PEM encoded client certificate chain.
+      DataSource cert_chain = 3;
+    }
+
+    // Local channel credentials. Only UDS is supported for now.
+    // See https://github.com/grpc/grpc/pull/15909.
+    message GoogleLocalCredentials {
+    }
+
+    // See https://grpc.io/docs/guides/auth.html#credential-types to understand Channel and Call
+    // credential types.
+    message ChannelCredentials {
+      oneof credential_specifier {
+        option (validate.required) = true;
+        SslCredentials ssl_credentials = 1;
+
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
+        google.protobuf.Empty google_default = 2;
+
+        GoogleLocalCredentials local_credentials = 3;
+      }
+    }
+
+    ChannelCredentials channel_credentials = 2;
+
+    message CallCredentials {
+      message ServiceAccountJWTAccessCredentials {
+        string json_key = 1;
+        uint64 token_lifetime_seconds = 2;
+      }
+
+      message GoogleIAMCredentials {
+        string authorization_token = 1;
+        string authority_selector = 2;
+      }
+
+      message MetadataCredentialsFromPlugin {
+        string name = 1;
+        oneof config_type {
+          google.protobuf.Struct config = 2;
+
+          google.protobuf.Any typed_config = 3;
+        }
+      }
+
+      oneof credential_specifier {
+        option (validate.required) = true;
+
+        // Access token credentials.
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#ad3a80da696ffdaea943f0f858d7a360d.
+        string access_token = 1;
+
+        // Google Compute Engine credentials.
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
+        google.protobuf.Empty google_compute_engine = 2;
+
+        // Google refresh token credentials.
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#a96901c997b91bc6513b08491e0dca37c.
+        string google_refresh_token = 3;
+
+        // Service Account JWT Access credentials.
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#a92a9f959d6102461f66ee973d8e9d3aa.
+        ServiceAccountJWTAccessCredentials service_account_jwt_access = 4;
+
+        // Google IAM credentials.
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#a9fc1fc101b41e680d47028166e76f9d0.
+        GoogleIAMCredentials google_iam = 5;
+
+        // Custom authenticator credentials.
+        // https://grpc.io/grpc/cpp/namespacegrpc.html#a823c6a4b19ffc71fb33e90154ee2ad07.
+        // https://grpc.io/docs/guides/auth.html#extending-grpc-to-support-other-authentication-mechanisms.
+        MetadataCredentialsFromPlugin from_plugin = 6;
+      }
+    }
+
+    // A set of call credentials that can be composed with `channel credentials
+    // <https://grpc.io/docs/guides/auth.html#credential-types>`_.
+    repeated CallCredentials call_credentials = 3;
+
+    // The human readable prefix to use when emitting statistics for the gRPC
+    // service.
+    //
+    // .. csv-table::
+    //    :header: Name, Type, Description
+    //    :widths: 1, 1, 2
+    //
+    //    streams_total, Counter, Total number of streams opened
+    //    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
+    string stat_prefix = 4 [(validate.rules).string.min_bytes = 1];
+
+    // The name of the Google gRPC credentials factory to use. This must have been registered with
+    // Envoy. If this is empty, a default credentials factory will be used that sets up channel
+    // credentials based on other configuration parameters.
+    string credentials_factory_name = 5;
+
+    // Additional configuration for site-specific customizations of the Google
+    // gRPC library.
+    google.protobuf.Struct config = 6;
+  }
+
+  oneof target_specifier {
+    option (validate.required) = true;
+
+    // Envoy's in-built gRPC client.
+    // See the :ref:`gRPC services overview <arch_overview_grpc_services>`
+    // documentation for discussion on gRPC client selection.
+    EnvoyGrpc envoy_grpc = 1;
+
+    // `Google C++ gRPC client <https://github.com/grpc/grpc>`_
+    // See the :ref:`gRPC services overview <arch_overview_grpc_services>`
+    // documentation for discussion on gRPC client selection.
+    GoogleGrpc google_grpc = 2;
+  }
+
+  // The timeout for the gRPC request. This is the timeout for a specific
+  // request.
+  google.protobuf.Duration timeout = 3;
+
+  // Field 4 reserved due to moving credentials inside the GoogleGrpc message
+  reserved 4;
+
+  // Additional metadata to include in streams initiated to the GrpcService.
+  // This can be used for scenarios in which additional ad hoc authorization
+  // headers (e.g. `x-foo-bar: baz-key`) are to be injected.
+  repeated HeaderValue initial_metadata = 5;
+}

--- a/api/envoy/api/v3alpha/core/health_check.proto
+++ b/api/envoy/api/v3alpha/core/health_check.proto
@@ -1,0 +1,271 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "HealthCheckProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/type/range.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Health check]
+// * Health checking :ref:`architecture overview <arch_overview_health_checking>`.
+// * If health checking is configured for a cluster, additional statistics are emitted. They are
+//   documented :ref:`here <config_cluster_manager_cluster_stats>`.
+
+message HealthCheck {
+  // The time to wait for a health check response. If the timeout is reached the
+  // health check attempt will be considered a failure.
+  google.protobuf.Duration timeout = 1 [
+    (validate.rules).duration = {
+      required: true,
+      gt: {seconds: 0}
+    },
+    (gogoproto.stdduration) = true
+  ];
+
+  // The interval between health checks.
+  google.protobuf.Duration interval = 2 [
+    (validate.rules).duration = {
+      required: true,
+      gt: {seconds: 0}
+    },
+    (gogoproto.stdduration) = true
+  ];
+
+  // An optional jitter amount in milliseconds. If specified, Envoy will start health
+  // checking after for a random time in ms between 0 and initial_jitter. This only
+  // applies to the first health check.
+  google.protobuf.Duration initial_jitter = 20;
+
+  // An optional jitter amount in milliseconds. If specified, during every
+  // interval Envoy will add interval_jitter to the wait time.
+  google.protobuf.Duration interval_jitter = 3;
+
+  // An optional jitter amount as a percentage of interval_ms. If specified,
+  // during every interval Envoy will add interval_ms *
+  // interval_jitter_percent / 100 to the wait time.
+  //
+  // If interval_jitter_ms and interval_jitter_percent are both set, both of
+  // them will be used to increase the wait time.
+  uint32 interval_jitter_percent = 18;
+
+  // The number of unhealthy health checks required before a host is marked
+  // unhealthy. Note that for *http* health checking if a host responds with 503
+  // this threshold is ignored and the host is considered unhealthy immediately.
+  google.protobuf.UInt32Value unhealthy_threshold = 4;
+
+  // The number of healthy health checks required before a host is marked
+  // healthy. Note that during startup, only a single successful health check is
+  // required to mark a host healthy.
+  google.protobuf.UInt32Value healthy_threshold = 5;
+
+  // [#not-implemented-hide:] Non-serving port for health checking.
+  google.protobuf.UInt32Value alt_port = 6;
+
+  // Reuse health check connection between health checks. Default is true.
+  google.protobuf.BoolValue reuse_connection = 7;
+
+  // Describes the encoding of the payload bytes in the payload.
+  message Payload {
+    oneof payload {
+      option (validate.required) = true;
+
+      // Hex encoded payload. E.g., "000000FF".
+      string text = 1 [(validate.rules).string.min_bytes = 1];
+
+      // [#not-implemented-hide:] Binary payload.
+      bytes binary = 2;
+    }
+  }
+
+  // [#comment:next free field: 10]
+  message HttpHealthCheck {
+    // The value of the host header in the HTTP health check request. If
+    // left empty (default value), the name of the cluster this health check is associated
+    // with will be used.
+    string host = 1;
+
+    // Specifies the HTTP path that will be requested during health checking. For example
+    // */healthcheck*.
+    string path = 2 [(validate.rules).string.min_bytes = 1];
+
+    // [#not-implemented-hide:] HTTP specific payload.
+    Payload send = 3;
+
+    // [#not-implemented-hide:] HTTP specific response.
+    Payload receive = 4;
+
+    // An optional service name parameter which is used to validate the identity of
+    // the health checked cluster. See the :ref:`architecture overview
+    // <arch_overview_health_checking_identity>` for more information.
+    string service_name = 5;
+
+    // Specifies a list of HTTP headers that should be added to each request that is sent to the
+    // health checked cluster. For more information, including details on header value syntax, see
+    // the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated core.HeaderValueOption request_headers_to_add = 6
+        [(validate.rules).repeated .max_items = 1000];
+
+    // Specifies a list of HTTP headers that should be removed from each request that is sent to the
+    // health checked cluster.
+    repeated string request_headers_to_remove = 8;
+
+    // If set, health checks will be made using http/2.
+    bool use_http2 = 7;
+
+    // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
+    // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open
+    // semantics of :ref:`Int64Range <envoy_api_msg_type.Int64Range>`.
+    repeated envoy.type.Int64Range expected_statuses = 9;
+  }
+
+  message TcpHealthCheck {
+    // Empty payloads imply a connect-only health check.
+    Payload send = 1;
+
+    // When checking the response, “fuzzy” matching is performed such that each
+    // binary block must be found, and in the order specified, but not
+    // necessarily contiguous.
+    repeated Payload receive = 2;
+  }
+
+  message RedisHealthCheck {
+    // If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
+    // from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other
+    // than 0 is considered a failure. This allows the user to mark a Redis instance for maintenance
+    // by setting the specified key to any value and waiting for traffic to drain.
+    string key = 1;
+  }
+
+  // `grpc.health.v1.Health
+  // <https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto>`_-based
+  // healthcheck. See `gRPC doc <https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`_
+  // for details.
+  message GrpcHealthCheck {
+    // An optional service name parameter which will be sent to gRPC service in
+    // `grpc.health.v1.HealthCheckRequest
+    // <https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto#L20>`_.
+    // message. See `gRPC health-checking overview
+    // <https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`_ for more information.
+    string service_name = 1;
+
+    // The value of the :authority header in the gRPC health check request. If
+    // left empty (default value), the name of the cluster this health check is associated
+    // with will be used.
+    string authority = 2;
+  }
+
+  // Custom health check.
+  message CustomHealthCheck {
+    // The registered name of the custom health checker.
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // A custom health checker specific configuration which depends on the custom health checker
+    // being instantiated. See :api:`envoy/config/health_checker` for reference.
+    oneof config_type {
+      google.protobuf.Struct config = 2;
+
+      google.protobuf.Any typed_config = 3;
+    }
+  }
+
+  oneof health_checker {
+    option (validate.required) = true;
+
+    // HTTP health check.
+    HttpHealthCheck http_health_check = 8;
+
+    // TCP health check.
+    TcpHealthCheck tcp_health_check = 9;
+
+    // gRPC health check.
+    GrpcHealthCheck grpc_health_check = 11;
+
+    // Custom health check.
+    CustomHealthCheck custom_health_check = 13;
+  }
+
+  reserved 10; // redis_health_check is deprecated by :ref:`custom_health_check
+               // <envoy_api_field_core.HealthCheck.custom_health_check>`
+  reserved "redis_health_check";
+
+  // The "no traffic interval" is a special health check interval that is used when a cluster has
+  // never had traffic routed to it. This lower interval allows cluster information to be kept up to
+  // date, without sending a potentially large amount of active health checking traffic for no
+  // reason. Once a cluster has been used for traffic routing, Envoy will shift back to using the
+  // standard health check interval that is defined. Note that this interval takes precedence over
+  // any other.
+  //
+  // The default value for "no traffic interval" is 60 seconds.
+  google.protobuf.Duration no_traffic_interval = 12 [(validate.rules).duration.gt = {}];
+
+  // The "unhealthy interval" is a health check interval that is used for hosts that are marked as
+  // unhealthy. As soon as the host is marked as healthy, Envoy will shift back to using the
+  // standard health check interval that is defined.
+  //
+  // The default value for "unhealthy interval" is the same as "interval".
+  google.protobuf.Duration unhealthy_interval = 14 [(validate.rules).duration.gt = {}];
+
+  // The "unhealthy edge interval" is a special health check interval that is used for the first
+  // health check right after a host is marked as unhealthy. For subsequent health checks
+  // Envoy will shift back to using either "unhealthy interval" if present or the standard health
+  // check interval that is defined.
+  //
+  // The default value for "unhealthy edge interval" is the same as "unhealthy interval".
+  google.protobuf.Duration unhealthy_edge_interval = 15 [(validate.rules).duration.gt = {}];
+
+  // The "healthy edge interval" is a special health check interval that is used for the first
+  // health check right after a host is marked as healthy. For subsequent health checks
+  // Envoy will shift back to using the standard health check interval that is defined.
+  //
+  // The default value for "healthy edge interval" is the same as the default interval.
+  google.protobuf.Duration healthy_edge_interval = 16 [(validate.rules).duration.gt = {}];
+
+  // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
+  // If empty, no event log will be written.
+  string event_log_path = 17;
+
+  // If set to true, health check failure events will always be logged. If set to false, only the
+  // initial health check failure event will be logged.
+  // The default value is false.
+  bool always_log_health_check_failures = 19;
+}
+
+// Endpoint health status.
+enum HealthStatus {
+  // The health status is not known. This is interpreted by Envoy as *HEALTHY*.
+  UNKNOWN = 0;
+
+  // Healthy.
+  HEALTHY = 1;
+
+  // Unhealthy.
+  UNHEALTHY = 2;
+
+  // Connection draining in progress. E.g.,
+  // `<https://aws.amazon.com/blogs/aws/elb-connection-draining-remove-instances-from-service-with-care/>`_
+  // or
+  // `<https://cloud.google.com/compute/docs/load-balancing/enabling-connection-draining>`_.
+  // This is interpreted by Envoy as *UNHEALTHY*.
+  DRAINING = 3;
+
+  // Health check timed out. This is part of HDS and is interpreted by Envoy as
+  // *UNHEALTHY*.
+  TIMEOUT = 4;
+
+  // Degraded.
+  DEGRADED = 5;
+}

--- a/api/envoy/api/v3alpha/core/http_uri.proto
+++ b/api/envoy/api/v3alpha/core/http_uri.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "HttpUriProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+
+import "google/protobuf/duration.proto";
+import "gogoproto/gogo.proto";
+
+import "validate/validate.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: HTTP Service URI ]
+
+// Envoy external URI descriptor
+message HttpUri {
+  // The HTTP server URI. It should be a full FQDN with protocol, host and path.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //    uri: https://www.googleapis.com/oauth2/v1/certs
+  //
+  string uri = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specify how `uri` is to be fetched. Today, this requires an explicit
+  // cluster, but in the future we may support dynamic cluster creation or
+  // inline DNS resolution. See `issue
+  // <https://github.com/envoyproxy/envoy/issues/1606>`_.
+  oneof http_upstream_type {
+    option (validate.required) = true;
+    // A cluster is created in the Envoy "cluster_manager" config
+    // section. This field specifies the cluster name.
+    //
+    // Example:
+    //
+    // .. code-block:: yaml
+    //
+    //    cluster: jwks_cluster
+    //
+    string cluster = 2 [(validate.rules).string.min_bytes = 1];
+  }
+
+  // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
+  google.protobuf.Duration timeout = 3 [
+    (validate.rules).duration.gte = {},
+    (validate.rules).duration.required = true,
+    (gogoproto.stdduration) = true
+  ];
+}

--- a/api/envoy/api/v3alpha/core/protocol.proto
+++ b/api/envoy/api/v3alpha/core/protocol.proto
@@ -1,0 +1,157 @@
+// [#protodoc-title: Protocol options]
+
+syntax = "proto3";
+
+package envoy.api.v3alpha.core;
+
+option java_outer_classname = "ProtocolProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Protocol options]
+
+// [#not-implemented-hide:]
+message TcpProtocolOptions {
+}
+
+message HttpProtocolOptions {
+  // The idle timeout for upstream connection pool connections. The idle timeout is defined as the
+  // period in which there are no active requests. If not set, there is no idle timeout. When the
+  // idle timeout is reached the connection will be closed. Note that request based timeouts mean
+  // that HTTP/2 PINGs will not keep the connection alive.
+  google.protobuf.Duration idle_timeout = 1 [(gogoproto.stdduration) = true];
+}
+
+message Http1ProtocolOptions {
+  // Handle HTTP requests with absolute URLs in the requests. These requests
+  // are generally sent by clients to forward/explicit proxies. This allows clients to configure
+  // envoy as their HTTP proxy. In Unix, for example, this is typically done by setting the
+  // *http_proxy* environment variable.
+  google.protobuf.BoolValue allow_absolute_url = 1;
+
+  // Handle incoming HTTP/1.0 and HTTP 0.9 requests.
+  // This is off by default, and not fully standards compliant. There is support for pre-HTTP/1.1
+  // style connect logic, dechunking, and handling lack of client host iff
+  // *default_host_for_http_10* is configured.
+  bool accept_http_10 = 2;
+
+  // A default host for HTTP/1.0 requests. This is highly suggested if *accept_http_10* is true as
+  // Envoy does not otherwise support HTTP/1.0 without a Host header.
+  // This is a no-op if *accept_http_10* is not true.
+  string default_host_for_http_10 = 3;
+}
+
+// [#comment:next free field: 13]
+message Http2ProtocolOptions {
+  // `Maximum table size <https://httpwg.org/specs/rfc7541.html#rfc.section.4.2>`_
+  // (in octets) that the encoder is permitted to use for the dynamic HPACK table. Valid values
+  // range from 0 to 4294967295 (2^32 - 1) and defaults to 4096. 0 effectively disables header
+  // compression.
+  google.protobuf.UInt32Value hpack_table_size = 1;
+
+  // `Maximum concurrent streams <https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
+  // allowed for peer on one HTTP/2 connection. Valid values range from 1 to 2147483647 (2^31 - 1)
+  // and defaults to 2147483647.
+  google.protobuf.UInt32Value max_concurrent_streams = 2
+      [(validate.rules).uint32 = {gte: 1, lte: 2147483647}];
+
+  // `Initial stream-level flow-control window
+  // <https://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
+  // (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum) and defaults to 268435456
+  // (256 * 1024 * 1024).
+  //
+  // NOTE: 65535 is the initial window size from HTTP/2 spec. We only support increasing the default
+  // window size now, so it's also the minimum.
+
+  // This field also acts as a soft limit on the number of bytes Envoy will buffer per-stream in the
+  // HTTP/2 codec buffers. Once the buffer reaches this pointer, watermark callbacks will fire to
+  // stop the flow of data to the codec buffers.
+  google.protobuf.UInt32Value initial_stream_window_size = 3
+      [(validate.rules).uint32 = {gte: 65535, lte: 2147483647}];
+
+  // Similar to *initial_stream_window_size*, but for connection-level flow-control
+  // window. Currently, this has the same minimum/maximum/default as *initial_stream_window_size*.
+  google.protobuf.UInt32Value initial_connection_window_size = 4
+      [(validate.rules).uint32 = {gte: 65535, lte: 2147483647}];
+
+  // Allows proxying Websocket and other upgrades over H2 connect.
+  bool allow_connect = 5;
+
+  // [#not-implemented-hide:] Hiding until envoy has full metadata support.
+  // Still under implementation. DO NOT USE.
+  //
+  // Allows metadata. See [metadata
+  // docs](https://github.com/envoyproxy/envoy/blob/master/source/docs/h2_metadata.md) for more
+  // information.
+  bool allow_metadata = 6;
+
+  // Limit the number of pending outbound downstream frames of all types (frames that are waiting to
+  // be written into the socket). Exceeding this limit triggers flood mitigation and connection is
+  // terminated. The ``http2.outbound_flood`` stat tracks the number of terminated connections due
+  // to flood mitigation. The default limit is 10000.
+  // [#comment:TODO: implement same limits for upstream outbound frames as well.]
+  google.protobuf.UInt32Value max_outbound_frames = 7 [(validate.rules).uint32 = {gte: 1}];
+
+  // Limit the number of pending outbound downstream frames of types PING, SETTINGS and RST_STREAM,
+  // preventing high memory utilization when receiving continuous stream of these frames. Exceeding
+  // this limit triggers flood mitigation and connection is terminated. The
+  // ``http2.outbound_control_flood`` stat tracks the number of terminated connections due to flood
+  // mitigation. The default limit is 1000.
+  // [#comment:TODO: implement same limits for upstream outbound frames as well.]
+  google.protobuf.UInt32Value max_outbound_control_frames = 8 [(validate.rules).uint32 = {gte: 1}];
+
+  // Limit the number of consecutive inbound frames of types HEADERS, CONTINUATION and DATA with an
+  // empty payload and no end stream flag. Those frames have no legitimate use and are abusive, but
+  // might be a result of a broken HTTP/2 implementation. The `http2.inbound_empty_frames_flood``
+  // stat tracks the number of connections terminated due to flood mitigation.
+  // Setting this to 0 will terminate connection upon receiving first frame with an empty payload
+  // and no end stream flag. The default limit is 1.
+  // [#comment:TODO: implement same limits for upstream inbound frames as well.]
+  google.protobuf.UInt32Value max_consecutive_inbound_frames_with_empty_payload = 9;
+
+  // Limit the number of inbound PRIORITY frames allowed per each opened stream. If the number
+  // of PRIORITY frames received over the lifetime of connection exceeds the value calculated
+  // using this formula::
+  //
+  //     max_inbound_priority_frames_per_stream * (1 + inbound_streams)
+  //
+  // the connection is terminated. The ``http2.inbound_priority_frames_flood`` stat tracks
+  // the number of connections terminated due to flood mitigation. The default limit is 100.
+  // [#comment:TODO: implement same limits for upstream inbound frames as well.]
+  google.protobuf.UInt32Value max_inbound_priority_frames_per_stream = 10;
+
+  // Limit the number of inbound WINDOW_UPDATE frames allowed per DATA frame sent. If the number
+  // of WINDOW_UPDATE frames received over the lifetime of connection exceeds the value calculated
+  // using this formula::
+  //
+  //     1 + 2 * (inbound_streams +
+  //              max_inbound_window_update_frames_per_data_frame_sent * outbound_data_frames)
+  //
+  // the connection is terminated. The ``http2.inbound_priority_frames_flood`` stat tracks
+  // the number of connections terminated due to flood mitigation. The default limit is 10.
+  // Setting this to 1 should be enough to support HTTP/2 implementations with basic flow control,
+  // but more complex implementations that try to estimate available bandwidth require at least 2.
+  // [#comment:TODO: implement same limits for upstream inbound frames as well.]
+  google.protobuf.UInt32Value max_inbound_window_update_frames_per_data_frame_sent = 11
+      [(validate.rules).uint32 = {gte: 1}];
+
+  // Allows invalid HTTP messaging and headers. When this option is disabled (default), then
+  // the whole HTTP/2 connection is terminated upon receiving invalid HEADERS frame. However,
+  // when this option is enabled, only the offending stream is terminated.
+  //
+  // See [RFC7540, sec. 8.1](https://tools.ietf.org/html/rfc7540#section-8.1) for details.
+  bool stream_error_on_invalid_http_messaging = 12;
+}
+
+// [#not-implemented-hide:]
+message GrpcProtocolOptions {
+  Http2ProtocolOptions http2_protocol_options = 1;
+}

--- a/api/envoy/api/v3alpha/discovery.proto
+++ b/api/envoy/api/v3alpha/discovery.proto
@@ -1,0 +1,230 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha;
+
+option java_outer_classname = "DiscoveryProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/any.proto";
+import "google/rpc/status.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: Common discovery API components]
+
+// A DiscoveryRequest requests a set of versioned resources of the same type for
+// a given Envoy node on some API.
+message DiscoveryRequest {
+  // The version_info provided in the request messages will be the version_info
+  // received with the most recent successfully processed response or empty on
+  // the first request. It is expected that no new request is sent after a
+  // response is received until the Envoy instance is ready to ACK/NACK the new
+  // configuration. ACK/NACK takes place by returning the new API config version
+  // as applied or the previous API config version respectively. Each type_url
+  // (see below) has an independent version associated with it.
+  string version_info = 1;
+
+  // The node making the request.
+  core.Node node = 2;
+
+  // List of resources to subscribe to, e.g. list of cluster names or a route
+  // configuration name. If this is empty, all resources for the API are
+  // returned. LDS/CDS may have empty resource_names, which will cause all
+  // resources for the Envoy instance to be returned. The LDS and CDS responses
+  // will then imply a number of resources that need to be fetched via EDS/RDS,
+  // which will be explicitly enumerated in resource_names.
+  repeated string resource_names = 3;
+
+  // Type of the resource that is being requested, e.g.
+  // "type.googleapis.com/envoy.api.v3alpha.ClusterLoadAssignment". This is implicit
+  // in requests made via singleton xDS APIs such as CDS, LDS, etc. but is
+  // required for ADS.
+  string type_url = 4;
+
+  // nonce corresponding to DiscoveryResponse being ACK/NACKed. See above
+  // discussion on version_info and the DiscoveryResponse nonce comment. This
+  // may be empty if no nonce is available, e.g. at startup or for non-stream
+  // xDS implementations.
+  string response_nonce = 5;
+
+  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+  // failed to update configuration. The *message* field in *error_details* provides the Envoy
+  // internal exception related to the failure. It is only intended for consumption during manual
+  // debugging, the string provided is not guaranteed to be stable across Envoy versions.
+  google.rpc.Status error_detail = 6;
+}
+
+message DiscoveryResponse {
+  // The version of the response data.
+  string version_info = 1;
+
+  // The response resources. These resources are typed and depend on the API being called.
+  repeated google.protobuf.Any resources = 2;
+
+  // [#not-implemented-hide:]
+  // Canary is used to support two Envoy command line flags:
+  //
+  // * --terminate-on-canary-transition-failure. When set, Envoy is able to
+  //   terminate if it detects that configuration is stuck at canary. Consider
+  //   this example sequence of updates:
+  //   - Management server applies a canary config successfully.
+  //   - Management server rolls back to a production config.
+  //   - Envoy rejects the new production config.
+  //   Since there is no sensible way to continue receiving configuration
+  //   updates, Envoy will then terminate and apply production config from a
+  //   clean slate.
+  // * --dry-run-canary. When set, a canary response will never be applied, only
+  //   validated via a dry run.
+  bool canary = 3;
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the 'resources' repeated Any (if non-empty).
+  string type_url = 4;
+
+  // For gRPC based subscriptions, the nonce provides a way to explicitly ack a
+  // specific DiscoveryResponse in a following DiscoveryRequest. Additional
+  // messages may have been sent by Envoy to the management server for the
+  // previous version on the stream prior to this DiscoveryResponse, that were
+  // unprocessed at response send time. The nonce allows the management server
+  // to ignore any further DiscoveryRequests for the previous version until a
+  // DiscoveryRequest bearing the nonce. The nonce is optional and is not
+  // required for non-stream based xDS implementations.
+  string nonce = 5;
+
+  // [#not-implemented-hide:]
+  // The control plane instance that sent the response.
+  core.ControlPlane control_plane = 6;
+}
+
+// DeltaDiscoveryRequest and DeltaDiscoveryResponse are used in a new gRPC
+// endpoint for Delta xDS.
+//
+// With Delta xDS, the DeltaDiscoveryResponses do not need to include a full
+// snapshot of the tracked resources. Instead, DeltaDiscoveryResponses are a
+// diff to the state of a xDS client.
+// In Delta XDS there are per-resource versions, which allow tracking state at
+// the resource granularity.
+// An xDS Delta session is always in the context of a gRPC bidirectional
+// stream. This allows the xDS server to keep track of the state of xDS clients
+// connected to it.
+//
+// In Delta xDS the nonce field is required and used to pair
+// DeltaDiscoveryResponse to a DeltaDiscoveryRequest ACK or NACK.
+// Optionally, a response message level system_version_info is present for
+// debugging purposes only.
+//
+// DeltaDiscoveryRequest plays two independent roles. Any DeltaDiscoveryRequest
+// can be either or both of: [1] informing the server of what resources the
+// client has gained/lost interest in (using resource_names_subscribe and
+// resource_names_unsubscribe), or [2] (N)ACKing an earlier resource update from
+// the server (using response_nonce, with presence of error_detail making it a NACK).
+// Additionally, the first message (for a given type_url) of a reconnected gRPC stream
+// has a third role: informing the server of the resources (and their versions)
+// that the client already possesses, using the initial_resource_versions field.
+//
+// As with state-of-the-world, when multiple resource types are multiplexed (ADS),
+// all requests/acknowledgments/updates are logically walled off by type_url:
+// a Cluster ACK exists in a completely separate world from a prior Route NACK.
+// In particular, initial_resource_versions being sent at the "start" of every
+// gRPC stream actually entails a message for each type_url, each with its own
+// initial_resource_versions.
+message DeltaDiscoveryRequest {
+  // The node making the request.
+  core.Node node = 1;
+
+  // Type of the resource that is being requested, e.g.
+  // "type.googleapis.com/envoy.api.v3alpha.ClusterLoadAssignment".
+  string type_url = 2;
+
+  // DeltaDiscoveryRequests allow the client to add or remove individual
+  // resources to the set of tracked resources in the context of a stream.
+  // All resource names in the resource_names_subscribe list are added to the
+  // set of tracked resources and all resource names in the resource_names_unsubscribe
+  // list are removed from the set of tracked resources.
+  //
+  // *Unlike* state-of-the-world xDS, an empty resource_names_subscribe or
+  // resource_names_unsubscribe list simply means that no resources are to be
+  // added or removed to the resource list.
+  // *Like* state-of-the-world xDS, the server must send updates for all tracked
+  // resources, but can also send updates for resources the client has not subscribed to.
+  //
+  // NOTE: the server must respond with all resources listed in resource_names_subscribe,
+  // even if it believes the client has the most recent version of them. The reason:
+  // the client may have dropped them, but then regained interest before it had a chance
+  // to send the unsubscribe message. See DeltaSubscriptionStateTest.RemoveThenAdd.
+  //
+  // These two fields can be set in any DeltaDiscoveryRequest, including ACKs
+  // and initial_resource_versions.
+  //
+  // A list of Resource names to add to the list of tracked resources.
+  repeated string resource_names_subscribe = 3;
+
+  // A list of Resource names to remove from the list of tracked resources.
+  repeated string resource_names_unsubscribe = 4;
+
+  // Informs the server of the versions of the resources the xDS client knows of, to enable the
+  // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
+  // It will not be populated: [1] in the very first stream of a session, since the client will
+  // not yet have any resources,  [2] in any message after the first in a stream (for a given
+  // type_url), since the server will already be correctly tracking the client's state.
+  // (In ADS, the first message *of each type_url* of a reconnected stream populates this map.)
+  // The map's keys are names of xDS resources known to the xDS client.
+  // The map's values are opaque resource versions.
+  map<string, string> initial_resource_versions = 5;
+
+  // When the DeltaDiscoveryRequest is a ACK or NACK message in response
+  // to a previous DeltaDiscoveryResponse, the response_nonce must be the
+  // nonce in the DeltaDiscoveryResponse.
+  // Otherwise response_nonce must be omitted.
+  string response_nonce = 6;
+
+  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+  // failed to update configuration. The *message* field in *error_details*
+  // provides the Envoy internal exception related to the failure.
+  google.rpc.Status error_detail = 7;
+}
+
+message DeltaDiscoveryResponse {
+  // The version of the response data (used for debugging).
+  string system_version_info = 1;
+
+  // The response resources. These are typed resources, whose types must match
+  // the type_url field.
+  repeated Resource resources = 2;
+
+  // field id 3 IS available!
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the Any within 'resources' if 'resources' is non-empty.
+  string type_url = 4;
+
+  // Resources names of resources that have be deleted and to be removed from the xDS Client.
+  // Removed resources for missing resources can be ignored.
+  repeated string removed_resources = 6;
+
+  // The nonce provides a way for DeltaDiscoveryRequests to uniquely
+  // reference a DeltaDiscoveryResponse when (N)ACKing. The nonce is required.
+  string nonce = 5;
+}
+
+message Resource {
+  // The resource's name, to distinguish it from others of the same type of resource.
+  string name = 3;
+
+  // [#not-implemented-hide:]
+  // The aliases are a list of other names that this resource can go by.
+  repeated string aliases = 4;
+
+  // The resource level version. It allows xDS to track the state of individual
+  // resources.
+  string version = 1;
+
+  // The resource being tracked.
+  google.protobuf.Any resource = 2;
+}

--- a/api/envoy/api/v3alpha/eds.proto
+++ b/api/envoy/api/v3alpha/eds.proto
@@ -1,0 +1,135 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha;
+
+option java_outer_classname = "EdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha";
+
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/discovery.proto";
+import "envoy/api/v3alpha/endpoint/endpoint.proto";
+import "envoy/type/percent.proto";
+
+import "google/api/annotations.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/duration.proto";
+
+option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: EDS]
+// Endpoint discovery :ref:`architecture overview <arch_overview_service_discovery_types_eds>`
+
+service EndpointDiscoveryService {
+  // The resource_names field in DiscoveryRequest specifies a list of clusters
+  // to subscribe to updates for.
+  rpc StreamEndpoints(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaEndpoints(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchEndpoints(DiscoveryRequest) returns (DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:endpoints"
+      body: "*"
+    };
+  }
+}
+
+// Each route from RDS will map to a single cluster or traffic split across
+// clusters using weights expressed in the RDS WeightedCluster.
+//
+// With EDS, each cluster is treated independently from a LB perspective, with
+// LB taking place between the Localities within a cluster and at a finer
+// granularity between the hosts within a locality. The percentage of traffic
+// for each endpoint is determined by both its load_balancing_weight, and the
+// load_balancing_weight of its locality. First, a locality will be selected,
+// then an endpoint within that locality will be chose based on its weight.
+message ClusterLoadAssignment {
+  // Name of the cluster. This will be the :ref:`service_name
+  // <envoy_api_field_Cluster.EdsClusterConfig.service_name>` value if specified
+  // in the cluster :ref:`EdsClusterConfig
+  // <envoy_api_msg_Cluster.EdsClusterConfig>`.
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // List of endpoints to load balance to.
+  repeated endpoint.LocalityLbEndpoints endpoints = 2;
+
+  // Map of named endpoints that can be referenced in LocalityLbEndpoints.
+  map<string, endpoint.Endpoint> named_endpoints = 5;
+
+  // Load balancing policy settings.
+  message Policy {
+    reserved 1;
+
+    message DropOverload {
+      // Identifier for the policy specifying the drop.
+      string category = 1 [(validate.rules).string.min_bytes = 1];
+
+      // Percentage of traffic that should be dropped for the category.
+      envoy.type.FractionalPercent drop_percentage = 2;
+    }
+    // Action to trim the overall incoming traffic to protect the upstream
+    // hosts. This action allows protection in case the hosts are unable to
+    // recover from an outage, or unable to autoscale or unable to handle
+    // incoming traffic volume for any reason.
+    //
+    // At the client each category is applied one after the other to generate
+    // the 'actual' drop percentage on all outgoing traffic. For example:
+    //
+    // .. code-block:: json
+    //
+    //  { "drop_overloads": [
+    //      { "category": "throttle", "drop_percentage": 60 }
+    //      { "category": "lb", "drop_percentage": 50 }
+    //  ]}
+    //
+    // The actual drop percentages applied to the traffic at the clients will be
+    //    "throttle"_drop = 60%
+    //    "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
+    //    actual_outgoing_load = 20% // remaining after applying all categories.
+    repeated DropOverload drop_overloads = 2;
+
+    // Priority levels and localities are considered overprovisioned with this
+    // factor (in percentage). This means that we don't consider a priority
+    // level or locality unhealthy until the percentage of healthy hosts
+    // multiplied by the overprovisioning factor drops below 100.
+    // With the default value 140(1.4), Envoy doesn't consider a priority level
+    // or a locality unhealthy until their percentage of healthy hosts drops
+    // below 72%. For example:
+    //
+    // .. code-block:: json
+    //
+    //  { "overprovisioning_factor": 100 }
+    //
+    // Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
+    // :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.
+    google.protobuf.UInt32Value overprovisioning_factor = 3 [(validate.rules).uint32.gt = 0];
+
+    // The max time until which the endpoints from this assignment can be used.
+    // If no new assignments are received before this time expires the endpoints
+    // are considered stale and should be marked unhealthy.
+    // Defaults to 0 which means endpoints never go stale.
+    google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration.gt.seconds = 0];
+
+    // The flag to disable overprovisioning. If it is set to true,
+    // :ref:`overprovisioning factor
+    // <arch_overview_load_balancing_overprovisioning_factor>` will be ignored
+    // and Envoy will not perform graceful failover between priority levels or
+    // localities as endpoints become unhealthy. Otherwise Envoy will perform
+    // graceful failover as :ref:`overprovisioning factor
+    // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
+    // [#next-major-version: Unify with overprovisioning config as a single message.]
+    // [#not-implemented-hide:]
+    bool disable_overprovisioning = 5;
+  }
+
+  // Load balancing policy settings.
+  Policy policy = 4;
+}

--- a/api/envoy/api/v3alpha/endpoint/BUILD
+++ b/api/envoy/api/v3alpha/endpoint/BUILD
@@ -1,0 +1,49 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "endpoint",
+    srcs = ["endpoint.proto"],
+    visibility = ["//envoy/api/v3alpha:friends"],
+    deps = [
+        "//envoy/api/v3alpha/auth:cert",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:config_source",
+        "//envoy/api/v3alpha/core:health_check",
+        "//envoy/api/v3alpha/core:protocol",
+    ],
+)
+
+api_go_proto_library(
+    name = "endpoint",
+    proto = ":endpoint",
+    deps = [
+        "//envoy/api/v3alpha/auth:cert_go_proto",
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:config_source_go_proto",
+        "//envoy/api/v3alpha/core:health_check_go_proto",
+        "//envoy/api/v3alpha/core:protocol_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "load_report",
+    srcs = ["load_report.proto"],
+    visibility = ["//envoy/api/v3alpha:friends"],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_go_proto_library(
+    name = "load_report",
+    proto = ":load_report",
+    deps = [
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)

--- a/api/envoy/api/v3alpha/endpoint/endpoint.proto
+++ b/api/envoy/api/v3alpha/endpoint/endpoint.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.endpoint;
+
+option java_outer_classname = "EndpointProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.endpoint";
+option go_package = "endpoint";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/health_check.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Endpoints]
+
+// Upstream host identifier.
+message Endpoint {
+  // The upstream host address.
+  //
+  // .. attention::
+  //
+  //   The form of host address depends on the given cluster type. For STATIC or EDS,
+  //   it is expected to be a direct IP address (or something resolvable by the
+  //   specified :ref:`resolver <envoy_api_field_core.SocketAddress.resolver_name>`
+  //   in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
+  //   and will be resolved via DNS.
+  core.Address address = 1;
+
+  // The optional health check configuration.
+  message HealthCheckConfig {
+    // Optional alternative health check port value.
+    //
+    // By default the health check address port of an upstream host is the same
+    // as the host's serving address port. This provides an alternative health
+    // check port. Setting this with a non-zero value allows an upstream host
+    // to have different health check address port.
+    uint32 port_value = 1 [(validate.rules).uint32.lte = 65535];
+  }
+
+  // The optional health check configuration is used as configuration for the
+  // health checker to contact the health checked host.
+  //
+  // .. attention::
+  //
+  //   This takes into effect only for upstream clusters with
+  //   :ref:`active health checking <arch_overview_health_checking>` enabled.
+  HealthCheckConfig health_check_config = 2;
+}
+
+// An Endpoint that Envoy can route traffic to.
+message LbEndpoint {
+  // Upstream host identifier or a named reference.
+  oneof host_identifier {
+    Endpoint endpoint = 1;
+    string endpoint_name = 5;
+  }
+
+  // Optional health status when known and supplied by EDS server.
+  core.HealthStatus health_status = 2;
+
+  // The endpoint metadata specifies values that may be used by the load
+  // balancer to select endpoints in a cluster for a given request. The filter
+  // name should be specified as *envoy.lb*. An example boolean key-value pair
+  // is *canary*, providing the optional canary status of the upstream host.
+  // This may be matched against in a route's
+  // :ref:`RouteAction <envoy_api_msg_route.RouteAction>` metadata_match field
+  // to subset the endpoints considered in cluster load balancing.
+  core.Metadata metadata = 3;
+
+  // The optional load balancing weight of the upstream host; at least 1.
+  // Envoy uses the load balancing weight in some of the built in load
+  // balancers. The load balancing weight for an endpoint is divided by the sum
+  // of the weights of all endpoints in the endpoint's locality to produce a
+  // percentage of traffic for the endpoint. This percentage is then further
+  // weighted by the endpoint's locality's load balancing weight from
+  // LocalityLbEndpoints. If unspecified, each host is presumed to have equal
+  // weight in a locality.
+  google.protobuf.UInt32Value load_balancing_weight = 4 [(validate.rules).uint32 = {gte: 1}];
+}
+
+// A group of endpoints belonging to a Locality.
+// One can have multiple LocalityLbEndpoints for a locality, but this is
+// generally only done if the different groups need to have different load
+// balancing weights or different priorities.
+message LocalityLbEndpoints {
+  // Identifies location of where the upstream hosts run.
+  core.Locality locality = 1;
+
+  // The group of endpoints belonging to the locality specified.
+  repeated LbEndpoint lb_endpoints = 2;
+
+  // Optional: Per priority/region/zone/sub_zone weight; at least 1. The load
+  // balancing weight for a locality is divided by the sum of the weights of all
+  // localities  at the same priority level to produce the effective percentage
+  // of traffic for the locality.
+  //
+  // Locality weights are only considered when :ref:`locality weighted load
+  // balancing <arch_overview_load_balancing_locality_weighted_lb>` is
+  // configured. These weights are ignored otherwise. If no weights are
+  // specified when locality weighted load balancing is enabled, the locality is
+  // assigned no load.
+  google.protobuf.UInt32Value load_balancing_weight = 3 [(validate.rules).uint32 = {gte: 1}];
+
+  // Optional: the priority for this LocalityLbEndpoints. If unspecified this will
+  // default to the highest priority (0).
+  //
+  // Under usual circumstances, Envoy will only select endpoints for the highest
+  // priority (0). In the event all endpoints for a particular priority are
+  // unavailable/unhealthy, Envoy will fail over to selecting endpoints for the
+  // next highest priority group.
+  //
+  // Priorities should range from 0 (highest) to N (lowest) without skipping.
+  uint32 priority = 5 [(validate.rules).uint32 = {lte: 128}];
+
+  // Optional: Per locality proximity value which indicates how close this
+  // locality is from the source locality. This value only provides ordering
+  // information (lower the value, closer it is to the source locality).
+  // This will be consumed by load balancing schemes that need proximity order
+  // to determine where to route the requests.
+  // [#not-implemented-hide:]
+  google.protobuf.UInt32Value proximity = 6;
+}

--- a/api/envoy/api/v3alpha/endpoint/load_report.proto
+++ b/api/envoy/api/v3alpha/endpoint/load_report.proto
@@ -1,0 +1,148 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.endpoint;
+
+option java_outer_classname = "LoadReportProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.endpoint";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// These are stats Envoy reports to GLB every so often. Report frequency is
+// defined by
+// :ref:`LoadStatsResponse.load_reporting_interval<envoy_api_field_load_stats.LoadStatsResponse.load_reporting_interval>`.
+// Stats per upstream region/zone and optionally per subzone.
+// [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+message UpstreamLocalityStats {
+  // Name of zone, region and optionally endpoint group these metrics were
+  // collected from. Zone and region names could be empty if unknown.
+  core.Locality locality = 1;
+
+  // The total number of requests successfully completed by the endpoints in the
+  // locality.
+  uint64 total_successful_requests = 2;
+
+  // The total number of unfinished requests
+  uint64 total_requests_in_progress = 3;
+
+  // The total number of requests that failed due to errors at the endpoint,
+  // aggregated over all endpoints in the locality.
+  uint64 total_error_requests = 4;
+
+  // The total number of requests that were issued by this Envoy since
+  // the last report. This information is aggregated over all the
+  // upstream endpoints in the locality.
+  uint64 total_issued_requests = 8;
+
+  // Stats for multi-dimensional load balancing.
+  repeated EndpointLoadMetricStats load_metric_stats = 5;
+
+  // Endpoint granularity stats information for this locality. This information
+  // is populated if the Server requests it by setting
+  // :ref:`LoadStatsResponse.report_endpoint_granularity<envoy_api_field_load_stats.LoadStatsResponse.report_endpoint_granularity>`.
+  repeated UpstreamEndpointStats upstream_endpoint_stats = 7;
+
+  // [#not-implemented-hide:] The priority of the endpoint group these metrics
+  // were collected from.
+  uint32 priority = 6;
+}
+
+message UpstreamEndpointStats {
+  // Upstream host address.
+  core.Address address = 1;
+
+  // Opaque and implementation dependent metadata of the
+  // endpoint. Envoy will pass this directly to the management server.
+  google.protobuf.Struct metadata = 6;
+
+  // The total number of requests successfully completed by the endpoints in the
+  // locality. These include non-5xx responses for HTTP, where errors
+  // originate at the client and the endpoint responded successfully. For gRPC,
+  // the grpc-status values are those not covered by total_error_requests below.
+  uint64 total_successful_requests = 2;
+
+  // The total number of unfinished requests for this endpoint.
+  uint64 total_requests_in_progress = 3;
+
+  // The total number of requests that failed due to errors at the endpoint.
+  // For HTTP these are responses with 5xx status codes and for gRPC the
+  // grpc-status values:
+  //
+  //   - DeadlineExceeded
+  //   - Unimplemented
+  //   - Internal
+  //   - Unavailable
+  //   - Unknown
+  //   - DataLoss
+  uint64 total_error_requests = 4;
+
+  // The total number of requests that were issued to this endpoint
+  // since the last report. A single TCP connection, HTTP or gRPC
+  // request or stream is counted as one request.
+  uint64 total_issued_requests = 7;
+
+  // Stats for multi-dimensional load balancing.
+  repeated EndpointLoadMetricStats load_metric_stats = 5;
+}
+
+// [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+message EndpointLoadMetricStats {
+  // Name of the metric; may be empty.
+  string metric_name = 1;
+
+  // Number of calls that finished and included this metric.
+  uint64 num_requests_finished_with_metric = 2;
+
+  // Sum of metric values across all calls that finished with this metric for
+  // load_reporting_interval.
+  double total_metric_value = 3;
+}
+
+// Per cluster load stats. Envoy reports these stats a management server in a
+// :ref:`LoadStatsRequest<envoy_api_msg_load_stats.LoadStatsRequest>`
+// [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+// Next ID: 7
+message ClusterStats {
+  // The name of the cluster.
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The eds_cluster_config service_name of the cluster.
+  // It's possible that two clusters send the same service_name to EDS,
+  // in that case, the management server is supposed to do aggregation on the load reports.
+  string cluster_service_name = 6;
+
+  // Need at least one.
+  repeated UpstreamLocalityStats upstream_locality_stats = 2
+      [(validate.rules).repeated .min_items = 1];
+
+  // Cluster-level stats such as total_successful_requests may be computed by
+  // summing upstream_locality_stats. In addition, below there are additional
+  // cluster-wide stats.
+  //
+  // The total number of dropped requests. This covers requests
+  // deliberately dropped by the drop_overload policy and circuit breaking.
+  uint64 total_dropped_requests = 3;
+
+  message DroppedRequests {
+    // Identifier for the policy specifying the drop.
+    string category = 1 [(validate.rules).string.min_bytes = 1];
+    // Total number of deliberately dropped requests for the category.
+    uint64 dropped_count = 2;
+  }
+  // Information about deliberately dropped requests for each category specified
+  // in the DropOverload policy.
+  repeated DroppedRequests dropped_requests = 5;
+
+  // Period over which the actual load report occurred. This will be guaranteed to include every
+  // request reported. Due to system load and delays between the *LoadStatsRequest* sent from Envoy
+  // and the *LoadStatsResponse* message sent from the management server, this may be longer than
+  // the requested load reporting interval in the *LoadStatsResponse*.
+  google.protobuf.Duration load_report_interval = 4;
+}

--- a/api/envoy/api/v3alpha/lds.proto
+++ b/api/envoy/api/v3alpha/lds.proto
@@ -1,0 +1,206 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha;
+
+option java_outer_classname = "LdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha";
+
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/discovery.proto";
+import "envoy/api/v3alpha/listener/listener.proto";
+import "envoy/api/v3alpha/listener/udp_listener_config.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Listener]
+// Listener :ref:`configuration overview <config_listeners>`
+
+// The Envoy instance initiates an RPC at startup to discover a list of
+// listeners. Updates are delivered via streaming from the LDS server and
+// consist of a complete update of all listeners. Existing connections will be
+// allowed to drain from listeners that are no longer present.
+service ListenerDiscoveryService {
+  rpc DeltaListeners(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+
+  rpc StreamListeners(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc FetchListeners(DiscoveryRequest) returns (DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:listeners"
+      body: "*"
+    };
+  }
+}
+
+// [#comment:next free field: 19]
+message Listener {
+  // The unique name by which this listener is known. If no name is provided,
+  // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
+  // updated or removed via :ref:`LDS <config_listeners_lds>` a unique name must be provided.
+  string name = 1;
+
+  // The address that the listener should listen on. In general, the address must be unique, though
+  // that is governed by the bind rules of the OS. E.g., multiple listeners can listen on port 0 on
+  // Linux as the actual port will be allocated by the OS.
+  core.Address address = 2 [(validate.rules).message.required = true];
+
+  // A list of filter chains to consider for this listener. The
+  // :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` with the most specific
+  // :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>` criteria is used on a
+  // connection.
+  //
+  // Example using SNI for filter chain selection can be found in the
+  // :ref:`FAQ entry <faq_how_to_setup_sni>`.
+  repeated listener.FilterChain filter_chains = 3;
+
+  // If a connection is redirected using *iptables*, the port on which the proxy
+  // receives it might be different from the original destination address. When this flag is set to
+  // true, the listener hands off redirected connections to the listener associated with the
+  // original destination address. If there is no listener associated with the original destination
+  // address, the connection is handled by the listener that receives it. Defaults to false.
+  //
+  // .. attention::
+  //
+  //   This field is deprecated. Use :ref:`an original_dst <config_listener_filters_original_dst>`
+  //   :ref:`listener filter <envoy_api_field_Listener.listener_filters>` instead.
+  //
+  //   Note that hand off to another listener is *NOT* performed without this flag. Once
+  //   :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>` is implemented this flag
+  //   will be removed, as filter chain matching can be used to select a filter chain based on the
+  //   restored destination address.
+  google.protobuf.BoolValue use_original_dst = 4 [deprecated = true];
+
+  // Soft limit on size of the listener’s new connection read and write buffers.
+  // If unspecified, an implementation defined default is applied (1MiB).
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
+
+  // Listener metadata.
+  core.Metadata metadata = 6;
+
+  // [#not-implemented-hide:]
+  message DeprecatedV1 {
+    // Whether the listener should bind to the port. A listener that doesn't
+    // bind can only receive connections redirected from other listeners that
+    // set use_original_dst parameter to true. Default is true.
+    //
+    // [V2-API-DIFF] This is deprecated in v2, all Listeners will bind to their
+    // port. An additional filter chain must be created for every original
+    // destination port this listener may redirect to in v2, with the original
+    // port specified in the FilterChainMatch destination_port field.
+    //
+    // [#comment:TODO(PiotrSikora): Remove this once verified that we no longer need it.]
+    google.protobuf.BoolValue bind_to_port = 1;
+  }
+
+  // [#not-implemented-hide:]
+  DeprecatedV1 deprecated_v1 = 7;
+
+  enum DrainType {
+    // Drain in response to calling /healthcheck/fail admin endpoint (along with the health check
+    // filter), listener removal/modification, and hot restart.
+    DEFAULT = 0;
+    // Drain in response to listener removal/modification and hot restart. This setting does not
+    // include /healthcheck/fail. This setting may be desirable if Envoy is hosting both ingress
+    // and egress listeners.
+    MODIFY_ONLY = 1;
+  }
+
+  // The type of draining to perform at a listener-wide level.
+  DrainType drain_type = 8;
+
+  // Listener filters have the opportunity to manipulate and augment the connection metadata that
+  // is used in connection filter chain matching, for example. These filters are run before any in
+  // :ref:`filter_chains <envoy_api_field_Listener.filter_chains>`. Order matters as the
+  // filters are processed sequentially right after a socket has been accepted by the listener, and
+  // before a connection is created.
+  // UDP Listener filters can be specified when the protocol in the listener socket address in
+  // :ref:`protocol <envoy_api_field_core.SocketAddress.protocol>` is :ref:'UDP
+  // <envoy_api_field_core.Protocol.UDP>`.
+  // UDP listeners currently support a single filter.
+  repeated listener.ListenerFilter listener_filters = 9;
+
+  // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
+  // the accepted socket is closed without a connection being created unless
+  // `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
+  // timeout. If not specified, a default timeout of 15s is used.
+  google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
+
+  // Whether a connection should be created when listener filters timeout. Default is false.
+  //
+  // .. attention::
+  //
+  //   Some listener filters, such as :ref:`Proxy Protocol filter
+  //   <config_listener_filters_proxy_protocol>`, should not be used with this option. It will cause
+  //   unexpected behavior when a connection is created.
+  bool continue_on_listener_filters_timeout = 17;
+
+  // Whether the listener should be set as a transparent socket.
+  // When this flag is set to true, connections can be redirected to the listener using an
+  // *iptables* *TPROXY* target, in which case the original source and destination addresses and
+  // ports are preserved on accepted connections. This flag should be used in combination with
+  // :ref:`an original_dst <config_listener_filters_original_dst>` :ref:`listener filter
+  // <envoy_api_field_Listener.listener_filters>` to mark the connections' local addresses as
+  // "restored." This can be used to hand off each redirected connection to another listener
+  // associated with the connection's destination address. Direct connections to the socket without
+  // using *TPROXY* cannot be distinguished from connections redirected using *TPROXY* and are
+  // therefore treated as if they were redirected.
+  // When this flag is set to false, the listener's socket is explicitly reset as non-transparent.
+  // Setting this flag requires Envoy to run with the *CAP_NET_ADMIN* capability.
+  // When this flag is not set (default), the socket is not modified, i.e. the transparent option
+  // is neither set nor reset.
+  google.protobuf.BoolValue transparent = 10;
+
+  // Whether the listener should set the *IP_FREEBIND* socket option. When this
+  // flag is set to true, listeners can be bound to an IP address that is not
+  // configured on the system running Envoy. When this flag is set to false, the
+  // option *IP_FREEBIND* is disabled on the socket. When this flag is not set
+  // (default), the socket is not modified, i.e. the option is neither enabled
+  // nor disabled.
+  google.protobuf.BoolValue freebind = 11;
+
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries.
+  repeated core.SocketOption socket_options = 13;
+
+  // Whether the listener should accept TCP Fast Open (TFO) connections.
+  // When this flag is set to a value greater than 0, the option TCP_FASTOPEN is enabled on
+  // the socket, with a queue length of the specified size
+  // (see `details in RFC7413 <https://tools.ietf.org/html/rfc7413#section-5.1>`_).
+  // When this flag is set to 0, the option TCP_FASTOPEN is disabled on the socket.
+  // When this flag is not set (default), the socket is not modified,
+  // i.e. the option is neither enabled nor disabled.
+  //
+  // On Linux, the net.ipv4.tcp_fastopen kernel parameter must include flag 0x2 to enable
+  // TCP_FASTOPEN.
+  // See `ip-sysctl.txt <https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt>`_.
+  //
+  // On macOS, only values of 0, 1, and unset are valid; other values may result in an error.
+  // To set the queue length on macOS, set the net.inet.tcp.fastopen_backlog kernel parameter.
+  google.protobuf.UInt32Value tcp_fast_open_queue_length = 12;
+
+  reserved 14;
+
+  // Specifies the intended direction of the traffic relative to the local Envoy.
+  core.TrafficDirection traffic_direction = 16;
+
+  // If the protocol in the listener socket address in :ref:`protocol
+  // <envoy_api_field_core.SocketAddress.protocol>` is :ref:'UDP
+  // <envoy_api_field_core.Protocol.UDP>`, this field specifies the actual udp listener to create,
+  // i.e. :ref:`udp_listener_name
+  // <envoy_api_field_listener.UdpListenerConfig.udp_listener_name>` = "raw_udp_listener" for
+  // creating a packet-oriented UDP listener. If not present, treat it as "raw_udp_listener".
+  listener.UdpListenerConfig udp_listener_config = 18;
+}

--- a/api/envoy/api/v3alpha/listener/BUILD
+++ b/api/envoy/api/v3alpha/listener/BUILD
@@ -1,0 +1,41 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "listener",
+    srcs = ["listener.proto"],
+    visibility = ["//envoy/api/v3alpha:friends"],
+    deps = [
+        "//envoy/api/v3alpha/auth:cert",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_go_proto_library(
+    name = "listener",
+    proto = ":listener",
+    deps = [
+        "//envoy/api/v3alpha/auth:cert_go_proto",
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "udp_listener_config",
+    srcs = ["udp_listener_config.proto"],
+    visibility = ["//envoy/api/v3alpha:friends"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_go_proto_library(
+    name = "udp_listener_config",
+    proto = ":udp_listener_config",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)

--- a/api/envoy/api/v3alpha/listener/listener.proto
+++ b/api/envoy/api/v3alpha/listener/listener.proto
@@ -1,0 +1,210 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.listener;
+
+option java_outer_classname = "ListenerProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.listener";
+option go_package = "listener";
+option csharp_namespace = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/auth/cert.proto";
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Listener components]
+// Listener :ref:`configuration overview <config_listeners>`
+
+message Filter {
+  // The name of the filter to instantiate. The name must match a
+  // :ref:`supported filter <config_network_filters>`.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Filter specific configuration which depends on the filter being
+  // instantiated. See the supported filters for further documentation.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 4;
+  }
+
+  reserved 3;
+}
+
+// Specifies the match criteria for selecting a specific filter chain for a
+// listener.
+//
+// In order for a filter chain to be selected, *ALL* of its criteria must be
+// fulfilled by the incoming connection, properties of which are set by the
+// networking stack and/or listener filters.
+//
+// The following order applies:
+//
+// 1. Destination port.
+// 2. Destination IP address.
+// 3. Server name (e.g. SNI for TLS protocol),
+// 4. Transport protocol.
+// 5. Application protocols (e.g. ALPN for TLS protocol).
+// 6. Source type (e.g. any, local or external network).
+// 7. Source IP address.
+// 8. Source port.
+//
+// For criteria that allow ranges or wildcards, the most specific value in any
+// of the configured filter chains that matches the incoming connection is going
+// to be used (e.g. for SNI ``www.example.com`` the most specific match would be
+// ``www.example.com``, then ``*.example.com``, then ``*.com``, then any filter
+// chain without ``server_names`` requirements).
+//
+// [#comment: Implemented rules are kept in the preference order, with deprecated fields
+// listed at the end, because that's how we want to list them in the docs.
+//
+// [#comment:TODO(PiotrSikora): Add support for configurable precedence of the rules]
+message FilterChainMatch {
+  // Optional destination port to consider when use_original_dst is set on the
+  // listener in determining a filter chain match.
+  google.protobuf.UInt32Value destination_port = 8 [(validate.rules).uint32 = {gte: 1, lte: 65535}];
+
+  // If non-empty, an IP address and prefix length to match addresses when the
+  // listener is bound to 0.0.0.0/:: or when use_original_dst is specified.
+  repeated core.CidrRange prefix_ranges = 3;
+
+  // If non-empty, an IP address and suffix length to match addresses when the
+  // listener is bound to 0.0.0.0/:: or when use_original_dst is specified.
+  // [#not-implemented-hide:]
+  string address_suffix = 4;
+
+  // [#not-implemented-hide:]
+  google.protobuf.UInt32Value suffix_len = 5;
+
+  enum ConnectionSourceType {
+    // Any connection source matches.
+    ANY = 0;
+    // Match a connection originating from the same host.
+    LOCAL = 1;
+    // Match a connection originating from a different host.
+    EXTERNAL = 2;
+  }
+
+  // Specifies the connection source IP match type. Can be any, local or external network.
+  ConnectionSourceType source_type = 12 [(validate.rules).enum.defined_only = true];
+
+  // The criteria is satisfied if the source IP address of the downstream
+  // connection is contained in at least one of the specified subnets. If the
+  // parameter is not specified or the list is empty, the source IP address is
+  // ignored.
+  repeated core.CidrRange source_prefix_ranges = 6;
+
+  // The criteria is satisfied if the source port of the downstream connection
+  // is contained in at least one of the specified ports. If the parameter is
+  // not specified, the source port is ignored.
+  repeated uint32 source_ports = 7 [(validate.rules).repeated .items.uint32 = {gte: 1, lte: 65535}];
+
+  // If non-empty, a list of server names (e.g. SNI for TLS protocol) to consider when determining
+  // a filter chain match. Those values will be compared against the server names of a new
+  // connection, when detected by one of the listener filters.
+  //
+  // The server name will be matched against all wildcard domains, i.e. ``www.example.com``
+  // will be first matched against ``www.example.com``, then ``*.example.com``, then ``*.com``.
+  //
+  // Note that partial wildcards are not supported, and values like ``*w.example.com`` are invalid.
+  //
+  // .. attention::
+  //
+  //   See the :ref:`FAQ entry <faq_how_to_setup_sni>` on how to configure SNI for more
+  //   information.
+  repeated string server_names = 11;
+
+  // If non-empty, a transport protocol to consider when determining a filter chain match.
+  // This value will be compared against the transport protocol of a new connection, when
+  // it's detected by one of the listener filters.
+  //
+  // Suggested values include:
+  //
+  // * ``raw_buffer`` - default, used when no transport protocol is detected,
+  // * ``tls`` - set by :ref:`envoy.listener.tls_inspector <config_listener_filters_tls_inspector>`
+  //   when TLS protocol is detected.
+  string transport_protocol = 9;
+
+  // If non-empty, a list of application protocols (e.g. ALPN for TLS protocol) to consider when
+  // determining a filter chain match. Those values will be compared against the application
+  // protocols of a new connection, when detected by one of the listener filters.
+  //
+  // Suggested values include:
+  //
+  // * ``http/1.1`` - set by :ref:`envoy.listener.tls_inspector
+  //   <config_listener_filters_tls_inspector>`,
+  // * ``h2`` - set by :ref:`envoy.listener.tls_inspector <config_listener_filters_tls_inspector>`
+  //
+  // .. attention::
+  //
+  //   Currently, only :ref:`TLS Inspector <config_listener_filters_tls_inspector>` provides
+  //   application protocol detection based on the requested
+  //   `ALPN <https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation>`_ values.
+  //
+  //   However, the use of ALPN is pretty much limited to the HTTP/2 traffic on the Internet,
+  //   and matching on values other than ``h2`` is going to lead to a lot of false negatives,
+  //   unless all connecting clients are known to use ALPN.
+  repeated string application_protocols = 10;
+
+  reserved 1;
+  reserved "sni_domains";
+}
+
+// A filter chain wraps a set of match criteria, an option TLS context, a set of filters, and
+// various other parameters.
+message FilterChain {
+  // The criteria to use when matching a connection to this filter chain.
+  FilterChainMatch filter_chain_match = 1;
+
+  // The TLS context for this filter chain.
+  auth.DownstreamTlsContext tls_context = 2;
+
+  // A list of individual network filters that make up the filter chain for
+  // connections established with the listener. Order matters as the filters are
+  // processed sequentially as connection events happen. Note: If the filter
+  // list is empty, the connection will close by default.
+  repeated Filter filters = 3;
+
+  // Whether the listener should expect a PROXY protocol V1 header on new
+  // connections. If this option is enabled, the listener will assume that that
+  // remote address of the connection is the one specified in the header. Some
+  // load balancers including the AWS ELB support this option. If the option is
+  // absent or set to false, Envoy will use the physical peer address of the
+  // connection as the remote address.
+  google.protobuf.BoolValue use_proxy_proto = 4;
+
+  // [#not-implemented-hide:] filter chain metadata.
+  core.Metadata metadata = 5;
+
+  // See :ref:`base.TransportSocket<envoy_api_msg_core.TransportSocket>` description.
+  core.TransportSocket transport_socket = 6;
+
+  // [#not-implemented-hide:] The unique name (or empty) by which this filter chain is known. If no
+  // name is provided, Envoy will allocate an internal UUID for the filter chain. If the filter
+  // chain is to be dynamically updated or removed via FCDS a unique name must be provided.
+  string name = 7;
+}
+
+message ListenerFilter {
+  // The name of the filter to instantiate. The name must match a
+  // :ref:`supported filter <config_listener_filters>`.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Filter specific configuration which depends on the filter being instantiated.
+  // See the supported filters for further documentation.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}

--- a/api/envoy/api/v3alpha/listener/udp_listener_config.proto
+++ b/api/envoy/api/v3alpha/listener/udp_listener_config.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.listener;
+
+option java_outer_classname = "UdpListenerConfigProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.listener";
+option go_package = "listener";
+option csharp_namespace = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
+
+// [#protodoc-title: Udp Listener Config]
+// Listener :ref:`configuration overview <config_listeners>`
+
+message UdpListenerConfig {
+  // Used to look up UDP listener factory, matches "raw_udp_listener" or
+  // "quic_listener" to create a specific udp listener.
+  // If not specified, treat as "raw_udp_listener".
+  string udp_listener_name = 1;
+
+  // Used to create a specific listener factory. To some factory, e.g.
+  // "raw_udp_listener", config is not needed.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}

--- a/api/envoy/api/v3alpha/ratelimit/BUILD
+++ b/api/envoy/api/v3alpha/ratelimit/BUILD
@@ -1,0 +1,14 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "ratelimit",
+    srcs = ["ratelimit.proto"],
+    visibility = ["//envoy/api/v3alpha:friends"],
+)
+
+api_go_proto_library(
+    name = "ratelimit",
+    proto = ":ratelimit",
+)

--- a/api/envoy/api/v3alpha/ratelimit/ratelimit.proto
+++ b/api/envoy/api/v3alpha/ratelimit/ratelimit.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.ratelimit;
+
+option java_outer_classname = "RatelimitProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.ratelimit";
+option go_package = "ratelimit";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Common rate limit components]
+
+// A RateLimitDescriptor is a list of hierarchical entries that are used by the service to
+// determine the final rate limit key and overall allowed limit. Here are some examples of how
+// they might be used for the domain "envoy".
+//
+// .. code-block:: cpp
+//
+//   ["authenticated": "false"], ["remote_address": "10.0.0.1"]
+//
+// What it does: Limits all unauthenticated traffic for the IP address 10.0.0.1. The
+// configuration supplies a default limit for the *remote_address* key. If there is a desire to
+// raise the limit for 10.0.0.1 or block it entirely it can be specified directly in the
+// configuration.
+//
+// .. code-block:: cpp
+//
+//   ["authenticated": "false"], ["path": "/foo/bar"]
+//
+// What it does: Limits all unauthenticated traffic globally for a specific path (or prefix if
+// configured that way in the service).
+//
+// .. code-block:: cpp
+//
+//   ["authenticated": "false"], ["path": "/foo/bar"], ["remote_address": "10.0.0.1"]
+//
+// What it does: Limits unauthenticated traffic to a specific path for a specific IP address.
+// Like (1) we can raise/block specific IP addresses if we want with an override configuration.
+//
+// .. code-block:: cpp
+//
+//   ["authenticated": "true"], ["client_id": "foo"]
+//
+// What it does: Limits all traffic for an authenticated client "foo"
+//
+// .. code-block:: cpp
+//
+//   ["authenticated": "true"], ["client_id": "foo"], ["path": "/foo/bar"]
+//
+// What it does: Limits traffic to a specific path for an authenticated client "foo"
+//
+// The idea behind the API is that (1)/(2)/(3) and (4)/(5) can be sent in 1 request if desired.
+// This enables building complex application scenarios with a generic backend.
+message RateLimitDescriptor {
+  message Entry {
+    // Descriptor key.
+    string key = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Descriptor value.
+    string value = 2 [(validate.rules).string.min_bytes = 1];
+  }
+
+  // Descriptor entries.
+  repeated Entry entries = 1 [(validate.rules).repeated .min_items = 1];
+}

--- a/api/envoy/api/v3alpha/rds.proto
+++ b/api/envoy/api/v3alpha/rds.proto
@@ -1,0 +1,135 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha;
+
+option java_outer_classname = "RdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha";
+
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/config_source.proto";
+import "envoy/api/v3alpha/discovery.proto";
+import "envoy/api/v3alpha/route/route.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: HTTP route configuration]
+// * Routing :ref:`architecture overview <arch_overview_http_routing>`
+// * HTTP :ref:`router filter <config_http_filters_router>`
+
+// The resource_names field in DiscoveryRequest specifies a route configuration.
+// This allows an Envoy configuration with multiple HTTP listeners (and
+// associated HTTP connection manager filters) to use different route
+// configurations. Each listener will bind its HTTP connection manager filter to
+// a route table via this identifier.
+service RouteDiscoveryService {
+  rpc StreamRoutes(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaRoutes(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchRoutes(DiscoveryRequest) returns (DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:routes"
+      body: "*"
+    };
+  }
+}
+
+// Virtual Host Discovery Service (VHDS) is used to dynamically update the list of virtual hosts for
+// a given RouteConfiguration. If VHDS is configured a virtual host list update will be triggered
+// during the processing of an HTTP request if a route for the request cannot be resolved. The
+// :ref:`resource_names_subscribe <envoy_api_msg_DeltaDiscoveryRequest.resource_names_subscribe>`
+// field contains a list of virtual host names or aliases to track. The contents of an alias would
+// be the contents of a *host* or *authority* header used to make an http request. An xDS server
+// will match an alias to a virtual host based on the content of :ref:`domains'
+// <envoy_api_msg_route.VirtualHost.domains>` field. The *resource_names_unsubscribe* field contains
+// a list of virtual host names that have been :ref:`unsubscribed <xds_protocol_unsubscribe>`
+// from the routing table associated with the RouteConfiguration.
+service VirtualHostDiscoveryService {
+  rpc DeltaVirtualHosts(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+}
+
+// [#comment:next free field: 10]
+message RouteConfiguration {
+  // The name of the route configuration. For example, it might match
+  // :ref:`route_config_name
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.Rds.route_config_name>`
+  // in :ref:`envoy_api_msg_config.filter.network.http_connection_manager.v3alpha.Rds`.
+  string name = 1;
+
+  // An array of virtual hosts that make up the route table.
+  repeated route.VirtualHost virtual_hosts = 2;
+
+  // An array of virtual hosts will be dynamically loaded via the VHDS API.
+  // Both *virtual_hosts* and *vhds* fields will be used when present. *virtual_hosts* can be used
+  // for a base routing table or for infrequently changing virtual hosts. *vhds* is used for
+  // on-demand discovery of virtual hosts. The contents of these two fields will be merged to
+  // generate a routing table for a given RouteConfiguration, with *vhds* derived configuration
+  // taking precedence.
+  // [#not-implemented-hide:]
+  Vhds vhds = 9;
+
+  // Optionally specifies a list of HTTP headers that the connection manager
+  // will consider to be internal only. If they are found on external requests they will be cleaned
+  // prior to filter invocation. See :ref:`config_http_conn_man_headers_x-envoy-internal` for more
+  // information.
+  repeated string internal_only_headers = 3;
+
+  // Specifies a list of HTTP headers that should be added to each response that
+  // the connection manager encodes. Headers specified at this level are applied
+  // after headers from any enclosed :ref:`envoy_api_msg_route.VirtualHost` or
+  // :ref:`envoy_api_msg_route.RouteAction`. For more information, including details on
+  // header value syntax, see the documentation on :ref:`custom request headers
+  // <config_http_conn_man_headers_custom_request_headers>`.
+  repeated core.HeaderValueOption response_headers_to_add = 4
+      [(validate.rules).repeated .max_items = 1000];
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // that the connection manager encodes.
+  repeated string response_headers_to_remove = 5;
+
+  // Specifies a list of HTTP headers that should be added to each request
+  // routed by the HTTP connection manager. Headers specified at this level are
+  // applied after headers from any enclosed :ref:`envoy_api_msg_route.VirtualHost` or
+  // :ref:`envoy_api_msg_route.RouteAction`. For more information, including details on
+  // header value syntax, see the documentation on :ref:`custom request headers
+  // <config_http_conn_man_headers_custom_request_headers>`.
+  repeated core.HeaderValueOption request_headers_to_add = 6
+      [(validate.rules).repeated .max_items = 1000];
+
+  // Specifies a list of HTTP headers that should be removed from each request
+  // routed by the HTTP connection manager.
+  repeated string request_headers_to_remove = 8;
+
+  // An optional boolean that specifies whether the clusters that the route
+  // table refers to will be validated by the cluster manager. If set to true
+  // and a route refers to a non-existent cluster, the route table will not
+  // load. If set to false and a route refers to a non-existent cluster, the
+  // route table will load and the router filter will return a 404 if the route
+  // is selected at runtime. This setting defaults to true if the route table
+  // is statically defined via the :ref:`route_config
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.route_config>`
+  // option. This setting default to false if the route table is loaded dynamically via the
+  // :ref:`rds
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.rds>`
+  // option. Users may wish to override the default behavior in certain cases (for example when
+  // using CDS with a static route table).
+  google.protobuf.BoolValue validate_clusters = 7;
+}
+
+// [#not-implemented-hide:]
+message Vhds {
+  // Configuration source specifier for VHDS.
+  envoy.api.v3alpha.core.ConfigSource config_source = 1 [(validate.rules).message.required = true];
+}

--- a/api/envoy/api/v3alpha/route/BUILD
+++ b/api/envoy/api/v3alpha/route/BUILD
@@ -1,0 +1,28 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "route",
+    srcs = ["route.proto"],
+    visibility = ["//envoy/api/v3alpha:friends"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/type:percent",
+        "//envoy/type:range",
+        "//envoy/type/matcher:regex",
+        "//envoy/type/matcher:string",
+    ],
+)
+
+api_go_proto_library(
+    name = "route",
+    proto = ":route",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/type:percent_go_proto",
+        "//envoy/type:range_go_proto",
+        "//envoy/type/matcher:regex_go_proto",
+        "//envoy/type/matcher:string_go_proto",
+    ],
+)

--- a/api/envoy/api/v3alpha/route/route.proto
+++ b/api/envoy/api/v3alpha/route/route.proto
@@ -1,0 +1,1404 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha.route;
+
+option java_outer_classname = "RouteProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.api.v3alpha.route";
+option go_package = "route";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/type/matcher/regex.proto";
+import "envoy/type/matcher/string.proto";
+import "envoy/type/percent.proto";
+import "envoy/type/range.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: HTTP route]
+// * Routing :ref:`architecture overview <arch_overview_http_routing>`
+// * HTTP :ref:`router filter <config_http_filters_router>`
+
+// The top level element in the routing configuration is a virtual host. Each virtual host has
+// a logical name as well as a set of domains that get routed to it based on the incoming request's
+// host header. This allows a single listener to service multiple top level domain path trees. Once
+// a virtual host is selected based on the domain, the routes are processed in order to see which
+// upstream cluster to route to or whether to perform a redirect.
+// [#comment:next free field: 17]
+message VirtualHost {
+  // The logical name of the virtual host. This is used when emitting certain
+  // statistics but is not relevant for routing.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // A list of domains (host/authority header) that will be matched to this
+  // virtual host. Wildcard hosts are supported in the suffix or prefix form.
+  //
+  // Domain search order:
+  //  1. Exact domain names: ``www.foo.com``.
+  //  2. Suffix domain wildcards: ``*.foo.com`` or ``*-bar.foo.com``.
+  //  3. Prefix domain wildcards: ``foo.*`` or ``foo-*``.
+  //  4. Special wildcard ``*`` matching any domain.
+  //
+  // .. note::
+  //
+  //   The wildcard will not match the empty string.
+  //   e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``.
+  //   The longest wildcards match first.
+  //   Only a single virtual host in the entire route configuration can match on ``*``. A domain
+  //   must be unique across all virtual hosts or the config will fail to load.
+  repeated string domains = 2 [(validate.rules).repeated .min_items = 1];
+
+  // The list of routes that will be matched, in order, for incoming requests.
+  // The first route that matches will be used.
+  repeated Route routes = 3;
+
+  enum TlsRequirementType {
+    // No TLS requirement for the virtual host.
+    NONE = 0;
+
+    // External requests must use TLS. If a request is external and it is not
+    // using TLS, a 301 redirect will be sent telling the client to use HTTPS.
+    EXTERNAL_ONLY = 1;
+
+    // All requests must use TLS. If a request is not using TLS, a 301 redirect
+    // will be sent telling the client to use HTTPS.
+    ALL = 2;
+  }
+
+  // Specifies the type of TLS enforcement the virtual host expects. If this option is not
+  // specified, there is no TLS requirement for the virtual host.
+  TlsRequirementType require_tls = 4;
+
+  // A list of virtual clusters defined for this virtual host. Virtual clusters
+  // are used for additional statistics gathering.
+  repeated VirtualCluster virtual_clusters = 5;
+
+  // Specifies a set of rate limit configurations that will be applied to the
+  // virtual host.
+  repeated RateLimit rate_limits = 6;
+
+  // Specifies a list of HTTP headers that should be added to each request
+  // handled by this virtual host. Headers specified at this level are applied
+  // after headers from enclosed :ref:`envoy_api_msg_route.Route` and before headers from the
+  // enclosing :ref:`envoy_api_msg_RouteConfiguration`. For more information, including
+  // details on header value syntax, see the documentation on :ref:`custom request headers
+  // <config_http_conn_man_headers_custom_request_headers>`.
+  repeated core.HeaderValueOption request_headers_to_add = 7
+      [(validate.rules).repeated .max_items = 1000];
+
+  // Specifies a list of HTTP headers that should be removed from each request
+  // handled by this virtual host.
+  repeated string request_headers_to_remove = 13;
+
+  // Specifies a list of HTTP headers that should be added to each response
+  // handled by this virtual host. Headers specified at this level are applied
+  // after headers from enclosed :ref:`envoy_api_msg_route.Route` and before headers from the
+  // enclosing :ref:`envoy_api_msg_RouteConfiguration`. For more information, including
+  // details on header value syntax, see the documentation on :ref:`custom request headers
+  // <config_http_conn_man_headers_custom_request_headers>`.
+  repeated core.HeaderValueOption response_headers_to_add = 10
+      [(validate.rules).repeated .max_items = 1000];
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // handled by this virtual host.
+  repeated string response_headers_to_remove = 11;
+
+  // Indicates that the virtual host has a CORS policy.
+  CorsPolicy cors = 8;
+
+  reserved 9;
+
+  // The per_filter_config field can be used to provide virtual host-specific
+  // configurations for filters. The key should match the filter name, such as
+  // *envoy.buffer* for the HTTP buffer filter. Use of this field is filter
+  // specific; see the :ref:`HTTP filter documentation <config_http_filters>`
+  // for if and how it is utilized.
+  map<string, google.protobuf.Struct> per_filter_config = 12;
+
+  // The per_filter_config field can be used to provide virtual host-specific
+  // configurations for filters. The key should match the filter name, such as
+  // *envoy.buffer* for the HTTP buffer filter. Use of this field is filter
+  // specific; see the :ref:`HTTP filter documentation <config_http_filters>`
+  // for if and how it is utilized.
+  map<string, google.protobuf.Any> typed_per_filter_config = 15;
+
+  // Decides whether the :ref:`x-envoy-attempt-count
+  // <config_http_filters_router_x-envoy-attempt-count>` header should be included
+  // in the upstream request. Setting this option will cause it to override any existing header
+  // value, so in the case of two Envoys on the request path with this option enabled, the upstream
+  // will see the attempt count as perceived by the second Envoy. Defaults to false.
+  // This header is unaffected by the
+  // :ref:`suppress_envoy_headers
+  // <envoy_api_field_config.filter.http.router.v3alpha.Router.suppress_envoy_headers>` flag.
+  bool include_request_attempt_count = 14;
+
+  // Indicates the retry policy for all routes in this virtual host. Note that setting a
+  // route level entry will take precedence over this config and it'll be treated
+  // independently (e.g.: values are not inherited).
+  RetryPolicy retry_policy = 16;
+
+  // Indicates the hedge policy for all routes in this virtual host. Note that setting a
+  // route level entry will take precedence over this config and it'll be treated
+  // independently (e.g.: values are not inherited).
+  HedgePolicy hedge_policy = 17;
+}
+
+// A route is both a specification of how to match a request as well as an indication of what to do
+// next (e.g., redirect, forward, rewrite, etc.).
+//
+// .. attention::
+//
+//   Envoy supports routing on HTTP method via :ref:`header matching
+//   <envoy_api_msg_route.HeaderMatcher>`.
+// [#comment:next free field: 15]
+message Route {
+  // Name for the route.
+  string name = 14;
+
+  // Route matching parameters.
+  RouteMatch match = 1 [(validate.rules).message.required = true];
+
+  oneof action {
+    option (validate.required) = true;
+
+    // Route request to some upstream cluster.
+    RouteAction route = 2;
+
+    // Return a redirect.
+    RedirectAction redirect = 3;
+
+    // Return an arbitrary HTTP response directly, without proxying.
+    DirectResponseAction direct_response = 7;
+  }
+
+  // The Metadata field can be used to provide additional information
+  // about the route. It can be used for configuration, stats, and logging.
+  // The metadata should go under the filter namespace that will need it.
+  // For instance, if the metadata is intended for the Router filter,
+  // the filter name should be specified as *envoy.router*.
+  core.Metadata metadata = 4;
+
+  // Decorator for the matched route.
+  Decorator decorator = 5;
+
+  reserved 6;
+
+  // The per_filter_config field can be used to provide route-specific
+  // configurations for filters. The key should match the filter name, such as
+  // *envoy.buffer* for the HTTP buffer filter. Use of this field is filter
+  // specific; see the :ref:`HTTP filter documentation <config_http_filters>` for
+  // if and how it is utilized.
+  map<string, google.protobuf.Struct> per_filter_config = 8;
+
+  // The per_filter_config field can be used to provide route-specific
+  // configurations for filters. The key should match the filter name, such as
+  // *envoy.buffer* for the HTTP buffer filter. Use of this field is filter
+  // specific; see the :ref:`HTTP filter documentation <config_http_filters>` for
+  // if and how it is utilized.
+  map<string, google.protobuf.Any> typed_per_filter_config = 13;
+
+  // Specifies a set of headers that will be added to requests matching this
+  // route. Headers specified at this level are applied before headers from the
+  // enclosing :ref:`envoy_api_msg_route.VirtualHost` and
+  // :ref:`envoy_api_msg_RouteConfiguration`. For more information, including details on
+  // header value syntax, see the documentation on :ref:`custom request headers
+  // <config_http_conn_man_headers_custom_request_headers>`.
+  repeated core.HeaderValueOption request_headers_to_add = 9
+      [(validate.rules).repeated .max_items = 1000];
+
+  // Specifies a list of HTTP headers that should be removed from each request
+  // matching this route.
+  repeated string request_headers_to_remove = 12;
+
+  // Specifies a set of headers that will be added to responses to requests
+  // matching this route. Headers specified at this level are applied before
+  // headers from the enclosing :ref:`envoy_api_msg_route.VirtualHost` and
+  // :ref:`envoy_api_msg_RouteConfiguration`. For more information, including
+  // details on header value syntax, see the documentation on
+  // :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`.
+  repeated core.HeaderValueOption response_headers_to_add = 10
+      [(validate.rules).repeated .max_items = 1000];
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // to requests matching this route.
+  repeated string response_headers_to_remove = 11;
+
+  // Presence of the object defines whether the connection manager's tracing configuration
+  // is overridden by this route specific instance.
+  Tracing tracing = 15;
+}
+
+// Compared to the :ref:`cluster <envoy_api_field_route.RouteAction.cluster>` field that specifies a
+// single upstream cluster as the target of a request, the :ref:`weighted_clusters
+// <envoy_api_field_route.RouteAction.weighted_clusters>` option allows for specification of
+// multiple upstream clusters along with weights that indicate the percentage of
+// traffic to be forwarded to each cluster. The router selects an upstream cluster based on the
+// weights.
+// [#comment:next free field: 11]
+message WeightedCluster {
+  message ClusterWeight {
+    // Name of the upstream cluster. The cluster must exist in the
+    // :ref:`cluster manager configuration <config_cluster_manager>`.
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // An integer between 0 and :ref:`total_weight
+    // <envoy_api_field_route.WeightedCluster.total_weight>`. When a request matches the route,
+    // the choice of an upstream cluster is determined by its weight. The sum of weights across all
+    // entries in the clusters array must add up to the total_weight, which defaults to 100.
+    google.protobuf.UInt32Value weight = 2;
+
+    // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
+    // the upstream cluster with metadata matching what is set in this field will be considered for
+    // load balancing. Note that this will be merged with what's provided in :ref:
+    // `RouteAction.MetadataMatch <envoy_api_field_route.RouteAction.metadata_match>`, with values
+    // here taking precedence. The filter name should be specified as *envoy.lb*.
+    core.Metadata metadata_match = 3;
+
+    // Specifies a list of headers to be added to requests when this cluster is selected
+    // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    // Headers specified at this level are applied before headers from the enclosing
+    // :ref:`envoy_api_msg_route.Route`, :ref:`envoy_api_msg_route.VirtualHost`, and
+    // :ref:`envoy_api_msg_RouteConfiguration`. For more information, including details on
+    // header value syntax, see the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated core.HeaderValueOption request_headers_to_add = 4
+        [(validate.rules).repeated .max_items = 1000];
+
+    // Specifies a list of HTTP headers that should be removed from each request when
+    // this cluster is selected through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    repeated string request_headers_to_remove = 9;
+
+    // Specifies a list of headers to be added to responses when this cluster is selected
+    // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    // Headers specified at this level are applied before headers from the enclosing
+    // :ref:`envoy_api_msg_route.Route`, :ref:`envoy_api_msg_route.VirtualHost`, and
+    // :ref:`envoy_api_msg_RouteConfiguration`. For more information, including details on
+    // header value syntax, see the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated core.HeaderValueOption response_headers_to_add = 5
+        [(validate.rules).repeated .max_items = 1000];
+
+    // Specifies a list of headers to be removed from responses when this cluster is selected
+    // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    repeated string response_headers_to_remove = 6;
+
+    reserved 7;
+
+    // The per_filter_config field can be used to provide weighted cluster-specific
+    // configurations for filters. The key should match the filter name, such as
+    // *envoy.buffer* for the HTTP buffer filter. Use of this field is filter
+    // specific; see the :ref:`HTTP filter documentation <config_http_filters>`
+    // for if and how it is utilized.
+    map<string, google.protobuf.Struct> per_filter_config = 8;
+
+    // The per_filter_config field can be used to provide weighted cluster-specific
+    // configurations for filters. The key should match the filter name, such as
+    // *envoy.buffer* for the HTTP buffer filter. Use of this field is filter
+    // specific; see the :ref:`HTTP filter documentation <config_http_filters>`
+    // for if and how it is utilized.
+    map<string, google.protobuf.Any> typed_per_filter_config = 10;
+  }
+
+  // Specifies one or more upstream clusters associated with the route.
+  repeated ClusterWeight clusters = 1 [(validate.rules).repeated .min_items = 1];
+
+  // Specifies the total weight across all clusters. The sum of all cluster weights must equal this
+  // value, which must be greater than 0. Defaults to 100.
+  google.protobuf.UInt32Value total_weight = 3 [(validate.rules).uint32.gte = 1];
+
+  // Specifies the runtime key prefix that should be used to construct the
+  // runtime keys associated with each cluster. When the *runtime_key_prefix* is
+  // specified, the router will look for weights associated with each upstream
+  // cluster under the key *runtime_key_prefix* + "." + *cluster[i].name* where
+  // *cluster[i]* denotes an entry in the clusters array field. If the runtime
+  // key for the cluster does not exist, the value specified in the
+  // configuration file will be used as the default weight. See the :ref:`runtime documentation
+  // <operations_runtime>` for how key names map to the underlying implementation.
+  string runtime_key_prefix = 2;
+}
+
+message RouteMatch {
+  oneof path_specifier {
+    option (validate.required) = true;
+
+    // If specified, the route is a prefix rule meaning that the prefix must
+    // match the beginning of the *:path* header.
+    string prefix = 1;
+
+    // If specified, the route is an exact path rule meaning that the path must
+    // exactly match the *:path* header once the query string is removed.
+    string path = 2;
+
+    // If specified, the route is a regular expression rule meaning that the
+    // regex must match the *:path* header once the query string is removed. The entire path
+    // (without the query string) must match the regex. The rule will not match if only a
+    // subsequence of the *:path* header matches the regex. The regex grammar is defined `here
+    // <https://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+    //
+    // Examples:
+    //
+    // * The regex */b[io]t* matches the path */bit*
+    // * The regex */b[io]t* matches the path */bot*
+    // * The regex */b[io]t* does not match the path */bite*
+    // * The regex */b[io]t* does not match the path */bit/bot*
+    //
+    // .. attention::
+    //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
+    //   untrusted input in all cases.
+    string regex = 3 [(validate.rules).string.max_bytes = 1024, deprecated = true];
+
+    // If specified, the route is a regular expression rule meaning that the
+    // regex must match the *:path* header once the query string is removed. The entire path
+    // (without the query string) must match the regex. The rule will not match if only a
+    // subsequence of the *:path* header matches the regex.
+    //
+    // [#next-major-version: In the v3 API we should redo how path specification works such
+    // that we utilize StringMatcher, and additionally have consistent options around whether we
+    // strip query strings, do a case sensitive match, etc. In the interim it will be too disruptive
+    // to deprecate the existing options. We should even consider whether we want to do away with
+    // path_specifier entirely and just rely on a set of header matchers which can already match
+    // on :path, etc. The issue with that is it is unclear how to generically deal with query string
+    // stripping. This needs more thought.]
+    type.matcher.RegexMatcher safe_regex = 10 [(validate.rules).message.required = true];
+  }
+
+  // Indicates that prefix/path matching should be case insensitive. The default
+  // is true.
+  google.protobuf.BoolValue case_sensitive = 4;
+
+  reserved 5;
+
+  // Indicates that the route should additionally match on a runtime key. Every time the route
+  // is considered for a match, it must also fall under the percentage of matches indicated by
+  // this field. For some fraction N/D, a random number in the range [0,D) is selected. If the
+  // number is <= the value of the numerator N, or if the key is not present, the default
+  // value, the router continues to evaluate the remaining match criteria. A runtime_fraction
+  // route configuration can be used to roll out route changes in a gradual manner without full
+  // code/config deploys. Refer to the :ref:`traffic shifting
+  // <config_http_conn_man_route_table_traffic_splitting_shift>` docs for additional documentation.
+  //
+  // .. note::
+  //
+  //    Parsing this field is implemented such that the runtime key's data may be represented
+  //    as a FractionalPercent proto represented as JSON/YAML and may also be represented as an
+  //    integer with the assumption that the value is an integral percentage out of 100. For
+  //    instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
+  //    whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
+  core.RuntimeFractionalPercent runtime_fraction = 9;
+
+  // Specifies a set of headers that the route should match on. The router will
+  // check the request’s headers against all the specified headers in the route
+  // config. A match will happen if all the headers in the route are present in
+  // the request with the same values (or based on presence if the value field
+  // is not in the config).
+  repeated HeaderMatcher headers = 6;
+
+  // Specifies a set of URL query parameters on which the route should
+  // match. The router will check the query string from the *path* header
+  // against all the specified query parameters. If the number of specified
+  // query parameters is nonzero, they all must match the *path* header's
+  // query string for a match to occur.
+  repeated QueryParameterMatcher query_parameters = 7;
+
+  message GrpcRouteMatchOptions {
+  }
+
+  // If specified, only gRPC requests will be matched. The router will check
+  // that the content-type header has a application/grpc or one of the various
+  // application/grpc+ values.
+  GrpcRouteMatchOptions grpc = 8;
+}
+
+// [#comment:next free field: 11]
+message CorsPolicy {
+  // Specifies the origins that will be allowed to do CORS requests.
+  //
+  // An origin is allowed if either allow_origin or allow_origin_regex match.
+  //
+  // .. attention::
+  //  This field has been deprecated in favor of `allow_origin_string_match`.
+  repeated string allow_origin = 1 [deprecated = true];
+
+  // Specifies regex patterns that match allowed origins.
+  //
+  // An origin is allowed if either allow_origin or allow_origin_regex match.
+  //
+  // .. attention::
+  //   This field has been deprecated in favor of `allow_origin_string_match` as it is not safe for
+  //   use with untrusted input in all cases.
+  repeated string allow_origin_regex = 8
+      [(validate.rules).repeated .items.string.max_bytes = 1024, deprecated = true];
+
+  // Specifies string patterns that match allowed origins. An origin is allowed if any of the
+  // string matchers match.
+  repeated type.matcher.StringMatcher allow_origin_string_match = 11;
+
+  // Specifies the content for the *access-control-allow-methods* header.
+  string allow_methods = 2;
+
+  // Specifies the content for the *access-control-allow-headers* header.
+  string allow_headers = 3;
+
+  // Specifies the content for the *access-control-expose-headers* header.
+  string expose_headers = 4;
+
+  // Specifies the content for the *access-control-max-age* header.
+  string max_age = 5;
+
+  // Specifies whether the resource allows credentials.
+  google.protobuf.BoolValue allow_credentials = 6;
+
+  oneof enabled_specifier {
+    // Specifies if CORS is enabled. Defaults to true. Only effective on route.
+    //
+    // .. attention::
+    //
+    //   **This field is deprecated**. Set the
+    //   :ref:`filter_enabled<envoy_api_field_route.CorsPolicy.filter_enabled>` field instead.
+    google.protobuf.BoolValue enabled = 7 [deprecated = true];
+
+    // Specifies if CORS is enabled.
+    //
+    // More information on how this can be controlled via runtime can be found
+    // :ref:`here <cors-runtime>`.
+    //
+    // .. note::
+    //
+    //   This field defaults to 100/:ref:`HUNDRED
+    //   <envoy_api_enum_type.FractionalPercent.DenominatorType>`.
+    core.RuntimeFractionalPercent filter_enabled = 9;
+  }
+
+  // Specifies if CORS policies are evaluated and tracked when filter is off but
+  // does not enforce any policies.
+  //
+  // More information on how this can be controlled via runtime can be found
+  // :ref:`here <cors-runtime>`.
+  //
+  // .. note::
+  //
+  //   This field defaults to 100/:ref:`HUNDRED
+  //   <envoy_api_enum_type.FractionalPercent.DenominatorType>`.
+  core.RuntimeFractionalPercent shadow_enabled = 10;
+}
+
+// [#comment:next free field: 30]
+message RouteAction {
+  oneof cluster_specifier {
+    option (validate.required) = true;
+
+    // Indicates the upstream cluster to which the request should be routed
+    // to.
+    string cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Envoy will determine the cluster to route to by reading the value of the
+    // HTTP header named by cluster_header from the request headers. If the
+    // header is not found or the referenced cluster does not exist, Envoy will
+    // return a 404 response.
+    //
+    // .. attention::
+    //
+    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+    string cluster_header = 2 [(validate.rules).string.min_bytes = 1];
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster. See
+    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+    // for additional documentation.
+    WeightedCluster weighted_clusters = 3;
+  }
+
+  enum ClusterNotFoundResponseCode {
+    // HTTP status code - 503 Service Unavailable.
+    SERVICE_UNAVAILABLE = 0;
+
+    // HTTP status code - 404 Not Found.
+    NOT_FOUND = 1;
+  }
+
+  // The HTTP status code to use when configured cluster is not found.
+  // The default response code is 503 Service Unavailable.
+  ClusterNotFoundResponseCode cluster_not_found_response_code = 20
+      [(validate.rules).enum.defined_only = true];
+
+  // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
+  // in the upstream cluster with metadata matching what's set in this field will be considered
+  // for load balancing. If using :ref:`weighted_clusters
+  // <envoy_api_field_route.RouteAction.weighted_clusters>`, metadata will be merged, with values
+  // provided there taking precedence. The filter name should be specified as *envoy.lb*.
+  core.Metadata metadata_match = 4;
+
+  // Indicates that during forwarding, the matched prefix (or path) should be
+  // swapped with this value. This option allows application URLs to be rooted
+  // at a different path from those exposed at the reverse proxy layer. The router filter will
+  // place the original path before rewrite into the :ref:`x-envoy-original-path
+  // <config_http_filters_router_x-envoy-original-path>` header.
+  //
+  // .. attention::
+  //
+  //   Pay careful attention to the use of trailing slashes in the
+  //   :ref:`route's match <envoy_api_field_route.Route.match>` prefix value.
+  //   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
+  //   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
+  //   :ref:`Route <envoy_api_msg_route.Route>`, as shown by the below config entries:
+  //
+  //   .. code-block:: yaml
+  //
+  //     - match:
+  //         prefix: "/prefix/"
+  //       route:
+  //         prefix_rewrite: "/"
+  //     - match:
+  //         prefix: "/prefix"
+  //       route:
+  //         prefix_rewrite: "/"
+  //
+  //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
+  //   requests to */prefix/etc* will be stripped to */etc*.
+  string prefix_rewrite = 5;
+
+  oneof host_rewrite_specifier {
+    // Indicates that during forwarding, the host header will be swapped with
+    // this value.
+    string host_rewrite = 6;
+
+    // Indicates that during forwarding, the host header will be swapped with
+    // the hostname of the upstream host chosen by the cluster manager. This
+    // option is applicable only when the destination cluster for a route is of
+    // type *strict_dns* or *logical_dns*. Setting this to true with other cluster
+    // types has no effect.
+    google.protobuf.BoolValue auto_host_rewrite = 7;
+
+    // Indicates that during forwarding, the host header will be swapped with the content of given
+    // downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
+    // If header value is empty, host header is left intact.
+    //
+    // .. attention::
+    //
+    //   Pay attention to the potential security implications of using this option. Provided header
+    //   must come from trusted source.
+    string auto_host_rewrite_header = 29;
+  }
+
+  // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
+  // spans between the point at which the entire downstream request (i.e. end-of-stream) has been
+  // processed and when the upstream response has been completely processed. A value of 0 will
+  // disable the route's timeout.
+  //
+  // .. note::
+  //
+  //   This timeout includes all retries. See also
+  //   :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
+  //   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
+  //   :ref:`retry overview <arch_overview_http_routing_retry>`.
+  google.protobuf.Duration timeout = 8 [(gogoproto.stdduration) = true];
+
+  // Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
+  // although the connection manager wide :ref:`stream_idle_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.stream_idle_timeout>`
+  // will still apply. A value of 0 will completely disable the route's idle timeout, even if a
+  // connection manager stream idle timeout is configured.
+  //
+  // The idle timeout is distinct to :ref:`timeout
+  // <envoy_api_field_route.RouteAction.timeout>`, which provides an upper bound
+  // on the upstream response time; :ref:`idle_timeout
+  // <envoy_api_field_route.RouteAction.idle_timeout>` instead bounds the amount
+  // of time the request's stream may be idle.
+  //
+  // After header decoding, the idle timeout will apply on downstream and
+  // upstream request events. Each time an encode/decode event for headers or
+  // data is processed for the stream, the timer will be reset. If the timeout
+  // fires, the stream is terminated with a 408 Request Timeout error code if no
+  // upstream response header has been received, otherwise a stream reset
+  // occurs.
+  google.protobuf.Duration idle_timeout = 24 [(gogoproto.stdduration) = true];
+
+  // Indicates that the route has a retry policy. Note that if this is set,
+  // it'll take precedence over the virtual host level retry policy entirely
+  // (e.g.: policies are not merged, most internal one becomes the enforced policy).
+  RetryPolicy retry_policy = 9;
+
+  // The router is capable of shadowing traffic from one cluster to another. The current
+  // implementation is "fire and forget," meaning Envoy will not wait for the shadow cluster to
+  // respond before returning the response from the primary cluster. All normal statistics are
+  // collected for the shadow cluster making this feature useful for testing.
+  //
+  // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
+  // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
+  message RequestMirrorPolicy {
+    // Specifies the cluster that requests will be mirrored to. The cluster must
+    // exist in the cluster manager configuration.
+    string cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+    // If not specified, all requests to the target cluster will be mirrored. If
+    // specified, Envoy will lookup the runtime key to get the % of requests to
+    // mirror. Valid values are from 0 to 10000, allowing for increments of
+    // 0.01% of requests to be mirrored. If the runtime key is specified in the
+    // configuration but not present in runtime, 0 is the default and thus 0% of
+    // requests will be mirrored.
+    //
+    // .. attention::
+    //
+    //   **This field is deprecated**. Set the
+    //   :ref:`runtime_fraction
+    //   <envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_fraction>` field instead.
+    string runtime_key = 2 [deprecated = true];
+
+    // If both :ref:`runtime_key
+    // <envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_key>` and this field are not
+    // specified, all requests to the target cluster will be mirrored.
+    //
+    // If specified, this field takes precedence over the `runtime_key` field and requests must also
+    // fall under the percentage of matches indicated by this field.
+    //
+    // For some fraction N/D, a random number in the range [0,D) is selected. If the
+    // number is <= the value of the numerator N, or if the key is not present, the default
+    // value, the request will be mirrored.
+    //
+    // .. note::
+    //
+    //   Parsing this field is implemented such that the runtime key's data may be represented
+    //   as a :ref:`FractionalPercent <envoy_api_msg_type.FractionalPercent>` proto represented
+    //   as JSON/YAML and may also be represented as an integer with the assumption that the value
+    //   is an integral percentage out of 100. For instance, a runtime key lookup returning the
+    //   value "42" would parse as a `FractionalPercent` whose numerator is 42 and denominator is
+    //   HUNDRED. This is behaviour is different to that of the deprecated `runtime_key` field,
+    //   where the implicit denominator is 10000.
+    core.RuntimeFractionalPercent runtime_fraction = 3;
+  }
+
+  // Indicates that the route has a request mirroring policy.
+  RequestMirrorPolicy request_mirror_policy = 10;
+
+  // Optionally specifies the :ref:`routing priority <arch_overview_http_routing_priority>`.
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+  // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+  core.RoutingPriority priority = 11;
+
+  reserved 12;
+  reserved 18;
+  reserved 19;
+
+  // Specifies a set of rate limit configurations that could be applied to the
+  // route.
+  repeated RateLimit rate_limits = 13;
+
+  // Specifies if the rate limit filter should include the virtual host rate
+  // limits. By default, if the route configured rate limits, the virtual host
+  // :ref:`rate_limits <envoy_api_field_route.VirtualHost.rate_limits>` are not applied to the
+  // request.
+  google.protobuf.BoolValue include_vh_rate_limits = 14;
+
+  // Specifies the route's hashing policy if the upstream cluster uses a hashing :ref:`load balancer
+  // <arch_overview_load_balancing_types>`.
+  message HashPolicy {
+    message Header {
+      // The name of the request header that will be used to obtain the hash
+      // key. If the request header is not present, no hash will be produced.
+      string header_name = 1 [(validate.rules).string.min_bytes = 1];
+    }
+
+    // Envoy supports two types of cookie affinity:
+    //
+    // 1. Passive. Envoy takes a cookie that's present in the cookies header and
+    //    hashes on its value.
+    //
+    // 2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
+    //    on the first request from the client in its response to the client,
+    //    based on the endpoint the request gets sent to. The client then
+    //    presents this on the next and all subsequent requests. The hash of
+    //    this is sufficient to ensure these requests get sent to the same
+    //    endpoint. The cookie is generated by hashing the source and
+    //    destination ports and addresses so that multiple independent HTTP2
+    //    streams on the same connection will independently receive the same
+    //    cookie, even if they arrive at the Envoy simultaneously.
+    message Cookie {
+      // The name of the cookie that will be used to obtain the hash key. If the
+      // cookie is not present and ttl below is not set, no hash will be
+      // produced.
+      string name = 1 [(validate.rules).string.min_bytes = 1];
+
+      // If specified, a cookie with the TTL will be generated if the cookie is
+      // not present. If the TTL is present and zero, the generated cookie will
+      // be a session cookie.
+      google.protobuf.Duration ttl = 2 [(gogoproto.stdduration) = true];
+
+      // The name of the path for the cookie. If no path is specified here, no path
+      // will be set for the cookie.
+      string path = 3;
+    }
+
+    message ConnectionProperties {
+      // Hash on source IP address.
+      bool source_ip = 1;
+    }
+
+    oneof policy_specifier {
+      option (validate.required) = true;
+
+      // Header hash policy.
+      Header header = 1;
+
+      // Cookie hash policy.
+      Cookie cookie = 2;
+
+      // Connection properties hash policy.
+      ConnectionProperties connection_properties = 3;
+    }
+
+    // The flag that shortcircuits the hash computing. This field provides a
+    // 'fallback' style of configuration: "if a terminal policy doesn't work,
+    // fallback to rest of the policy list", it saves time when the terminal
+    // policy works.
+    //
+    // If true, and there is already a hash computed, ignore rest of the
+    // list of hash polices.
+    // For example, if the following hash methods are configured:
+    //
+    //  ========= ========
+    //  specifier terminal
+    //  ========= ========
+    //  Header A  true
+    //  Header B  false
+    //  Header C  false
+    //  ========= ========
+    //
+    // The generateHash process ends if policy "header A" generates a hash, as
+    // it's a terminal policy.
+    bool terminal = 4;
+  }
+
+  // Specifies a list of hash policies to use for ring hash load balancing. Each
+  // hash policy is evaluated individually and the combined result is used to
+  // route the request. The method of combination is deterministic such that
+  // identical lists of hash policies will produce the same hash. Since a hash
+  // policy examines specific parts of a request, it can fail to produce a hash
+  // (i.e. if the hashed header is not present). If (and only if) all configured
+  // hash policies fail to generate a hash, no hash will be produced for
+  // the route. In this case, the behavior is the same as if no hash policies
+  // were specified (i.e. the ring hash load balancer will choose a random
+  // backend). If a hash policy has the "terminal" attribute set to true, and
+  // there is already a hash generated, the hash is returned immediately,
+  // ignoring the rest of the hash policy list.
+  repeated HashPolicy hash_policy = 15;
+
+  reserved 16;
+  reserved 22;
+
+  // Indicates that the route has a CORS policy.
+  CorsPolicy cors = 17;
+
+  reserved 21;
+
+  // If present, and the request is a gRPC request, use the
+  // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
+  // or its default value (infinity) instead of
+  // :ref:`timeout <envoy_api_field_route.RouteAction.timeout>`, but limit the applied timeout
+  // to the maximum value specified here. If configured as 0, the maximum allowed timeout for
+  // gRPC requests is infinity. If not configured at all, the `grpc-timeout` header is not used
+  // and gRPC requests time out like any other requests using
+  // :ref:`timeout <envoy_api_field_route.RouteAction.timeout>` or its default.
+  // This can be used to prevent unexpected upstream request timeouts due to potentially long
+  // time gaps between gRPC request and response in gRPC streaming mode.
+  google.protobuf.Duration max_grpc_timeout = 23 [(gogoproto.stdduration) = true];
+
+  // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
+  // the provided duration from the header. This is useful in allowing Envoy to set its global
+  // timeout to be less than that of the deadline imposed by the calling client, which makes it more
+  // likely that Envoy will handle the timeout instead of having the call canceled by the client.
+  // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
+  // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
+  // infinity).
+  google.protobuf.Duration grpc_timeout_offset = 28 [(gogoproto.stdduration) = true];
+
+  // Allows enabling and disabling upgrades on a per-route basis.
+  // This overrides any enabled/disabled upgrade filter chain specified in the
+  // HttpConnectionManager
+  // :ref:upgrade_configs`
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.upgrade_configs>`
+  // but does not affect any custom filter chain specified there.
+  message UpgradeConfig {
+    // The case-insensitive name of this upgrade, e.g. "websocket".
+    // For each upgrade type present in upgrade_configs, requests with
+    // Upgrade: [upgrade_type] will be proxied upstream.
+    string upgrade_type = 1;
+    // Determines if upgrades are available on this route. Defaults to true.
+    google.protobuf.BoolValue enabled = 2;
+  };
+  repeated UpgradeConfig upgrade_configs = 25;
+
+  // Configures :ref:`internal redirect <arch_overview_internal_redirects>` behavior.
+  enum InternalRedirectAction {
+    PASS_THROUGH_INTERNAL_REDIRECT = 0;
+    HANDLE_INTERNAL_REDIRECT = 1;
+  }
+  InternalRedirectAction internal_redirect_action = 26;
+
+  // Indicates that the route has a hedge policy. Note that if this is set,
+  // it'll take precedence over the virtual host level hedge policy entirely
+  // (e.g.: policies are not merged, most internal one becomes the enforced policy).
+  HedgePolicy hedge_policy = 27;
+}
+
+// HTTP retry :ref:`architecture overview <arch_overview_http_routing_retry>`.
+// [#comment:next free field: 9]
+message RetryPolicy {
+  // Specifies the conditions under which retry takes place. These are the same
+  // conditions documented for :ref:`config_http_filters_router_x-envoy-retry-on` and
+  // :ref:`config_http_filters_router_x-envoy-retry-grpc-on`.
+  string retry_on = 1;
+
+  // Specifies the allowed number of retries. This parameter is optional and
+  // defaults to 1. These are the same conditions documented for
+  // :ref:`config_http_filters_router_x-envoy-max-retries`.
+  google.protobuf.UInt32Value num_retries = 2;
+
+  // Specifies a non-zero upstream timeout per retry attempt. This parameter is optional. The
+  // same conditions documented for
+  // :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms` apply.
+  //
+  // .. note::
+  //
+  //   If left unspecified, Envoy will use the global
+  //   :ref:`route timeout <envoy_api_field_route.RouteAction.timeout>` for the request.
+  //   Consequently, when using a :ref:`5xx <config_http_filters_router_x-envoy-retry-on>` based
+  //   retry policy, a request that times out will not be retried as the total timeout budget
+  //   would have been exhausted.
+  google.protobuf.Duration per_try_timeout = 3 [(gogoproto.stdduration) = true];
+
+  message RetryPriority {
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+    oneof config_type {
+      google.protobuf.Struct config = 2;
+
+      google.protobuf.Any typed_config = 3;
+    }
+  }
+
+  // Specifies an implementation of a RetryPriority which is used to determine the
+  // distribution of load across priorities used for retries. Refer to
+  // :ref:`retry plugin configuration <arch_overview_http_retry_plugins>` for more details.
+  RetryPriority retry_priority = 4;
+
+  message RetryHostPredicate {
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+    oneof config_type {
+      google.protobuf.Struct config = 2;
+
+      google.protobuf.Any typed_config = 3;
+    }
+  }
+
+  // Specifies a collection of RetryHostPredicates that will be consulted when selecting a host
+  // for retries. If any of the predicates reject the host, host selection will be reattempted.
+  // Refer to :ref:`retry plugin configuration <arch_overview_http_retry_plugins>` for more
+  // details.
+  repeated RetryHostPredicate retry_host_predicate = 5;
+
+  // The maximum number of times host selection will be reattempted before giving up, at which
+  // point the host that was last selected will be routed to. If unspecified, this will default to
+  // retrying once.
+  int64 host_selection_retry_max_attempts = 6;
+
+  // HTTP status codes that should trigger a retry in addition to those specified by retry_on.
+  repeated uint32 retriable_status_codes = 7;
+
+  message RetryBackOff {
+    // Specifies the base interval between retries. This parameter is required and must be greater
+    // than zero. Values less than 1 ms are rounded up to 1 ms.
+    // See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion of Envoy's
+    // back-off algorithm.
+    google.protobuf.Duration base_interval = 1 [
+      (validate.rules).duration = {
+        required: true,
+        gt: {seconds: 0}
+      },
+      (gogoproto.stdduration) = true
+    ];
+
+    // Specifies the maximum interval between retries. This parameter is optional, but must be
+    // greater than or equal to the `base_interval` if set. The default is 10 times the
+    // `base_interval`. See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion
+    // of Envoy's back-off algorithm.
+    google.protobuf.Duration max_interval = 2
+        [(validate.rules).duration.gt = {seconds: 0}, (gogoproto.stdduration) = true];
+  }
+
+  // Specifies parameters that control retry back off. This parameter is optional, in which case the
+  // default base interval is 25 milliseconds or, if set, the current value of the
+  // `upstream.base_retry_backoff_ms` runtime parameter. The default maximum interval is 10 times
+  // the base interval. The documentation for :ref:`config_http_filters_router_x-envoy-max-retries`
+  // describes Envoy's back-off algorithm.
+  RetryBackOff retry_back_off = 8;
+}
+
+// HTTP request hedging :ref:`architecture overview <arch_overview_http_routing_hedging>`.
+message HedgePolicy {
+  // Specifies the number of initial requests that should be sent upstream.
+  // Must be at least 1.
+  // Defaults to 1.
+  // [#not-implemented-hide:]
+  google.protobuf.UInt32Value initial_requests = 1 [(validate.rules).uint32.gte = 1];
+
+  // Specifies a probability that an additional upstream request should be sent
+  // on top of what is specified by initial_requests.
+  // Defaults to 0.
+  // [#not-implemented-hide:]
+  envoy.type.FractionalPercent additional_request_chance = 2;
+
+  // Indicates that a hedged request should be sent when the per-try timeout
+  // is hit. This will only occur if the retry policy also indicates that a
+  // timed out request should be retried.
+  // Once a timed out request is retried due to per try timeout, the router
+  // filter will ensure that it is not retried again even if the returned
+  // response headers would otherwise be retried according the specified
+  // :ref:`RetryPolicy <envoy_api_msg_route.RetryPolicy>`.
+  // Defaults to false.
+  bool hedge_on_per_try_timeout = 3;
+}
+
+message RedirectAction {
+  // When the scheme redirection take place, the following rules apply:
+  //  1. If the source URI scheme is `http` and the port is explicitly
+  //     set to `:80`, the port will be removed after the redirection
+  //  2. If the source URI scheme is `https` and the port is explicitly
+  //     set to `:443`, the port will be removed after the redirection
+  oneof scheme_rewrite_specifier {
+    // The scheme portion of the URL will be swapped with "https".
+    bool https_redirect = 4;
+    // The scheme portion of the URL will be swapped with this value.
+    string scheme_redirect = 7;
+  }
+  // The host portion of the URL will be swapped with this value.
+  string host_redirect = 1;
+  // The port value of the URL will be swapped with this value.
+  uint32 port_redirect = 8;
+
+  oneof path_rewrite_specifier {
+    // The path portion of the URL will be swapped with this value.
+    string path_redirect = 2;
+
+    // Indicates that during redirection, the matched prefix (or path)
+    // should be swapped with this value. This option allows redirect URLs be dynamically created
+    // based on the request.
+    //
+    // .. attention::
+    //
+    //   Pay attention to the use of trailing slashes as mentioned in
+    //   :ref:`RouteAction's prefix_rewrite <envoy_api_field_route.RouteAction.prefix_rewrite>`.
+    string prefix_rewrite = 5;
+  }
+
+  enum RedirectResponseCode {
+    // Moved Permanently HTTP Status Code - 301.
+    MOVED_PERMANENTLY = 0;
+
+    // Found HTTP Status Code - 302.
+    FOUND = 1;
+
+    // See Other HTTP Status Code - 303.
+    SEE_OTHER = 2;
+
+    // Temporary Redirect HTTP Status Code - 307.
+    TEMPORARY_REDIRECT = 3;
+
+    // Permanent Redirect HTTP Status Code - 308.
+    PERMANENT_REDIRECT = 4;
+  }
+
+  // The HTTP status code to use in the redirect response. The default response
+  // code is MOVED_PERMANENTLY (301).
+  RedirectResponseCode response_code = 3 [(validate.rules).enum.defined_only = true];
+
+  // Indicates that during redirection, the query portion of the URL will
+  // be removed. Default value is false.
+  bool strip_query = 6;
+}
+
+message DirectResponseAction {
+  // Specifies the HTTP response status to be returned.
+  uint32 status = 1 [(validate.rules).uint32 = {gte: 100, lt: 600}];
+
+  // Specifies the content of the response body. If this setting is omitted,
+  // no body is included in the generated response.
+  //
+  // .. note::
+  //
+  //   Headers can be specified using *response_headers_to_add* in the enclosing
+  //   :ref:`envoy_api_msg_route.Route`, :ref:`envoy_api_msg_RouteConfiguration` or
+  //   :ref:`envoy_api_msg_route.VirtualHost`.
+  core.DataSource body = 2;
+}
+
+message Decorator {
+  // The operation name associated with the request matched to this route. If tracing is
+  // enabled, this information will be used as the span name reported for this request.
+  //
+  // .. note::
+  //
+  //   For ingress (inbound) requests, or egress (outbound) responses, this value may be overridden
+  //   by the :ref:`x-envoy-decorator-operation
+  //   <config_http_filters_router_x-envoy-decorator-operation>` header.
+  string operation = 1 [(validate.rules).string.min_bytes = 1];
+}
+
+message Tracing {
+
+  // Target percentage of requests managed by this HTTP connection manager that will be force
+  // traced if the :ref:`x-client-trace-id <config_http_conn_man_headers_x-client-trace-id>`
+  // header is set. This field is a direct analog for the runtime variable
+  // 'tracing.client_sampling' in the :ref:`HTTP Connection Manager
+  // <config_http_conn_man_runtime>`.
+  // Default: 100%
+  envoy.type.FractionalPercent client_sampling = 1;
+
+  // Target percentage of requests managed by this HTTP connection manager that will be randomly
+  // selected for trace generation, if not requested by the client or not forced. This field is
+  // a direct analog for the runtime variable 'tracing.random_sampling' in the
+  // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+  // Default: 100%
+  envoy.type.FractionalPercent random_sampling = 2;
+
+  // Target percentage of requests managed by this HTTP connection manager that will be traced
+  // after all other sampling checks have been applied (client-directed, force tracing, random
+  // sampling). This field functions as an upper limit on the total configured sampling rate. For
+  // instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1%
+  // of client requests with the appropriate headers to be force traced. This field is a direct
+  // analog for the runtime variable 'tracing.global_enabled' in the
+  // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+  // Default: 100%
+  envoy.type.FractionalPercent overall_sampling = 3;
+}
+
+// A virtual cluster is a way of specifying a regex matching rule against
+// certain important endpoints such that statistics are generated explicitly for
+// the matched requests. The reason this is useful is that when doing
+// prefix/path matching Envoy does not always know what the application
+// considers to be an endpoint. Thus, it’s impossible for Envoy to generically
+// emit per endpoint statistics. However, often systems have highly critical
+// endpoints that they wish to get “perfect” statistics on. Virtual cluster
+// statistics are perfect in the sense that they are emitted on the downstream
+// side such that they include network level failures.
+//
+// Documentation for :ref:`virtual cluster statistics <config_http_filters_router_stats>`.
+//
+// .. note::
+//
+//    Virtual clusters are a useful tool, but we do not recommend setting up a virtual cluster for
+//    every application endpoint. This is both not easily maintainable and as well the matching and
+//    statistics output are not free.
+message VirtualCluster {
+  // Specifies a regex pattern to use for matching requests. The entire path of the request
+  // must match the regex. The regex grammar used is defined `here
+  // <https://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+  //
+  // Examples:
+  //
+  // * The regex */rides/\d+* matches the path */rides/0*
+  // * The regex */rides/\d+* matches the path */rides/123*
+  // * The regex */rides/\d+* does not match the path */rides/123/456*
+  //
+  // .. attention::
+  //   This field has been deprecated in favor of `headers` as it is not safe for use with
+  //   untrusted input in all cases.
+  string pattern = 1 [(validate.rules).string.max_bytes = 1024, deprecated = true];
+
+  // Specifies a list of header matchers to use for matching requests. Each specified header must
+  // match. The pseudo-headers `:path` and `:method` can be used to match the request path and
+  // method, respectively.
+  repeated HeaderMatcher headers = 4;
+
+  // Specifies the name of the virtual cluster. The virtual cluster name as well
+  // as the virtual host name are used when emitting statistics. The statistics are emitted by the
+  // router filter and are documented :ref:`here <config_http_filters_router_stats>`.
+  string name = 2 [(validate.rules).string.min_bytes = 1];
+
+  // Optionally specifies the HTTP method to match on. For example GET, PUT,
+  // etc.
+  //
+  // .. attention::
+  //   This field has been deprecated in favor of `headers`.
+  core.RequestMethod method = 3 [deprecated = true];
+}
+
+// Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
+message RateLimit {
+  // Refers to the stage set in the filter. The rate limit configuration only
+  // applies to filters with the same stage number. The default stage number is
+  // 0.
+  //
+  // .. note::
+  //
+  //   The filter supports a range of 0 - 10 inclusively for stage numbers.
+  google.protobuf.UInt32Value stage = 1 [(validate.rules).uint32.lte = 10];
+
+  // The key to be set in runtime to disable this rate limit configuration.
+  string disable_key = 2;
+
+  message Action {
+    // The following descriptor entry is appended to the descriptor:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("source_cluster", "<local service cluster>")
+    //
+    // <local service cluster> is derived from the :option:`--service-cluster` option.
+    message SourceCluster {
+    }
+
+    // The following descriptor entry is appended to the descriptor:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("destination_cluster", "<routed target cluster>")
+    //
+    // Once a request matches against a route table rule, a routed cluster is determined by one of
+    // the following :ref:`route table configuration <envoy_api_msg_RouteConfiguration>`
+    // settings:
+    //
+    // * :ref:`cluster <envoy_api_field_route.RouteAction.cluster>` indicates the upstream cluster
+    //   to route to.
+    // * :ref:`weighted_clusters <envoy_api_field_route.RouteAction.weighted_clusters>`
+    //   chooses a cluster randomly from a set of clusters with attributed weight.
+    // * :ref:`cluster_header <envoy_api_field_route.RouteAction.cluster_header>` indicates which
+    //   header in the request contains the target cluster.
+    message DestinationCluster {
+    }
+
+    // The following descriptor entry is appended when a header contains a key that matches the
+    // *header_name*:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("<descriptor_key>", "<header_value_queried_from_header>")
+    message RequestHeaders {
+      // The header name to be queried from the request headers. The header’s
+      // value is used to populate the value of the descriptor entry for the
+      // descriptor_key.
+      string header_name = 1 [(validate.rules).string.min_bytes = 1];
+
+      // The key to use in the descriptor entry.
+      string descriptor_key = 2 [(validate.rules).string.min_bytes = 1];
+    }
+
+    // The following descriptor entry is appended to the descriptor and is populated using the
+    // trusted address from :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>`:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("remote_address", "<trusted address from x-forwarded-for>")
+    message RemoteAddress {
+    }
+
+    // The following descriptor entry is appended to the descriptor:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("generic_key", "<descriptor_value>")
+    message GenericKey {
+      // The value to use in the descriptor entry.
+      string descriptor_value = 1 [(validate.rules).string.min_bytes = 1];
+    }
+
+    // The following descriptor entry is appended to the descriptor:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("header_match", "<descriptor_value>")
+    message HeaderValueMatch {
+      // The value to use in the descriptor entry.
+      string descriptor_value = 1 [(validate.rules).string.min_bytes = 1];
+
+      // If set to true, the action will append a descriptor entry when the
+      // request matches the headers. If set to false, the action will append a
+      // descriptor entry when the request does not match the headers. The
+      // default value is true.
+      google.protobuf.BoolValue expect_match = 2;
+
+      // Specifies a set of headers that the rate limit action should match
+      // on. The action will check the request’s headers against all the
+      // specified headers in the config. A match will happen if all the
+      // headers in the config are present in the request with the same values
+      // (or based on presence if the value field is not in the config).
+      repeated HeaderMatcher headers = 3 [(validate.rules).repeated .min_items = 1];
+    }
+
+    oneof action_specifier {
+      option (validate.required) = true;
+
+      // Rate limit on source cluster.
+      SourceCluster source_cluster = 1;
+
+      // Rate limit on destination cluster.
+      DestinationCluster destination_cluster = 2;
+
+      // Rate limit on request headers.
+      RequestHeaders request_headers = 3;
+
+      // Rate limit on remote address.
+      RemoteAddress remote_address = 4;
+
+      // Rate limit on a generic key.
+      GenericKey generic_key = 5;
+
+      // Rate limit on the existence of request headers.
+      HeaderValueMatch header_value_match = 6;
+    }
+  }
+
+  // A list of actions that are to be applied for this rate limit configuration.
+  // Order matters as the actions are processed sequentially and the descriptor
+  // is composed by appending descriptor entries in that sequence. If an action
+  // cannot append a descriptor entry, no descriptor is generated for the
+  // configuration. See :ref:`composing actions
+  // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
+  repeated Action actions = 3 [(validate.rules).repeated .min_items = 1];
+}
+
+// .. attention::
+//
+//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+//
+// .. attention::
+//
+//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//
+//   .. code-block:: json
+//
+//     {
+//       "name": ":method",
+//       "exact_match": "POST"
+//     }
+//
+// .. attention::
+//   In the absence of any header match specifier, match will default to :ref:`present_match
+//   <envoy_api_field_route.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
+//   <envoy_api_field_route.HeaderMatcher.name>` header will match, regardless of the header's
+//   value.
+//
+//  [#next-major-version: HeaderMatcher should be refactored to use StringMatcher.]
+message HeaderMatcher {
+  // Specifies the name of the header in the request.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  reserved 2; // value deprecated by :ref:`exact_match
+              // <envoy_api_field_route.HeaderMatcher.exact_match>`
+
+  reserved 3; // regex deprecated by :ref:`regex_match
+              // <envoy_api_field_route.HeaderMatcher.regex_match>`
+
+  // Specifies how the header match will be performed to route the request.
+  oneof header_match_specifier {
+    // If specified, header match will be performed based on the value of the header.
+    string exact_match = 4;
+
+    // If specified, this regex string is a regular expression rule which implies the entire request
+    // header value must match the regex. The rule will not match if only a subsequence of the
+    // request header value matches the regex. The regex grammar used in the value field is defined
+    // `here <https://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+    //
+    // Examples:
+    //
+    // * The regex *\d{3}* matches the value *123*
+    // * The regex *\d{3}* does not match the value *1234*
+    // * The regex *\d{3}* does not match the value *123.456*
+    //
+    // .. attention::
+    //   This field has been deprecated in favor of `safe_regex_match` as it is not safe for use
+    //   with untrusted input in all cases.
+    string regex_match = 5 [(validate.rules).string.max_bytes = 1024, deprecated = true];
+
+    // If specified, this regex string is a regular expression rule which implies the entire request
+    // header value must match the regex. The rule will not match if only a subsequence of the
+    // request header value matches the regex.
+    type.matcher.RegexMatcher safe_regex_match = 11;
+
+    // If specified, header match will be performed based on range.
+    // The rule will match if the request header value is within this range.
+    // The entire request header value must represent an integer in base 10 notation: consisting of
+    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
+    // the header value does not represent an integer. Match will fail for empty values, floating
+    // point numbers or if only a subsequence of the header value is an integer.
+    //
+    // Examples:
+    //
+    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+    //   "-1somestring"
+    envoy.type.Int64Range range_match = 6;
+
+    // If specified, header match will be performed based on whether the header is in the
+    // request.
+    bool present_match = 7;
+
+    // If specified, header match will be performed based on the prefix of the header value.
+    // Note: empty prefix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
+    string prefix_match = 9 [(validate.rules).string.min_bytes = 1];
+
+    // If specified, header match will be performed based on the suffix of the header value.
+    // Note: empty suffix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
+    string suffix_match = 10 [(validate.rules).string.min_bytes = 1];
+  }
+
+  // If specified, the match result will be inverted before checking. Defaults to false.
+  //
+  // Examples:
+  //
+  // * The regex *\d{3}* does not match the value *1234*, so it will match when inverted.
+  // * The range [-10,0) will match the value -1, so it will not match when inverted.
+  bool invert_match = 8;
+}
+
+// Query parameter matching treats the query string of a request's :path header
+// as an ampersand-separated list of keys and/or key=value elements.
+message QueryParameterMatcher {
+  // Specifies the name of a key that must be present in the requested
+  // *path*'s query string.
+  string name = 1 [(validate.rules).string = {min_bytes: 1, max_bytes: 1024}];
+
+  // Specifies the value of the key. If the value is absent, a request
+  // that contains the key in its query string will match, whether the
+  // key appears with a value (e.g., "?debug=true") or not (e.g., "?debug")
+  //
+  // ..attention::
+  //   This field is deprecated. Use an `exact` match inside the `string_match` field.
+  string value = 3 [deprecated = true];
+
+  // Specifies whether the query parameter value is a regular expression.
+  // Defaults to false. The entire query parameter value (i.e., the part to
+  // the right of the equals sign in "key=value") must match the regex.
+  // E.g., the regex "\d+$" will match "123" but not "a123" or "123a".
+  //
+  // ..attention::
+  //   This field is deprecated. Use a `safe_regex` match inside the `string_match` field.
+  google.protobuf.BoolValue regex = 4 [deprecated = true];
+
+  oneof query_parameter_match_specifier {
+    // Specifies whether a query parameter value should match against a string.
+    type.matcher.StringMatcher string_match = 5 [(validate.rules).message.required = true];
+
+    // Specifies whether a query parameter should be present.
+    bool present_match = 6;
+  }
+}

--- a/api/envoy/api/v3alpha/srds.proto
+++ b/api/envoy/api/v3alpha/srds.proto
@@ -1,0 +1,135 @@
+syntax = "proto3";
+
+package envoy.api.v3alpha;
+
+import "envoy/api/v3alpha/discovery.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "validate/validate.proto";
+
+option java_outer_classname = "SrdsProto";
+option java_package = "io.envoyproxy.envoy.api.v3alpha";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: HTTP scoped routing configuration]
+// * Routing :ref:`architecture overview <arch_overview_http_routing>`
+//
+// The Scoped Routes Discovery Service (SRDS) API distributes
+// :ref:`ScopedRouteConfiguration<envoy_api_msg.ScopedRouteConfiguration>`
+// resources. Each ScopedRouteConfiguration resource represents a "routing
+// scope" containing a mapping that allows the HTTP connection manager to
+// dynamically assign a routing table (specified via a
+// :ref:`RouteConfiguration<envoy_api_msg_RouteConfiguration>` message) to each
+// HTTP request.
+// [#proto-status: experimental]
+service ScopedRoutesDiscoveryService {
+  rpc StreamScopedRoutes(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaScopedRoutes(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchScopedRoutes(DiscoveryRequest) returns (DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:scoped-routes"
+      body: "*"
+    };
+  }
+}
+
+// Specifies a routing scope, which associates a
+// :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>` to a
+// :ref:`envoy_api_msg_RouteConfiguration` (identified by its resource name).
+//
+// The HTTP connection manager builds up a table consisting of these Key to
+// RouteConfiguration mappings, and looks up the RouteConfiguration to use per
+// request according to the algorithm specified in the
+// :ref:`scope_key_builder<envoy_api_field_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.scope_key_builder>`
+// assigned to the HttpConnectionManager.
+//
+// For example, with the following configurations (in YAML):
+//
+// HttpConnectionManager config:
+//
+// .. code::
+//
+//   ...
+//   scoped_routes:
+//     name: foo-scoped-routes
+//     scope_key_builder:
+//       fragments:
+//         - header_value_extractor:
+//             name: X-Route-Selector
+//             element_separator: ,
+//             element:
+//               separator: =
+//               key: vip
+//
+// ScopedRouteConfiguration resources (specified statically via
+// :ref:`scoped_route_configurations_list<envoy_api_field_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.scoped_route_configurations_list>`
+// or obtained dynamically via SRDS):
+//
+// .. code::
+//
+//  (1)
+//   name: route-scope1
+//   route_configuration_name: route-config1
+//   key:
+//      fragments:
+//        - string_key: 172.10.10.20
+//
+//  (2)
+//   name: route-scope2
+//   route_configuration_name: route-config2
+//   key:
+//     fragments:
+//       - string_key: 172.20.20.30
+//
+// A request from a client such as:
+//
+// .. code::
+//
+//     GET / HTTP/1.1
+//     Host: foo.com
+//     X-Route-Selector: vip=172.10.10.20
+//
+// would result in the routing table defined by the `route-config1`
+// RouteConfiguration being assigned to the HTTP request/stream.
+//
+// [#comment:next free field: 4]
+// [#proto-status: experimental]
+message ScopedRouteConfiguration {
+  // The name assigned to the routing scope.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specifies a key which is matched against the output of the
+  // :ref:`scope_key_builder<envoy_api_field_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.scope_key_builder>`
+  // specified in the HttpConnectionManager. The matching is done per HTTP
+  // request and is dependent on the order of the fragments contained in the
+  // Key.
+  message Key {
+    message Fragment {
+      oneof type {
+        option (validate.required) = true;
+
+        // A string to match against.
+        string string_key = 1;
+      }
+    }
+
+    // The ordered set of fragments to match against. The order must match the
+    // fragments in the corresponding
+    // :ref:`scope_key_builder<envoy_api_field_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.scope_key_builder>`.
+    repeated Fragment fragments = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  // The resource name to use for a :ref:`envoy_api_msg_DiscoveryRequest` to an
+  // RDS server to fetch the :ref:`envoy_api_msg_RouteConfiguration` associated
+  // with this scope.
+  string route_configuration_name = 2 [(validate.rules).string.min_bytes = 1];
+
+  // The key to match against.
+  Key key = 3 [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/accesslog/v3alpha/BUILD
+++ b/api/envoy/config/accesslog/v3alpha/BUILD
@@ -1,0 +1,22 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "als",
+    srcs = ["als.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service",
+    ],
+)
+
+api_proto_library_internal(
+    name = "file",
+    srcs = ["file.proto"],
+)
+
+api_go_proto_library(
+    name = "als",
+    proto = ":als",
+    deps = ["//envoy/api/v3alpha/core:grpc_service_go_proto"],
+)

--- a/api/envoy/config/accesslog/v3alpha/als.proto
+++ b/api/envoy/config/accesslog/v3alpha/als.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package envoy.config.accesslog.v3alpha;
+
+option java_outer_classname = "AlsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.accesslog.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/grpc_service.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: gRPC Access Log Service (ALS)]
+
+// Configuration for the built-in *envoy.http_grpc_access_log*
+// :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v3alpha.AccessLog>`. This configuration
+// will populate :ref:`StreamAccessLogsMessage.http_logs
+// <envoy_api_field_service.accesslog.v3alpha.StreamAccessLogsMessage.http_logs>`.
+message HttpGrpcAccessLogConfig {
+  CommonGrpcAccessLogConfig common_config = 1 [(validate.rules).message.required = true];
+
+  // Additional request headers to log in :ref:`HTTPRequestProperties.request_headers
+  // <envoy_api_field_data.accesslog.v3alpha.HTTPRequestProperties.request_headers>`.
+  repeated string additional_request_headers_to_log = 2;
+
+  // Additional response headers to log in :ref:`HTTPResponseProperties.response_headers
+  // <envoy_api_field_data.accesslog.v3alpha.HTTPResponseProperties.response_headers>`.
+  repeated string additional_response_headers_to_log = 3;
+
+  // Additional response trailers to log in :ref:`HTTPResponseProperties.response_trailers
+  // <envoy_api_field_data.accesslog.v3alpha.HTTPResponseProperties.response_trailers>`.
+  repeated string additional_response_trailers_to_log = 4;
+}
+
+// Configuration for the built-in *envoy.tcp_grpc_access_log* type. This configuration will
+// populate *StreamAccessLogsMessage.tcp_logs*.
+message TcpGrpcAccessLogConfig {
+  CommonGrpcAccessLogConfig common_config = 1 [(validate.rules).message.required = true];
+}
+
+// Common configuration for gRPC access logs.
+message CommonGrpcAccessLogConfig {
+  // The friendly name of the access log to be returned in :ref:`StreamAccessLogsMessage.Identifier
+  // <envoy_api_msg_service.accesslog.v3alpha.StreamAccessLogsMessage.Identifier>`. This allows the
+  // access log server to differentiate between different access logs coming from the same Envoy.
+  string log_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The gRPC service for the access log service.
+  envoy.api.v3alpha.core.GrpcService grpc_service = 2 [(validate.rules).message.required = true];
+
+  // Interval for flushing access logs to the gRPC stream. Logger will flush requests every time
+  // this interval is elapsed, or when batch size limit is hit, whichever comes first. Defaults to
+  // 1 second.
+  google.protobuf.Duration buffer_flush_interval = 3 [(validate.rules).duration.gt = {}];
+
+  // Soft size limit in bytes for access log entries buffer. Logger will buffer requests until
+  // this limit it hit, or every time flush interval is elapsed, whichever comes first. Setting it
+  // to zero effectively disables the batching. Defaults to 16384.
+  google.protobuf.UInt32Value buffer_size_bytes = 4;
+}

--- a/api/envoy/config/accesslog/v3alpha/file.proto
+++ b/api/envoy/config/accesslog/v3alpha/file.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package envoy.config.accesslog.v3alpha;
+
+option java_outer_classname = "FileProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.accesslog.v3alpha";
+option go_package = "v2";
+
+import "validate/validate.proto";
+import "google/protobuf/struct.proto";
+
+// [#protodoc-title: File access log]
+
+// Custom configuration for an :ref:`AccessLog
+// <envoy_api_msg_config.filter.accesslog.v3alpha.AccessLog>` that writes log entries directly to a
+// file. Configures the built-in *envoy.file_access_log* AccessLog.
+message FileAccessLog {
+  // A path to a local file to which to write the access log entries.
+  string path = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Access log format. Envoy supports :ref:`custom access log formats
+  // <config_access_log_format>` as well as a :ref:`default format
+  // <config_access_log_default_format>`.
+  oneof access_log_format {
+    // Access log :ref:`format string<config_access_log_format_strings>`
+    string format = 2;
+
+    // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`
+    google.protobuf.Struct json_format = 3;
+  }
+}

--- a/api/envoy/config/bootstrap/v3alpha/BUILD
+++ b/api/envoy/config/bootstrap/v3alpha/BUILD
@@ -1,0 +1,40 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "bootstrap",
+    srcs = ["bootstrap.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha:cds",
+        "//envoy/api/v3alpha:lds",
+        "//envoy/api/v3alpha/auth:cert",
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:config_source",
+        "//envoy/config/metrics/v3alpha:metrics_service",
+        "//envoy/config/metrics/v3alpha:stats",
+        "//envoy/config/overload/v3alpha:overload",
+        "//envoy/config/ratelimit/v3alpha:rls",
+        "//envoy/config/trace/v3alpha:trace",
+    ],
+)
+
+api_go_proto_library(
+    name = "bootstrap",
+    proto = ":bootstrap",
+    deps = [
+        "//envoy/api/v3alpha:cds_go_grpc",
+        "//envoy/api/v3alpha:lds_go_grpc",
+        "//envoy/api/v3alpha/auth:cert_go_proto",
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:config_source_go_proto",
+        "//envoy/config/metrics/v3alpha:metrics_service_go_proto",
+        "//envoy/config/metrics/v3alpha:stats_go_proto",
+        "//envoy/config/overload/v3alpha:overload_go_proto",
+        "//envoy/config/ratelimit/v3alpha:rls_go_grpc",
+        "//envoy/config/trace/v3alpha:trace_go_proto",
+    ],
+)

--- a/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
@@ -1,0 +1,318 @@
+// [#protodoc-title: Bootstrap]
+// This proto is supplied via the :option:`-c` CLI flag and acts as the root
+// of the Envoy v2 configuration. See the :ref:`v2 configuration overview
+// <config_overview_v2_bootstrap>` for more detail.
+
+syntax = "proto3";
+
+package envoy.config.bootstrap.v3alpha;
+
+option java_outer_classname = "BootstrapProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.bootstrap.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/auth/cert.proto";
+import "envoy/api/v3alpha/core/config_source.proto";
+import "envoy/api/v3alpha/cds.proto";
+import "envoy/api/v3alpha/lds.proto";
+import "envoy/config/trace/v3alpha/trace.proto";
+import "envoy/config/metrics/v3alpha/stats.proto";
+import "envoy/config/overload/v3alpha/overload.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
+message Bootstrap {
+  // Node identity to present to the management server and for instance
+  // identification purposes (e.g. in generated headers).
+  envoy.api.v3alpha.core.Node node = 1;
+
+  message StaticResources {
+    // Static :ref:`Listeners <envoy_api_msg_Listener>`. These listeners are
+    // available regardless of LDS configuration.
+    repeated envoy.api.v3alpha.Listener listeners = 1;
+
+    // If a network based configuration source is specified for :ref:`cds_config
+    // <envoy_api_field_config.bootstrap.v3alpha.Bootstrap.DynamicResources.cds_config>`, it's
+    // necessary to have some initial cluster definitions available to allow Envoy to know how to
+    // speak to the management server. These cluster definitions may not use :ref:`EDS
+    // <arch_overview_dynamic_config_eds>` (i.e. they should be static IP or DNS-based).
+    repeated envoy.api.v3alpha.Cluster clusters = 2;
+
+    // These static secrets can be used by :ref:`SdsSecretConfig
+    // <envoy_api_msg_auth.SdsSecretConfig>`
+    repeated envoy.api.v3alpha.auth.Secret secrets = 3;
+  }
+  // Statically specified resources.
+  StaticResources static_resources = 2;
+
+  message DynamicResources {
+    // All :ref:`Listeners <envoy_api_msg_Listener>` are provided by a single
+    // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
+    envoy.api.v3alpha.core.ConfigSource lds_config = 1;
+
+    // All post-bootstrap :ref:`Cluster <envoy_api_msg_Cluster>` definitions are
+    // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
+    // configuration source.
+    envoy.api.v3alpha.core.ConfigSource cds_config = 2;
+
+    // A single :ref:`ADS <config_overview_v2_ads>` source may be optionally
+    // specified. This must have :ref:`api_type
+    // <envoy_api_field_core.ApiConfigSource.api_type>` :ref:`GRPC
+    // <envoy_api_enum_value_core.ApiConfigSource.ApiType.GRPC>`. Only
+    // :ref:`ConfigSources <envoy_api_msg_core.ConfigSource>` that have
+    // the :ref:`ads <envoy_api_field_core.ConfigSource.ads>` field set will be
+    // streamed on the ADS channel.
+    envoy.api.v3alpha.core.ApiConfigSource ads_config = 3;
+
+    reserved 4;
+  }
+  // xDS configuration sources.
+  DynamicResources dynamic_resources = 3;
+
+  // Configuration for the cluster manager which owns all upstream clusters
+  // within the server.
+  ClusterManager cluster_manager = 4;
+
+  // Health discovery service config option.
+  // (:ref:`core.ApiConfigSource <envoy_api_msg_core.ApiConfigSource>`)
+  envoy.api.v3alpha.core.ApiConfigSource hds_config = 14;
+
+  // Optional file system path to search for startup flag files.
+  string flags_path = 5;
+
+  // Optional set of stats sinks.
+  repeated envoy.config.metrics.v3alpha.StatsSink stats_sinks = 6;
+
+  // Configuration for internal processing of stats.
+  envoy.config.metrics.v3alpha.StatsConfig stats_config = 13;
+
+  // Optional duration between flushes to configured stats sinks. For
+  // performance reasons Envoy latches counters and only flushes counters and
+  // gauges at a periodic interval. If not specified the default is 5000ms (5
+  // seconds).
+  // Duration must be at least 1ms and at most 5 min.
+  google.protobuf.Duration stats_flush_interval = 7 [
+    (validate.rules).duration = {
+      lt: {seconds: 300},
+      gte: {nanos: 1000000}
+    },
+    (gogoproto.stdduration) = true
+  ];
+
+  // Optional watchdog configuration.
+  Watchdog watchdog = 8;
+
+  // Configuration for an external tracing provider. If not specified, no
+  // tracing will be performed.
+  envoy.config.trace.v3alpha.Tracing tracing = 9;
+
+  reserved 10;
+
+  // Configuration for the runtime configuration provider (deprecated). If not
+  // specified, a “null” provider will be used which will result in all defaults
+  // being used.
+  Runtime runtime = 11 [deprecated = true];
+
+  // Configuration for the runtime configuration provider. If not
+  // specified, a “null” provider will be used which will result in all defaults
+  // being used.
+  LayeredRuntime layered_runtime = 17;
+
+  // Configuration for the local administration HTTP server.
+  Admin admin = 12;
+
+  // Optional overload manager configuration.
+  envoy.config.overload.v3alpha.OverloadManager overload_manager = 15;
+
+  // Enable :ref:`stats for event dispatcher <operations_performance>`, defaults to false.
+  // Note that this records a value for each iteration of the event loop on every thread. This
+  // should normally be minimal overhead, but when using
+  // :ref:`statsd <envoy_api_msg_config.metrics.v3alpha.StatsdSink>`, it will send each observed
+  // value over the wire individually because the statsd protocol doesn't have any way to represent
+  // a histogram summary. Be aware that this can be a very large volume of data.
+  bool enable_dispatcher_stats = 16;
+
+  // Optional string which will be used in lieu of x-envoy in prefixing headers.
+  //
+  // For example, if this string is present and set to X-Foo, then x-envoy-retry-on will be
+  // transformed into x-foo-retry-on etc.
+  //
+  // Note this applies to the headers Envoy will generate, the headers Envoy will sanitize, and the
+  // headers Envoy will trust for core code and core extensions only. Be VERY careful making
+  // changes to this string, especially in multi-layer Envoy deployments or deployments using
+  // extensions which are not upstream.
+  string header_prefix = 18;
+}
+
+// Administration interface :ref:`operations documentation
+// <operations_admin_interface>`.
+message Admin {
+  // The path to write the access log for the administration server. If no
+  // access log is desired specify ‘/dev/null’. This is only required if
+  // :ref:`address <envoy_api_field_config.bootstrap.v3alpha.Admin.address>` is set.
+  string access_log_path = 1;
+
+  // The cpu profiler output path for the administration server. If no profile
+  // path is specified, the default is ‘/var/log/envoy/envoy.prof’.
+  string profile_path = 2;
+
+  // The TCP address that the administration server will listen on.
+  // If not specified, Envoy will not start an administration server.
+  envoy.api.v3alpha.core.Address address = 3;
+
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries.
+  repeated envoy.api.v3alpha.core.SocketOption socket_options = 4;
+}
+
+// Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.
+message ClusterManager {
+  // Name of the local cluster (i.e., the cluster that owns the Envoy running
+  // this configuration). In order to enable :ref:`zone aware routing
+  // <arch_overview_load_balancing_zone_aware_routing>` this option must be set.
+  // If *local_cluster_name* is defined then :ref:`clusters
+  // <envoy_api_msg_Cluster>` must be defined in the :ref:`Bootstrap
+  // static cluster resources
+  // <envoy_api_field_config.bootstrap.v3alpha.Bootstrap.StaticResources.clusters>`. This is
+  // unrelated to the :option:`--service-cluster` option which does not `affect zone aware routing
+  // <https://github.com/envoyproxy/envoy/issues/774>`_.
+  string local_cluster_name = 1;
+
+  message OutlierDetection {
+    // Specifies the path to the outlier event log.
+    string event_log_path = 1;
+  }
+  // Optional global configuration for outlier detection.
+  OutlierDetection outlier_detection = 2;
+
+  // Optional configuration used to bind newly established upstream connections.
+  // This may be overridden on a per-cluster basis by upstream_bind_config in the cds_config.
+  envoy.api.v3alpha.core.BindConfig upstream_bind_config = 3;
+
+  // A management server endpoint to stream load stats to via
+  // *StreamLoadStats*. This must have :ref:`api_type
+  // <envoy_api_field_core.ApiConfigSource.api_type>` :ref:`GRPC
+  // <envoy_api_enum_value_core.ApiConfigSource.ApiType.GRPC>`.
+  envoy.api.v3alpha.core.ApiConfigSource load_stats_config = 4;
+}
+
+// Envoy process watchdog configuration. When configured, this monitors for
+// nonresponsive threads and kills the process after the configured thresholds.
+message Watchdog {
+  // The duration after which Envoy counts a nonresponsive thread in the
+  // *server.watchdog_miss* statistic. If not specified the default is 200ms.
+  google.protobuf.Duration miss_timeout = 1;
+
+  // The duration after which Envoy counts a nonresponsive thread in the
+  // *server.watchdog_mega_miss* statistic. If not specified the default is
+  // 1000ms.
+  google.protobuf.Duration megamiss_timeout = 2;
+
+  // If a watched thread has been nonresponsive for this duration, assume a
+  // programming error and kill the entire Envoy process. Set to 0 to disable
+  // kill behavior. If not specified the default is 0 (disabled).
+  google.protobuf.Duration kill_timeout = 3;
+
+  // If at least two watched threads have been nonresponsive for at least this
+  // duration assume a true deadlock and kill the entire Envoy process. Set to 0
+  // to disable this behavior. If not specified the default is 0 (disabled).
+  google.protobuf.Duration multikill_timeout = 4;
+}
+
+// Runtime :ref:`configuration overview <config_runtime>` (deprecated).
+message Runtime {
+  // The implementation assumes that the file system tree is accessed via a
+  // symbolic link. An atomic link swap is used when a new tree should be
+  // switched to. This parameter specifies the path to the symbolic link. Envoy
+  // will watch the location for changes and reload the file system tree when
+  // they happen. If this parameter is not set, there will be no disk based
+  // runtime.
+  string symlink_root = 1;
+
+  // Specifies the subdirectory to load within the root directory. This is
+  // useful if multiple systems share the same delivery mechanism. Envoy
+  // configuration elements can be contained in a dedicated subdirectory.
+  string subdirectory = 2;
+
+  // Specifies an optional subdirectory to load within the root directory. If
+  // specified and the directory exists, configuration values within this
+  // directory will override those found in the primary subdirectory. This is
+  // useful when Envoy is deployed across many different types of servers.
+  // Sometimes it is useful to have a per service cluster directory for runtime
+  // configuration. See below for exactly how the override directory is used.
+  string override_subdirectory = 3;
+
+  // Static base runtime. This will be :ref:`overridden
+  // <config_runtime_layering>` by other runtime layers, e.g.
+  // disk or admin. This follows the :ref:`runtime protobuf JSON representation
+  // encoding <config_runtime_proto_json>`.
+  google.protobuf.Struct base = 4;
+}
+
+message RuntimeLayer {
+  // :ref:`Disk runtime <config_runtime_local_disk>` layer.
+  message DiskLayer {
+    // The implementation assumes that the file system tree is accessed via a
+    // symbolic link. An atomic link swap is used when a new tree should be
+    // switched to. This parameter specifies the path to the symbolic link.
+    // Envoy will watch the location for changes and reload the file system tree
+    // when they happen. See documentation on runtime :ref:`atomicity
+    // <config_runtime_atomicity>` for further details on how reloads are
+    // treated.
+    string symlink_root = 1;
+
+    // Specifies the subdirectory to load within the root directory. This is
+    // useful if multiple systems share the same delivery mechanism. Envoy
+    // configuration elements can be contained in a dedicated subdirectory.
+    string subdirectory = 3;
+
+    // :ref:`Append <config_runtime_local_disk_service_cluster_subdirs>` the
+    // service cluster to the path under symlink root.
+    bool append_service_cluster = 2;
+  }
+
+  // :ref:`Admin console runtime <config_runtime_admin>` layer.
+  message AdminLayer {
+  }
+
+  // :ref:`Runtime Discovery Service (RTDS) <config_runtime_rtds>` layer.
+  message RtdsLayer {
+    // Resource to subscribe to at *rtds_config* for the RTDS layer.
+    string name = 1;
+
+    // RTDS configuration source.
+    envoy.api.v3alpha.core.ConfigSource rtds_config = 2;
+  }
+
+  // Descriptive name for the runtime layer. This is only used for the runtime
+  // :http:get:`/runtime` output.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  oneof layer_specifier {
+    // :ref:`Static runtime <config_runtime_bootstrap>` layer.
+    // This follows the :ref:`runtime protobuf JSON representation encoding
+    // <config_runtime_proto_json>`. Unlike static xDS resources, this static
+    // layer is overridable by later layers in the runtime virtual filesystem.
+    option (validate.required) = true;
+
+    google.protobuf.Struct static_layer = 2;
+    DiskLayer disk_layer = 3;
+    AdminLayer admin_layer = 4;
+    RtdsLayer rtds_layer = 5;
+  }
+}
+
+// Runtime :ref:`configuration overview <config_runtime>`.
+message LayeredRuntime {
+  // The :ref:`layers <config_runtime_layering>` of the runtime. This is ordered
+  // such that later layers in the list overlay earlier entries.
+  repeated RuntimeLayer layers = 1;
+}

--- a/api/envoy/config/cluster/dynamic_forward_proxy/v3alpha/BUILD
+++ b/api/envoy/config/cluster/dynamic_forward_proxy/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "cluster",
+    srcs = ["cluster.proto"],
+    deps = [
+        "//envoy/config/common/dynamic_forward_proxy/v3alpha:dns_cache",
+    ],
+)

--- a/api/envoy/config/cluster/dynamic_forward_proxy/v3alpha/cluster.proto
+++ b/api/envoy/config/cluster/dynamic_forward_proxy/v3alpha/cluster.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.cluster.dynamic_forward_proxy.v3alpha;
+
+option java_outer_classname = "DynamicForwardProxyClusterProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.cluster.dynamic_forward_proxy.v3alpha";
+option go_package = "v2alpha";
+
+import "envoy/config/common/dynamic_forward_proxy/v3alpha/dns_cache.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Dynamic forward proxy cluster configuration]
+
+// Configuration for the dynamic forward proxy cluster. See the :ref:`architecture overview
+// <arch_overview_http_dynamic_forward_proxy>` for more information.
+message ClusterConfig {
+  // The DNS cache configuration that the cluster will attach to. Note this configuration must
+  // match that of associated :ref:`dynamic forward proxy HTTP filter configuration
+  // <envoy_api_field_config.filter.http.dynamic_forward_proxy.v3alpha.FilterConfig.dns_cache_config>`.
+  common.dynamic_forward_proxy.v3alpha.DnsCacheConfig dns_cache_config = 1
+      [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/common/dynamic_forward_proxy/v3alpha/BUILD
+++ b/api/envoy/config/common/dynamic_forward_proxy/v3alpha/BUILD
@@ -1,0 +1,12 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "dns_cache",
+    srcs = ["dns_cache.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha:cds",
+    ],
+)

--- a/api/envoy/config/common/dynamic_forward_proxy/v3alpha/dns_cache.proto
+++ b/api/envoy/config/common/dynamic_forward_proxy/v3alpha/dns_cache.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package envoy.config.common.dynamic_forward_proxy.v3alpha;
+
+option java_outer_classname = "DnsCacheProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.common.dynamic_forward_proxy.v3alpha";
+
+import "envoy/api/v3alpha/cds.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Dynamic forward proxy common configuration]
+
+// Configuration for the dynamic forward proxy DNS cache. See the :ref:`architecture overview
+// <arch_overview_http_dynamic_forward_proxy>` for more information.
+message DnsCacheConfig {
+  // The name of the cache. Multiple named caches allow independent dynamic forward proxy
+  // configurations to operate within a single Envoy process using different configurations. All
+  // configurations with the same name *must* otherwise have the same settings when referenced
+  // from different configuration components. Configuration will fail to load if this is not
+  // the case.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The DNS lookup family to use during resolution.
+  //
+  // [#comment:TODO(mattklein123): Figure out how to support IPv4/IPv6 "happy eyeballs" mode. The
+  // way this might work is a new lookup family which returns both IPv4 and IPv6 addresses, and
+  // then configures a host to have a primary and fall back address. With this, we could very
+  // likely build a "happy eyeballs" connection pool which would race the primary / fall back
+  // address and return the one that wins. This same method could potentially also be used for
+  // QUIC to TCP fall back.]
+  api.v3alpha.Cluster.DnsLookupFamily dns_lookup_family = 2
+      [(validate.rules).enum.defined_only = true];
+
+  // The DNS refresh rate for currently cached DNS hosts. If not specified defaults to 60s.
+  //
+  // .. note:
+  //
+  //  The returned DNS TTL is not currently used to alter the refresh rate. This feature will be
+  //  added in a future change.
+  google.protobuf.Duration dns_refresh_rate = 3 [(validate.rules).duration.gt = {}];
+
+  // The TTL for hosts that are unused. Hosts that have not been used in the configured time
+  // interval will be purged. If not specified defaults to 5m.
+  //
+  // .. note:
+  //
+  //   The TTL is only checked at the time of DNS refresh, as specified by *dns_refresh_rate*. This
+  //   means that if the configured TTL is shorter than the refresh rate the host may not be removed
+  //   immediately.
+  //
+  //  .. note:
+  //
+  //   The TTL has no relation to DNS TTL and is only used to control Envoy's resource usage.
+  google.protobuf.Duration host_ttl = 4 [(validate.rules).duration.gt = {}];
+
+  // The maximum number of hosts that the cache will hold. If not specified defaults to 1024.
+  //
+  // .. note:
+  //
+  //   The implementation is approximate and enforced independently on each worker thread, thus
+  //   it is possible for the maximum hosts in the cache to go slightly above the configured
+  //   value depending on timing. This is similar to how other circuit breakers work.
+  google.protobuf.UInt32Value max_hosts = 5 [(validate.rules).uint32.gt = 0];
+}

--- a/api/envoy/config/common/tap/v3alpha/BUILD
+++ b/api/envoy/config/common/tap/v3alpha/BUILD
@@ -1,0 +1,13 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "common",
+    srcs = ["common.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha/core:config_source",
+        "//envoy/service/tap/v3alpha:common",
+    ],
+)

--- a/api/envoy/config/common/tap/v3alpha/common.proto
+++ b/api/envoy/config/common/tap/v3alpha/common.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+import "envoy/service/tap/v3alpha/common.proto";
+import "envoy/api/v3alpha/core/config_source.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+package envoy.config.common.tap.v3alpha;
+
+option java_outer_classname = "CommonProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.common.tap.v3alpha";
+
+// [#protodoc-title: Common tap extension configuration]
+
+// Common configuration for all tap extensions.
+message CommonExtensionConfig {
+
+  // [#not-implemented-hide:]
+  message TapDSConfig {
+    // Configuration for the source of TapDS updates for this Cluster.
+    envoy.api.v3alpha.core.ConfigSource config_source = 1
+        [(validate.rules).message.required = true];
+
+    // Tap config to request from XDS server.
+    string name = 2 [(validate.rules).string.min_bytes = 1];
+  }
+
+  oneof config_type {
+    option (validate.required) = true;
+
+    // If specified, the tap filter will be configured via an admin handler.
+    AdminConfig admin_config = 1;
+
+    // If specified, the tap filter will be configured via a static configuration that cannot be
+    // changed.
+    service.tap.v3alpha.TapConfig static_config = 2;
+
+    // [#not-implemented-hide:] Configuration to use for TapDS updates for the filter.
+    TapDSConfig tapds_config = 3;
+  }
+}
+
+// Configuration for the admin handler. See :ref:`here <config_http_filters_tap_admin_handler>` for
+// more information.
+message AdminConfig {
+  // Opaque configuration ID. When requests are made to the admin handler, the passed opaque ID is
+  // matched to the configured filter opaque ID to determine which filter to configure.
+  string config_id = 1 [(validate.rules).string.min_bytes = 1];
+}

--- a/api/envoy/config/filter/accesslog/v3alpha/BUILD
+++ b/api/envoy/config/filter/accesslog/v3alpha/BUILD
@@ -1,0 +1,28 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "accesslog",
+    srcs = ["accesslog.proto"],
+    visibility = [
+        "//envoy/config/filter/http/router/v3alpha:__pkg__",
+        "//envoy/config/filter/network/http_connection_manager/v3alpha:__pkg__",
+        "//envoy/config/filter/network/tcp_proxy/v3alpha:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/route",
+        "//envoy/type:percent",
+    ],
+)
+
+api_go_proto_library(
+    name = "accesslog",
+    proto = ":accesslog",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/route:route_go_proto",
+        "//envoy/type:percent_go_proto",
+    ],
+)

--- a/api/envoy/config/filter/accesslog/v3alpha/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v3alpha/accesslog.proto
@@ -1,0 +1,248 @@
+syntax = "proto3";
+
+package envoy.config.filter.accesslog.v3alpha;
+
+option java_outer_classname = "AccesslogProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.accesslog.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/route/route.proto";
+import "envoy/type/percent.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Common access log types]
+
+message AccessLog {
+  // The name of the access log implementation to instantiate. The name must
+  // match a statically registered access log. Current built-in loggers include:
+  //
+  // #. "envoy.file_access_log"
+  // #. "envoy.http_grpc_access_log"
+  // #. "envoy.tcp_grpc_access_log"
+  string name = 1;
+
+  // Filter which is used to determine if the access log needs to be written.
+  AccessLogFilter filter = 2;
+
+  // Custom configuration that depends on the access log being instantiated. Built-in
+  // configurations include:
+  //
+  // #. "envoy.file_access_log": :ref:`FileAccessLog
+  //    <envoy_api_msg_config.accesslog.v3alpha.FileAccessLog>`
+  // #. "envoy.http_grpc_access_log": :ref:`HttpGrpcAccessLogConfig
+  //    <envoy_api_msg_config.accesslog.v3alpha.HttpGrpcAccessLogConfig>`
+  // #. "envoy.tcp_grpc_access_log": :ref:`TcpGrpcAccessLogConfig
+  //    <envoy_api_msg_config.accesslog.v3alpha.TcpGrpcAccessLogConfig>`
+  oneof config_type {
+    google.protobuf.Struct config = 3;
+
+    google.protobuf.Any typed_config = 4;
+  }
+}
+
+message AccessLogFilter {
+  oneof filter_specifier {
+    option (validate.required) = true;
+
+    // Status code filter.
+    StatusCodeFilter status_code_filter = 1;
+
+    // Duration filter.
+    DurationFilter duration_filter = 2;
+
+    // Not health check filter.
+    NotHealthCheckFilter not_health_check_filter = 3;
+
+    // Traceable filter.
+    TraceableFilter traceable_filter = 4;
+
+    // Runtime filter.
+    RuntimeFilter runtime_filter = 5;
+
+    // And filter.
+    AndFilter and_filter = 6;
+
+    // Or filter.
+    OrFilter or_filter = 7;
+
+    // Header filter.
+    HeaderFilter header_filter = 8;
+
+    // Response flag filter.
+    ResponseFlagFilter response_flag_filter = 9;
+
+    // gRPC status filter.
+    GrpcStatusFilter grpc_status_filter = 10;
+
+    // Extension filter.
+    ExtensionFilter extension_filter = 11;
+  }
+}
+
+// Filter on an integer comparison.
+message ComparisonFilter {
+  enum Op {
+    // =
+    EQ = 0;
+
+    // >=
+    GE = 1;
+
+    // <=
+    LE = 2;
+  }
+
+  // Comparison operator.
+  Op op = 1 [(validate.rules).enum.defined_only = true];
+
+  // Value to compare against.
+  envoy.api.v3alpha.core.RuntimeUInt32 value = 2;
+}
+
+// Filters on HTTP response/status code.
+message StatusCodeFilter {
+  // Comparison.
+  ComparisonFilter comparison = 1 [(validate.rules).message.required = true];
+}
+
+// Filters on total request duration in milliseconds.
+message DurationFilter {
+  // Comparison.
+  ComparisonFilter comparison = 1 [(validate.rules).message.required = true];
+}
+
+// Filters for requests that are not health check requests. A health check
+// request is marked by the health check filter.
+message NotHealthCheckFilter {
+}
+
+// Filters for requests that are traceable. See the tracing overview for more
+// information on how a request becomes traceable.
+message TraceableFilter {
+}
+
+// Filters for random sampling of requests.
+message RuntimeFilter {
+  // Runtime key to get an optional overridden numerator for use in the *percent_sampled* field.
+  // If found in runtime, this value will replace the default numerator.
+  string runtime_key = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The default sampling percentage. If not specified, defaults to 0% with denominator of 100.
+  envoy.type.FractionalPercent percent_sampled = 2;
+
+  // By default, sampling pivots on the header
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being present. If
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` is present, the filter will
+  // consistently sample across multiple hosts based on the runtime key value and the value
+  // extracted from :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
+  // missing, or *use_independent_randomness* is set to true, the filter will randomly sample based
+  // on the runtime key value alone. *use_independent_randomness* can be used for logging kill
+  // switches within complex nested :ref:`AndFilter
+  // <envoy_api_msg_config.filter.accesslog.v3alpha.AndFilter>` and :ref:`OrFilter
+  // <envoy_api_msg_config.filter.accesslog.v3alpha.OrFilter>` blocks that are easier to reason
+  // about from a probability perspective (i.e., setting to true will cause the filter to behave
+  // like an independent random variable when composed within logical operator filters).
+  bool use_independent_randomness = 3;
+}
+
+// Performs a logical “and” operation on the result of each filter in filters.
+// Filters are evaluated sequentially and if one of them returns false, the
+// filter returns false immediately.
+message AndFilter {
+  repeated AccessLogFilter filters = 1 [(validate.rules).repeated .min_items = 2];
+}
+
+// Performs a logical “or” operation on the result of each individual filter.
+// Filters are evaluated sequentially and if one of them returns true, the
+// filter returns true immediately.
+message OrFilter {
+  repeated AccessLogFilter filters = 2 [(validate.rules).repeated .min_items = 2];
+}
+
+// Filters requests based on the presence or value of a request header.
+message HeaderFilter {
+  // Only requests with a header which matches the specified HeaderMatcher will pass the filter
+  // check.
+  envoy.api.v3alpha.route.HeaderMatcher header = 1 [(validate.rules).message.required = true];
+}
+
+// Filters requests that received responses with an Envoy response flag set.
+// A list of the response flags can be found
+// in the access log formatter :ref:`documentation<config_access_log_format_response_flags>`.
+message ResponseFlagFilter {
+  // Only responses with the any of the flags listed in this field will be logged.
+  // This field is optional. If it is not specified, then any response flag will pass
+  // the filter check.
+  repeated string flags = 1 [(validate.rules).repeated .items.string = {
+    in: [
+      "LH",
+      "UH",
+      "UT",
+      "LR",
+      "UR",
+      "UF",
+      "UC",
+      "UO",
+      "NR",
+      "DI",
+      "FI",
+      "RL",
+      "UAEX",
+      "RLSE",
+      "DC",
+      "URX",
+      "SI",
+      "IH"
+    ]
+  }];
+}
+
+// Filters gRPC requests based on their response status. If a gRPC status is not provided, the
+// filter will infer the status from the HTTP status code.
+message GrpcStatusFilter {
+  enum Status {
+    OK = 0;
+    CANCELED = 1;
+    UNKNOWN = 2;
+    INVALID_ARGUMENT = 3;
+    DEADLINE_EXCEEDED = 4;
+    NOT_FOUND = 5;
+    ALREADY_EXISTS = 6;
+    PERMISSION_DENIED = 7;
+    RESOURCE_EXHAUSTED = 8;
+    FAILED_PRECONDITION = 9;
+    ABORTED = 10;
+    OUT_OF_RANGE = 11;
+    UNIMPLEMENTED = 12;
+    INTERNAL = 13;
+    UNAVAILABLE = 14;
+    DATA_LOSS = 15;
+    UNAUTHENTICATED = 16;
+  }
+
+  // Logs only responses that have any one of the gRPC statuses in this field.
+  repeated Status statuses = 1 [(validate.rules).repeated .items.enum.defined_only = true];
+
+  // If included and set to true, the filter will instead block all responses with a gRPC status or
+  // inferred gRPC status enumerated in statuses, and allow all other responses.
+  bool exclude = 2;
+}
+
+// Extension filter is statically registered at runtime.
+message ExtensionFilter {
+  // The name of the filter implementation to instantiate. The name must
+  // match a statically registered filter.
+  string name = 1;
+
+  // Custom configuration that depends on the filter being instantiated.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+    google.protobuf.Any typed_config = 3;
+  }
+}

--- a/api/envoy/config/filter/fault/v3alpha/BUILD
+++ b/api/envoy/config/filter/fault/v3alpha/BUILD
@@ -1,0 +1,13 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "fault",
+    srcs = ["fault.proto"],
+    visibility = [
+        "//envoy/config/filter/http/fault/v3alpha:__pkg__",
+        "//envoy/config/filter/network/mongo_proxy/v3alpha:__pkg__",
+    ],
+    deps = ["//envoy/type:percent"],
+)

--- a/api/envoy/config/filter/fault/v3alpha/fault.proto
+++ b/api/envoy/config/filter/fault/v3alpha/fault.proto
@@ -1,0 +1,84 @@
+syntax = "proto3";
+
+package envoy.config.filter.fault.v3alpha;
+
+option java_outer_classname = "FaultProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.fault.v3alpha";
+option go_package = "v2";
+
+import "envoy/type/percent.proto";
+
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Common fault injection types]
+
+// Delay specification is used to inject latency into the
+// HTTP/gRPC/Mongo/Redis operation or delay proxying of TCP connections.
+message FaultDelay {
+  // Fault delays are controlled via an HTTP header (if applicable). See the
+  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // more information.
+  message HeaderDelay {
+  }
+
+  enum FaultDelayType {
+    // Unused and deprecated.
+    FIXED = 0;
+  }
+
+  // Unused and deprecated. Will be removed in the next release.
+  FaultDelayType type = 1 [deprecated = true];
+
+  reserved 2;
+
+  oneof fault_delay_secifier {
+    option (validate.required) = true;
+
+    // Add a fixed delay before forwarding the operation upstream. See
+    // https://developers.google.com/protocol-buffers/docs/proto3#json for
+    // the JSON/YAML Duration mapping. For HTTP/Mongo/Redis, the specified
+    // delay will be injected before a new request/operation. For TCP
+    // connections, the proxying of the connection upstream will be delayed
+    // for the specified period. This is required if type is FIXED.
+    google.protobuf.Duration fixed_delay = 3
+        [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+
+    // Fault delays are controlled via an HTTP header (if applicable).
+    HeaderDelay header_delay = 5;
+  }
+
+  // The percentage of operations/connections/requests on which the delay will be injected.
+  type.FractionalPercent percentage = 4;
+}
+
+// Describes a rate limit to be applied.
+message FaultRateLimit {
+  // Describes a fixed/constant rate limit.
+  message FixedLimit {
+    // The limit supplied in KiB/s.
+    uint64 limit_kbps = 1 [(validate.rules).uint64.gte = 1];
+  }
+
+  // Rate limits are controlled via an HTTP header (if applicable). See the
+  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // more information.
+  message HeaderLimit {
+  }
+
+  oneof limit_type {
+    option (validate.required) = true;
+
+    // A fixed rate limit.
+    FixedLimit fixed_limit = 1;
+
+    // Rate limits are controlled via an HTTP header (if applicable).
+    HeaderLimit header_limit = 3;
+  }
+
+  // The percentage of operations/connections/requests on which the rate limit will be injected.
+  type.FractionalPercent percentage = 2;
+}

--- a/api/envoy/config/filter/http/adaptive_concurrency/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/adaptive_concurrency/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "adaptive_concurrency",
+    srcs = ["adaptive_concurrency.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+    ],
+)

--- a/api/envoy/config/filter/http/adaptive_concurrency/v3alpha/adaptive_concurrency.proto
+++ b/api/envoy/config/filter/http/adaptive_concurrency/v3alpha/adaptive_concurrency.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.adaptive_concurrency.v3alpha;
+
+option java_package = "io.envoyproxy.envoy.config.filter.http.adaptive_concurrency.v3alpha";
+option java_outer_classname = "AdaptiveConcurrencyProto";
+option java_multiple_files = true;
+option go_package = "v2alpha";
+
+message AdaptiveConcurrency {
+}

--- a/api/envoy/config/filter/http/buffer/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/buffer/v3alpha/BUILD
@@ -1,0 +1,8 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "buffer",
+    srcs = ["buffer.proto"],
+)

--- a/api/envoy/config/filter/http/buffer/v3alpha/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v3alpha/buffer.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.buffer.v3alpha;
+
+option java_outer_classname = "BufferProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.buffer.v3alpha";
+option go_package = "v2";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Buffer]
+// Buffer :ref:`configuration overview <config_http_filters_buffer>`.
+
+message Buffer {
+  reserved 2; // formerly max_request_time
+
+  // The maximum request size that the filter will buffer before the connection
+  // manager will stop buffering and return a 413 response.
+  google.protobuf.UInt32Value max_request_bytes = 1 [(validate.rules).uint32.gt = 0];
+}
+
+message BufferPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the buffer filter for this particular vhost or route.
+    bool disabled = 1 [(validate.rules).bool.const = true];
+
+    // Override the global configuration of the filter with this new config.
+    Buffer buffer = 2 [(validate.rules).message.required = true];
+  }
+}

--- a/api/envoy/config/filter/http/csrf/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/csrf/v3alpha/BUILD
@@ -1,0 +1,12 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "csrf",
+    srcs = ["csrf.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/type/matcher:string",
+    ],
+)

--- a/api/envoy/config/filter/http/csrf/v3alpha/csrf.proto
+++ b/api/envoy/config/filter/http/csrf/v3alpha/csrf.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.csrf.v3alpha;
+
+option java_outer_classname = "CsrfPolicyProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.csrf.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/type/matcher/string.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: CSRF]
+// Cross-Site Request Forgery :ref:`configuration overview <config_http_filters_csrf>`.
+
+// CSRF filter config.
+message CsrfPolicy {
+  // Specifies if CSRF is enabled.
+  //
+  // More information on how this can be controlled via runtime can be found
+  // :ref:`here <csrf-runtime>`.
+  //
+  // .. note::
+  //
+  //   This field defaults to 100/:ref:`HUNDRED
+  //   <envoy_api_enum_type.FractionalPercent.DenominatorType>`.
+  envoy.api.v3alpha.core.RuntimeFractionalPercent filter_enabled = 1
+      [(validate.rules).message.required = true];
+
+  // Specifies that CSRF policies will be evaluated and tracked, but not enforced.
+  // This is intended to be used when filter_enabled is off.
+  //
+  // More information on how this can be controlled via runtime can be found
+  // :ref:`here <csrf-runtime>`.
+  //
+  // .. note::
+  //
+  //   This field defaults to 100/:ref:`HUNDRED
+  //   <envoy_api_enum_type.FractionalPercent.DenominatorType>`.
+  envoy.api.v3alpha.core.RuntimeFractionalPercent shadow_enabled = 2;
+
+  // Specifies additional source origins that will be allowed in addition to
+  // the destination origin.
+  //
+  // More information on how this can be configured via runtime can be found
+  // :ref:`here <csrf-configuration>`.
+  repeated envoy.type.matcher.StringMatcher additional_origins = 3;
+}

--- a/api/envoy/config/filter/http/dynamic_forward_proxy/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/dynamic_forward_proxy/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "dynamic_forward_proxy",
+    srcs = ["dynamic_forward_proxy.proto"],
+    deps = [
+        "//envoy/config/common/dynamic_forward_proxy/v3alpha:dns_cache",
+    ],
+)

--- a/api/envoy/config/filter/http/dynamic_forward_proxy/v3alpha/dynamic_forward_proxy.proto
+++ b/api/envoy/config/filter/http/dynamic_forward_proxy/v3alpha/dynamic_forward_proxy.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.dynamic_forward_proxy.v3alpha;
+
+option java_outer_classname = "DynamicForwardProxyProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.dynamic_forward_proxy.v3alpha";
+option go_package = "v2alpha";
+
+import "envoy/config/common/dynamic_forward_proxy/v3alpha/dns_cache.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Dynamic forward proxy]
+
+// Configuration for the dynamic forward proxy HTTP filter. See the :ref:`architecture overview
+// <arch_overview_http_dynamic_forward_proxy>` for more information.
+message FilterConfig {
+  // The DNS cache configuration that the filter will attach to. Note this configuration must
+  // match that of associated :ref:`dynamic forward proxy cluster configuration
+  // <envoy_api_field_config.cluster.dynamic_forward_proxy.v3alpha.ClusterConfig.dns_cache_config>`.
+  common.dynamic_forward_proxy.v3alpha.DnsCacheConfig dns_cache_config = 1
+      [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/filter/http/ext_authz/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/ext_authz/v3alpha/BUILD
@@ -1,0 +1,15 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "ext_authz",
+    srcs = ["ext_authz.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:grpc_service",
+        "//envoy/api/v3alpha/core:http_uri",
+        "//envoy/type:http_status",
+        "//envoy/type/matcher:string",
+    ],
+)

--- a/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.proto
@@ -1,0 +1,209 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.ext_authz.v3alpha;
+
+option java_outer_classname = "ExtAuthzProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.ext_authz.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/grpc_service.proto";
+import "envoy/api/v3alpha/core/http_uri.proto";
+
+import "envoy/type/http_status.proto";
+import "envoy/type/matcher/string.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: External Authorization]
+// External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
+
+message ExtAuthz {
+  // External authorization service configuration.
+  oneof services {
+    // gRPC service configuration (default timeout: 200ms).
+    envoy.api.v3alpha.core.GrpcService grpc_service = 1;
+
+    // HTTP service configuration (default timeout: 200ms).
+    HttpService http_service = 3;
+  }
+
+  //  Changes filter's behaviour on errors:
+  //
+  //  1. When set to true, the filter will *accept* client request even if the communication with
+  //  the authorization service has failed, or if the authorization service has returned a HTTP 5xx
+  //  error.
+  //
+  //  2. When set to false, ext-authz will *reject* client requests and return a *Forbidden*
+  //  response if the communication with the authorization service has failed, or if the
+  //  authorization service has returned a HTTP 5xx error.
+  //
+  // Note that errors can be *always* tracked in the :ref:`stats
+  // <config_http_filters_ext_authz_stats>`.
+  bool failure_mode_allow = 2;
+
+  // Sets the package version the gRPC service should use. This is particularly
+  // useful when transitioning from alpha to release versions assuming that both definitions are
+  // semantically compatible. Deprecation note: This field is deprecated and should only be used for
+  // version upgrade. See release notes for more details.
+  bool use_alpha = 4 [deprecated = true];
+
+  // Enables filter to buffer the client request body and send it within the authorization request.
+  // A ``x-envoy-auth-partial-body: false|true`` metadata header will be added to the authorization
+  // request message indicating if the body data is partial.
+  BufferSettings with_request_body = 5;
+
+  // Clears route cache in order to allow the external authorization service to correctly affect
+  // routing decisions. Filter clears all cached routes when:
+  //
+  // 1. The field is set to *true*.
+  //
+  // 2. The status returned from the authorization service is a HTTP 200 or gRPC 0.
+  //
+  // 3. At least one *authorization response header* is added to the client request, or is used for
+  // altering another client request header.
+  //
+  bool clear_route_cache = 6;
+
+  // Sets the HTTP status that is returned to the client when there is a network error between the
+  // filter and the authorization server. The default status is HTTP 403 Forbidden.
+  envoy.type.HttpStatus status_on_error = 7;
+
+  // Specifies a list of metadata namespaces whose values, if present, will be passed to the
+  // ext_authz service as an opaque *protobuf::Struct*.
+  //
+  // For example, if the *jwt_authn* filter is used and :ref:`payload_in_metadata
+  // <envoy_api_field_config.filter.http.jwt_authn.v3alpha.JwtProvider.payload_in_metadata>` is set,
+  // then the following will pass the jwt payload to the authorization server.
+  //
+  // .. code-block:: yaml
+  //
+  //    metadata_context_namespaces:
+  //    - envoy.filters.http.jwt_authn
+  //
+  repeated string metadata_context_namespaces = 8;
+}
+
+// Configuration for buffering the request data.
+message BufferSettings {
+  // Sets the maximum size of a message body that the filter will hold in memory. Envoy will return
+  // *HTTP 413* and will *not* initiate the authorization process when buffer reaches the number
+  // set in this field. Note that this setting will have precedence over :ref:`failure_mode_allow
+  // <envoy_api_field_config.filter.http.ext_authz.v3alpha.ExtAuthz.failure_mode_allow>`.
+  uint32 max_request_bytes = 1 [(validate.rules).uint32.gt = 0];
+
+  // When this field is true, Envoy will buffer the message until *max_request_bytes* is reached.
+  // The authorization request will be dispatched and no 413 HTTP error will be returned by the
+  // filter.
+  bool allow_partial_message = 2;
+}
+
+// HttpService is used for raw HTTP communication between the filter and the authorization service.
+// When configured, the filter will parse the client request and use these attributes to call the
+// authorization server. Depending on the response, the filter may reject or accept the client
+// request. Note that in any of these events, metadata can be added, removed or overridden by the
+// filter:
+//
+// *On authorization request*, a list of allowed request headers may be supplied. See
+// :ref:`allowed_headers
+// <envoy_api_field_config.filter.http.ext_authz.v3alpha.AuthorizationRequest.allowed_headers>`
+// for details. Additional headers metadata may be added to the authorization request. See
+// :ref:`headers_to_add
+// <envoy_api_field_config.filter.http.ext_authz.v3alpha.AuthorizationRequest.headers_to_add>` for
+// details.
+//
+// On authorization response status HTTP 200 OK, the filter will allow traffic to the upstream and
+// additional headers metadata may be added to the original client request. See
+// :ref:`allowed_upstream_headers
+// <envoy_api_field_config.filter.http.ext_authz.v3alpha.AuthorizationResponse.allowed_upstream_headers>`
+// for details.
+//
+// On other authorization response statuses, the filter will not allow traffic. Additional headers
+// metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
+// <envoy_api_field_config.filter.http.ext_authz.v3alpha.AuthorizationResponse.allowed_client_headers>`
+// for details.
+message HttpService {
+  // Sets the HTTP server URI which the authorization requests must be sent to.
+  envoy.api.v3alpha.core.HttpUri server_uri = 1;
+
+  // Sets a prefix to the value of authorization request header *Path*.
+  string path_prefix = 2;
+
+  reserved 3;
+  reserved 4;
+  reserved 5;
+  reserved 6;
+
+  // Settings used for controlling authorization request metadata.
+  AuthorizationRequest authorization_request = 7;
+
+  // Settings used for controlling authorization response metadata.
+  AuthorizationResponse authorization_response = 8;
+}
+
+message AuthorizationRequest {
+  // Authorization request will include the client request headers that have a correspondent match
+  // in the :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>`. Note that in addition to the
+  // user's supplied matchers:
+  //
+  // 1. *Host*, *Method*, *Path* and *Content-Length* are automatically included to the list.
+  //
+  // 2. *Content-Length* will be set to 0 and the request to the authorization service will not have
+  // a message body.
+  //
+  envoy.type.matcher.ListStringMatcher allowed_headers = 1;
+
+  // Sets a list of headers that will be included to the request to authorization service. Note that
+  // client request of the same key will be overridden.
+  repeated envoy.api.v3alpha.core.HeaderValue headers_to_add = 2;
+}
+
+message AuthorizationResponse {
+  // When this :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>` is set, authorization
+  // response headers that have a correspondent match will be added to the original client request.
+  // Note that coexistent headers will be overridden.
+  envoy.type.matcher.ListStringMatcher allowed_upstream_headers = 1;
+
+  // When this :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>`. is set, authorization
+  // response headers that have a correspondent match will be added to the client's response. Note
+  // that when this list is *not* set, all the authorization response headers, except *Authority
+  // (Host)* will be in the response to the client. When a header is included in this list, *Path*,
+  // *Status*, *Content-Length*, *WWWAuthenticate* and *Location* are automatically added.
+  envoy.type.matcher.ListStringMatcher allowed_client_headers = 2;
+}
+
+// Extra settings on a per virtualhost/route/weighted-cluster level.
+message ExtAuthzPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the ext auth filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool.const = true];
+
+    // Check request settings for this route.
+    CheckSettings check_settings = 2 [(validate.rules).message.required = true];
+  }
+}
+
+// Extra settings for the check request. You can use this to provide extra context for the
+// external authorization server on specific virtual hosts \ routes. For example, adding a context
+// extension on the virtual host level can give the ext-authz server information on what virtual
+// host is used without needing to parse the host header. If CheckSettings is specified in multiple
+// per-filter-configs, they will be merged in order, and the result will be used.
+message CheckSettings {
+  // Context extensions to set on the CheckRequest's
+  // :ref:`AttributeContext.context_extensions<envoy_api_field_service.auth.v3alpha.AttributeContext.context_extensions>`
+  //
+  // Merge semantics for this field are such that keys from more specific configs override.
+  //
+  // .. note::
+  //
+  //   These settings are only applied to a filter configured with a
+  //   :ref:`grpc_service<envoy_api_field_config.filter.http.ext_authz.v3alpha.ExtAuthz.grpc_service>`.
+  map<string, string> context_extensions = 1;
+}

--- a/api/envoy/config/filter/http/fault/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/fault/v3alpha/BUILD
@@ -1,0 +1,13 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "fault",
+    srcs = ["fault.proto"],
+    deps = [
+        "//envoy/api/v3alpha/route",
+        "//envoy/config/filter/fault/v3alpha:fault",
+        "//envoy/type:percent",
+    ],
+)

--- a/api/envoy/config/filter/http/fault/v3alpha/fault.proto
+++ b/api/envoy/config/filter/http/fault/v3alpha/fault.proto
@@ -1,0 +1,115 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.fault.v3alpha;
+
+option java_outer_classname = "FaultProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.fault.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/route/route.proto";
+import "envoy/config/filter/fault/v3alpha/fault.proto";
+import "envoy/type/percent.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Fault Injection]
+// Fault Injection :ref:`configuration overview <config_http_filters_fault_injection>`.
+
+message FaultAbort {
+  reserved 1;
+
+  oneof error_type {
+    option (validate.required) = true;
+
+    // HTTP status code to use to abort the HTTP request.
+    uint32 http_status = 2 [(validate.rules).uint32 = {gte: 200, lt: 600}];
+  }
+
+  // The percentage of requests/operations/connections that will be aborted with the error code
+  // provided.
+  type.FractionalPercent percentage = 3;
+}
+
+message HTTPFault {
+  // If specified, the filter will inject delays based on the values in the
+  // object.
+  filter.fault.v3alpha.FaultDelay delay = 1;
+
+  // If specified, the filter will abort requests based on the values in
+  // the object. At least *abort* or *delay* must be specified.
+  FaultAbort abort = 2;
+
+  // Specifies the name of the (destination) upstream cluster that the
+  // filter should match on. Fault injection will be restricted to requests
+  // bound to the specific upstream cluster.
+  string upstream_cluster = 3;
+
+  // Specifies a set of headers that the filter should match on. The fault
+  // injection filter can be applied selectively to requests that match a set of
+  // headers specified in the fault filter config. The chances of actual fault
+  // injection further depend on the value of the :ref:`percentage
+  // <envoy_api_field_config.filter.http.fault.v3alpha.FaultAbort.percentage>` field.
+  // The filter will check the request's headers against all the specified
+  // headers in the filter config. A match will happen if all the headers in the
+  // config are present in the request with the same values (or based on
+  // presence if the *value* field is not in the config).
+  repeated envoy.api.v3alpha.route.HeaderMatcher headers = 4;
+
+  // Faults are injected for the specified list of downstream hosts. If this
+  // setting is not set, faults are injected for all downstream nodes.
+  // Downstream node name is taken from :ref:`the HTTP
+  // x-envoy-downstream-service-node
+  // <config_http_conn_man_headers_downstream-service-node>` header and compared
+  // against downstream_nodes list.
+  repeated string downstream_nodes = 5;
+
+  // The maximum number of faults that can be active at a single time via the configured fault
+  // filter. Note that because this setting can be overridden at the route level, it's possible
+  // for the number of active faults to be greater than this value (if injected via a different
+  // route). If not specified, defaults to unlimited. This setting can be overridden via
+  // `runtime <config_http_filters_fault_injection_runtime>` and any faults that are not injected
+  // due to overflow will be indicated via the `faults_overflow
+  // <config_http_filters_fault_injection_stats>` stat.
+  //
+  // .. attention::
+  //   Like other :ref:`circuit breakers <arch_overview_circuit_break>` in Envoy, this is a fuzzy
+  //   limit. It's possible for the number of active faults to rise slightly above the configured
+  //   amount due to the implementation details.
+  google.protobuf.UInt32Value max_active_faults = 6;
+
+  // The response rate limit to be applied to the response body of the stream. When configured,
+  // the percentage can be overridden by the :ref:`fault.http.rate_limit.response_percent
+  // <config_http_filters_fault_injection_runtime>` runtime key.
+  //
+  // .. attention::
+  //  This is a per-stream limit versus a connection level limit. This means that concurrent streams
+  //  will each get an independent limit.
+  filter.fault.v3alpha.FaultRateLimit response_rate_limit = 7;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.delay.fixed_delay_percent
+  string delay_percent_runtime = 8;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.abort.abort_percent
+  string abort_percent_runtime = 9;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.delay.fixed_duration_ms
+  string delay_duration_runtime = 10;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.abort.http_status
+  string abort_http_status_runtime = 11;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.max_active_faults
+  string max_active_faults_runtime = 12;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.rate_limit.response_percent
+  string response_rate_limit_percent_runtime = 13;
+}

--- a/api/envoy/config/filter/http/gzip/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/gzip/v3alpha/BUILD
@@ -1,0 +1,8 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "gzip",
+    srcs = ["gzip.proto"],
+)

--- a/api/envoy/config/filter/http/gzip/v3alpha/gzip.proto
+++ b/api/envoy/config/filter/http/gzip/v3alpha/gzip.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.gzip.v3alpha;
+
+option java_outer_classname = "GzipProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.gzip.v3alpha";
+option go_package = "v2";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Gzip]
+// Gzip :ref:`configuration overview <config_http_filters_gzip>`.
+
+message Gzip {
+  // Value from 1 to 9 that controls the amount of internal memory used by zlib. Higher values
+  // use more memory, but are faster and produce better compression results. The default value is 5.
+  google.protobuf.UInt32Value memory_level = 1 [(validate.rules).uint32 = {gte: 1, lte: 9}];
+
+  // Minimum response length, in bytes, which will trigger compression. The default value is 30.
+  google.protobuf.UInt32Value content_length = 2 [(validate.rules).uint32.gte = 30];
+
+  message CompressionLevel {
+    enum Enum {
+      DEFAULT = 0;
+      BEST = 1;
+      SPEED = 2;
+    }
+  }
+
+  // A value used for selecting the zlib compression level. This setting will affect speed and
+  // amount of compression applied to the content. "BEST" provides higher compression at the cost of
+  // higher latency, "SPEED" provides lower compression with minimum impact on response time.
+  // "DEFAULT" provides an optimal result between speed and compression. This field will be set to
+  // "DEFAULT" if not specified.
+  CompressionLevel.Enum compression_level = 3 [(validate.rules).enum.defined_only = true];
+
+  enum CompressionStrategy {
+    DEFAULT = 0;
+    FILTERED = 1;
+    HUFFMAN = 2;
+    RLE = 3;
+  }
+
+  // A value used for selecting the zlib compression strategy which is directly related to the
+  // characteristics of the content. Most of the time "DEFAULT" will be the best choice, though
+  // there are situations which changing this parameter might produce better results. For example,
+  // run-length encoding (RLE) is typically used when the content is known for having sequences
+  // which same data occurs many consecutive times. For more information about each strategy, please
+  // refer to zlib manual.
+  CompressionStrategy compression_strategy = 4 [(validate.rules).enum.defined_only = true];
+
+  // Set of strings that allows specifying which mime-types yield compression; e.g.,
+  // application/json, text/html, etc. When this field is not defined, compression will be applied
+  // to the following mime-types: "application/javascript", "application/json",
+  // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml".
+  repeated string content_type = 6 [(validate.rules).repeated = {max_items: 50}];
+
+  // If true, disables compression when the response contains an etag header. When it is false, the
+  // filter will preserve weak etags and remove the ones that require strong validation.
+  bool disable_on_etag_header = 7;
+
+  // If true, removes accept-encoding from the request headers before dispatching it to the upstream
+  // so that responses do not get compressed before reaching the filter.
+  bool remove_accept_encoding_header = 8;
+
+  // Value from 9 to 15 that represents the base two logarithmic of the compressor's window size.
+  // Larger window results in better compression at the expense of memory usage. The default is 12
+  // which will produce a 4096 bytes window. For more details about this parameter, please refer to
+  // zlib manual > deflateInit2.
+  google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {gte: 9, lte: 15}];
+}

--- a/api/envoy/config/filter/http/header_to_metadata/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/header_to_metadata/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "header_to_metadata",
+    srcs = ["header_to_metadata.proto"],
+    deps = [],
+)

--- a/api/envoy/config/filter/http/header_to_metadata/v3alpha/header_to_metadata.proto
+++ b/api/envoy/config/filter/http/header_to_metadata/v3alpha/header_to_metadata.proto
@@ -1,0 +1,92 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.header_to_metadata.v3alpha;
+
+option java_outer_classname = "HeaderToMetadataProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.header_to_metadata.v3alpha";
+option go_package = "v2";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Header-To-Metadata Filter]
+//
+// The configuration for transforming headers into metadata. This is useful
+// for matching load balancer subsets, logging, etc.
+//
+// Header to Metadata :ref:`configuration overview <config_http_filters_header_to_metadata>`.
+
+message Config {
+  enum ValueType {
+    STRING = 0;
+    NUMBER = 1;
+
+    // The value is a serialized `protobuf.Value
+    // <https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto#L62>`_.
+    PROTOBUF_VALUE = 2;
+  }
+
+  // ValueEncode defines the encoding algorithm.
+  enum ValueEncode {
+    // The value is not encoded.
+    NONE = 0;
+
+    // The value is encoded in `Base64 <https://tools.ietf.org/html/rfc4648#section-4>`_.
+    // Note: this is mostly used for STRING and PROTOBUF_VALUE to escape the
+    // non-ASCII characters in the header.
+    BASE64 = 1;
+  }
+
+  message KeyValuePair {
+    // The namespace — if this is empty, the filter's namespace will be used.
+    string metadata_namespace = 1;
+
+    // The key to use within the namespace.
+    string key = 2 [(validate.rules).string.min_bytes = 1];
+
+    // The value to pair with the given key.
+    //
+    // When used for a `on_header_present` case, if value is non-empty it'll be used
+    // instead of the header value. If both are empty, no metadata is added.
+    //
+    // When used for a `on_header_missing` case, a non-empty value must be provided
+    // otherwise no metadata is added.
+    string value = 3;
+
+    // The value's type — defaults to string.
+    ValueType type = 4;
+
+    // How is the value encoded, default is NONE (not encoded).
+    // The value will be decoded accordingly before storing to metadata.
+    ValueEncode encode = 5;
+  }
+
+  // A Rule defines what metadata to apply when a header is present or missing.
+  message Rule {
+    // The header that triggers this rule — required.
+    string header = 1 [(validate.rules).string.min_bytes = 1];
+
+    // If the header is present, apply this metadata KeyValuePair.
+    //
+    // If the value in the KeyValuePair is non-empty, it'll be used instead
+    // of the header value.
+    KeyValuePair on_header_present = 2;
+
+    // If the header is not present, apply this metadata KeyValuePair.
+    //
+    // The value in the KeyValuePair must be set, since it'll be used in lieu
+    // of the missing header value.
+    KeyValuePair on_header_missing = 3;
+
+    // Whether or not to remove the header after a rule is applied.
+    //
+    // This prevents headers from leaking.
+    bool remove = 4;
+  }
+
+  // The list of rules to apply to requests.
+  repeated Rule request_rules = 1;
+
+  // The list of rules to apply to responses.
+  repeated Rule response_rules = 2;
+}

--- a/api/envoy/config/filter/http/health_check/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/health_check/v3alpha/BUILD
@@ -1,0 +1,21 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "health_check",
+    srcs = ["health_check.proto"],
+    deps = [
+        "//envoy/api/v3alpha/route",
+        "//envoy/type:percent",
+    ],
+)
+
+api_go_proto_library(
+    name = "health_check",
+    proto = ":health_check",
+    deps = [
+        "//envoy/api/v3alpha/route:route_go_proto",
+        "//envoy/type:percent_go_proto",
+    ],
+)

--- a/api/envoy/config/filter/http/health_check/v3alpha/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v3alpha/health_check.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.health_check.v3alpha;
+
+option java_outer_classname = "HealthCheckProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.health_check.v3alpha";
+option go_package = "v2";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "envoy/api/v3alpha/route/route.proto";
+import "envoy/type/percent.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: Health check]
+// Health check :ref:`configuration overview <config_http_filters_health_check>`.
+
+message HealthCheck {
+  // Specifies whether the filter operates in pass through mode or not.
+  google.protobuf.BoolValue pass_through_mode = 1 [(validate.rules).message.required = true];
+
+  reserved 2;
+  reserved "endpoint";
+
+  // If operating in pass through mode, the amount of time in milliseconds
+  // that the filter should cache the upstream response.
+  google.protobuf.Duration cache_time = 3 [(gogoproto.stdduration) = true];
+
+  // If operating in non-pass-through mode, specifies a set of upstream cluster
+  // names and the minimum percentage of servers in each of those clusters that
+  // must be healthy or degraded in order for the filter to return a 200.
+  map<string, envoy.type.Percent> cluster_min_healthy_percentages = 4;
+
+  // Specifies a set of health check request headers to match on. The health check filter will
+  // check a request’s headers against all the specified headers. To specify the health check
+  // endpoint, set the ``:path`` header to match on.
+  repeated envoy.api.v3alpha.route.HeaderMatcher headers = 5;
+}

--- a/api/envoy/config/filter/http/ip_tagging/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/ip_tagging/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "ip_tagging",
+    srcs = ["ip_tagging.proto"],
+    deps = ["//envoy/api/v3alpha/core:address"],
+)

--- a/api/envoy/config/filter/http/ip_tagging/v3alpha/ip_tagging.proto
+++ b/api/envoy/config/filter/http/ip_tagging/v3alpha/ip_tagging.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.ip_tagging.v3alpha;
+
+option java_outer_classname = "IpTaggingProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.ip_tagging.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/address.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: IP tagging]
+// IP tagging :ref:`configuration overview <config_http_filters_ip_tagging>`.
+
+message IPTagging {
+
+  // The type of requests the filter should apply to. The supported types
+  // are internal, external or both. The
+  // :ref:`x-forwarded-for<config_http_conn_man_headers_x-forwarded-for_internal_origin>` header is
+  // used to determine if a request is internal and will result in
+  // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>`
+  // being set. The filter defaults to both, and it will apply to all request types.
+  enum RequestType {
+    // Both external and internal requests will be tagged. This is the default value.
+    BOTH = 0;
+
+    // Only internal requests will be tagged.
+    INTERNAL = 1;
+
+    // Only external requests will be tagged.
+    EXTERNAL = 2;
+  }
+
+  // The type of request the filter should apply to.
+  RequestType request_type = 1 [(validate.rules).enum.defined_only = true];
+
+  // Supplies the IP tag name and the IP address subnets.
+  message IPTag {
+    // Specifies the IP tag name to apply.
+    string ip_tag_name = 1;
+
+    // A list of IP address subnets that will be tagged with
+    // ip_tag_name. Both IPv4 and IPv6 are supported.
+    repeated envoy.api.v3alpha.core.CidrRange ip_list = 2;
+  }
+
+  // [#comment:TODO(ccaraman): Extend functionality to load IP tags from file system.
+  // Tracked by issue https://github.com/envoyproxy/envoy/issues/2695]
+  // The set of IP tags for the filter.
+  repeated IPTag ip_tags = 4 [(validate.rules).repeated .min_items = 1];
+}

--- a/api/envoy/config/filter/http/jwt_authn/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/jwt_authn/v3alpha/BUILD
@@ -1,0 +1,23 @@
+licenses(["notice"])  # Apache 2
+
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+api_proto_library_internal(
+    name = "jwt_authn",
+    srcs = ["config.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:http_uri",
+        "//envoy/api/v3alpha/route",
+    ],
+)
+
+api_go_proto_library(
+    name = "jwt_authn",
+    proto = ":jwt_authn",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:http_uri_go_proto",
+        "//envoy/api/v3alpha/route:route_go_proto",
+    ],
+)

--- a/api/envoy/config/filter/http/jwt_authn/v3alpha/README.md
+++ b/api/envoy/config/filter/http/jwt_authn/v3alpha/README.md
@@ -1,0 +1,66 @@
+# JWT Authentication HTTP filter config
+
+## Overview
+
+1. The proto file in this folder defines an HTTP filter config for "jwt_authn" filter.
+
+2. This filter will verify the JWT in the HTTP request as:
+    - The signature should be valid
+    - JWT should not be expired
+    - Issuer and audiences are valid and specified in the filter config.
+
+3. [JWK](https://tools.ietf.org/html/rfc7517#appendix-A) is needed to verify JWT signature. It can be fetched from a remote server or read from a local file. If the JWKS is fetched remotely, it will be cached by the filter.
+
+3. If a JWT is valid, the user is authenticated and the request will be forwarded to the backend server. If a JWT is not valid, the request will be rejected with an error message.
+
+## The locations to extract JWT
+
+JWT will be extracted from the HTTP headers or query parameters. The default location is the HTTP header:
+```
+Authorization: Bearer <token>
+```
+The next default location is in the query parameter as:
+```
+?access_token=<TOKEN>
+```
+
+If a custom location is desired, `from_headers` or `from_params` can be used to specify custom locations to extract JWT.
+
+## HTTP header to pass successfully verified JWT
+
+If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64 encoded JWT payload in JSON.
+
+
+## Further header options
+
+In addition to the `name` field, which specifies the HTTP header name,
+the `from_headers` section can specify an optional `value_prefix` value, as in:
+
+```yaml
+    from_headers:
+      - name: bespoke
+        value_prefix: jwt_value
+```
+
+The above will cause the jwt_authn filter to look for the JWT in the `bespoke` header, following the tag `jwt_value`.
+
+Any non-JWT characters (i.e., anything _other than_ alphanumerics, `_`, `-`, and `.`) will be skipped,
+and all following, contiguous, JWT-legal chars will be taken as the JWT.
+
+This means all of the following will return a JWT of `eyJFbnZveSI6ICJyb2NrcyJ9.e30.c2lnbmVk`:
+
+```text
+bespoke: jwt_value=eyJFbnZveSI6ICJyb2NrcyJ9.e30.c2lnbmVk
+
+bespoke: {"jwt_value": "eyJFbnZveSI6ICJyb2NrcyJ9.e30.c2lnbmVk"}
+
+bespoke: beta:true,jwt_value:"eyJFbnZveSI6ICJyb2NrcyJ9.e30.c2lnbmVk",trace=1234
+```
+
+The header `name` may be `Authorization`.
+
+The `value_prefix` must match exactly, i.e., case-sensitively.
+If the `value_prefix` is not found, the header is skipped: not considered as a source for a JWT token.
+
+If there are no JWT-legal characters after the `value_prefix`, the entire string after it
+is taken to be the JWT token. This is unlikely to succeed; the error will reported by the JWT parser.

--- a/api/envoy/config/filter/http/jwt_authn/v3alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v3alpha/config.proto
@@ -1,0 +1,467 @@
+
+syntax = "proto3";
+
+package envoy.config.filter.http.jwt_authn.v3alpha;
+
+option java_outer_classname = "ConfigProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.jwt_authn.v3alpha";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/http_uri.proto";
+import "envoy/api/v3alpha/route/route.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: JWT Authentication]
+// JWT Authentication :ref:`configuration overview <config_http_filters_jwt_authn>`.
+
+// Please see following for JWT authentication flow:
+//
+// * `JSON Web Token (JWT) <https://tools.ietf.org/html/rfc7519>`_
+// * `The OAuth 2.0 Authorization Framework <https://tools.ietf.org/html/rfc6749>`_
+// * `OpenID Connect <http://openid.net/connect>`_
+//
+// A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
+//
+// * issuer: the principal that issues the JWT. It has to match the one from the token.
+// * allowed audiences: the ones in the token have to be listed here.
+// * how to fetch public key JWKS to verify the token signature.
+// * how to extract JWT token in the request.
+// * how to pass successfully verified token payload.
+//
+// Example:
+//
+// .. code-block:: yaml
+//
+//     issuer: https://example.com
+//     audiences:
+//     - bookstore_android.apps.googleusercontent.com
+//     - bookstore_web.apps.googleusercontent.com
+//     remote_jwks:
+//       http_uri:
+//         uri: https://example.com/.well-known/jwks.json
+//         cluster: example_jwks_cluster
+//       cache_duration:
+//         seconds: 300
+//
+message JwtProvider {
+  // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
+  // the JWT, usually a URL or an email address.
+  //
+  // Example: https://securetoken.google.com
+  // Example: 1234567-compute@developer.gserviceaccount.com
+  //
+  string issuer = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The list of JWT `audiences <https://tools.ietf.org/html/rfc7519#section-4.1.3>`_ are
+  // allowed to access. A JWT containing any of these audiences will be accepted. If not specified,
+  // will not check audiences in the token.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //     audiences:
+  //     - bookstore_android.apps.googleusercontent.com
+  //     - bookstore_web.apps.googleusercontent.com
+  //
+  repeated string audiences = 2;
+
+  // `JSON Web Key Set (JWKS) <https://tools.ietf.org/html/rfc7517#appendix-A>`_ is needed to
+  // validate signature of a JWT. This field specifies where to fetch JWKS.
+  oneof jwks_source_specifier {
+    option (validate.required) = true;
+
+    // JWKS can be fetched from remote server via HTTP/HTTPS. This field specifies the remote HTTP
+    // URI and how the fetched JWKS should be cached.
+    //
+    // Example:
+    //
+    // .. code-block:: yaml
+    //
+    //    remote_jwks:
+    //      http_uri:
+    //        uri: https://www.googleapis.com/oauth2/v1/certs
+    //        cluster: jwt.www.googleapis.com|443
+    //      cache_duration:
+    //        seconds: 300
+    //
+    RemoteJwks remote_jwks = 3;
+
+    // JWKS is in local data source. It could be either in a local file or embedded in the
+    // inline_string.
+    //
+    // Example: local file
+    //
+    // .. code-block:: yaml
+    //
+    //    local_jwks:
+    //      filename: /etc/envoy/jwks/jwks1.txt
+    //
+    // Example: inline_string
+    //
+    // .. code-block:: yaml
+    //
+    //    local_jwks:
+    //      inline_string: ACADADADADA
+    //
+    envoy.api.v3alpha.core.DataSource local_jwks = 4;
+  }
+
+  // If false, the JWT is removed in the request after a success verification. If true, the JWT is
+  // not removed in the request. Default value is false.
+  bool forward = 5;
+
+  // Two fields below define where to extract the JWT from an HTTP request.
+  //
+  // If no explicit location is specified, the following default locations are tried in order:
+  //
+  // 1. The Authorization header using the `Bearer schema
+  // <https://tools.ietf.org/html/rfc6750#section-2.1>`_. Example::
+  //
+  //    Authorization: Bearer <token>.
+  //
+  // 2. `access_token <https://tools.ietf.org/html/rfc6750#section-2.3>`_ query parameter.
+  //
+  // Multiple JWTs can be verified for a request. Each JWT has to be extracted from the locations
+  // its provider specified or from the default locations.
+  //
+  // Specify the HTTP headers to extract JWT token. For examples, following config:
+  //
+  // .. code-block:: yaml
+  //
+  //   from_headers:
+  //   - name: x-goog-iap-jwt-assertion
+  //
+  // can be used to extract token from header::
+  //
+  //   x-goog-iap-jwt-assertion: <JWT>.
+  //
+  repeated JwtHeader from_headers = 6;
+
+  // JWT is sent in a query parameter. `jwt_params` represents the query parameter names.
+  //
+  // For example, if config is:
+  //
+  // .. code-block:: yaml
+  //
+  //   from_params:
+  //   - jwt_token
+  //
+  // The JWT format in query parameter is::
+  //
+  //    /path?jwt_token=<JWT>
+  //
+  repeated string from_params = 7;
+
+  // This field specifies the header name to forward a successfully verified JWT payload to the
+  // backend. The forwarded data is::
+  //
+  //    base64_encoded(jwt_payload_in_JSON)
+  //
+  // If it is not specified, the payload will not be forwarded.
+  string forward_payload_header = 8;
+
+  // If non empty, successfully verified JWT payloads will be written to StreamInfo DynamicMetadata
+  // in the format as: *namespace* is the jwt_authn filter name as **envoy.filters.http.jwt_authn**
+  // The value is the *protobuf::Struct*. The value of this field will be the key for its *fields*
+  // and the value is the *protobuf::Struct* converted from JWT JSON payload.
+  //
+  // For example, if payload_in_metadata is *my_payload*:
+  //
+  // .. code-block:: yaml
+  //
+  //   envoy.filters.http.jwt_authn:
+  //     my_payload:
+  //       iss: https://example.com
+  //       sub: test@example.com
+  //       aud: https://example.com
+  //       exp: 1501281058
+  //
+  string payload_in_metadata = 9;
+}
+
+// This message specifies how to fetch JWKS from remote and how to cache it.
+message RemoteJwks {
+  // The HTTP URI to fetch the JWKS. For example:
+  //
+  // .. code-block:: yaml
+  //
+  //    http_uri:
+  //      uri: https://www.googleapis.com/oauth2/v1/certs
+  //      cluster: jwt.www.googleapis.com|443
+  //
+  envoy.api.v3alpha.core.HttpUri http_uri = 1;
+
+  // Duration after which the cached JWKS should be expired. If not specified, default cache
+  // duration is 5 minutes.
+  google.protobuf.Duration cache_duration = 2;
+}
+
+// This message specifies a header location to extract JWT token.
+message JwtHeader {
+  // The HTTP header name.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The value prefix. The value format is "value_prefix<token>"
+  // For example, for "Authorization: Bearer <token>", value_prefix="Bearer " with a space at the
+  // end.
+  string value_prefix = 2;
+}
+
+// Specify a required provider with audiences.
+message ProviderWithAudiences {
+  // Specify a required provider name.
+  string provider_name = 1;
+
+  // This field overrides the one specified in the JwtProvider.
+  repeated string audiences = 2;
+}
+
+// This message specifies a Jwt requirement. An empty message means JWT verification is not
+// required. Here are some config examples:
+//
+// .. code-block:: yaml
+//
+//  # Example 1: not required with an empty message
+//
+//  # Example 2: require A
+//  provider_name: provider-A
+//
+//  # Example 3: require A or B
+//  requires_any:
+//    requirements:
+//      - provider_name: provider-A
+//      - provider_name: provider-B
+//
+//  # Example 4: require A and B
+//  requires_all:
+//    requirements:
+//      - provider_name: provider-A
+//      - provider_name: provider-B
+//
+//  # Example 5: require A and (B or C)
+//  requires_all:
+//    requirements:
+//      - provider_name: provider-A
+//      - requires_any:
+//        requirements:
+//          - provider_name: provider-B
+//          - provider_name: provider-C
+//
+//  # Example 6: require A or (B and C)
+//  requires_any:
+//    requirements:
+//      - provider_name: provider-A
+//      - requires_all:
+//        requirements:
+//          - provider_name: provider-B
+//          - provider_name: provider-C
+//
+message JwtRequirement {
+  oneof requires_type {
+    // Specify a required provider name.
+    string provider_name = 1;
+
+    // Specify a required provider with audiences.
+    ProviderWithAudiences provider_and_audiences = 2;
+
+    // Specify list of JwtRequirement. Their results are OR-ed.
+    // If any one of them passes, the result is passed.
+    JwtRequirementOrList requires_any = 3;
+
+    // Specify list of JwtRequirement. Their results are AND-ed.
+    // All of them must pass, if one of them fails or missing, it fails.
+    JwtRequirementAndList requires_all = 4;
+
+    // The requirement is always satisfied even if JWT is missing or the JWT
+    // verification fails. A typical usage is: this filter is used to only verify
+    // JWTs and pass the verified JWT payloads to another filter, the other filter
+    // will make decision. In this mode, all JWT tokens will be verified.
+    google.protobuf.Empty allow_missing_or_failed = 5;
+  }
+}
+
+// This message specifies a list of RequiredProvider.
+// Their results are OR-ed; if any one of them passes, the result is passed
+message JwtRequirementOrList {
+  // Specify a list of JwtRequirement.
+  repeated JwtRequirement requirements = 1 [(validate.rules).repeated .min_items = 2];
+}
+
+// This message specifies a list of RequiredProvider.
+// Their results are AND-ed; all of them must pass, if one of them fails or missing, it fails.
+message JwtRequirementAndList {
+  // Specify a list of JwtRequirement.
+  repeated JwtRequirement requirements = 1 [(validate.rules).repeated .min_items = 2];
+}
+
+// This message specifies a Jwt requirement for a specific Route condition.
+// Example 1:
+//
+// .. code-block:: yaml
+//
+//    - match:
+//        prefix: /healthz
+//
+// In above example, "requires" field is empty for /healthz prefix match,
+// it means that requests matching the path prefix don't require JWT authentication.
+//
+// Example 2:
+//
+// .. code-block:: yaml
+//
+//    - match:
+//        prefix: /
+//      requires: { provider_name: provider-A }
+//
+// In above example, all requests matched the path prefix require jwt authentication
+// from "provider-A".
+message RequirementRule {
+  // The route matching parameter. Only when the match is satisfied, the "requires" field will
+  // apply.
+  //
+  // For example: following match will match all requests.
+  //
+  // .. code-block:: yaml
+  //
+  //    match:
+  //      prefix: /
+  //
+  envoy.api.v3alpha.route.RouteMatch match = 1 [(validate.rules).message.required = true];
+
+  // Specify a Jwt Requirement. Please detail comment in message JwtRequirement.
+  JwtRequirement requires = 2;
+}
+
+// This message specifies Jwt requirements based on stream_info.filterState.
+// This FilterState should use `Router::StringAccessor` object to set a string value.
+// Other HTTP filters can use it to specify Jwt requirements dynamically.
+//
+// Example:
+//
+// .. code-block:: yaml
+//
+//    name: jwt_selector
+//    requires:
+//      issuer_1:
+//        provider_name: issuer1
+//      issuer_2:
+//        provider_name: issuer2
+//
+// If a filter set "jwt_selector" with "issuer_1" to FilterState for a request,
+// jwt_authn filter will use JwtRequirement{"provider_name": "issuer1"} to verify.
+message FilterStateRule {
+  // The filter state name to retrieve the `Router::StringAccessor` object.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // A map of string keys to requirements. The string key is the string value
+  // in the FilterState with the name specified in the *name* field above.
+  map<string, JwtRequirement> requires = 3;
+}
+
+// This is the Envoy HTTP filter config for JWT authentication.
+//
+// For example:
+//
+// .. code-block:: yaml
+//
+//   providers:
+//      provider1:
+//        issuer: issuer1
+//        audiences:
+//        - audience1
+//        - audience2
+//        remote_jwks:
+//          http_uri:
+//            uri: https://example.com/.well-known/jwks.json
+//            cluster: example_jwks_cluster
+//      provider2:
+//        issuer: issuer2
+//        local_jwks:
+//          inline_string: jwks_string
+//
+//   rules:
+//      # Not jwt verification is required for /health path
+//      - match:
+//          prefix: /health
+//
+//      # Jwt verification for provider1 is required for path prefixed with "prefix"
+//      - match:
+//          prefix: /prefix
+//        requires:
+//          provider_name: provider1
+//
+//      # Jwt verification for either provider1 or provider2 is required for all other requests.
+//      - match:
+//          prefix: /
+//        requires:
+//          requires_any:
+//            requirements:
+//              - provider_name: provider1
+//              - provider_name: provider2
+//
+message JwtAuthentication {
+  // Map of provider names to JwtProviders.
+  //
+  // .. code-block:: yaml
+  //
+  //   providers:
+  //     provider1:
+  //        issuer: issuer1
+  //        audiences:
+  //        - audience1
+  //        - audience2
+  //        remote_jwks:
+  //          http_uri:
+  //            uri: https://example.com/.well-known/jwks.json
+  //            cluster: example_jwks_cluster
+  //      provider2:
+  //        issuer: provider2
+  //        local_jwks:
+  //          inline_string: jwks_string
+  //
+  map<string, JwtProvider> providers = 1;
+
+  // Specifies requirements based on the route matches. The first matched requirement will be
+  // applied. If there are overlapped match conditions, please put the most specific match first.
+  //
+  // Examples
+  //
+  // .. code-block:: yaml
+  //
+  // rules:
+  //   - match:
+  //       prefix: /healthz
+  //   - match:
+  //       prefix: /baz
+  //     requires:
+  //       provider_name: provider1
+  //   - match:
+  //       prefix: /foo
+  //     requires:
+  //       requires_any:
+  //         requirements:
+  //           - provider_name: provider1
+  //           - provider_name: provider2
+  //   - match:
+  //       prefix: /bar
+  //     requires:
+  //       requires_all:
+  //         requirements:
+  //           - provider_name: provider1
+  //           - provider_name: provider2
+  //
+  repeated RequirementRule rules = 2;
+
+  // This message specifies Jwt requirements based on stream_info.filterState.
+  // Other HTTP filters can use it to specify Jwt requirements dynamically.
+  // The *rules* field above is checked first, if it could not find any matches,
+  // check this one.
+  FilterStateRule filter_state_rules = 3;
+}

--- a/api/envoy/config/filter/http/lua/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/lua/v3alpha/BUILD
@@ -1,0 +1,8 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "lua",
+    srcs = ["lua.proto"],
+)

--- a/api/envoy/config/filter/http/lua/v3alpha/lua.proto
+++ b/api/envoy/config/filter/http/lua/v3alpha/lua.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.lua.v3alpha;
+
+option java_outer_classname = "LuaProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.lua.v3alpha";
+option go_package = "v2";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Lua]
+// Lua :ref:`configuration overview <config_http_filters_lua>`.
+
+message Lua {
+  // The Lua code that Envoy will execute. This can be a very small script that
+  // further loads code from disk if desired. Note that if JSON configuration is used, the code must
+  // be properly escaped. YAML configuration may be easier to read since YAML supports multi-line
+  // strings so complex scripts can be easily expressed inline in the configuration.
+  string inline_code = 1 [(validate.rules).string.min_bytes = 1];
+}

--- a/api/envoy/config/filter/http/rate_limit/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/rate_limit/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "rate_limit",
+    srcs = ["rate_limit.proto"],
+    deps = [
+        "//envoy/config/ratelimit/v3alpha:rls",
+    ],
+)

--- a/api/envoy/config/filter/http/rate_limit/v3alpha/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v3alpha/rate_limit.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.rate_limit.v3alpha;
+
+option java_outer_classname = "RateLimitProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.rate_limit.v3alpha";
+option go_package = "v2";
+
+import "envoy/config/ratelimit/v3alpha/rls.proto";
+
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Rate limit]
+// Rate limit :ref:`configuration overview <config_http_filters_rate_limit>`.
+
+message RateLimit {
+  // The rate limit domain to use when calling the rate limit service.
+  string domain = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specifies the rate limit configurations to be applied with the same
+  // stage number. If not set, the default stage number is 0.
+  //
+  // .. note::
+  //
+  //  The filter supports a range of 0 - 10 inclusively for stage numbers.
+  uint32 stage = 2 [(validate.rules).uint32.lte = 10];
+
+  // The type of requests the filter should apply to. The supported
+  // types are *internal*, *external* or *both*. A request is considered internal if
+  // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is set to true. If
+  // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
+  // request is considered external. The filter defaults to *both*, and it will apply to all request
+  // types.
+  string request_type = 3;
+
+  // The timeout in milliseconds for the rate limit service RPC. If not
+  // set, this defaults to 20ms.
+  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
+
+  // The filter's behaviour in case the rate limiting service does
+  // not respond back. When it is set to true, Envoy will not allow traffic in case of
+  // communication failure between rate limiting service and the proxy.
+  // Defaults to false.
+  bool failure_mode_deny = 5;
+
+  // Specifies whether a `RESOURCE_EXHAUSTED` gRPC code must be returned instead
+  // of the default `UNAVAILABLE` gRPC code for a rate limited gRPC call. The
+  // HTTP code will be 200 for a gRPC response.
+  bool rate_limited_as_resource_exhausted = 6;
+
+  // Configuration for an external rate limit service provider. If not
+  // specified, any calls to the rate limit service will immediately return
+  // success.
+  envoy.config.ratelimit.v3alpha.RateLimitServiceConfig rate_limit_service = 7
+      [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/filter/http/rbac/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/rbac/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "rbac",
+    srcs = ["rbac.proto"],
+    deps = ["//envoy/config/rbac/v3alpha:rbac"],
+)

--- a/api/envoy/config/filter/http/rbac/v3alpha/rbac.proto
+++ b/api/envoy/config/filter/http/rbac/v3alpha/rbac.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.rbac.v3alpha;
+
+option java_outer_classname = "RbacProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.rbac.v3alpha";
+option go_package = "v2";
+
+import "envoy/config/rbac/v3alpha/rbac.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: RBAC]
+// Role-Based Access Control :ref:`configuration overview <config_http_filters_rbac>`.
+
+// RBAC filter config.
+message RBAC {
+  // Specify the RBAC rules to be applied globally.
+  // If absent, no enforcing RBAC policy will be applied.
+  config.rbac.v3alpha.RBAC rules = 1;
+
+  // Shadow rules are not enforced by the filter (i.e., returning a 403)
+  // but will emit stats and logs and can be used for rule testing.
+  // If absent, no shadow RBAC policy will be applied.
+  config.rbac.v3alpha.RBAC shadow_rules = 2;
+}
+
+message RBACPerRoute {
+  reserved 1;
+
+  reserved "disabled";
+
+  // Override the global configuration of the filter with this new config.
+  // If absent, the global RBAC policy will be disabled for this route.
+  RBAC rbac = 2;
+}

--- a/api/envoy/config/filter/http/router/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/router/v3alpha/BUILD
@@ -1,0 +1,15 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "router",
+    srcs = ["router.proto"],
+    deps = ["//envoy/config/filter/accesslog/v3alpha:accesslog"],
+)
+
+api_go_proto_library(
+    name = "router",
+    proto = ":router",
+    deps = ["//envoy/config/filter/accesslog/v3alpha:accesslog_go_proto"],
+)

--- a/api/envoy/config/filter/http/router/v3alpha/router.proto
+++ b/api/envoy/config/filter/http/router/v3alpha/router.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.router.v3alpha;
+
+option java_outer_classname = "RouterProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.router.v3alpha";
+option go_package = "v2";
+
+import "envoy/config/filter/accesslog/v3alpha/accesslog.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Router]
+// Router :ref:`configuration overview <config_http_filters_router>`.
+
+message Router {
+  // Whether the router generates dynamic cluster statistics. Defaults to
+  // true. Can be disabled in high performance scenarios.
+  google.protobuf.BoolValue dynamic_stats = 1;
+
+  // Whether to start a child span for egress routed calls. This can be
+  // useful in scenarios where other filters (auth, ratelimit, etc.) make
+  // outbound calls and have child spans rooted at the same ingress
+  // parent. Defaults to false.
+  bool start_child_span = 2;
+
+  // Configuration for HTTP upstream logs emitted by the router. Upstream logs
+  // are configured in the same way as access logs, but each log entry represents
+  // an upstream request. Presuming retries are configured, multiple upstream
+  // requests may be made for each downstream (inbound) request.
+  repeated envoy.config.filter.accesslog.v3alpha.AccessLog upstream_log = 3;
+
+  // Do not add any additional *x-envoy-* headers to requests or responses. This
+  // only affects the :ref:`router filter generated *x-envoy-* headers
+  // <config_http_filters_router_headers_set>`, other Envoy filters and the HTTP
+  // connection manager may continue to set *x-envoy-* headers.
+  bool suppress_envoy_headers = 4;
+
+  // Specifies a list of HTTP headers to strictly validate. Envoy will reject a
+  // request and respond with HTTP status 400 if the request contains an invalid
+  // value for any of the headers listed in this field. Strict header checking
+  // is only supported for the following headers:
+  //
+  // Value must be a ','-delimited list (i.e. no spaces) of supported retry
+  // policy values:
+  //
+  // * :ref:`config_http_filters_router_x-envoy-retry-grpc-on`
+  // * :ref:`config_http_filters_router_x-envoy-retry-on`
+  //
+  // Value must be an integer:
+  //
+  // * :ref:`config_http_filters_router_x-envoy-max-retries`
+  // * :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`
+  // * :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`
+  repeated string strict_check_headers = 5 [(validate.rules).repeated .items.string = {
+    in: [
+      "x-envoy-upstream-rq-timeout-ms",
+      "x-envoy-upstream-rq-per-try-timeout-ms",
+      "x-envoy-max-retries",
+      "x-envoy-retry-grpc-on",
+      "x-envoy-retry-on"
+    ]
+  }];
+}

--- a/api/envoy/config/filter/http/squash/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/squash/v3alpha/BUILD
@@ -1,0 +1,8 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "squash",
+    srcs = ["squash.proto"],
+)

--- a/api/envoy/config/filter/http/squash/v3alpha/squash.proto
+++ b/api/envoy/config/filter/http/squash/v3alpha/squash.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.squash.v3alpha;
+
+option java_outer_classname = "SquashProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.squash.v3alpha";
+option go_package = "v2";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Squash]
+// Squash :ref:`configuration overview <config_http_filters_squash>`.
+
+// [#proto-status: experimental]
+message Squash {
+  // The name of the cluster that hosts the Squash server.
+  string cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+  // When the filter requests the Squash server to create a DebugAttachment, it will use this
+  // structure as template for the body of the request. It can contain reference to environment
+  // variables in the form of '{{ ENV_VAR_NAME }}'. These can be used to provide the Squash server
+  // with more information to find the process to attach the debugger to. For example, in a
+  // Istio/k8s environment, this will contain information on the pod:
+  //
+  // .. code-block:: json
+  //
+  //  {
+  //    "spec": {
+  //      "attachment": {
+  //        "pod": "{{ POD_NAME }}",
+  //        "namespace": "{{ POD_NAMESPACE }}"
+  //      },
+  //      "match_request": true
+  //    }
+  //  }
+  //
+  // (where POD_NAME, POD_NAMESPACE are configured in the pod via the Downward API)
+  google.protobuf.Struct attachment_template = 2;
+
+  // The timeout for individual requests sent to the Squash cluster. Defaults to 1 second.
+  google.protobuf.Duration request_timeout = 3 [(gogoproto.stdduration) = true];
+
+  // The total timeout Squash will delay a request and wait for it to be attached. Defaults to 60
+  // seconds.
+  google.protobuf.Duration attachment_timeout = 4 [(gogoproto.stdduration) = true];
+
+  // Amount of time to poll for the status of the attachment object in the Squash server
+  // (to check if has been attached). Defaults to 1 second.
+  google.protobuf.Duration attachment_poll_period = 5 [(gogoproto.stdduration) = true];
+}

--- a/api/envoy/config/filter/http/tap/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/tap/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "tap",
+    srcs = ["tap.proto"],
+    deps = [
+        "//envoy/config/common/tap/v3alpha:common",
+    ],
+)

--- a/api/envoy/config/filter/http/tap/v3alpha/tap.proto
+++ b/api/envoy/config/filter/http/tap/v3alpha/tap.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+import "envoy/config/common/tap/v3alpha/common.proto";
+
+import "validate/validate.proto";
+
+package envoy.config.filter.http.tap.v3alpha;
+
+option java_outer_classname = "TapProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.tap.v3alpha";
+
+// [#protodoc-title: Tap]
+// Tap :ref:`configuration overview <config_http_filters_tap>`.
+
+// Top level configuration for the tap filter.
+message Tap {
+  // Common configuration for the HTTP tap filter.
+  common.tap.v3alpha.CommonExtensionConfig common_config = 1
+      [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/filter/http/transcoder/v3alpha/BUILD
+++ b/api/envoy/config/filter/http/transcoder/v3alpha/BUILD
@@ -1,0 +1,13 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "transcoder",
+    srcs = ["transcoder.proto"],
+)
+
+api_go_proto_library(
+    name = "transcoder",
+    proto = ":transcoder",
+)

--- a/api/envoy/config/filter/http/transcoder/v3alpha/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v3alpha/transcoder.proto
@@ -1,0 +1,123 @@
+syntax = "proto3";
+
+package envoy.config.filter.http.transcoder.v3alpha;
+
+option java_outer_classname = "TranscoderProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.http.transcoder.v3alpha";
+option go_package = "v2";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: gRPC-JSON transcoder]
+// gRPC-JSON transcoder :ref:`configuration overview <config_http_filters_grpc_json_transcoder>`.
+
+message GrpcJsonTranscoder {
+  oneof descriptor_set {
+    option (validate.required) = true;
+
+    // Supplies the filename of
+    // :ref:`the proto descriptor set <config_grpc_json_generate_proto_descriptor_set>` for the gRPC
+    // services.
+    string proto_descriptor = 1;
+
+    // Supplies the binary content of
+    // :ref:`the proto descriptor set <config_grpc_json_generate_proto_descriptor_set>` for the gRPC
+    // services.
+    bytes proto_descriptor_bin = 4;
+  }
+
+  // A list of strings that
+  // supplies the fully qualified service names (i.e. "package_name.service_name") that
+  // the transcoder will translate. If the service name doesn't exist in ``proto_descriptor``,
+  // Envoy will fail at startup. The ``proto_descriptor`` may contain more services than
+  // the service names specified here, but they won't be translated.
+  repeated string services = 2 [(validate.rules).repeated .min_items = 1];
+
+  message PrintOptions {
+    // Whether to add spaces, line breaks and indentation to make the JSON
+    // output easy to read. Defaults to false.
+    bool add_whitespace = 1;
+
+    // Whether to always print primitive fields. By default primitive
+    // fields with default values will be omitted in JSON output. For
+    // example, an int32 field set to 0 will be omitted. Setting this flag to
+    // true will override the default behavior and print primitive fields
+    // regardless of their values. Defaults to false.
+    bool always_print_primitive_fields = 2;
+
+    // Whether to always print enums as ints. By default they are rendered
+    // as strings. Defaults to false.
+    bool always_print_enums_as_ints = 3;
+
+    // Whether to preserve proto field names. By default protobuf will
+    // generate JSON field names using the ``json_name`` option, or lower camel case,
+    // in that order. Setting this flag will preserve the original field names. Defaults to false.
+    bool preserve_proto_field_names = 4;
+  };
+
+  // Control options for response JSON. These options are passed directly to
+  // `JsonPrintOptions <https://developers.google.com/protocol-buffers/docs/reference/cpp/
+  // google.protobuf.util.json_util#JsonPrintOptions>`_.
+  PrintOptions print_options = 3;
+
+  // Whether to keep the incoming request route after the outgoing headers have been transformed to
+  // the match the upstream gRPC service. Note: This means that routes for gRPC services that are
+  // not transcoded cannot be used in combination with *match_incoming_request_route*.
+  bool match_incoming_request_route = 5;
+
+  // A list of query parameters to be ignored for transcoding method mapping.
+  // By default, the transcoder filter will not transcode a request if there are any
+  // unknown/invalid query parameters.
+  //
+  // Example :
+  //
+  // .. code-block:: proto
+  //
+  //     service Bookstore {
+  //       rpc GetShelf(GetShelfRequest) returns (Shelf) {
+  //         option (google.api.http) = {
+  //           get: "/shelves/{shelf}"
+  //         };
+  //       }
+  //     }
+  //
+  //     message GetShelfRequest {
+  //       int64 shelf = 1;
+  //     }
+  //
+  //     message Shelf {}
+  //
+  // The request ``/shelves/100?foo=bar`` will not be mapped to ``GetShelf``` because variable
+  // binding for ``foo`` is not defined. Adding ``foo`` to ``ignored_query_parameters`` will allow
+  // the same request to be mapped to ``GetShelf``.
+  repeated string ignored_query_parameters = 6;
+
+  // Whether to route methods without the ``google.api.http`` option.
+  //
+  // Example :
+  //
+  // .. code-block:: proto
+  //
+  //     package bookstore;
+  //
+  //     service Bookstore {
+  //       rpc GetShelf(GetShelfRequest) returns (Shelf) {}
+  //     }
+  //
+  //     message GetShelfRequest {
+  //       int64 shelf = 1;
+  //     }
+  //
+  //     message Shelf {}
+  //
+  // The client could ``post`` a json body ``{"shelf": 1234}`` with the path of
+  // ``/bookstore.Bookstore/GetShelfRequest`` to call ``GetShelfRequest``.
+  bool auto_mapping = 7;
+
+  // Whether to ignore query parameters that cannot be mapped to a corresponding
+  // protobuf field. Use this if you cannot control the query parameters and do
+  // not know them beforehand. Otherwise use ``ignored_query_parameters``.
+  // Defaults to false.
+  bool ignore_unknown_query_parameters = 8;
+}

--- a/api/envoy/config/filter/network/client_ssl_auth/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/client_ssl_auth/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "client_ssl_auth",
+    srcs = ["client_ssl_auth.proto"],
+    deps = ["//envoy/api/v3alpha/core:address"],
+)

--- a/api/envoy/config/filter/network/client_ssl_auth/v3alpha/client_ssl_auth.proto
+++ b/api/envoy/config/filter/network/client_ssl_auth/v3alpha/client_ssl_auth.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.client_ssl_auth.v3alpha;
+
+option java_outer_classname = "ClientSslAuthProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.client_ssl_auth.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Client TLS authentication]
+// Client TLS authentication
+// :ref:`configuration overview <config_network_filters_client_ssl_auth>`.
+
+message ClientSSLAuth {
+  // The :ref:`cluster manager <arch_overview_cluster_manager>` cluster that runs
+  // the authentication service. The filter will connect to the service every 60s to fetch the list
+  // of principals. The service must support the expected :ref:`REST API
+  // <config_network_filters_client_ssl_auth_rest_api>`.
+  string auth_api_cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The prefix to use when emitting :ref:`statistics
+  // <config_network_filters_client_ssl_auth_stats>`.
+  string stat_prefix = 2 [(validate.rules).string.min_bytes = 1];
+
+  // Time in milliseconds between principal refreshes from the
+  // authentication service. Default is 60000 (60s). The actual fetch time
+  // will be this value plus a random jittered value between
+  // 0-refresh_delay_ms milliseconds.
+  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+
+  // An optional list of IP address and subnet masks that should be white
+  // listed for access by the filter. If no list is provided, there is no
+  // IP white list.
+  repeated envoy.api.v3alpha.core.CidrRange ip_white_list = 4;
+}

--- a/api/envoy/config/filter/network/ext_authz/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/ext_authz/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "ext_authz",
+    srcs = ["ext_authz.proto"],
+    deps = ["//envoy/api/v3alpha/core:grpc_service"],
+)

--- a/api/envoy/config/filter/network/ext_authz/v3alpha/ext_authz.proto
+++ b/api/envoy/config/filter/network/ext_authz/v3alpha/ext_authz.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.ext_authz.v3alpha;
+
+option java_outer_classname = "ExtAuthzProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.ext_authz.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/grpc_service.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Network External Authorization ]
+// The network layer external authorization service configuration
+// :ref:`configuration overview <config_network_filters_ext_authz>`.
+
+// External Authorization filter calls out to an external service over the
+// gRPC Authorization API defined by
+// :ref:`CheckRequest <envoy_api_msg_service.auth.v3alpha.CheckRequest>`.
+// A failed check will cause this filter to close the TCP connection.
+message ExtAuthz {
+  // The prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The external authorization gRPC service configuration.
+  // The default timeout is set to 200ms by this filter.
+  envoy.api.v3alpha.core.GrpcService grpc_service = 2;
+
+  // The filter's behaviour in case the external authorization service does
+  // not respond back. When it is set to true, Envoy will also allow traffic in case of
+  // communication failure between authorization service and the proxy.
+  // Defaults to false.
+  bool failure_mode_allow = 3;
+}

--- a/api/envoy/config/filter/network/http_connection_manager/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/http_connection_manager/v3alpha/BUILD
@@ -1,0 +1,31 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "http_connection_manager",
+    srcs = ["http_connection_manager.proto"],
+    deps = [
+        "//envoy/api/v3alpha:rds",
+        "//envoy/api/v3alpha:srds",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:config_source",
+        "//envoy/api/v3alpha/core:protocol",
+        "//envoy/config/filter/accesslog/v3alpha:accesslog",
+        "//envoy/type:percent",
+    ],
+)
+
+api_go_proto_library(
+    name = "http_connection_manager",
+    proto = ":http_connection_manager",
+    deps = [
+        "//envoy/api/v3alpha:rds_go_grpc",
+        "//envoy/api/v3alpha:srds_go_grpc",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:config_source_go_proto",
+        "//envoy/api/v3alpha/core:protocol_go_proto",
+        "//envoy/config/filter/accesslog/v3alpha:accesslog_go_proto",
+        "//envoy/type:percent_go_proto",
+    ],
+)

--- a/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.proto
@@ -1,0 +1,599 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.http_connection_manager.v3alpha;
+
+option java_outer_classname = "HttpConnectionManagerProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.http_connection_manager.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/config_source.proto";
+import "envoy/api/v3alpha/core/protocol.proto";
+import "envoy/api/v3alpha/rds.proto";
+import "envoy/api/v3alpha/srds.proto";
+import "envoy/config/filter/accesslog/v3alpha/accesslog.proto";
+import "envoy/type/percent.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: HTTP connection manager]
+// HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
+
+// [#comment:next free field: 35]
+message HttpConnectionManager {
+  enum CodecType {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    // For every new connection, the connection manager will determine which
+    // codec to use. This mode supports both ALPN for TLS listeners as well as
+    // protocol inference for plaintext listeners. If ALPN data is available, it
+    // is preferred, otherwise protocol inference is used. In almost all cases,
+    // this is the right option to choose for this setting.
+    AUTO = 0;
+
+    // The connection manager will assume that the client is speaking HTTP/1.1.
+    HTTP1 = 1;
+
+    // The connection manager will assume that the client is speaking HTTP/2
+    // (Envoy does not require HTTP/2 to take place over TLS or to use ALPN.
+    // Prior knowledge is allowed).
+    HTTP2 = 2;
+  }
+
+  // Supplies the type of codec that the connection manager should use.
+  CodecType codec_type = 1 [(validate.rules).enum.defined_only = true];
+
+  // The human readable prefix to use when emitting statistics for the
+  // connection manager. See the :ref:`statistics documentation <config_http_conn_man_stats>` for
+  // more information.
+  string stat_prefix = 2 [(validate.rules).string.min_bytes = 1];
+
+  oneof route_specifier {
+    option (validate.required) = true;
+
+    // The connection manager’s route table will be dynamically loaded via the RDS API.
+    Rds rds = 3;
+
+    // The route table for the connection manager is static and is specified in this property.
+    envoy.api.v3alpha.RouteConfiguration route_config = 4;
+
+    // A route table will be dynamically assigned to each request based on request attributes
+    // (e.g., the value of a header). The "routing scopes" (i.e., route tables) and "scope keys" are
+    // specified in this message.
+    ScopedRoutes scoped_routes = 31;
+  }
+
+  // A list of individual HTTP filters that make up the filter chain for
+  // requests made to the connection manager. Order matters as the filters are
+  // processed sequentially as request events happen.
+  repeated HttpFilter http_filters = 5;
+
+  // Whether the connection manager manipulates the :ref:`config_http_conn_man_headers_user-agent`
+  // and :ref:`config_http_conn_man_headers_downstream-service-cluster` headers. See the linked
+  // documentation for more information. Defaults to false.
+  google.protobuf.BoolValue add_user_agent = 6;
+
+  message Tracing {
+    // [#comment:TODO(kyessenov): Align this field with listener traffic direction field.]
+    enum OperationName {
+      option (gogoproto.goproto_enum_prefix) = false;
+
+      // The HTTP listener is used for ingress/incoming requests.
+      INGRESS = 0;
+
+      // The HTTP listener is used for egress/outgoing requests.
+      EGRESS = 1;
+    }
+
+    // The span name will be derived from this field.
+    OperationName operation_name = 1 [(validate.rules).enum.defined_only = true];
+
+    // A list of header names used to create tags for the active span. The header name is used to
+    // populate the tag name, and the header value is used to populate the tag value. The tag is
+    // created if the specified header name is present in the request's headers.
+    repeated string request_headers_for_tags = 2;
+
+    // Target percentage of requests managed by this HTTP connection manager that will be force
+    // traced if the :ref:`x-client-trace-id <config_http_conn_man_headers_x-client-trace-id>`
+    // header is set. This field is a direct analog for the runtime variable
+    // 'tracing.client_sampling' in the :ref:`HTTP Connection Manager
+    // <config_http_conn_man_runtime>`.
+    // Default: 100%
+    envoy.type.Percent client_sampling = 3;
+
+    // Target percentage of requests managed by this HTTP connection manager that will be randomly
+    // selected for trace generation, if not requested by the client or not forced. This field is
+    // a direct analog for the runtime variable 'tracing.random_sampling' in the
+    // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // Default: 100%
+    envoy.type.Percent random_sampling = 4;
+
+    // Target percentage of requests managed by this HTTP connection manager that will be traced
+    // after all other sampling checks have been applied (client-directed, force tracing, random
+    // sampling). This field functions as an upper limit on the total configured sampling rate. For
+    // instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1%
+    // of client requests with the appropriate headers to be force traced. This field is a direct
+    // analog for the runtime variable 'tracing.global_enabled' in the
+    // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // Default: 100%
+    envoy.type.Percent overall_sampling = 5;
+
+    // Whether to annotate spans with additional data. If true, spans will include logs for stream
+    // events.
+    bool verbose = 6;
+  }
+
+  // Presence of the object defines whether the connection manager
+  // emits :ref:`tracing <arch_overview_tracing>` data to the :ref:`configured tracing provider
+  // <envoy_api_msg_config.trace.v3alpha.Tracing>`.
+  Tracing tracing = 7;
+
+  // Additional HTTP/1 settings that are passed to the HTTP/1 codec.
+  envoy.api.v3alpha.core.Http1ProtocolOptions http_protocol_options = 8;
+
+  // Additional HTTP/2 settings that are passed directly to the HTTP/2 codec.
+  envoy.api.v3alpha.core.Http2ProtocolOptions http2_protocol_options = 9;
+
+  // An optional override that the connection manager will write to the server
+  // header in responses. If not set, the default is *envoy*.
+  string server_name = 10;
+
+  enum ServerHeaderTransformation {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    // Overwrite any Server header with the contents of server_name.
+    OVERWRITE = 0;
+    // If no Server header is present, append Server server_name
+    // If a Server header is present, pass it through.
+    APPEND_IF_ABSENT = 1;
+    // Pass through the value of the server header, and do not append a header
+    // if none is present.
+    PASS_THROUGH = 2;
+  }
+  // Defines the action to be applied to the Server header on the response path.
+  // By default, Envoy will overwrite the header with the value specified in
+  // server_name.
+  ServerHeaderTransformation server_header_transformation = 34
+      [(validate.rules).enum.defined_only = true];
+
+  // The maximum request headers size for incoming connections.
+  // If unconfigured, the default max request headers allowed is 60 KiB.
+  // Requests that exceed this limit will receive a 431 response.
+  // The max configurable limit is 96 KiB, based on current implementation
+  // constraints.
+  google.protobuf.UInt32Value max_request_headers_kb = 29
+      [(validate.rules).uint32.gt = 0, (validate.rules).uint32.lte = 96];
+
+  // The idle timeout for connections managed by the connection manager. The
+  // idle timeout is defined as the period in which there are no active
+  // requests. If not set, there is no idle timeout. When the idle timeout is
+  // reached the connection will be closed. If the connection is an HTTP/2
+  // connection a drain sequence will occur prior to closing the connection. See
+  // :ref:`drain_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.drain_timeout>`.
+  google.protobuf.Duration idle_timeout = 11 [(gogoproto.stdduration) = true];
+
+  // The stream idle timeout for connections managed by the connection manager.
+  // If not specified, this defaults to 5 minutes. The default value was selected
+  // so as not to interfere with any smaller configured timeouts that may have
+  // existed in configurations prior to the introduction of this feature, while
+  // introducing robustness to TCP connections that terminate without a FIN.
+  //
+  // This idle timeout applies to new streams and is overridable by the
+  // :ref:`route-level idle_timeout
+  // <envoy_api_field_route.RouteAction.idle_timeout>`. Even on a stream in
+  // which the override applies, prior to receipt of the initial request
+  // headers, the :ref:`stream_idle_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.stream_idle_timeout>`
+  // applies. Each time an encode/decode event for headers or data is processed
+  // for the stream, the timer will be reset. If the timeout fires, the stream
+  // is terminated with a 408 Request Timeout error code if no upstream response
+  // header has been received, otherwise a stream reset occurs.
+  //
+  // Note that it is possible to idle timeout even if the wire traffic for a stream is non-idle, due
+  // to the granularity of events presented to the connection manager. For example, while receiving
+  // very large request headers, it may be the case that there is traffic regularly arriving on the
+  // wire while the connection manage is only able to observe the end-of-headers event, hence the
+  // stream may still idle timeout.
+  //
+  // A value of 0 will completely disable the connection manager stream idle
+  // timeout, although per-route idle timeout overrides will continue to apply.
+  google.protobuf.Duration stream_idle_timeout = 24 [(gogoproto.stdduration) = true];
+
+  // A timeout for idle requests managed by the connection manager.
+  // The timer is activated when the request is initiated, and is disarmed when the last byte of the
+  // request is sent upstream (i.e. all decoding filters have processed the request), OR when the
+  // response is initiated. If not specified or set to 0, this timeout is disabled.
+  google.protobuf.Duration request_timeout = 28 [(gogoproto.stdduration) = true];
+
+  // The time that Envoy will wait between sending an HTTP/2 “shutdown
+  // notification” (GOAWAY frame with max stream ID) and a final GOAWAY frame.
+  // This is used so that Envoy provides a grace period for new streams that
+  // race with the final GOAWAY frame. During this grace period, Envoy will
+  // continue to accept new streams. After the grace period, a final GOAWAY
+  // frame is sent and Envoy will start refusing new streams. Draining occurs
+  // both when a connection hits the idle timeout or during general server
+  // draining. The default grace period is 5000 milliseconds (5 seconds) if this
+  // option is not specified.
+  google.protobuf.Duration drain_timeout = 12 [(gogoproto.stdduration) = true];
+
+  // The delayed close timeout is for downstream connections managed by the HTTP connection manager.
+  // It is defined as a grace period after connection close processing has been locally initiated
+  // during which Envoy will wait for the peer to close (i.e., a TCP FIN/RST is received by Envoy
+  // from the downstream connection) prior to Envoy closing the socket associated with that
+  // connection.
+  // NOTE: This timeout is enforced even when the socket associated with the downstream connection
+  // is pending a flush of the write buffer. However, any progress made writing data to the socket
+  // will restart the timer associated with this timeout. This means that the total grace period for
+  // a socket in this state will be
+  // <total_time_waiting_for_write_buffer_flushes>+<delayed_close_timeout>.
+  //
+  // Delaying Envoy's connection close and giving the peer the opportunity to initiate the close
+  // sequence mitigates a race condition that exists when downstream clients do not drain/process
+  // data in a connection's receive buffer after a remote close has been detected via a socket
+  // write(). This race leads to such clients failing to process the response code sent by Envoy,
+  // which could result in erroneous downstream processing.
+  //
+  // If the timeout triggers, Envoy will close the connection's socket.
+  //
+  // The default timeout is 1000 ms if this option is not specified.
+  //
+  // .. NOTE::
+  //    To be useful in avoiding the race condition described above, this timeout must be set
+  //    to *at least* <max round trip time expected between clients and Envoy>+<100ms to account for
+  //    a reasonsable "worst" case processing time for a full iteration of Envoy's event loop>.
+  //
+  // .. WARNING::
+  //    A value of 0 will completely disable delayed close processing. When disabled, the downstream
+  //    connection's socket will be closed immediately after the write flush is completed or will
+  //    never close if the write flush does not complete.
+  google.protobuf.Duration delayed_close_timeout = 26 [(gogoproto.stdduration) = true];
+
+  // Configuration for :ref:`HTTP access logs <arch_overview_access_logs>`
+  // emitted by the connection manager.
+  repeated envoy.config.filter.accesslog.v3alpha.AccessLog access_log = 13;
+
+  // If set to true, the connection manager will use the real remote address
+  // of the client connection when determining internal versus external origin and manipulating
+  // various headers. If set to false or absent, the connection manager will use the
+  // :ref:`config_http_conn_man_headers_x-forwarded-for` HTTP header. See the documentation for
+  // :ref:`config_http_conn_man_headers_x-forwarded-for`,
+  // :ref:`config_http_conn_man_headers_x-envoy-internal`, and
+  // :ref:`config_http_conn_man_headers_x-envoy-external-address` for more information.
+  google.protobuf.BoolValue use_remote_address = 14;
+
+  // The number of additional ingress proxy hops from the right side of the
+  // :ref:`config_http_conn_man_headers_x-forwarded-for` HTTP header to trust when
+  // determining the origin client's IP address. The default is zero if this option
+  // is not specified. See the documentation for
+  // :ref:`config_http_conn_man_headers_x-forwarded-for` for more information.
+  uint32 xff_num_trusted_hops = 19;
+
+  message InternalAddressConfig {
+    // Whether unix socket addresses should be considered internal.
+    bool unix_sockets = 1;
+  }
+
+  // Configures what network addresses are considered internal for stats and header sanitation
+  // purposes. If unspecified, only RFC1918 IP addresses will be considered internal.
+  // See the documentation for :ref:`config_http_conn_man_headers_x-envoy-internal` for more
+  // information about internal/external addresses.
+  InternalAddressConfig internal_address_config = 25;
+
+  // If set, Envoy will not append the remote address to the
+  // :ref:`config_http_conn_man_headers_x-forwarded-for` HTTP header. This may be used in
+  // conjunction with HTTP filters that explicitly manipulate XFF after the HTTP connection manager
+  // has mutated the request headers. While :ref:`use_remote_address
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.use_remote_address>`
+  // will also suppress XFF addition, it has consequences for logging and other
+  // Envoy uses of the remote address, so *skip_xff_append* should be used
+  // when only an elision of XFF addition is intended.
+  bool skip_xff_append = 21;
+
+  // Via header value to append to request and response headers. If this is
+  // empty, no via header will be appended.
+  string via = 22;
+
+  // Whether the connection manager will generate the :ref:`x-request-id
+  // <config_http_conn_man_headers_x-request-id>` header if it does not exist. This defaults to
+  // true. Generating a random UUID4 is expensive so in high throughput scenarios where this feature
+  // is not desired it can be disabled.
+  google.protobuf.BoolValue generate_request_id = 15;
+
+  // Whether the connection manager will keep the :ref:`x-request-id
+  // <config_http_conn_man_headers_x-request-id>` header if passed for a request that is edge
+  // (Edge request is the request from external clients to front Envoy) and not reset it, which
+  // is the current Envoy behaviour. This defaults to false.
+  bool preserve_external_request_id = 32;
+
+  // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
+  // header.
+  enum ForwardClientCertDetails {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    // Do not send the XFCC header to the next hop. This is the default value.
+    SANITIZE = 0;
+
+    // When the client connection is mTLS (Mutual TLS), forward the XFCC header
+    // in the request.
+    FORWARD_ONLY = 1;
+
+    // When the client connection is mTLS, append the client certificate
+    // information to the request’s XFCC header and forward it.
+    APPEND_FORWARD = 2;
+
+    // When the client connection is mTLS, reset the XFCC header with the client
+    // certificate information and send it to the next hop.
+    SANITIZE_SET = 3;
+
+    // Always forward the XFCC header in the request, regardless of whether the
+    // client connection is mTLS.
+    ALWAYS_FORWARD_ONLY = 4;
+  };
+
+  // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
+  // header.
+  ForwardClientCertDetails forward_client_cert_details = 16
+      [(validate.rules).enum.defined_only = true];
+
+  // [#comment:next free field: 7]
+  message SetCurrentClientCertDetails {
+    // Whether to forward the subject of the client cert. Defaults to false.
+    google.protobuf.BoolValue subject = 1;
+
+    reserved 2; // san deprecated by uri
+
+    // Whether to forward the entire client cert in URL encoded PEM format. This will appear in the
+    // XFCC header comma separated from other values with the value Cert="PEM".
+    // Defaults to false.
+    bool cert = 3;
+
+    // Whether to forward the entire client cert chain (including the leaf cert) in URL encoded PEM
+    // format. This will appear in the XFCC header comma separated from other values with the value
+    // Chain="PEM".
+    // Defaults to false.
+    bool chain = 6;
+
+    // Whether to forward the DNS type Subject Alternative Names of the client cert.
+    // Defaults to false.
+    bool dns = 4;
+
+    // Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to
+    // false.
+    bool uri = 5;
+  };
+
+  // This field is valid only when :ref:`forward_client_cert_details
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.forward_client_cert_details>`
+  // is APPEND_FORWARD or SANITIZE_SET and the client connection is mTLS. It specifies the fields in
+  // the client certificate to be forwarded. Note that in the
+  // :ref:`config_http_conn_man_headers_x-forwarded-client-cert` header, *Hash* is always set, and
+  // *By* is always set when the client certificate presents the URI type Subject Alternative Name
+  // value.
+  SetCurrentClientCertDetails set_current_client_cert_details = 17;
+
+  // If proxy_100_continue is true, Envoy will proxy incoming "Expect:
+  // 100-continue" headers upstream, and forward "100 Continue" responses
+  // downstream. If this is false or not set, Envoy will instead strip the
+  // "Expect: 100-continue" header, and send a "100 Continue" response itself.
+  bool proxy_100_continue = 18;
+
+  // If
+  // :ref:`use_remote_address
+  // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.use_remote_address>`
+  // is true and represent_ipv4_remote_address_as_ipv4_mapped_ipv6 is true and the remote address is
+  // an IPv4 address, the address will be mapped to IPv6 before it is appended to *x-forwarded-for*.
+  // This is useful for testing compatibility of upstream services that parse the header value. For
+  // example, 50.0.0.1 is represented as ::FFFF:50.0.0.1. See `IPv4-Mapped IPv6 Addresses
+  // <https://tools.ietf.org/html/rfc4291#section-2.5.5.2>`_ for details. This will also affect the
+  // :ref:`config_http_conn_man_headers_x-envoy-external-address` header. See
+  // :ref:`http_connection_manager.represent_ipv4_remote_address_as_ipv4_mapped_ipv6
+  // <config_http_conn_man_runtime_represent_ipv4_remote_address_as_ipv4_mapped_ipv6>` for runtime
+  // control.
+  // [#not-implemented-hide:]
+  bool represent_ipv4_remote_address_as_ipv4_mapped_ipv6 = 20;
+
+  // The configuration for HTTP upgrades.
+  // For each upgrade type desired, an UpgradeConfig must be added.
+  //
+  // .. warning::
+  //
+  //    The current implementation of upgrade headers does not handle
+  //    multi-valued upgrade headers. Support for multi-valued headers may be
+  //    added in the future if needed.
+  //
+  // .. warning::
+  //    The current implementation of upgrade headers does not work with HTTP/2
+  //    upstreams.
+  message UpgradeConfig {
+    // The case-insensitive name of this upgrade, e.g. "websocket".
+    // For each upgrade type present in upgrade_configs, requests with
+    // Upgrade: [upgrade_type]
+    // will be proxied upstream.
+    string upgrade_type = 1;
+    // If present, this represents the filter chain which will be created for
+    // this type of upgrade. If no filters are present, the filter chain for
+    // HTTP connections will be used for this upgrade type.
+    repeated HttpFilter filters = 2;
+    // Determines if upgrades are enabled or disabled by default. Defaults to true.
+    // This can be overridden on a per-route basis with :ref:`cluster
+    // <envoy_api_field_route.RouteAction.upgrade_configs>` as documented in the
+    // :ref:`upgrade documentation <arch_overview_websocket>`.
+    google.protobuf.BoolValue enabled = 3;
+  };
+  repeated UpgradeConfig upgrade_configs = 23;
+
+  reserved 27;
+
+  // Should paths be normalized according to RFC 3986 before any processing of
+  // requests by HTTP filters or routing? This affects the upstream *:path* header
+  // as well. For paths that fail this check, Envoy will respond with 400 to
+  // paths that are malformed. This defaults to false currently but will default
+  // true in the future. When not specified, this value may be overridden by the
+  // runtime variable
+  // :ref:`http_connection_manager.normalize_path<config_http_conn_man_runtime_normalize_path>`.
+  // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
+  // for details of normalization.
+  // Note that Envoy does not perform
+  // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
+  google.protobuf.BoolValue normalize_path = 30;
+
+  // Determines if adjacent slashes in the path are merged into one before any processing of
+  // requests by HTTP filters or routing. This affects the upstream *:path* header as well. Without
+  // setting this option, incoming requests with path `//dir///file` will not match against route
+  // with `prefix` match set to `/dir`. Defaults to `false`. Note that slash merging is not part of
+  // `HTTP spec <https://tools.ietf.org/html/rfc3986>` and is provided for convenience.
+  bool merge_slashes = 33;
+}
+
+message Rds {
+  // Configuration source specifier for RDS.
+  envoy.api.v3alpha.core.ConfigSource config_source = 1 [(validate.rules).message.required = true];
+
+  // The name of the route configuration. This name will be passed to the RDS
+  // API. This allows an Envoy configuration with multiple HTTP listeners (and
+  // associated HTTP connection manager filters) to use different route
+  // configurations.
+  string route_config_name = 2 [(validate.rules).string.min_bytes = 1];
+}
+
+// This message is used to work around the limitations with 'oneof' and repeated fields.
+message ScopedRouteConfigurationsList {
+  repeated envoy.api.v3alpha.ScopedRouteConfiguration scoped_route_configurations = 1
+      [(validate.rules).repeated .min_items = 1];
+}
+
+message ScopedRoutes {
+  // The name assigned to the scoped routing configuration.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specifies the mechanism for constructing "scope keys" based on HTTP request attributes. These
+  // keys are matched against a set of :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>`
+  // objects assembled from :ref:`ScopedRouteConfiguration<envoy_api_msg_ScopedRouteConfiguration>`
+  // messages distributed via SRDS (the Scoped Route Discovery Service) or assigned statically via
+  // :ref:`scoped_route_configurations_list<envoy_api_field_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.scoped_route_configurations_list>`.
+  //
+  // Upon receiving a request's headers, the Router will build a key using the algorithm specified
+  // by this message. This key will be used to look up the routing table (i.e., the
+  // :ref:`RouteConfiguration<envoy_api_msg_RouteConfiguration>`) to use for the request.
+  message ScopeKeyBuilder {
+    // Specifies the mechanism for constructing key fragments which are composed into scope keys.
+    message FragmentBuilder {
+      // Specifies how the value of a header should be extracted.
+      // The following example maps the structure of a header to the fields in this message.
+      //
+      // .. code::
+      //
+      //              <0> <1>   <-- index
+      //    X-Header: a=b;c=d
+      //    |         || |
+      //    |         || \----> <element_separator>
+      //    |         ||
+      //    |         |\----> <element.separator>
+      //    |         |
+      //    |         \----> <element.key>
+      //    |
+      //    \----> <name>
+      //
+      //    Each 'a=b' key-value pair constitutes an 'element' of the header field.
+      message HeaderValueExtractor {
+        // The name of the header field to extract the value from.
+        string name = 1 [(validate.rules).string.min_bytes = 1];
+
+        // The element separator (e.g., ';' separates 'a;b;c;d').
+        // Default: empty string. This causes the entirety of the header field to be extracted.
+        // If this field is set to an empty string and 'index' is used in the oneof below, 'index'
+        // must be set to 0.
+        string element_separator = 2;
+
+        // Specifies a header field's key value pair to match on.
+        message KvElement {
+          // The separator between key and value (e.g., '=' separates 'k=v;...').
+          // If an element is an empty string, the element is ignored.
+          // If an element contains no separator, the whole element is parsed as key and the
+          // fragment value is an empty string.
+          // If there are multiple values for a matched key, the first value is returned.
+          string separator = 1 [(validate.rules).string.min_bytes = 1];
+
+          // The key to match on.
+          string key = 2 [(validate.rules).string.min_bytes = 1];
+        }
+
+        oneof extract_type {
+          // Specifies the zero based index of the element to extract.
+          // Note Envoy concatenates multiple values of the same header key into a comma separated
+          // string, the splitting always happens after the concatenation.
+          uint32 index = 3;
+
+          // Specifies the key value pair to extract the value from.
+          KvElement element = 4;
+        }
+      }
+
+      oneof type {
+        option (validate.required) = true;
+
+        // Specifies how a header field's value should be extracted.
+        HeaderValueExtractor header_value_extractor = 1;
+      }
+    }
+
+    // The final scope key consists of the ordered union of these fragments.
+    repeated FragmentBuilder fragments = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  // The algorithm to use for constructing a scope key for each request.
+  ScopeKeyBuilder scope_key_builder = 2 [(validate.rules).message.required = true];
+
+  // Configuration source specifier for RDS.
+  // This config source is used to subscribe to RouteConfiguration resources specified in
+  // ScopedRouteConfiguration messages.
+  envoy.api.v3alpha.core.ConfigSource rds_config_source = 3
+      [(validate.rules).message.required = true];
+
+  oneof config_specifier {
+    option (validate.required) = true;
+
+    // The set of routing scopes corresponding to the HCM. A scope is assigned to a request by
+    // matching a key constructed from the request's attributes according to the algorithm specified
+    // by the
+    // :ref:`ScopeKeyBuilder<envoy_api_msg_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.ScopeKeyBuilder>`
+    // in this message.
+    ScopedRouteConfigurationsList scoped_route_configurations_list = 4;
+
+    // The set of routing scopes associated with the HCM will be dynamically loaded via the SRDS
+    // API. A scope is assigned to a request by matching a key constructed from the request's
+    // attributes according to the algorithm specified by the
+    // :ref:`ScopeKeyBuilder<envoy_api_msg_config.filter.network.http_connection_manager.v3alpha.ScopedRoutes.ScopeKeyBuilder>`
+    // in this message.
+    ScopedRds scoped_rds = 5;
+  }
+}
+
+message ScopedRds {
+  // Configuration source specifier for scoped RDS.
+  envoy.api.v3alpha.core.ConfigSource scoped_rds_config_source = 1
+      [(validate.rules).message.required = true];
+}
+
+message HttpFilter {
+  // The name of the filter to instantiate. The name must match a
+  // :ref:`supported filter <config_http_filters>`.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Filter specific configuration which depends on the filter being instantiated. See the supported
+  // filters for further documentation.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 4;
+  }
+
+  reserved 3;
+}

--- a/api/envoy/config/filter/network/mongo_proxy/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/mongo_proxy/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "mongo_proxy",
+    srcs = ["mongo_proxy.proto"],
+    deps = ["//envoy/config/filter/fault/v3alpha:fault"],
+)

--- a/api/envoy/config/filter/network/mongo_proxy/v3alpha/mongo_proxy.proto
+++ b/api/envoy/config/filter/network/mongo_proxy/v3alpha/mongo_proxy.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.mongo_proxy.v3alpha;
+
+option java_outer_classname = "MongoProxyProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.mongo_proxy.v3alpha";
+option go_package = "v2";
+
+import "envoy/config/filter/fault/v3alpha/fault.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Mongo proxy]
+// MongoDB :ref:`configuration overview <config_network_filters_mongo_proxy>`.
+
+message MongoProxy {
+  // The human readable prefix to use when emitting :ref:`statistics
+  // <config_network_filters_mongo_proxy_stats>`.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The optional path to use for writing Mongo access logs. If not access log
+  // path is specified no access logs will be written. Note that access log is
+  // also gated :ref:`runtime <config_network_filters_mongo_proxy_runtime>`.
+  string access_log = 2;
+
+  // Inject a fixed delay before proxying a Mongo operation. Delays are
+  // applied to the following MongoDB operations: Query, Insert, GetMore,
+  // and KillCursors. Once an active delay is in progress, all incoming
+  // data up until the timer event fires will be a part of the delay.
+  envoy.config.filter.fault.v3alpha.FaultDelay delay = 3;
+
+  // Flag to specify whether :ref:`dynamic metadata
+  // <config_network_filters_mongo_proxy_dynamic_metadata>` should be emitted. Defaults to false.
+  bool emit_dynamic_metadata = 4;
+}

--- a/api/envoy/config/filter/network/rate_limit/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/rate_limit/v3alpha/BUILD
@@ -1,0 +1,12 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "rate_limit",
+    srcs = ["rate_limit.proto"],
+    deps = [
+        "//envoy/api/v3alpha/ratelimit",
+        "//envoy/config/ratelimit/v3alpha:rls",
+    ],
+)

--- a/api/envoy/config/filter/network/rate_limit/v3alpha/rate_limit.proto
+++ b/api/envoy/config/filter/network/rate_limit/v3alpha/rate_limit.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.rate_limit.v3alpha;
+
+option java_outer_classname = "RateLimitProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.rate_limit.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/ratelimit/ratelimit.proto";
+import "envoy/config/ratelimit/v3alpha/rls.proto";
+
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Rate limit]
+// Rate limit :ref:`configuration overview <config_network_filters_rate_limit>`.
+
+message RateLimit {
+  // The prefix to use when emitting :ref:`statistics <config_network_filters_rate_limit_stats>`.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The rate limit domain to use in the rate limit service request.
+  string domain = 2 [(validate.rules).string.min_bytes = 1];
+
+  // The rate limit descriptor list to use in the rate limit service request.
+  repeated envoy.api.v3alpha.ratelimit.RateLimitDescriptor descriptors = 3
+      [(validate.rules).repeated .min_items = 1];
+
+  // The timeout in milliseconds for the rate limit service RPC. If not
+  // set, this defaults to 20ms.
+  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
+
+  // The filter's behaviour in case the rate limiting service does
+  // not respond back. When it is set to true, Envoy will not allow traffic in case of
+  // communication failure between rate limiting service and the proxy.
+  // Defaults to false.
+  bool failure_mode_deny = 5;
+
+  // Configuration for an external rate limit service provider. If not
+  // specified, any calls to the rate limit service will immediately return
+  // success.
+  envoy.config.ratelimit.v3alpha.RateLimitServiceConfig rate_limit_service = 6
+      [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/filter/network/rbac/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/rbac/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "rbac",
+    srcs = ["rbac.proto"],
+    deps = ["//envoy/config/rbac/v3alpha:rbac"],
+)

--- a/api/envoy/config/filter/network/rbac/v3alpha/rbac.proto
+++ b/api/envoy/config/filter/network/rbac/v3alpha/rbac.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.rbac.v3alpha;
+
+option java_outer_classname = "RbacProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.rbac.v3alpha";
+option go_package = "v2";
+
+import "envoy/config/rbac/v3alpha/rbac.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: RBAC]
+// Role-Based Access Control :ref:`configuration overview <config_network_filters_rbac>`.
+
+// RBAC network filter config.
+//
+// Header should not be used in rules/shadow_rules in RBAC network filter as
+// this information is only available in :ref:`RBAC http filter <config_http_filters_rbac>`.
+message RBAC {
+  // Specify the RBAC rules to be applied globally.
+  // If absent, no enforcing RBAC policy will be applied.
+  config.rbac.v3alpha.RBAC rules = 1;
+
+  // Shadow rules are not enforced by the filter but will emit stats and logs
+  // and can be used for rule testing.
+  // If absent, no shadow RBAC policy will be applied.
+  config.rbac.v3alpha.RBAC shadow_rules = 2;
+
+  // The prefix to use when emitting statistics.
+  string stat_prefix = 3 [(validate.rules).string.min_bytes = 1];
+
+  enum EnforcementType {
+    // Apply RBAC policies when the first byte of data arrives on the connection.
+    ONE_TIME_ON_FIRST_BYTE = 0;
+
+    // Continuously apply RBAC policies as data arrives. Use this mode when
+    // using RBAC with message oriented protocols such as Mongo, MySQL, Kafka,
+    // etc. when the protocol decoders emit dynamic metadata such as the
+    // resources being accessed and the operations on the resources.
+    CONTINUOUS = 1;
+  };
+
+  // RBAC enforcement strategy. By default RBAC will be enforced only once
+  // when the first byte of data arrives from the downstream. When used in
+  // conjunction with filters that emit dynamic metadata after decoding
+  // every payload (e.g., Mongo, MySQL, Kafka) set the enforcement type to
+  // CONTINUOUS to enforce RBAC policies on every message boundary.
+  EnforcementType enforcement_type = 4;
+}

--- a/api/envoy/config/filter/network/redis_proxy/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/redis_proxy/v3alpha/BUILD
@@ -1,0 +1,12 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "redis_proxy",
+    srcs = ["redis_proxy.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/type:percent",
+    ],
+)

--- a/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.proto
@@ -1,0 +1,236 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.redis_proxy.v3alpha;
+
+option java_outer_classname = "RedisProxyProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.redis_proxy.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: Redis Proxy]
+// Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
+
+message RedisProxy {
+  // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Name of cluster from cluster manager. See the :ref:`configuration section
+  // <arch_overview_redis_configuration>` of the architecture overview for recommendations on
+  // configuring the backing cluster.
+  //
+  // .. attention::
+  //
+  //   This field is deprecated. Use a :ref:`catch_all
+  //   route<envoy_api_field_config.filter.network.redis_proxy.v3alpha.RedisProxy.PrefixRoutes.catch_all_route>`
+  //   instead.
+  string cluster = 2 [deprecated = true];
+
+  // Redis connection pool settings.
+  message ConnPoolSettings {
+    // Per-operation timeout in milliseconds. The timer starts when the first
+    // command of a pipeline is written to the backend connection. Each response received from Redis
+    // resets the timer since it signifies that the next command is being processed by the backend.
+    // The only exception to this behavior is when a connection to a backend is not yet established.
+    // In that case, the connect timeout on the cluster will govern the timeout until the connection
+    // is ready.
+    google.protobuf.Duration op_timeout = 1
+        [(validate.rules).duration.required = true, (gogoproto.stdduration) = true];
+
+    // Use hash tagging on every redis key to guarantee that keys with the same hash tag will be
+    // forwarded to the same upstream. The hash key used for determining the upstream in a
+    // consistent hash ring configuration will be computed from the hash tagged key instead of the
+    // whole key. The algorithm used to compute the hash tag is identical to the `redis-cluster
+    // implementation <https://redis.io/topics/cluster-spec#keys-hash-tags>`_.
+    //
+    // Examples:
+    //
+    // * '{user1000}.following' and '{user1000}.followers' **will** be sent to the same upstream
+    // * '{user1000}.following' and '{user1001}.following' **might** be sent to the same upstream
+    bool enable_hashtagging = 2;
+
+    // Accept `moved and ask redirection
+    // <https://redis.io/topics/cluster-spec#redirection-and-resharding>`_ errors from upstream
+    // redis servers, and retry commands to the specified target server. The target server does not
+    // need to be known to the cluster manager. If the command cannot be redirected, then the
+    // original error is passed downstream unchanged. By default, this support is not enabled.
+    bool enable_redirection = 3;
+
+    // Maximum size of encoded request buffer before flush is triggered and encoded requests
+    // are sent upstream. If this is unset, the buffer flushes whenever it receives data
+    // and performs no batching.
+    // This feature makes it possible for multiple clients to send requests to Envoy and have
+    // them batched- for example if one is running several worker processes, each with its own
+    // Redis connection. There is no benefit to using this with a single downstream process.
+    // Recommended size (if enabled) is 1024 bytes.
+    uint32 max_buffer_size_before_flush = 4;
+
+    // The encoded request buffer is flushed N milliseconds after the first request has been
+    // encoded, unless the buffer size has already exceeded `max_buffer_size_before_flush`.
+    // If `max_buffer_size_before_flush` is not set, this flush timer is not used. Otherwise,
+    // the timer should be set according to the number of clients, overall request rate and
+    // desired maximum latency for a single command. For example, if there are many requests
+    // being batched together at a high rate, the buffer will likely be filled before the timer
+    // fires. Alternatively, if the request rate is lower the buffer will not be filled as often
+    // before the timer fires.
+    // If `max_buffer_size_before_flush` is set, but `buffer_flush_timeout` is not, the latter
+    // defaults to 3ms.
+    google.protobuf.Duration buffer_flush_timeout = 5 [(gogoproto.stdduration) = true];
+
+    // `max_upstream_unknown_connections` controls how many upstream connections to unknown hosts
+    // can be created at any given time by any given worker thread (see `enable_redirection` for
+    // more details). If the host is unknown and a connection cannot be created due to enforcing
+    // this limit, then redirection will fail and the original redirection error will be passed
+    // downstream unchanged. This limit defaults to 100.
+    google.protobuf.UInt32Value max_upstream_unknown_connections = 6;
+
+    // ReadPolicy controls how Envoy routes read commands to Redis nodes. This is currently
+    // supported for Redis Cluster. All ReadPolicy settings except MASTER may return stale data
+    // because replication is asynchronous and requires some delay. You need to ensure that your
+    // application can tolerate stale data.
+    enum ReadPolicy {
+      // Default mode. Read from the current master node.
+      MASTER = 0;
+      // Read from the master, but if it is unavailable, read from replica nodes.
+      PREFER_MASTER = 1;
+      // Read from replica nodes. If multiple replica nodes are present within a shard, a random
+      // node is selected. Healthy nodes have precedent over unhealthy nodes.
+      REPLICA = 2;
+      // Read from the replica nodes (similar to REPLICA), but if all replicas are unavailable (not
+      // present or unhealthy), read from the master.
+      PREFER_REPLICA = 3;
+      // Read from any node of the cluster. A random node is selected among the master and replicas,
+      // healthy nodes have precedent over unhealthy nodes.
+      ANY = 4;
+    }
+
+    // Read policy. The default is to read from the master.
+    ReadPolicy read_policy = 7 [(validate.rules).enum.defined_only = true];
+  }
+
+  // Network settings for the connection pool to the upstream clusters.
+  ConnPoolSettings settings = 3 [(validate.rules).message.required = true];
+
+  // Indicates that latency stat should be computed in microseconds. By default it is computed in
+  // milliseconds.
+  bool latency_in_micros = 4;
+
+  message PrefixRoutes {
+    message Route {
+      // String prefix that must match the beginning of the keys. Envoy will always favor the
+      // longest match.
+      string prefix = 1;
+
+      // Indicates if the prefix needs to be removed from the key when forwarded.
+      bool remove_prefix = 2;
+
+      // Upstream cluster to forward the command to.
+      string cluster = 3 [(validate.rules).string.min_bytes = 1];
+
+      // The router is capable of shadowing traffic from one cluster to another. The current
+      // implementation is "fire and forget," meaning Envoy will not wait for the shadow cluster to
+      // respond before returning the response from the primary cluster. All normal statistics are
+      // collected for the shadow cluster making this feature useful for testing.
+      message RequestMirrorPolicy {
+        // Specifies the cluster that requests will be mirrored to. The cluster must
+        // exist in the cluster manager configuration.
+        string cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+        // If not specified or the runtime key is not present, all requests to the target cluster
+        // will be mirrored.
+        //
+        // If specified, Envoy will lookup the runtime key to get the percentage of requests to the
+        // mirror.
+        //
+        // Parsing this field is implemented such that the runtime key's data may be represented
+        // as a :ref:`FractionalPercent <envoy_api_msg_type.FractionalPercent>` proto represented
+        // as JSON/YAML and may also be represented as an integer with the assumption that the value
+        // is an integral percentage out of 100. For instance, a runtime key lookup returning the
+        // value "42" would parse as a `FractionalPercent` whose numerator is 42 and denominator is
+        // HUNDRED.
+        envoy.api.v3alpha.core.RuntimeFractionalPercent runtime_fraction = 2;
+
+        // Set this to TRUE to only mirror write commands, this is effectively replicating the
+        // writes in a "fire and forget" manner.
+        bool exclude_read_commands = 3;
+      }
+
+      // Indicates that the route has a request mirroring policy.
+      repeated RequestMirrorPolicy request_mirror_policy = 4;
+    }
+
+    // List of prefix routes.
+    repeated Route routes = 1;
+
+    // Indicates that prefix matching should be case insensitive.
+    bool case_insensitive = 2;
+
+    // Optional catch-all route to forward commands that doesn't match any of the routes. The
+    // catch-all route becomes required when no routes are specified.
+    // .. attention::
+    //
+    //   This field is deprecated. Use a :ref:`catch_all
+    //   route<envoy_api_field_config.filter.network.redis_proxy.v3alpha.RedisProxy.PrefixRoutes.catch_all_route>`
+    //   instead.
+    string catch_all_cluster = 3 [deprecated = true];
+
+    // Optional catch-all route to forward commands that doesn't match any of the routes. The
+    // catch-all route becomes required when no routes are specified.
+    Route catch_all_route = 4;
+  }
+
+  // List of **unique** prefixes used to separate keys from different workloads to different
+  // clusters. Envoy will always favor the longest match first in case of overlap. A catch-all
+  // cluster can be used to forward commands when there is no match. Time complexity of the
+  // lookups are in O(min(longest key prefix, key length)).
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //    prefix_routes:
+  //      routes:
+  //        - prefix: "ab"
+  //          cluster: "cluster_a"
+  //        - prefix: "abc"
+  //          cluster: "cluster_b"
+  //
+  // When using the above routes, the following prefixes would be sent to:
+  //
+  // * 'get abc:users' would retrive the key 'abc:users' from cluster_b.
+  // * 'get ab:users' would retrive the key 'ab:users' from cluster_a.
+  // * 'get z:users' would return a NoUpstreamHost error. A :ref:`catch-all
+  //   route<envoy_api_field_config.filter.network.redis_proxy.v3alpha.RedisProxy.PrefixRoutes.catch_all_route>`
+  //   would have retrieved the key from that cluster instead.
+  //
+  // See the :ref:`configuration section
+  // <arch_overview_redis_configuration>` of the architecture overview for recommendations on
+  // configuring the backing clusters.
+  PrefixRoutes prefix_routes = 5;
+
+  // Authenticate Redis client connections locally by forcing downstream clients to issue a 'Redis
+  // AUTH command <https://redis.io/commands/auth>`_ with this password before enabling any other
+  // command. If an AUTH command's password matches this password, an "OK" response will be returned
+  // to the client. If the AUTH command password does not match this password, then an "ERR invalid
+  // password" error will be returned. If any other command is received before AUTH when this
+  // password is set, then a "NOAUTH Authentication required." error response will be sent to the
+  // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
+  // AUTH, but no password is set" error will be returned.
+  envoy.api.v3alpha.core.DataSource downstream_auth_password = 6;
+}
+
+// RedisProtocolOptions specifies Redis upstream protocol options. This object is used in
+// :ref:`extension_protocol_options<envoy_api_field_Cluster.extension_protocol_options>`, keyed
+// by the name `envoy.redis_proxy`.
+message RedisProtocolOptions {
+  // Upstream server password as defined by the `requirepass directive
+  // <https://redis.io/topics/config>`_ in the server's configuration file.
+  envoy.api.v3alpha.core.DataSource auth_password = 1;
+}

--- a/api/envoy/config/filter/network/tcp_proxy/v3alpha/BUILD
+++ b/api/envoy/config/filter/network/tcp_proxy/v3alpha/BUILD
@@ -1,0 +1,23 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "tcp_proxy",
+    srcs = ["tcp_proxy.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/config/filter/accesslog/v3alpha:accesslog",
+    ],
+)
+
+api_go_proto_library(
+    name = "tcp_proxy",
+    proto = ":tcp_proxy",
+    deps = [
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/config/filter/accesslog/v3alpha:accesslog_go_proto",
+    ],
+)

--- a/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.proto
@@ -1,0 +1,146 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.tcp_proxy.v3alpha;
+
+option java_outer_classname = "TcpProxyProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.filter.network.tcp_proxy.v3alpha";
+option go_package = "v2";
+
+import "envoy/config/filter/accesslog/v3alpha/accesslog.proto";
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+// [#protodoc-title: TCP Proxy]
+// TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
+
+message TcpProxy {
+  // The prefix to use when emitting :ref:`statistics
+  // <config_network_filters_tcp_proxy_stats>`.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  oneof cluster_specifier {
+    option (validate.required) = true;
+
+    // The upstream cluster to connect to.
+    //
+    string cluster = 2;
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster.
+    WeightedCluster weighted_clusters = 10;
+  }
+
+  // Optional endpoint metadata match criteria. Only endpoints in the upstream
+  // cluster with metadata matching that set in metadata_match will be
+  // considered. The filter name should be specified as *envoy.lb*.
+  envoy.api.v3alpha.core.Metadata metadata_match = 9;
+
+  // The idle timeout for connections managed by the TCP proxy filter. The idle timeout
+  // is defined as the period in which there are no bytes sent or received on either
+  // the upstream or downstream connection. If not set, connections will never be closed
+  // by the TCP proxy due to being idle.
+  google.protobuf.Duration idle_timeout = 8
+      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+
+  // [#not-implemented-hide:] The idle timeout for connections managed by the TCP proxy
+  // filter. The idle timeout is defined as the period in which there is no
+  // active traffic. If not set, there is no idle timeout. When the idle timeout
+  // is reached the connection will be closed. The distinction between
+  // downstream_idle_timeout/upstream_idle_timeout provides a means to set
+  // timeout based on the last byte sent on the downstream/upstream connection.
+  google.protobuf.Duration downstream_idle_timeout = 3;
+
+  // [#not-implemented-hide:]
+  google.protobuf.Duration upstream_idle_timeout = 4;
+
+  // Configuration for :ref:`access logs <arch_overview_access_logs>`
+  // emitted by the this tcp_proxy.
+  repeated envoy.config.filter.accesslog.v3alpha.AccessLog access_log = 5;
+
+  // [#not-implemented-hide:] Deprecated.
+  // TCP Proxy filter configuration using V1 format.
+  message DeprecatedV1 {
+    // A TCP proxy route consists of a set of optional L4 criteria and the
+    // name of a cluster. If a downstream connection matches all the
+    // specified criteria, the cluster in the route is used for the
+    // corresponding upstream connection. Routes are tried in the order
+    // specified until a match is found. If no match is found, the connection
+    // is closed. A route with no criteria is valid and always produces a
+    // match.
+    message TCPRoute {
+      // The cluster to connect to when a the downstream network connection
+      // matches the specified criteria.
+      string cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+      // An optional list of IP address subnets in the form
+      // “ip_address/xx”. The criteria is satisfied if the destination IP
+      // address of the downstream connection is contained in at least one of
+      // the specified subnets. If the parameter is not specified or the list
+      // is empty, the destination IP address is ignored. The destination IP
+      // address of the downstream connection might be different from the
+      // addresses on which the proxy is listening if the connection has been
+      // redirected.
+      repeated envoy.api.v3alpha.core.CidrRange destination_ip_list = 2;
+
+      // An optional string containing a comma-separated list of port numbers
+      // or ranges. The criteria is satisfied if the destination port of the
+      // downstream connection is contained in at least one of the specified
+      // ranges. If the parameter is not specified, the destination port is
+      // ignored. The destination port address of the downstream connection
+      // might be different from the port on which the proxy is listening if
+      // the connection has been redirected.
+      string destination_ports = 3;
+
+      // An optional list of IP address subnets in the form
+      // “ip_address/xx”. The criteria is satisfied if the source IP address
+      // of the downstream connection is contained in at least one of the
+      // specified subnets. If the parameter is not specified or the list is
+      // empty, the source IP address is ignored.
+      repeated envoy.api.v3alpha.core.CidrRange source_ip_list = 4;
+
+      // An optional string containing a comma-separated list of port numbers
+      // or ranges. The criteria is satisfied if the source port of the
+      // downstream connection is contained in at least one of the specified
+      // ranges. If the parameter is not specified, the source port is
+      // ignored.
+      string source_ports = 5;
+    }
+
+    // The route table for the filter. All filter instances must have a route
+    // table, even if it is empty.
+    repeated TCPRoute routes = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  // [#not-implemented-hide:] Deprecated.
+  DeprecatedV1 deprecated_v1 = 6 [deprecated = true];
+
+  // The maximum number of unsuccessful connection attempts that will be made before
+  // giving up. If the parameter is not specified, 1 connection attempt will be made.
+  google.protobuf.UInt32Value max_connect_attempts = 7 [(validate.rules).uint32.gte = 1];
+
+  // Allows for specification of multiple upstream clusters along with weights
+  // that indicate the percentage of traffic to be forwarded to each cluster.
+  // The router selects an upstream cluster based on these weights.
+  message WeightedCluster {
+    message ClusterWeight {
+      // Name of the upstream cluster.
+      string name = 1 [(validate.rules).string.min_bytes = 1];
+
+      // When a request matches the route, the choice of an upstream cluster is
+      // determined by its weight. The sum of weights across all entries in the
+      // clusters array determines the total weight.
+      uint32 weight = 2 [(validate.rules).uint32.gte = 1];
+    }
+
+    // Specifies one or more upstream clusters associated with the route.
+    repeated ClusterWeight clusters = 1 [(validate.rules).repeated .min_items = 1];
+  }
+}

--- a/api/envoy/config/grpc_credential/v3alpha/BUILD
+++ b/api/envoy/config/grpc_credential/v3alpha/BUILD
@@ -1,0 +1,27 @@
+licenses(["notice"])  # Apache 2
+
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+api_proto_library_internal(
+    name = "file_based_metadata",
+    srcs = ["file_based_metadata.proto"],
+    deps = ["//envoy/api/v3alpha/core:base"],
+)
+
+api_go_proto_library(
+    name = "file_based_metadata",
+    proto = ":file_based_metadata",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "aws_iam",
+    srcs = ["aws_iam.proto"],
+)
+
+api_go_proto_library(
+    name = "aws_iam",
+    proto = ":aws_iam",
+)

--- a/api/envoy/config/grpc_credential/v3alpha/aws_iam.proto
+++ b/api/envoy/config/grpc_credential/v3alpha/aws_iam.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+// [#protodoc-title: Grpc Credentials AWS IAM]
+// Configuration for AWS IAM Grpc Credentials Plugin
+
+package envoy.config.grpc_credential.v3alpha;
+
+option java_outer_classname = "AwsIamProto";
+option java_package = "io.envoyproxy.envoy.config.grpc_credential.v3alpha";
+option java_multiple_files = true;
+option go_package = "v2alpha";
+
+import "validate/validate.proto";
+
+message AwsIamConfig {
+  // The `service namespace
+  // <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces>`_
+  // of the Grpc endpoint.
+  //
+  // Example: appmesh
+  string service_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The `region <https://docs.aws.amazon.com/general/latest/gr/rande.html>`_ hosting the Grpc
+  // endpoint. If unspecified, the extension will use the value in the ``AWS_REGION`` environment
+  // variable.
+  //
+  // Example: us-west-2
+  string region = 2;
+}

--- a/api/envoy/config/grpc_credential/v3alpha/file_based_metadata.proto
+++ b/api/envoy/config/grpc_credential/v3alpha/file_based_metadata.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+// [#protodoc-title: Grpc Credentials File Based Metadata]
+// Configuration for File Based Metadata Grpc Credentials Plugin
+
+package envoy.config.grpc_credential.v3alpha;
+
+option java_outer_classname = "FileBasedMetadataProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.grpc_credential.v3alpha";
+option go_package = "v2alpha";
+
+import "envoy/api/v3alpha/core/base.proto";
+
+message FileBasedMetadataConfig {
+
+  // Location or inline data of secret to use for authentication of the Google gRPC connection
+  // this secret will be attached to a header of the gRPC connection
+  envoy.api.v3alpha.core.DataSource secret_data = 1;
+
+  // Metadata header key to use for sending the secret data
+  // if no header key is set, "authorization" header will be used
+  string header_key = 2;
+
+  // Prefix to prepend to the secret in the metadata header
+  // if no prefix is set, the default is to use no prefix
+  string header_prefix = 3;
+}

--- a/api/envoy/config/health_checker/redis/v3alpha/BUILD
+++ b/api/envoy/config/health_checker/redis/v3alpha/BUILD
@@ -1,0 +1,8 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "redis",
+    srcs = ["redis.proto"],
+)

--- a/api/envoy/config/health_checker/redis/v3alpha/redis.proto
+++ b/api/envoy/config/health_checker/redis/v3alpha/redis.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package envoy.config.health_checker.redis.v3alpha;
+
+option java_outer_classname = "RedisProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.health_checker.redis.v3alpha";
+option go_package = "v2";
+
+// [#protodoc-title: Redis]
+// Redis health checker :ref:`configuration overview <config_health_checkers_redis>`.
+
+message Redis {
+  // If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
+  // from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other
+  // than 0 is considered a failure. This allows the user to mark a Redis instance for maintenance
+  // by setting the specified key to any value and waiting for traffic to drain.
+  string key = 1;
+}

--- a/api/envoy/config/metrics/v3alpha/BUILD
+++ b/api/envoy/config/metrics/v3alpha/BUILD
@@ -1,0 +1,43 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "metrics_service",
+    srcs = ["metrics_service.proto"],
+    visibility = [
+        "//envoy/config/bootstrap/v3alpha:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service",
+    ],
+)
+
+api_go_proto_library(
+    name = "metrics_service",
+    proto = ":metrics_service",
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "stats",
+    srcs = ["stats.proto"],
+    visibility = [
+        "//envoy/config/bootstrap/v3alpha:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/type/matcher:string",
+    ],
+)
+
+api_go_proto_library(
+    name = "stats",
+    proto = ":stats",
+    deps = [
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/type/matcher:string_go_proto",
+    ],
+)

--- a/api/envoy/config/metrics/v3alpha/metrics_service.proto
+++ b/api/envoy/config/metrics/v3alpha/metrics_service.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+// [#protodoc-title: Metrics service]
+
+package envoy.config.metrics.v3alpha;
+
+option java_outer_classname = "MetricsServiceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.metrics.v3alpha";
+
+import "envoy/api/v3alpha/core/grpc_service.proto";
+
+import "validate/validate.proto";
+
+// Metrics Service is configured as a built-in *envoy.metrics_service* :ref:`StatsSink
+// <envoy_api_msg_config.metrics.v3alpha.StatsSink>`. This opaque configuration will be used to
+// create Metrics Service.
+message MetricsServiceConfig {
+  // The upstream gRPC cluster that hosts the metrics service.
+  envoy.api.v3alpha.core.GrpcService grpc_service = 1 [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/metrics/v3alpha/stats.proto
+++ b/api/envoy/config/metrics/v3alpha/stats.proto
@@ -1,0 +1,331 @@
+// [#protodoc-title: Stats]
+// Statistics :ref:`architecture overview <arch_overview_statistics>`.
+
+syntax = "proto3";
+
+package envoy.config.metrics.v3alpha;
+
+option java_outer_classname = "StatsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.metrics.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/type/matcher/string.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+// Configuration for pluggable stats sinks.
+message StatsSink {
+  // The name of the stats sink to instantiate. The name must match a supported
+  // stats sink. The built-in stats sinks are:
+  //
+  // * :ref:`envoy.statsd <envoy_api_msg_config.metrics.v3alpha.StatsdSink>`
+  // * :ref:`envoy.dog_statsd <envoy_api_msg_config.metrics.v3alpha.DogStatsdSink>`
+  // * :ref:`envoy.metrics_service <envoy_api_msg_config.metrics.v3alpha.MetricsServiceConfig>`
+  // * :ref:`envoy.stat_sinks.hystrix <envoy_api_msg_config.metrics.v3alpha.HystrixSink>`
+  //
+  // Sinks optionally support tagged/multiple dimensional metrics.
+  string name = 1;
+
+  // Stats sink specific configuration which depends on the sink being instantiated. See
+  // :ref:`StatsdSink <envoy_api_msg_config.metrics.v3alpha.StatsdSink>` for an example.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}
+
+// Statistics configuration such as tagging.
+message StatsConfig {
+  // Each stat name is iteratively processed through these tag specifiers.
+  // When a tag is matched, the first capture group is removed from the name so
+  // later :ref:`TagSpecifiers <envoy_api_msg_config.metrics.v3alpha.TagSpecifier>` cannot match
+  // that same portion of the match.
+  repeated TagSpecifier stats_tags = 1;
+
+  // Use all default tag regexes specified in Envoy. These can be combined with
+  // custom tags specified in :ref:`stats_tags
+  // <envoy_api_field_config.metrics.v3alpha.StatsConfig.stats_tags>`. They will be processed before
+  // the custom tags.
+  //
+  // .. note::
+  //
+  //   If any default tags are specified twice, the config will be considered
+  //   invalid.
+  //
+  // See :repo:`well_known_names.h <source/common/config/well_known_names.h>` for a list of the
+  // default tags in Envoy.
+  //
+  // If not provided, the value is assumed to be true.
+  google.protobuf.BoolValue use_all_default_tags = 2;
+
+  // Inclusion/exclusion matcher for stat name creation. If not provided, all stats are instantiated
+  // as normal. Preventing the instantiation of certain families of stats can improve memory
+  // performance for Envoys running especially large configs.
+  StatsMatcher stats_matcher = 3;
+}
+
+// Configuration for disabling stat instantiation.
+message StatsMatcher {
+  // The instantiation of stats is unrestricted by default. If the goal is to configure Envoy to
+  // instantiate all stats, there is no need to construct a StatsMatcher.
+  //
+  // However, StatsMatcher can be used to limit the creation of families of stats in order to
+  // conserve memory. Stats can either be disabled entirely, or they can be
+  // limited by either an exclusion or an inclusion list of :ref:`StringMatcher
+  // <envoy_api_msg_type.matcher.StringMatcher>` protos:
+  //
+  // * If `reject_all` is set to `true`, no stats will be instantiated. If `reject_all` is set to
+  //   `false`, all stats will be instantiated.
+  //
+  // * If an exclusion list is supplied, any stat name matching *any* of the StringMatchers in the
+  //   list will not instantiate.
+  //
+  // * If an inclusion list is supplied, no stats will instantiate, except those matching *any* of
+  //   the StringMatchers in the list.
+  //
+  //
+  // A StringMatcher can be used to match against an exact string, a suffix / prefix, or a regex.
+  // **NB:** For performance reasons, it is highly recommended to use a prefix- or suffix-based
+  // matcher rather than a regex-based matcher.
+  //
+  // Example 1. Excluding all stats.
+  //
+  // .. code-block:: json
+  //
+  //   {
+  //     "statsMatcher": {
+  //       "rejectAll": "true"
+  //     }
+  //   }
+  //
+  // Example 2. Excluding all cluster-specific stats, but not cluster-manager stats:
+  //
+  // .. code-block:: json
+  //
+  //   {
+  //     "statsMatcher": {
+  //       "exclusionList": {
+  //         "patterns": [
+  //           {
+  //             "prefix": "cluster."
+  //           }
+  //         ]
+  //       }
+  //     }
+  //   }
+  //
+  // Example 3. Including only manager-related stats:
+  //
+  // .. code-block:: json
+  //
+  //   {
+  //     "statsMatcher": {
+  //       "inclusionList": {
+  //         "patterns": [
+  //           {
+  //             "prefix": "cluster_manager."
+  //           },
+  //           {
+  //             "prefix": "listener_manager."
+  //           }
+  //         ]
+  //       }
+  //     }
+  //   }
+  //
+
+  oneof stats_matcher {
+    option (validate.required) = true;
+
+    // If `reject_all` is true, then all stats are disabled. If `reject_all` is false, then all
+    // stats are enabled.
+    bool reject_all = 1;
+
+    // Exclusive match. All stats are enabled except for those matching one of the supplied
+    // StringMatcher protos.
+    envoy.type.matcher.ListStringMatcher exclusion_list = 2;
+
+    // Inclusive match. No stats are enabled except for those matching one of the supplied
+    // StringMatcher protos.
+    envoy.type.matcher.ListStringMatcher inclusion_list = 3;
+  };
+}
+
+// Designates a tag name and value pair. The value may be either a fixed value
+// or a regex providing the value via capture groups. The specified tag will be
+// unconditionally set if a fixed value, otherwise it will only be set if one
+// or more capture groups in the regex match.
+message TagSpecifier {
+  // Attaches an identifier to the tag values to identify the tag being in the
+  // sink. Envoy has a set of default names and regexes to extract dynamic
+  // portions of existing stats, which can be found in :repo:`well_known_names.h
+  // <source/common/config/well_known_names.h>` in the Envoy repository. If a :ref:`tag_name
+  // <envoy_api_field_config.metrics.v3alpha.TagSpecifier.tag_name>` is provided in the config and
+  // neither :ref:`regex <envoy_api_field_config.metrics.v3alpha.TagSpecifier.regex>` or
+  // :ref:`fixed_value <envoy_api_field_config.metrics.v3alpha.TagSpecifier.fixed_value>` were
+  // specified, Envoy will attempt to find that name in its set of defaults and use the accompanying
+  // regex.
+  //
+  // .. note::
+  //
+  //   It is invalid to specify the same tag name twice in a config.
+  string tag_name = 1;
+
+  oneof tag_value {
+    // Designates a tag to strip from the tag extracted name and provide as a named
+    // tag value for all statistics. This will only occur if any part of the name
+    // matches the regex provided with one or more capture groups.
+    //
+    // The first capture group identifies the portion of the name to remove. The
+    // second capture group (which will normally be nested inside the first) will
+    // designate the value of the tag for the statistic. If no second capture
+    // group is provided, the first will also be used to set the value of the tag.
+    // All other capture groups will be ignored.
+    //
+    // Example 1. a stat name ``cluster.foo_cluster.upstream_rq_timeout`` and
+    // one tag specifier:
+    //
+    // .. code-block:: json
+    //
+    //   {
+    //     "tag_name": "envoy.cluster_name",
+    //     "regex": "^cluster\.((.+?)\.)"
+    //   }
+    //
+    // Note that the regex will remove ``foo_cluster.`` making the tag extracted
+    // name ``cluster.upstream_rq_timeout`` and the tag value for
+    // ``envoy.cluster_name`` will be ``foo_cluster`` (note: there will be no
+    // ``.`` character because of the second capture group).
+    //
+    // Example 2. a stat name
+    // ``http.connection_manager_1.user_agent.ios.downstream_cx_total`` and two
+    // tag specifiers:
+    //
+    // .. code-block:: json
+    //
+    //   [
+    //     {
+    //       "tag_name": "envoy.http_user_agent",
+    //       "regex": "^http(?=\.).*?\.user_agent\.((.+?)\.)\w+?$"
+    //     },
+    //     {
+    //       "tag_name": "envoy.http_conn_manager_prefix",
+    //       "regex": "^http\.((.*?)\.)"
+    //     }
+    //   ]
+    //
+    // The two regexes of the specifiers will be processed in the definition order.
+    //
+    // The first regex will remove ``ios.``, leaving the tag extracted name
+    // ``http.connection_manager_1.user_agent.downstream_cx_total``. The tag
+    // ``envoy.http_user_agent`` will be added with tag value ``ios``.
+    //
+    // The second regex will remove ``connection_manager_1.`` from the tag
+    // extracted name produced by the first regex
+    // ``http.connection_manager_1.user_agent.downstream_cx_total``, leaving
+    // ``http.user_agent.downstream_cx_total`` as the tag extracted name. The tag
+    // ``envoy.http_conn_manager_prefix`` will be added with the tag value
+    // ``connection_manager_1``.
+    string regex = 2 [(validate.rules).string.max_bytes = 1024];
+
+    // Specifies a fixed tag value for the ``tag_name``.
+    string fixed_value = 3;
+  }
+}
+
+// Stats configuration proto schema for built-in *envoy.statsd* sink. This sink does not support
+// tagged metrics.
+message StatsdSink {
+  oneof statsd_specifier {
+    option (validate.required) = true;
+
+    // The UDP address of a running `statsd <https://github.com/etsy/statsd>`_
+    // compliant listener. If specified, statistics will be flushed to this
+    // address.
+    envoy.api.v3alpha.core.Address address = 1;
+
+    // The name of a cluster that is running a TCP `statsd
+    // <https://github.com/etsy/statsd>`_ compliant listener. If specified,
+    // Envoy will connect to this cluster to flush statistics.
+    string tcp_cluster_name = 2;
+  }
+  // Optional custom prefix for StatsdSink. If
+  // specified, this will override the default prefix.
+  // For example:
+  //
+  // .. code-block:: json
+  //
+  //   {
+  //     "prefix" : "envoy-prod"
+  //   }
+  //
+  // will change emitted stats to
+  //
+  // .. code-block:: cpp
+  //
+  //   envoy-prod.test_counter:1|c
+  //   envoy-prod.test_timer:5|ms
+  //
+  // Note that the default prefix, "envoy", will be used if a prefix is not
+  // specified.
+  //
+  // Stats with default prefix:
+  //
+  // .. code-block:: cpp
+  //
+  //   envoy.test_counter:1|c
+  //   envoy.test_timer:5|ms
+  string prefix = 3;
+}
+
+// Stats configuration proto schema for built-in *envoy.dog_statsd* sink.
+// The sink emits stats with `DogStatsD <https://docs.datadoghq.com/guides/dogstatsd/>`_
+// compatible tags. Tags are configurable via :ref:`StatsConfig
+// <envoy_api_msg_config.metrics.v3alpha.StatsConfig>`.
+// [#comment:next free field: 3]
+message DogStatsdSink {
+  oneof dog_statsd_specifier {
+    option (validate.required) = true;
+
+    // The UDP address of a running DogStatsD compliant listener. If specified,
+    // statistics will be flushed to this address.
+    envoy.api.v3alpha.core.Address address = 1;
+  }
+
+  reserved 2;
+
+  // Optional custom metric name prefix. See :ref:`StatsdSink's prefix field
+  // <envoy_api_field_config.metrics.v3alpha.StatsdSink.prefix>` for more details.
+  string prefix = 3;
+}
+
+// Stats configuration proto schema for built-in *envoy.stat_sinks.hystrix* sink.
+// The sink emits stats in `text/event-stream
+// <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events>`_
+// formatted stream for use by `Hystrix dashboard
+// <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
+//
+// Note that only a single HystrixSink should be configured.
+//
+// Streaming is started through an admin endpoint :http:get:`/hystrix_event_stream`.
+message HystrixSink {
+  // The number of buckets the rolling statistical window is divided into.
+  //
+  // Each time the sink is flushed, all relevant Envoy statistics are sampled and
+  // added to the rolling window (removing the oldest samples in the window
+  // in the process). The sink then outputs the aggregate statistics across the
+  // current rolling window to the event stream(s).
+  //
+  // rolling_window(ms) = stats_flush_interval(ms) * num_of_buckets
+  //
+  // More detailed explanation can be found in `Hystrix wiki
+  // <https://github.com/Netflix/Hystrix/wiki/Metrics-and-Monitoring#hystrixrollingnumber>`_.
+  int64 num_buckets = 1;
+}

--- a/api/envoy/config/overload/v3alpha/BUILD
+++ b/api/envoy/config/overload/v3alpha/BUILD
@@ -1,0 +1,14 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "overload",
+    srcs = ["overload.proto"],
+    visibility = ["//visibility:public"],
+)
+
+api_go_proto_library(
+    name = "overload",
+    proto = ":overload",
+)

--- a/api/envoy/config/overload/v3alpha/overload.proto
+++ b/api/envoy/config/overload/v3alpha/overload.proto
@@ -1,0 +1,78 @@
+syntax = "proto3";
+
+package envoy.config.overload.v3alpha;
+
+option java_outer_classname = "OverloadProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.overload.v3alpha";
+option go_package = "v2alpha";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Overload Manager]
+
+// The Overload Manager provides an extensible framework to protect Envoy instances
+// from overload of various resources (memory, cpu, file descriptors, etc).
+// It monitors a configurable set of resources and notifies registered listeners
+// when triggers related to those resources fire.
+
+message ResourceMonitor {
+  // The name of the resource monitor to instantiate. Must match a registered
+  // resource monitor type. The built-in resource monitors are:
+  //
+  // * :ref:`envoy.resource_monitors.fixed_heap
+  //   <envoy_api_msg_config.resource_monitor.fixed_heap.v3alpha.FixedHeapConfig>`
+  // * :ref:`envoy.resource_monitors.injected_resource
+  //   <envoy_api_msg_config.resource_monitor.injected_resource.v3alpha.InjectedResourceConfig>`
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Configuration for the resource monitor being instantiated.
+  oneof config_type {
+    google.protobuf.Struct config = 2;
+
+    google.protobuf.Any typed_config = 3;
+  }
+}
+
+message ThresholdTrigger {
+  // If the resource pressure is greater than or equal to this value, the trigger
+  // will fire.
+  double value = 1 [(validate.rules).double = {gte: 0, lte: 1}];
+}
+
+message Trigger {
+  // The name of the resource this is a trigger for.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  oneof trigger_oneof {
+    option (validate.required) = true;
+    ThresholdTrigger threshold = 2;
+  }
+}
+
+message OverloadAction {
+  // The name of the overload action. This is just a well-known string that listeners can
+  // use for registering callbacks. Custom overload actions should be named using reverse
+  // DNS to ensure uniqueness.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // A set of triggers for this action. If any of these triggers fire the overload action
+  // is activated. Listeners are notified when the overload action transitions from
+  // inactivated to activated, or vice versa.
+  repeated Trigger triggers = 2 [(validate.rules).repeated .min_items = 1];
+}
+
+message OverloadManager {
+  // The interval for refreshing resource usage.
+  google.protobuf.Duration refresh_interval = 1;
+
+  // The set of resources to monitor.
+  repeated ResourceMonitor resource_monitors = 2 [(validate.rules).repeated .min_items = 1];
+
+  // The set of overload actions.
+  repeated OverloadAction actions = 3;
+}

--- a/api/envoy/config/ratelimit/v3alpha/BUILD
+++ b/api/envoy/config/ratelimit/v3alpha/BUILD
@@ -1,0 +1,20 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "rls",
+    srcs = ["rls.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service",
+    ],
+)
+
+api_go_grpc_library(
+    name = "rls",
+    proto = ":rls",
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service_go_proto",
+    ],
+)

--- a/api/envoy/config/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/config/ratelimit/v3alpha/rls.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package envoy.config.ratelimit.v3alpha;
+
+option java_outer_classname = "RlsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.ratelimit.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/grpc_service.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Rate limit service]
+
+// Rate limit :ref:`configuration overview <config_rate_limit_service>`.
+message RateLimitServiceConfig {
+  reserved 1;
+
+  // Specifies the gRPC service that hosts the rate limit service. The client
+  // will connect to this cluster when it needs to make rate limit service
+  // requests.
+  envoy.api.v3alpha.core.GrpcService grpc_service = 2 [(validate.rules).message.required = true];
+
+  reserved 3;
+}

--- a/api/envoy/config/rbac/v3alpha/BUILD
+++ b/api/envoy/config/rbac/v3alpha/BUILD
@@ -1,0 +1,36 @@
+licenses(["notice"])  # Apache 2
+
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+api_proto_library_internal(
+    name = "rbac",
+    srcs = ["rbac.proto"],
+    external_cc_proto_deps = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
+    ],
+    external_proto_deps = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:syntax_proto",
+    ],
+    external_py_proto_deps = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:syntax_py_proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/route",
+        "//envoy/type/matcher:metadata",
+        "//envoy/type/matcher:string",
+    ],
+)
+
+api_go_proto_library(
+    name = "rbac",
+    proto = ":rbac",
+    deps = [
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/route:route_go_proto",
+        "//envoy/type/matcher:metadata_go_proto",
+        "//envoy/type/matcher:string_go_proto",
+        "@com_google_googleapis//google/api/expr/v1alpha1:cel_go_proto",
+    ],
+)

--- a/api/envoy/config/rbac/v3alpha/rbac.proto
+++ b/api/envoy/config/rbac/v3alpha/rbac.proto
@@ -1,0 +1,215 @@
+syntax = "proto3";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/route/route.proto";
+import "envoy/type/matcher/metadata.proto";
+import "envoy/type/matcher/string.proto";
+
+import "google/api/expr/v1alpha1/syntax.proto";
+
+package envoy.config.rbac.v3alpha;
+
+option java_outer_classname = "RbacProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.rbac.v3alpha";
+option go_package = "v2";
+
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: Role Based Access Control (RBAC)]
+
+// Role Based Access Control (RBAC) provides service-level and method-level access control for a
+// service. RBAC policies are additive. The policies are examined in order. A request is allowed
+// once a matching policy is found (suppose the `action` is ALLOW).
+//
+// Here is an example of RBAC configuration. It has two policies:
+//
+// * Service account "cluster.local/ns/default/sa/admin" has full access to the service, and so
+//   does "cluster.local/ns/default/sa/superuser".
+//
+// * Any user can read ("GET") the service at paths with prefix "/products", so long as the
+//   destination port is either 80 or 443.
+//
+//  .. code-block:: yaml
+//
+//   action: ALLOW
+//   policies:
+//     "service-admin":
+//       permissions:
+//         - any: true
+//       principals:
+//         - authenticated:
+//             principal_name:
+//               exact: "cluster.local/ns/default/sa/admin"
+//         - authenticated:
+//             principal_name:
+//               exact: "cluster.local/ns/default/sa/superuser"
+//     "product-viewer":
+//       permissions:
+//           - and_rules:
+//               rules:
+//                 - header: { name: ":method", exact_match: "GET" }
+//                 - header: { name: ":path", regex_match: "/products(/.*)?" }
+//                 - or_rules:
+//                     rules:
+//                       - destination_port: 80
+//                       - destination_port: 443
+//       principals:
+//         - any: true
+//
+message RBAC {
+  // Should we do safe-list or block-list style access control?
+  enum Action {
+    // The policies grant access to principals. The rest is denied. This is safe-list style
+    // access control. This is the default type.
+    ALLOW = 0;
+
+    // The policies deny access to principals. The rest is allowed. This is block-list style
+    // access control.
+    DENY = 1;
+  }
+
+  // The action to take if a policy matches. The request is allowed if and only if:
+  //
+  //   * `action` is "ALLOWED" and at least one policy matches
+  //   * `action` is "DENY" and none of the policies match
+  Action action = 1;
+
+  // Maps from policy name to policy. A match occurs when at least one policy matches the request.
+  map<string, Policy> policies = 2;
+}
+
+// Policy specifies a role and the principals that are assigned/denied the role. A policy matches if
+// and only if at least one of its permissions match the action taking place AND at least one of its
+// principals match the downstream AND the condition is true if specified.
+message Policy {
+  // Required. The set of permissions that define a role. Each permission is matched with OR
+  // semantics. To match all actions for this policy, a single Permission with the `any` field set
+  // to true should be used.
+  repeated Permission permissions = 1 [(validate.rules).repeated .min_items = 1];
+
+  // Required. The set of principals that are assigned/denied the role based on “action”. Each
+  // principal is matched with OR semantics. To match all downstreams for this policy, a single
+  // Principal with the `any` field set to true should be used.
+  repeated Principal principals = 2 [(validate.rules).repeated .min_items = 1];
+
+  // An optional symbolic expression specifying an access control condition.
+  // The condition is combined with AND semantics.
+  google.api.expr.v1alpha1.Expr condition = 3;
+}
+
+// Permission defines an action (or actions) that a principal can take.
+message Permission {
+
+  // Used in the `and_rules` and `or_rules` fields in the `rule` oneof. Depending on the context,
+  // each are applied with the associated behavior.
+  message Set {
+    repeated Permission rules = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set of rules that all must match in order to define the action.
+    Set and_rules = 1;
+
+    // A set of rules where at least one must match in order to define the action.
+    Set or_rules = 2;
+
+    // When any is set, it matches any action.
+    bool any = 3 [(validate.rules).bool.const = true];
+
+    // A header (or pseudo-header such as :path or :method) on the incoming HTTP request. Only
+    // available for HTTP request.
+    envoy.api.v3alpha.route.HeaderMatcher header = 4;
+
+    // A CIDR block that describes the destination IP.
+    envoy.api.v3alpha.core.CidrRange destination_ip = 5;
+
+    // A port number that describes the destination port connecting to.
+    uint32 destination_port = 6 [(validate.rules).uint32.lte = 65535];
+
+    // Metadata that describes additional information about the action.
+    envoy.type.matcher.MetadataMatcher metadata = 7;
+
+    // Negates matching the provided permission. For instance, if the value of `not_rule` would
+    // match, this permission would not match. Conversely, if the value of `not_rule` would not
+    // match, this permission would match.
+    Permission not_rule = 8;
+
+    // The request server from the client's connection request. This is
+    // typically TLS SNI.
+    //
+    // .. attention::
+    //
+    //   The behavior of this field may be affected by how Envoy is configured
+    //   as explained below.
+    //
+    //   * If the :ref:`TLS Inspector <config_listener_filters_tls_inspector>`
+    //     filter is not added, and if a `FilterChainMatch` is not defined for
+    //     the :ref:`server name <envoy_api_field_Listener.FilterChainMatch.server_names>`,
+    //     a TLS connection's requested SNI server name will be treated as if it
+    //     wasn't present.
+    //
+    //   * A :ref:`listener filter <arch_overview_listener_filters>` may
+    //     overwrite a connection's requested server name within Envoy.
+    //
+    // Please refer to :ref:`this FAQ entry <faq_how_to_setup_sni>` to learn to
+    // setup SNI.
+    envoy.type.matcher.StringMatcher requested_server_name = 9;
+  }
+}
+
+// Principal defines an identity or a group of identities for a downstream subject.
+message Principal {
+
+  // Used in the `and_ids` and `or_ids` fields in the `identifier` oneof. Depending on the context,
+  // each are applied with the associated behavior.
+  message Set {
+    repeated Principal ids = 1 [(validate.rules).repeated .min_items = 1];
+  }
+
+  // Authentication attributes for a downstream.
+  message Authenticated {
+    reserved 1;
+    reserved "name";
+
+    // The name of the principal. If set, The URI SAN or DNS SAN in that order is used from the
+    // certificate, otherwise the subject field is used. If unset, it applies to any user that is
+    // authenticated.
+    envoy.type.matcher.StringMatcher principal_name = 2;
+  }
+
+  oneof identifier {
+    option (validate.required) = true;
+
+    // A set of identifiers that all must match in order to define the downstream.
+    Set and_ids = 1;
+
+    // A set of identifiers at least one must match in order to define the downstream.
+    Set or_ids = 2;
+
+    // When any is set, it matches any downstream.
+    bool any = 3 [(validate.rules).bool.const = true];
+
+    // Authenticated attributes that identify the downstream.
+    Authenticated authenticated = 4;
+
+    // A CIDR block that describes the downstream IP.
+    envoy.api.v3alpha.core.CidrRange source_ip = 5;
+
+    // A header (or pseudo-header such as :path or :method) on the incoming HTTP request. Only
+    // available for HTTP request.
+    envoy.api.v3alpha.route.HeaderMatcher header = 6;
+
+    // Metadata that describes additional information about the principal.
+    envoy.type.matcher.MetadataMatcher metadata = 7;
+
+    // Negates matching the provided principal. For instance, if the value of `not_id` would match,
+    // this principal would not match. Conversely, if the value of `not_id` would not match, this
+    // principal would match.
+    Principal not_id = 8;
+  }
+}

--- a/api/envoy/config/resource_monitor/fixed_heap/v3alpha/BUILD
+++ b/api/envoy/config/resource_monitor/fixed_heap/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "fixed_heap",
+    srcs = ["fixed_heap.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/api/envoy/config/resource_monitor/fixed_heap/v3alpha/fixed_heap.proto
+++ b/api/envoy/config/resource_monitor/fixed_heap/v3alpha/fixed_heap.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package envoy.config.resource_monitor.fixed_heap.v3alpha;
+
+option java_outer_classname = "FixedHeapProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.resource_monitor.fixed_heap.v3alpha";
+option go_package = "v2alpha";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Fixed heap]
+
+// The fixed heap resource monitor reports the Envoy process memory pressure, computed as a
+// fraction of currently reserved heap memory divided by a statically configured maximum
+// specified in the FixedHeapConfig.
+message FixedHeapConfig {
+  uint64 max_heap_size_bytes = 1 [(validate.rules).uint64.gt = 0];
+}

--- a/api/envoy/config/resource_monitor/injected_resource/v3alpha/BUILD
+++ b/api/envoy/config/resource_monitor/injected_resource/v3alpha/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "injected_resource",
+    srcs = ["injected_resource.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/api/envoy/config/resource_monitor/injected_resource/v3alpha/injected_resource.proto
+++ b/api/envoy/config/resource_monitor/injected_resource/v3alpha/injected_resource.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package envoy.config.resource_monitor.injected_resource.v3alpha;
+
+option java_outer_classname = "InjectedResourceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.resource_monitor.injected_resource.v3alpha";
+option go_package = "v2alpha";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Injected resource]
+
+// The injected resource monitor allows injecting a synthetic resource pressure into Envoy
+// via a text file, which must contain a floating-point number in the range [0..1] representing
+// the resource pressure and be updated atomically by a symbolic link swap.
+// This is intended primarily for integration tests to force Envoy into an overloaded state.
+message InjectedResourceConfig {
+  string filename = 1 [(validate.rules).string.min_bytes = 1];
+}

--- a/api/envoy/config/trace/v3alpha/BUILD
+++ b/api/envoy/config/trace/v3alpha/BUILD
@@ -1,0 +1,24 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "trace",
+    srcs = ["trace.proto"],
+    visibility = [
+        "//envoy/config/bootstrap/v3alpha:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service",
+        "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto",
+    ],
+)
+
+api_go_proto_library(
+    name = "trace",
+    proto = ":trace",
+    deps = [
+        "//envoy/api/v3alpha/core:grpc_service_go_proto",
+        "@opencensus_proto//opencensus/proto/trace/v1:trace_and_config_proto_go",
+    ],
+)

--- a/api/envoy/config/trace/v3alpha/trace.proto
+++ b/api/envoy/config/trace/v3alpha/trace.proto
@@ -1,0 +1,204 @@
+// [#protodoc-title: Tracing]
+// Tracing :ref:`architecture overview <arch_overview_tracing>`.
+
+syntax = "proto3";
+
+package envoy.config.trace.v3alpha;
+
+option java_outer_classname = "TraceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.trace.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/grpc_service.proto";
+import "opencensus/proto/trace/v1/trace_config.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+// The tracing configuration specifies global
+// settings for the HTTP tracer used by Envoy. The configuration is defined by
+// the :ref:`Bootstrap <envoy_api_msg_config.bootstrap.v3alpha.Bootstrap>` :ref:`tracing
+// <envoy_api_field_config.bootstrap.v3alpha.Bootstrap.tracing>` field. Envoy may support other
+// tracers in the future, but right now the HTTP tracer is the only one supported.
+message Tracing {
+  message Http {
+    // The name of the HTTP trace driver to instantiate. The name must match a
+    // supported HTTP trace driver. Built-in trace drivers:
+    //
+    // - *envoy.lightstep*
+    // - *envoy.zipkin*
+    // - *envoy.dynamic.ot*
+    // - *envoy.tracers.datadog*
+    // - *envoy.tracers.opencensus*
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Trace driver specific configuration which depends on the driver being instantiated.
+    // See the trace drivers for examples:
+    //
+    // - :ref:`LightstepConfig <envoy_api_msg_config.trace.v3alpha.LightstepConfig>`
+    // - :ref:`ZipkinConfig <envoy_api_msg_config.trace.v3alpha.ZipkinConfig>`
+    // - :ref:`DynamicOtConfig <envoy_api_msg_config.trace.v3alpha.DynamicOtConfig>`
+    // - :ref:`DatadogConfig <envoy_api_msg_config.trace.v3alpha.DatadogConfig>`
+    // - :ref:`OpenCensusConfig <envoy_api_msg_config.trace.v3alpha.OpenCensusConfig>`
+    oneof config_type {
+      google.protobuf.Struct config = 2;
+
+      google.protobuf.Any typed_config = 3;
+    }
+  }
+  // Provides configuration for the HTTP tracer.
+  Http http = 1;
+}
+
+// Configuration for the LightStep tracer.
+message LightstepConfig {
+  // The cluster manager cluster that hosts the LightStep collectors.
+  string collector_cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+  // File containing the access token to the `LightStep
+  // <https://lightstep.com/>`_ API.
+  string access_token_file = 2 [(validate.rules).string.min_bytes = 1];
+}
+
+// Configuration for the Zipkin tracer.
+message ZipkinConfig {
+  // The cluster manager cluster that hosts the Zipkin collectors. Note that the
+  // Zipkin cluster must be defined in the :ref:`Bootstrap static cluster
+  // resources <envoy_api_field_config.bootstrap.v3alpha.Bootstrap.StaticResources.clusters>`.
+  string collector_cluster = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The API endpoint of the Zipkin service where the spans will be sent. When
+  // using a standard Zipkin installation, the API endpoint is typically
+  // /api/v1/spans, which is the default value.
+  string collector_endpoint = 2 [(validate.rules).string.min_bytes = 1];
+
+  // Determines whether a 128bit trace id will be used when creating a new
+  // trace instance. The default value is false, which will result in a 64 bit trace id being used.
+  bool trace_id_128bit = 3;
+
+  // Determines whether client and server spans will share the same span context.
+  // The default value is true.
+  google.protobuf.BoolValue shared_span_context = 4;
+
+  // Available Zipkin collector endpoint versions.
+  enum CollectorEndpointVersion {
+    // Zipkin API v1, JSON over HTTP.
+    // [#comment: The default implementation of Zipkin client before this field is added was only v1
+    // and the way user configure this was by not explicitly specifying the version. Consequently,
+    // before this is added, the corresponding Zipkin collector expected to receive v1 payload.
+    // Hence the motivation of adding HTTP_JSON_V1 as the default is to avoid a breaking change when
+    // user upgrading Envoy with this change. Furthermore, we also immediately deprecate this field,
+    // since in Zipkin realm this v1 version is considered to be not preferable anymore.]
+    HTTP_JSON_V1 = 0 [deprecated = true];
+
+    // Zipkin API v2, JSON over HTTP.
+    HTTP_JSON = 1;
+
+    // Zipkin API v2, protobuf over HTTP.
+    HTTP_PROTO = 2;
+
+    // [#not-implemented-hide:]
+    GRPC = 3;
+  }
+
+  // Determines the selected collector endpoint version. By default, the ``HTTP_JSON_V1`` will be
+  // used.
+  CollectorEndpointVersion collector_endpoint_version = 5;
+}
+
+// DynamicOtConfig is used to dynamically load a tracer from a shared library
+// that implements the `OpenTracing dynamic loading API
+// <https://github.com/opentracing/opentracing-cpp>`_.
+message DynamicOtConfig {
+  // Dynamic library implementing the `OpenTracing API
+  // <https://github.com/opentracing/opentracing-cpp>`_.
+  string library = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The configuration to use when creating a tracer from the given dynamic
+  // library.
+  google.protobuf.Struct config = 2;
+}
+
+// Configuration for the Datadog tracer.
+message DatadogConfig {
+  // The cluster to use for submitting traces to the Datadog agent.
+  string collector_cluster = 1 [(validate.rules).string.min_bytes = 1];
+  // The name used for the service when traces are generated by envoy.
+  string service_name = 2 [(validate.rules).string.min_bytes = 1];
+}
+
+// Configuration for the OpenCensus tracer.
+// [#proto-status: experimental]
+message OpenCensusConfig {
+  // Configures tracing, e.g. the sampler, max number of annotations, etc.
+  opencensus.proto.trace.v1.TraceConfig trace_config = 1;
+
+  // Enables the stdout exporter if set to true. This is intended for debugging
+  // purposes.
+  bool stdout_exporter_enabled = 2;
+
+  // Enables the Stackdriver exporter if set to true. The project_id must also
+  // be set.
+  bool stackdriver_exporter_enabled = 3;
+
+  // The Cloud project_id to use for Stackdriver tracing.
+  string stackdriver_project_id = 4;
+
+  // (optional) By default, the Stackdriver exporter will connect to production
+  // Stackdriver. If stackdriver_address is non-empty, it will instead connect
+  // to this address, which is in the gRPC format:
+  // https://github.com/grpc/grpc/blob/master/doc/naming.md
+  string stackdriver_address = 10;
+
+  // Enables the Zipkin exporter if set to true. The url and service name must
+  // also be set.
+  bool zipkin_exporter_enabled = 5;
+
+  // The URL to Zipkin, e.g. "http://127.0.0.1:9411/api/v3alpha/spans"
+  string zipkin_url = 6;
+
+  // Enables the OpenCensus Agent exporter if set to true. The address must also
+  // be set.
+  bool ocagent_exporter_enabled = 11;
+
+  // The address of the OpenCensus Agent, if its exporter is enabled, in gRPC
+  // format: https://github.com/grpc/grpc/blob/master/doc/naming.md
+  string ocagent_address = 12;
+
+  reserved 7; // Formerly zipkin_service_name.
+
+  enum TraceContext {
+    // No-op default, no trace context is utilized.
+    NONE = 0;
+
+    // W3C Trace-Context format "traceparent:" header.
+    TRACE_CONTEXT = 1;
+
+    // Binary "grpc-trace-bin:" header.
+    GRPC_TRACE_BIN = 2;
+
+    // "X-Cloud-Trace-Context:" header.
+    CLOUD_TRACE_CONTEXT = 3;
+
+    // X-B3-* headers.
+    B3 = 4;
+  }
+
+  // List of incoming trace context headers we will accept. First one found
+  // wins.
+  repeated TraceContext incoming_trace_context = 8;
+
+  // List of outgoing trace context headers we will produce.
+  repeated TraceContext outgoing_trace_context = 9;
+}
+
+// Configuration structure.
+message TraceServiceConfig {
+  // The upstream gRPC cluster that hosts the metrics service.
+  envoy.api.v3alpha.core.GrpcService grpc_service = 1 [(validate.rules).message.required = true];
+}

--- a/api/envoy/config/transport_socket/alts/v3alpha/BUILD
+++ b/api/envoy/config/transport_socket/alts/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "alts",
+    srcs = ["alts.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+    ],
+)

--- a/api/envoy/config/transport_socket/alts/v3alpha/alts.proto
+++ b/api/envoy/config/transport_socket/alts/v3alpha/alts.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.transport_socket.alts.v3alpha;
+
+option java_outer_classname = "AltsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.transport_socket.alts.v3alpha";
+option go_package = "v2";
+
+// [#protodoc-title: ALTS]
+
+import "validate/validate.proto";
+
+// Configuration for ALTS transport socket. This provides Google's ALTS protocol to Envoy.
+// https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security/
+message Alts {
+  // The location of a handshaker service, this is usually 169.254.169.254:8080
+  // on GCE.
+  string handshaker_service = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The acceptable service accounts from peer, peers not in the list will be rejected in the
+  // handshake validation step. If empty, no validation will be performed.
+  repeated string peer_service_accounts = 2;
+}

--- a/api/envoy/config/transport_socket/tap/v3alpha/BUILD
+++ b/api/envoy/config/transport_socket/tap/v3alpha/BUILD
@@ -1,0 +1,12 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "tap",
+    srcs = ["tap.proto"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/config/common/tap/v3alpha:common",
+    ],
+)

--- a/api/envoy/config/transport_socket/tap/v3alpha/tap.proto
+++ b/api/envoy/config/transport_socket/tap/v3alpha/tap.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package envoy.config.transport_socket.tap.v3alpha;
+
+option java_outer_classname = "TapProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.config.transport_socket.tap.v3alpha";
+option go_package = "v2";
+
+// [#protodoc-title: Tap]
+
+import "envoy/config/common/tap/v3alpha/common.proto";
+import "envoy/api/v3alpha/core/base.proto";
+
+import "validate/validate.proto";
+
+// Configuration for tap transport socket. This wraps another transport socket, providing the
+// ability to interpose and record in plain text any traffic that is surfaced to Envoy.
+message Tap {
+  // Common configuration for the tap transport socket.
+  common.tap.v3alpha.CommonExtensionConfig common_config = 1
+      [(validate.rules).message.required = true];
+
+  // The underlying transport socket being wrapped.
+  api.v3alpha.core.TransportSocket transport_socket = 2 [(validate.rules).message.required = true];
+}

--- a/api/envoy/data/accesslog/v3alpha/BUILD
+++ b/api/envoy/data/accesslog/v3alpha/BUILD
@@ -1,0 +1,24 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "accesslog",
+    srcs = ["accesslog.proto"],
+    visibility = [
+        "//envoy/service/accesslog/v3alpha:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_go_proto_library(
+    name = "accesslog",
+    proto = ":accesslog",
+    deps = [
+        "//envoy/api/v3alpha/core:address_go_proto",
+        "//envoy/api/v3alpha/core:base_go_proto",
+    ],
+)

--- a/api/envoy/data/accesslog/v3alpha/accesslog.proto
+++ b/api/envoy/data/accesslog/v3alpha/accesslog.proto
@@ -1,0 +1,356 @@
+syntax = "proto3";
+
+package envoy.data.accesslog.v3alpha;
+
+option java_outer_classname = "AccesslogProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.accesslog.v3alpha";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "gogoproto/gogo.proto";
+import "validate/validate.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: gRPC access logs]
+// Envoy access logs describe incoming interaction with Envoy over a fixed
+// period of time, and typically cover a single request/response exchange,
+// (e.g. HTTP), stream (e.g. over HTTP/gRPC), or proxied connection (e.g. TCP).
+// Access logs contain fields defined in protocol-specific protobuf messages.
+//
+// Except where explicitly declared otherwise, all fields describe
+// *downstream* interaction between Envoy and a connected client.
+// Fields describing *upstream* interaction will explicitly include ``upstream``
+// in their name.
+
+message TCPAccessLogEntry {
+  // Common properties shared by all Envoy access logs.
+  AccessLogCommon common_properties = 1;
+
+  // Properties of the TCP connection.
+  ConnectionProperties connection_properties = 2;
+}
+
+message HTTPAccessLogEntry {
+  // Common properties shared by all Envoy access logs.
+  AccessLogCommon common_properties = 1;
+
+  // HTTP version
+  enum HTTPVersion {
+    PROTOCOL_UNSPECIFIED = 0;
+    HTTP10 = 1;
+    HTTP11 = 2;
+    HTTP2 = 3;
+  }
+  HTTPVersion protocol_version = 2;
+
+  // Description of the incoming HTTP request.
+  HTTPRequestProperties request = 3;
+
+  // Description of the outgoing HTTP response.
+  HTTPResponseProperties response = 4;
+}
+
+// Defines fields for a connection
+message ConnectionProperties {
+  // Number of bytes received from downstream.
+  uint64 received_bytes = 1;
+
+  // Number of bytes sent to downstream.
+  uint64 sent_bytes = 2;
+}
+
+// Defines fields that are shared by all Envoy access logs.
+message AccessLogCommon {
+  // [#not-implemented-hide:]
+  // This field indicates the rate at which this log entry was sampled.
+  // Valid range is (0.0, 1.0].
+  double sample_rate = 1 [(validate.rules).double.gt = 0.0, (validate.rules).double.lte = 1.0];
+
+  // This field is the remote/origin address on which the request from the user was received.
+  // Note: This may not be the physical peer. E.g, if the remote address is inferred from for
+  // example the x-forwarder-for header, proxy protocol, etc.
+  envoy.api.v3alpha.core.Address downstream_remote_address = 2;
+
+  // This field is the local/destination address on which the request from the user was received.
+  envoy.api.v3alpha.core.Address downstream_local_address = 3;
+
+  // If the connection is secure,S this field will contain TLS properties.
+  TLSProperties tls_properties = 4;
+
+  // The time that Envoy started servicing this request. This is effectively the time that the first
+  // downstream byte is received.
+  google.protobuf.Timestamp start_time = 5 [(gogoproto.stdtime) = true];
+
+  // Interval between the first downstream byte received and the last
+  // downstream byte received (i.e. time it takes to receive a request).
+  google.protobuf.Duration time_to_last_rx_byte = 6 [(gogoproto.stdduration) = true];
+
+  // Interval between the first downstream byte received and the first upstream byte sent. There may
+  // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
+  // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
+  // not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_first_upstream_tx_byte = 7 [(gogoproto.stdduration) = true];
+
+  // Interval between the first downstream byte received and the last upstream byte sent. There may
+  // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
+  // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
+  // not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_last_upstream_tx_byte = 8 [(gogoproto.stdduration) = true];
+
+  // Interval between the first downstream byte received and the first upstream
+  // byte received (i.e. time it takes to start receiving a response).
+  google.protobuf.Duration time_to_first_upstream_rx_byte = 9 [(gogoproto.stdduration) = true];
+
+  // Interval between the first downstream byte received and the last upstream
+  // byte received (i.e. time it takes to receive a complete response).
+  google.protobuf.Duration time_to_last_upstream_rx_byte = 10 [(gogoproto.stdduration) = true];
+
+  // Interval between the first downstream byte received and the first downstream byte sent.
+  // There may be a considerable delta between the *time_to_first_upstream_rx_byte* and this field
+  // due to filters. Additionally, the same caveats apply as documented in
+  // *time_to_last_downstream_tx_byte* about not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_first_downstream_tx_byte = 11 [(gogoproto.stdduration) = true];
+
+  // Interval between the first downstream byte received and the last downstream byte sent.
+  // Depending on protocol, buffering, windowing, filters, etc. there may be a considerable delta
+  // between *time_to_last_upstream_rx_byte* and this field. Note also that this is an approximate
+  // time. In the current implementation it does not include kernel socket buffer time. In the
+  // current implementation it also does not include send window buffering inside the HTTP/2 codec.
+  // In the future it is likely that work will be done to make this duration more accurate.
+  google.protobuf.Duration time_to_last_downstream_tx_byte = 12 [(gogoproto.stdduration) = true];
+
+  // The upstream remote/destination address that handles this exchange. This does not include
+  // retries.
+  envoy.api.v3alpha.core.Address upstream_remote_address = 13;
+
+  // The upstream local/origin address that handles this exchange. This does not include retries.
+  envoy.api.v3alpha.core.Address upstream_local_address = 14;
+
+  // The upstream cluster that *upstream_remote_address* belongs to.
+  string upstream_cluster = 15;
+
+  // Flags indicating occurrences during request/response processing.
+  ResponseFlags response_flags = 16;
+
+  // All metadata encountered during request processing, including endpoint
+  // selection.
+  //
+  // This can be used to associate IDs attached to the various configurations
+  // used to process this request with the access log entry. For example, a
+  // route created from a higher level forwarding rule with some ID can place
+  // that ID in this field and cross reference later. It can also be used to
+  // determine if a canary endpoint was used or not.
+  envoy.api.v3alpha.core.Metadata metadata = 17;
+
+  // If upstream connection failed due to transport socket (e.g. TLS handshake), provides the
+  // failure reason from the transport socket. The format of this field depends on the configured
+  // upstream transport socket. Common TLS failures are in
+  // :ref:`TLS trouble shooting <arch_overview_ssl_trouble_shooting>`.
+  string upstream_transport_failure_reason = 18;
+
+  // The name of the route
+  string route_name = 19;
+}
+
+// Flags indicating occurrences during request/response processing.
+message ResponseFlags {
+  // Indicates local server healthcheck failed.
+  bool failed_local_healthcheck = 1;
+
+  // Indicates there was no healthy upstream.
+  bool no_healthy_upstream = 2;
+
+  // Indicates an there was an upstream request timeout.
+  bool upstream_request_timeout = 3;
+
+  // Indicates local codec level reset was sent on the stream.
+  bool local_reset = 4;
+
+  // Indicates remote codec level reset was received on the stream.
+  bool upstream_remote_reset = 5;
+
+  // Indicates there was a local reset by a connection pool due to an initial connection failure.
+  bool upstream_connection_failure = 6;
+
+  // Indicates the stream was reset due to an upstream connection termination.
+  bool upstream_connection_termination = 7;
+
+  // Indicates the stream was reset because of a resource overflow.
+  bool upstream_overflow = 8;
+
+  // Indicates no route was found for the request.
+  bool no_route_found = 9;
+
+  // Indicates that the request was delayed before proxying.
+  bool delay_injected = 10;
+
+  // Indicates that the request was aborted with an injected error code.
+  bool fault_injected = 11;
+
+  // Indicates that the request was rate-limited locally.
+  bool rate_limited = 12;
+
+  message Unauthorized {
+    // Reasons why the request was unauthorized
+    enum Reason {
+      REASON_UNSPECIFIED = 0;
+      // The request was denied by the external authorization service.
+      EXTERNAL_SERVICE = 1;
+    }
+
+    Reason reason = 1;
+  }
+
+  // Indicates if the request was deemed unauthorized and the reason for it.
+  Unauthorized unauthorized_details = 13;
+
+  // Indicates that the request was rejected because there was an error in rate limit service.
+  bool rate_limit_service_error = 14;
+
+  // Indicates the stream was reset due to a downstream connection termination.
+  bool downstream_connection_termination = 15;
+
+  // Indicates that the upstream retry limit was exceeded, resulting in a downstream error.
+  bool upstream_retry_limit_exceeded = 16;
+
+  // Indicates that the stream idle timeout was hit, resulting in a downstream 408.
+  bool stream_idle_timeout = 17;
+
+  // Indicates that the request was rejected because an envoy request header failed strict
+  // validation.
+  bool invalid_envoy_request_headers = 18;
+}
+
+// Properties of a negotiated TLS connection.
+message TLSProperties {
+  enum TLSVersion {
+    VERSION_UNSPECIFIED = 0;
+    TLSv1 = 1;
+    TLSv1_1 = 2;
+    TLSv1_2 = 3;
+    TLSv1_3 = 4;
+  }
+  // Version of TLS that was negotiated.
+  TLSVersion tls_version = 1;
+
+  // TLS cipher suite negotiated during handshake. The value is a
+  // four-digit hex code defined by the IANA TLS Cipher Suite Registry
+  // (e.g. ``009C`` for ``TLS_RSA_WITH_AES_128_GCM_SHA256``).
+  //
+  // Here it is expressed as an integer.
+  google.protobuf.UInt32Value tls_cipher_suite = 2;
+
+  // SNI hostname from handshake.
+  string tls_sni_hostname = 3;
+
+  message CertificateProperties {
+    message SubjectAltName {
+      oneof san {
+        string uri = 1;
+        // [#not-implemented-hide:]
+        string dns = 2;
+      }
+    }
+
+    // SANs present in the certificate.
+    repeated SubjectAltName subject_alt_name = 1;
+
+    // The subject field of the certificate.
+    string subject = 2;
+  }
+
+  // Properties of the local certificate used to negotiate TLS.
+  CertificateProperties local_certificate_properties = 4;
+
+  // Properties of the peer certificate used to negotiate TLS.
+  CertificateProperties peer_certificate_properties = 5;
+
+  // The TLS session ID.
+  string tls_session_id = 6;
+}
+
+message HTTPRequestProperties {
+  // The request method (RFC 7231/2616).
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+  // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+  envoy.api.v3alpha.core.RequestMethod request_method = 1;
+
+  // The scheme portion of the incoming request URI.
+  string scheme = 2;
+
+  // HTTP/2 ``:authority`` or HTTP/1.1 ``Host`` header value.
+  string authority = 3;
+
+  // The port of the incoming request URI
+  // (unused currently, as port is composed onto authority).
+  google.protobuf.UInt32Value port = 4;
+
+  // The path portion from the incoming request URI.
+  string path = 5;
+
+  // Value of the ``User-Agent`` request header.
+  string user_agent = 6;
+
+  // Value of the ``Referer`` request header.
+  string referer = 7;
+
+  // Value of the ``X-Forwarded-For`` request header.
+  string forwarded_for = 8;
+
+  // Value of the ``X-Request-Id`` request header
+  //
+  // This header is used by Envoy to uniquely identify a request.
+  // It will be generated for all external requests and internal requests that
+  // do not already have a request ID.
+  string request_id = 9;
+
+  // Value of the ``X-Envoy-Original-Path`` request header.
+  string original_path = 10;
+
+  // Size of the HTTP request headers in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 request_headers_bytes = 11;
+
+  // Size of the HTTP request body in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 request_body_bytes = 12;
+
+  // Map of additional headers that have been configured to be logged.
+  map<string, string> request_headers = 13;
+}
+
+message HTTPResponseProperties {
+  // The HTTP response code returned by Envoy.
+  google.protobuf.UInt32Value response_code = 1;
+
+  // Size of the HTTP response headers in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 response_headers_bytes = 2;
+
+  // Size of the HTTP response body in bytes.
+  //
+  // This value is captured from the OSI layer 7 perspective, i.e. it does not
+  // include overhead from framing or encoding at other networking layers.
+  uint64 response_body_bytes = 3;
+
+  // Map of additional headers configured to be logged.
+  map<string, string> response_headers = 4;
+
+  // Map of trailers configured to be logged.
+  map<string, string> response_trailers = 5;
+
+  // The HTTP response code details.
+  string response_code_details = 6;
+}

--- a/api/envoy/data/cluster/v3alpha/BUILD
+++ b/api/envoy/data/cluster/v3alpha/BUILD
@@ -1,0 +1,11 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "outlier_detection_event",
+    srcs = ["outlier_detection_event.proto"],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/api/envoy/data/cluster/v3alpha/outlier_detection_event.proto
+++ b/api/envoy/data/cluster/v3alpha/outlier_detection_event.proto
@@ -1,0 +1,102 @@
+syntax = "proto3";
+
+package envoy.data.cluster.v3alpha;
+
+option java_outer_classname = "OutlierDetectionEventProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.cluster.v3alpha";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Outlier detection logging events]
+// :ref:`Outlier detection logging <arch_overview_outlier_detection_logging>`.
+
+message OutlierDetectionEvent {
+  // In case of eject represents type of ejection that took place.
+  OutlierEjectionType type = 1 [(validate.rules).enum.defined_only = true];
+  // Timestamp for event.
+  google.protobuf.Timestamp timestamp = 2 [(gogoproto.stdtime) = true];
+  // The time in seconds since the last action (either an ejection or unejection) took place.
+  google.protobuf.UInt64Value secs_since_last_action = 3;
+  // The :ref:`cluster <envoy_api_msg_Cluster>` that owns the ejected host.
+  string cluster_name = 4 [(validate.rules).string.min_bytes = 1];
+  // The URL of the ejected host. E.g., ``tcp://1.2.3.4:80``.
+  string upstream_url = 5 [(validate.rules).string.min_bytes = 1];
+  // The action that took place.
+  Action action = 6 [(validate.rules).enum.defined_only = true];
+  // If ``action`` is ``eject``, specifies the number of times the host has been ejected (local to
+  // that Envoy and gets reset if the host gets removed from the upstream cluster for any reason and
+  // then re-added).
+  uint32 num_ejections = 7;
+  // If ``action`` is ``eject``, specifies if the ejection was enforced. ``true`` means the host was
+  // ejected. ``false`` means the event was logged but the host was not actually ejected.
+  bool enforced = 8;
+
+  oneof event {
+    option (validate.required) = true;
+    OutlierEjectSuccessRate eject_success_rate_event = 9;
+    OutlierEjectConsecutive eject_consecutive_event = 10;
+  }
+}
+
+// Type of ejection that took place
+enum OutlierEjectionType {
+  // In case upstream host returns certain number of consecutive 5xx.
+  // If
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *false*, all type of errors are treated as HTTP 5xx errors.
+  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
+  // details.
+  CONSECUTIVE_5XX = 0;
+  // In case upstream host returns certain number of consecutive gateway errors
+  CONSECUTIVE_GATEWAY_FAILURE = 1;
+  // Runs over aggregated success rate statistics from every host in cluster
+  // and selects hosts for which ratio of successful replies deviates from other hosts
+  // in the cluster.
+  // If
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is *false*, all errors (externally and locally generated) are used to calculate success rate
+  // statistics. See :ref:`Cluster outlier detection <arch_overview_outlier_detection>`
+  // documentation for details.
+  SUCCESS_RATE = 2;
+  // Consecutive local origin failures: Connection failures, resets, timeouts, etc
+  // This type of ejection happens only when
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is set to *true*.
+  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
+  CONSECUTIVE_LOCAL_ORIGIN_FAILURE = 3;
+  // Runs over aggregated success rate statistics for local origin failures
+  // for all hosts in the cluster and selects hosts for which success rate deviates from other
+  // hosts in the cluster. This type of ejection happens only when
+  // :ref:`outlier_detection.split_external_local_origin_errors<envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>`
+  // is set to *true*.
+  // See :ref:`Cluster outlier detection <arch_overview_outlier_detection>` documentation for
+  SUCCESS_RATE_LOCAL_ORIGIN = 4;
+}
+
+// Represents possible action applied to upstream host
+enum Action {
+  // In case host was excluded from service
+  EJECT = 0;
+  // In case host was brought back into service
+  UNEJECT = 1;
+}
+
+message OutlierEjectSuccessRate {
+  // Host’s success rate at the time of the ejection event on a 0-100 range.
+  uint32 host_success_rate = 1 [(validate.rules).uint32.lte = 100];
+  // Average success rate of the hosts in the cluster at the time of the ejection event on a 0-100
+  // range.
+  uint32 cluster_average_success_rate = 2 [(validate.rules).uint32.lte = 100];
+  // Success rate ejection threshold at the time of the ejection event.
+  uint32 cluster_success_rate_ejection_threshold = 3 [(validate.rules).uint32.lte = 100];
+}
+
+message OutlierEjectConsecutive {
+}

--- a/api/envoy/data/core/v3alpha/BUILD
+++ b/api/envoy/data/core/v3alpha/BUILD
@@ -1,0 +1,15 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "health_check_event",
+    srcs = ["health_check_event.proto"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+    ],
+)

--- a/api/envoy/data/core/v3alpha/health_check_event.proto
+++ b/api/envoy/data/core/v3alpha/health_check_event.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package envoy.data.core.v3alpha;
+
+option java_outer_classname = "HealthCheckEventProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.core.v3alpha";
+
+import "envoy/api/v3alpha/core/address.proto";
+
+import "google/protobuf/timestamp.proto";
+
+import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
+
+// [#protodoc-title: Health check logging events]
+// :ref:`Health check logging <arch_overview_health_check_logging>`.
+
+message HealthCheckEvent {
+  HealthCheckerType health_checker_type = 1 [(validate.rules).enum.defined_only = true];
+  envoy.api.v3alpha.core.Address host = 2;
+  string cluster_name = 3 [(validate.rules).string.min_bytes = 1];
+
+  oneof event {
+    option (validate.required) = true;
+
+    // Host ejection.
+    HealthCheckEjectUnhealthy eject_unhealthy_event = 4;
+
+    // Host addition.
+    HealthCheckAddHealthy add_healthy_event = 5;
+
+    // Host failure.
+    HealthCheckFailure health_check_failure_event = 7;
+
+    // Healthy host became degraded.
+    DegradedHealthyHost degraded_healthy_host = 8;
+
+    // A degraded host returned to being healthy.
+    NoLongerDegradedHost no_longer_degraded_host = 9;
+  }
+
+  // Timestamp for event.
+  google.protobuf.Timestamp timestamp = 6 [(gogoproto.stdtime) = true];
+}
+
+enum HealthCheckFailureType {
+  ACTIVE = 0;
+  PASSIVE = 1;
+  NETWORK = 2;
+}
+
+enum HealthCheckerType {
+  HTTP = 0;
+  TCP = 1;
+  GRPC = 2;
+  REDIS = 3;
+}
+
+message HealthCheckEjectUnhealthy {
+  // The type of failure that caused this ejection.
+  HealthCheckFailureType failure_type = 1 [(validate.rules).enum.defined_only = true];
+}
+
+message HealthCheckAddHealthy {
+  // Whether this addition is the result of the first ever health check on a host, in which case
+  // the configured :ref:`healthy threshold <envoy_api_field_core.HealthCheck.healthy_threshold>`
+  // is bypassed and the host is immediately added.
+  bool first_check = 1;
+}
+
+message HealthCheckFailure {
+  // The type of failure that caused this event.
+  HealthCheckFailureType failure_type = 1 [(validate.rules).enum.defined_only = true];
+  // Whether this event is the result of the first ever health check on a host.
+  bool first_check = 2;
+}
+
+message DegradedHealthyHost {
+}
+
+message NoLongerDegradedHost {
+}

--- a/api/envoy/data/tap/v3alpha/BUILD
+++ b/api/envoy/data/tap/v3alpha/BUILD
@@ -1,0 +1,37 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "common",
+    srcs = ["common.proto"],
+)
+
+api_proto_library_internal(
+    name = "transport",
+    srcs = ["transport.proto"],
+    deps = [
+        ":common",
+        "//envoy/api/v3alpha/core:address",
+    ],
+)
+
+api_proto_library_internal(
+    name = "http",
+    srcs = ["http.proto"],
+    deps = [
+        ":common",
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_proto_library_internal(
+    name = "wrapper",
+    srcs = ["wrapper.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":http",
+        ":transport",
+        "//envoy/api/v3alpha/core:address",
+    ],
+)

--- a/api/envoy/data/tap/v3alpha/common.proto
+++ b/api/envoy/data/tap/v3alpha/common.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package envoy.data.tap.v3alpha;
+
+option java_outer_classname = "CommonProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.tap.v3alpha";
+
+// [#protodoc-title: Tap common data]
+
+// Wrapper for tapped body data. This includes HTTP request/response body, transport socket received
+// and transmitted data, etc.
+message Body {
+  oneof body_type {
+    // Body data as bytes. By default, tap body data will be present in this field, as the proto
+    // `bytes` type can contain any valid byte.
+    bytes as_bytes = 1;
+
+    // Body data as string. This field is only used when the :ref:`JSON_BODY_AS_STRING
+    // <envoy_api_enum_value_service.tap.v3alpha.OutputSink.Format.JSON_BODY_AS_STRING>` sink
+    // format type is selected. See the documentation for that option for why this is useful.
+    string as_string = 2;
+  }
+
+  // Specifies whether body data has been truncated to fit within the specified
+  // :ref:`max_buffered_rx_bytes
+  // <envoy_api_field_service.tap.v3alpha.OutputConfig.max_buffered_rx_bytes>` and
+  // :ref:`max_buffered_tx_bytes
+  // <envoy_api_field_service.tap.v3alpha.OutputConfig.max_buffered_tx_bytes>` settings.
+  bool truncated = 3;
+}

--- a/api/envoy/data/tap/v3alpha/http.proto
+++ b/api/envoy/data/tap/v3alpha/http.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package envoy.data.tap.v3alpha;
+
+option java_outer_classname = "HttpProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.tap.v3alpha";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/data/tap/v3alpha/common.proto";
+
+// [#protodoc-title: HTTP tap data]
+
+// A fully buffered HTTP trace message.
+message HttpBufferedTrace {
+  // HTTP message wrapper.
+  message Message {
+    // Message headers.
+    repeated api.v3alpha.core.HeaderValue headers = 1;
+
+    // Message body.
+    Body body = 2;
+
+    // Message trailers.
+    repeated api.v3alpha.core.HeaderValue trailers = 3;
+  }
+
+  // Request message.
+  Message request = 1;
+
+  // Response message.
+  Message response = 2;
+}
+
+// A streamed HTTP trace segment. Multiple segments make up a full trace.
+message HttpStreamedTraceSegment {
+  // Trace ID unique to the originating Envoy only. Trace IDs can repeat and should not be used
+  // for long term stable uniqueness.
+  uint64 trace_id = 1;
+
+  oneof message_piece {
+    // Request headers.
+    api.v3alpha.core.HeaderMap request_headers = 2;
+
+    // Request body chunk.
+    Body request_body_chunk = 3;
+
+    // Request trailers.
+    api.v3alpha.core.HeaderMap request_trailers = 4;
+
+    // Response headers.
+    api.v3alpha.core.HeaderMap response_headers = 5;
+
+    // Response body chunk.
+    Body response_body_chunk = 6;
+
+    // Response trailers.
+    api.v3alpha.core.HeaderMap response_trailers = 7;
+  }
+}

--- a/api/envoy/data/tap/v3alpha/transport.proto
+++ b/api/envoy/data/tap/v3alpha/transport.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+// [#protodoc-title: Transport tap data]
+// Trace format for the tap transport socket extension. This dumps plain text read/write
+// sequences on a socket.
+
+package envoy.data.tap.v3alpha;
+
+option java_outer_classname = "TransportProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.tap.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/data/tap/v3alpha/common.proto";
+
+import "google/protobuf/timestamp.proto";
+
+// Connection properties.
+message Connection {
+  // Local address.
+  envoy.api.v3alpha.core.Address local_address = 2;
+
+  // Remote address.
+  envoy.api.v3alpha.core.Address remote_address = 3;
+}
+
+// Event in a socket trace.
+message SocketEvent {
+  // Timestamp for event.
+  google.protobuf.Timestamp timestamp = 1;
+
+  // Data read by Envoy from the transport socket.
+  message Read {
+    // Binary data read.
+    Body data = 1;
+
+    // TODO(htuch): Half-close for reads.
+  }
+
+  // Data written by Envoy to the transport socket.
+  message Write {
+    // Binary data written.
+    Body data = 1;
+
+    // Stream was half closed after this write.
+    bool end_stream = 2;
+  }
+
+  // The connection was closed.
+  message Closed {
+    // TODO(mattklein123): Close event type.
+  }
+
+  // Read or write with content as bytes string.
+  oneof event_selector {
+    Read read = 2;
+    Write write = 3;
+    Closed closed = 4;
+  }
+}
+
+// Sequence of read/write events that constitute a buffered trace on a socket.
+message SocketBufferedTrace {
+  // Trace ID unique to the originating Envoy only. Trace IDs can repeat and should not be used
+  // for long term stable uniqueness. Matches connection IDs used in Envoy logs.
+  uint64 trace_id = 1;
+
+  // Connection properties.
+  Connection connection = 2;
+
+  // Sequence of observed events.
+  repeated SocketEvent events = 3;
+
+  // Set to true if read events were truncated due to the :ref:`max_buffered_rx_bytes
+  // <envoy_api_field_service.tap.v3alpha.OutputConfig.max_buffered_rx_bytes>` setting.
+  bool read_truncated = 4;
+
+  // Set to true if write events were truncated due to the :ref:`max_buffered_tx_bytes
+  // <envoy_api_field_service.tap.v3alpha.OutputConfig.max_buffered_tx_bytes>` setting.
+  bool write_truncated = 5;
+}
+
+// A streamed socket trace segment. Multiple segments make up a full trace.
+message SocketStreamedTraceSegment {
+  // Trace ID unique to the originating Envoy only. Trace IDs can repeat and should not be used
+  // for long term stable uniqueness. Matches connection IDs used in Envoy logs.
+  uint64 trace_id = 1;
+
+  oneof message_piece {
+    // Connection properties.
+    Connection connection = 2;
+
+    // Socket event.
+    SocketEvent event = 3;
+  }
+}

--- a/api/envoy/data/tap/v3alpha/wrapper.proto
+++ b/api/envoy/data/tap/v3alpha/wrapper.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+import "envoy/data/tap/v3alpha/http.proto";
+import "envoy/data/tap/v3alpha/transport.proto";
+
+import "validate/validate.proto";
+
+package envoy.data.tap.v3alpha;
+
+option java_outer_classname = "WrapperProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.data.tap.v3alpha";
+
+// [#protodoc-title: Tap data wrappers]
+
+// Wrapper for all fully buffered and streamed tap traces that Envoy emits. This is required for
+// sending traces over gRPC APIs or more easily persisting binary messages to files.
+message TraceWrapper {
+  oneof trace {
+    option (validate.required) = true;
+
+    // An HTTP buffered tap trace.
+    HttpBufferedTrace http_buffered_trace = 1;
+
+    // An HTTP streamed tap trace segment.
+    HttpStreamedTraceSegment http_streamed_trace_segment = 2;
+
+    // A socket buffered tap trace.
+    SocketBufferedTrace socket_buffered_trace = 3;
+
+    // A socket streamed tap trace segment.
+    SocketStreamedTraceSegment socket_streamed_trace_segment = 4;
+  }
+}

--- a/api/envoy/service/accesslog/v3alpha/BUILD
+++ b/api/envoy/service/accesslog/v3alpha/BUILD
@@ -1,0 +1,23 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "als",
+    srcs = ["als.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:grpc_service",
+        "//envoy/data/accesslog/v3alpha:accesslog",
+    ],
+)
+
+api_go_grpc_library(
+    name = "als",
+    proto = ":als",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/data/accesslog/v3alpha:accesslog_go_proto",
+    ],
+)

--- a/api/envoy/service/accesslog/v3alpha/als.proto
+++ b/api/envoy/service/accesslog/v3alpha/als.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+package envoy.service.accesslog.v3alpha;
+
+option java_outer_classname = "AlsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.accesslog.v3alpha";
+option go_package = "v2";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/data/accesslog/v3alpha/accesslog.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: gRPC Access Log Service (ALS)]
+
+// Service for streaming access logs from Envoy to an access log server.
+service AccessLogService {
+  // Envoy will connect and send StreamAccessLogsMessage messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure. The server should
+  // disconnect if it expects Envoy to reconnect. In the future we may decide to add a different
+  // API for "critical" access logs in which Envoy will buffer access logs for some period of time
+  // until it gets an ACK so it could then retry. This API is designed for high throughput with the
+  // expectation that it might be lossy.
+  rpc StreamAccessLogs(stream StreamAccessLogsMessage) returns (StreamAccessLogsResponse) {
+  }
+}
+
+// Empty response for the StreamAccessLogs API. Will never be sent. See below.
+message StreamAccessLogsResponse {
+}
+
+// Stream message for the StreamAccessLogs API. Envoy will open a stream to the server and stream
+// access logs without ever expecting a response.
+message StreamAccessLogsMessage {
+  message Identifier {
+    // The node sending the access log messages over the stream.
+    envoy.api.v3alpha.core.Node node = 1 [(validate.rules).message.required = true];
+
+    // The friendly name of the log configured in :ref:`CommonGrpcAccessLogConfig
+    // <envoy_api_msg_config.accesslog.v3alpha.CommonGrpcAccessLogConfig>`.
+    string log_name = 2 [(validate.rules).string.min_bytes = 1];
+  }
+
+  // Identifier data that will only be sent in the first message on the stream. This is effectively
+  // structured metadata and is a performance optimization.
+  Identifier identifier = 1;
+
+  // Wrapper for batches of HTTP access log entries.
+  message HTTPAccessLogEntries {
+    repeated envoy.data.accesslog.v3alpha.HTTPAccessLogEntry log_entry = 1
+        [(validate.rules).repeated .min_items = 1];
+  }
+
+  // Wrapper for batches of TCP access log entries.
+  message TCPAccessLogEntries {
+    repeated envoy.data.accesslog.v3alpha.TCPAccessLogEntry log_entry = 1
+        [(validate.rules).repeated .min_items = 1];
+  }
+
+  // Batches of log entries of a single type. Generally speaking, a given stream should only
+  // ever include one type of log entry.
+  oneof log_entries {
+    option (validate.required) = true;
+
+    HTTPAccessLogEntries http_logs = 2;
+
+    TCPAccessLogEntries tcp_logs = 3;
+  }
+}

--- a/api/envoy/service/auth/v3alpha/BUILD
+++ b/api/envoy/service/auth/v3alpha/BUILD
@@ -1,0 +1,28 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "attribute_context",
+    srcs = [
+        "attribute_context.proto",
+    ],
+    deps = [
+        "//envoy/api/v3alpha/core:address",
+        "//envoy/api/v3alpha/core:base",
+    ],
+)
+
+api_proto_library_internal(
+    name = "external_auth",
+    srcs = [
+        "external_auth.proto",
+    ],
+    has_services = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":attribute_context",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/type:http_status",
+    ],
+)

--- a/api/envoy/service/auth/v3alpha/attribute_context.proto
+++ b/api/envoy/service/auth/v3alpha/attribute_context.proto
@@ -1,0 +1,154 @@
+syntax = "proto3";
+
+package envoy.service.auth.v3alpha;
+
+option java_outer_classname = "AttributeContextProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.auth.v3alpha";
+
+import "envoy/api/v3alpha/core/address.proto";
+import "envoy/api/v3alpha/core/base.proto";
+
+import "google/protobuf/timestamp.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.stable_marshaler_all) = true;
+
+// [#protodoc-title: Attribute Context ]
+
+// See :ref:`network filter configuration overview <config_network_filters_ext_authz>`
+// and :ref:`HTTP filter configuration overview <config_http_filters_ext_authz>`.
+
+// An attribute is a piece of metadata that describes an activity on a network.
+// For example, the size of an HTTP request, or the status code of an HTTP response.
+//
+// Each attribute has a type and a name, which is logically defined as a proto message field
+// of the `AttributeContext`. The `AttributeContext` is a collection of individual attributes
+// supported by Envoy authorization system.
+message AttributeContext {
+  // This message defines attributes for a node that handles a network request.
+  // The node can be either a service or an application that sends, forwards,
+  // or receives the request. Service peers should fill in the `service`,
+  // `principal`, and `labels` as appropriate.
+  message Peer {
+    // The address of the peer, this is typically the IP address.
+    // It can also be UDS path, or others.
+    envoy.api.v3alpha.core.Address address = 1;
+
+    // The canonical service name of the peer.
+    // It should be set to :ref:`the HTTP x-envoy-downstream-service-cluster
+    // <config_http_conn_man_headers_downstream-service-cluster>`
+    // If a more trusted source of the service name is available through mTLS/secure naming, it
+    // should be used.
+    string service = 2;
+
+    // The labels associated with the peer.
+    // These could be pod labels for Kubernetes or tags for VMs.
+    // The source of the labels could be an X.509 certificate or other configuration.
+    map<string, string> labels = 3;
+
+    // The authenticated identity of this peer.
+    // For example, the identity associated with the workload such as a service account.
+    // If an X.509 certificate is used to assert the identity this field should be sourced from
+    // `URI Subject Alternative Names`, `DNS Subject Alternate Names` or `Subject` in that order.
+    // The primary identity should be the principal. The principal format is issuer specific.
+    //
+    // Example:
+    // *    SPIFFE format is `spiffe://trust-domain/path`
+    // *    Google account format is `https://accounts.google.com/{userid}`
+    string principal = 4;
+  }
+
+  // Represents a network request, such as an HTTP request.
+  message Request {
+    // The timestamp when the proxy receives the first byte of the request.
+    google.protobuf.Timestamp time = 1;
+
+    // Represents an HTTP request or an HTTP-like request.
+    HttpRequest http = 2;
+
+    // More request types are added here as necessary.
+  }
+
+  // This message defines attributes for an HTTP request.
+  // HTTP/1.x, HTTP/2, gRPC are all considered as HTTP requests.
+  message HttpRequest {
+    // The unique ID for a request, which can be propagated to downstream
+    // systems. The ID should have low probability of collision
+    // within a single day for a specific service.
+    // For HTTP requests, it should be X-Request-ID or equivalent.
+    string id = 1;
+
+    // The HTTP request method, such as `GET`, `POST`.
+    string method = 2;
+
+    // The HTTP request headers. If multiple headers share the same key, they
+    // must be merged according to the HTTP spec. All header keys must be
+    // lowercased, because HTTP header keys are case-insensitive.
+    map<string, string> headers = 3;
+
+    // The request target, as it appears in the first line of the HTTP request. This includes
+    // the URL path and query-string. No decoding is performed.
+    string path = 4;
+
+    // The HTTP request `Host` or 'Authority` header value.
+    string host = 5;
+
+    // The HTTP URL scheme, such as `http` and `https`.
+    string scheme = 6;
+
+    // This field is always empty, and exists for compatibility reasons. The HTTP URL query is
+    // included in `path` field.
+    string query = 7;
+
+    // This field is always empty, and exists for compatibility reasons. The URL fragment is
+    // not submitted as part of HTTP requests; it is unknowable.
+    string fragment = 8;
+
+    // The HTTP request size in bytes. If unknown, it must be -1.
+    int64 size = 9;
+
+    // The network protocol used with the request, such as "HTTP/1.0", "HTTP/1.1", or "HTTP/2".
+    //
+    // See :repo:`headers.h:ProtocolStrings <source/common/http/headers.h>` for a list of all
+    // possible values.
+    string protocol = 10;
+
+    // The HTTP request body.
+    string body = 11;
+  }
+
+  // The source of a network activity, such as starting a TCP connection.
+  // In a multi hop network activity, the source represents the sender of the
+  // last hop.
+  Peer source = 1;
+
+  // The destination of a network activity, such as accepting a TCP connection.
+  // In a multi hop network activity, the destination represents the receiver of
+  // the last hop.
+  Peer destination = 2;
+
+  // Represents a network request, such as an HTTP request.
+  Request request = 4;
+
+  // This is analogous to http_request.headers, however these contents will not be sent to the
+  // upstream server. Context_extensions provide an extension mechanism for sending additional
+  // information to the auth server without modifying the proto definition. It maps to the
+  // internal opaque context in the filter chain.
+  map<string, string> context_extensions = 10;
+
+  // Dynamic metadata associated with the request.
+  envoy.api.v3alpha.core.Metadata metadata_context = 11;
+}
+
+// The following items are left out of this proto
+// Request.Auth field for jwt tokens
+// Request.Api for api management
+// Origin peer that originated the request
+// Caching Protocol
+// request_context return values to inject back into the filter chain
+// peer.claims -- from X.509 extensions
+// Configuration
+// - field mask to send
+// - which return values from request_context are copied back
+// - which return values are copied into request_headers

--- a/api/envoy/service/auth/v3alpha/external_auth.proto
+++ b/api/envoy/service/auth/v3alpha/external_auth.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package envoy.service.auth.v3alpha;
+
+option java_outer_classname = "ExternalAuthProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.auth.v3alpha";
+option go_package = "v2";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/type/http_status.proto";
+import "envoy/service/auth/v3alpha/attribute_context.proto";
+
+import "google/rpc/status.proto";
+import "validate/validate.proto";
+
+// [#protodoc-title: Authorization Service ]
+
+// The authorization service request messages used by external authorization :ref:`network filter
+// <config_network_filters_ext_authz>` and :ref:`HTTP filter <config_http_filters_ext_authz>`.
+
+// A generic interface for performing authorization check on incoming
+// requests to a networked service.
+service Authorization {
+  // Performs authorization check based on the attributes associated with the
+  // incoming request, and returns status `OK` or not `OK`.
+  rpc Check(CheckRequest) returns (CheckResponse);
+}
+
+message CheckRequest {
+  // The request attributes.
+  AttributeContext attributes = 1;
+}
+
+// HTTP attributes for a denied response.
+message DeniedHttpResponse {
+  // This field allows the authorization service to send a HTTP response status
+  // code to the downstream client other than 403 (Forbidden).
+  envoy.type.HttpStatus status = 1 [(validate.rules).message.required = true];
+
+  // This field allows the authorization service to send HTTP response headers
+  // to the downstream client.
+  repeated envoy.api.v3alpha.core.HeaderValueOption headers = 2;
+
+  // This field allows the authorization service to send a response body data
+  // to the downstream client.
+  string body = 3;
+}
+
+// HTTP attributes for an ok response.
+message OkHttpResponse {
+  // HTTP entity headers in addition to the original request headers. This allows the authorization
+  // service to append, to add or to override headers from the original request before
+  // dispatching it to the upstream. By setting `append` field to `true` in the `HeaderValueOption`,
+  // the filter will append the correspondent header value to the matched request header. Note that
+  // by Leaving `append` as false, the filter will either add a new header, or override an existing
+  // one if there is a match.
+  repeated envoy.api.v3alpha.core.HeaderValueOption headers = 2;
+}
+
+// Intended for gRPC and Network Authorization servers `only`.
+message CheckResponse {
+  // Status `OK` allows the request. Any other status indicates the request should be denied.
+  google.rpc.Status status = 1;
+
+  // An message that contains HTTP response attributes. This message is
+  // used when the authorization service needs to send custom responses to the
+  // downstream client or, to modify/add request headers being dispatched to the upstream.
+  oneof http_response {
+    // Supplies http attributes for a denied response.
+    DeniedHttpResponse denied_response = 2;
+
+    // Supplies http attributes for an ok response.
+    OkHttpResponse ok_response = 3;
+  }
+}

--- a/api/envoy/service/discovery/v3alpha/BUILD
+++ b/api/envoy/service/discovery/v3alpha/BUILD
@@ -1,0 +1,75 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "ads",
+    srcs = ["ads.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha:discovery",
+    ],
+)
+
+api_go_grpc_library(
+    name = "ads",
+    proto = ":ads",
+    deps = [
+        "//envoy/api/v3alpha:discovery_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "hds",
+    srcs = ["hds.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:health_check",
+        "//envoy/api/v3alpha/endpoint",
+    ],
+)
+
+api_go_grpc_library(
+    name = "hds",
+    proto = ":hds",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:health_check_go_proto",
+        "//envoy/api/v3alpha/endpoint:endpoint_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "sds",
+    srcs = ["sds.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha:discovery",
+    ],
+)
+
+api_go_grpc_library(
+    name = "sds",
+    proto = ":sds",
+    deps = [
+        "//envoy/api/v3alpha:discovery_go_proto",
+    ],
+)
+
+api_proto_library_internal(
+    name = "rtds",
+    srcs = ["rtds.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha:discovery",
+    ],
+)
+
+api_go_grpc_library(
+    name = "rtds",
+    proto = ":rtds",
+    deps = [
+        "//envoy/api/v3alpha:discovery_go_proto",
+    ],
+)

--- a/api/envoy/service/discovery/v3alpha/ads.proto
+++ b/api/envoy/service/discovery/v3alpha/ads.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v3alpha;
+
+option java_outer_classname = "AdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.discovery.v3alpha";
+option go_package = "v2";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/discovery.proto";
+
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message AdsDummy {
+}
+
+// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// and listeners are retained in the package `envoy.api.v3alpha` for backwards
+// compatibility with existing management servers. New development in discovery
+// services should proceed in the package `envoy.service.discovery.v3alpha`.
+
+// See https://github.com/lyft/envoy-api#apis for a description of the role of
+// ADS and how it is intended to be used by a management server. ADS requests
+// have the same structure as their singleton xDS counterparts, but can
+// multiplex many resource types on a single stream. The type_url in the
+// DiscoveryRequest/DiscoveryResponse provides sufficient information to recover
+// the multiplexed singleton APIs at the Envoy instance and management server.
+service AggregatedDiscoveryService {
+  // This is a gRPC-only API.
+  rpc StreamAggregatedResources(stream envoy.api.v3alpha.DiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DiscoveryResponse) {
+  }
+
+  rpc DeltaAggregatedResources(stream envoy.api.v3alpha.DeltaDiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DeltaDiscoveryResponse) {
+  }
+}

--- a/api/envoy/service/discovery/v3alpha/hds.proto
+++ b/api/envoy/service/discovery/v3alpha/hds.proto
@@ -1,0 +1,127 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v3alpha;
+
+option java_outer_classname = "HdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.discovery.v3alpha";
+
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/health_check.proto";
+import "envoy/api/v3alpha/endpoint/endpoint.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
+
+// [#proto-status: experimental]
+// HDS is Health Discovery Service. It compliments Envoy’s health checking
+// service by designating this Envoy to be a healthchecker for a subset of hosts
+// in the cluster. The status of these health checks will be reported to the
+// management server, where it can be aggregated etc and redistributed back to
+// Envoy through EDS.
+service HealthDiscoveryService {
+  // 1. Envoy starts up and if its can_healthcheck option in the static
+  //    bootstrap config is enabled, sends HealthCheckRequest to the management
+  //    server. It supplies its capabilities (which protocol it can health check
+  //    with, what zone it resides in, etc.).
+  // 2. In response to (1), the management server designates this Envoy as a
+  //    healthchecker to health check a subset of all upstream hosts for a given
+  //    cluster (for example upstream Host 1 and Host 2). It streams
+  //    HealthCheckSpecifier messages with cluster related configuration for all
+  //    clusters this Envoy is designated to health check. Subsequent
+  //    HealthCheckSpecifier message will be sent on changes to:
+  //    a. Endpoints to health checks
+  //    b. Per cluster configuration change
+  // 3. Envoy creates a health probe based on the HealthCheck config and sends
+  //    it to endpoint(ip:port) of Host 1 and 2. Based on the HealthCheck
+  //    configuration Envoy waits upon the arrival of the probe response and
+  //    looks at the content of the response to decide whether the endpoint is
+  //    healthy or not. If a response hasn't been received within the timeout
+  //    interval, the endpoint health status is considered TIMEOUT.
+  // 4. Envoy reports results back in an EndpointHealthResponse message.
+  //    Envoy streams responses as often as the interval configured by the
+  //    management server in HealthCheckSpecifier.
+  // 5. The management Server collects health statuses for all endpoints in the
+  //    cluster (for all clusters) and uses this information to construct
+  //    EndpointDiscoveryResponse messages.
+  // 6. Once Envoy has a list of upstream endpoints to send traffic to, it load
+  //    balances traffic to them without additional health checking. It may
+  //    use inline healthcheck (i.e. consider endpoint UNHEALTHY if connection
+  //    failed to a particular endpoint to account for health status propagation
+  //    delay between HDS and EDS).
+  // By default, can_healthcheck is true. If can_healthcheck is false, Cluster
+  // configuration may not contain HealthCheck message.
+  // TODO(htuch): How is can_healthcheck communicated to CDS to ensure the above
+  // invariant?
+  // TODO(htuch): Add @amb67's diagram.
+  rpc StreamHealthCheck(stream HealthCheckRequestOrEndpointHealthResponse)
+      returns (stream HealthCheckSpecifier) {
+  }
+
+  // TODO(htuch): Unlike the gRPC version, there is no stream-based binding of
+  // request/response. Should we add an identifier to the HealthCheckSpecifier
+  // to bind with the response?
+  rpc FetchHealthCheck(HealthCheckRequestOrEndpointHealthResponse) returns (HealthCheckSpecifier) {
+    option (google.api.http) = {
+      post: "/v2/discovery:health_check"
+      body: "*"
+    };
+  }
+}
+
+// Defines supported protocols etc, so the management server can assign proper
+// endpoints to healthcheck.
+message Capability {
+  // Different Envoy instances may have different capabilities (e.g. Redis)
+  // and/or have ports enabled for different protocols.
+  enum Protocol {
+    HTTP = 0;
+    TCP = 1;
+    REDIS = 2;
+  }
+  repeated Protocol health_check_protocols = 1;
+}
+
+message HealthCheckRequest {
+  envoy.api.v3alpha.core.Node node = 1;
+  Capability capability = 2;
+}
+
+message EndpointHealth {
+  envoy.api.v3alpha.endpoint.Endpoint endpoint = 1;
+  envoy.api.v3alpha.core.HealthStatus health_status = 2;
+}
+
+message EndpointHealthResponse {
+  repeated EndpointHealth endpoints_health = 1;
+}
+
+message HealthCheckRequestOrEndpointHealthResponse {
+  oneof request_type {
+    HealthCheckRequest health_check_request = 1;
+    EndpointHealthResponse endpoint_health_response = 2;
+  }
+}
+
+message LocalityEndpoints {
+  envoy.api.v3alpha.core.Locality locality = 1;
+  repeated envoy.api.v3alpha.endpoint.Endpoint endpoints = 2;
+}
+
+// The cluster name and locality is provided to Envoy for the endpoints that it
+// health checks to support statistics reporting, logging and debugging by the
+// Envoy instance (outside of HDS). For maximum usefulness, it should match the
+// same cluster structure as that provided by EDS.
+message ClusterHealthCheck {
+  string cluster_name = 1;
+  repeated envoy.api.v3alpha.core.HealthCheck health_checks = 2;
+  repeated LocalityEndpoints locality_endpoints = 3;
+}
+
+message HealthCheckSpecifier {
+  repeated ClusterHealthCheck cluster_health_checks = 1;
+  // The default is 1 second.
+  google.protobuf.Duration interval = 2;
+}

--- a/api/envoy/service/discovery/v3alpha/rtds.proto
+++ b/api/envoy/service/discovery/v3alpha/rtds.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v3alpha;
+
+option java_outer_classname = "RtdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.discovery.v3alpha";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/discovery.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Runtime Discovery Service (RTDS)]
+// RTDS :ref:`configuration overview <config_runtime_rtds>`
+
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message RtdsDummy {
+}
+
+// Discovery service for Runtime resources.
+service RuntimeDiscoveryService {
+  rpc StreamRuntime(stream envoy.api.v3alpha.DiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DiscoveryResponse) {
+  }
+
+  rpc DeltaRuntime(stream envoy.api.v3alpha.DeltaDiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchRuntime(envoy.api.v3alpha.DiscoveryRequest)
+      returns (envoy.api.v3alpha.DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:runtime"
+      body: "*"
+    };
+  }
+}
+
+// RTDS resource type. This describes a layer in the runtime virtual filesystem.
+message Runtime {
+  // Runtime resource name. This makes the Runtime a self-describing xDS
+  // resource.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+  google.protobuf.Struct layer = 2;
+}

--- a/api/envoy/service/discovery/v3alpha/sds.proto
+++ b/api/envoy/service/discovery/v3alpha/sds.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v3alpha;
+
+option java_outer_classname = "SdsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.discovery.v3alpha";
+
+import "envoy/api/v3alpha/discovery.proto";
+
+import "google/api/annotations.proto";
+
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message SdsDummy {
+}
+
+service SecretDiscoveryService {
+  rpc DeltaSecrets(stream envoy.api.v3alpha.DeltaDiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DeltaDiscoveryResponse) {
+  }
+
+  rpc StreamSecrets(stream envoy.api.v3alpha.DiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DiscoveryResponse) {
+  }
+
+  rpc FetchSecrets(envoy.api.v3alpha.DiscoveryRequest)
+      returns (envoy.api.v3alpha.DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:secrets"
+      body: "*"
+    };
+  }
+}

--- a/api/envoy/service/load_stats/v3alpha/BUILD
+++ b/api/envoy/service/load_stats/v3alpha/BUILD
@@ -1,0 +1,22 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "lrs",
+    srcs = ["lrs.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/endpoint:load_report",
+    ],
+)
+
+api_go_grpc_library(
+    name = "lrs",
+    proto = ":lrs",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/endpoint:load_report_go_proto",
+    ],
+)

--- a/api/envoy/service/load_stats/v3alpha/lrs.proto
+++ b/api/envoy/service/load_stats/v3alpha/lrs.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+
+package envoy.service.load_stats.v3alpha;
+
+option java_outer_classname = "LrsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.load_stats.v3alpha";
+option go_package = "v2";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/endpoint/load_report.proto";
+
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Load reporting service]
+
+service LoadReportingService {
+  // Advanced API to allow for multi-dimensional load balancing by remote
+  // server. For receiving LB assignments, the steps are:
+  // 1, The management server is configured with per cluster/zone/load metric
+  //    capacity configuration. The capacity configuration definition is
+  //    outside of the scope of this document.
+  // 2. Envoy issues a standard {Stream,Fetch}Endpoints request for the clusters
+  //    to balance.
+  //
+  // Independently, Envoy will initiate a StreamLoadStats bidi stream with a
+  // management server:
+  // 1. Once a connection establishes, the management server publishes a
+  //    LoadStatsResponse for all clusters it is interested in learning load
+  //    stats about.
+  // 2. For each cluster, Envoy load balances incoming traffic to upstream hosts
+  //    based on per-zone weights and/or per-instance weights (if specified)
+  //    based on intra-zone LbPolicy. This information comes from the above
+  //    {Stream,Fetch}Endpoints.
+  // 3. When upstream hosts reply, they optionally add header <define header
+  //    name> with ASCII representation of EndpointLoadMetricStats.
+  // 4. Envoy aggregates load reports over the period of time given to it in
+  //    LoadStatsResponse.load_reporting_interval. This includes aggregation
+  //    stats Envoy maintains by itself (total_requests, rpc_errors etc.) as
+  //    well as load metrics from upstream hosts.
+  // 5. When the timer of load_reporting_interval expires, Envoy sends new
+  //    LoadStatsRequest filled with load reports for each cluster.
+  // 6. The management server uses the load reports from all reported Envoys
+  //    from around the world, computes global assignment and prepares traffic
+  //    assignment destined for each zone Envoys are located in. Goto 2.
+  rpc StreamLoadStats(stream LoadStatsRequest) returns (stream LoadStatsResponse) {
+  }
+}
+
+// A load report Envoy sends to the management server.
+// [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+message LoadStatsRequest {
+  // Node identifier for Envoy instance.
+  envoy.api.v3alpha.core.Node node = 1;
+
+  // A list of load stats to report.
+  repeated envoy.api.v3alpha.endpoint.ClusterStats cluster_stats = 2;
+}
+
+// The management server sends envoy a LoadStatsResponse with all clusters it
+// is interested in learning load stats about.
+// [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+message LoadStatsResponse {
+  // Clusters to report stats for.
+  repeated string clusters = 1 [(validate.rules).repeated .min_items = 1];
+
+  // The minimum interval of time to collect stats over. This is only a minimum for two reasons:
+  // 1. There may be some delay from when the timer fires until stats sampling occurs.
+  // 2. For clusters that were already feature in the previous *LoadStatsResponse*, any traffic
+  //    that is observed in between the corresponding previous *LoadStatsRequest* and this
+  //    *LoadStatsResponse* will also be accumulated and billed to the cluster. This avoids a period
+  //    of inobservability that might otherwise exists between the messages. New clusters are not
+  //    subject to this consideration.
+  google.protobuf.Duration load_reporting_interval = 2;
+
+  // Set to *true* if the management server supports endpoint granularity
+  // report.
+  bool report_endpoint_granularity = 3;
+}

--- a/api/envoy/service/metrics/v3alpha/BUILD
+++ b/api/envoy/service/metrics/v3alpha/BUILD
@@ -1,0 +1,24 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "metrics_service",
+    srcs = ["metrics_service.proto"],
+    has_services = 1,
+    require_py = 0,
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:grpc_service",
+        "@prometheus_metrics_model//:client_model",
+    ],
+)
+
+api_go_grpc_library(
+    name = "metrics_service",
+    proto = ":metrics_service",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "@prometheus_metrics_model//:client_model_go_proto",
+    ],
+)

--- a/api/envoy/service/metrics/v3alpha/metrics_service.proto
+++ b/api/envoy/service/metrics/v3alpha/metrics_service.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package envoy.service.metrics.v3alpha;
+
+option java_outer_classname = "MetricsServiceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.metrics.v3alpha";
+option go_package = "v2";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+
+import "metrics.proto";
+
+import "validate/validate.proto";
+
+// Service for streaming metrics to server that consumes the metrics data. It uses Prometheus metric
+// data model as a standard to represent metrics information.
+service MetricsService {
+  // Envoy will connect and send StreamMetricsMessage messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure.
+  rpc StreamMetrics(stream StreamMetricsMessage) returns (StreamMetricsResponse) {
+  }
+}
+
+message StreamMetricsResponse {
+}
+
+message StreamMetricsMessage {
+  message Identifier {
+    // The node sending metrics over the stream.
+    envoy.api.v3alpha.core.Node node = 1 [(validate.rules).message.required = true];
+  }
+
+  // Identifier data effectively is a structured metadata. As a performance optimization this will
+  // only be sent in the first message on the stream.
+  Identifier identifier = 1;
+
+  // A list of metric entries
+  repeated io.prometheus.client.MetricFamily envoy_metrics = 2;
+}

--- a/api/envoy/service/ratelimit/v3alpha/BUILD
+++ b/api/envoy/service/ratelimit/v3alpha/BUILD
@@ -1,0 +1,24 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "rls",
+    srcs = ["rls.proto"],
+    has_services = 1,
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:grpc_service",
+        "//envoy/api/v3alpha/ratelimit",
+    ],
+)
+
+api_go_grpc_library(
+    name = "rls",
+    proto = ":rls",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "//envoy/api/v3alpha/core:grpc_service_go_proto",
+        "//envoy/api/v3alpha/ratelimit:ratelimit_go_proto",
+    ],
+)

--- a/api/envoy/service/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/service/ratelimit/v3alpha/rls.proto
@@ -1,0 +1,95 @@
+syntax = "proto3";
+
+package envoy.service.ratelimit.v3alpha;
+
+option java_outer_classname = "RlsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.ratelimit.v3alpha";
+option go_package = "v2";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/ratelimit/ratelimit.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Rate Limit Service (RLS)]
+
+service RateLimitService {
+  // Determine whether rate limiting should take place.
+  rpc ShouldRateLimit(RateLimitRequest) returns (RateLimitResponse) {
+  }
+}
+
+// Main message for a rate limit request. The rate limit service is designed to be fully generic
+// in the sense that it can operate on arbitrary hierarchical key/value pairs. The loaded
+// configuration will parse the request and find the most specific limit to apply. In addition,
+// a RateLimitRequest can contain multiple "descriptors" to limit on. When multiple descriptors
+// are provided, the server will limit on *ALL* of them and return an OVER_LIMIT response if any
+// of them are over limit. This enables more complex application level rate limiting scenarios
+// if desired.
+message RateLimitRequest {
+  // All rate limit requests must specify a domain. This enables the configuration to be per
+  // application without fear of overlap. E.g., "envoy".
+  string domain = 1;
+
+  // All rate limit requests must specify at least one RateLimitDescriptor. Each descriptor is
+  // processed by the service (see below). If any of the descriptors are over limit, the entire
+  // request is considered to be over limit.
+  repeated envoy.api.v3alpha.ratelimit.RateLimitDescriptor descriptors = 2;
+
+  // Rate limit requests can optionally specify the number of hits a request adds to the matched
+  // limit. If the value is not set in the message, a request increases the matched limit by 1.
+  uint32 hits_addend = 3;
+}
+
+// A response from a ShouldRateLimit call.
+message RateLimitResponse {
+  enum Code {
+    // The response code is not known.
+    UNKNOWN = 0;
+    // The response code to notify that the number of requests are under limit.
+    OK = 1;
+    // The response code to notify that the number of requests are over limit.
+    OVER_LIMIT = 2;
+  }
+
+  // Defines an actual rate limit in terms of requests per unit of time and the unit itself.
+  message RateLimit {
+    enum Unit {
+      // The time unit is not known.
+      UNKNOWN = 0;
+      // The time unit representing a second.
+      SECOND = 1;
+      // The time unit representing a minute.
+      MINUTE = 2;
+      // The time unit representing an hour.
+      HOUR = 3;
+      // The time unit representing a day.
+      DAY = 4;
+    }
+
+    // The number of requests per unit of time.
+    uint32 requests_per_unit = 1;
+    // The unit of time.
+    Unit unit = 2;
+  }
+
+  message DescriptorStatus {
+    // The response code for an individual descriptor.
+    Code code = 1;
+    // The current limit as configured by the server. Useful for debugging, etc.
+    RateLimit current_limit = 2;
+    // The limit remaining in the current time unit.
+    uint32 limit_remaining = 3;
+  }
+
+  // The overall response code which takes into account all of the descriptors that were passed
+  // in the RateLimitRequest message.
+  Code overall_code = 1;
+  // A list of DescriptorStatus messages which matches the length of the descriptor list passed
+  // in the RateLimitRequest. This can be used by the caller to determine which individual
+  // descriptors failed and/or what the currently configured limits are for all of them.
+  repeated DescriptorStatus statuses = 2;
+  // A list of headers to add to the response
+  repeated envoy.api.v3alpha.core.HeaderValue headers = 3;
+}

--- a/api/envoy/service/tap/v3alpha/BUILD
+++ b/api/envoy/service/tap/v3alpha/BUILD
@@ -1,0 +1,36 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "common",
+    srcs = ["common.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/api/v3alpha/core:grpc_service",
+        "//envoy/api/v3alpha/route",
+    ],
+)
+
+api_proto_library_internal(
+    name = "tap",
+    srcs = ["tap.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha:discovery",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/data/tap/v3alpha:wrapper",
+    ],
+)
+
+api_proto_library_internal(
+    name = "tapds",
+    srcs = ["tapds.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//envoy/api/v3alpha:discovery",
+        "//envoy/api/v3alpha/core:base",
+        "//envoy/service/tap/v3alpha:common",
+    ],
+)

--- a/api/envoy/service/tap/v3alpha/common.proto
+++ b/api/envoy/service/tap/v3alpha/common.proto
@@ -1,0 +1,200 @@
+syntax = "proto3";
+
+import "envoy/api/v3alpha/route/route.proto";
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/api/v3alpha/core/grpc_service.proto";
+
+import "google/protobuf/wrappers.proto";
+
+import "validate/validate.proto";
+
+package envoy.service.tap.v3alpha;
+
+option java_outer_classname = "CommonProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.tap.v3alpha";
+
+// [#protodoc-title: Common tap configuration]
+
+// Tap configuration.
+message TapConfig {
+  // The match configuration. If the configuration matches the data source being tapped, a tap will
+  // occur, with the result written to the configured output.
+  MatchPredicate match_config = 1 [(validate.rules).message.required = true];
+
+  // The tap output configuration. If a match configuration matches a data source being tapped,
+  // a tap will occur and the data will be written to the configured output.
+  OutputConfig output_config = 2 [(validate.rules).message.required = true];
+
+  // [#not-implemented-hide:] Specify if Tap matching is enabled. The % of requests\connections for
+  // which the tap matching is enabled. When not enabled, the request\connection will not be
+  // recorded.
+  //
+  // .. note::
+  //
+  //   This field defaults to 100/:ref:`HUNDRED
+  //   <envoy_api_enum_type.FractionalPercent.DenominatorType>`.
+  envoy.api.v3alpha.core.RuntimeFractionalPercent tap_enabled = 3;
+
+  // [#comment:TODO(mattklein123): Rate limiting]
+}
+
+// Tap match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+message MatchPredicate {
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated .min_items = 2];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool.const = true];
+
+    // HTTP request headers match configuration.
+    HttpHeadersMatch http_request_headers_match = 5;
+
+    // HTTP request trailers match configuration.
+    HttpHeadersMatch http_request_trailers_match = 6;
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_response_headers_match = 7;
+
+    // HTTP response trailers match configuration.
+    HttpHeadersMatch http_response_trailers_match = 8;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  // HTTP headers to match.
+  repeated api.v3alpha.route.HeaderMatcher headers = 1;
+}
+
+// Tap output configuration.
+message OutputConfig {
+  // Output sinks for tap data. Currently a single sink is allowed in the list. Once multiple
+  // sink types are supported this constraint will be relaxed.
+  repeated OutputSink sinks = 1 [(validate.rules).repeated = {min_items: 1, max_items: 1}];
+
+  // For buffered tapping, the maximum amount of received body that will be buffered prior to
+  // truncation. If truncation occurs, the :ref:`truncated
+  // <envoy_api_field_data.tap.v3alpha.Body.truncated>` field will be set. If not specified, the
+  // default is 1KiB.
+  google.protobuf.UInt32Value max_buffered_rx_bytes = 2;
+
+  // For buffered tapping, the maximum amount of transmitted body that will be buffered prior to
+  // truncation. If truncation occurs, the :ref:`truncated
+  // <envoy_api_field_data.tap.v3alpha.Body.truncated>` field will be set. If not specified, the
+  // default is 1KiB.
+  google.protobuf.UInt32Value max_buffered_tx_bytes = 3;
+
+  // Indicates whether taps produce a single buffered message per tap, or multiple streamed
+  // messages per tap in the emitted :ref:`TraceWrapper
+  // <envoy_api_msg_data.tap.v3alpha.TraceWrapper>` messages. Note that streamed tapping does not
+  // mean that no buffering takes place. Buffering may be required if data is processed before a
+  // match can be determined. See the HTTP tap filter :ref:`streaming
+  // <config_http_filters_tap_streaming>` documentation for more information.
+  bool streaming = 4;
+}
+
+// Tap output sink configuration.
+message OutputSink {
+  // Output format. All output is in the form of one or more :ref:`TraceWrapper
+  // <envoy_api_msg_data.tap.v3alpha.TraceWrapper>` messages. This enumeration indicates
+  // how those messages are written. Note that not all sinks support all output formats. See
+  // individual sink documentation for more information.
+  enum Format {
+    // Each message will be written as JSON. Any :ref:`body <envoy_api_msg_data.tap.v3alpha.Body>`
+    // data will be present in the :ref:`as_bytes
+    // <envoy_api_field_data.tap.v3alpha.Body.as_bytes>` field. This means that body data will be
+    // base64 encoded as per the `proto3 JSON mappings
+    // <https://developers.google.com/protocol-buffers/docs/proto3#json>`_.
+    JSON_BODY_AS_BYTES = 0;
+
+    // Each message will be written as JSON. Any :ref:`body <envoy_api_msg_data.tap.v3alpha.Body>`
+    // data will be present in the :ref:`as_string
+    // <envoy_api_field_data.tap.v3alpha.Body.as_string>` field. This means that body data will be
+    // string encoded as per the `proto3 JSON mappings
+    // <https://developers.google.com/protocol-buffers/docs/proto3#json>`_. This format type is
+    // useful when it is known that that body is human readable (e.g., JSON over HTTP) and the
+    // user wishes to view it directly without being forced to base64 decode the body.
+    JSON_BODY_AS_STRING = 1;
+
+    // Binary proto format. Note that binary proto is not self-delimiting. If a sink writes
+    // multiple binary messages without any length information the data stream will not be
+    // useful. However, for certain sinks that are self-delimiting (e.g., one message per file)
+    // this output format makes consumption simpler.
+    PROTO_BINARY = 2;
+
+    // Messages are written as a sequence tuples, where each tuple is the message length encoded
+    // as a `protobuf 32-bit varint
+    // <https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.coded_stream>`_
+    // followed by the binary message. The messages can be read back using the language specific
+    // protobuf coded stream implementation to obtain the message length and the message.
+    PROTO_BINARY_LENGTH_DELIMITED = 3;
+
+    // Text proto format.
+    PROTO_TEXT = 4;
+  }
+
+  // Sink output format.
+  Format format = 1 [(validate.rules).enum.defined_only = true];
+
+  oneof output_sink_type {
+    option (validate.required) = true;
+
+    // Tap output will be streamed out the :http:post:`/tap` admin endpoint.
+    //
+    // .. attention::
+    //
+    //   It is only allowed to specify the streaming admin output sink if the tap is being
+    //   configured from the :http:post:`/tap` admin endpoint. Thus, if an extension has
+    //   been configured to receive tap configuration from some other source (e.g., static
+    //   file, XDS, etc.) configuring the streaming admin output type will fail.
+    StreamingAdminSink streaming_admin = 2;
+
+    // Tap output will be written to a file per tap sink.
+    FilePerTapSink file_per_tap = 3;
+
+    // [#not-implemented-hide:]
+    // GrpcService to stream data to. The format argument must be PROTO_BINARY.
+    StreamingGrpcSink streaming_grpc = 4;
+  }
+}
+
+// Streaming admin sink configuration.
+message StreamingAdminSink {
+}
+
+// The file per tap sink outputs a discrete file for every tapped stream.
+message FilePerTapSink {
+  // Path prefix. The output file will be of the form <path_prefix>_<id>.pb, where <id> is an
+  // identifier distinguishing the recorded trace for stream instances (the Envoy
+  // connection ID, HTTP stream ID, etc.).
+  string path_prefix = 1 [(validate.rules).string.min_bytes = 1];
+}
+
+// [#not-implemented-hide:] Streaming gRPC sink configuration sends the taps to an external gRPC
+// server.
+message StreamingGrpcSink {
+  // Opaque identifier, that will be sent back to the streaming grpc server.
+  string tap_id = 1;
+
+  // The gRPC server that hosts the Tap Sink Service.
+  envoy.api.v3alpha.core.GrpcService grpc_service = 2 [(validate.rules).message.required = true];
+}

--- a/api/envoy/service/tap/v3alpha/tap.proto
+++ b/api/envoy/service/tap/v3alpha/tap.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+import "envoy/api/v3alpha/core/base.proto";
+import "envoy/data/tap/v3alpha/wrapper.proto";
+
+package envoy.service.tap.v3alpha;
+
+import "validate/validate.proto";
+
+option java_outer_classname = "TapProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.tap.v3alpha";
+
+// [#protodoc-title: Tap Sink Service]
+
+// [#not-implemented-hide:] Stream message for the Tap API. Envoy will open a stream to the server
+// and stream taps without ever expecting a response.
+message StreamTapsRequest {
+  message Identifier {
+    // The node sending taps over the stream.
+    envoy.api.v3alpha.core.Node node = 1 [(validate.rules).message.required = true];
+    // The opaque identifier that was set in the :ref:`output config
+    // <envoy_api_field_service.tap.v3alpha.StreamingGrpcSink.tap_id>`.
+    string tap_id = 2;
+  }
+
+  // Identifier data effectively is a structured metadata. As a performance optimization this will
+  // only be sent in the first message on the stream.
+  Identifier identifier = 1;
+  // The trace id. this can be used to merge together a streaming trace. Note that the trace_id
+  // is not guaranteed to be spatially or temporally unique.
+  uint64 trace_id = 2;
+  // The trace data.
+  envoy.data.tap.v3alpha.TraceWrapper trace = 3;
+}
+
+// [#not-implemented-hide:]
+message StreamTapsResponse {
+}
+
+// [#not-implemented-hide:] A tap service to receive incoming taps. Envoy will call
+// StreamTaps to deliver captured taps to the server
+service TapSinkService {
+
+  // Envoy will connect and send StreamTapsRequest messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure. The server should
+  // disconnect if it expects Envoy to reconnect.
+  rpc StreamTaps(stream StreamTapsRequest) returns (StreamTapsResponse) {
+  }
+}

--- a/api/envoy/service/tap/v3alpha/tapds.proto
+++ b/api/envoy/service/tap/v3alpha/tapds.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+import "envoy/api/v3alpha/discovery.proto";
+import "envoy/service/tap/v3alpha/common.proto";
+import "validate/validate.proto";
+
+package envoy.service.tap.v3alpha;
+
+import "google/api/annotations.proto";
+
+option java_outer_classname = "TapDsProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.tap.v3alpha";
+
+// [#protodoc-title: Tap discovery service]
+
+// [#not-implemented-hide:] Tap discovery service.
+service TapDiscoveryService {
+  rpc StreamTapConfigs(stream envoy.api.v3alpha.DiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DiscoveryResponse) {
+  }
+
+  rpc DeltaTapConfigs(stream envoy.api.v3alpha.DeltaDiscoveryRequest)
+      returns (stream envoy.api.v3alpha.DeltaDiscoveryResponse) {
+  }
+
+  rpc FetchTapConfigs(envoy.api.v3alpha.DiscoveryRequest)
+      returns (envoy.api.v3alpha.DiscoveryResponse) {
+    option (google.api.http) = {
+      post: "/v2/discovery:tap_configs"
+      body: "*"
+    };
+  }
+}
+
+// [#not-implemented-hide:] A tap resource is essentially a tap configuration with a name
+// The filter TapDS config references this name.
+message TapResource {
+  // The name of the tap configuration.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Tap config to apply
+  TapConfig config = 2;
+}

--- a/api/envoy/service/trace/v3alpha/BUILD
+++ b/api/envoy/service/trace/v3alpha/BUILD
@@ -1,0 +1,23 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "trace_service",
+    srcs = ["trace_service.proto"],
+    has_services = 1,
+    require_py = 0,
+    deps = [
+        "//envoy/api/v3alpha/core:base",
+        "@opencensus_proto//opencensus/proto/trace/v1:trace_proto",
+    ],
+)
+
+api_go_grpc_library(
+    name = "trace_service",
+    proto = ":trace_service",
+    deps = [
+        "//envoy/api/v3alpha/core:base_go_proto",
+        "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_go",
+    ],
+)

--- a/api/envoy/service/trace/v3alpha/trace_service.proto
+++ b/api/envoy/service/trace/v3alpha/trace_service.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+// [#proto-status: draft]
+
+package envoy.service.trace.v3alpha;
+
+option java_outer_classname = "TraceServiceProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.service.trace.v3alpha";
+option go_package = "v2";
+option java_generic_services = true;
+
+import "envoy/api/v3alpha/core/base.proto";
+import "opencensus/proto/trace/v1/trace.proto";
+
+import "google/api/annotations.proto";
+
+import "validate/validate.proto";
+
+// Service for streaming traces to server that consumes the trace data. It
+// uses OpenCensus data model as a standard to represent trace information.
+service TraceService {
+  // Envoy will connect and send StreamTracesMessage messages forever. It does
+  // not expect any response to be sent as nothing would be done in the case
+  // of failure.
+  rpc StreamTraces(stream StreamTracesMessage) returns (StreamTracesResponse) {
+  }
+}
+
+message StreamTracesResponse {
+}
+
+message StreamTracesMessage {
+  message Identifier {
+    // The node sending the access log messages over the stream.
+    envoy.api.v3alpha.core.Node node = 1 [(validate.rules).message.required = true];
+  }
+
+  // Identifier data effectively is a structured metadata.
+  // As a performance optimization this will only be sent in the first message
+  // on the stream.
+  Identifier identifier = 1;
+
+  // A list of Span entries
+  repeated opencensus.proto.trace.v1.Span spans = 2;
+}

--- a/api/migration/v3alpha.sh
+++ b/api/migration/v3alpha.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+./tools/api/clone.sh v2 v3alpha
+./tools/check_format.py fix

--- a/tools/api/clone.sh
+++ b/tools/api/clone.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Simple script to clone vM to vN API, performing sed-style heuristic fixup of
+# build paths and package references.
+#
+# Usage:
+#
+# ./tools/api/clone.sh v2 v3
+
+set -e
+
+declare -r OLD_VERSION="$1"
+declare -r NEW_VERSION="$2"
+
+function replace_build() {
+  sed -i -e "s#\(//$1[^\S]*\)/${OLD_VERSION}alpha#\1/${NEW_VERSION}#g" "$2"
+  sed -i -e "s#\(//$1[^\S]*\)/${OLD_VERSION}#\1/${NEW_VERSION}#g" "$2"
+}
+
+function replace_proto() {
+  sed -i -e "s#\($1\S*[\./]\)${OLD_VERSION}alpha#\1${NEW_VERSION}#g" "$2"
+  sed -i -e "s#\($1\S*[\./]\)${OLD_VERSION}#\1${NEW_VERSION}#g" "$2"
+}
+
+for p in $(find api/ -name "${OLD_VERSION}" -o -name "${OLD_VERSION}alpha")
+do
+  declare PACKAGE_ROOT="$(dirname "$p")"
+  declare OLD_VERSION_ROOT="${PACKAGE_ROOT}/${OLD_VERSION}"
+  declare NEW_VERSION_ROOT="${PACKAGE_ROOT}/${NEW_VERSION}"
+
+  # Deal with the situation where there is both vM and vMalpha, we only want vM.
+  if [[ -a "${OLD_VERSION_ROOT}" && "$p" != "${OLD_VERSION_ROOT}" ]]
+  then
+    continue
+  fi
+
+  # Copy BUILD and .protos across
+  rsync -a "${p}"/ "${NEW_VERSION_ROOT}/"
+
+  # Update BUILD files with vM -> vN
+  for b in $(find "${NEW_VERSION_ROOT}" -name BUILD)
+  do
+    replace_build envoy "$b"
+  done
+
+  # Update .proto files with vM -> vN
+  for f in $(find "${NEW_VERSION_ROOT}" -name "*.proto")
+  do
+    replace_proto envoy "$f"
+    replace_proto api "$f"
+    replace_proto service "$f"
+    replace_proto common "$f"
+    replace_proto config "$f"
+    replace_proto filter "$f"
+  done
+done

--- a/tools/api/clone.sh
+++ b/tools/api/clone.sh
@@ -12,16 +12,22 @@ set -e
 declare -r OLD_VERSION="$1"
 declare -r NEW_VERSION="$2"
 
+# For vM -> vN, replace //$1*/vMalpha with //$1*/vN in BUILD file $2
+# For vM -> vN, replace //$1*/vM with //$1*/vN in BUILD file $2
 function replace_build() {
   sed -i -e "s#\(//$1[^\S]*\)/${OLD_VERSION}alpha#\1/${NEW_VERSION}#g" "$2"
   sed -i -e "s#\(//$1[^\S]*\)/${OLD_VERSION}#\1/${NEW_VERSION}#g" "$2"
 }
 
+# For vM -> vN, replace $1*[./]vMalpha with $1*[./]vN in .proto file $2
+# For vM -> vN, replace $1*[./]vM with $1*[./]vN in .proto file $2
 function replace_proto() {
   sed -i -e "s#\($1\S*[\./]\)${OLD_VERSION}alpha#\1${NEW_VERSION}#g" "$2"
   sed -i -e "s#\($1\S*[\./]\)${OLD_VERSION}#\1${NEW_VERSION}#g" "$2"
 }
 
+# We consider both {vM, vMalpha} to deal with the multiple possible combinations
+# of {vM, vMalpha} existence for a given package.
 for p in $(find api/ -name "${OLD_VERSION}" -o -name "${OLD_VERSION}alpha")
 do
   declare PACKAGE_ROOT="$(dirname "$p")"


### PR DESCRIPTION
This patch establishes a v3alpha baseline API, by doing a simple copy of
v2[alpha] dirs and some sed-style heuristic fixups of BUILD dependencies
and proto package namespaces.

The objective is provide a baseline which we can compare the output from
tooling described in #8083 in later PRs, providing smaller visual diffs.

The core philosophy of the API migration is that every step will be
captured in a script (at least until the last manual steps),
api/migration/v3alpha.sh. This script will capture deterministic
migration steps, allowing v2[alpha] to continue to be updated until we
finalize v3.

There is likely to be significant changes, e.g. in addition to the work
scoped for v3, we might want to reduce the amount of API churn by
referring back to v2 protos where it makes sense. This will be done via
tooling in later PRs.

Part of #8083.

Risk level: Low
Testing: build @envoy_api//...

Signed-off-by: Harvey Tuch <htuch@google.com>