### PR TITLE
cds: add debug log when cluster is skipped

### DIFF
--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -77,6 +77,8 @@ void CdsApiImpl::onConfigUpdate(
       if (cm_.addOrUpdateCluster(cluster, resource.version())) {
         any_applied = true;
         ENVOY_LOG(debug, "cds: add/update cluster '{}'", cluster.name());
+      } else {
+        ENVOY_LOG(debug, "cds: add/update cluster '{}' skipped", cluster.name());
       }
     } catch (const EnvoyException& e) {
       exception_msgs.push_back(fmt::format("{}: {}", cluster.name(), e.what()));


### PR DESCRIPTION
Description: Adds a debug log line when a cluster is skipped from CDS response.
Risk Level: None
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

