### PR TITLE
[dont review this is wrong but used for debugging the leak] Fix memory leak

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -118,7 +118,6 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
         if (item->x509) {
           X509_STORE_add_cert(store, item->x509);
           if (ca_cert_ == nullptr) {
-            X509_up_ref(item->x509);
             ca_cert_.reset(item->x509);
           }
         }


### PR DESCRIPTION
Per @ipuustin's suggestion, dropping the `X509_up_ref()` at:

https://github.com/envoyproxy/envoy/blob/master/source/extensions/transport_sockets/tls/context_impl.cc#L121

fixes the mem leak reported at #8149. We do have a local deterministic
repro for this, but I'll try to provide a unit test for this as well.

Fixes #8149.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
