### PR TITLE
api: generate v3alpha from v2 via protoxform.

### DIFF
--- a/api/envoy/api/v3alpha/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v3alpha/cluster/circuit_breaker.proto
@@ -5,8 +5,6 @@ package envoy.api.v3alpha.cluster;
 option java_outer_classname = "CircuitBreakerProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.cluster";
-option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "envoy/api/v3alpha/core/base.proto";
 

--- a/api/envoy/api/v3alpha/cluster/filter.proto
+++ b/api/envoy/api/v3alpha/cluster/filter.proto
@@ -5,8 +5,6 @@ package envoy.api.v3alpha.cluster;
 option java_outer_classname = "FilterProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.cluster";
-option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/any.proto";
 

--- a/api/envoy/api/v3alpha/cluster/outlier_detection.proto
+++ b/api/envoy/api/v3alpha/cluster/outlier_detection.proto
@@ -5,8 +5,6 @@ package envoy.api.v3alpha.cluster;
 option java_outer_classname = "OutlierDetectionProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.cluster";
-option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";

--- a/api/envoy/api/v3alpha/listener/listener.proto
+++ b/api/envoy/api/v3alpha/listener/listener.proto
@@ -5,8 +5,6 @@ package envoy.api.v3alpha.listener;
 option java_outer_classname = "ListenerProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.listener";
-option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
 
 import "envoy/api/v3alpha/auth/cert.proto";
 import "envoy/api/v3alpha/core/address.proto";

--- a/api/envoy/api/v3alpha/listener/quic_config.proto
+++ b/api/envoy/api/v3alpha/listener/quic_config.proto
@@ -5,8 +5,6 @@ package envoy.api.v3alpha.listener;
 option java_outer_classname = "QuicConfigProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.listener";
-option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";

--- a/api/envoy/api/v3alpha/listener/udp_listener_config.proto
+++ b/api/envoy/api/v3alpha/listener/udp_listener_config.proto
@@ -5,8 +5,6 @@ package envoy.api.v3alpha.listener;
 option java_outer_classname = "UdpListenerConfigProto";
 option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v3alpha.listener";
-option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";

--- a/api/envoy/config/trace/v3alpha/trace.proto
+++ b/api/envoy/config/trace/v3alpha/trace.proto
@@ -179,7 +179,7 @@ message OpenCensusConfig {
   // also be set.
   bool zipkin_exporter_enabled = 5;
 
-  // The URL to Zipkin, e.g. "http://127.0.0.1:9411/api/v3alpha/spans"
+  // The URL to Zipkin, e.g. "http://127.0.0.1:9411/api/v2/spans"
   string zipkin_url = 6;
 
   // Enables the OpenCensus Agent exporter if set to true. The address must also

--- a/tools/api_proto_plugin/plugin.py
+++ b/tools/api_proto_plugin/plugin.py
@@ -1,6 +1,7 @@
 """Python protoc plugin for Envoy APIs."""
 
 import cProfile
+from collections import namedtuple
 import io
 import os
 import pstats
@@ -10,8 +11,26 @@ from tools.api_proto_plugin import traverse
 
 from google.protobuf.compiler import plugin_pb2
 
+OutputDescriptor = namedtuple(
+    'OutputDescriptor',
+    [
+        # Output files are generated alongside their corresponding input .proto,
+        # with the output_suffix appended.
+        'output_suffix',
+        # The visitor is a visitor.Visitor defining the business logic of the plugin
+        # for the specific output descriptor.
+        'visitor',
+        # FileDescriptorProto transformer; this is applied to the input
+        # before any output generation.
+        'xform',
+    ])
 
-def Plugin(output_suffix, visitor):
+
+def DirectOutputDescriptor(output_suffix, visitor):
+  return OutputDescriptor(output_suffix, visitor, lambda x: x)
+
+
+def Plugin(output_descriptors):
   """Protoc plugin entry point.
 
   This defines protoc plugin and manages the stdin -> stdout flow. An
@@ -22,9 +41,7 @@ def Plugin(output_suffix, visitor):
   for further details on protoc plugin basics.
 
   Args:
-    output_suffix: output files are generated alongside their corresponding
-      input .proto, with this filename suffix.
-    visitor: visitor.Visitor defining the business logic of the plugin.
+    output_descriptors: a list of OutputDescriptors.
   """
   request = plugin_pb2.CodeGeneratorRequest()
   request.ParseFromString(sys.stdin.buffer.read())
@@ -37,21 +54,20 @@ def Plugin(output_suffix, visitor):
   for file_to_generate in request.file_to_generate:
     # Find the FileDescriptorProto for the file we actually are generating.
     file_proto = [pf for pf in request.proto_file if pf.name == file_to_generate][0]
-    f = response.file.add()
-    f.name = file_proto.name + output_suffix
     if cprofile_enabled:
       pr = cProfile.Profile()
       pr.enable()
-    # We don't actually generate any RST right now, we just string dump the
-    # input proto file descriptor into the output file.
-    f.content = traverse.TraverseFile(file_proto, visitor)
+      for od in output_descriptors:
+        f = response.file.add()
+        f.name = file_proto.name + od.output_suffix
+        f.content = traverse.TraverseFile(od.xform(file_proto), od.visitor)
     if cprofile_enabled:
       pr.disable()
       stats_stream = io.StringIO()
       ps = pstats.Stats(pr,
                         stream=stats_stream).sort_stats(os.getenv('CPROFILE_SORTBY', 'cumulative'))
       stats_file = response.file.add()
-      stats_file.name = file_proto.name + output_suffix + '.profile'
+      stats_file.name = file_proto.name + '.profile'
       ps.print_stats()
       stats_file.content = stats_stream.getvalue()
     # Also include the original FileDescriptorProto as text proto, this is

--- a/tools/api_proto_plugin/traverse.py
+++ b/tools/api_proto_plugin/traverse.py
@@ -4,7 +4,7 @@ from tools.api_proto_plugin import type_context
 
 
 def TraverseService(type_context, service_proto, visitor):
-  """Traverse an enum definition.
+  """Traverse a service definition.
 
   Args:
     type_context: type_context.TypeContext for service type.

--- a/tools/proto_format.sh
+++ b/tools/proto_format.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+[[ "$1" == "check" || "$1" == "fix" ]] || (echo "Usage: $0 <check|fix>"; exit 1)
+
 # Clean up any stale files in the API tree output. Bazel remembers valid cached
 # files still.
 rm -rf bazel-bin/external/envoy_api
@@ -16,36 +18,7 @@ bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
   tools/protoxform/protoxform.bzl%proto_xform_aspect --output_groups=proto --action_env=CPROFILE_ENABLED=1 \
   --spawn_strategy=standalone --host_force_python=PY3
 
-# We do ** matching below to deal with Bazel cache blah (source proto artifacts
-# are nested inside source package targets).
-shopt -s globstar
-
 # Find all source protos.
-declare -r PROTO_TARGET=$(bazel query "labels(srcs, labels(deps, @envoy_api//docs:protos))")
+declare -r PROTO_TARGETS=$(bazel query "labels(srcs, labels(deps, @envoy_api//docs:protos))")
 
-# Copy protos from Bazel build-cache back into source tree.
-for p in ${PROTO_TARGET}
-do
-  declare PROTO_FILE_WITHOUT_PREFIX="${p#@envoy_api//}"
-  declare PROTO_FILE_CANONICAL="${PROTO_FILE_WITHOUT_PREFIX/://}"
-  # We use ** glob matching here to deal with the fact that we have something
-  # like
-  # bazel-bin/external/envoy_api/envoy/admin/v2alpha/pkg/envoy/admin/v2alpha/certs.proto.proto
-  # and we don't want to have to do a nested loop and slow bazel query to
-  # recover the canonical package part of the path.
-  declare SRCS=(bazel-bin/external/envoy_api/**/"${PROTO_FILE_CANONICAL}.proto")
-  # While we may have reformatted the file multiple times due to the transitive
-  # dependencies in the aspect above, they all look the same. So, just pick an
-  # arbitrary match and we're done.
-  declare SRC="${SRCS[0]}"
-  declare DST="api/${PROTO_FILE_CANONICAL}"
-
-  if [[ "$1" == "fix" ]]
-  then
-    [[ -f "${DST}" ]]
-    cp -f "${SRC}" "${DST}"
-  else
-    diff ${SRC} "${DST}" || \
-      (echo "$0 mismatch, either run ./ci/do_ci.sh fix_format or $0 fix to reformat."; exit 1)
-  fi
-done
+./tools/proto_sync.py "$1" ${PROTO_TARGETS}

--- a/tools/proto_sync.py
+++ b/tools/proto_sync.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+
+# Diff or copy protoxform artifacts from Bazel cache back to the source tree.
+
+import glob
+import re
+import shutil
+import subprocess
+import sys
+
+
+def LabelPaths(label, src_suffix):
+  """Compute single proto file source/destination paths from a Bazel proto label.
+
+  Args:
+    label: Bazel source proto label string.
+    src_suffix: suffix string to append to source path.
+  Returns:
+    source, destination path tuple. The source indicates where in the Bazel
+      cache the protoxform.py artifact with src_suffix can be found. The
+      destination is a provisional path in the Envoy source tree for copying the
+      contents of source when run in fix mode.
+  """
+  assert (label.startswith('@envoy_api//'))
+  proto_file_canonical = label[len('@envoy_api//'):].replace(':', '/')
+  # We use ** glob matching here to deal with the fact that we have something
+  # like
+  # bazel-bin/external/envoy_api/envoy/admin/v2alpha/pkg/envoy/admin/v2alpha/certs.proto.proto
+  # and we don't want to have to do a nested loop and slow bazel query to
+  # recover the canonical package part of the path.
+  # While we may have reformatted the file multiple times due to the transitive
+  # dependencies in the aspect above, they all look the same. So, just pick an
+  # arbitrary match and we're done.
+  glob_pattern = 'bazel-bin/external/envoy_api/**/%s.%s' % (proto_file_canonical, src_suffix)
+  src = glob.glob(glob_pattern, recursive=True)[0]
+  dst = 'api/%s' % proto_file_canonical
+  return src, dst
+
+
+def SyncProtoFile(cmd, src, dst):
+  """Diff or in-place update a single proto file from protoxform.py Bazel cache artifacts."
+
+  Args:
+    cmd: 'check' or 'fix'.
+    src: source path.
+    dst: destination path.
+  """
+  if cmd == 'fix':
+    shutil.copyfile(src, dst)
+  else:
+    try:
+      subprocess.check_call(['diff', src, dst])
+    except subprocess.CalledProcessError:
+      sys.stderr.write(
+          '%s and %s do not match, either run ./ci/do_ci.sh fix_format or %s fix to reformat.\n' %
+          (src, dst, sys.argv[0]))
+      sys.exit(1)
+
+
+def SyncV2(cmd, src_labels):
+  """Diff or in-place update v2 protos from protoxform.py Bazel cache artifacts."
+
+  Args:
+    cmd: 'check' or 'fix'.
+    src_labels: Bazel label for source protos.
+  """
+  for s in src_labels:
+    src, dst = LabelPaths(s, 'v2.proto')
+    SyncProtoFile(cmd, src, dst)
+
+
+def SyncV3Alpha(cmd, src_labels):
+  """Diff or in-place update v3alpha protos from protoxform.py Bazel cache artifacts."
+
+  Args:
+    cmd: 'check' or 'fix'.
+    src_labels: Bazel label for source protos.
+  """
+  for s in src_labels:
+    src, dst = LabelPaths(s, 'v3alpha.proto')
+    # Skip unversioned package namespaces
+    if 'v2' in dst:
+      dst = re.sub('v2alpha\d?|v2', 'v3alpha', dst)
+      SyncProtoFile(cmd, src, dst)
+
+
+if __name__ == '__main__':
+  cmd = sys.argv[1]
+  src_labels = sys.argv[2:]
+  SyncV2(cmd, src_labels)
+  SyncV3Alpha(cmd, src_labels)

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -499,7 +499,7 @@ class RstFormatVisitor(visitor.Visitor):
 
 
 def Main():
-  plugin.Plugin('.rst', RstFormatVisitor())
+  plugin.Plugin([plugin.DirectOutputDescriptor('.rst', RstFormatVisitor())])
 
 
 if __name__ == '__main__':

--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -2,7 +2,10 @@ licenses(["notice"])  # Apache 2
 
 py_binary(
     name = "protoxform",
-    srcs = ["protoxform.py"],
+    srcs = [
+        "migrate.py",
+        "protoxform.py",
+    ],
     python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/protoxform/migrate.py
+++ b/tools/protoxform/migrate.py
@@ -1,0 +1,91 @@
+# API upgrade business logic.
+
+import copy
+import re
+
+from tools.api_proto_plugin import visitor
+
+from google.api import annotations_pb2
+
+
+def UpgradedType(t):
+  return re.sub(r'(\.?envoy[\w\.]*\.)(v2alpha\d?|v2)', r'\1v3alpha', t)
+
+
+def UpgradedPath(p):
+  return re.sub(r'(envoy/[\w/]*/)(v2alpha\d?|v2)', r'\1v3alpha', p)
+
+
+def UpgradedComment(c):
+  # We approximate what needs to be done for comments by just updating anything
+  # that looks like a path or comment. This isn't perfect, e.g. we miss out on
+  # REST URLs etc.
+  # TODO(htuch): audit and improve this.
+  return UpgradedType(UpgradedPath(c))
+
+
+def UpgradedPostMethod(m):
+  return re.sub(r'^/v2/', '/v3alpha/', m)
+
+
+def UpgradeService(service_proto):
+  """In-place upgrade a ServiceDescriptorProto from v2[alpha\d] to v3alpha.
+
+  Args:
+    service_proto: v2[alpha\d] ServiceDescriptorProto message.
+  """
+  for m in service_proto.method:
+    if m.options.HasExtension(annotations_pb2.http):
+      http_options = m.options.Extensions[annotations_pb2.http]
+      http_options.post = UpgradedPostMethod(http_options.post)
+    m.input_type = UpgradedType(m.input_type)
+    m.output_type = UpgradedType(m.output_type)
+
+
+def UpgradeMessage(msg_proto):
+  """In-place upgrade a DescriptorProto from v2[alpha\d] to v3alpha.
+
+  Args:
+    msg_proto: v2[alpha\d] DescriptorProto message.
+  """
+  for f in msg_proto.field:
+    f.type_name = UpgradedType(f.type_name)
+  for m in msg_proto.nested_type:
+    UpgradeMessage(m)
+
+
+def UpgradeFile(file_proto):
+  """In-place upgrade a FileDescriptorProto from v2[alpha\d] to v3alpha.
+
+  Args:
+    file_proto: v2[alpha\d] FileDescriptorProto message.
+  """
+  # Upgrade package.
+  file_proto.package = UpgradedType(file_proto.package)
+  # Upgrade imports.
+  for n, d in enumerate(file_proto.dependency):
+    file_proto.dependency[n] = UpgradedPath(d)
+  # Upgrade comments.
+  for location in file_proto.source_code_info.location:
+    location.leading_comments = UpgradedComment(location.leading_comments)
+    location.trailing_comments = UpgradedComment(location.trailing_comments)
+    for n, c in enumerate(location.leading_detached_comments):
+      location.leading_detached_comments[n] = UpgradedComment(c)
+  # Upgrade services.
+  for s in file_proto.service:
+    UpgradeService(s)
+  # Upgrade messages.
+  for m in file_proto.message_type:
+    UpgradeMessage(m)
+  return file_proto
+
+
+def V3MigrationXform(file_proto):
+  """Transform a FileDescriptorProto from v2[alpha\d] to v3alpha.
+
+  Args:
+    file_proto: v2[alpha\d] FileDescriptorProto message.
+  Returns:
+    v3 FileDescriptorProto message.
+  """
+  return UpgradeFile(copy.deepcopy(file_proto))

--- a/tools/protoxform/protoxform.bzl
+++ b/tools/protoxform/protoxform.bzl
@@ -54,8 +54,11 @@ def _proto_xform_aspect_impl(target, ctx):
 
     # The outputs live in the ctx.label's package root. We add some additional
     # path information to match with protoc's notion of path relative locations.
-    outputs = [ctx.actions.declare_file(ctx.label.name + "/" + _proto_path(f) +
-                                        ".proto") for f in proto_sources]
+    api_versions = ["v2", "v3alpha"]
+    outputs = []
+    for api_version in api_versions:
+        outputs += [ctx.actions.declare_file(ctx.label.name + "/" + _proto_path(f) +
+                                             ".%s.proto" % api_version) for f in proto_sources]
 
     # Create the protoc command-line args.
     ctx_path = ctx.label.package + "/" + ctx.label.name

--- a/tools/protoxform/protoxform.py
+++ b/tools/protoxform/protoxform.py
@@ -17,6 +17,7 @@ import subprocess
 
 from tools.api_proto_plugin import plugin
 from tools.api_proto_plugin import visitor
+from tools.protoxform import migrate
 
 from google.api import annotations_pb2
 from google.protobuf import text_format
@@ -416,7 +417,10 @@ class ProtoFormatVisitor(visitor.Visitor):
 
 
 def Main():
-  plugin.Plugin('.proto', ProtoFormatVisitor())
+  plugin.Plugin([
+      plugin.DirectOutputDescriptor('.v2.proto', ProtoFormatVisitor()),
+      plugin.OutputDescriptor('.v3alpha.proto', ProtoFormatVisitor(), migrate.V3MigrationXform)
+  ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This takes protoxform from being a v2 format tool to being able to
generate something similar to what ./api/migration/v3alpha.sh generates.

Risk level: Low (v3alpha not used yet)
Testing: fix_format, manual verification that the delta from
  ./api/migration/v3alpha.sh makes sense (for now).

Signed-off-by: Harvey Tuch <htuch@google.com>