### PR TITLE
access log: add support downstream direct remote address

### DIFF
--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -153,6 +153,11 @@ message AccessLogCommon {
 
   // The name of the route
   string route_name = 19;
+
+  // This field is the downstream direct remote address on which the request from the user was
+  // received. Note: This is always the physical peer, even if the remote address is inferred from
+  // for example the x-forwarder-for header, proxy protocol, etc.
+  envoy.api.v2.core.Address downstream_direct_remote_address = 20;
 }
 
 // Flags indicating occurrences during request/response processing.

--- a/docs/root/configuration/observability/access_log.rst
+++ b/docs/root/configuration/observability/access_log.rst
@@ -274,6 +274,26 @@ The following command operators are supported:
     :ref:`proxy proto <envoy_api_field_listener.FilterChain.use_proxy_proto>` or :ref:`x-forwarded-for
     <config_http_conn_man_headers_x-forwarded-for>`.
 
+%DOWNSTREAM_DIRECT_REMOTE_ADDRESS%
+  Direct remote address of the downstream connection. If the address is an IP address it includes both
+  address and port.
+
+  .. note::
+
+    This is always the physical remote address of the peer even if the downstream remote address has 
+    been inferred from :ref:`proxy proto <envoy_api_field_listener.FilterChain.use_proxy_proto>`
+    or :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>`.
+
+%DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT%
+  The direct remote address of the downstream connection. If the address is an IP address the output does
+  *not* include port.
+
+  .. note::
+
+    This is always the physical remote address of the peer even if the downstream remote address has 
+    been inferred from :ref:`proxy proto <envoy_api_field_listener.FilterChain.use_proxy_proto>`
+    or :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>`.
+
 %DOWNSTREAM_LOCAL_ADDRESS%
   Local address of the downstream connection. If the address is an IP address it includes both
   address and port.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.12.0 (pending)
 ================
 * access log: added :ref:`buffering <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_size_bytes>` and :ref:`periodical flushing <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_flush_interval>` support to gRPC access logger. Defaults to 16KB buffer and flushing every 1 second.
+* access log: added DOWNSTREAM_DIRECT_REMOTE_ADDRESS and DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT :ref:`access log formatters <config_access_log_format>` and gRPC access logger.
 * access log: gRPC Access Log Service (ALS) support added for :ref:`TCP access logs <envoy_api_msg_config.accesslog.v2.TcpGrpcAccessLogConfig>`.
 * access log: reintroduce :ref:`filesystem <filesystem_stats>` stats and added the `write_failed` counter to track failed log writes
 * admin: added ability to configure listener :ref:`socket options <envoy_api_field_config.bootstrap.v2.Admin.socket_options>`.

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -401,6 +401,15 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
       return StreamInfo::Utility::formatDownstreamAddressNoPort(
           *stream_info.downstreamRemoteAddress());
     };
+  } else if (field_name == "DOWNSTREAM_DIRECT_REMOTE_ADDRESS") {
+    field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
+      return stream_info.downstreamDirectRemoteAddress()->asString();
+    };
+  } else if (field_name == "DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT") {
+    field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
+      return StreamInfo::Utility::formatDownstreamAddressNoPort(
+          *stream_info.downstreamDirectRemoteAddress());
+    };
   } else if (field_name == "REQUESTED_SERVER_NAME") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
       if (!stream_info.requestedServerName().empty()) {

--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
@@ -122,6 +122,11 @@ void Utility::extractCommonAccessLogProperties(
         *stream_info.downstreamRemoteAddress(),
         *common_access_log.mutable_downstream_remote_address());
   }
+  if (stream_info.downstreamDirectRemoteAddress() != nullptr) {
+    Network::Utility::addressToProtobufAddress(
+        *stream_info.downstreamDirectRemoteAddress(),
+        *common_access_log.mutable_downstream_direct_remote_address());
+  }
   if (stream_info.downstreamLocalAddress() != nullptr) {
     Network::Utility::addressToProtobufAddress(
         *stream_info.downstreamLocalAddress(),

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -203,6 +203,16 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
   }
 
   {
+    StreamInfoFormatter upstream_format("DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT");
+    EXPECT_EQ("127.0.0.1", upstream_format.format(header, header, header, stream_info));
+  }
+
+  {
+    StreamInfoFormatter upstream_format("DOWNSTREAM_DIRECT_REMOTE_ADDRESS");
+    EXPECT_EQ("127.0.0.1:0", upstream_format.format(header, header, header, stream_info));
+  }
+
+  {
     StreamInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
     std::string requested_server_name = "stub_server";
     EXPECT_CALL(stream_info, requestedServerName())

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -89,6 +89,10 @@ common_properties:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
+  downstream_direct_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
   downstream_local_address:
     socket_address:
       address: "127.0.0.2"
@@ -130,6 +134,10 @@ common_properties:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
+  downstream_direct_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
   downstream_local_address:
     pipe:
       path: "/foo"
@@ -155,6 +163,10 @@ response: {}
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
+  downstream_direct_remote_address:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
@@ -212,6 +224,10 @@ response: {}
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
+  downstream_direct_remote_address:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
@@ -286,6 +302,10 @@ common_properties:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
+  downstream_direct_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
   downstream_local_address:
     socket_address:
       address: "127.0.0.2"
@@ -331,6 +351,10 @@ response: {}
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
+  downstream_direct_remote_address:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
@@ -390,6 +414,10 @@ common_properties:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
+  downstream_direct_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
   downstream_local_address:
     socket_address:
       address: "127.0.0.2"
@@ -433,6 +461,10 @@ response: {}
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
+  downstream_direct_remote_address:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
@@ -482,6 +514,10 @@ common_properties:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
+  downstream_direct_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
   downstream_local_address:
     socket_address:
       address: "127.0.0.2"
@@ -525,6 +561,10 @@ response: {}
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
+  downstream_direct_remote_address:
     socket_address:
       address: "127.0.0.1"
       port_value: 0
@@ -598,6 +638,10 @@ TEST_F(HttpGrpcAccessLogTest, MarshallingAdditionalHeaders) {
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 0
+  downstream_direct_remote_address:
     socket_address:
       address: "127.0.0.1"
       port_value: 0

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
@@ -79,6 +79,7 @@ public:
     // Clear fields which are not deterministic.
     auto* log_entry = request_msg.mutable_http_logs()->mutable_log_entry(0);
     log_entry->mutable_common_properties()->clear_downstream_remote_address();
+    log_entry->mutable_common_properties()->clear_downstream_direct_remote_address();
     log_entry->mutable_common_properties()->clear_downstream_local_address();
     log_entry->mutable_common_properties()->clear_start_time();
     log_entry->mutable_common_properties()->clear_time_to_last_rx_byte();


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Add downstream direct remote address to access log formatter and gRPC access logger.

Risk Level: Low
Testing: CI
Docs Changes: Added
Release Notes: Added
