### PR TITLE
test: remove CONSTRUCT_ON_FIRST_USE from ads_integration_test

### DIFF
--- a/test/integration/ads_integration.h
+++ b/test/integration/ads_integration.h
@@ -14,6 +14,7 @@
 
 namespace Envoy {
 static std::string AdsIntegrationConfig() {
+  // Note: do not use CONSTRUCT_ON_FIRST_USE here!
   return R"EOF(
 dynamic_resources:
   lds_config: {ads: {}}

--- a/test/integration/ads_integration.h
+++ b/test/integration/ads_integration.h
@@ -13,8 +13,8 @@
 #include "test/integration/http_integration.h"
 
 namespace Envoy {
-static const std::string& AdsIntegrationConfig() {
-  CONSTRUCT_ON_FIRST_USE(std::string, R"EOF(
+static std::string AdsIntegrationConfig() {
+  return R"EOF(
 dynamic_resources:
   lds_config: {ads: {}}
   cds_config: {ads: {}}
@@ -38,7 +38,7 @@ admin:
     socket_address:
       address: 127.0.0.1
       port_value: 0
-)EOF");
+)EOF";
 }
 
 class AdsIntegrationTest : public Grpc::GrpcClientIntegrationParamTest, public HttpIntegrationTest {


### PR DESCRIPTION
This string constant is not constant when ads_integration_test is parameterized on delta/SotW.

Risk Level: none
Testing: test-only change