### PR TITLE
server: expose ProcessContext via the Api interface

### DIFF
--- a/include/envoy/api/BUILD
+++ b/include/envoy/api/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/filesystem:filesystem_interface",
+        "//include/envoy/server:process_context_interface",
         "//include/envoy/thread:thread_interface",
     ],
 )

--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -6,6 +6,7 @@
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
+#include "envoy/server/process_context.h"
 #include "envoy/stats/store.h"
 #include "envoy/thread/thread.h"
 
@@ -52,6 +53,11 @@ public:
    * @return a constant reference to the root Stats::Scope
    */
   virtual const Stats::Scope& rootScope() PURE;
+
+  /**
+   * @return an optional reference to the ProcessContext
+   */
+  virtual OptProcessContextRef processContext() PURE;
 };
 
 using ApiPtr = std::unique_ptr<Api>;

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -180,10 +180,10 @@ public:
   virtual Grpc::Context& grpcContext() PURE;
 
   /**
-   * @return absl::optional<std::reference_wrapper<ProcessContext>> an optional reference to the
+   * @return OptProcessContextRef an optional reference to the
    * process context. Will be unset when running in validation mode.
    */
-  virtual absl::optional<std::reference_wrapper<ProcessContext>> processContext() PURE;
+  virtual OptProcessContextRef processContext() PURE;
 };
 
 class ListenerFactoryContext : public virtual FactoryContext {

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -196,7 +196,7 @@ public:
   /**
    * @return the server-wide process context.
    */
-  virtual absl::optional<std::reference_wrapper<ProcessContext>> processContext() PURE;
+  virtual OptProcessContextRef processContext() PURE;
 
   /**
    * @return ThreadLocal::Instance& the thread local storage engine for the server. This is used to

--- a/include/envoy/server/process_context.h
+++ b/include/envoy/server/process_context.h
@@ -2,6 +2,8 @@
 
 #include "envoy/common/pure.h"
 
+#include "absl/types/optional.h"
+
 namespace Envoy {
 
 /**
@@ -25,5 +27,7 @@ public:
    */
   virtual ProcessObject& get() const PURE;
 };
+
+using OptProcessContextRef = absl::optional<std::reference_wrapper<ProcessContext>>;
 
 } // namespace Envoy

--- a/source/common/api/api_impl.cc
+++ b/source/common/api/api_impl.cc
@@ -10,9 +10,10 @@ namespace Envoy {
 namespace Api {
 
 Impl::Impl(Thread::ThreadFactory& thread_factory, Stats::Store& store,
-           Event::TimeSystem& time_system, Filesystem::Instance& file_system)
+           Event::TimeSystem& time_system, Filesystem::Instance& file_system,
+           const OptProcessContextRef& process_context)
     : thread_factory_(thread_factory), store_(store), time_system_(time_system),
-      file_system_(file_system) {}
+      file_system_(file_system), process_context_(process_context) {}
 
 Event::DispatcherPtr Impl::allocateDispatcher() {
   return std::make_unique<Event::DispatcherImpl>(*this, time_system_);

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -17,7 +17,8 @@ namespace Api {
 class Impl : public Api {
 public:
   Impl(Thread::ThreadFactory& thread_factory, Stats::Store& store, Event::TimeSystem& time_system,
-       Filesystem::Instance& file_system);
+       Filesystem::Instance& file_system,
+       const OptProcessContextRef& process_context = absl::nullopt);
 
   // Api::Api
   Event::DispatcherPtr allocateDispatcher() override;
@@ -26,12 +27,14 @@ public:
   Filesystem::Instance& fileSystem() override { return file_system_; }
   TimeSource& timeSource() override { return time_system_; }
   const Stats::Scope& rootScope() override { return store_; }
+  OptProcessContextRef processContext() override { return process_context_; }
 
 private:
   Thread::ThreadFactory& thread_factory_;
   Stats::Store& store_;
   Event::TimeSystem& time_system_;
   Filesystem::Instance& file_system_;
+  OptProcessContextRef process_context_;
 };
 
 } // namespace Api

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -94,9 +94,7 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  absl::optional<std::reference_wrapper<ProcessContext>> processContext() override {
-    return absl::nullopt;
-  }
+  OptProcessContextRef processContext() override { return absl::nullopt; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
   TimeSource& timeSource() override { return api_->timeSource(); }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -324,9 +324,7 @@ public:
   ServerLifecycleNotifier& lifecycleNotifier() override {
     return parent_.server_.lifecycleNotifier();
   }
-  absl::optional<std::reference_wrapper<ProcessContext>> processContext() override {
-    return parent_.server_.processContext();
-  }
+  OptProcessContextRef processContext() override { return parent_.server_.processContext(); }
 
   // Network::DrainDecision
   bool drainClose() const override;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -61,7 +61,7 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
                           !options.rejectUnknownDynamicFields()),
       time_source_(time_system), restarter_(restarter), start_time_(time(nullptr)),
       original_start_time_(start_time_), stats_store_(store), thread_local_(tls),
-      api_(new Api::Impl(thread_factory, store, time_system, file_system)),
+      api_(new Api::Impl(thread_factory, store, time_system, file_system, *process_context)),
       dispatcher_(api_->allocateDispatcher()),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory())),
       handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -61,7 +61,9 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
                           !options.rejectUnknownDynamicFields()),
       time_source_(time_system), restarter_(restarter), start_time_(time(nullptr)),
       original_start_time_(start_time_), stats_store_(store), thread_local_(tls),
-      api_(new Api::Impl(thread_factory, store, time_system, file_system, *process_context)),
+      api_(new Api::Impl(thread_factory, store, time_system, file_system,
+                         process_context ? OptProcessContextRef(std::ref(*process_context))
+                                         : absl::nullopt)),
       dispatcher_(api_->allocateDispatcher()),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory())),
       handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -194,9 +194,7 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  absl::optional<std::reference_wrapper<ProcessContext>> processContext() override {
-    return *process_context_;
-  }
+  OptProcessContextRef processContext() override { return *process_context_; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -40,6 +40,7 @@ public:
   MOCK_METHOD0(fileSystem, Filesystem::Instance&());
   MOCK_METHOD0(threadFactory, Thread::ThreadFactory&());
   MOCK_METHOD0(rootScope, const Stats::Scope&());
+  MOCK_METHOD0(processContext, OptProcessContextRef());
 
   testing::NiceMock<Filesystem::MockInstance> file_system_;
   Event::GlobalTimeSystem time_system_;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -470,7 +470,7 @@ public:
   Event::TestTimeSystem& timeSystem() { return time_system_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  MOCK_METHOD0(processContext, absl::optional<std::reference_wrapper<ProcessContext>>());
+  MOCK_METHOD0(processContext, OptProcessContextRef());
   MOCK_METHOD0(messageValidationVisitor, ProtobufMessage::ValidationVisitor&());
   MOCK_METHOD0(api, Api::Api&());
 


### PR DESCRIPTION
Description: expose an optional ProcessContext in the Api interface so it is accessible to extensions that don't get a FactoryContext
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>