### PR TITLE
Grpc transcoding: set content-type to json for tailer-only

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -356,11 +356,13 @@ void JsonTranscoderFilter::setDecoderFilterCallbacks(
 void JsonTranscoderFilter::encodeGrpcStatusMessage(Http::HeaderMap& trailers) {
   const absl::optional<Grpc::Status::GrpcStatus> grpc_status =
       Grpc::Common::getGrpcStatus(trailers);
-  if (grpc_status.value() == Grpc::Status::GrpcStatus::InvalidCode) {
-    response_headers_->Status()->value(enumToInt(Http::Code::ServiceUnavailable));
-  } else if (grpc_status) {
-    response_headers_->Status()->value(Grpc::Utility::grpcToHttpStatus(grpc_status.value()));
-    response_headers_->insertGrpcStatus().value(enumToInt(grpc_status.value()));
+  if (grpc_status) {
+    if (grpc_status.value() == Grpc::Status::GrpcStatus::InvalidCode) {
+      response_headers_->Status()->value(enumToInt(Http::Code::ServiceUnavailable));
+    } else {
+      response_headers_->Status()->value(Grpc::Utility::grpcToHttpStatus(grpc_status.value()));
+      response_headers_->insertGrpcStatus().value(enumToInt(grpc_status.value()));
+    }
   }
 
   const Http::HeaderEntry* grpc_message_header = trailers.GrpcMessage();

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -126,6 +126,7 @@ private:
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
   void buildResponseFromHttpBodyOutput(Http::HeaderMap& response_headers, Buffer::Instance& data);
   bool hasHttpBodyAsOutputType();
+  void encodeGrpcStatusMessage(Http::HeaderMap& trailers);
 
   JsonTranscoderConfig& config_;
   std::unique_ptr<google::grpc::transcoding::Transcoder> transcoder_;

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -527,7 +527,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, DeepStruct) {
       Http::TestHeaderMapImpl{
           {":method", "POST"}, {":path", "/echoStruct"}, {":authority", "host"}},
       createDeepJson(100, true), {}, {}, Status(),
-      Http::TestHeaderMapImpl{{":status", "503"}, {"content-type", "application/grpc"}}, "");
+      Http::TestHeaderMapImpl{{":status", "503"}, {"content-type", "application/json"}}, "");
 
   // The invalid deep struct is detected.
   testTranscoding<bookstore::EchoStructReqResp, bookstore::EchoStructReqResp>(


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Description:

Set the content-type as application/json for tailer only response. 

Risk Level: Low
Testing:  integration test.
Fixes https://github.com/envoyproxy/envoy/issues/5011

