### PR TITLE
RdsConfigProvider dedup

### DIFF
--- a/include/envoy/config/config_provider.h
+++ b/include/envoy/config/config_provider.h
@@ -121,7 +121,7 @@ public:
     for (const auto* elem : config_protos) {
       ret_protos.push_back(static_cast<const P*>(elem));
     }
-    return ConfigProtoInfoVector<P>{ret_protos, getConfigVersion()};
+    return ConfigProtoInfoVector<P>{std::move(ret_protos), getConfigVersion()};
   }
 
   /**

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -56,6 +56,7 @@ public:
 };
 
 using RouteConfigProviderPtr = std::unique_ptr<RouteConfigProvider>;
+using RouteConfigProviderSharedPtr = std::shared_ptr<RouteConfigProvider>;
 
 } // namespace Router
 } // namespace Envoy

--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -36,7 +36,7 @@ public:
    * @param init_manager the Init::Manager used to coordinate initialization of a the underlying RDS
    * subscription.
    */
-  virtual RouteConfigProviderPtr createRdsRouteConfigProvider(
+  virtual RouteConfigProviderSharedPtr createRdsRouteConfigProvider(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
       Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
       Init::Manager& init_manager) PURE;

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -111,6 +111,8 @@ class FactoryContext : public virtual CommonFactoryContext {
 public:
   ~FactoryContext() override = default;
 
+  virtual FactoryContext* getServerContext() { return nullptr; }
+
   /**
    * @return AccessLogManager for use by the entire server.
    */

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -228,17 +228,17 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::createRdsRo
   // RdsRouteConfigSubscriptions are unique based on their serialized RDS config.
   const uint64_t manager_identifier = MessageUtil::hash(rds);
 
-
   auto it = dynamic_route_config_providers_.find(manager_identifier);
   if (it == dynamic_route_config_providers_.end()) {
     // std::make_shared does not work for classes with private constructors. There are ways
     // around it. However, since this is not a performance critical path we err on the side
     // of simplicity.
-    RdsRouteConfigSubscriptionSharedPtr subscription(new RdsRouteConfigSubscription(rds, manager_identifier, factory_context,
-                                                      stat_prefix, *this));
+    RdsRouteConfigSubscriptionSharedPtr subscription(new RdsRouteConfigSubscription(
+        rds, manager_identifier, factory_context, stat_prefix, *this));
     init_manager.add(subscription->init_target_);
-    std::shared_ptr<RdsRouteConfigProviderImpl> provider {new RdsRouteConfigProviderImpl(std::move(subscription), factory_context)};
-    dynamic_route_config_providers_.insert({manager_identifier, provider /* to_weak */}); 
+    std::shared_ptr<RdsRouteConfigProviderImpl> provider{
+        new RdsRouteConfigProviderImpl(std::move(subscription), factory_context)};
+    dynamic_route_config_providers_.insert({manager_identifier, provider /* to_weak */});
     return provider;
   } else {
     // Because the RouteConfigProviderManager's weak_ptrs only get cleaned up

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -44,7 +44,7 @@ public:
    * @return RouteConfigProviderPtr a new route configuration provider based on the supplied proto
    *         configuration.
    */
-  static RouteConfigProviderPtr
+  static RouteConfigProviderSharedPtr
   create(const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
              config,
          Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
@@ -204,7 +204,7 @@ public:
   std::unique_ptr<envoy::admin::v2alpha::RoutesConfigDump> dumpRouteConfigs() const;
 
   // RouteConfigProviderManager
-  RouteConfigProviderPtr createRdsRouteConfigProvider(
+  RouteConfigProviderSharedPtr createRdsRouteConfigProvider(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
       Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
       Init::Manager& init_manager) override;
@@ -217,8 +217,8 @@ private:
   // TODO(jsedgwick) These two members are prime candidates for the owned-entry list/map
   // as in ConfigTracker. I.e. the ProviderImpls would have an EntryOwner for these lists
   // Then the lifetime management stuff is centralized and opaque.
-  std::unordered_map<uint64_t, std::weak_ptr<RdsRouteConfigSubscription>>
-      route_config_subscriptions_;
+  std::unordered_map<uint64_t, std::weak_ptr<RdsRouteConfigProviderImpl>>
+      dynamic_route_config_providers_;
   std::unordered_set<RouteConfigProvider*> static_route_config_providers_;
   Server::ConfigTracker::EntryOwnerPtr config_tracker_entry_;
 

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -116,7 +116,7 @@ ScopedRdsConfigSubscription::RdsRouteConfigProviderHelper::RdsRouteConfigProvide
           parent_.route_config_provider_manager_
               .createRdsRouteConfigProvider(rds, parent_.factory_context_, parent_.stat_prefix_,
                                             init_manager)
-              .release())),
+              .get())),
       rds_update_callback_handle_(route_provider_->subscription().addUpdateCallback([this]() {
         // Subscribe to RDS update.
         parent_.onRdsConfigUpdate(scope_name_, route_provider_->subscription());

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -178,7 +178,7 @@ private:
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_;
   std::chrono::milliseconds request_timeout_;
-  Router::RouteConfigProviderPtr route_config_provider_;
+  Router::RouteConfigProviderSharedPtr route_config_provider_;
   Config::ConfigProviderPtr scoped_routes_config_provider_;
   std::chrono::milliseconds drain_timeout_;
   bool generate_request_id_;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -192,7 +192,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                            ListenerManagerImpl& parent, const std::string& name, bool added_via_api,
                            bool workers_started, uint64_t hash,
                            ProtobufMessage::ValidationVisitor& validation_visitor)
-    : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
+    : parent_(parent), server_factory_context_(parent.server_factory_context_),
+      address_(Network::Address::resolveProtoAddress(config.address())),
       filter_chain_manager_(address_),
       socket_type_(Network::Utility::protobufAddressSocketType(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
@@ -341,6 +342,8 @@ ListenerImpl::~ListenerImpl() {
   init_watcher_.reset();
 }
 
+Configuration::FactoryContext* ListenerImpl::getServerContext() { return &server_factory_context_; }
+
 namespace {
 
 // Template function for creating a CIDR list entry for either source or destination address.
@@ -439,7 +442,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
                                          ListenerComponentFactory& listener_factory,
                                          WorkerFactory& worker_factory,
                                          bool enable_dispatcher_stats)
-    : server_(server), factory_(listener_factory),
+    : server_(server), server_factory_context_(server), factory_(listener_factory),
       scope_(server.stats().createScope("listener_manager.")), stats_(generateStats(*scope_)),
       config_tracker_entry_(server.admin().getConfigTracker().add(
           "listeners", [this] { return dumpListenerConfigs(); })),

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -108,7 +108,7 @@ public:
   NiceMock<Stats::MockStore> scope_;
   NiceMock<Server::MockInstance> server_;
   std::unique_ptr<RouteConfigProviderManagerImpl> route_config_provider_manager_;
-  RouteConfigProviderPtr rds_;
+  RouteConfigProviderSharedPtr rds_;
 };
 
 TEST_F(RdsImplTest, RdsAndStatic) {
@@ -280,7 +280,7 @@ public:
 
   envoy::config::filter::network::http_connection_manager::v2::Rds rds_;
   std::unique_ptr<RouteConfigProviderManagerImpl> route_config_provider_manager_;
-  RouteConfigProviderPtr provider_;
+  RouteConfigProviderSharedPtr provider_;
 };
 
 envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
@@ -415,12 +415,15 @@ virtual_hosts:
   factory_context_.cluster_manager_.subscription_factory_.callbacks_->onConfigUpdate(route_configs,
                                                                                      "1");
 
-  RouteConfigProviderPtr provider2 = route_config_provider_manager_->createRdsRouteConfigProvider(
-      rds_, factory_context_, "foo_prefix", factory_context_.initManager());
+  RouteConfigProviderSharedPtr provider2 =
+      route_config_provider_manager_->createRdsRouteConfigProvider(
+          rds_, factory_context_, "foo_prefix", factory_context_.initManager());
 
   // provider2 should have route config immediately after create
   EXPECT_TRUE(provider2->configInfo().has_value());
 
+  EXPECT_EQ(provider_.get(), provider2.get())
+      << "same rds config provider object should be generate";
   // So this means that both provider have same subscription.
   EXPECT_EQ(&dynamic_cast<RdsRouteConfigProviderImpl&>(*provider_).subscription(),
             &dynamic_cast<RdsRouteConfigProviderImpl&>(*provider2).subscription());
@@ -429,8 +432,9 @@ virtual_hosts:
   envoy::config::filter::network::http_connection_manager::v2::Rds rds2;
   rds2.set_route_config_name("foo_route_config");
   rds2.mutable_config_source()->set_path("bar_path");
-  RouteConfigProviderPtr provider3 = route_config_provider_manager_->createRdsRouteConfigProvider(
-      rds2, factory_context_, "foo_prefix", factory_context_.initManager());
+  RouteConfigProviderSharedPtr provider3 =
+      route_config_provider_manager_->createRdsRouteConfigProvider(
+          rds2, factory_context_, "foo_prefix", factory_context_.initManager());
   EXPECT_NE(provider3, provider_);
   factory_context_.cluster_manager_.subscription_factory_.callbacks_->onConfigUpdate(route_configs,
                                                                                      "provider3");

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -402,7 +402,7 @@ public:
   ~MockRouteConfigProviderManager() override;
 
   MOCK_METHOD4(createRdsRouteConfigProvider,
-               RouteConfigProviderPtr(
+               RouteConfigProviderSharedPtr(
                    const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
                    Server::Configuration::FactoryContext& factory_context,
                    const std::string& stat_prefix, Init::Manager& init_manager));


### PR DESCRIPTION
WIP still fixing tests

Description:
If N http conn managers refers the same rds config name, currently envoy 
* create only one subscription (good!)
* create N rds config provider at main thread (hmm...)
* thundering herd when rds is update, since all N rds configs need updating

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
