### PR TITLE
make ssl dependencies indirect to swap impls

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,13 @@
 workspace(name = "envoy")
 
+local_repository(
+  name = "ssl",
+  path = "ssl",
+  repo_mapping = {
+    "@ssl": "@envoy",
+  },
+)
+
 load("//bazel:api_binding.bzl", "envoy_api_binding")
 
 envoy_api_binding()

--- a/ssl/BUILD
+++ b/ssl/BUILD
@@ -1,0 +1,86 @@
+licenses(["notice"])  # Apache 2
+
+alias(
+    name = "crypto_utility_headers_lib",
+    actual = "@envoy//source/common/crypto:utility_lib",
+)
+
+alias(
+    name = "crypto_utility_lib",
+    actual = "@envoy//source/extensions/common/crypto:utility_lib",
+)
+
+alias(
+    name = "tls_inspector_lib",
+    actual = "@envoy//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
+)
+
+alias(
+    name = "tls_inspector_config",
+    actual = "@envoy//source/extensions/filters/listener/tls_inspector:config",
+)
+
+alias(
+    name = "tls_inspector_test_utility_lib",
+    actual = "@envoy//test/extensions/filters/listener/tls_inspector:tls_utility_lib",
+)
+
+alias(
+    name = "openssl_impl_lib",
+    actual = "@envoy//source/extensions/filters/listener/tls_inspector:openssl_impl_lib",
+)
+
+alias(
+    name = "tls_config",
+    actual = "@envoy//source/extensions/transport_sockets/tls:config",
+)
+
+alias(
+    name = "tls_context_config_lib",
+    actual = "@envoy//source/extensions/transport_sockets/tls:context_config_lib",
+)
+
+alias(
+    name = "tls_context_lib",
+    actual = "@envoy//source/extensions/transport_sockets/tls:context_lib",
+)
+
+alias(
+    name = "tls_utility_lib",
+    actual = "@envoy//source/extensions/transport_sockets/tls:utility_lib",
+)
+
+alias(
+    name = "tls_ssl_socket_lib",
+    actual = "@envoy//source/extensions/transport_sockets/tls:ssl_socket_lib",
+)
+
+alias(
+    name = "tls_test_data_certs",
+    actual = "@envoy//test/extensions/transport_sockets/tls/test_data:certs",
+)
+
+alias(
+    name = "tls_test_data_cert_infos",
+    actual = "@envoy//test/extensions/transport_sockets/tls/test_data:cert_infos",
+)
+
+alias(
+    name = "tls_ssl_test_utils",
+    actual = "@envoy//test/extensions/transport_sockets/tls:ssl_test_utils",
+)
+
+alias(
+    name = "lua_filter_lib",
+    actual = "@envoy//source/extensions/filters/http/lua:lua_filter_lib",
+)
+
+alias(
+    name = "lua_wrappers_lib",
+    actual = "@envoy//source/extensions/filters/http/lua:wrappers_lib",
+)
+
+alias(
+    name = "lua_config",
+    actual = "@envoy//source/extensions/filters/http/lua:config",
+)

--- a/ssl/WORKSPACE
+++ b/ssl/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "ssl")

--- a/test/common/crypto/BUILD
+++ b/test/common/crypto/BUILD
@@ -20,6 +20,6 @@ envoy_cc_test(
         "//bazel:crypto_utility_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:hex_lib",
-        "//source/common/crypto:utility_lib",
+        "@ssl//:crypto_utility_lib",
     ],
 )

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -48,7 +48,6 @@ envoy_cc_test(
         "//source/common/upstream:cluster_manager_lib",
         "//source/common/upstream:subset_lb_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//test/integration/clusters:custom_static_cluster",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/api:api_mocks",
@@ -67,6 +66,7 @@ envoy_cc_test(
         "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2:cds_cc",
+        "@ssl//:tls_context_lib",
     ],
 )
 
@@ -200,7 +200,6 @@ envoy_cc_test(
     srcs = ["hds_test.cc"],
     deps = [
         "//source/common/upstream:health_discovery_service_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/grpc:grpc_mocks",
@@ -213,6 +212,7 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2/endpoint:load_report_cc",
         "@envoy_api//envoy/service/discovery/v2:hds_cc",
+        "@ssl//:tls_context_lib",
     ],
 )
 

--- a/test/extensions/clusters/dynamic_forward_proxy/BUILD
+++ b/test/extensions/clusters/dynamic_forward_proxy/BUILD
@@ -21,12 +21,12 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:config",
         "//test/common/upstream:utility_lib",
         "//test/extensions/common/dynamic_forward_proxy:mocks",
         "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/test_common:environment_lib",
+        "@ssl//:tls_config",
     ],
 )

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -17,13 +17,13 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.http.lua",
     deps = [
         "//source/common/stream_info:stream_info_lib",
-        "//source/extensions/filters/http/lua:lua_filter_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",
+        "@ssl//:lua_filter_lib",
     ],
 )
 
@@ -33,10 +33,10 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.http.lua",
     deps = [
         "//source/common/stream_info:stream_info_lib",
-        "//source/extensions/filters/http/lua:wrappers_lib",
         "//test/extensions/filters/common/lua:lua_wrappers_lib",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
+        "@ssl//:lua_wrappers_lib",
     ],
 )
 
@@ -45,9 +45,9 @@ envoy_extension_cc_test(
     srcs = ["lua_integration_test.cc"],
     extension_name = "envoy.filters.http.lua",
     deps = [
-        "//source/extensions/filters/http/lua:config",
         "//test/integration:http_integration_lib",
         "//test/test_common:utility_lib",
+        "@ssl//:lua_config",
     ],
 )
 
@@ -56,7 +56,7 @@ envoy_extension_cc_test(
     srcs = ["config_test.cc"],
     extension_name = "envoy.filters.http.lua",
     deps = [
-        "//source/extensions/filters/http/lua:config",
         "//test/mocks/server:server_mocks",
+        "@ssl//:lua_config",
     ],
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -454,7 +454,6 @@ envoy_cc_test_library(
         "//source/extensions/access_loggers/file:config",
         "//source/extensions/transport_sockets/raw_buffer:config",
         "//source/extensions/transport_sockets/tap:config",
-        "//source/extensions/transport_sockets/tls:config",
         "//source/server:connection_handler_lib",
         "//source/server:hot_restart_nop_lib",
         "//source/server:listener_hooks_lib",
@@ -475,6 +474,7 @@ envoy_cc_test_library(
         "//test/test_common:test_time_lib",
         "//test/test_common:test_time_system_interface",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_config",
     ],
 )
 
@@ -688,12 +688,12 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//source/common/network:connection_lib",
         "//source/common/network:utility_lib",
-        "//source/extensions/filters/listener/tls_inspector:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//test/mocks/secret:secret_mocks",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_config",
+        "@ssl//:tls_context_config_lib",
+        "@ssl//:tls_context_lib",
+        "@ssl//:tls_inspector_config",
     ],
 )
 
@@ -713,14 +713,14 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//source/common/network:connection_lib",
         "//source/common/network:utility_lib",
-        "//source/extensions/filters/listener/tls_inspector:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/secret:secret_mocks",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_config",
+        "@ssl//:tls_context_config_lib",
+        "@ssl//:tls_context_lib",
+        "@ssl//:tls_inspector_config",
     ],
 )
 
@@ -740,12 +740,12 @@ envoy_cc_test(
         "//source/common/network:utility_lib",
         "//source/extensions/access_loggers/file:config",
         "//source/extensions/filters/network/tcp_proxy:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/secret:secret_mocks",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_config",
+        "@ssl//:tls_context_config_lib",
+        "@ssl//:tls_context_lib",
     ],
 )
 
@@ -824,10 +824,10 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         "//source/common/http:header_map_lib",
-        "//source/extensions/filters/listener/tls_inspector:config",
-        "//source/extensions/transport_sockets/tls:config",
         "//test/mocks/server:server_mocks",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_config",
+        "@ssl//:tls_inspector_config",
     ],
 )
 

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -31,7 +31,6 @@ envoy_cc_mock(
         "//source/common/secret:secret_manager_impl_lib",
         "//source/common/singleton:manager_impl_lib",
         "//source/common/stats:stats_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",
@@ -47,5 +46,6 @@ envoy_cc_mock(
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:test_time_lib",
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
+        "@ssl//:tls_context_lib",
     ],
 )

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -190,15 +190,15 @@ envoy_cc_test(
         "//source/common/network:utility_lib",
         "//source/common/protobuf",
         "//source/extensions/filters/listener/original_dst:config",
-        "//source/extensions/filters/listener/tls_inspector:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/filters/network/tcp_proxy:config",
         "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//source/extensions/transport_sockets/tls:ssl_socket_lib",
         "//source/server:active_raw_udp_listener_config",
         "//test/test_common:registry_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
+        "@ssl//:tls_config",
+        "@ssl//:tls_inspector_config",
+        "@ssl//:tls_ssl_socket_lib",
     ],
 )
 
@@ -229,11 +229,8 @@ envoy_cc_test(
         "//source/common/network:utility_lib",
         "//source/common/protobuf",
         "//source/extensions/filters/listener/original_dst:config",
-        "//source/extensions/filters/listener/tls_inspector:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/transport_sockets/raw_buffer:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//source/extensions/transport_sockets/tls:ssl_socket_lib",
         "//source/server:filter_chain_manager_lib",
         "//source/server:listener_manager_lib",
         "//test/mocks/network:network_mocks",
@@ -243,6 +240,9 @@ envoy_cc_test(
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:test_time_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
+        "@ssl//:tls_config",
+        "@ssl//:tls_inspector_config",
+        "@ssl//:tls_ssl_socket_lib",
     ],
 )
 
@@ -365,6 +365,6 @@ envoy_cc_test_binary(
         "//test/test_common:environment_lib",
         "//test/mocks/network:network_mocks",
         # tranport socket config registration
-        "//source/extensions/transport_sockets/tls:config",
+        "@ssl//:tls_config",
     ],
 )

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -30,7 +30,6 @@ envoy_cc_test(
         "//include/envoy/upstream:upstream_interface",
         "//source/common/api:api_lib",
         "//source/common/stats:stats_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
         "//source/server/config_validation:cluster_manager_lib",
         "//source/server/config_validation:dns_lib",
         "//test/mocks/access_log:access_log_mocks",
@@ -46,6 +45,7 @@ envoy_cc_test(
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_context_lib",
     ],
 )
 
@@ -59,13 +59,13 @@ envoy_cc_test(
     deps = [
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",
-        "//source/extensions/transport_sockets/tls:config",
         "//source/server/config_validation:server_lib",
         "//test/integration:integration_lib",
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
+        "@ssl//:tls_config",
     ],
 )
 

--- a/test/server/http/BUILD
+++ b/test/server/http/BUILD
@@ -21,7 +21,6 @@ envoy_cc_test(
         "//source/common/protobuf:utility_lib",
         "//source/common/stats:symbol_table_creator_lib",
         "//source/common/stats:thread_local_store_lib",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
         "//source/server/http:admin_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_mocks",
@@ -30,6 +29,7 @@ envoy_cc_test(
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/admin/v2alpha:memory_cc",
+        "@ssl//:tls_context_config_lib",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: William DeCoste <bdecoste@gmail.com>

Description: This PR allows for pluggable ssl dependencies by making the dependency definitions in the BUILD files indirect. The boringssl-specific dependencies can be replaced with other ssl implementation specific dependencies (e.g. openssl) when envoy is configured as a git submodule (see http://github.com/envoyproxy/envoy-openssl). 
Risk Level: Low
Testing: Passes all standard tests
Docs Changes: None
Release Notes: None

