### PR TITLE
docs: add line on installing xcode for macOS build flow

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -65,6 +65,7 @@ for how to update or override dependencies.
     ```
     _notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`
 
+    XCode is also required to build Envoy on macOS.
     Envoy compiles and passes tests with the version of clang installed by XCode 9.3.0:
     Apple LLVM version 9.1.0 (clang-902.0.30).
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -133,8 +133,8 @@ The macOS CI build is part of the [CircleCI](https://circleci.com/gh/envoyproxy/
 Dependencies are installed by the `ci/mac_ci_setup.sh` script, via [Homebrew](https://brew.sh),
 which is pre-installed on the CircleCI macOS image. The dependencies are cached are re-installed
 on every build. The `ci/mac_ci_steps.sh` script executes the specific commands that
-build and test Envoy. If Envoy cannot be built (`error: /Library/Developer/CommandLineTools/usr/bin/libtool: no output file specified (specify with -o output)
-`), ensure that XCode is installed.
+build and test Envoy. If Envoy cannot be built (`error: /Library/Developer/CommandLineTools/usr/bin/libtool: no output file specified (specify with -o output)`),
+ensure that XCode is installed.
 
 # Coverity Scan Build Flow
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -133,7 +133,8 @@ The macOS CI build is part of the [CircleCI](https://circleci.com/gh/envoyproxy/
 Dependencies are installed by the `ci/mac_ci_setup.sh` script, via [Homebrew](https://brew.sh),
 which is pre-installed on the CircleCI macOS image. The dependencies are cached are re-installed
 on every build. The `ci/mac_ci_steps.sh` script executes the specific commands that
-build and test Envoy.
+build and test Envoy. If Envoy cannot be built (`error: /Library/Developer/CommandLineTools/usr/bin/libtool: no output file specified (specify with -o output)
+`), ensure that XCode is installed.
 
 # Coverity Scan Build Flow
 


### PR DESCRIPTION
Signed-off-by: Lisa Lu <lisalu@lyft.com>

Description: Because of rules_foreign_cc in bazelbuild, Envoy will not compile successfully when following the instructions in the build docs due to how the tools are referenced. One fix for this is installing Xcode from the App Store (see https://github.com/bazelbuild/rules_foreign_cc/issues/185).

Risk Level: Low
Testing: N/A (docs change)
Docs Changes: see Description
Release Notes: N/A
