### PR TITLE
http inspector: rename h2 to h2c

### DIFF
--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -123,6 +123,7 @@ void Filter::done(bool success) {
       ASSERT(protocol_ == "HTTP/2");
       config_->stats().http2_found_.inc();
       // h2 HTTP/2 over TLS, h2c HTTP/2 over TCP
+      // TODO(yxue): use detected protocol from http inspector and support h2c token in HCM
       protocol = "h2c";
     }
 

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -122,7 +122,8 @@ void Filter::done(bool success) {
     } else {
       ASSERT(protocol_ == "HTTP/2");
       config_->stats().http2_found_.inc();
-      protocol = "h2";
+      // h2 HTTP/2 over TLS, h2c HTTP/2 over TCP
+      protocol = "h2c";
     }
 
     cb_->socket().setRequestedApplicationProtocols({protocol});

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -199,7 +199,7 @@ TEST_F(HttpInspectorTest, InspectHttp2) {
         return Api::SysCallSizeResult{ssize_t(data.size()), 0};
       }));
 
-  const std::vector<absl::string_view> alpn_protos{absl::string_view("h2")};
+  const std::vector<absl::string_view> alpn_protos{absl::string_view("h2c")};
 
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
   EXPECT_CALL(cb_, continueFilterChain(true));
@@ -240,7 +240,7 @@ TEST_F(HttpInspectorTest, ReadError) {
 TEST_F(HttpInspectorTest, MultipleReadsHttp2) {
 
   init();
-  const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
+  const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2c")};
 
   const std::string header =
       "505249202a20485454502f322e300d0a0d0a534d0d0a0d0a00000c04000000000000041000000000020000000000"


### PR DESCRIPTION
Signed-off-by: crazyxy <yxyan@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Rename h2 to h2c to respect the standard
Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
