### PR TITLE
xds: add a status manager tracking the status of DS components.

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -94,6 +94,7 @@ envoy_cc_library(
         ":lifecycle_notifier_interface",
         ":listener_manager_interface",
         ":options_interface",
+        ":status_manager_interface",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/api:api_interface",
         "//include/envoy/common:mutex_tracer",
@@ -245,6 +246,11 @@ envoy_cc_library(
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/singleton:const_singleton",
     ],
+)
+
+envoy_cc_library(
+    name = "status_manager_interface",
+    hdrs = ["status_manager.h"],
 )
 
 envoy_cc_library(

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -22,6 +22,7 @@
 #include "envoy/server/listener_manager.h"
 #include "envoy/server/options.h"
 #include "envoy/server/overload_manager.h"
+#include "envoy/server/status_manager.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"
@@ -107,6 +108,13 @@ public:
    *         will start listening.
    */
   virtual Init::Manager& initManager() PURE;
+
+  /**
+   * @return the server's status manager. This can be used to track status for the status of
+   * arbitrary reloadable components in Envoy. Eventually it is likely this
+   * status will be exposed via the admin page.
+   */
+  virtual StatusManager& statusManager() PURE;
 
   /**
    * @return the server's listener manager.

--- a/include/envoy/server/status_manager.h
+++ b/include/envoy/server/status_manager.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Server {
+
+/* A class to track the status of reloadable components */
+class StatusManager {
+public:
+  struct StatusHandle {
+    StatusHandle(bool success, std::string details) : success_(success), details_(details) {}
+    // True if the last load of the component was successful, false otherwise.
+    bool success_;
+    // Details about the last status load.
+    std::string details_;
+  };
+
+  virtual ~StatusManager() {}
+
+  /**
+   * Adds a new component to track status of.
+   *
+   * @param component supplies the component for the StatusManager to track
+   * updateStatus() and status() should only be called for components which have
+   * been added in this way
+   */
+  virtual void addComponent(absl::string_view component) PURE;
+
+  /**
+   * Updates the status of a given component.
+   *
+   * @param component supplies the component to update the status of
+   * @param details supplies the latest status for the supplied component
+   */
+  virtual void updateStatus(absl::string_view component,
+                            std::unique_ptr<StatusHandle>&& details) PURE;
+
+  /**
+   * Returns the status of a given component
+   *
+   * @param component supplies the component to return the status of
+   * @return StatusHandle the status of the component supplied
+   */
+  virtual StatusHandle status(absl::string_view component) PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -240,6 +240,7 @@ envoy_cc_library(
     srcs = ["lds_api.cc"],
     hdrs = ["lds_api.h"],
     deps = [
+        ":status_manager_lib",
         "//include/envoy/config:subscription_factory_interface",
         "//include/envoy/config:subscription_interface",
         "//include/envoy/init:manager_interface",
@@ -348,6 +349,7 @@ envoy_cc_library(
         ":listener_hooks_lib",
         ":listener_manager_lib",
         ":ssl_context_manager_lib",
+        ":status_manager_lib",
         ":worker_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:signal_interface",
@@ -400,6 +402,15 @@ envoy_cc_library(
     deps = [
         "//include/envoy/registry",
         "//include/envoy/ssl:context_manager_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "status_manager_lib",
+    srcs = ["status_manager_impl.cc"],
+    hdrs = ["status_manager_impl.h"],
+    deps = [
+        "//include/envoy/server:status_manager_interface",
     ],
 )
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -77,6 +77,7 @@ public:
   void failHealthcheck(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   HotRestart& hotRestart() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Init::Manager& initManager() override { return init_manager_; }
+  StatusManager& statusManager() override { return status_manager_; }
   ServerLifecycleNotifier& lifecycleNotifier() override { return *this; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
@@ -110,8 +111,8 @@ public:
 
   // Server::ListenerComponentFactory
   LdsApiPtr createLdsApi(const envoy::api::v2::core::ConfigSource& lds_config) override {
-    return std::make_unique<LdsApiImpl>(lds_config, clusterManager(), initManager(), stats(),
-                                        listenerManager(),
+    return std::make_unique<LdsApiImpl>(lds_config, clusterManager(), initManager(),
+                                        statusManager(), stats(), listenerManager(),
                                         messageValidationContext().dynamicValidationVisitor());
   }
   std::vector<Network::FilterFactoryCb> createNetworkFilterFactoryList(
@@ -165,6 +166,7 @@ private:
   // only after referencing members are gone, since initialization continuation can potentially
   // occur at any point during member lifetime.
   Init::ManagerImpl init_manager_{"Validation server"};
+  StatusManagerImpl status_manager_;
   Init::WatcherImpl init_watcher_{"(no-op)", []() {}};
   // secret_manager_ must come before listener_manager_, config_ and dispatcher_, and destructed
   // only after these members can no longer reference it, since:

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -7,6 +7,7 @@
 #include "envoy/config/subscription_factory.h"
 #include "envoy/init/manager.h"
 #include "envoy/server/listener_manager.h"
+#include "envoy/server/status_manager.h"
 #include "envoy/stats/scope.h"
 
 #include "common/common/logger.h"
@@ -23,8 +24,8 @@ class LdsApiImpl : public LdsApi,
                    Logger::Loggable<Logger::Id::upstream> {
 public:
   LdsApiImpl(const envoy::api::v2::core::ConfigSource& lds_config, Upstream::ClusterManager& cm,
-             Init::Manager& init_manager, Stats::Scope& scope, ListenerManager& lm,
-             ProtobufMessage::ValidationVisitor& validation_visitor);
+             Init::Manager& init_manager, StatusManager& status_manager, Stats::Scope& scope,
+             ListenerManager& lm, ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // Server::LdsApi
   std::string versionInfo() const override { return system_version_info_; }
@@ -48,6 +49,7 @@ private:
   Stats::ScopePtr scope_;
   Upstream::ClusterManager& cm_;
   Init::TargetImpl init_target_;
+  StatusManager& status_manager_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
 };
 

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -61,8 +61,9 @@ public:
   // Server::ListenerComponentFactory
   LdsApiPtr createLdsApi(const envoy::api::v2::core::ConfigSource& lds_config) override {
     return std::make_unique<LdsApiImpl>(
-        lds_config, server_.clusterManager(), server_.initManager(), server_.stats(),
-        server_.listenerManager(), server_.messageValidationContext().dynamicValidationVisitor());
+        lds_config, server_.clusterManager(), server_.initManager(), server_.statusManager(),
+        server_.stats(), server_.listenerManager(),
+        server_.messageValidationContext().dynamicValidationVisitor());
   }
   std::vector<Network::FilterFactoryCb> createNetworkFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::api::v2::listener::Filter>& filters,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -37,6 +37,7 @@
 #include "server/listener_hooks.h"
 #include "server/listener_manager_impl.h"
 #include "server/overload_manager_impl.h"
+#include "server/status_manager_impl.h"
 #include "server/worker_impl.h"
 
 #include "absl/container/node_hash_map.h"
@@ -176,6 +177,7 @@ public:
   void failHealthcheck(bool fail) override;
   HotRestart& hotRestart() override { return restarter_; }
   Init::Manager& initManager() override { return init_manager_; }
+  StatusManager& statusManager() override { return status_manager_; }
   ServerLifecycleNotifier& lifecycleNotifier() override { return *this; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
@@ -228,6 +230,8 @@ private:
   // only after referencing members are gone, since initialization continuation can potentially
   // occur at any point during member lifetime. This init manager is populated with LdsApi targets.
   Init::ManagerImpl init_manager_{"Server"};
+  // status_manager_ has the same lifetime constraints as the init_manager_.
+  StatusManagerImpl status_manager_;
   // secret_manager_ must come before listener_manager_, config_ and dispatcher_, and destructed
   // only after these members can no longer reference it, since:
   // - There may be active filter chains referencing it in listener_manager_.

--- a/source/server/status_manager_impl.cc
+++ b/source/server/status_manager_impl.cc
@@ -1,0 +1,25 @@
+#include "server/status_manager_impl.h"
+
+namespace Envoy {
+namespace Server {
+
+void StatusManagerImpl::addComponent(absl::string_view component) {
+  absl::WriterMutexLock lock(&status_map_lock_);
+  status_map_[component] = nullptr;
+}
+
+void StatusManagerImpl::updateStatus(absl::string_view component,
+                                     std::unique_ptr<StatusHandle>&& status) {
+  absl::WriterMutexLock lock(&status_map_lock_);
+  auto it = status_map_.find(component);
+  it->second = std::move(status);
+}
+
+StatusManager::StatusHandle StatusManagerImpl::status(absl::string_view component) {
+  absl::ReaderMutexLock lock(&status_map_lock_);
+  StatusHandle ret = *status_map_.find(component)->second;
+  return ret;
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/status_manager_impl.h
+++ b/source/server/status_manager_impl.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "envoy/server/status_manager.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+
+namespace Envoy {
+namespace Server {
+
+class StatusManagerImpl : public StatusManager {
+public:
+  void addComponent(absl::string_view component) override;
+  void updateStatus(absl::string_view component, std::unique_ptr<StatusHandle>&& status) override;
+  StatusHandle status(absl::string_view component) override;
+
+private:
+  using StatusMap = absl::flat_hash_map<std::string, std::unique_ptr<StatusManager::StatusHandle>>;
+  absl::Mutex status_map_lock_;
+  StatusMap status_map_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -442,8 +442,8 @@ void BaseIntegrationTest::createGeneratedApiTestServer(const std::string& bootst
       if (!allow_lds_rejection) {
         RELEASE_ASSERT(test_server_->counter(rejected) == nullptr ||
                            test_server_->counter(rejected)->value() == 0,
-                       "Lds update failed. For details, run test with -l trace and look for "
-                       "\"Error adding/updating listener(s)\" in the logs.");
+                       absl::StrCat("\nLds update failed:\n",
+                                    test_server_->server().statusManager().status("LDS").details_));
       }
       time_system_.sleep(std::chrono::milliseconds(10));
     }

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -153,6 +153,7 @@ MockInstance::MockInstance()
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, drainManager()).WillByDefault(ReturnRef(drain_manager_));
   ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
+  ON_CALL(*this, statusManager()).WillByDefault(ReturnRef(status_manager_));
   ON_CALL(*this, listenerManager()).WillByDefault(ReturnRef(listener_manager_));
   ON_CALL(*this, mutexTracer()).WillByDefault(Return(nullptr));
   ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(*singleton_manager_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -108,6 +108,13 @@ public:
   bool cpuset_threads_enabled_{};
 };
 
+class MockStatusManager : public StatusManager {
+public:
+  MOCK_METHOD1(addComponent, void(absl::string_view));
+  MOCK_METHOD2(updateStatus, void(absl::string_view, std::unique_ptr<StatusHandle>&&));
+  MOCK_METHOD1(status, StatusManager::StatusHandle(absl::string_view));
+};
+
 class MockConfigTracker : public ConfigTracker {
 public:
   MockConfigTracker();
@@ -366,6 +373,7 @@ public:
   MOCK_METHOD0(healthCheckFailed, bool());
   MOCK_METHOD0(hotRestart, HotRestart&());
   MOCK_METHOD0(initManager, Init::Manager&());
+  MOCK_METHOD0(statusManager, StatusManager&());
   MOCK_METHOD0(lifecycleNotifier, ServerLifecycleNotifier&());
   MOCK_METHOD0(listenerManager, ListenerManager&());
   MOCK_METHOD0(mutexTracer, Envoy::MutexTracer*());
@@ -411,6 +419,7 @@ public:
   testing::NiceMock<MockServerLifecycleNotifier> lifecycle_notifier_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
   testing::NiceMock<Init::MockManager> init_manager_;
+  testing::NiceMock<MockStatusManager> status_manager_;
   testing::NiceMock<MockListenerManager> listener_manager_;
   testing::NiceMock<MockOverloadManager> overload_manager_;
   Singleton::ManagerPtr singleton_manager_;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -241,6 +241,14 @@ envoy_cc_fuzz_test(
     ] + envoy_all_extensions(),
 )
 
+envoy_cc_test(
+    name = "status_manager_impl_test",
+    srcs = ["status_manager_impl_test.cc"],
+    deps = [
+        "//source/server:status_manager_lib",
+    ],
+)
+
 filegroup(
     name = "runtime_test_data",
     srcs = glob(["test_data/runtime/**"]),

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -35,8 +35,9 @@ public:
   void setup() {
     envoy::api::v2::core::ConfigSource lds_config;
     EXPECT_CALL(init_manager_, add(_));
-    lds_ = std::make_unique<LdsApiImpl>(lds_config, cluster_manager_, init_manager_, store_,
-                                        listener_manager_, validation_visitor_);
+    lds_ =
+        std::make_unique<LdsApiImpl>(lds_config, cluster_manager_, init_manager_, status_manager_,
+                                     store_, listener_manager_, validation_visitor_);
     EXPECT_CALL(*cluster_manager_.subscription_factory_.subscription_, start(_));
     init_target_handle_->initialize(init_watcher_);
     lds_callbacks_ = cluster_manager_.subscription_factory_.callbacks_;
@@ -92,6 +93,7 @@ public:
   Config::SubscriptionCallbacks* lds_callbacks_{};
   std::unique_ptr<LdsApiImpl> lds_;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
+  NiceMock<Server::MockStatusManager> status_manager_;
 
 private:
   std::list<NiceMock<Network::MockListenerConfig>> listeners_;

--- a/test/server/status_manager_impl_test.cc
+++ b/test/server/status_manager_impl_test.cc
@@ -1,0 +1,21 @@
+#include "server/status_manager_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Server {
+
+TEST(StatusManagerImpl, BasicFunctionality) {
+  StatusManagerImpl impl;
+  impl.addComponent("foo");
+
+  auto status = std::make_unique<StatusManager::StatusHandle>(true, "details");
+  impl.updateStatus("foo", std::move(status));
+
+  StatusManager::StatusHandle returned_status = impl.status("foo");
+  EXPECT_EQ("details", returned_status.details_);
+  EXPECT_EQ(true, returned_status.success_);
+}
+
+} // namespace Server
+} // namespace Envoy


### PR DESCRIPTION
I think if we go with this we're going to want to

- implement this for all DS classes
- add load time as something we track
- make it visible via an admin page

but I'd like to start small and sort out a locking strategy and make sure we don't need the double layer of indirection from the init manager before moving forward

Description: Tracking load status for LDS with a new status manager class
Risk Level: Medium: lock grabbing on LDS updates
Testing: new UT, manual integration testing of now useful logs
Docs Changes: n/a
Release Notes: n/a
#8039