### PR TITLE
health check: Set grpc timeout for gRPC health checks

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -614,6 +614,10 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
                                    parent_.service_method_.name(), absl::nullopt);
   headers_message->headers().insertUserAgent().value().setReference(
       Http::Headers::get().UserAgentValues.EnvoyHealthChecker);
+
+  Grpc::Common::toGrpcTimeout(parent_.timeout_,
+                              headers_message->headers().insertGrpcTimeout().value());
+
   Router::FilterUtility::setUpstreamScheme(headers_message->headers(), *parent_.cluster_.info());
 
   request_encoder_->encodeHeaders(headers_message->headers(), false);


### PR DESCRIPTION
Signed-off-by: Erik Lindblad <erili@spotify.com>

Description: Since using deadlines is strongly recommended (https://grpc.io/blog/deadlines/) our infra enforces that deadlines are present by default. This goes at-odds when adding a gRPC health check service to our upstreams, since envoy isn't setting the deadline. 

To me it seems that it's perfectly fine to set deadline to the health check timeout value inherited from the base HC type. A positive consequence would be that upstreams can chose to fail the HC fast in case they know they won't complete whatever health checking logic they perform in time to meet the deadline.

Risk Level: low
Testing: not much, ran it locally and it sets the deadline as expected
Docs Changes: N/A
Release Notes: not sure if this warrants a release note...
[Optional Fixes #Issue]
[Optional Deprecated:]
