### PR TITLE
http: turning on absolute url support by default

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -32,7 +32,7 @@ Version history
 * http: added the ability to configure the behavior of the server response header, via the :ref:`server_header_transformation<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.server_header_transformation>` field.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
 * http: remove h2c upgrade headers for HTTP/1 as h2c upgrades are currently not supported.
-* http: absolute URL support is not on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
+* http: absolute URL support is now on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
 * listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * lua: extended `httpCall()` and `respond()` APIs to accept headers with entry values that can be a string or table of strings.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -32,6 +32,7 @@ Version history
 * http: added the ability to configure the behavior of the server response header, via the :ref:`server_header_transformation<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.server_header_transformation>` field.
 * http: added the ability to :ref:`merge adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
 * http: remove h2c upgrade headers for HTTP/1 as h2c upgrades are currently not supported.
+* http: absolute URL support is not on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
 * listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * lua: extended `httpCall()` and `respond()` APIs to accept headers with entry values that can be a string or table of strings.

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -273,7 +273,7 @@ Utility::parseHttp2Settings(const envoy::api::v2::core::Http2ProtocolOptions& co
 Http1Settings
 Utility::parseHttp1Settings(const envoy::api::v2::core::Http1ProtocolOptions& config) {
   Http1Settings ret;
-  ret.allow_absolute_url_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, allow_absolute_url, false);
+  ret.allow_absolute_url_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, allow_absolute_url, true);
   ret.accept_http_10_ = config.accept_http_10();
   ret.default_host_for_http_10_ = config.default_host_for_http_10();
   return ret;

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -35,9 +35,6 @@ std::string normalizeDate(const std::string& s) {
 
 void setDisallowAbsoluteUrl(
     envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm) {
-  envoy::api::v2::core::Http1ProtocolOptions options;
-  //  options.mutable_allow_absolute_url()->set_value(false);
-  //  hcm.mutable_http_protocol_options()->CopyFrom(options);
   hcm.mutable_http_protocol_options()->mutable_allow_absolute_url()->set_value(false);
 };
 


### PR DESCRIPTION
As discussed on #8078 absolute URLs are part of the HTTP/1 spec and the code has been used for some time now - turning it up by default.

Risk Level: Medium (changes to L7 for many users)
Testing: updated tests for new defaults
Docs Changes: no
Release Notes: yes

