### PR TITLE
fix windows implementation of PlatformImpl

### DIFF
--- a/source/exe/platform_impl.h
+++ b/source/exe/platform_impl.h
@@ -8,6 +8,7 @@ namespace Envoy {
 class PlatformImpl {
 public:
   PlatformImpl();
+  ~PlatformImpl();
   Thread::ThreadFactory& threadFactory() { return *thread_factory_; }
   Filesystem::Instance& fileSystem() { return *file_system_; }
 

--- a/source/exe/posix/platform_impl.cc
+++ b/source/exe/posix/platform_impl.cc
@@ -9,4 +9,6 @@ PlatformImpl::PlatformImpl()
     : thread_factory_(std::make_unique<Thread::ThreadFactoryImplPosix>()),
       file_system_(std::make_unique<Filesystem::InstanceImplPosix>()) {}
 
+PlatformImpl::~PlatformImpl() {}
+
 } // namespace Envoy

--- a/source/exe/posix/platform_impl.cc
+++ b/source/exe/posix/platform_impl.cc
@@ -9,6 +9,6 @@ PlatformImpl::PlatformImpl()
     : thread_factory_(std::make_unique<Thread::ThreadFactoryImplPosix>()),
       file_system_(std::make_unique<Filesystem::InstanceImplPosix>()) {}
 
-PlatformImpl::~PlatformImpl() {}
+PlatformImpl::~PlatformImpl() = default;
 
 } // namespace Envoy

--- a/source/exe/win32/platform_impl.cc
+++ b/source/exe/win32/platform_impl.cc
@@ -19,8 +19,6 @@ PlatformImpl::PlatformImpl()
   RELEASE_ASSERT(rc == 0, "WSAStartup failed with error");
 }
 
-~PlatformImpl() { ::WSACleanup(); }
-
-}; // namespace Envoy
+PlatformImpl::~PlatformImpl() { ::WSACleanup(); }
 
 } // namespace Envoy


### PR DESCRIPTION
Description:

- Add missing destructor to class deceleration
- Fix copy/paste errors

These errors were apparently introduced in e1cd4cca46179562cf80de7f81774f4dc6354085

Signed-off-by: William Rowe <wrowe@pivotal.io>

Risk Level: Low

Testing: Passed Windows testing locally

Docs Changes: None

Release Notes:
