### PR TITLE
Update envoy.yaml in Redis proxy example

### DIFF
--- a/examples/redis/Dockerfile-proxy
+++ b/examples/redis/Dockerfile-proxy
@@ -1,2 +1,2 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-dev:latest
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy

--- a/examples/redis/Dockerfile-proxy
+++ b/examples/redis/Dockerfile-proxy
@@ -1,2 +1,2 @@
-FROM envoyproxy/envoy-dev:latest
+FROM envoyproxy/envoy:latest
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy

--- a/examples/redis/envoy.yaml
+++ b/examples/redis/envoy.yaml
@@ -11,9 +11,11 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           stat_prefix: egress_redis
-          cluster: redis_cluster
           settings:
             op_timeout: 5s
+          prefix_routes:
+            catch_all_route:
+              cluster: redis_cluster
   clusters:
   - name: redis_cluster
     connect_timeout: 1s


### PR DESCRIPTION
`docker-compose up` fails due to `Proto constraint validation failed` error since `cluster` is currently deprecated. Make use of `catch_all_route` as per the deprecation
notice(https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated#version-1-11-0-july-11-2019).
Also, make use of `envoyproxy/envoy:latest` since it currently supports Redis.

Signed-off-by: Raju Kadam <rkadam@atlassian.com>

Description: Make Redis example use `catch_all_route`
Risk Level: Low
Testing: Done. `docker-compose up --build` brings up envoy proxy and I was able to run `Redis` commands using `redis-cli`
Docs Changes: n/a
Release Notes: n/a

