### PR TITLE
server: return processContext as optional reference

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -180,10 +180,10 @@ public:
   virtual Grpc::Context& grpcContext() PURE;
 
   /**
-   * @return ProcessContext* a pointer to the process context. Will be null when running in
-   * validation mode.
+   * @return absl::optional<std::reference_wrapper<ProcessContext>> an optional reference to the
+   * process context. Will be unset when running in validation mode.
    */
-  virtual ProcessContext* processContext() PURE;
+  virtual absl::optional<std::reference_wrapper<ProcessContext>> processContext() PURE;
 };
 
 class ListenerFactoryContext : public virtual FactoryContext {

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -180,9 +180,10 @@ public:
   virtual Grpc::Context& grpcContext() PURE;
 
   /**
-   * @return ProcessContext& a reference to the process context.
+   * @return ProcessContext* a pointer to the process context. Will be null when running in
+   * validation mode.
    */
-  virtual ProcessContext& processContext() PURE;
+  virtual ProcessContext* processContext() PURE;
 };
 
 class ListenerFactoryContext : public virtual FactoryContext {

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -196,7 +196,7 @@ public:
   /**
    * @return the server-wide process context.
    */
-  virtual ProcessContext* processContext() PURE;
+  virtual absl::optional<std::reference_wrapper<ProcessContext>> processContext() PURE;
 
   /**
    * @return ThreadLocal::Instance& the thread local storage engine for the server. This is used to

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -196,7 +196,7 @@ public:
   /**
    * @return the server-wide process context.
    */
-  virtual ProcessContext& processContext() PURE;
+  virtual ProcessContext* processContext() PURE;
 
   /**
    * @return ThreadLocal::Instance& the thread local storage engine for the server. This is used to

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -94,7 +94,9 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  ProcessContext* processContext() override { return nullptr; }
+  absl::optional<std::reference_wrapper<ProcessContext>> processContext() override {
+    return absl::nullopt;
+  }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
   TimeSource& timeSource() override { return api_->timeSource(); }

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -94,7 +94,7 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  ProcessContext& processContext() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ProcessContext* processContext() override { return nullptr; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
   TimeSource& timeSource() override { return api_->timeSource(); }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -324,7 +324,9 @@ public:
   ServerLifecycleNotifier& lifecycleNotifier() override {
     return parent_.server_.lifecycleNotifier();
   }
-  ProcessContext* processContext() override { return parent_.server_.processContext(); }
+  absl::optional<std::reference_wrapper<ProcessContext>> processContext() override {
+    return parent_.server_.processContext();
+  }
 
   // Network::DrainDecision
   bool drainClose() const override;

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -324,7 +324,7 @@ public:
   ServerLifecycleNotifier& lifecycleNotifier() override {
     return parent_.server_.lifecycleNotifier();
   }
-  ProcessContext& processContext() override { return parent_.server_.processContext(); }
+  ProcessContext* processContext() override { return parent_.server_.processContext(); }
 
   // Network::DrainDecision
   bool drainClose() const override;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -194,7 +194,7 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  ProcessContext& processContext() override { return *process_context_; }
+  ProcessContext* processContext() override { return process_context_.get(); }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -194,7 +194,9 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  ProcessContext* processContext() override { return process_context_.get(); }
+  absl::optional<std::reference_wrapper<ProcessContext>> processContext() override {
+    return *process_context_;
+  }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }

--- a/test/integration/filters/process_context_filter.cc
+++ b/test/integration/filters/process_context_filter.cc
@@ -44,7 +44,7 @@ public:
                Server::Configuration::FactoryContext& factory_context) override {
     return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {
       callbacks.addStreamFilter(
-          std::make_shared<ProcessContextFilter>(factory_context.processContext()));
+          std::make_shared<ProcessContextFilter>(*factory_context.processContext()));
     };
   }
 };

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -382,7 +382,7 @@ public:
   MOCK_METHOD0(stats, Stats::Store&());
   MOCK_METHOD0(grpcContext, Grpc::Context&());
   MOCK_METHOD0(httpContext, Http::Context&());
-  MOCK_METHOD0(processContext, ProcessContext*());
+  MOCK_METHOD0(processContext, absl::optional<std::reference_wrapper<ProcessContext>>());
   MOCK_METHOD0(threadLocal, ThreadLocal::Instance&());
   MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_CONST_METHOD0(statsFlushInterval, std::chrono::milliseconds());
@@ -470,7 +470,7 @@ public:
   Event::TestTimeSystem& timeSystem() { return time_system_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  MOCK_METHOD0(processContext, ProcessContext*());
+  MOCK_METHOD0(processContext, absl::optional<std::reference_wrapper<ProcessContext>>());
   MOCK_METHOD0(messageValidationVisitor, ProtobufMessage::ValidationVisitor&());
   MOCK_METHOD0(api, Api::Api&());
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -382,7 +382,7 @@ public:
   MOCK_METHOD0(stats, Stats::Store&());
   MOCK_METHOD0(grpcContext, Grpc::Context&());
   MOCK_METHOD0(httpContext, Http::Context&());
-  MOCK_METHOD0(processContext, ProcessContext&());
+  MOCK_METHOD0(processContext, ProcessContext*());
   MOCK_METHOD0(threadLocal, ThreadLocal::Instance&());
   MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_CONST_METHOD0(statsFlushInterval, std::chrono::milliseconds());
@@ -470,7 +470,7 @@ public:
   Event::TestTimeSystem& timeSystem() { return time_system_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  MOCK_METHOD0(processContext, ProcessContext&());
+  MOCK_METHOD0(processContext, ProcessContext*());
   MOCK_METHOD0(messageValidationVisitor, ProtobufMessage::ValidationVisitor&());
   MOCK_METHOD0(api, Api::Api&());
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -839,7 +839,7 @@ TEST_P(ServerInstanceImplTest, WithProcessContext) {
 
   EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
 
-  ProcessContext* context = server_->processContext();
+  auto context = server_->processContext();
   auto& object_from_context = dynamic_cast<TestObject&>(context->get());
   EXPECT_EQ(&object_from_context, &object);
   EXPECT_TRUE(object_from_context.boolean_flag_);

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -840,7 +840,7 @@ TEST_P(ServerInstanceImplTest, WithProcessContext) {
   EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
 
   auto context = server_->processContext();
-  auto& object_from_context = dynamic_cast<TestObject&>(context->get());
+  auto& object_from_context = dynamic_cast<TestObject&>(context->get().get());
   EXPECT_EQ(&object_from_context, &object);
   EXPECT_TRUE(object_from_context.boolean_flag_);
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -839,8 +839,8 @@ TEST_P(ServerInstanceImplTest, WithProcessContext) {
 
   EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
 
-  ProcessContext& context = server_->processContext();
-  auto& object_from_context = dynamic_cast<TestObject&>(context.get());
+  ProcessContext* context = server_->processContext();
+  auto& object_from_context = dynamic_cast<TestObject&>(context->get());
   EXPECT_EQ(&object_from_context, &object);
   EXPECT_TRUE(object_from_context.boolean_flag_);
 


### PR DESCRIPTION
Description: return an optional reference to the ProcessContext from the factory context rather than a reference. The ProcessContext will be unset when running in validation mode
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
