### PR TITLE
build: Support tags[] arg for more specific build control

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -90,6 +90,7 @@ def api_proto_library(
         visibility = ["//visibility:private"],
         srcs = [],
         deps = [],
+        tags = [],
         external_proto_deps = [],
         external_cc_proto_deps = [],
         external_py_proto_deps = [],
@@ -100,6 +101,7 @@ def api_proto_library(
         name = name,
         srcs = srcs,
         deps = deps + external_proto_deps + _COMMON_PROTO_DEPS,
+        tags = tags,
         visibility = visibility,
     )
     pgv_cc_proto_library(

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -19,7 +19,8 @@ def envoy_cc_binary(
         repository = "",
         stamped = False,
         deps = [],
-        linkopts = []):
+        linkopts = [],
+        tags = []):
     if not linkopts:
         linkopts = _envoy_linkopts()
     if stamped:
@@ -38,6 +39,7 @@ def envoy_cc_binary(
         malloc = tcmalloc_external_dep(repository),
         stamp = 1,
         deps = deps,
+        tags = tags,
     )
 
 # Select the given values if exporting is enabled in the current build.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -180,13 +180,10 @@ def envoy_cc_test(
         linkopts = _envoy_test_linkopts(),
         linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
-        deps = select({
-            "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
-            "//conditions:default": [
-                ":" + name + "_lib_internal_only",
-                repository + "//test:main",
-            ],
-        }) + envoy_stdlib_deps(),
+        deps = envoy_stdlib_deps() + [
+            ":" + name + "_lib_internal_only",
+            repository + "//test:main",
+        ],
         # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51
         # 2 - by default, mocks act as StrictMocks.
         args = args + ["--gmock_default_mock_behavior=2"],

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -93,6 +93,7 @@ def envoy_cc_fuzz_test(
             repository + "//bazel:dynamic_stdlib",
         ],
         repository = repository,
+        tags = tags,
         **kwargs
     )
     native.cc_test(
@@ -155,9 +156,10 @@ def envoy_cc_test(
         coverage = True,
         local = False,
         size = "medium"):
-    test_lib_tags = []
     if coverage:
-        test_lib_tags.append("coverage_test_lib")
+        coverage_tags = tags + ["coverage_test_lib"]
+    else:
+        coverage_tags = tags
     _envoy_cc_test_infrastructure_library(
         name = name + "_lib_internal_only",
         srcs = srcs,
@@ -165,25 +167,30 @@ def envoy_cc_test(
         external_deps = external_deps,
         deps = deps + [repository + "//test/test_common:printers_includes"],
         repository = repository,
-        tags = test_lib_tags,
+        tags = coverage_tags,
         copts = copts,
         # Allow public visibility so these can be consumed in coverage tests in external projects.
         visibility = ["//visibility:public"],
     )
+    if coverage:
+        coverage_tags = tags + ["coverage_test"]
     native.cc_test(
         name = name,
         copts = envoy_copts(repository, test = True) + copts,
         linkopts = _envoy_test_linkopts(),
         linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
-        deps = envoy_stdlib_deps() + [
-            ":" + name + "_lib_internal_only",
-            repository + "//test:main",
-        ],
+        deps = select({
+            "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
+            "//conditions:default": [
+                ":" + name + "_lib_internal_only",
+                repository + "//test:main",
+            ],
+        }) + envoy_stdlib_deps(),
         # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51
         # 2 - by default, mocks act as StrictMocks.
         args = args + ["--gmock_default_mock_behavior=2"],
-        tags = tags + ["coverage_test"],
+        tags = coverage_tags,
         local = local,
         shard_count = shard_count,
         size = size,
@@ -254,6 +261,7 @@ def envoy_sh_test(
         srcs = [],
         data = [],
         coverage = True,
+        tags = [],
         **kargs):
     if coverage:
         test_runner_cc = name + "_test_runner.cc"
@@ -268,7 +276,7 @@ def envoy_sh_test(
             name = name + "_lib",
             srcs = [test_runner_cc],
             data = srcs + data,
-            tags = ["coverage_test_lib"],
+            tags = tags + ["coverage_test_lib"],
             deps = ["//test/test_common:environment_lib"],
         )
     native.sh_test(
@@ -276,5 +284,6 @@ def envoy_sh_test(
         srcs = ["//bazel:sh_test_wrapper.sh"],
         data = srcs + data,
         args = srcs,
+        tags = tags,
         **kargs
     )


### PR DESCRIPTION
*Description*:
Support tags[] arg for more specific build control. 
Where the underlying bazel primitives support tags[], envoy_() should support them.

*Risk Level*: Low
*Testing*: Local on Windows and Linux CI
*Docs Changes*: None
*Release Notes*: None

