### PR TITLE
Make SlotImpl detachable from its owner, and add a new runOnAllThreads interface to Slot.

### DIFF
--- a/include/envoy/thread_local/thread_local.h
+++ b/include/envoy/thread_local/thread_local.h
@@ -74,6 +74,16 @@ public:
    */
   using InitializeCb = std::function<ThreadLocalObjectSharedPtr(Event::Dispatcher& dispatcher)>;
   virtual void set(InitializeCb cb) PURE;
+
+  // UpdateCb takes the current stored data, and returns an updated/new version data.
+  // TLS will run the callback and replace the stored data with the returned value *in each thread*.
+  // NOTE: The update callback is not supposed to capture the Slot, or its owner. As the owner may
+  // be destructed in main thread before the update_cb gets called in a worker thread.
+  //
+  using UpdateCb = std::function<ThreadLocalObjectSharedPtr(ThreadLocalObjectSharedPtr)>;
+  virtual void runOnAllThreads(const UpdateCb&& update_cb) PURE;
+
+  virtual void runOnAllThreads(const UpdateCb&& update_cb, Event::PostCb complete_cb) PURE;
 };
 
 using SlotPtr = std::unique_ptr<Slot>;

--- a/source/common/config/config_provider_impl.h
+++ b/source/common/config/config_provider_impl.h
@@ -219,16 +219,7 @@ protected:
    * @param complete_cb the callback to run when the update propagation is done.
    */
   void applyConfigUpdate(
-      const ConfigUpdateCb& update_fn, const Event::PostCb& complete_cb = []() {}) {
-    tls_->runOnAllThreads(
-        [this, update_fn]() {
-          // NOTE: there is a known race condition between *this* subscription being teared down in
-          // main thread and the posted callback being executed before the destruction. See more
-          // details in https://github.com/envoyproxy/envoy/issues/7902
-          tls_->getTyped<ThreadLocalConfig>().config_ = update_fn(getConfig());
-        },
-        complete_cb);
-  }
+      const ConfigUpdateCb& update_fn, const Event::PostCb& complete_cb = []() {});
 
   void setLastUpdated() { last_updated_ = time_source_.systemTime(); }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -199,8 +199,11 @@ Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() {
 void RdsRouteConfigProviderImpl::onConfigUpdate() {
   ConfigConstSharedPtr new_config(
       new ConfigImpl(config_update_info_->routeConfiguration(), factory_context_, false));
-  tls_->runOnAllThreads(
-      [this, new_config]() -> void { tls_->getTyped<ThreadLocalConfig>().config_ = new_config; });
+  tls_->runOnAllThreads([new_config](ThreadLocal::ThreadLocalObjectSharedPtr previous)
+                            -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    static_cast<ThreadLocalConfig*>(previous.get())->config_ = new_config;
+    return previous;
+  });
 }
 
 void RdsRouteConfigProviderImpl::validateConfig(

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -27,8 +27,9 @@ SlotPtr InstanceImpl::allocateSlot() {
 
   if (free_slot_indexes_.empty()) {
     std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, slots_.size()));
-    slots_.push_back(slot.get());
-    return slot;
+    auto wrapper = std::make_unique<Bookkeeper>(*this, std::move(slot));
+    slots_.push_back(&wrapper->slot());
+    return wrapper;
   }
   const uint32_t idx = free_slot_indexes_.front();
   free_slot_indexes_.pop_front();
@@ -41,10 +42,48 @@ SlotPtr InstanceImpl::allocateSlot() {
 bool InstanceImpl::SlotImpl::currentThreadRegistered() {
   return thread_local_data_.data_.size() > index_;
 }
+void InstanceImpl::SlotImpl::runOnAllThreads(const UpdateCb&& cb) {
+  parent_.runOnAllThreads([this, cb = std::move(cb)]() { setThreadLocal(index_, cb(get())); });
+}
+
+void InstanceImpl::SlotImpl::runOnAllThreads(const UpdateCb&& cb, Event::PostCb complete_cb) {
+  parent_.runOnAllThreads([this, cb = std::move(cb)]() { setThreadLocal(index_, cb(get())); },
+                          complete_cb);
+}
 
 ThreadLocalObjectSharedPtr InstanceImpl::SlotImpl::get() {
   ASSERT(currentThreadRegistered());
   return thread_local_data_.data_[index_];
+}
+
+InstanceImpl::Bookkeeper::Bookkeeper(InstanceImpl& parent, std::unique_ptr<SlotImpl>&& slot)
+    : parent_(parent), holder_(std::make_unique<SlotHolder>(std::move(slot))) {}
+
+ThreadLocalObjectSharedPtr InstanceImpl::Bookkeeper::get() { return slot().get(); }
+void InstanceImpl::Bookkeeper::runOnAllThreads(const UpdateCb&& cb, Event::PostCb complete_cb) {
+  slot().runOnAllThreads([cb = std::move(cb), ref_count = holder_->ref_count_](
+                             ThreadLocalObjectSharedPtr previous) { return cb(previous); },
+                         complete_cb);
+}
+void InstanceImpl::Bookkeeper::runOnAllThreads(const UpdateCb&& cb) {
+  slot().runOnAllThreads([cb = std::move(cb), ref_count = holder_->ref_count_](
+                             ThreadLocalObjectSharedPtr previous) { return cb(previous); });
+}
+bool InstanceImpl::Bookkeeper::currentThreadRegistered() {
+  return slot().currentThreadRegistered();
+}
+void InstanceImpl::Bookkeeper::runOnAllThreads(Event::PostCb cb) {
+  // Use holder_.ref_count_ to bookkeep how many on-the-fly callback are out there.
+  slot().runOnAllThreads([cb, ref_count = holder_->ref_count_]() { cb(); });
+}
+void InstanceImpl::Bookkeeper::runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) {
+  // Use holder_.ref_count_ to bookkeep how many on-the-fly callback are out there.
+  slot().runOnAllThreads([cb, main_callback, ref_count = holder_->ref_count_]() { cb(); },
+                         main_callback);
+}
+void InstanceImpl::Bookkeeper::set(InitializeCb cb) {
+  slot().set([cb, ref_count = holder_->ref_count_](Event::Dispatcher& dispatcher)
+                 -> ThreadLocalObjectSharedPtr { return cb(dispatcher); });
 }
 
 void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_thread) {
@@ -59,6 +98,32 @@ void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_threa
     registered_threads_.push_back(dispatcher);
     dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
   }
+}
+void InstanceImpl::recycle(std::unique_ptr<SlotHolder>&& holder) {
+  if (holder->isRecycleable()) {
+    holder.reset();
+    return;
+  }
+  deferred_deletes_.emplace_back(std::move(holder));
+  scheduleCleanup();
+}
+
+void InstanceImpl::scheduleCleanup() {
+  ASSERT(main_thread_dispatcher_ != nullptr);
+  if (shutdown_) {
+    return;
+  }
+  if (deferred_deletes_.empty()) {
+    return;
+  }
+  main_thread_dispatcher_->post([this]() {
+    deferred_deletes_.remove_if(
+        [](std::unique_ptr<SlotHolder>& holder) -> bool { return holder->isRecycleable(); });
+    if (!deferred_deletes_.empty()) {
+      // Recursively.
+      scheduleCleanup();
+    }
+  });
 }
 
 void InstanceImpl::removeSlot(SlotImpl& slot) {

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -32,9 +32,17 @@ private:
     SlotImpl(InstanceImpl& parent, uint64_t index) : parent_(parent), index_(index) {}
     ~SlotImpl() override { parent_.removeSlot(*this); }
 
+    // non copyable, non moveable.
+    SlotImpl(const SlotImpl&) = delete;
+    SlotImpl(SlotImpl&&) = delete;
+    SlotImpl& operator=(const SlotImpl&) = delete;
+    SlotImpl& operator=(SlotImpl&&) = delete;
+
     // ThreadLocal::Slot
     ThreadLocalObjectSharedPtr get() override;
     bool currentThreadRegistered() override;
+    void runOnAllThreads(const UpdateCb&& cb) override;
+    void runOnAllThreads(const UpdateCb&& cb, Event::PostCb complete_cb) override;
     void runOnAllThreads(Event::PostCb cb) override { parent_.runOnAllThreads(cb); }
     void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override {
       parent_.runOnAllThreads(cb, main_callback);
@@ -45,17 +53,55 @@ private:
     const uint64_t index_;
   };
 
+  // A helper class for holding a SlotImpl and its bookkeeping shared_ptr which counts the number of
+  // update callbacks on-the-fly.
+  struct SlotHolder {
+    SlotHolder(std::unique_ptr<SlotImpl>&& slot) : slot_(std::move(slot)) {}
+    bool isRecycleable() { return ref_count_.use_count() == 1; }
+
+    std::unique_ptr<SlotImpl> slot_;
+    std::shared_ptr<int> ref_count_{new int(0)};
+  };
+
+  // A Wrapper of SlotImpl which on destruction returns the SlotImpl to the deferred delete queue
+  // (detaches it).
+  struct Bookkeeper : public Slot {
+    Bookkeeper(InstanceImpl& parent, std::unique_ptr<SlotImpl>&& slot);
+    ~Bookkeeper() { parent_.recycle(std::move(holder_)); }
+    SlotImpl& slot() { return *(holder_->slot_); }
+
+    // ThreadLocal::Slot
+    ThreadLocalObjectSharedPtr get() override;
+    void runOnAllThreads(const UpdateCb&& cb) override;
+    void runOnAllThreads(const UpdateCb&& cb, Event::PostCb complete_cb) override;
+    bool currentThreadRegistered() override;
+    void runOnAllThreads(Event::PostCb cb) override;
+    void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override;
+    void set(InitializeCb cb) override;
+
+    InstanceImpl& parent_;
+    std::unique_ptr<SlotHolder> holder_;
+  };
+
   struct ThreadLocalData {
     Event::Dispatcher* dispatcher_{};
     std::vector<ThreadLocalObjectSharedPtr> data_;
   };
 
+  void recycle(std::unique_ptr<SlotHolder>&& holder);
+  // Cleanup the deferred deletes queue.
+  void scheduleCleanup();
   void removeSlot(SlotImpl& slot);
   void runOnAllThreads(Event::PostCb cb);
   void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback);
   static void setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr object);
 
   static thread_local ThreadLocalData thread_local_data_;
+
+  // A queue for Slots that has to be deferred to delete due to out-going callbacks
+  // pointing to the Slot.
+  std::list<std::unique_ptr<SlotHolder>> deferred_deletes_;
+
   std::vector<SlotImpl*> slots_;
   // A list of index of freed slots.
   std::list<uint32_t> free_slot_indexes_;

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -85,6 +85,39 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   tls_.shutdownThread();
 }
 
+TEST_F(ThreadLocalInstanceImplTest, UpdateCallback) {
+  InSequence s;
+
+  SlotPtr slot = tls_.allocateSlot();
+
+  auto newer_version = std::make_shared<TestThreadLocalObject>();
+  bool update_called = false;
+
+  TestThreadLocalObject& object_ref = setObject(*slot);
+  auto update_cb = [&object_ref, &update_called,
+                    newer_version](ThreadLocalObjectSharedPtr obj) -> ThreadLocalObjectSharedPtr {
+    // The unit test setup have two dispatchers registered, but only one thread, this lambda will be
+    // called twice in the same thread.
+    if (!update_called) {
+      EXPECT_EQ(obj.get(), &object_ref);
+      update_called = true;
+    } else {
+      EXPECT_EQ(obj.get(), newer_version.get());
+    }
+
+    return newer_version;
+  };
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  EXPECT_CALL(object_ref, onDestroy());
+  EXPECT_CALL(*newer_version, onDestroy());
+  slot->runOnAllThreads(update_cb);
+
+  EXPECT_EQ(newer_version.get(), &slot->getTyped<TestThreadLocalObject>());
+
+  tls_.shutdownGlobalThreading();
+  tls_.shutdownThread();
+}
+
 // TODO(ramaraochavali): Run this test with real threads. The current issue in the unit
 // testing environment is, the post to main_dispatcher is not working as expected.
 

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -85,6 +85,7 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   tls_.shutdownThread();
 }
 
+// Test that the config passed into the update callback is the previous version stored in the slot.
 TEST_F(ThreadLocalInstanceImplTest, UpdateCallback) {
   InSequence s;
 

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -63,6 +63,16 @@ public:
     void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override {
       parent_.runOnAllThreads(cb, main_callback);
     }
+    void runOnAllThreads(const UpdateCb&& cb) override {
+      parent_.runOnAllThreads(
+          [cb = std::move(cb), this]() { parent_.data_[index_] = cb(parent_.data_[index_]); });
+    }
+    void runOnAllThreads(const UpdateCb&& cb, Event::PostCb main_callback) override {
+      parent_.runOnAllThreads(
+          [cb = std::move(cb), this]() { parent_.data_[index_] = cb(parent_.data_[index_]); },
+          main_callback);
+    }
+
     void set(InitializeCb cb) override { parent_.data_[index_] = cb(parent_.dispatcher_); }
 
     MockInstance& parent_;


### PR DESCRIPTION
Description:
See the issue in #7902, this PR is to make the SlotImpl detachable from its owner, by introducing a Booker object wraps around a SlotImpl,  which bookkeeps all the on-the-fly update callbacks. And on its destruction, if there are still on-the-fly callbacks, move the SlotImpl to an deferred-delete queue, instead of destructing the SlotImpl which may cause an SEGV error.

More importantly, introduce a new runOnAllThreads(ThreadLocal::UpdateCb cb) API to Slot, which requests a Slot Owner to not assume that the Slot or its owner will out-live (in Main thread) the fired on-the-fly update callbacks, and should not capture the Slot or its owner in the update_cb.

>Introducing an new runOnAllThreads(UpdateCb) api to Slot interface, for which a update callback is expected to receive the currently stored ThreadLocal object, the callback may update or return a new ThreadLocal object that will be stored in the slot.
>A Bookkeeper wraps around SlotImpl, which bookkeeps how many outgoing callbacks are on-the-fly. On its destruction been called in main thread, if the number doesn't go to zero, it will put the wrapped SlotImpl and its use count into a deffered delete queue.
>In TLS InstanceImpl, add a deferred delete queue, a scheduleCleanup method will post a callback to main dispatcher. The callback deletes SlotImpl from the deferred delete queue, and reschedule another cleanup if the queue is not empty.

> Picked RDS and config-providers-framework as examples to demonstrate that this change works. {i.e., changed from the runOnAllThreads(Event::PostCb) to the new runOnAllThreads(TLS::UpdateCb) interface. }

If the PR looks good, I will migrate existing (probably not all?)  call-sites of runOnAllThreads to the new form in a follow up PR. 


Risk Level: Medium
Testing: unit test 
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] #7902 