### PR TITLE
Add retriable headers retry policy.

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -934,9 +934,10 @@ message RetryPolicy {
   // describes Envoy's back-off algorithm.
   RetryBackOff retry_back_off = 8;
 
-  // HTTP headers that trigger a retry if present in the response (the value doesn't matter).
+  // HTTP headers that trigger a retry if present in the response. A retry will be
+  // triggered if any of the header matches match the upstream response headers.
   // The field is only consulted if 'retriable-headers' retry policy is active.
-  repeated string retriable_headers = 9;
+  repeated HeaderMatcher retriable_headers = 9;
 }
 
 // HTTP request hedging :ref:`architecture overview <arch_overview_http_routing_hedging>`.

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -848,7 +848,7 @@ message RouteAction {
 }
 
 // HTTP retry :ref:`architecture overview <arch_overview_http_routing_retry>`.
-// [#comment:next free field: 9]
+// [#comment:next free field: 10]
 message RetryPolicy {
   // Specifies the conditions under which retry takes place. These are the same
   // conditions documented for :ref:`config_http_filters_router_x-envoy-retry-on` and
@@ -933,6 +933,10 @@ message RetryPolicy {
   // the base interval. The documentation for :ref:`config_http_filters_router_x-envoy-max-retries`
   // describes Envoy's back-off algorithm.
   RetryBackOff retry_back_off = 8;
+
+  // HTTP headers that trigger a retry if present in the response (the value doesn't matter).
+  // The field is only consulted if 'retriable-headers' retry policy is active.
+  repeated string retriable_headers = 9;
 }
 
 // HTTP request hedging :ref:`architecture overview <arch_overview_http_routing_hedging>`.

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -110,6 +110,11 @@ retriable-status-codes
   in either :ref:`the retry policy <envoy_api_field_route.RetryPolicy.retriable_status_codes>`
   or in the :ref:`config_http_filters_router_x-envoy-retriable-status-codes` header.
 
+retriable-headers
+  Envoy will attempt a retry if the upstream server response includes any headers matching in either
+  :ref:`the retry policy <envoy_api_field_route.RetryPolicy.retriable_headers>` or in the
+  :ref:`config_http_filters_router_x-envoy-retriable-header-names` header.
+
 The number of retries can be controlled via the
 :ref:`config_http_filters_router_x-envoy-max-retries` header or via the :ref:`route
 configuration <envoy_api_field_route.RouteAction.retry_policy>` or via the
@@ -157,6 +162,25 @@ Note that retry policies can also be applied at the :ref:`route level
 :ref:`virtual host level <envoy_api_field_route.VirtualHost.retry_policy>`.
 
 By default, Envoy will *not* perform retries unless you've configured them per above.
+
+.. _config_http_filters_router_x-envoy-retriable-header-names:
+
+x-envoy-retriable-header-names
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Setting this header informs Envoy about what response headers should be considered retriable. It is used
+in conjunction with the :ref:`retriable-headers <config_http_filters_router_x-envoy-retry-on>` retry policy.
+When the corresponding retry policy is set, the response headers provided by this list header value will be
+considered retriable in addition to the response headers enabled for retry through other retry policies.
+
+The list is a comma-separated list of header names: "X-Upstream-Retry,X-Try-Again" would cause any upstream
+responses containing either one of the specified headers to be retriable if 'retriable-headers' retry policy
+is enabled. Header names are case-insensitive.
+
+Only the names of retriable response headers can be specified via the request header. A more sophisticated
+retry policy based on the response headers can be specified by using arbitrary header matching rules
+via :ref:`retry policy configuration <envoy_api_field_route.RetryPolicy.retriable_headers>`.
+
+This header will only be honored for requests from internal clients.
 
 .. _config_http_filters_router_x-envoy-retriable-status-codes:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -49,6 +49,7 @@ Version history
 * rbac: added conditions to the policy, see :ref:`condition <envoy_api_field_config.rbac.v2.Policy.condition>`.
 * router: added :ref:`rq_retry_skipped_request_not_complete <config_http_filters_router_stats>` counter stat to router stats.
 * router: :ref:`Scoped routing <arch_overview_http_routing_route_scope>` is supported.
+* router: added new :ref:`retriable-headers <config_http_filters_router_x-envoy-retry-on>` retry policy. Retries can now be configured to trigger by arbitrary response header matching.
 * router check tool: add coverage reporting & enforcement.
 * router check tool: add comprehensive coverage reporting.
 * router check tool: add deprecated field check.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -300,6 +300,7 @@ private:
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyRetryGrpcOn)                                                                    \
   HEADER_FUNC(EnvoyRetriableStatusCodes)                                                           \
+  HEADER_FUNC(EnvoyRetriableHeaders)                                                               \
   HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \
   HEADER_FUNC(EnvoyUpstreamCanary)                                                                 \
   HEADER_FUNC(EnvoyUpstreamHealthCheckedCluster)                                                   \

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -556,5 +556,20 @@ using HeaderMapPtr = std::unique_ptr<HeaderMap>;
  */
 using HeaderVector = std::vector<std::pair<LowerCaseString, std::string>>;
 
+/**
+ * An interface to be implemented by header matchers.
+ */
+class HeaderMatcher {
+public:
+  virtual ~HeaderMatcher() = default;
+
+  /*
+   * Check whether header matcher matches any headers in a given HeaderMap.
+   */
+  virtual bool matchesHeaders(const HeaderMap& headers) const PURE;
+};
+
+using HeaderMatcherSharedPtr = std::shared_ptr<HeaderMatcher>;
+
 } // namespace Http
 } // namespace Envoy

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -300,7 +300,7 @@ private:
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyRetryGrpcOn)                                                                    \
   HEADER_FUNC(EnvoyRetriableStatusCodes)                                                           \
-  HEADER_FUNC(EnvoyRetriableHeaders)                                                               \
+  HEADER_FUNC(EnvoyRetriableHeaderNames)                                                           \
   HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \
   HEADER_FUNC(EnvoyUpstreamCanary)                                                                 \
   HEADER_FUNC(EnvoyUpstreamHealthCheckedCluster)                                                   \

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -160,6 +160,7 @@ public:
   static const uint32_t RETRY_ON_GRPC_INTERNAL           = 0x200;
   static const uint32_t RETRY_ON_RETRIABLE_STATUS_CODES  = 0x400;
   static const uint32_t RETRY_ON_RESET                   = 0x800;
+  static const uint32_t RETRY_ON_RETRIABLE_HEADERS       = 0x1000;
   // clang-format on
 
   virtual ~RetryPolicy() = default;
@@ -203,6 +204,12 @@ public:
    * policy is enabled.
    */
   virtual const std::vector<uint32_t>& retriableStatusCodes() const PURE;
+
+  /**
+   * @return std::vector<Http::LowerCaseString>& list of response headers that should trigger a
+   * retry when the retriable-headers retry policy is enabled.
+   */
+  virtual const std::vector<Http::LowerCaseString>& retriableHeaders() const PURE;
 
   /**
    * @return absl::optional<std::chrono::milliseconds> base retry interval

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -206,10 +206,10 @@ public:
   virtual const std::vector<uint32_t>& retriableStatusCodes() const PURE;
 
   /**
-   * @return std::vector<Http::LowerCaseString>& list of response headers that should trigger a
-   * retry when the retriable-headers retry policy is enabled.
+   * @return std::vector<Http::HeaderMatcherSharedPtr>& list of response header matchers that
+   * will be checked when the 'retriable-headers' retry policy is enabled.
    */
-  virtual const std::vector<Http::LowerCaseString>& retriableHeaders() const PURE;
+  virtual const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const PURE;
 
   /**
    * @return absl::optional<std::chrono::milliseconds> base retry interval

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -132,7 +132,7 @@ private:
     const std::vector<uint32_t>& retriableStatusCodes() const override {
       return retriable_status_codes_;
     }
-    const std::vector<LowerCaseString>& retriableHeaders() const override {
+    const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
       return retriable_headers_;
     }
     absl::optional<std::chrono::milliseconds> baseInterval() const override {
@@ -141,7 +141,7 @@ private:
     absl::optional<std::chrono::milliseconds> maxInterval() const override { return absl::nullopt; }
 
     const std::vector<uint32_t> retriable_status_codes_{};
-    const std::vector<LowerCaseString> retriable_headers_{};
+    const std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_{};
   };
 
   struct NullShadowPolicy : public Router::ShadowPolicy {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -132,12 +132,16 @@ private:
     const std::vector<uint32_t>& retriableStatusCodes() const override {
       return retriable_status_codes_;
     }
+    const std::vector<LowerCaseString>& retriableHeaders() const override {
+      return retriable_headers_;
+    }
     absl::optional<std::chrono::milliseconds> baseInterval() const override {
       return absl::nullopt;
     }
     absl::optional<std::chrono::milliseconds> maxInterval() const override { return absl::nullopt; }
 
     const std::vector<uint32_t> retriable_status_codes_{};
+    const std::vector<LowerCaseString> retriable_headers_{};
   };
 
   struct NullShadowPolicy : public Router::ShadowPolicy {

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -176,7 +176,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
     }
 
     request_headers.removeEnvoyRetriableStatusCodes();
-    request_headers.removeEnvoyRetriableHeaders();
+    request_headers.removeEnvoyRetriableHeaderNames();
     request_headers.removeEnvoyRetryOn();
     request_headers.removeEnvoyRetryGrpcOn();
     request_headers.removeEnvoyMaxRetries();

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -176,6 +176,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
     }
 
     request_headers.removeEnvoyRetriableStatusCodes();
+    request_headers.removeEnvoyRetriableHeaders();
     request_headers.removeEnvoyRetryOn();
     request_headers.removeEnvoyRetryGrpcOn();
     request_headers.removeEnvoyMaxRetries();

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -46,9 +46,7 @@ public:
     envoy::type::Int64Range range_;
     const bool invert_match_;
 
-    /**
-     * Returns true if any of the headers in HeaderMap matches this HeaderData.
-     */
+    // HeaderMatcher
     bool matchesHeaders(const HeaderMap& headers) const override {
       return HeaderUtility::matchHeaders(headers, *this);
     };

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -35,7 +35,7 @@ public:
   // A HeaderData specifies one of exact value or regex or range element
   // to match in a request's header, specified in the header_match_type_ member.
   // It is the runtime equivalent of the HeaderMatchSpecifier proto in RDS API.
-  struct HeaderData {
+  struct HeaderData : public HeaderMatcher {
     HeaderData(const envoy::api::v2::route::HeaderMatcher& config);
     HeaderData(const Json::Object& config);
 
@@ -45,18 +45,37 @@ public:
     Regex::CompiledMatcherPtr regex_;
     envoy::type::Int64Range range_;
     const bool invert_match_;
+
+    /**
+     * Returns true if any of the headers in HeaderMap matches this HeaderData.
+     */
+    bool matchesHeaders(const HeaderMap& headers) const override {
+      return HeaderUtility::matchHeaders(headers, *this);
+    };
   };
 
   using HeaderDataPtr = std::unique_ptr<HeaderData>;
 
   /**
-   * Build a vector of HeaderData given input config.
+   * Build a vector of HeaderDataPtr given input config.
    */
   static std::vector<HeaderUtility::HeaderDataPtr> buildHeaderDataVector(
       const Protobuf::RepeatedPtrField<envoy::api::v2::route::HeaderMatcher>& header_matchers) {
     std::vector<HeaderUtility::HeaderDataPtr> ret;
-    for (const auto& header_match : header_matchers) {
-      ret.emplace_back(std::make_unique<HeaderUtility::HeaderData>(header_match));
+    for (const auto& header_matcher : header_matchers) {
+      ret.emplace_back(std::make_unique<HeaderUtility::HeaderData>(header_matcher));
+    }
+    return ret;
+  }
+
+  /**
+   * Build a vector of HeaderMatcherSharedPtr given input config.
+   */
+  static std::vector<Http::HeaderMatcherSharedPtr> buildHeaderMatcherVector(
+      const Protobuf::RepeatedPtrField<envoy::api::v2::route::HeaderMatcher>& header_matchers) {
+    std::vector<Http::HeaderMatcherSharedPtr> ret;
+    for (const auto& header_matcher : header_matchers) {
+      ret.emplace_back(std::make_shared<HeaderUtility::HeaderData>(header_matcher));
     }
     return ret;
   }

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -97,7 +97,8 @@ public:
   const LowerCaseString EnvoyRetryGrpcOn{absl::StrCat(prefix(), "-retry-grpc-on")};
   const LowerCaseString EnvoyRetriableStatusCodes{
       absl::StrCat(prefix(), "-retriable-status-codes")};
-  const LowerCaseString EnvoyRetriableHeaderNames{absl::StrCat(prefix(), "-retriable-header-names")};
+  const LowerCaseString EnvoyRetriableHeaderNames{
+      absl::StrCat(prefix(), "-retriable-header-names")};
   const LowerCaseString EnvoyUpstreamAltStatName{absl::StrCat(prefix(), "-upstream-alt-stat-name")};
   const LowerCaseString EnvoyUpstreamCanary{absl::StrCat(prefix(), "-upstream-canary")};
   const LowerCaseString EnvoyUpstreamHostAddress{absl::StrCat(prefix(), "-upstream-host-address")};

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -97,6 +97,7 @@ public:
   const LowerCaseString EnvoyRetryGrpcOn{absl::StrCat(prefix(), "-retry-grpc-on")};
   const LowerCaseString EnvoyRetriableStatusCodes{
       absl::StrCat(prefix(), "-retriable-status-codes")};
+  const LowerCaseString EnvoyRetriableHeaders{absl::StrCat(prefix(), "-retriable-headers")};
   const LowerCaseString EnvoyUpstreamAltStatName{absl::StrCat(prefix(), "-upstream-alt-stat-name")};
   const LowerCaseString EnvoyUpstreamCanary{absl::StrCat(prefix(), "-upstream-canary")};
   const LowerCaseString EnvoyUpstreamHostAddress{absl::StrCat(prefix(), "-upstream-host-address")};
@@ -208,6 +209,7 @@ public:
     const std::string RefusedStream{"refused-stream"};
     const std::string Retriable4xx{"retriable-4xx"};
     const std::string RetriableStatusCodes{"retriable-status-codes"};
+    const std::string RetriableHeaders{"retriable-headers"};
     const std::string Reset{"reset"};
   } EnvoyRetryOnValues;
 

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -97,7 +97,7 @@ public:
   const LowerCaseString EnvoyRetryGrpcOn{absl::StrCat(prefix(), "-retry-grpc-on")};
   const LowerCaseString EnvoyRetriableStatusCodes{
       absl::StrCat(prefix(), "-retriable-status-codes")};
-  const LowerCaseString EnvoyRetriableHeaders{absl::StrCat(prefix(), "-retriable-headers")};
+  const LowerCaseString EnvoyRetriableHeaderNames{absl::StrCat(prefix(), "-retriable-header-names")};
   const LowerCaseString EnvoyUpstreamAltStatName{absl::StrCat(prefix(), "-upstream-alt-stat-name")};
   const LowerCaseString EnvoyUpstreamCanary{absl::StrCat(prefix(), "-upstream-canary")};
   const LowerCaseString EnvoyUpstreamHostAddress{absl::StrCat(prefix(), "-upstream-host-address")};

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -203,6 +203,7 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/grpc:common_lib",
         "//source/common/http:codes_lib",
+        "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
     ],

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -100,6 +100,10 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry
     retriable_status_codes_.emplace_back(code);
   }
 
+  for (auto& header : retry_policy.retriable_headers()) {
+    retriable_headers_.emplace_back(header);
+  }
+
   if (retry_policy.has_retry_back_off()) {
     base_interval_ = std::chrono::milliseconds(
         PROTOBUF_GET_MS_REQUIRED(retry_policy.retry_back_off(), base_interval));

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -67,7 +67,9 @@ HedgePolicyImpl::HedgePolicyImpl()
 
 RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry_policy,
                                  ProtobufMessage::ValidationVisitor& validation_visitor)
-    : validation_visitor_(&validation_visitor) {
+    : retriable_headers_(
+          Http::HeaderUtility::buildHeaderMatcherVector(retry_policy.retriable_headers())),
+      validation_visitor_(&validation_visitor) {
   per_try_timeout_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_timeout, 0));
   num_retries_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(retry_policy, num_retries, 1);
@@ -98,10 +100,6 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RetryPolicy& retry
 
   for (auto code : retry_policy.retriable_status_codes()) {
     retriable_status_codes_.emplace_back(code);
-  }
-
-  for (auto& header : retry_policy.retriable_headers()) {
-    retriable_headers_.emplace_back(header);
   }
 
   if (retry_policy.has_retry_back_off()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -239,7 +239,7 @@ public:
   const std::vector<uint32_t>& retriableStatusCodes() const override {
     return retriable_status_codes_;
   }
-  const std::vector<Http::LowerCaseString>& retriableHeaders() const override {
+  const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
     return retriable_headers_;
   }
   absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
@@ -258,7 +258,7 @@ private:
   std::pair<std::string, ProtobufTypes::MessagePtr> retry_priority_config_;
   uint32_t host_selection_attempts_{1};
   std::vector<uint32_t> retriable_status_codes_;
-  std::vector<Http::LowerCaseString> retriable_headers_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
   absl::optional<std::chrono::milliseconds> base_interval_;
   absl::optional<std::chrono::milliseconds> max_interval_;
   ProtobufMessage::ValidationVisitor* validation_visitor_{};

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -239,6 +239,9 @@ public:
   const std::vector<uint32_t>& retriableStatusCodes() const override {
     return retriable_status_codes_;
   }
+  const std::vector<Http::LowerCaseString>& retriableHeaders() const override {
+    return retriable_headers_;
+  }
   absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
   absl::optional<std::chrono::milliseconds> maxInterval() const override { return max_interval_; }
 
@@ -255,6 +258,7 @@ private:
   std::pair<std::string, ProtobufTypes::MessagePtr> retry_priority_config_;
   uint32_t host_selection_attempts_{1};
   std::vector<uint32_t> retriable_status_codes_;
+  std::vector<Http::LowerCaseString> retriable_headers_;
   absl::optional<std::chrono::milliseconds> base_interval_;
   absl::optional<std::chrono::milliseconds> max_interval_;
   ProtobufMessage::ValidationVisitor* validation_visitor_{};

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -21,6 +21,7 @@ const uint32_t RetryPolicy::RETRY_ON_5XX;
 const uint32_t RetryPolicy::RETRY_ON_GATEWAY_ERROR;
 const uint32_t RetryPolicy::RETRY_ON_CONNECT_FAILURE;
 const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_4XX;
+const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
 const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES;
 const uint32_t RetryPolicy::RETRY_ON_RESET;
 const uint32_t RetryPolicy::RETRY_ON_GRPC_CANCELLED;
@@ -56,7 +57,8 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
     : cluster_(cluster), runtime_(runtime), random_(random), dispatcher_(dispatcher),
       priority_(priority), retry_host_predicates_(route_policy.retryHostPredicates()),
       retry_priority_(route_policy.retryPriority()),
-      retriable_status_codes_(route_policy.retriableStatusCodes()) {
+      retriable_status_codes_(route_policy.retriableStatusCodes()),
+      retriable_headers_(route_policy.retriableHeaders()) {
 
   retry_on_ = route_policy.retryOn();
   retries_remaining_ = std::max(retries_remaining_, route_policy.numRetries());
@@ -93,6 +95,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
       retries_remaining_ = temp;
     }
   }
+
   if (request_headers.EnvoyRetriableStatusCodes()) {
     for (const auto code : StringUtil::splitToken(
              request_headers.EnvoyRetriableStatusCodes()->value().getStringView(), ",")) {
@@ -100,6 +103,13 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
       if (absl::SimpleAtoi(code, &out)) {
         retriable_status_codes_.emplace_back(out);
       }
+    }
+  }
+
+  if (request_headers.EnvoyRetriableHeaders()) {
+    for (const auto header : StringUtil::splitToken(
+             request_headers.EnvoyRetriableHeaders()->value().getStringView(), ",")) {
+      retriable_headers_.emplace_back(std::string(absl::StripAsciiWhitespace(header)));
     }
   }
 }
@@ -131,6 +141,8 @@ std::pair<uint32_t, bool> RetryStateImpl::parseRetryOn(absl::string_view config)
       ret |= RetryPolicy::RETRY_ON_REFUSED_STREAM;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.RetriableStatusCodes) {
       ret |= RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES;
+    } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.RetriableHeaders) {
+      ret |= RetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.Reset) {
       ret |= RetryPolicy::RETRY_ON_RESET;
     } else {
@@ -260,6 +272,14 @@ bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_heade
   if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES)) {
     for (auto code : retriable_status_codes_) {
       if (Http::Utility::getResponseStatus(response_headers) == code) {
+        return true;
+      }
+    }
+  }
+
+  if (retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_HEADERS) {
+    for (const auto& header_name : retriable_headers_) {
+      if (response_headers.get(header_name) != nullptr) {
         return true;
       }
     }

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -106,14 +106,14 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
     }
   }
 
-  if (request_headers.EnvoyRetriableHeaders()) {
+  if (request_headers.EnvoyRetriableHeaderNames()) {
     // Retriable headers in the configuration are specified via HeaderMatcher.
     // Giving the same flexibility via request header would require the user
     // to provide HeaderMatcher serialized into a string. To avoid this extra
     // complexity we only support name-only header matchers via request
     // header. Anything more sophisticated needs to be provided via config.
     for (const auto header_name : StringUtil::splitToken(
-             request_headers.EnvoyRetriableHeaders()->value().getStringView(), ",")) {
+             request_headers.EnvoyRetriableHeaderNames()->value().getStringView(), ",")) {
       envoy::api::v2::route::HeaderMatcher header_matcher;
       header_matcher.set_name(std::string(absl::StripAsciiWhitespace(header_name)));
       retriable_headers_.emplace_back(

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -108,6 +108,7 @@ private:
   Upstream::RetryPrioritySharedPtr retry_priority_;
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;
+  std::vector<Http::LowerCaseString> retriable_headers_;
 };
 
 } // namespace Router

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/common/backoff_strategy.h"
+#include "common/http/header_utility.h"
 
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -108,7 +109,7 @@ private:
   Upstream::RetryPrioritySharedPtr retry_priority_;
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;
-  std::vector<Http::LowerCaseString> retriable_headers_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
 };
 
 } // namespace Router

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -617,7 +617,8 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersMergedConfigAndRequestHeaders) 
 
   // Request header supplements the config: as a result we retry on 200.
   {
-    Http::TestHeaderMapImpl request_headers{{"x-envoy-retriable-header-names", "  :status,  FOOBAR  "}};
+    Http::TestHeaderMapImpl request_headers{
+        {"x-envoy-retriable-header-names", "  :status,  FOOBAR  "}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -415,41 +415,142 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodesHeader) {
 // Test that when 'retriable-headers' policy is set via request header, certain configured headers
 // trigger retries.
 TEST_F(RouterRetryStateImplTest, RetriableHeadersPolicySetViaRequestHeader) {
-  policy_.retriable_headers_.emplace_back("x-upstream-pushback");
-  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-headers"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
+  policy_.retry_on_ = RetryPolicy::RETRY_ON_5XX;
 
-  expectTimerCreateAndEnable();
+  Protobuf::RepeatedPtrField<envoy::api::v2::route::HeaderMatcher> matchers;
+  auto* matcher = matchers.Add();
+  matcher->set_name("X-Upstream-Pushback");
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "true"}};
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  policy_.retriable_headers_ = Http::HeaderUtility::buildHeaderMatcherVector(matchers);
+
+  // No retries based on response headers: retry mode isn't enabled.
+  {
+    Http::TestHeaderMapImpl request_headers;
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "true"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
+  // Retries based on response headers: retry mode enabled via request header.
+  {
+    Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-headers"}};
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+    expectTimerCreateAndEnable();
+
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "true"}};
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
 }
 
-// Test that when 'retriable-headers' policy is set via retry policy configuration, certain
-// configured headers trigger retries.
+// Test that when 'retriable-headers' policy is set via retry policy configuration,
+// configured header matcher conditions trigger retries.
 TEST_F(RouterRetryStateImplTest, RetriableHeadersPolicyViaRetryPolicyConfiguration) {
   policy_.retry_on_ = RetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
-  policy_.retriable_headers_.emplace_back("x-upstream-pushback");
-  Http::TestHeaderMapImpl request_headers;
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
 
-  expectTimerCreateAndEnable();
+  Protobuf::RepeatedPtrField<envoy::api::v2::route::HeaderMatcher> matchers;
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "true"}};
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-}
+  auto* matcher1 = matchers.Add();
+  matcher1->set_name("X-Upstream-Pushback");
 
-// Test that when 'retriable-headers' policy is not set, configured retrieable headers are ignored.
-TEST_F(RouterRetryStateImplTest, RetriableHeadersNoPolicy) {
-  policy_.retriable_headers_.emplace_back("x-upstream-pushback");
-  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
+  auto* matcher2 = matchers.Add();
+  matcher2->set_name("should-retry");
+  matcher2->set_exact_match("yes");
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "true"}};
-  EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  auto* matcher3 = matchers.Add();
+  matcher3->set_name("X-Verdict");
+  matcher3->set_prefix_match("retry");
+
+  auto* matcher4 = matchers.Add();
+  matcher4->set_name(":status");
+  matcher4->mutable_range_match()->set_start(500);
+  matcher4->mutable_range_match()->set_end(505);
+
+  policy_.retriable_headers_ = Http::HeaderUtility::buildHeaderMatcherVector(matchers);
+
+  auto setup_request = [this]() {
+    Http::TestHeaderMapImpl request_headers;
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+  };
+
+  // matcher1: header presence (any value).
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    expectTimerCreateAndEnable();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "true"}};
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    expectTimerCreateAndEnable();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-upstream-pushback", "false"}};
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
+  // matcher2: exact header value match.
+  {
+    setup_request();
+    expectTimerCreateAndEnable();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"should-retry", "yes"}};
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"should-retry", "no"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
+  // matcher3: prefix match.
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"x-verdict", "retry-please"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "200"},
+                                             {"x-verdict", "dont-retry-please"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
+  // matcher4: status code range (note half-open semantics: [start, end)).
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "499"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "500"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "503"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "504"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+  {
+    setup_request();
+    Http::TestHeaderMapImpl response_headers{{":status", "505"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
 }
 
 // Test various combinations of retry headers set via request headers.
@@ -487,6 +588,43 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersSetViaRequestHeader) {
 
     Http::TestHeaderMapImpl response_headers{{":status", "200"}};
     EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+}
+
+// Test merging retriable headers set via request headers and via config file.
+TEST_F(RouterRetryStateImplTest, RetriableHeadersMergedConfigAndRequestHeaders) {
+  policy_.retry_on_ = RetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::route::HeaderMatcher> matchers;
+
+  // Config says: retry if response is not 200.
+  auto* matcher = matchers.Add();
+  matcher->set_name(":status");
+  matcher->set_exact_match("200");
+  matcher->set_invert_match(true);
+
+  policy_.retriable_headers_ = Http::HeaderUtility::buildHeaderMatcherVector(matchers);
+
+  // No retries according to config.
+  {
+    Http::TestHeaderMapImpl request_headers;
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
+  // Request header supplements the config: as a result we retry on 200.
+  {
+    Http::TestHeaderMapImpl request_headers{{"x-envoy-retriable-headers", "  :status,  FOOBAR  "}};
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+
+    expectTimerCreateAndEnable();
+
+    Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
 }
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -558,7 +558,7 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersSetViaRequestHeader) {
   {
     Http::TestHeaderMapImpl request_headers{
         {"x-envoy-retry-on", "retriable-headers"},
-        {"x-envoy-retriable-headers", "X-Upstream-Pushback,FOOBAR"}};
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback,FOOBAR"}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
 
@@ -570,7 +570,7 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersSetViaRequestHeader) {
   {
     Http::TestHeaderMapImpl request_headers{
         {"x-envoy-retry-on", "retriable-headers"},
-        {"x-envoy-retriable-headers", "X-Upstream-Pushback,  FOOBAR  "}};
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback,  FOOBAR  "}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
 
@@ -582,7 +582,7 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersSetViaRequestHeader) {
   {
     Http::TestHeaderMapImpl request_headers{
         {"x-envoy-retry-on", "retriable-headers"},
-        {"x-envoy-retriable-headers", "X-Upstream-Pushback,,FOOBAR"}};
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback,,FOOBAR"}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
 
@@ -617,7 +617,7 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersMergedConfigAndRequestHeaders) 
 
   // Request header supplements the config: as a result we retry on 200.
   {
-    Http::TestHeaderMapImpl request_headers{{"x-envoy-retriable-headers", "  :status,  FOOBAR  "}};
+    Http::TestHeaderMapImpl request_headers{{"x-envoy-retriable-header-names", "  :status,  FOOBAR  "}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -100,6 +100,9 @@ public:
   const std::vector<uint32_t>& retriableStatusCodes() const override {
     return retriable_status_codes_;
   }
+  const std::vector<Http::LowerCaseString>& retriableHeaders() const override {
+    return retriable_headers_;
+  }
   absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
   absl::optional<std::chrono::milliseconds> maxInterval() const override { return max_interval_; }
 
@@ -108,6 +111,7 @@ public:
   uint32_t retry_on_{};
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;
+  std::vector<Http::LowerCaseString> retriable_headers_;
   absl::optional<std::chrono::milliseconds> base_interval_{};
   absl::optional<std::chrono::milliseconds> max_interval_{};
 };

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -100,7 +100,7 @@ public:
   const std::vector<uint32_t>& retriableStatusCodes() const override {
     return retriable_status_codes_;
   }
-  const std::vector<Http::LowerCaseString>& retriableHeaders() const override {
+  const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
     return retriable_headers_;
   }
   absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
@@ -111,7 +111,7 @@ public:
   uint32_t retry_on_{};
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;
-  std::vector<Http::LowerCaseString> retriable_headers_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
   absl::optional<std::chrono::milliseconds> base_interval_{};
   absl::optional<std::chrono::milliseconds> max_interval_{};
 };


### PR DESCRIPTION
Signed-off-by: Oleg Shaldibin <olegsh@google.com>

Description: implements the retriable headers retry policy as described in #8185.
Risk Level: low.
Testing: unit tests, manual testing.
Docs Changes: TBD.
Release Notes: new 'retriable-headers' retry policy.
Fixes #8185.
