### PR TITLE
sds: add validation callback for all secret providers

### DIFF
--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -24,6 +24,16 @@ public:
   virtual const SecretType* secret() const PURE;
 
   /**
+   * Add secret validation callback into secret provider.
+   * It is safe to call this method by main thread and callback is safe to be invoked
+   * on main thread.
+   * @param callback callback that is executed by secret provider.
+   * @return CallbackHandle the handle which can remove that validation callback.
+   */
+  virtual Common::CallbackHandle* addValidationCallback(
+      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)> callback) PURE;
+
+  /**
    * Add secret update callback into secret provider.
    * It is safe to call this method by main thread and callback is safe to be invoked
    * on main thread.

--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -30,8 +30,8 @@ public:
    * @param callback callback that is executed by secret provider.
    * @return CallbackHandle the handle which can remove that validation callback.
    */
-  virtual Common::CallbackHandle* addValidationCallback(
-      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)> callback) PURE;
+  virtual Common::CallbackHandle*
+  addValidationCallback(std::function<void(const SecretType&)> callback) PURE;
 
   /**
    * Add secret update callback into secret provider.

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -117,6 +117,10 @@ public:
   const envoy::api::v2::auth::TlsCertificate* secret() const override {
     return tls_certificate_secrets_.get();
   }
+  Common::CallbackHandle* addValidationCallback(
+      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)>) override {
+    return nullptr;
+  }
   Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
     return update_callback_manager_.add(callback);
   }
@@ -172,7 +176,8 @@ public:
   }
 
   Common::CallbackHandle* addValidationCallback(
-      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)> callback) {
+      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)> callback)
+      override {
     return validation_callback_manager_.add(callback);
   }
 

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -117,8 +117,8 @@ public:
   const envoy::api::v2::auth::TlsCertificate* secret() const override {
     return tls_certificate_secrets_.get();
   }
-  Common::CallbackHandle* addValidationCallback(
-      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)>) override {
+  Common::CallbackHandle*
+  addValidationCallback(std::function<void(const envoy::api::v2::auth::TlsCertificate&)>) override {
     return nullptr;
   }
   Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {

--- a/source/common/secret/secret_provider_impl.h
+++ b/source/common/secret/secret_provider_impl.h
@@ -18,8 +18,8 @@ public:
     return tls_certificate_.get();
   }
 
-  Common::CallbackHandle* addValidationCallback(
-      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)>) override {
+  Common::CallbackHandle*
+  addValidationCallback(std::function<void(const envoy::api::v2::auth::TlsCertificate&)>) override {
     return nullptr;
   }
 

--- a/source/common/secret/secret_provider_impl.h
+++ b/source/common/secret/secret_provider_impl.h
@@ -18,6 +18,11 @@ public:
     return tls_certificate_.get();
   }
 
+  Common::CallbackHandle* addValidationCallback(
+      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)>) override {
+    return nullptr;
+  }
+
   Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
 
 private:
@@ -32,6 +37,11 @@ public:
 
   const envoy::api::v2::auth::CertificateValidationContext* secret() const override {
     return certificate_validation_context_.get();
+  }
+
+  Common::CallbackHandle* addValidationCallback(
+      std::function<void(const envoy::api::v2::auth::CertificateValidationContext&)>) override {
+    return nullptr;
   }
 
   Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -132,16 +132,11 @@ ContextConfigImpl::ContextConfigImpl(
     // validation of combined certificate validation context fails,
     // getCombinedValidationContextConfig() throws exception, validation_context_config_ will not
     // get updated.
-    auto certificate_validation_context_sds_api_provider =
-        dynamic_cast<Secret::CertificateValidationContextSdsApi*>(
-            certificate_validation_context_provider_.get());
-    if (certificate_validation_context_sds_api_provider != nullptr) {
-      cvc_validation_callback_handle_ =
-          certificate_validation_context_sds_api_provider->addValidationCallback(
-              [this](const envoy::api::v2::auth::CertificateValidationContext& dynamic_cvc) {
-                getCombinedValidationContextConfig(dynamic_cvc);
-              });
-    }
+    cvc_validation_callback_handle_ =
+        certificate_validation_context_provider_->addValidationCallback(
+            [this](const envoy::api::v2::auth::CertificateValidationContext& dynamic_cvc) {
+              getCombinedValidationContextConfig(dynamic_cvc);
+            });
   }
   // Load inline or static secret into tls_certificate_config_.
   if (!tls_certificate_providers_.empty()) {

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -132,13 +132,16 @@ ContextConfigImpl::ContextConfigImpl(
     // validation of combined certificate validation context fails,
     // getCombinedValidationContextConfig() throws exception, validation_context_config_ will not
     // get updated.
-    cvc_validation_callback_handle_ =
+    auto certificate_validation_context_sds_api_provider =
         dynamic_cast<Secret::CertificateValidationContextSdsApi*>(
-            certificate_validation_context_provider_.get())
-            ->addValidationCallback(
-                [this](const envoy::api::v2::auth::CertificateValidationContext& dynamic_cvc) {
-                  getCombinedValidationContextConfig(dynamic_cvc);
-                });
+            certificate_validation_context_provider_.get());
+    if (certificate_validation_context_sds_api_provider != nullptr) {
+      cvc_validation_callback_handle_ =
+          certificate_validation_context_sds_api_provider->addValidationCallback(
+              [this](const envoy::api::v2::auth::CertificateValidationContext& dynamic_cvc) {
+                getCombinedValidationContextConfig(dynamic_cvc);
+              });
+    }
   }
   // Load inline or static secret into tls_certificate_config_.
   if (!tls_certificate_providers_.empty()) {

--- a/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-5729922022113280
+++ b/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-5729922022113280
@@ -1,0 +1,251 @@
+static_resources {
+  clusters {
+    name: "i?aress_http"
+    type: LOGICAL_DNS
+    connect_timeout {
+      seconds: 2304
+      nanos: 707406378
+    }
+    tls_context {
+      common_tls_context {
+        alpn_protocols: ""
+        alpn_protocols: ""
+        combined_validation_context {
+          default_validation_context {
+            trusted_ca {
+              inline_bytes: "\302\000\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\000\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302"
+            }
+            require_signed_certificate_timestamp {
+            }
+          }
+          validation_context_sds_secret_config {
+          }
+        }
+      }
+      sni: "mane"
+    }
+    alt_stat_name: "["
+  }
+  clusters {
+    name: "i?aress_http"
+    type: LOGICAL_DNS
+    connect_timeout {
+      nanos: 538970747
+    }
+    hosts {
+      pipe {
+        path: "\000\000\000\000`"
+      }
+    }
+    hosts {
+      pipe {
+        path: "2"
+      }
+    }
+    hosts {
+      pipe {
+        path: "`"
+      }
+    }
+    hosts {
+      pipe {
+        path: "2"
+      }
+    }
+    tls_context {
+      common_tls_context {
+        combined_validation_context {
+          default_validation_context {
+            trusted_ca {
+              inline_bytes: "\302\000\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\000\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302"
+            }
+            require_signed_certificate_timestamp {
+            }
+          }
+          validation_context_sds_secret_config {
+            sds_config {
+              api_config_source {
+                refresh_delay {
+                  seconds: 8391050737688276324
+                  nanos: 64
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    http_protocol_options {
+      allow_absolute_url {
+        value: true
+      }
+    }
+    alt_stat_name: "["
+    upstream_connection_options {
+      tcp_keepalive {
+        keepalive_probes {
+          value: 589824
+        }
+      }
+    }
+  }
+  clusters {
+    name: "p`ne"
+    type: STRICT_DNS
+    connect_timeout {
+      nanos: 707406378
+    }
+    hosts {
+      pipe {
+        path: "2"
+      }
+    }
+    hosts {
+      pipe {
+        path: "`"
+      }
+    }
+    tls_context {
+      common_tls_context {
+        alpn_protocols: ""
+        alpn_protocols: ""
+        combined_validation_context {
+          default_validation_context {
+            trusted_ca {
+              inline_bytes: "\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302\302"
+            }
+            require_signed_certificate_timestamp {
+            }
+          }
+          validation_context_sds_secret_config {
+            sds_config {
+              api_config_source {
+                refresh_delay {
+                  seconds: 8391050737688276324
+                  nanos: 64
+                }
+              }
+            }
+          }
+        }
+      }
+      sni: "mane"
+    }
+    http_protocol_options {
+      allow_absolute_url {
+        value: true
+      }
+    }
+    alt_stat_name: "["
+  }
+  secrets {
+    validation_context {
+    }
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "2"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "Z"
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "type.googleapis.com/envoy.api.v2.route.Route"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\nJ1"
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\022*J.:*static\'_resourc\022es {(\n  cluster`s"
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "type.googleapis.com/envoy.api.v2.route.Route"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "type.googleapis.com/envoy.api.v2.route.Route"
+  }
+}
+stats_sinks {
+  name: "]"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "type.googleatis.com/google.protobuf.Value"
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\022*J.:*static_resourc\001es {(\n  cluster`s"
+  }
+}
+stats_sinks {
+  name: ","
+}
+stats_sinks {
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\022*J :2222622222222222222222221\022"
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "\013"
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\nJ1"
+  }
+}
+stats_sinks {
+}

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5674078337236992
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5674078337236992
@@ -1,0 +1,119 @@
+static_resources {
+  clusters {
+    name: "p"
+    connect_timeout {
+      nanos: 786870912
+    }
+    hosts {
+      pipe {
+        path: "`"
+      }
+    }
+    hosts {
+      pipe {
+        path: "`"
+      }
+    }
+    tls_context {
+      common_tls_context {
+        tls_params {
+          ecdh_curves: "P"
+          ecdh_curves: "P"
+        }
+        tls_certificates {
+          private_key {
+            filename: "\001\000\000\t"
+          }
+          password {
+            inline_string: "#\000\000\000\000\000\000\000"
+          }
+          ocsp_staple {
+            filename: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+          }
+        }
+        tls_certificates {
+          private_key {
+            filename: "\001\000\000\t"
+          }
+          password {
+            inline_string: "#\000\000\000\000\000\000\000"
+          }
+          ocsp_staple {
+            filename: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+          }
+        }
+        tls_certificates {
+          private_key {
+            filename: "\001static_resources {\n  clusters {\n    name: \"z:\"\n    type: STRICT_DNS\n    connect_timeout {\n      seconds: -210453399808\n      nanos: 250002048\n    }\n    http2_protocol_options {\n      allow_connect: true\n    }\n    dns_lookup_family: V4_ONLY\n    common_lb_config {\n      ignore_new_hosts_until_first_hc: true\n    }\n    alt_stat_name: \"\\020\"\n    close_connections_on_host_health_failure: true\n    filters {\n      name: \"%\"\n    }\n  }\n  clusters {\n    name: \"service_google\"\n    connect_timeout {\n      nanos\000: 786870912\n    }\n    per_connection_buffer_limit_bytes {\n      value: 4143972352\n    }\n    lb_policy: RING_HASH\n    hosts {\n      pipe {\n        path: \"`\"\n      }\n    }\n    hosts {\n      pipe {\n        path: \"#\"\n      }\n    }\n    hosts {\n      pipe {\n        path: \"`\"\n      }\n    }\n    tls_context {\n      common_tls_conte\000xt {\n        tls_params {\n          ecdh_curves: \"P\"\n        }\n        tls_certificates {\n          private_key {\n            filename: \"\\001\\0\t00\\000\\t\"\n          }\n          password {\n            inline_string: \"#\\000\\000\\000\\000\\000\\000\\000\"\n          }\n          ocsp_staple {\n            filename: \"\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\"\n          }\n        }\n        tls_certificates"
+          }
+          ocsp_staple {
+            filename: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+          }
+        }
+        combined_validation_context {
+          default_validation_context {
+            verify_subject_alt_name: "\001\000\000\000\000\000\000\006"
+            require_ocsp_staple {
+              value: true
+            }
+            require_signed_certificate_timestamp {
+            }
+          }
+          validation_context_sds_secret_config {
+          }
+        }
+      }
+    }
+    close_connections_on_host_health_failure: true
+  }
+  secrets {
+    validation_context {
+      trusted_ca {
+        inline_bytes: "\316"
+      }
+    }
+  }
+}
+cluster_manager {
+  local_cluster_name: ","
+  upstream_bind_config {
+    source_address {
+      address: "\032"
+      port_value: 8192
+      ipv4_compat: true
+    }
+  }
+  load_stats_config {
+    refresh_delay {
+      seconds: 4611686018427387903
+    }
+    set_node_on_first_message_only: true
+  }
+}
+stats_sinks {
+  typed_config {
+    type_url: "\001\000\000\t"
+    value: "\230*Vs{{{{{{{{{{{{{{{{{{{{{{{{{{||{|||{{{{{{{{{{{{{{{{{{{{{{{{{||||||||||||||||||||||||||st|||||||||||||||||||||stt"
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+  name: "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
+  typed_config {
+    type_url: "\001\000\000\t"
+  }
+}
+watchdog {
+  miss_timeout {
+    seconds: 2147483707
+  }
+  kill_timeout {
+    seconds: 2046820352
+  }
+}
+hds_config {
+}
+layered_runtime {
+}
+header_prefix: ":"


### PR DESCRIPTION
This adds an implementation of `addValidationCallback` for all secret providers. This is a no-op, unless the secret provider is a `CertificateValidationContextSdsApi.

Envoy crashes when trying to add a validation callback to CertificateValidationContextProvider due to a bad dynamic cast. When `certificate_validation_context_provider_` isn't a `CertificateValidationContextSdsApi`, we no-op. 

Fixes: #7892 and OSS-Fuzz Issues
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17001
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16766
Testing: add corpus entry

Signed-off-by: Asra Ali <asraa@google.com>