### PR TITLE
bazel: Update protobuf and other needed dependencies

### DIFF
--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -1,28 +1,8 @@
-diff --git a/src/google/protobuf/stubs/strutil.cc b/src/google/protobuf/stubs/strutil.cc
-index 3844fa6b8b..5486887295 100644
---- a/src/google/protobuf/stubs/strutil.cc
-+++ b/src/google/protobuf/stubs/strutil.cc
-@@ -1065,10 +1065,12 @@ char* FastUInt32ToBufferLeft(uint32 u, char* buffer) {
- }
- 
- char* FastInt32ToBufferLeft(int32 i, char* buffer) {
--  uint32 u = i;
-+  uint32 u = 0;
-   if (i < 0) {
-     *buffer++ = '-';
--    u = -i;
-+    u -= i;
-+  } else {
-+    u = i;
-   }
-   return FastUInt32ToBufferLeft(u, buffer);
- }
-
 diff --git a/BUILD b/BUILD
 index 6665de94..55f28582 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -19,6 +19,6 @@ config_setting(
+@@ -19,7 +19,7 @@ config_setting(
  # ZLIB configuration
  ################################################################################
  

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -107,8 +107,9 @@ def envoy_dependencies(skip_targets = []):
     if "envoy_build_config" not in native.existing_rules().keys():
         _default_envoy_build_config(name = "envoy_build_config")
 
-    # Setup rules_foreign_cc
+    # Setup external Bazel rules
     _foreign_cc_dependencies()
+    _rules_proto_dependencies()
 
     # Binding to an alias pointing to the selected version of BoringSSL:
     # - BoringSSL FIPS from @boringssl_fips//:ssl,
@@ -317,6 +318,12 @@ def _net_zlib():
         actual = "@envoy//bazel/foreign_cc:zlib",
     )
 
+    # Bind for grpc.
+    native.bind(
+        name = "madler_zlib",
+        actual = "@envoy//bazel/foreign_cc:zlib",
+    )
+
 def _com_google_cel_cpp():
     _repository_impl("com_google_cel_cpp")
 
@@ -412,6 +419,12 @@ def _com_google_absl():
         name = "abseil_base",
         actual = "@com_google_absl//absl/base:base",
     )
+
+    # Bind for grpc.
+    native.bind(
+        name = "absl-base",
+        actual = "@com_google_absl//absl/base",
+    )
     native.bind(
         name = "abseil_flat_hash_map",
         actual = "@com_google_absl//absl/container:flat_hash_map",
@@ -477,6 +490,12 @@ def _com_google_absl():
     # direct dependency jwt_verify_lib.
     native.bind(
         name = "abseil_time",
+        actual = "@com_google_absl//absl/time:time",
+    )
+
+    # Bind for grpc.
+    native.bind(
+        name = "absl-time",
         actual = "@com_google_absl//absl/time:time",
     )
 
@@ -708,6 +727,9 @@ def _com_github_gperftools_gperftools():
 
 def _foreign_cc_dependencies():
     _repository_impl("rules_foreign_cc")
+
+def _rules_proto_dependencies():
+    _repository_impl("rules_proto")
 
 def _is_linux(ctxt):
     return ctxt.os.name == "linux"

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -93,10 +93,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gperftools/gperftools/archive/fc00474ddc21fff618fc3f009b46590e241e425e.tar.gz"],
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "bcb01ac7029a7fb5219ad2cbbc4f0a2df3ef32db42e236ce7814597f4b04b541",
-        strip_prefix = "grpc-79a8b5289e3122d2cea2da3be7151d37313d6f46",
-        # Commit from 2019-05-30
-        urls = ["https://github.com/grpc/grpc/archive/79a8b5289e3122d2cea2da3be7151d37313d6f46.tar.gz"],
+        sha256 = "cce1d4585dd017980d4a407d8c5e9f8fc8c1dbb03f249b99e88a387ebb45a035",
+        strip_prefix = "grpc-1.22.1",
+        urls = ["https://github.com/grpc/grpc/archive/v1.22.1.tar.gz"],
     ),
     com_github_luajit_luajit = dict(
         sha256 = "409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8",
@@ -210,9 +209,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/googletest/archive/d7003576dd133856432e2e07340f45926242cc3a.tar.gz"],
     ),
     com_google_protobuf = dict(
-        sha256 = "b7220b41481011305bf9100847cf294393973e869973a9661046601959b2960b",
-        strip_prefix = "protobuf-3.8.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protobuf-all-3.8.0.tar.gz"],
+        sha256 = "3040a5b946d9df7aa89c0bf6981330bf92b7844fd90e71b61da0c721e421a421",
+        strip_prefix = "protobuf-3.9.1",
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protobuf-all-3.9.1.tar.gz"],
     ),
     grpc_httpjson_transcoding = dict(
         sha256 = "a447458b47ea4dc1d31499f555769af437c5d129d988ec1e13d5fdd0a6a36b4e",
@@ -229,6 +228,15 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "rules_foreign_cc-a209b642c7687a8894c19b3dd40e43e6d3f38e83",
         # 2019-07-17
         urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/a209b642c7687a8894c19b3dd40e43e6d3f38e83.tar.gz"],
+    ),
+    rules_proto = dict(
+        sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+        strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+        # 2019-08-02
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        ],
     ),
     six_archive = dict(
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",


### PR DESCRIPTION
This change updated the following dependencies:

- protobuf - 3.9.1
- grpc - 1.22.1

And introduces the new dependencies, needed by the new protobuf:

- rules_proto

Risk Level: Medium
Testing: Unit and integration tests.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>