### PR TITLE
Fix grpc transcoding content type not matching response body

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -400,13 +400,16 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& h
   response_headers_ = &headers;
 
   if (end_stream) {
+
+    if (method_->server_streaming()) {
+      // When there is no body in a streaming response, a empty JSON array is
+      // returned by default. Set the content type correctly.
+      headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Json);
+    }
+
     // In gRPC wire protocol, headers frame with end_stream is a trailers-only response.
     // The return value from encodeTrailers is ignored since it is always continue.
     encodeTrailers(headers);
-
-    // When there is no body, a empty JSON array is returned by default. Set the content type
-    // correctly.
-    headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Json);
 
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -403,6 +403,11 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& h
     // In gRPC wire protocol, headers frame with end_stream is a trailers-only response.
     // The return value from encodeTrailers is ignored since it is always continue.
     encodeTrailers(headers);
+
+    // When there is no body, a empty JSON array is returned by default. Set the content type
+    // correctly.
+    headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Json);
+
     return Http::FilterHeadersStatus::Continue;
   }
 

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -446,13 +446,10 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingGet) {
   // Response type is a valid JSON, so content type should be application/json.
   // Regression test for github.com/envoyproxy/envoy#5011
   testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
-      Http::TestHeaderMapImpl{{":method", "GET"}, {":path", "/shelves/2/books"}, {":authority", "host"}},
-      "",
-      {"shelf: 2"},
-      {},
-      Status(),
-      Http::TestHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
-      "[]");
+      Http::TestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/shelves/2/books"}, {":authority", "host"}},
+      "", {"shelf: 2"}, {}, Status(),
+      Http::TestHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}}, "[]");
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, StreamingPost) {

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -430,6 +430,8 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, BindingAndBody) {
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingGet) {
   HttpIntegrationTest::initialize();
+
+  // 1: Normal streaming get
   testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
       Http::TestHeaderMapImpl{
           {":method", "GET"}, {":path", "/shelves/1/books"}, {":authority", "host"}},
@@ -439,6 +441,18 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingGet) {
       Status(), Http::TestHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
       R"([{"id":"1","author":"Neal Stephenson","title":"Readme"})"
       R"(,{"id":"2","author":"George R.R. Martin","title":"A Game of Thrones"}])");
+
+  // 2: Empty response (trailers only) from streaming backend.
+  // Response type is a valid JSON, so content type should be application/json.
+  // Regression test for github.com/envoyproxy/envoy#5011
+  testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
+      Http::TestHeaderMapImpl{{":method", "GET"}, {":path", "/shelves/2/books"}, {":authority", "host"}},
+      "",
+      {"shelf: 2"},
+      {},
+      Status(),
+      Http::TestHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      "[]");
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, StreamingPost) {
@@ -553,11 +567,12 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, DeepStruct) {
 
   // The valid deep struct is parsed successfully.
   // Since we didn't set the response, it return 503.
+  // Response body is empty (not a valid JSON), so content type should be application/grpc.
   testTranscoding<bookstore::EchoStructReqResp, bookstore::EchoStructReqResp>(
       Http::TestHeaderMapImpl{
           {":method", "POST"}, {":path", "/echoStruct"}, {":authority", "host"}},
       createDeepJson(100, true), {}, {}, Status(),
-      Http::TestHeaderMapImpl{{":status", "503"}, {"content-type", "application/json"}}, "");
+      Http::TestHeaderMapImpl{{":status", "503"}, {"content-type", "application/grpc"}}, "");
 
   // The invalid deep struct is detected.
   testTranscoding<bookstore::EchoStructReqResp, bookstore::EchoStructReqResp>(

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -557,7 +557,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, DeepStruct) {
       Http::TestHeaderMapImpl{
           {":method", "POST"}, {":path", "/echoStruct"}, {":authority", "host"}},
       createDeepJson(100, true), {}, {}, Status(),
-      Http::TestHeaderMapImpl{{":status", "503"}, {"content-type", "application/grpc"}}, "");
+      Http::TestHeaderMapImpl{{":status", "503"}, {"content-type", "application/json"}}, "");
 
   // The invalid deep struct is detected.
   testTranscoding<bookstore::EchoStructReqResp, bookstore::EchoStructReqResp>(

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -450,6 +450,13 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingGet) {
           {":method", "GET"}, {":path", "/shelves/2/books"}, {":authority", "host"}},
       "", {"shelf: 2"}, {}, Status(),
       Http::TestHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}}, "[]");
+
+  // 3: Empty response (trailers only) from streaming backend, with a gRPC error.
+  testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
+      Http::TestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/shelves/37/books"}, {":authority", "host"}},
+      "", {"shelf: 37"}, {}, Status(Code::NOT_FOUND, "Shelf 37 not found"),
+      Http::TestHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}}, "[]");
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, StreamingPost) {


### PR DESCRIPTION
For a trailer-only gRPC streaming response, ensure that the returned content type is `application/json`. This is required because the response body is an empty JSON array.

Risk Level: Low
Testing: Added an integration test to catch this bug.
Docs Changes: None
Release Notes: None

Fixes: #5011
Ref: #8158
Ref: #8009

Please note this fixes issues for responses that are:
- Trailer-only (either an empty body or a gRPC error)
- Streaming (not unary)

Signed-off-by: Teju Nareddy <nareddyt@google.com>