### PR TITLE
[docs] fix email templates

### DIFF
--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -28,7 +28,7 @@ $PERSON (on behalf of the Envoy maintainers)
 
 ```
 Subject: [CONFIDENTIAL] Further details on security release of Envoy $VERSION
-To: envoy-announce@googlegroups.com
+To: cncf-envoy-distributors-announce@lists.cncf.io
 Cc: envoy-security@googlegroups.com
 
 Hello Envoy Distributors,


### PR DESCRIPTION
Fixes To: field of security email templates

Risk level: Low

Signed-off-by: Asra Ali <asraa@google.com>

