### PR TITLE
stat: Adding new stat to find actual initial_fetch_timeout per xds

### DIFF
--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -97,19 +97,20 @@ using SubscriptionPtr = std::unique_ptr<Subscription>;
 /**
  * Per subscription stats. @see stats_macros.h
  */
-#define ALL_SUBSCRIPTION_STATS(COUNTER, GAUGE)                                                     \
+#define ALL_SUBSCRIPTION_STATS(COUNTER, GAUGE, HISTOGRAM)                                          \
   COUNTER(init_fetch_timeout)                                                                      \
   COUNTER(update_attempt)                                                                          \
   COUNTER(update_failure)                                                                          \
   COUNTER(update_rejected)                                                                         \
   COUNTER(update_success)                                                                          \
-  GAUGE(version, NeverImport)
+  GAUGE(version, NeverImport)                                                                      \
+  HISTOGRAM(init_fetch_time)
 
 /**
  * Struct definition for per subscription stats. @see stats_macros.h
  */
 struct SubscriptionStats {
-  ALL_SUBSCRIPTION_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+  ALL_SUBSCRIPTION_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 } // namespace Config

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -196,6 +196,7 @@ envoy_cc_library(
         "//include/envoy/config:grpc_mux_interface",
         "//include/envoy/config:subscription_interface",
         "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/stats:timespan",
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/grpc:common_lib",

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -4,6 +4,7 @@
 #include "envoy/config/grpc_mux.h"
 #include "envoy/config/subscription.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/stats/timespan.h"
 
 #include "common/common/logger.h"
 
@@ -44,6 +45,7 @@ private:
   Event::Dispatcher& dispatcher_;
   std::chrono::milliseconds init_fetch_timeout_;
   Event::TimerPtr init_fetch_timeout_timer_;
+  Stats::TimespanPtr init_fetch_timer_;
 };
 
 } // namespace Config

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -191,7 +191,7 @@ public:
    * @return SubscriptionStats for scope.
    */
   static SubscriptionStats generateStats(Stats::Scope& scope) {
-    return {ALL_SUBSCRIPTION_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope))};
+    return {ALL_SUBSCRIPTION_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope), POOL_HISTOGRAM(scope))};
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>

Description: 
>New stat for granular xds initial_fetch_timeout . 
We are investigating a slowness in envoy's initialization_time_ms p50 percentiles.
From our investigation it looks like it is mostly due to the slowness of xds endpoints(most probably eds). However there are no granular stats today to tell if cds/eds is causing the slowness and by how much.
Also, we want to configure the initial_fetch_timeout of each resource to a number close to the real value, rather than setting it to an arbitrary value.

Risk Level: Moderate
Testing: Todo . Add unit test
Docs Changes: Todo
Release Notes: Todo
