### PR TITLE
hotrestart: remove dynamic_resources from config used by hotrestart_test

### DIFF
--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -79,27 +79,6 @@ static_resources:
             catch_all_route:
               cluster: redis
   clusters:
-  - name: cds
-    connect_timeout: 5s
-    hosts:
-    - socket_address:
-        address: {{ ip_loopback_address }}
-        port_value: 4
-    dns_lookup_family: "{{ dns_lookup_family }}"
-  - name: rds
-    connect_timeout: 5s
-    hosts:
-    - socket_address:
-        address: {{ ip_loopback_address }}
-        port_value: 4
-    dns_lookup_family: "{{ dns_lookup_family }}"
-  - name: lds
-    connect_timeout: 5s
-    hosts:
-    - socket_address:
-        address: {{ ip_loopback_address }}
-        port_value: 4
-    dns_lookup_family: "{{ dns_lookup_family }}"
   - name: cluster_1
     connect_timeout: 5s
     hosts:
@@ -141,19 +120,7 @@ static_resources:
         port_value: 4
     dns_lookup_family: "{{ dns_lookup_family }}"
     outlier_detection: {}
-dynamic_resources:
-  lds_config:
-    api_config_source:
-      api_type: REST
-      cluster_names:
-      - lds
-      refresh_delay: 30s
-  cds_config:
-    api_config_source:
-      api_type: REST
-      cluster_names:
-      - cds
-      refresh_delay: 30s
+dynamic_resources: {}
 cluster_manager: {}
 flags_path: "/invalid_flags"
 stats_sinks:


### PR DESCRIPTION
hotrestart: remove dynamic_resources from config used by hotrestart_test

Description:
In the server config file `test/config/integration/server.yaml` used by
//test/integration:hotrestart_test, `dynamic_resources` includes `lds_config`
and `cds_config` definitions, which use HTTP API to fetch config, but CDS and
LDS service do not exist, so the initial fetch will be failed with a
connection failure, then Envoy server continue startup.

Envoy server shouldn't continue startup because connection failure, see
issue #8046.

For this test, `dynamic_resources` is not needed, this change clean it up.

Signed-off-by: lhuang8 <lhuang8@ebay.com>

Risk Level: Minor