### PR TITLE
grpc: Separate out grpc_init into its own class

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -163,7 +163,12 @@ envoy_cc_library(
     srcs = ["google_grpc_context.cc"],
     hdrs = ["google_grpc_context.h"],
     external_deps = ["grpc"],
-    deps = ["//source/common/common:assert_lib"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/common:lock_guard_lib",
+        "//source/common/common:macros",
+        "//source/common/common:thread_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -142,6 +142,7 @@ envoy_cc_library(
     ],
     deps = [
         ":context_lib",
+        ":google_grpc_context_lib",
         ":google_grpc_creds_lib",
         ":google_grpc_utils_lib",
         ":typed_async_client_lib",
@@ -154,6 +155,14 @@ envoy_cc_library(
         "//source/common/common:thread_annotations",
         "//source/common/tracing:http_tracer_lib",
     ],
+)
+
+envoy_cc_library(
+    name = "google_grpc_context_lib",
+    srcs = ["google_grpc_context.cc"],
+    hdrs = ["google_grpc_context.h"],
+    external_deps = ["grpc"],
+    deps = ["//source/common/common:assert_lib"],
 )
 
 envoy_cc_library(

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -74,6 +74,8 @@ GoogleAsyncClientImpl::GoogleAsyncClientImpl(Event::Dispatcher& dispatcher,
                                              Api::Api& api)
     : dispatcher_(dispatcher), tls_(tls), stat_prefix_(config.google_grpc().stat_prefix()),
       initial_metadata_(config.initial_metadata()), scope_(scope) {
+  grpc_init();
+
   // We rebuild the channel each time we construct the channel. It appears that the gRPC library is
   // smart enough to do connection pooling and reuse with identical channel args, so this should
   // have comparable overhead to what we are doing in Grpc::AsyncClientImpl, i.e. no expensive

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -74,8 +74,6 @@ GoogleAsyncClientImpl::GoogleAsyncClientImpl(Event::Dispatcher& dispatcher,
                                              Api::Api& api)
     : dispatcher_(dispatcher), tls_(tls), stat_prefix_(config.google_grpc().stat_prefix()),
       initial_metadata_(config.initial_metadata()), scope_(scope) {
-  grpc_init();
-
   // We rebuild the channel each time we construct the channel. It appears that the gRPC library is
   // smart enough to do connection pooling and reuse with identical channel args, so this should
   // have comparable overhead to what we are doing in Grpc::AsyncClientImpl, i.e. no expensive

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -85,6 +85,9 @@ public:
 private:
   void completionThread();
 
+  // Instantiate this first to ensure grpc_init() is called.
+  GoogleGrpcContext google_grpc_context_;
+
   // The CompletionQueue for in-flight operations. This must precede completion_thread_ to ensure it
   // is constructed before the thread runs.
   grpc::CompletionQueue cq_;
@@ -175,7 +178,6 @@ private:
   static std::shared_ptr<grpc::Channel>
   createChannel(const envoy::api::v2::core::GrpcService::GoogleGrpc& config);
 
-  GoogleGrpcContext google_grpc_context_;
   Event::Dispatcher& dispatcher_;
   GoogleAsyncClientThreadLocal& tls_;
   // This is shared with child streams, so that they can cleanup independent of

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -12,6 +12,7 @@
 #include "common/common/linked_object.h"
 #include "common/common/thread.h"
 #include "common/common/thread_annotations.h"
+#include "common/grpc/google_grpc_context.h"
 #include "common/grpc/typed_async_client.h"
 #include "common/tracing/http_tracer_impl.h"
 
@@ -174,6 +175,7 @@ private:
   static std::shared_ptr<grpc::Channel>
   createChannel(const envoy::api::v2::core::GrpcService::GoogleGrpc& config);
 
+  GoogleGrpcContext google_grpc_context_;
   Event::Dispatcher& dispatcher_;
   GoogleAsyncClientThreadLocal& tls_;
   // This is shared with child streams, so that they can cleanup independent of

--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -13,14 +13,18 @@ std::atomic<uint64_t> GoogleGrpcContext::live_instances_{0};
 
 GoogleGrpcContext::GoogleGrpcContext() {
   if (++live_instances_ == 1) {
+#ifdef ENVOY_GOOGLE_GRPC
     grpc_init();
+#endif
   }
 }
 
 GoogleGrpcContext::~GoogleGrpcContext() {
   ASSERT(live_instances_ > 0);
   if (--live_instances_ == 0) {
+#ifdef ENVOY_GOOGLE_GRPC
     grpc_shutdown();
+#endif
   }
 }
 

--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -1,0 +1,28 @@
+#include "common/grpc/google_grpc_context.h"
+
+#include <atomic>
+
+#include "common/common/assert.h"
+
+#include "grpcpp/grpcpp.h"
+
+namespace Envoy {
+namespace Grpc {
+
+std::atomic<uint64_t> GoogleGrpcContext::live_instances_{0};
+
+GoogleGrpcContext::GoogleGrpcContext() {
+  if (++live_instances_ == 1) {
+    grpc_init();
+  }
+}
+
+GoogleGrpcContext::~GoogleGrpcContext() {
+  ASSERT(live_instances_ > 0);
+  if (--live_instances_ == 0) {
+    grpc_shutdown();
+  }
+}
+
+} // namespace Grpc
+} // namespace Envoy

--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -23,7 +23,7 @@ GoogleGrpcContext::~GoogleGrpcContext() {
   ASSERT(live_instances_ > 0);
   if (--live_instances_ == 0) {
 #ifdef ENVOY_GOOGLE_GRPC
-    grpc_shutdown();
+    grpc_shutdown_blocking(); // Waiting for quiescence avoids non-determinism in tests.
 #endif
   }
 }

--- a/source/common/grpc/google_grpc_context.h
+++ b/source/common/grpc/google_grpc_context.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <atomic>
+
+namespace Envoy {
+namespace Grpc {
+
+// Captures global grpc initialization and shutdown. Note that grpc
+// initialization starts several threads, so it is a little annoying to run them
+// alongside unrelated tests, particularly if they are trying to track memory
+// usage, or you are exploiting otherwise consistent run-to-run pointer values
+// during debug.
+//
+// Instantiating this class makes it easy to ensure classes that depend on grpc
+// libraries get them initialized.
+class GoogleGrpcContext {
+public:
+  GoogleGrpcContext();
+  ~GoogleGrpcContext();
+
+private:
+  static std::atomic<uint64_t> live_instances_;
+};
+
+} // namespace Grpc
+} // namespace Envoy

--- a/source/common/grpc/google_grpc_context.h
+++ b/source/common/grpc/google_grpc_context.h
@@ -21,7 +21,7 @@ public:
 private:
   struct InstanceTracker {
     Thread::MutexBasicLockable mutex_;
-    uint64_t live_instances_{0};
+    uint64_t live_instances_ GUARDED_BY(mutex_) = 0;
   };
 
   static InstanceTracker& instanceTracker();

--- a/source/common/grpc/google_grpc_context.h
+++ b/source/common/grpc/google_grpc_context.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <atomic>
+#include "common/common/thread.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -19,7 +19,14 @@ public:
   ~GoogleGrpcContext();
 
 private:
-  static std::atomic<uint64_t> live_instances_;
+  struct InstanceTracker {
+    Thread::MutexBasicLockable mutex_;
+    uint64_t live_instances_{0};
+  };
+
+  static InstanceTracker& instanceTracker();
+
+  InstanceTracker& instance_tracker_;
 };
 
 } // namespace Grpc

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -71,6 +71,7 @@ envoy_cc_library(
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:compiler_requirements_lib",
         "//source/common/common:perf_annotation_lib",
+        "//source/common/grpc:google_grpc_context_lib",
         "//source/common/stats:symbol_table_creator_lib",
         "//source/server:hot_restart_lib",
         "//source/server:hot_restart_nop_lib",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -7,7 +7,6 @@ load(
     "envoy_cc_platform_dep",
     "envoy_cc_posix_library",
     "envoy_cc_win32_library",
-    "envoy_google_grpc_external_deps",
     "envoy_package",
 )
 load(
@@ -95,7 +94,7 @@ envoy_cc_library(
         "//source/common/event:libevent_lib",
         "//source/common/http/http2:nghttp2_lib",
         "//source/server:proto_descriptors_lib",
-    ] + envoy_google_grpc_external_deps(),
+    ],
 )
 
 envoy_cc_library(

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -5,6 +5,7 @@
 
 #include "common/common/thread.h"
 #include "common/event/real_time_system.h"
+#include "common/grpc/google_grpc_context.h"
 #include "common/stats/fake_symbol_table_impl.h"
 #include "common/stats/thread_local_store.h"
 #include "common/thread_local/thread_local_impl.h"
@@ -65,7 +66,10 @@ public:
                     const AdminRequestFn& handler);
 
 protected:
-  ProcessWide process_wide_; // Process-wide state setup/teardown.
+  ProcessWide process_wide_; // Process-wide state setup/teardown (excluding grpc).
+#ifdef ENVOY_GOOGLE_GRPC
+  Grpc::GoogleGrpcContext google_grpc_context_;
+#endif
   const Envoy::OptionsImpl& options_;
   Server::ComponentFactory& component_factory_;
   Thread::ThreadFactory& thread_factory_;

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -67,9 +67,7 @@ public:
 
 protected:
   ProcessWide process_wide_; // Process-wide state setup/teardown (excluding grpc).
-#ifdef ENVOY_GOOGLE_GRPC
   Grpc::GoogleGrpcContext google_grpc_context_;
-#endif
   const Envoy::OptionsImpl& options_;
   Server::ComponentFactory& component_factory_;
   Thread::ThreadFactory& thread_factory_;

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -23,7 +23,7 @@ ProcessWide::ProcessWide() : initialization_depth_(process_wide_initialized) {
     Envoy::Server::validateProtoDescriptors();
     Http::Http2::initializeNghttp2Logging();
 
-    // We do not initialize Google grpc here -- we instead instantiate
+    // We do not initialize Google gRPC here -- we instead instantiate
     // Grpc::GoogleGrpcContext in MainCommon immediately after instantiating
     // ProcessWide. This is because ProcessWide is instantiated in the unit-test
     // flow in test/test_runner.h, and grpc_init() instantiates threads which
@@ -31,7 +31,7 @@ ProcessWide::ProcessWide() : initialization_depth_(process_wide_initialized) {
     // accurately measure memory consumption, and making unit-test debugging
     // non-deterministic. See https://github.com/envoyproxy/envoy/issues/8282
     // for details. Of course we also need grpc_init called in unit-tests that
-    // test Google grpc, and the relevant classes must also instantiate
+    // test Google gRPC, and the relevant classes must also instantiate
     // Grpc::GoogleGrpcContext, which allows for nested instantiation.
     //
     // It appears that grpc_init() started instantiating threads in grpc 1.22.1,

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -8,10 +8,6 @@
 
 #include "ares.h"
 
-#ifdef ENVOY_GOOGLE_GRPC
-#include "grpc/grpc.h"
-#endif
-
 namespace Envoy {
 namespace {
 // Static variable to count initialization pairs. For tests like
@@ -22,9 +18,6 @@ uint32_t process_wide_initialized;
 
 ProcessWide::ProcessWide() : initialization_depth_(process_wide_initialized) {
   if (process_wide_initialized++ == 0) {
-#ifdef ENVOY_GOOGLE_GRPC
-    grpc_init();
-#endif
     ares_library_init(ARES_LIB_INIT_ALL);
     Event::Libevent::Global::initialize();
     Envoy::Server::validateProtoDescriptors();
@@ -37,9 +30,6 @@ ProcessWide::~ProcessWide() {
   if (--process_wide_initialized == 0) {
     process_wide_initialized = false;
     ares_library_cleanup();
-#ifdef ENVOY_GOOGLE_GRPC
-    grpc_shutdown();
-#endif
   }
   ASSERT(process_wide_initialized == initialization_depth_);
 }

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -22,6 +22,21 @@ ProcessWide::ProcessWide() : initialization_depth_(process_wide_initialized) {
     Event::Libevent::Global::initialize();
     Envoy::Server::validateProtoDescriptors();
     Http::Http2::initializeNghttp2Logging();
+
+    // We do not initialize Google grpc here -- we instead instantiate
+    // Grpc::GoogleGrpcContext in MainCommon immediately after instantiating
+    // ProcessWide. This is because ProcessWide is instantiated in the unit-test
+    // flow in test/test_runner.h, and grpc_init() instantiates threads which
+    // allocate memory asynchronous to running tests, making it hard to
+    // accurately measure memory consumption, and making unit-test debugging
+    // non-deterministic. See https://github.com/envoyproxy/envoy/issues/8282
+    // for details. Of course we also need grpc_init called in unit-tests that
+    // test Google grpc, and the relevant classes must also instantiate
+    // Grpc::GoogleGrpcContext, which allows for nested instantiation.
+    //
+    // It appears that grpc_init() started instantiating threads in grpc 1.22.1,
+    // which was integrated in https://github.com/envoyproxy/envoy/pull/8196,
+    // around the time the flakes in #8282 started being reported.
   }
 }
 

--- a/source/exe/process_wide.h
+++ b/source/exe/process_wide.h
@@ -5,7 +5,7 @@
 namespace Envoy {
 
 // Process-wide lifecycle events for global state in third-party dependencies,
-// e.g. gRPC, c-ares. There should only ever be a single instance of this.
+// e.g. c-ares. There should only ever be a single instance of this.
 class ProcessWide {
 public:
   ProcessWide();

--- a/source/extensions/transport_sockets/alts/BUILD
+++ b/source/extensions/transport_sockets/alts/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         ":tsi_socket",
         "//include/envoy/registry",
         "//include/envoy/server:transport_socket_config_interface",
+        "//source/common/grpc:google_grpc_context_lib",
         "//source/extensions/transport_sockets:well_known_names",
         "@envoy_api//envoy/config/transport_socket/alts/v2alpha:alts_cc",
     ],

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -6,6 +6,7 @@
 #include "envoy/server/transport_socket_config.h"
 
 #include "common/common/assert.h"
+#include "common/grpc/google_grpc_context.h"
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
 
@@ -65,6 +66,9 @@ public:
   AltsSharedState() { grpc_alts_shared_resource_dedicated_init(); }
 
   ~AltsSharedState() override { grpc_alts_shared_resource_dedicated_shutdown(); }
+
+private:
+  Grpc::GoogleGrpcContext google_grpc_context_;
 };
 
 SINGLETON_MANAGER_REGISTRATION(alts_shared_state);

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -592,12 +592,16 @@ def checkSourceLine(line, file_path, reportError):
     reportError("Don't use std::regex in code that handles untrusted input. Use RegexMatcher")
 
   if not whitelistedForGrpcInit(file_path):
-    grpc_init = line.find("grpc_init()")
-    if grpc_init != -1:
+    grpc_init_or_shutdown = line.find("grpc_init()")
+    grpc_shutdown = line.find("grpc_shutdown()")
+    if grpc_init_or_shutdown == -1 or (grpc_shutdown != -1 and
+                                       grpc_shutdown < grpc_init_or_shutdown):
+      grpc_init_or_shutdown = grpc_shutdown
+    if grpc_init_or_shutdown != -1:
       comment = line.find("// ")
-      if comment == -1 or comment > grpc_init:
-        reportError(
-            "Don't call grpc_init() directly, instantiate Grpc::GoogleGrpcContext. See #8282")
+      if comment == -1 or comment > grpc_init_or_shutdown:
+        reportError("Don't call grpc_init() or grpc_shutdown() directly, instantiate " +
+                    "Grpc::GoogleGrpcContext. See #8282")
 
 
 def checkBuildLine(line, file_path, reportError):

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -219,6 +219,9 @@ if __name__ == "__main__":
       "Don't lookup stats by name at runtime; use StatName saved during construction")
   errors += checkUnfixableError(
       "regex.cc", "Don't use std::regex in code that handles untrusted input. Use RegexMatcher")
+  errors += checkUnfixableError(
+      "grpc_init.cc",
+      "Don't call grpc_init() directly, instantiate Grpc::GoogleGrpcContext. See #8282")
 
   errors += fixFileExpectingFailure(
       "api/missing_package.proto",

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -221,7 +221,12 @@ if __name__ == "__main__":
       "regex.cc", "Don't use std::regex in code that handles untrusted input. Use RegexMatcher")
   errors += checkUnfixableError(
       "grpc_init.cc",
-      "Don't call grpc_init() directly, instantiate Grpc::GoogleGrpcContext. See #8282")
+      "Don't call grpc_init() or grpc_shutdown() directly, instantiate Grpc::GoogleGrpcContext. " +
+      "See #8282")
+  errors += checkUnfixableError(
+      "grpc_shutdown.cc",
+      "Don't call grpc_init() or grpc_shutdown() directly, instantiate Grpc::GoogleGrpcContext. " +
+      "See #8282")
 
   errors += fixFileExpectingFailure(
       "api/missing_package.proto",

--- a/tools/testdata/check_format/grpc_init.cc
+++ b/tools/testdata/check_format/grpc_init.cc
@@ -1,0 +1,7 @@
+namespace Envoy {
+
+void foo() {
+  grpc_init();
+}
+
+} // namespace Envoy

--- a/tools/testdata/check_format/grpc_shutdown.cc
+++ b/tools/testdata/check_format/grpc_shutdown.cc
@@ -1,0 +1,7 @@
+namespace Envoy {
+
+void foo() {
+  grpc_shutdown();
+}
+
+} // namespace Envoy


### PR DESCRIPTION
Description: Resolves memory-allocation non-determinism stemming from async activity initiated from grpc_init(). See https://github.com/grpc/grpc/issues/20303 for background.
Risk Level: medium -- changes the way grpc is initialized in tests, but in prod should be the same.
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Fixes: #8282 

