### PR TITLE
api: strip gogoproto annotations

### DIFF
--- a/api/bazel/BUILD
+++ b/api/bazel/BUILD
@@ -10,3 +10,12 @@ go_proto_compiler(
     valid_archive = False,
     visibility = ["//visibility:public"],
 )
+
+go_proto_compiler(
+    name = "pgv_plugin_gogo",
+    options = ["lang=gogo"],
+    plugin = "@com_envoyproxy_protoc_gen_validate//:protoc-gen-validate",
+    suffix = ".pb.validate.go",
+    valid_archive = False,
+    visibility = ["//visibility:public"],
+)

--- a/api/bazel/BUILD
+++ b/api/bazel/BUILD
@@ -10,12 +10,3 @@ go_proto_compiler(
     valid_archive = False,
     visibility = ["//visibility:public"],
 )
-
-go_proto_compiler(
-    name = "pgv_plugin_gogo",
-    options = ["lang=gogo"],
-    plugin = "@com_envoyproxy_protoc_gen_validate//:protoc-gen-validate",
-    suffix = ".pb.validate.go",
-    valid_archive = False,
-    visibility = ["//visibility:public"],
-)

--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -8,8 +8,6 @@ _CC_SUFFIX = "_cc"
 _CC_EXPORT_SUFFIX = "_export_cc"
 _GO_PROTO_SUFFIX = "_go_proto"
 _GO_IMPORTPATH_PREFIX = "github.com/envoyproxy/data-plane-api/api/"
-_GOGO_PROTO_SUFFIX = "_gogo_proto"
-_GOGO_IMPORTPATH_PREFIX = "github.com/envoyproxy/go-control-plane/"
 
 _COMMON_PROTO_DEPS = [
     "@com_google_protobuf//:any_proto",
@@ -157,9 +155,6 @@ def go_proto_mapping(dep):
         return _Suffix("@" + Label(dep).workspace_name + "//" + Label(dep).package + ":" + Label(dep).name, _GO_PROTO_SUFFIX)
     return mapped
 
-def gogo_proto_mapping(dep):
-    return _Suffix("@" + Label(dep).workspace_name + "//" + Label(dep).package + ":" + Label(dep).name, _GOGO_PROTO_SUFFIX)
-
 def api_proto_package(name = "pkg", srcs = [], deps = [], has_services = False, visibility = ["//visibility:public"]):
     if srcs == []:
         srcs = native.glob(["*.proto"])
@@ -191,17 +186,5 @@ def api_proto_package(name = "pkg", srcs = [], deps = [], has_services = False, 
             "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
             "@com_google_googleapis//google/api:annotations_go_proto",
             "@com_google_googleapis//google/rpc:status_go_proto",
-        ],
-    )
-
-    go_proto_library(
-        name = _Suffix(name, _GOGO_PROTO_SUFFIX),
-        compilers = ["@io_bazel_rules_go//proto:gogofast_proto", "//bazel:pgv_plugin_gogo"],
-        importpath = _Suffix(_GOGO_IMPORTPATH_PREFIX, native.package_name()),
-        proto = name,
-        visibility = ["//visibility:public"],
-        deps = [gogo_proto_mapping(dep) for dep in deps] + [
-            "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
-            "@io_istio_gogo_genproto//googleapis/google/rpc:go_default_library",
         ],
     )

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -19,11 +19,7 @@ def api_dependencies():
         name = "com_github_cncf_udpa",
         locations = REPOSITORY_LOCATIONS,
     )
-    envoy_http_archive(
-        name = "com_github_gogo_protobuf",
-        locations = REPOSITORY_LOCATIONS,
-        build_file_content = GOGOPROTO_BUILD_CONTENT,
-    )
+
     envoy_http_archive(
         name = "prometheus_metrics_model",
         locations = REPOSITORY_LOCATIONS,
@@ -43,61 +39,6 @@ def api_dependencies():
         locations = REPOSITORY_LOCATIONS,
         build_file_content = ZIPKINAPI_BUILD_CONTENT,
     )
-
-GOGOPROTO_BUILD_CONTENT = """
-load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-
-proto_library(
-    name = "gogo_proto",
-    srcs = [
-        "gogoproto/gogo.proto",
-    ],
-    deps = [
-        "@com_google_protobuf//:descriptor_proto",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "descriptor_go_proto",
-    importpath = "github.com/golang/protobuf/protoc-gen-go/descriptor",
-    proto = "@com_google_protobuf//:descriptor_proto",
-    visibility = ["//visibility:public"],
-)
-
-cc_proto_library(
-    name = "gogo_proto_cc",
-    srcs = [
-        "gogoproto/gogo.proto",
-    ],
-    default_runtime = "@com_google_protobuf//:protobuf",
-    protoc = "@com_google_protobuf//:protoc",
-    deps = ["@com_google_protobuf//:cc_wkt_protos"],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "gogo_proto_go",
-    importpath = "gogoproto",
-    proto = ":gogo_proto",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":descriptor_go_proto",
-    ],
-)
-
-py_proto_library(
-    name = "gogo_proto_py",
-    srcs = [
-        "gogoproto/gogo.proto",
-    ],
-    default_runtime = "@com_google_protobuf//:protobuf_python",
-    protoc = "@com_google_protobuf//:protoc",
-    visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:protobuf_python"],
-)
-"""
 
 PROMETHEUSMETRICS_BUILD_CONTENT = """
 load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")

--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -1,9 +1,6 @@
 BAZEL_SKYLIB_RELEASE = "0.8.0"
 BAZEL_SKYLIB_SHA256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e"
 
-GOGOPROTO_RELEASE = "1.2.1"
-GOGOPROTO_SHA256 = "99e423905ba8921e86817607a5294ffeedb66fdd4a85efce5eb2848f715fdb3a"
-
 OPENCENSUS_PROTO_GIT_SHA = "5cec5ea58c3efa81fa808f2bd38ce182da9ee731"  # Jul 25, 2019
 OPENCENSUS_PROTO_SHA256 = "faeb93f293ff715b0cb530d273901c0e2e99277b9ed1c0a0326bca9ec5774ad2"
 
@@ -44,11 +41,6 @@ REPOSITORY_LOCATIONS = dict(
         sha256 = UDPA_SHA256,
         strip_prefix = "udpa-" + UDPA_GIT_SHA,
         urls = ["https://github.com/cncf/udpa/archive/" + UDPA_GIT_SHA + ".tar.gz"],
-    ),
-    com_github_gogo_protobuf = dict(
-        sha256 = GOGOPROTO_SHA256,
-        strip_prefix = "protobuf-" + GOGOPROTO_RELEASE,
-        urls = ["https://github.com/gogo/protobuf/archive/v" + GOGOPROTO_RELEASE + ".tar.gz"],
     ),
     prometheus_metrics_model = dict(
         sha256 = PROMETHEUS_SHA,

--- a/api/envoy/admin/v2alpha/config_dump.proto
+++ b/api/envoy/admin/v2alpha/config_dump.proto
@@ -16,8 +16,6 @@ import "envoy/config/bootstrap/v2/bootstrap.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-import "gogoproto/gogo.proto";
-
 // [#protodoc-title: ConfigDump]
 
 // The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper

--- a/api/envoy/admin/v3alpha/config_dump.proto
+++ b/api/envoy/admin/v3alpha/config_dump.proto
@@ -16,8 +16,6 @@ import "envoy/config/bootstrap/v3alpha/bootstrap.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-import "gogoproto/gogo.proto";
-
 // [#protodoc-title: ConfigDump]
 
 // The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -14,9 +14,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Common TLS configuration]
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -28,10 +28,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {
@@ -127,8 +123,7 @@ message Cluster {
   EdsClusterConfig eds_cluster_config = 3;
 
   // The timeout for new network connections to hosts in the cluster.
-  google.protobuf.Duration connect_timeout = 4
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration connect_timeout = 4 [(validate.rules).duration.gt = {}];
 
   // Soft limit on size of the cluster’s connections read and write buffers. If
   // unspecified, an implementation defined default is applied (1MiB).
@@ -274,8 +269,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  google.protobuf.Duration dns_refresh_rate = 16
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration dns_refresh_rate = 16 [(validate.rules).duration.gt = {}];
 
   // Optional configuration for setting cluster's DNS refresh rate. If the value is set to true,
   // cluster's DNS refresh rate will be set to resource record's TTL which comes from DNS
@@ -333,8 +327,7 @@ message Cluster {
   // value defaults to 5000ms. For cluster types other than
   // :ref:`ORIGINAL_DST<envoy_api_enum_value_Cluster.DiscoveryType.ORIGINAL_DST>`
   // this setting is ignored.
-  google.protobuf.Duration cleanup_interval = 20
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration cleanup_interval = 20 [(validate.rules).duration.gt = {}];
 
   // Optional configuration used to bind newly established upstream connections.
   // This overrides any bind_config specified in the bootstrap proto.

--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -12,10 +12,6 @@ import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/wrappers.proto";
 
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-
 // [#protodoc-title: Circuit breakers]
 
 // :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be

--- a/api/envoy/api/v2/cluster/filter.proto
+++ b/api/envoy/api/v2/cluster/filter.proto
@@ -11,9 +11,6 @@ option ruby_package = "Envoy.Api.V2.ClusterNS";
 import "google/protobuf/any.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Upstream filters]
 //

--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Outlier detection]
 

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -11,9 +11,6 @@ import "envoy/api/v2/core/base.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Network addresses]
 
@@ -27,7 +24,6 @@ message Pipe {
 
 message SocketAddress {
   enum Protocol {
-    option (gogoproto.goproto_enum_prefix) = false;
     TCP = 0;
     // [#not-implemented-hide:]
     UDP = 1;

--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -13,12 +13,8 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 import "envoy/type/percent.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common types]
 
@@ -131,7 +127,6 @@ enum RoutingPriority {
 
 // HTTP request method.
 enum RequestMethod {
-  option (gogoproto.goproto_enum_prefix) = false;
   METHOD_UNSPECIFIED = 0;
   GET = 1;
   HEAD = 2;
@@ -247,7 +242,6 @@ message SocketOption {
     bytes buf_value = 5;
   }
   enum SocketState {
-    option (gogoproto.goproto_enum_prefix) = false;
     // Socket options are applied after socket creation but before binding the socket to a port
     STATE_PREBIND = 0;
     // Socket options are applied after binding the socket to a port but before calling listen()

--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Configuration sources]
 
@@ -56,11 +53,10 @@ message ApiConfigSource {
   repeated GrpcService grpc_services = 4;
 
   // For REST APIs, the delay between successive polls.
-  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration refresh_delay = 3;
 
   // For REST APIs, the request timeout. If not set, a default value of 1s will be used.
-  google.protobuf.Duration request_timeout = 5
-      [(validate.rules).duration.gt.seconds = 0, (gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 5 [(validate.rules).duration.gt.seconds = 0];
 
   // For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
   // rate limited.

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -14,9 +14,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/empty.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: gRPC services]
 

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -15,9 +15,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Health check]
 // * Health checking :ref:`architecture overview <arch_overview_health_checking>`.
@@ -27,22 +24,16 @@ option (gogoproto.equal_all) = true;
 message HealthCheck {
   // The time to wait for a health check response. If the timeout is reached the
   // health check attempt will be considered a failure.
-  google.protobuf.Duration timeout = 1 [
-    (validate.rules).duration = {
-      required: true,
-      gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
-  ];
+  google.protobuf.Duration timeout = 1 [(validate.rules).duration = {
+    required: true,
+    gt: {seconds: 0}
+  }];
 
   // The interval between health checks.
-  google.protobuf.Duration interval = 2 [
-    (validate.rules).duration = {
-      required: true,
-      gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
-  ];
+  google.protobuf.Duration interval = 2 [(validate.rules).duration = {
+    required: true,
+    gt: {seconds: 0}
+  }];
 
   // An optional jitter amount in milliseconds. If specified, Envoy will start health
   // checking after for a random time in ms between 0 and initial_jitter. This only

--- a/api/envoy/api/v2/core/http_uri.proto
+++ b/api/envoy/api/v2/core/http_uri.proto
@@ -7,11 +7,8 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 
 import "google/protobuf/duration.proto";
-import "gogoproto/gogo.proto";
 
 import "validate/validate.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP Service URI ]
 
@@ -48,7 +45,6 @@ message HttpUri {
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
   google.protobuf.Duration timeout = 3 [
     (validate.rules).duration.gte = {},
-    (validate.rules).duration.required = true,
-    (gogoproto.stdduration) = true
+    (validate.rules).duration.required = true
   ];
 }

--- a/api/envoy/api/v2/core/http_uri.proto
+++ b/api/envoy/api/v2/core/http_uri.proto
@@ -43,8 +43,6 @@ message HttpUri {
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
-  google.protobuf.Duration timeout = 3 [
-    (validate.rules).duration.gte = {},
-    (validate.rules).duration.required = true
-  ];
+  google.protobuf.Duration timeout = 3
+      [(validate.rules).duration.gte = {}, (validate.rules).duration.required = true];
 }

--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Protocol options]
 
@@ -27,7 +24,7 @@ message HttpProtocolOptions {
   // period in which there are no active requests. If not set, there is no idle timeout. When the
   // idle timeout is reached the connection will be closed. Note that request based timeouts mean
   // that HTTP/2 PINGs will not keep the connection alive.
-  google.protobuf.Duration idle_timeout = 1 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 1;
 }
 
 message Http1ProtocolOptions {

--- a/api/envoy/api/v2/discovery.proto
+++ b/api/envoy/api/v2/discovery.proto
@@ -10,10 +10,6 @@ import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common discovery API components]
 

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -15,12 +15,8 @@ import "envoy/type/percent.proto";
 import "google/api/annotations.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/duration.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: EDS]
 // Endpoint discovery :ref:`architecture overview <arch_overview_service_discovery_types_eds>`

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -13,9 +13,6 @@ import "envoy/api/v2/core/health_check.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Endpoints]
 

--- a/api/envoy/api/v2/endpoint/load_report.proto
+++ b/api/envoy/api/v2/endpoint/load_report.proto
@@ -13,7 +13,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // These are stats Envoy reports to GLB every so often. Report frequency is
 // defined by

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -19,9 +19,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Listener]
 // Listener :ref:`configuration overview <config_listeners>`
@@ -136,7 +133,7 @@ message Listener {
   // the accepted socket is closed without a connection being created unless
   // `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
   // timeout. If not specified, a default timeout of 15s is used.
-  google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration listener_filters_timeout = 15;
 
   // Whether a connection should be created when listener filters timeout. Default is false.
   //

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -17,9 +17,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Listener components]
 // Listener :ref:`configuration overview <config_listeners>`

--- a/api/envoy/api/v2/rds.proto
+++ b/api/envoy/api/v2/rds.proto
@@ -17,9 +17,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP route configuration]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -19,10 +19,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: HTTP route]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
@@ -602,7 +598,7 @@ message RouteAction {
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //   :ref:`retry overview <arch_overview_http_routing_retry>`.
-  google.protobuf.Duration timeout = 8 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 8;
 
   // Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
   // although the connection manager wide :ref:`stream_idle_timeout
@@ -622,7 +618,7 @@ message RouteAction {
   // fires, the stream is terminated with a 408 Request Timeout error code if no
   // upstream response header has been received, otherwise a stream reset
   // occurs.
-  google.protobuf.Duration idle_timeout = 24 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 24;
 
   // Indicates that the route has a retry policy. Note that if this is set,
   // it'll take precedence over the virtual host level retry policy entirely
@@ -732,7 +728,7 @@ message RouteAction {
       // If specified, a cookie with the TTL will be generated if the cookie is
       // not present. If the TTL is present and zero, the generated cookie will
       // be a session cookie.
-      google.protobuf.Duration ttl = 2 [(gogoproto.stdduration) = true];
+      google.protobuf.Duration ttl = 2;
 
       // The name of the path for the cookie. If no path is specified here, no path
       // will be set for the cookie.
@@ -811,7 +807,7 @@ message RouteAction {
   // :ref:`timeout <envoy_api_field_route.RouteAction.timeout>` or its default.
   // This can be used to prevent unexpected upstream request timeouts due to potentially long
   // time gaps between gRPC request and response in gRPC streaming mode.
-  google.protobuf.Duration max_grpc_timeout = 23 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration max_grpc_timeout = 23;
 
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
@@ -820,7 +816,7 @@ message RouteAction {
   // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
   // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
   // infinity).
-  google.protobuf.Duration grpc_timeout_offset = 28 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration grpc_timeout_offset = 28;
 
   // Allows enabling and disabling upgrades on a per-route basis.
   // This overrides any enabled/disabled upgrade filter chain specified in the
@@ -875,7 +871,7 @@ message RetryPolicy {
   //   Consequently, when using a :ref:`5xx <config_http_filters_router_x-envoy-retry-on>` based
   //   retry policy, a request that times out will not be retried as the total timeout budget
   //   would have been exhausted.
-  google.protobuf.Duration per_try_timeout = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration per_try_timeout = 3;
 
   message RetryPriority {
     string name = 1 [(validate.rules).string.min_bytes = 1];
@@ -919,20 +915,16 @@ message RetryPolicy {
     // than zero. Values less than 1 ms are rounded up to 1 ms.
     // See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion of Envoy's
     // back-off algorithm.
-    google.protobuf.Duration base_interval = 1 [
-      (validate.rules).duration = {
-        required: true,
-        gt: {seconds: 0}
-      },
-      (gogoproto.stdduration) = true
-    ];
+    google.protobuf.Duration base_interval = 1 [(validate.rules).duration = {
+      required: true,
+      gt: {seconds: 0}
+    }];
 
     // Specifies the maximum interval between retries. This parameter is optional, but must be
     // greater than or equal to the `base_interval` if set. The default is 10 times the
     // `base_interval`. See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion
     // of Envoy's back-off algorithm.
-    google.protobuf.Duration max_interval = 2
-        [(validate.rules).duration.gt = {seconds: 0}, (gogoproto.stdduration) = true];
+    google.protobuf.Duration max_interval = 2 [(validate.rules).duration.gt = {seconds: 0}];
   }
 
   // Specifies parameters that control retry back off. This parameter is optional, in which case the

--- a/api/envoy/api/v2/srds.proto
+++ b/api/envoy/api/v2/srds.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.api.v2;
 
 import "envoy/api/v2/discovery.proto";
-import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "validate/validate.proto";
 
@@ -11,7 +10,6 @@ option java_outer_classname = "SrdsProto";
 option java_package = "io.envoyproxy.envoy.api.v2";
 option java_multiple_files = true;
 option java_generic_services = true;
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP scoped routing configuration]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`

--- a/api/envoy/api/v3alpha/auth/cert.proto
+++ b/api/envoy/api/v3alpha/auth/cert.proto
@@ -14,9 +14,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Common TLS configuration]
 

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -28,10 +28,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {
@@ -127,8 +123,7 @@ message Cluster {
   EdsClusterConfig eds_cluster_config = 3;
 
   // The timeout for new network connections to hosts in the cluster.
-  google.protobuf.Duration connect_timeout = 4
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration connect_timeout = 4 [(validate.rules).duration.gt = {}];
 
   // Soft limit on size of the cluster’s connections read and write buffers. If
   // unspecified, an implementation defined default is applied (1MiB).
@@ -274,8 +269,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  google.protobuf.Duration dns_refresh_rate = 16
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration dns_refresh_rate = 16 [(validate.rules).duration.gt = {}];
 
   // Optional configuration for setting cluster's DNS refresh rate. If the value is set to true,
   // cluster's DNS refresh rate will be set to resource record's TTL which comes from DNS
@@ -333,8 +327,7 @@ message Cluster {
   // value defaults to 5000ms. For cluster types other than
   // :ref:`ORIGINAL_DST<envoy_api_enum_value_Cluster.DiscoveryType.ORIGINAL_DST>`
   // this setting is ignored.
-  google.protobuf.Duration cleanup_interval = 20
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration cleanup_interval = 20 [(validate.rules).duration.gt = {}];
 
   // Optional configuration used to bind newly established upstream connections.
   // This overrides any bind_config specified in the bootstrap proto.

--- a/api/envoy/api/v3alpha/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v3alpha/cluster/circuit_breaker.proto
@@ -12,10 +12,6 @@ import "envoy/api/v3alpha/core/base.proto";
 
 import "google/protobuf/wrappers.proto";
 
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-
 // [#protodoc-title: Circuit breakers]
 
 // :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be

--- a/api/envoy/api/v3alpha/cluster/filter.proto
+++ b/api/envoy/api/v3alpha/cluster/filter.proto
@@ -11,9 +11,6 @@ option ruby_package = "Envoy.Api.V2.ClusterNS";
 import "google/protobuf/any.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Upstream filters]
 //

--- a/api/envoy/api/v3alpha/cluster/outlier_detection.proto
+++ b/api/envoy/api/v3alpha/cluster/outlier_detection.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Outlier detection]
 

--- a/api/envoy/api/v3alpha/core/address.proto
+++ b/api/envoy/api/v3alpha/core/address.proto
@@ -11,9 +11,6 @@ import "envoy/api/v3alpha/core/base.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Network addresses]
 
@@ -27,7 +24,6 @@ message Pipe {
 
 message SocketAddress {
   enum Protocol {
-    option (gogoproto.goproto_enum_prefix) = false;
     TCP = 0;
     // [#not-implemented-hide:]
     UDP = 1;

--- a/api/envoy/api/v3alpha/core/base.proto
+++ b/api/envoy/api/v3alpha/core/base.proto
@@ -13,12 +13,8 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 import "envoy/type/percent.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common types]
 
@@ -131,7 +127,6 @@ enum RoutingPriority {
 
 // HTTP request method.
 enum RequestMethod {
-  option (gogoproto.goproto_enum_prefix) = false;
   METHOD_UNSPECIFIED = 0;
   GET = 1;
   HEAD = 2;
@@ -247,7 +242,6 @@ message SocketOption {
     bytes buf_value = 5;
   }
   enum SocketState {
-    option (gogoproto.goproto_enum_prefix) = false;
     // Socket options are applied after socket creation but before binding the socket to a port
     STATE_PREBIND = 0;
     // Socket options are applied after binding the socket to a port but before calling listen()

--- a/api/envoy/api/v3alpha/core/config_source.proto
+++ b/api/envoy/api/v3alpha/core/config_source.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Configuration sources]
 
@@ -56,11 +53,10 @@ message ApiConfigSource {
   repeated GrpcService grpc_services = 4;
 
   // For REST APIs, the delay between successive polls.
-  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration refresh_delay = 3;
 
   // For REST APIs, the request timeout. If not set, a default value of 1s will be used.
-  google.protobuf.Duration request_timeout = 5
-      [(validate.rules).duration.gt.seconds = 0, (gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 5 [(validate.rules).duration.gt.seconds = 0];
 
   // For GRPC APIs, the rate limit settings. If present, discovery requests made by Envoy will be
   // rate limited.

--- a/api/envoy/api/v3alpha/core/grpc_service.proto
+++ b/api/envoy/api/v3alpha/core/grpc_service.proto
@@ -14,9 +14,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/empty.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: gRPC services]
 

--- a/api/envoy/api/v3alpha/core/health_check.proto
+++ b/api/envoy/api/v3alpha/core/health_check.proto
@@ -24,20 +24,16 @@ import "validate/validate.proto";
 message HealthCheck {
   // The time to wait for a health check response. If the timeout is reached the
   // health check attempt will be considered a failure.
-  google.protobuf.Duration timeout = 1 [
-    (validate.rules).duration = {
-      required: true,
-      gt: {seconds: 0}
-    }
-  ];
+  google.protobuf.Duration timeout = 1 [(validate.rules).duration = {
+    required: true,
+    gt: {seconds: 0}
+  }];
 
   // The interval between health checks.
-  google.protobuf.Duration interval = 2 [
-    (validate.rules).duration = {
-      required: true,
-      gt: {seconds: 0}
-    }
-  ];
+  google.protobuf.Duration interval = 2 [(validate.rules).duration = {
+    required: true,
+    gt: {seconds: 0}
+  }];
 
   // An optional jitter amount in milliseconds. If specified, Envoy will start health
   // checking after for a random time in ms between 0 and initial_jitter. This only

--- a/api/envoy/api/v3alpha/core/health_check.proto
+++ b/api/envoy/api/v3alpha/core/health_check.proto
@@ -15,9 +15,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Health check]
 // * Health checking :ref:`architecture overview <arch_overview_health_checking>`.
@@ -31,8 +28,7 @@ message HealthCheck {
     (validate.rules).duration = {
       required: true,
       gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
+    }
   ];
 
   // The interval between health checks.
@@ -40,8 +36,7 @@ message HealthCheck {
     (validate.rules).duration = {
       required: true,
       gt: {seconds: 0}
-    },
-    (gogoproto.stdduration) = true
+    }
   ];
 
   // An optional jitter amount in milliseconds. If specified, Envoy will start health

--- a/api/envoy/api/v3alpha/core/http_uri.proto
+++ b/api/envoy/api/v3alpha/core/http_uri.proto
@@ -43,8 +43,6 @@ message HttpUri {
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
-  google.protobuf.Duration timeout = 3 [
-    (validate.rules).duration.gte = {},
-    (validate.rules).duration.required = true
-  ];
+  google.protobuf.Duration timeout = 3
+      [(validate.rules).duration.gte = {}, (validate.rules).duration.required = true];
 }

--- a/api/envoy/api/v3alpha/core/http_uri.proto
+++ b/api/envoy/api/v3alpha/core/http_uri.proto
@@ -7,11 +7,8 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.core";
 
 import "google/protobuf/duration.proto";
-import "gogoproto/gogo.proto";
 
 import "validate/validate.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP Service URI ]
 
@@ -48,7 +45,6 @@ message HttpUri {
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.
   google.protobuf.Duration timeout = 3 [
     (validate.rules).duration.gte = {},
-    (validate.rules).duration.required = true,
-    (gogoproto.stdduration) = true
+    (validate.rules).duration.required = true
   ];
 }

--- a/api/envoy/api/v3alpha/core/protocol.proto
+++ b/api/envoy/api/v3alpha/core/protocol.proto
@@ -12,9 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Protocol options]
 
@@ -27,7 +24,7 @@ message HttpProtocolOptions {
   // period in which there are no active requests. If not set, there is no idle timeout. When the
   // idle timeout is reached the connection will be closed. Note that request based timeouts mean
   // that HTTP/2 PINGs will not keep the connection alive.
-  google.protobuf.Duration idle_timeout = 1 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 1;
 }
 
 message Http1ProtocolOptions {

--- a/api/envoy/api/v3alpha/discovery.proto
+++ b/api/envoy/api/v3alpha/discovery.proto
@@ -10,10 +10,6 @@ import "envoy/api/v3alpha/core/base.proto";
 
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Common discovery API components]
 

--- a/api/envoy/api/v3alpha/eds.proto
+++ b/api/envoy/api/v3alpha/eds.proto
@@ -15,12 +15,8 @@ import "envoy/type/percent.proto";
 import "google/api/annotations.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/duration.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: EDS]
 // Endpoint discovery :ref:`architecture overview <arch_overview_service_discovery_types_eds>`

--- a/api/envoy/api/v3alpha/endpoint/endpoint.proto
+++ b/api/envoy/api/v3alpha/endpoint/endpoint.proto
@@ -13,9 +13,6 @@ import "envoy/api/v3alpha/core/health_check.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Endpoints]
 

--- a/api/envoy/api/v3alpha/endpoint/load_report.proto
+++ b/api/envoy/api/v3alpha/endpoint/load_report.proto
@@ -13,7 +13,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // These are stats Envoy reports to GLB every so often. Report frequency is
 // defined by

--- a/api/envoy/api/v3alpha/lds.proto
+++ b/api/envoy/api/v3alpha/lds.proto
@@ -19,9 +19,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Listener]
 // Listener :ref:`configuration overview <config_listeners>`
@@ -136,7 +133,7 @@ message Listener {
   // the accepted socket is closed without a connection being created unless
   // `continue_on_listener_filters_timeout` is set to true. Specify 0 to disable the
   // timeout. If not specified, a default timeout of 15s is used.
-  google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration listener_filters_timeout = 15;
 
   // Whether a connection should be created when listener filters timeout. Default is false.
   //

--- a/api/envoy/api/v3alpha/listener/listener.proto
+++ b/api/envoy/api/v3alpha/listener/listener.proto
@@ -17,9 +17,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Listener components]
 // Listener :ref:`configuration overview <config_listeners>`

--- a/api/envoy/api/v3alpha/rds.proto
+++ b/api/envoy/api/v3alpha/rds.proto
@@ -17,9 +17,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP route configuration]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`

--- a/api/envoy/api/v3alpha/route/route.proto
+++ b/api/envoy/api/v3alpha/route/route.proto
@@ -915,12 +915,10 @@ message RetryPolicy {
     // than zero. Values less than 1 ms are rounded up to 1 ms.
     // See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion of Envoy's
     // back-off algorithm.
-    google.protobuf.Duration base_interval = 1 [
-      (validate.rules).duration = {
-        required: true,
-        gt: {seconds: 0}
-      }
-    ];
+    google.protobuf.Duration base_interval = 1 [(validate.rules).duration = {
+      required: true,
+      gt: {seconds: 0}
+    }];
 
     // Specifies the maximum interval between retries. This parameter is optional, but must be
     // greater than or equal to the `base_interval` if set. The default is 10 times the

--- a/api/envoy/api/v3alpha/route/route.proto
+++ b/api/envoy/api/v3alpha/route/route.proto
@@ -19,10 +19,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: HTTP route]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
@@ -602,7 +598,7 @@ message RouteAction {
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //   :ref:`retry overview <arch_overview_http_routing_retry>`.
-  google.protobuf.Duration timeout = 8 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 8;
 
   // Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
   // although the connection manager wide :ref:`stream_idle_timeout
@@ -622,7 +618,7 @@ message RouteAction {
   // fires, the stream is terminated with a 408 Request Timeout error code if no
   // upstream response header has been received, otherwise a stream reset
   // occurs.
-  google.protobuf.Duration idle_timeout = 24 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 24;
 
   // Indicates that the route has a retry policy. Note that if this is set,
   // it'll take precedence over the virtual host level retry policy entirely
@@ -732,7 +728,7 @@ message RouteAction {
       // If specified, a cookie with the TTL will be generated if the cookie is
       // not present. If the TTL is present and zero, the generated cookie will
       // be a session cookie.
-      google.protobuf.Duration ttl = 2 [(gogoproto.stdduration) = true];
+      google.protobuf.Duration ttl = 2;
 
       // The name of the path for the cookie. If no path is specified here, no path
       // will be set for the cookie.
@@ -811,7 +807,7 @@ message RouteAction {
   // :ref:`timeout <envoy_api_field_route.RouteAction.timeout>` or its default.
   // This can be used to prevent unexpected upstream request timeouts due to potentially long
   // time gaps between gRPC request and response in gRPC streaming mode.
-  google.protobuf.Duration max_grpc_timeout = 23 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration max_grpc_timeout = 23;
 
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
@@ -820,7 +816,7 @@ message RouteAction {
   // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
   // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
   // infinity).
-  google.protobuf.Duration grpc_timeout_offset = 28 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration grpc_timeout_offset = 28;
 
   // Allows enabling and disabling upgrades on a per-route basis.
   // This overrides any enabled/disabled upgrade filter chain specified in the
@@ -875,7 +871,7 @@ message RetryPolicy {
   //   Consequently, when using a :ref:`5xx <config_http_filters_router_x-envoy-retry-on>` based
   //   retry policy, a request that times out will not be retried as the total timeout budget
   //   would have been exhausted.
-  google.protobuf.Duration per_try_timeout = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration per_try_timeout = 3;
 
   message RetryPriority {
     string name = 1 [(validate.rules).string.min_bytes = 1];
@@ -923,16 +919,14 @@ message RetryPolicy {
       (validate.rules).duration = {
         required: true,
         gt: {seconds: 0}
-      },
-      (gogoproto.stdduration) = true
+      }
     ];
 
     // Specifies the maximum interval between retries. This parameter is optional, but must be
     // greater than or equal to the `base_interval` if set. The default is 10 times the
     // `base_interval`. See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion
     // of Envoy's back-off algorithm.
-    google.protobuf.Duration max_interval = 2
-        [(validate.rules).duration.gt = {seconds: 0}, (gogoproto.stdduration) = true];
+    google.protobuf.Duration max_interval = 2 [(validate.rules).duration.gt = {seconds: 0}];
   }
 
   // Specifies parameters that control retry back off. This parameter is optional, in which case the

--- a/api/envoy/api/v3alpha/srds.proto
+++ b/api/envoy/api/v3alpha/srds.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.api.v3alpha;
 
 import "envoy/api/v3alpha/discovery.proto";
-import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "validate/validate.proto";
 
@@ -11,7 +10,6 @@ option java_outer_classname = "SrdsProto";
 option java_package = "io.envoyproxy.envoy.api.v3alpha";
 option java_multiple_files = true;
 option java_generic_services = true;
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: HTTP scoped routing configuration]
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`

--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -25,7 +25,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
 message Bootstrap {
@@ -103,8 +102,7 @@ message Bootstrap {
     (validate.rules).duration = {
       lt: {seconds: 300},
       gte: {nanos: 1000000}
-    },
-    (gogoproto.stdduration) = true
+    }
   ];
 
   // Optional watchdog configuration.

--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -98,12 +98,10 @@ message Bootstrap {
   // gauges at a periodic interval. If not specified the default is 5000ms (5
   // seconds).
   // Duration must be at least 1ms and at most 5 min.
-  google.protobuf.Duration stats_flush_interval = 7 [
-    (validate.rules).duration = {
-      lt: {seconds: 300},
-      gte: {nanos: 1000000}
-    }
-  ];
+  google.protobuf.Duration stats_flush_interval = 7 [(validate.rules).duration = {
+    lt: {seconds: 300},
+    gte: {nanos: 1000000}
+  }];
 
   // Optional watchdog configuration.
   Watchdog watchdog = 8;

--- a/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
@@ -25,7 +25,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
 message Bootstrap {
@@ -102,8 +101,7 @@ message Bootstrap {
     (validate.rules).duration = {
       lt: {seconds: 300},
       gte: {nanos: 1000000}
-    },
-    (gogoproto.stdduration) = true
+    }
   ];
 
   // Optional watchdog configuration.

--- a/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
@@ -97,12 +97,10 @@ message Bootstrap {
   // gauges at a periodic interval. If not specified the default is 5000ms (5
   // seconds).
   // Duration must be at least 1ms and at most 5 min.
-  google.protobuf.Duration stats_flush_interval = 7 [
-    (validate.rules).duration = {
-      lt: {seconds: 300},
-      gte: {nanos: 1000000}
-    }
-  ];
+  google.protobuf.Duration stats_flush_interval = 7 [(validate.rules).duration = {
+    lt: {seconds: 300},
+    gte: {nanos: 1000000}
+  }];
 
   // Optional watchdog configuration.
   Watchdog watchdog = 8;

--- a/api/envoy/config/cluster/redis/redis_cluster.proto
+++ b/api/envoy/config/cluster/redis/redis_cluster.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.cluster.redis";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Redis Cluster Configuration]
 // This cluster adds support for `Redis Cluster <https://redis.io/topics/cluster-spec>`_, as part
@@ -44,10 +43,8 @@ import "gogoproto/gogo.proto";
 
 message RedisClusterConfig {
   // Interval between successive topology refresh requests. If not set, this defaults to 5s.
-  google.protobuf.Duration cluster_refresh_rate = 1
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration cluster_refresh_rate = 1 [(validate.rules).duration.gt = {}];
 
   // Timeout for topology refresh request. If not set, this defaults to 3s.
-  google.protobuf.Duration cluster_refresh_timeout = 2
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration cluster_refresh_timeout = 2 [(validate.rules).duration.gt = {}];
 }

--- a/api/envoy/config/common/tap/v2alpha/common.proto
+++ b/api/envoy/config/common/tap/v2alpha/common.proto
@@ -4,7 +4,6 @@ import "envoy/service/tap/v2alpha/common.proto";
 import "envoy/api/v2/core/config_source.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 package envoy.config.common.tap.v2alpha;
 

--- a/api/envoy/config/common/tap/v3alpha/common.proto
+++ b/api/envoy/config/common/tap/v3alpha/common.proto
@@ -4,7 +4,6 @@ import "envoy/service/tap/v3alpha/common.proto";
 import "envoy/api/v3alpha/core/config_source.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 package envoy.config.common.tap.v3alpha;
 

--- a/api/envoy/config/filter/fault/v2/fault.proto
+++ b/api/envoy/config/filter/fault/v2/fault.proto
@@ -11,7 +11,6 @@ import "envoy/type/percent.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Common fault injection types]
 
@@ -43,8 +42,7 @@ message FaultDelay {
     // delay will be injected before a new request/operation. For TCP
     // connections, the proxying of the connection upstream will be delayed
     // for the specified period. This is required if type is FIXED.
-    google.protobuf.Duration fixed_delay = 3
-        [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+    google.protobuf.Duration fixed_delay = 3 [(validate.rules).duration.gt = {}];
 
     // Fault delays are controlled via an HTTP header (if applicable).
     HeaderDelay header_delay = 5;

--- a/api/envoy/config/filter/fault/v3alpha/fault.proto
+++ b/api/envoy/config/filter/fault/v3alpha/fault.proto
@@ -11,7 +11,6 @@ import "envoy/type/percent.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Common fault injection types]
 
@@ -43,8 +42,7 @@ message FaultDelay {
     // delay will be injected before a new request/operation. For TCP
     // connections, the proxying of the connection upstream will be delayed
     // for the specified period. This is required if type is FIXED.
-    google.protobuf.Duration fixed_delay = 3
-        [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+    google.protobuf.Duration fixed_delay = 3 [(validate.rules).duration.gt = {}];
 
     // Fault delays are controlled via an HTTP header (if applicable).
     HeaderDelay header_delay = 5;

--- a/api/envoy/config/filter/http/buffer/v2/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v2/buffer.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.buffer.v2";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Buffer]
 // Buffer :ref:`configuration overview <config_http_filters_buffer>`.

--- a/api/envoy/config/filter/http/buffer/v3alpha/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v3alpha/buffer.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.buffer.v3alpha";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Buffer]
 // Buffer :ref:`configuration overview <config_http_filters_buffer>`.

--- a/api/envoy/config/filter/http/csrf/v2/csrf.proto
+++ b/api/envoy/config/filter/http/csrf/v2/csrf.proto
@@ -10,7 +10,6 @@ import "envoy/api/v2/core/base.proto";
 import "envoy/type/matcher/string.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: CSRF]
 // Cross-Site Request Forgery :ref:`configuration overview <config_http_filters_csrf>`.

--- a/api/envoy/config/filter/http/csrf/v3alpha/csrf.proto
+++ b/api/envoy/config/filter/http/csrf/v3alpha/csrf.proto
@@ -10,7 +10,6 @@ import "envoy/api/v3alpha/core/base.proto";
 import "envoy/type/matcher/string.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: CSRF]
 // Cross-Site Request Forgery :ref:`configuration overview <config_http_filters_csrf>`.

--- a/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -14,9 +14,6 @@ import "envoy/type/http_status.proto";
 import "envoy/type/matcher/string.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: External Authorization]
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.

--- a/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.proto
@@ -14,9 +14,6 @@ import "envoy/type/http_status.proto";
 import "envoy/type/matcher/string.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: External Authorization]
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.

--- a/api/envoy/config/filter/http/gzip/v2/gzip.proto
+++ b/api/envoy/config/filter/http/gzip/v2/gzip.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.gzip.v2";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Gzip]
 // Gzip :ref:`configuration overview <config_http_filters_gzip>`.

--- a/api/envoy/config/filter/http/gzip/v3alpha/gzip.proto
+++ b/api/envoy/config/filter/http/gzip/v3alpha/gzip.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.gzip.v3alpha";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Gzip]
 // Gzip :ref:`configuration overview <config_http_filters_gzip>`.

--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -13,9 +13,6 @@ import "envoy/api/v2/route/route.proto";
 import "envoy/type/percent.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Health check]
 // Health check :ref:`configuration overview <config_http_filters_health_check>`.
@@ -29,7 +26,7 @@ message HealthCheck {
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.
-  google.protobuf.Duration cache_time = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration cache_time = 3;
 
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that

--- a/api/envoy/config/filter/http/health_check/v3alpha/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v3alpha/health_check.proto
@@ -13,9 +13,6 @@ import "envoy/api/v3alpha/route/route.proto";
 import "envoy/type/percent.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Health check]
 // Health check :ref:`configuration overview <config_http_filters_health_check>`.
@@ -29,7 +26,7 @@ message HealthCheck {
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.
-  google.protobuf.Duration cache_time = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration cache_time = 3;
 
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -13,9 +13,6 @@ import "envoy/api/v2/route/route.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: JWT Authentication]
 // JWT Authentication :ref:`configuration overview <config_http_filters_jwt_authn>`.

--- a/api/envoy/config/filter/http/jwt_authn/v3alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v3alpha/config.proto
@@ -13,9 +13,6 @@ import "envoy/api/v3alpha/route/route.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: JWT Authentication]
 // JWT Authentication :ref:`configuration overview <config_http_filters_jwt_authn>`.

--- a/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -11,7 +11,6 @@ import "envoy/config/ratelimit/v2/rls.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Rate limit]
 // Rate limit :ref:`configuration overview <config_http_filters_rate_limit>`.
@@ -38,7 +37,7 @@ message RateLimit {
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.
-  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 4;
 
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of

--- a/api/envoy/config/filter/http/rate_limit/v3alpha/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v3alpha/rate_limit.proto
@@ -11,7 +11,6 @@ import "envoy/config/ratelimit/v3alpha/rls.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Rate limit]
 // Rate limit :ref:`configuration overview <config_http_filters_rate_limit>`.
@@ -38,7 +37,7 @@ message RateLimit {
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.
-  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 4;
 
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of

--- a/api/envoy/config/filter/http/rbac/v2/rbac.proto
+++ b/api/envoy/config/filter/http/rbac/v2/rbac.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.rbac.v2";
 import "envoy/config/rbac/v2/rbac.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: RBAC]
 // Role-Based Access Control :ref:`configuration overview <config_http_filters_rbac>`.

--- a/api/envoy/config/filter/http/rbac/v3alpha/rbac.proto
+++ b/api/envoy/config/filter/http/rbac/v3alpha/rbac.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.http.rbac.v3alpha";
 import "envoy/config/rbac/v3alpha/rbac.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: RBAC]
 // Role-Based Access Control :ref:`configuration overview <config_http_filters_rbac>`.

--- a/api/envoy/config/filter/http/squash/v2/squash.proto
+++ b/api/envoy/config/filter/http/squash/v2/squash.proto
@@ -10,7 +10,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Squash]
 // Squash :ref:`configuration overview <config_http_filters_squash>`.
@@ -42,13 +41,13 @@ message Squash {
   google.protobuf.Struct attachment_template = 2;
 
   // The timeout for individual requests sent to the Squash cluster. Defaults to 1 second.
-  google.protobuf.Duration request_timeout = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 3;
 
   // The total timeout Squash will delay a request and wait for it to be attached. Defaults to 60
   // seconds.
-  google.protobuf.Duration attachment_timeout = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration attachment_timeout = 4;
 
   // Amount of time to poll for the status of the attachment object in the Squash server
   // (to check if has been attached). Defaults to 1 second.
-  google.protobuf.Duration attachment_poll_period = 5 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration attachment_poll_period = 5;
 }

--- a/api/envoy/config/filter/http/squash/v3alpha/squash.proto
+++ b/api/envoy/config/filter/http/squash/v3alpha/squash.proto
@@ -10,7 +10,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Squash]
 // Squash :ref:`configuration overview <config_http_filters_squash>`.
@@ -42,13 +41,13 @@ message Squash {
   google.protobuf.Struct attachment_template = 2;
 
   // The timeout for individual requests sent to the Squash cluster. Defaults to 1 second.
-  google.protobuf.Duration request_timeout = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 3;
 
   // The total timeout Squash will delay a request and wait for it to be attached. Defaults to 60
   // seconds.
-  google.protobuf.Duration attachment_timeout = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration attachment_timeout = 4;
 
   // Amount of time to poll for the status of the attachment object in the Squash server
   // (to check if has been attached). Defaults to 1 second.
-  google.protobuf.Duration attachment_poll_period = 5 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration attachment_poll_period = 5;
 }

--- a/api/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.proto
+++ b/api/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.proto
@@ -10,7 +10,6 @@ import "envoy/api/v2/core/address.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Client TLS authentication]
 // Client TLS authentication
@@ -31,7 +30,7 @@ message ClientSSLAuth {
   // authentication service. Default is 60000 (60s). The actual fetch time
   // will be this value plus a random jittered value between
   // 0-refresh_delay_ms milliseconds.
-  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration refresh_delay = 3;
 
   // An optional list of IP address and subnet masks that should be white
   // listed for access by the filter. If no list is provided, there is no

--- a/api/envoy/config/filter/network/client_ssl_auth/v3alpha/client_ssl_auth.proto
+++ b/api/envoy/config/filter/network/client_ssl_auth/v3alpha/client_ssl_auth.proto
@@ -10,7 +10,6 @@ import "envoy/api/v3alpha/core/address.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Client TLS authentication]
 // Client TLS authentication
@@ -31,7 +30,7 @@ message ClientSSLAuth {
   // authentication service. Default is 60000 (60s). The actual fetch time
   // will be this value plus a random jittered value between
   // 0-refresh_delay_ms milliseconds.
-  google.protobuf.Duration refresh_delay = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration refresh_delay = 3;
 
   // An optional list of IP address and subnet masks that should be white
   // listed for access by the filter. If no list is provided, there is no

--- a/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.proto
+++ b/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.proto
@@ -11,7 +11,6 @@ import "envoy/config/filter/network/dubbo_proxy/v2alpha1/route.proto";
 import "google/protobuf/any.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Dubbo Proxy]
 // Dubbo Proxy :ref:`configuration overview <config_network_filters_dubbo_proxy>`.

--- a/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.proto
@@ -13,9 +13,6 @@ import "envoy/type/range.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Dubbo Proxy Route Configuration]
 // Dubbo Proxy :ref:`configuration overview <config_network_filters_dubbo_proxy>`.

--- a/api/envoy/config/filter/network/dubbo_proxy/v3alpha/dubbo_proxy.proto
+++ b/api/envoy/config/filter/network/dubbo_proxy/v3alpha/dubbo_proxy.proto
@@ -11,7 +11,6 @@ import "envoy/config/filter/network/dubbo_proxy/v3alpha/route.proto";
 import "google/protobuf/any.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Dubbo Proxy]
 // Dubbo Proxy :ref:`configuration overview <config_network_filters_dubbo_proxy>`.

--- a/api/envoy/config/filter/network/dubbo_proxy/v3alpha/route.proto
+++ b/api/envoy/config/filter/network/dubbo_proxy/v3alpha/route.proto
@@ -13,9 +13,6 @@ import "envoy/type/range.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Dubbo Proxy Route Configuration]
 // Dubbo Proxy :ref:`configuration overview <config_network_filters_dubbo_proxy>`.

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -19,7 +19,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
@@ -27,7 +26,6 @@ import "gogoproto/gogo.proto";
 // [#comment:next free field: 35]
 message HttpConnectionManager {
   enum CodecType {
-    option (gogoproto.goproto_enum_prefix) = false;
 
     // For every new connection, the connection manager will determine which
     // codec to use. This mode supports both ALPN for TLS listeners as well as
@@ -80,7 +78,6 @@ message HttpConnectionManager {
 
   message Tracing {
     enum OperationName {
-      option (gogoproto.goproto_enum_prefix) = false;
 
       // The HTTP listener is used for ingress/incoming requests.
       INGRESS = 0;
@@ -148,7 +145,6 @@ message HttpConnectionManager {
   string server_name = 10;
 
   enum ServerHeaderTransformation {
-    option (gogoproto.goproto_enum_prefix) = false;
 
     // Overwrite any Server header with the contents of server_name.
     OVERWRITE = 0;
@@ -180,7 +176,7 @@ message HttpConnectionManager {
   // connection a drain sequence will occur prior to closing the connection. See
   // :ref:`drain_timeout
   // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`.
-  google.protobuf.Duration idle_timeout = 11 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 11;
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected
@@ -207,13 +203,13 @@ message HttpConnectionManager {
   //
   // A value of 0 will completely disable the connection manager stream idle
   // timeout, although per-route idle timeout overrides will continue to apply.
-  google.protobuf.Duration stream_idle_timeout = 24 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration stream_idle_timeout = 24;
 
   // A timeout for idle requests managed by the connection manager.
   // The timer is activated when the request is initiated, and is disarmed when the last byte of the
   // request is sent upstream (i.e. all decoding filters have processed the request), OR when the
   // response is initiated. If not specified or set to 0, this timeout is disabled.
-  google.protobuf.Duration request_timeout = 28 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 28;
 
   // The time that Envoy will wait between sending an HTTP/2 “shutdown
   // notification” (GOAWAY frame with max stream ID) and a final GOAWAY frame.
@@ -224,7 +220,7 @@ message HttpConnectionManager {
   // both when a connection hits the idle timeout or during general server
   // draining. The default grace period is 5000 milliseconds (5 seconds) if this
   // option is not specified.
-  google.protobuf.Duration drain_timeout = 12 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration drain_timeout = 12;
 
   // The delayed close timeout is for downstream connections managed by the HTTP connection manager.
   // It is defined as a grace period after connection close processing has been locally initiated
@@ -256,7 +252,7 @@ message HttpConnectionManager {
   //    A value of 0 will completely disable delayed close processing. When disabled, the downstream
   //    connection's socket will be closed immediately after the write flush is completed or will
   //    never close if the write flush does not complete.
-  google.protobuf.Duration delayed_close_timeout = 26 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration delayed_close_timeout = 26;
 
   // Configuration for :ref:`HTTP access logs <arch_overview_access_logs>`
   // emitted by the connection manager.
@@ -318,7 +314,6 @@ message HttpConnectionManager {
   // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
   // header.
   enum ForwardClientCertDetails {
-    option (gogoproto.goproto_enum_prefix) = false;
 
     // Do not send the XFCC header to the next hop. This is the default value.
     SANITIZE = 0;

--- a/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.proto
@@ -19,7 +19,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
@@ -27,7 +26,6 @@ import "gogoproto/gogo.proto";
 // [#comment:next free field: 35]
 message HttpConnectionManager {
   enum CodecType {
-    option (gogoproto.goproto_enum_prefix) = false;
 
     // For every new connection, the connection manager will determine which
     // codec to use. This mode supports both ALPN for TLS listeners as well as
@@ -81,7 +79,6 @@ message HttpConnectionManager {
   message Tracing {
     // [#comment:TODO(kyessenov): Align this field with listener traffic direction field.]
     enum OperationName {
-      option (gogoproto.goproto_enum_prefix) = false;
 
       // The HTTP listener is used for ingress/incoming requests.
       INGRESS = 0;
@@ -144,7 +141,6 @@ message HttpConnectionManager {
   string server_name = 10;
 
   enum ServerHeaderTransformation {
-    option (gogoproto.goproto_enum_prefix) = false;
 
     // Overwrite any Server header with the contents of server_name.
     OVERWRITE = 0;
@@ -176,7 +172,7 @@ message HttpConnectionManager {
   // connection a drain sequence will occur prior to closing the connection. See
   // :ref:`drain_timeout
   // <envoy_api_field_config.filter.network.http_connection_manager.v3alpha.HttpConnectionManager.drain_timeout>`.
-  google.protobuf.Duration idle_timeout = 11 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 11;
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected
@@ -203,13 +199,13 @@ message HttpConnectionManager {
   //
   // A value of 0 will completely disable the connection manager stream idle
   // timeout, although per-route idle timeout overrides will continue to apply.
-  google.protobuf.Duration stream_idle_timeout = 24 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration stream_idle_timeout = 24;
 
   // A timeout for idle requests managed by the connection manager.
   // The timer is activated when the request is initiated, and is disarmed when the last byte of the
   // request is sent upstream (i.e. all decoding filters have processed the request), OR when the
   // response is initiated. If not specified or set to 0, this timeout is disabled.
-  google.protobuf.Duration request_timeout = 28 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration request_timeout = 28;
 
   // The time that Envoy will wait between sending an HTTP/2 “shutdown
   // notification” (GOAWAY frame with max stream ID) and a final GOAWAY frame.
@@ -220,7 +216,7 @@ message HttpConnectionManager {
   // both when a connection hits the idle timeout or during general server
   // draining. The default grace period is 5000 milliseconds (5 seconds) if this
   // option is not specified.
-  google.protobuf.Duration drain_timeout = 12 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration drain_timeout = 12;
 
   // The delayed close timeout is for downstream connections managed by the HTTP connection manager.
   // It is defined as a grace period after connection close processing has been locally initiated
@@ -252,7 +248,7 @@ message HttpConnectionManager {
   //    A value of 0 will completely disable delayed close processing. When disabled, the downstream
   //    connection's socket will be closed immediately after the write flush is completed or will
   //    never close if the write flush does not complete.
-  google.protobuf.Duration delayed_close_timeout = 26 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration delayed_close_timeout = 26;
 
   // Configuration for :ref:`HTTP access logs <arch_overview_access_logs>`
   // emitted by the connection manager.
@@ -314,7 +310,6 @@ message HttpConnectionManager {
   // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
   // header.
   enum ForwardClientCertDetails {
-    option (gogoproto.goproto_enum_prefix) = false;
 
     // Do not send the XFCC header to the next hop. This is the default value.
     SANITIZE = 0;

--- a/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
@@ -12,7 +12,6 @@ import "envoy/config/ratelimit/v2/rls.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Rate limit]
 // Rate limit :ref:`configuration overview <config_network_filters_rate_limit>`.
@@ -30,7 +29,7 @@ message RateLimit {
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.
-  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 4;
 
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of

--- a/api/envoy/config/filter/network/rate_limit/v3alpha/rate_limit.proto
+++ b/api/envoy/config/filter/network/rate_limit/v3alpha/rate_limit.proto
@@ -12,7 +12,6 @@ import "envoy/config/ratelimit/v3alpha/rls.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Rate limit]
 // Rate limit :ref:`configuration overview <config_network_filters_rate_limit>`.
@@ -30,7 +29,7 @@ message RateLimit {
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.
-  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 4;
 
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of

--- a/api/envoy/config/filter/network/rbac/v2/rbac.proto
+++ b/api/envoy/config/filter/network/rbac/v2/rbac.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.network.rbac.v2";
 import "envoy/config/rbac/v2/rbac.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: RBAC]
 // Role-Based Access Control :ref:`configuration overview <config_network_filters_rbac>`.

--- a/api/envoy/config/filter/network/rbac/v3alpha/rbac.proto
+++ b/api/envoy/config/filter/network/rbac/v3alpha/rbac.proto
@@ -9,7 +9,6 @@ option java_package = "io.envoyproxy.envoy.config.filter.network.rbac.v3alpha";
 import "envoy/config/rbac/v3alpha/rbac.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: RBAC]
 // Role-Based Access Control :ref:`configuration overview <config_network_filters_rbac>`.

--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -12,7 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Redis Proxy]
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
@@ -40,8 +39,7 @@ message RedisProxy {
     // The only exception to this behavior is when a connection to a backend is not yet established.
     // In that case, the connect timeout on the cluster will govern the timeout until the connection
     // is ready.
-    google.protobuf.Duration op_timeout = 1
-        [(validate.rules).duration.required = true, (gogoproto.stdduration) = true];
+    google.protobuf.Duration op_timeout = 1 [(validate.rules).duration.required = true];
 
     // Use hash tagging on every redis key to guarantee that keys with the same hash tag will be
     // forwarded to the same upstream. The hash key used for determining the upstream in a
@@ -81,7 +79,7 @@ message RedisProxy {
     // before the timer fires.
     // If `max_buffer_size_before_flush` is set, but `buffer_flush_timeout` is not, the latter
     // defaults to 3ms.
-    google.protobuf.Duration buffer_flush_timeout = 5 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration buffer_flush_timeout = 5;
 
     // `max_upstream_unknown_connections` controls how many upstream connections to unknown hosts
     // can be created at any given time by any given worker thread (see `enable_redirection` for

--- a/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.proto
@@ -12,7 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Redis Proxy]
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
@@ -40,8 +39,7 @@ message RedisProxy {
     // The only exception to this behavior is when a connection to a backend is not yet established.
     // In that case, the connect timeout on the cluster will govern the timeout until the connection
     // is ready.
-    google.protobuf.Duration op_timeout = 1
-        [(validate.rules).duration.required = true, (gogoproto.stdduration) = true];
+    google.protobuf.Duration op_timeout = 1 [(validate.rules).duration.required = true];
 
     // Use hash tagging on every redis key to guarantee that keys with the same hash tag will be
     // forwarded to the same upstream. The hash key used for determining the upstream in a
@@ -81,7 +79,7 @@ message RedisProxy {
     // before the timer fires.
     // If `max_buffer_size_before_flush` is set, but `buffer_flush_timeout` is not, the latter
     // defaults to 3ms.
-    google.protobuf.Duration buffer_flush_timeout = 5 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration buffer_flush_timeout = 5;
 
     // `max_upstream_unknown_connections` controls how many upstream connections to unknown hosts
     // can be created at any given time by any given worker thread (see `enable_redirection` for

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -14,7 +14,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: TCP Proxy]
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
@@ -46,8 +45,7 @@ message TcpProxy {
   // is defined as the period in which there are no bytes sent or received on either
   // the upstream or downstream connection. If not set, connections will never be closed
   // by the TCP proxy due to being idle.
-  google.protobuf.Duration idle_timeout = 8
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 8 [(validate.rules).duration.gt = {}];
 
   // [#not-implemented-hide:] The idle timeout for connections managed by the TCP proxy
   // filter. The idle timeout is defined as the period in which there is no

--- a/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.proto
@@ -14,7 +14,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: TCP Proxy]
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
@@ -46,8 +45,7 @@ message TcpProxy {
   // is defined as the period in which there are no bytes sent or received on either
   // the upstream or downstream connection. If not set, connections will never be closed
   // by the TCP proxy due to being idle.
-  google.protobuf.Duration idle_timeout = 8
-      [(validate.rules).duration.gt = {}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration idle_timeout = 8 [(validate.rules).duration.gt = {}];
 
   // [#not-implemented-hide:] The idle timeout for connections managed by the TCP proxy
   // filter. The idle timeout is defined as the period in which there is no

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -12,7 +12,6 @@ import "envoy/api/v2/route/route.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Thrift Proxy Route Configuration]
 // Thrift Proxy :ref:`configuration overview <config_network_filters_thrift_proxy>`.

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.proto
@@ -12,7 +12,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Thrift Proxy]
 // Thrift Proxy :ref:`configuration overview <config_network_filters_thrift_proxy>`.
@@ -42,7 +41,6 @@ message ThriftProxy {
 
 // Thrift transport types supported by Envoy.
 enum TransportType {
-  option (gogoproto.goproto_enum_prefix) = false;
 
   // For downstream connections, the Thrift proxy will attempt to determine which transport to use.
   // For upstream connections, the Thrift proxy will use same transport as the downstream
@@ -61,7 +59,6 @@ enum TransportType {
 
 // Thrift Protocol types supported by Envoy.
 enum ProtocolType {
-  option (gogoproto.goproto_enum_prefix) = false;
 
   // For downstream connections, the Thrift proxy will attempt to determine which protocol to use.
   // Note that the older, non-strict (or lax) binary protocol is not included in automatic protocol

--- a/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
@@ -12,7 +12,6 @@ import "envoy/api/v3alpha/route/route.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Thrift Proxy Route Configuration]
 // Thrift Proxy :ref:`configuration overview <config_network_filters_thrift_proxy>`.

--- a/api/envoy/config/filter/network/thrift_proxy/v3alpha/thrift_proxy.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v3alpha/thrift_proxy.proto
@@ -12,7 +12,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Thrift Proxy]
 // Thrift Proxy :ref:`configuration overview <config_network_filters_thrift_proxy>`.
@@ -42,7 +41,6 @@ message ThriftProxy {
 
 // Thrift transport types supported by Envoy.
 enum TransportType {
-  option (gogoproto.goproto_enum_prefix) = false;
 
   // For downstream connections, the Thrift proxy will attempt to determine which transport to use.
   // For upstream connections, the Thrift proxy will use same transport as the downstream
@@ -61,7 +59,6 @@ enum TransportType {
 
 // Thrift Protocol types supported by Envoy.
 enum ProtocolType {
-  option (gogoproto.goproto_enum_prefix) = false;
 
   // For downstream connections, the Thrift proxy will attempt to determine which protocol to use.
   // Note that the older, non-strict (or lax) binary protocol is not included in automatic protocol

--- a/api/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.proto
+++ b/api/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.proto
@@ -11,7 +11,6 @@ import "envoy/config/ratelimit/v2/rls.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Rate limit]
 // Rate limit :ref:`configuration overview <config_thrift_filters_rate_limit>`.
@@ -34,7 +33,7 @@ message RateLimit {
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.
-  google.protobuf.Duration timeout = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 3;
 
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of

--- a/api/envoy/config/filter/thrift/rate_limit/v3alpha/rate_limit.proto
+++ b/api/envoy/config/filter/thrift/rate_limit/v3alpha/rate_limit.proto
@@ -11,7 +11,6 @@ import "envoy/config/ratelimit/v3alpha/rls.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 
 // [#protodoc-title: Rate limit]
 // Rate limit :ref:`configuration overview <config_thrift_filters_rate_limit>`.
@@ -34,7 +33,7 @@ message RateLimit {
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.
-  google.protobuf.Duration timeout = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration timeout = 3;
 
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of

--- a/api/envoy/config/rbac/v2/rbac.proto
+++ b/api/envoy/config/rbac/v2/rbac.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/route/route.proto";
 import "envoy/type/matcher/metadata.proto";
@@ -14,8 +13,6 @@ package envoy.config.rbac.v2;
 option java_outer_classname = "RbacProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.config.rbac.v2";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Role Based Access Control (RBAC)]
 

--- a/api/envoy/config/rbac/v3alpha/rbac.proto
+++ b/api/envoy/config/rbac/v3alpha/rbac.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
 import "envoy/api/v3alpha/core/address.proto";
 import "envoy/api/v3alpha/route/route.proto";
 import "envoy/type/matcher/metadata.proto";
@@ -14,8 +13,6 @@ package envoy.config.rbac.v3alpha;
 option java_outer_classname = "RbacProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.config.rbac.v3alpha";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Role Based Access Control (RBAC)]
 

--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -12,10 +12,7 @@ import "envoy/api/v2/core/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-import "gogoproto/gogo.proto";
 import "validate/validate.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: gRPC access logs]
 // Envoy access logs describe incoming interaction with Envoy over a fixed
@@ -85,37 +82,37 @@ message AccessLogCommon {
 
   // The time that Envoy started servicing this request. This is effectively the time that the first
   // downstream byte is received.
-  google.protobuf.Timestamp start_time = 5 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp start_time = 5;
 
   // Interval between the first downstream byte received and the last
   // downstream byte received (i.e. time it takes to receive a request).
-  google.protobuf.Duration time_to_last_rx_byte = 6 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_rx_byte = 6;
 
   // Interval between the first downstream byte received and the first upstream byte sent. There may
   // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
   // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
   // not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_first_upstream_tx_byte = 7 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_upstream_tx_byte = 7;
 
   // Interval between the first downstream byte received and the last upstream byte sent. There may
   // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
   // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
   // not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_last_upstream_tx_byte = 8 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_upstream_tx_byte = 8;
 
   // Interval between the first downstream byte received and the first upstream
   // byte received (i.e. time it takes to start receiving a response).
-  google.protobuf.Duration time_to_first_upstream_rx_byte = 9 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_upstream_rx_byte = 9;
 
   // Interval between the first downstream byte received and the last upstream
   // byte received (i.e. time it takes to receive a complete response).
-  google.protobuf.Duration time_to_last_upstream_rx_byte = 10 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_upstream_rx_byte = 10;
 
   // Interval between the first downstream byte received and the first downstream byte sent.
   // There may be a considerable delta between the *time_to_first_upstream_rx_byte* and this field
   // due to filters. Additionally, the same caveats apply as documented in
   // *time_to_last_downstream_tx_byte* about not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_first_downstream_tx_byte = 11 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_downstream_tx_byte = 11;
 
   // Interval between the first downstream byte received and the last downstream byte sent.
   // Depending on protocol, buffering, windowing, filters, etc. there may be a considerable delta
@@ -123,7 +120,7 @@ message AccessLogCommon {
   // time. In the current implementation it does not include kernel socket buffer time. In the
   // current implementation it also does not include send window buffering inside the HTTP/2 codec.
   // In the future it is likely that work will be done to make this duration more accurate.
-  google.protobuf.Duration time_to_last_downstream_tx_byte = 12 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_downstream_tx_byte = 12;
 
   // The upstream remote/destination address that handles this exchange. This does not include
   // retries.

--- a/api/envoy/data/accesslog/v3alpha/accesslog.proto
+++ b/api/envoy/data/accesslog/v3alpha/accesslog.proto
@@ -12,10 +12,7 @@ import "envoy/api/v3alpha/core/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-import "gogoproto/gogo.proto";
 import "validate/validate.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: gRPC access logs]
 // Envoy access logs describe incoming interaction with Envoy over a fixed
@@ -85,37 +82,37 @@ message AccessLogCommon {
 
   // The time that Envoy started servicing this request. This is effectively the time that the first
   // downstream byte is received.
-  google.protobuf.Timestamp start_time = 5 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp start_time = 5;
 
   // Interval between the first downstream byte received and the last
   // downstream byte received (i.e. time it takes to receive a request).
-  google.protobuf.Duration time_to_last_rx_byte = 6 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_rx_byte = 6;
 
   // Interval between the first downstream byte received and the first upstream byte sent. There may
   // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
   // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
   // not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_first_upstream_tx_byte = 7 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_upstream_tx_byte = 7;
 
   // Interval between the first downstream byte received and the last upstream byte sent. There may
   // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
   // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
   // not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_last_upstream_tx_byte = 8 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_upstream_tx_byte = 8;
 
   // Interval between the first downstream byte received and the first upstream
   // byte received (i.e. time it takes to start receiving a response).
-  google.protobuf.Duration time_to_first_upstream_rx_byte = 9 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_upstream_rx_byte = 9;
 
   // Interval between the first downstream byte received and the last upstream
   // byte received (i.e. time it takes to receive a complete response).
-  google.protobuf.Duration time_to_last_upstream_rx_byte = 10 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_upstream_rx_byte = 10;
 
   // Interval between the first downstream byte received and the first downstream byte sent.
   // There may be a considerable delta between the *time_to_first_upstream_rx_byte* and this field
   // due to filters. Additionally, the same caveats apply as documented in
   // *time_to_last_downstream_tx_byte* about not accounting for kernel socket buffer time, etc.
-  google.protobuf.Duration time_to_first_downstream_tx_byte = 11 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_first_downstream_tx_byte = 11;
 
   // Interval between the first downstream byte received and the last downstream byte sent.
   // Depending on protocol, buffering, windowing, filters, etc. there may be a considerable delta
@@ -123,7 +120,7 @@ message AccessLogCommon {
   // time. In the current implementation it does not include kernel socket buffer time. In the
   // current implementation it also does not include send window buffering inside the HTTP/2 codec.
   // In the future it is likely that work will be done to make this duration more accurate.
-  google.protobuf.Duration time_to_last_downstream_tx_byte = 12 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration time_to_last_downstream_tx_byte = 12;
 
   // The upstream remote/destination address that handles this exchange. This does not include
   // retries.

--- a/api/envoy/data/cluster/v2alpha/outlier_detection_event.proto
+++ b/api/envoy/data/cluster/v2alpha/outlier_detection_event.proto
@@ -10,9 +10,6 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Outlier detection logging events]
 // :ref:`Outlier detection logging <arch_overview_outlier_detection_logging>`.
@@ -21,7 +18,7 @@ message OutlierDetectionEvent {
   // In case of eject represents type of ejection that took place.
   OutlierEjectionType type = 1 [(validate.rules).enum.defined_only = true];
   // Timestamp for event.
-  google.protobuf.Timestamp timestamp = 2 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp timestamp = 2;
   // The time in seconds since the last action (either an ejection or unejection) took place.
   google.protobuf.UInt64Value secs_since_last_action = 3;
   // The :ref:`cluster <envoy_api_msg_Cluster>` that owns the ejected host.

--- a/api/envoy/data/cluster/v3alpha/outlier_detection_event.proto
+++ b/api/envoy/data/cluster/v3alpha/outlier_detection_event.proto
@@ -10,9 +10,6 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Outlier detection logging events]
 // :ref:`Outlier detection logging <arch_overview_outlier_detection_logging>`.
@@ -21,7 +18,7 @@ message OutlierDetectionEvent {
   // In case of eject represents type of ejection that took place.
   OutlierEjectionType type = 1 [(validate.rules).enum.defined_only = true];
   // Timestamp for event.
-  google.protobuf.Timestamp timestamp = 2 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp timestamp = 2;
   // The time in seconds since the last action (either an ejection or unejection) took place.
   google.protobuf.UInt64Value secs_since_last_action = 3;
   // The :ref:`cluster <envoy_api_msg_Cluster>` that owns the ejected host.

--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -11,9 +11,6 @@ import "envoy/api/v2/core/address.proto";
 import "google/protobuf/timestamp.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Health check logging events]
 // :ref:`Health check logging <arch_overview_health_check_logging>`.
@@ -43,7 +40,7 @@ message HealthCheckEvent {
   }
 
   // Timestamp for event.
-  google.protobuf.Timestamp timestamp = 6 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp timestamp = 6;
 }
 
 enum HealthCheckFailureType {

--- a/api/envoy/data/core/v3alpha/health_check_event.proto
+++ b/api/envoy/data/core/v3alpha/health_check_event.proto
@@ -11,9 +11,6 @@ import "envoy/api/v3alpha/core/address.proto";
 import "google/protobuf/timestamp.proto";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Health check logging events]
 // :ref:`Health check logging <arch_overview_health_check_logging>`.
@@ -43,7 +40,7 @@ message HealthCheckEvent {
   }
 
   // Timestamp for event.
-  google.protobuf.Timestamp timestamp = 6 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp timestamp = 6;
 }
 
 enum HealthCheckFailureType {

--- a/api/envoy/service/auth/v2/attribute_context.proto
+++ b/api/envoy/service/auth/v2/attribute_context.proto
@@ -10,9 +10,6 @@ import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/timestamp.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Attribute Context ]
 

--- a/api/envoy/service/auth/v3alpha/attribute_context.proto
+++ b/api/envoy/service/auth/v3alpha/attribute_context.proto
@@ -10,9 +10,6 @@ import "envoy/api/v3alpha/core/address.proto";
 import "envoy/api/v3alpha/core/base.proto";
 
 import "google/protobuf/timestamp.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.stable_marshaler_all) = true;
 
 // [#protodoc-title: Attribute Context ]
 

--- a/api/envoy/type/percent.proto
+++ b/api/envoy/type/percent.proto
@@ -7,9 +7,6 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type";
 
 import "validate/validate.proto";
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Percent]
 

--- a/api/envoy/type/range.proto
+++ b/api/envoy/type/range.proto
@@ -6,10 +6,6 @@ option java_outer_classname = "RangeProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.type";
 
-import "gogoproto/gogo.proto";
-
-option (gogoproto.equal_all) = true;
-
 // [#protodoc-title: Range]
 
 // Specifies the int64 start and end of the range using half-open interval semantics [start,

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -7,13 +7,6 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 GO_VERSION = "1.12.8"
 
 def envoy_dependency_imports(go_version = GO_VERSION):
-    go_repository(
-        name = "com_github_gogo_protobuf",
-        importpath = "github.com/gogo/protobuf",
-        sum = "h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=",
-        version = "v1.3.0",
-    )
-
     rules_foreign_cc_dependencies()
     go_rules_dependencies()
     go_register_toolchains(go_version)
@@ -40,10 +33,4 @@ def envoy_dependency_imports(go_version = GO_VERSION):
         importpath = "golang.org/x/text",
         sum = "h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=",
         version = "v0.3.0",
-    )
-
-    go_repository(
-        name = "io_istio_gogo_genproto",
-        importpath = "istio.io/gogo-genproto",
-        commit = "ee07f27854802700b55adf4cf76bbcefed623563",
     )

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -7,6 +7,13 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 GO_VERSION = "1.12.8"
 
 def envoy_dependency_imports(go_version = GO_VERSION):
+    go_repository(
+        name = "com_github_gogo_protobuf",
+        importpath = "github.com/gogo/protobuf",
+        sum = "h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=",
+        version = "v1.3.0",
+    )
+
     rules_foreign_cc_dependencies()
     go_rules_dependencies()
     go_register_toolchains(go_version)
@@ -33,4 +40,10 @@ def envoy_dependency_imports(go_version = GO_VERSION):
         importpath = "golang.org/x/text",
         sum = "h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=",
         version = "v0.3.0",
+    )
+
+    go_repository(
+        name = "io_istio_gogo_genproto",
+        importpath = "istio.io/gogo-genproto",
+        commit = "ee07f27854802700b55adf4cf76bbcefed623563",
     )


### PR DESCRIPTION
Description:
Remove gogoproto annotations. They can be replaced with a custom gogoproto compiler (e.g. something like https://github.com/gogo/googleapis/tree/master/protoc-gen-gogogoogleapis). I have an experimental version of it to validate that it's possible to re-apply important annotations in the compiler.

Risk Level: low
Testing: builds
Docs Changes: none
Release Notes:
