### PR TITLE
ci: temporarily disable go_mirror while figuring out SSH keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,10 @@ jobs:
            fingerprints:
              - "fb:f3:fe:be:1c:b2:ec:b6:25:f9:7b:a6:87:54:02:8c"
        - run: ci/api_mirror.sh
-       - run: ci/go_mirror.sh
        - store_artifacts:
            path: /build/envoy/generated
            destination: /
+
    filter_example_mirror:
      executor: ubuntu-build
      steps:


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
To unblock master CI
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
