### PR TITLE
docs: remove extraneous escape

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -58,9 +58,9 @@ do
   for p in $(bazel query "labels(srcs, ${PROTO_TARGET})" )
   do
     declare PROTO_TARGET_WITHOUT_PREFIX="${PROTO_TARGET#@envoy_api//}"
-    declare PROTO_TARGET_CANONICAL="${PROTO_TARGET_WITHOUT_PREFIX/:/\/}"
+    declare PROTO_TARGET_CANONICAL="${PROTO_TARGET_WITHOUT_PREFIX/://}"
     declare PROTO_FILE_WITHOUT_PREFIX="${p#@envoy_api//}"
-    declare PROTO_FILE_CANONICAL="${PROTO_FILE_WITHOUT_PREFIX/:/\/}"
+    declare PROTO_FILE_CANONICAL="${PROTO_FILE_WITHOUT_PREFIX/://}"
     declare DEST="${GENERATED_RST_DIR}/api-v2/${PROTO_FILE_CANONICAL#envoy/}".rst
     mkdir -p "$(dirname "${DEST}")"
     cp -f bazel-bin/external/envoy_api/"${PROTO_TARGET_CANONICAL}/${PROTO_FILE_CANONICAL}.rst" "$(dirname "${DEST}")"


### PR DESCRIPTION
Old versions of bash (e.g. on macOS) don't handle `${P/:/\/}` the same way as modern versions. In particular, the expanded parameter on macOS includes a backslash, causing subsequent use of the string as a filename to include a slash (/) instead of treating the slash as a directory separator. Both versions of bash accept `${P/://}` as a way to substitute : with /. Verified that this change does not alter the generated docs when running under Linux.

Risk Level: low
Testing: generated docs under linux & macOS
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
