### PR TITLE
protodoc: single source-of-truth for doc protos.

### DIFF
--- a/api/CONTRIBUTING.md
+++ b/api/CONTRIBUTING.md
@@ -8,7 +8,7 @@ API changes are regular PRs in https://github.com/envoyproxy/envoy for the API/c
 changes. They may be as part of a larger implementation PR. Please follow the standard Bazel and CI
 process for validating build/test sanity of `api/` before submitting a PR.
 
-*Note: New .proto files should be also included to [build.sh](https://github.com/envoyproxy/envoy/blob/master/docs/build.sh) and
+*Note: New .proto files should be added to
 [BUILD](https://github.com/envoyproxy/envoy/blob/master/api/docs/BUILD) in order to get the RSTs generated.*
 
 ## Documentation changes

--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -7,8 +7,7 @@ package_group(
     ],
 )
 
-# TODO(htuch): Grow this to cover everything we want to generate docs for, so we can just invoke
-# bazel build //docs:protos --aspects tools/protodoc/protodoc.bzl%proto_doc_aspect  --output_groups=rst
+# This is where you add protos that will participate in docs RST generation.
 proto_library(
     name = "protos",
     deps = [
@@ -94,8 +93,6 @@ proto_library(
         "//envoy/service/auth/v2:external_auth",
         "//envoy/service/discovery/v2:ads",
         "//envoy/service/discovery/v2:rtds",
-        "//envoy/service/load_stats/v2:lrs",
-        "//envoy/service/metrics/v2:metrics_service",
         "//envoy/service/ratelimit/v2:rls",
         "//envoy/service/tap/v2alpha:common",
         "//envoy/type:percent",

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -50,7 +50,7 @@ bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
   tools/protodoc/protodoc.bzl%proto_doc_aspect --output_groups=rst --action_env=CPROFILE_ENABLED=1 \
   --action_env=ENVOY_BLOB_SHA --spawn_strategy=standalone --host_force_python=PY3
 
-declare -r DOC_PROTOS=$(bazel query  "deps(@envoy_api//docs:protos)"  | grep "^@envoy_api.*proto$")
+declare -r DOC_PROTOS=$(bazel query "deps(@envoy_api//docs:protos)" | grep "^@envoy_api.*proto$")
 
 # Only copy in the protos we care about and know how to deal with in protodoc.
 for p in ${DOC_PROTOS}

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -50,126 +50,19 @@ bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
   tools/protodoc/protodoc.bzl%proto_doc_aspect --output_groups=rst --action_env=CPROFILE_ENABLED \
   --action_env=ENVOY_BLOB_SHA --spawn_strategy=standalone --host_force_python=PY2
 
-# These are the protos we want to put in docs, this list will grow.
-# TODO(htuch): Factor this out of this script.
-PROTO_RST="
-  /envoy/admin/v2alpha/certs/envoy/admin/v2alpha/certs.proto.rst
-  /envoy/admin/v2alpha/clusters/envoy/admin/v2alpha/clusters.proto.rst
-  /envoy/admin/v2alpha/config_dump/envoy/admin/v2alpha/config_dump.proto.rst
-  /envoy/admin/v2alpha/listeners/envoy/admin/v2alpha/listeners.proto.rst
-  /envoy/admin/v2alpha/memory/envoy/admin/v2alpha/memory.proto.rst
-  /envoy/admin/v2alpha/clusters/envoy/admin/v2alpha/metrics.proto.rst
-  /envoy/admin/v2alpha/mutex_stats/envoy/admin/v2alpha/mutex_stats.proto.rst
-  /envoy/admin/v2alpha/server_info/envoy/admin/v2alpha/server_info.proto.rst
-  /envoy/admin/v2alpha/tap/envoy/admin/v2alpha/tap.proto.rst
-  /envoy/api/v2/core/address/envoy/api/v2/core/address.proto.rst
-  /envoy/api/v2/core/base/envoy/api/v2/core/base.proto.rst
-  /envoy/api/v2/core/http_uri/envoy/api/v2/core/http_uri.proto.rst
-  /envoy/api/v2/core/config_source/envoy/api/v2/core/config_source.proto.rst
-  /envoy/api/v2/core/grpc_service/envoy/api/v2/core/grpc_service.proto.rst
-  /envoy/api/v2/core/health_check/envoy/api/v2/core/health_check.proto.rst
-  /envoy/api/v2/core/protocol/envoy/api/v2/core/protocol.proto.rst
-  /envoy/api/v2/discovery/envoy/api/v2/discovery.proto.rst
-  /envoy/api/v2/auth/cert/envoy/api/v2/auth/cert.proto.rst
-  /envoy/api/v2/eds/envoy/api/v2/eds.proto.rst
-  /envoy/api/v2/endpoint/endpoint/envoy/api/v2/endpoint/endpoint.proto.rst
-  /envoy/api/v2/cds/envoy/api/v2/cds.proto.rst
-  /envoy/api/v2/cluster/outlier_detection/envoy/api/v2/cluster/outlier_detection.proto.rst
-  /envoy/api/v2/cluster/circuit_breaker/envoy/api/v2/cluster/circuit_breaker.proto.rst
-  /envoy/api/v2/cluster/filter/envoy/api/v2/cluster/filter.proto.rst
-  /envoy/api/v2/rds/envoy/api/v2/rds.proto.rst
-  /envoy/api/v2/route/route/envoy/api/v2/route/route.proto.rst
-  /envoy/api/v2/srds/envoy/api/v2/srds.proto.rst
-  /envoy/api/v2/lds/envoy/api/v2/lds.proto.rst
-  /envoy/api/v2/listener/listener/envoy/api/v2/listener/listener.proto.rst
-  /envoy/api/v2/listener/udp_listener_config/envoy/api/v2/listener/udp_listener_config.proto.rst
-  /envoy/api/v2/ratelimit/ratelimit/envoy/api/v2/ratelimit/ratelimit.proto.rst
-  /envoy/config/accesslog/v2/als/envoy/config/accesslog/v2/als.proto.rst
-  /envoy/config/accesslog/v2/file/envoy/config/accesslog/v2/file.proto.rst
-  /envoy/config/bootstrap/v2/bootstrap/envoy/config/bootstrap/v2/bootstrap.proto.rst
-  /envoy/config/cluster/dynamic_forward_proxy/v2alpha/cluster/envoy/config/cluster/dynamic_forward_proxy/v2alpha/cluster.proto.rst
-  /envoy/config/cluster/redis/redis_cluster/envoy/config/cluster/redis/redis_cluster.proto.rst
-  /envoy/config/common/dynamic_forward_proxy/v2alpha/dns_cache/envoy/config/common/dynamic_forward_proxy/v2alpha/dns_cache.proto.rst
-  /envoy/config/common/tap/v2alpha/common/envoy/config/common/tap/v2alpha/common.proto.rst
-  /envoy/config/ratelimit/v2/rls/envoy/config/ratelimit/v2/rls.proto.rst
-  /envoy/config/metrics/v2/metrics_service/envoy/config/metrics/v2/metrics_service.proto.rst
-  /envoy/config/metrics/v2/stats/envoy/config/metrics/v2/stats.proto.rst
-  /envoy/config/trace/v2/trace/envoy/config/trace/v2/trace.proto.rst
-  /envoy/config/filter/accesslog/v2/accesslog/envoy/config/filter/accesslog/v2/accesslog.proto.rst
-  /envoy/config/filter/fault/v2/fault/envoy/config/filter/fault/v2/fault.proto.rst
-  /envoy/config/filter/http/buffer/v2/buffer/envoy/config/filter/http/buffer/v2/buffer.proto.rst
-  /envoy/config/filter/http/csrf/v2/csrf/envoy/config/filter/http/csrf/v2/csrf.proto.rst
-  /envoy/config/filter/http/dynamic_forward_proxy/v2alpha/dynamic_forward_proxy/envoy/config/filter/http/dynamic_forward_proxy/v2alpha/dynamic_forward_proxy.proto.rst
-  /envoy/config/filter/http/ext_authz/v2/ext_authz/envoy/config/filter/http/ext_authz/v2/ext_authz.proto.rst
-  /envoy/config/filter/http/fault/v2/fault/envoy/config/filter/http/fault/v2/fault.proto.rst
-  /envoy/config/filter/http/gzip/v2/gzip/envoy/config/filter/http/gzip/v2/gzip.proto.rst
-  /envoy/config/filter/http/health_check/v2/health_check/envoy/config/filter/http/health_check/v2/health_check.proto.rst
-  /envoy/config/filter/http/header_to_metadata/v2/header_to_metadata/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.proto.rst
-  /envoy/config/filter/http/ip_tagging/v2/ip_tagging/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto.rst
-  /envoy/config/filter/http/jwt_authn/v2alpha/jwt_authn/envoy/config/filter/http/jwt_authn/v2alpha/config.proto.rst
-  /envoy/config/filter/http/lua/v2/lua/envoy/config/filter/http/lua/v2/lua.proto.rst
-  /envoy/config/filter/http/original_src/v2alpha1/original_src/envoy/config/filter/http/original_src/v2alpha1/original_src.proto.rst
-  /envoy/config/filter/http/rate_limit/v2/rate_limit/envoy/config/filter/http/rate_limit/v2/rate_limit.proto.rst
-  /envoy/config/filter/http/rbac/v2/rbac/envoy/config/filter/http/rbac/v2/rbac.proto.rst
-  /envoy/config/filter/http/router/v2/router/envoy/config/filter/http/router/v2/router.proto.rst
-  /envoy/config/filter/http/squash/v2/squash/envoy/config/filter/http/squash/v2/squash.proto.rst
-  /envoy/config/filter/http/tap/v2alpha/tap/envoy/config/filter/http/tap/v2alpha/tap.proto.rst
-  /envoy/config/filter/http/transcoder/v2/transcoder/envoy/config/filter/http/transcoder/v2/transcoder.proto.rst
-  /envoy/config/filter/listener/original_src/v2alpha1/original_src/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto.rst
-  /envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.proto.rst
-  /envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.proto.rst
-  /envoy/config/filter/dubbo/router/v2alpha1/router/envoy/config/filter/dubbo/router/v2alpha1/router.proto.rst
-  /envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.proto.rst
-  /envoy/config/filter/network/ext_authz/v2/ext_authz/envoy/config/filter/network/ext_authz/v2/ext_authz.proto.rst
-  /envoy/config/filter/network/http_connection_manager/v2/http_connection_manager/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto.rst
-  /envoy/config/filter/network/mongo_proxy/v2/mongo_proxy/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto.rst
-  /envoy/config/filter/network/rate_limit/v2/rate_limit/envoy/config/filter/network/rate_limit/v2/rate_limit.proto.rst
-  /envoy/config/filter/network/rbac/v2/rbac/envoy/config/filter/network/rbac/v2/rbac.proto.rst
-  /envoy/config/filter/network/redis_proxy/v2/redis_proxy/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto.rst
-  /envoy/config/filter/network/tcp_proxy/v2/tcp_proxy/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto.rst
-  /envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.proto.rst
-  /envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto.rst
-  /envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.proto.rst
-  /envoy/config/filter/thrift/router/v2alpha1/router/envoy/config/filter/thrift/router/v2alpha1/router.proto.rst
-  /envoy/config/grpc_credential/v2alpha/aws_iam/envoy/config/grpc_credential/v2alpha/aws_iam.proto.rst
-  /envoy/config/health_checker/redis/v2/redis/envoy/config/health_checker/redis/v2/redis.proto.rst
-  /envoy/config/overload/v2alpha/overload/envoy/config/overload/v2alpha/overload.proto.rst
-  /envoy/config/rbac/v2/rbac/envoy/config/rbac/v2/rbac.proto.rst
-  /envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto.rst
-  /envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.proto.rst
-  /envoy/config/transport_socket/tap/v2alpha/tap/envoy/config/transport_socket/tap/v2alpha/tap.proto.rst
-  /envoy/data/accesslog/v2/accesslog/envoy/data/accesslog/v2/accesslog.proto.rst
-  /envoy/data/core/v2alpha/health_check_event/envoy/data/core/v2alpha/health_check_event.proto.rst
-  /envoy/data/tap/v2alpha/common/envoy/data/tap/v2alpha/common.proto.rst
-  /envoy/data/tap/v2alpha/transport/envoy/data/tap/v2alpha/transport.proto.rst
-  /envoy/data/tap/v2alpha/http/envoy/data/tap/v2alpha/http.proto.rst
-  /envoy/data/tap/v2alpha/wrapper/envoy/data/tap/v2alpha/wrapper.proto.rst
-  /envoy/data/cluster/v2alpha/outlier_detection_event/envoy/data/cluster/v2alpha/outlier_detection_event.proto.rst
-  /envoy/service/accesslog/v2/als/envoy/service/accesslog/v2/als.proto.rst
-  /envoy/service/auth/v2/external_auth/envoy/service/auth/v2/attribute_context.proto.rst
-  /envoy/service/auth/v2/external_auth/envoy/service/auth/v2/external_auth.proto.rst
-  /envoy/service/discovery/v2/rtds/envoy/service/discovery/v2/rtds.proto.rst
-  /envoy/service/ratelimit/v2/rls/envoy/service/ratelimit/v2/rls.proto.rst
-  /envoy/service/tap/v2alpha/common/envoy/service/tap/v2alpha/common.proto.rst
-  /envoy/type/http_status/envoy/type/http_status.proto.rst
-  /envoy/type/percent/envoy/type/percent.proto.rst
-  /envoy/type/range/envoy/type/range.proto.rst
-  /envoy/type/matcher/metadata/envoy/type/matcher/metadata.proto.rst
-  /envoy/type/matcher/value/envoy/type/matcher/value.proto.rst
-  /envoy/type/matcher/number/envoy/type/matcher/number.proto.rst
-  /envoy/type/matcher/regex/envoy/type/matcher/regex.proto.rst
-  /envoy/type/matcher/string/envoy/type/matcher/string.proto.rst
-"
-
-# Dump all the generated RST so they can be added to PROTO_RST easily.
-find -L bazel-bin/external/envoy_api -name "*.proto.rst"
+declare -r DOC_PROTOS=$(bazel query  "deps(@envoy_api//docs:protos)"  | grep "^@envoy_api.*proto$")
 
 # Only copy in the protos we care about and know how to deal with in protodoc.
-for p in $PROTO_RST
+for p in ${DOC_PROTOS}
 do
-  DEST="${GENERATED_RST_DIR}/api-v2/$(sed -e 's#/envoy\/.*/envoy/##' <<< "$p")"
+  declare PROTO_TARGET=$(bazel query "kind(proto_library, same_pkg_direct_rdeps($p))")
+  declare PROTO_TARGET_WITHOUT_PREFIX="${PROTO_TARGET#@envoy_api//}"
+  declare PROTO_TARGET_CANONICAL="${PROTO_TARGET_WITHOUT_PREFIX/:/\/}"
+  declare PROTO_FILE_WITHOUT_PREFIX="${p#@envoy_api//}"
+  declare PROTO_FILE_CANONICAL="${PROTO_FILE_WITHOUT_PREFIX/:/\/}"
+  declare DEST="${GENERATED_RST_DIR}/api-v2/${PROTO_FILE_CANONICAL#envoy/}".rst
   mkdir -p "$(dirname "${DEST}")"
-  cp -f bazel-bin/external/envoy_api/"${p}" "$(dirname "${DEST}")"
+  cp -f bazel-bin/external/envoy_api/"${PROTO_TARGET_CANONICAL}/${PROTO_FILE_CANONICAL}.rst" "$(dirname "${DEST}")"
   [ -n "${CPROFILE_ENABLED}" ] && cp -f bazel-bin/"${p}".profile "$(dirname "${DEST}")"
 done
 

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -713,8 +713,11 @@ def Main():
   response = plugin_pb2.CodeGeneratorResponse()
   cprofile_enabled = os.getenv('CPROFILE_ENABLED')
 
+  # We use file_to_generate rather than proto_file here since we are invoked
+  # inside a Bazel aspect, each node in the DAG will be visited once by the
+  # aspect and we only want to generate docs for the current node.
   for file_to_generate in request.file_to_generate:
-    # Find the FileDescriptorProto for the file we actually are generating
+    # Find the FileDescriptorProto for the file we actually are generating.
     proto_file = None
     for pf in request.proto_file:
       if pf.name == file_to_generate:

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -713,7 +713,14 @@ def Main():
   response = plugin_pb2.CodeGeneratorResponse()
   cprofile_enabled = os.getenv('CPROFILE_ENABLED')
 
-  for proto_file in request.proto_file:
+  for file_to_generate in request.file_to_generate:
+    # Find the FileDescriptorProto for the file we actually are generating
+    proto_file = None
+    for pf in request.proto_file:
+      if pf.name == file_to_generate:
+        proto_file = pf
+        break
+    assert(proto_file is not None)
     f = response.file.add()
     f.name = proto_file.name + '.rst'
     if cprofile_enabled:

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -720,7 +720,7 @@ def Main():
       if pf.name == file_to_generate:
         proto_file = pf
         break
-    assert(proto_file is not None)
+    assert (proto_file is not None)
     f = response.file.add()
     f.name = proto_file.name + '.rst'
     if cprofile_enabled:


### PR DESCRIPTION
This avoids having to list new docs protos in both docs/build.sh and
api/docs/BUILD. This technical debt cleanup is helpful in v3 proto work
to simplify collecting proto artifacts from a Bazel aspect.

Risk level: Low
Testing: docs/build.sh, visual inspection of docs.

Signed-off-by: Harvey Tuch <htuch@google.com>