### PR TITLE
docs: update deprecation note for operation_name

### DIFF
--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -38,7 +38,9 @@ Version 1.12.0 (pending)
   <envoy_api_msg_config.filter.network.http_connection_manager.v2.HttpConnectionManager>`
   has been deprecated in favor of the `traffic_direction` field in
   :ref:`Listener <envoy_api_msg_Listener>`. The latter takes priority if
-  specified.
+  specified. Note that the default value `INGRESS` of the `operation_name`
+  field is not detected as being set, so the deprecation warning is not
+  triggered for it.
 
 Version 1.11.0 (July 11, 2019)
 ==============================


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: Minor clarification explaining why `operation_name: INGRESS` is not triggering the deprecation warnings.

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
