### PR TITLE
debug: add envoy version stamp to backtrace

### DIFF
--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -13,12 +13,13 @@ namespace Envoy {
 const std::string& VersionInfo::revision() {
   CONSTRUCT_ON_FIRST_USE(std::string, build_scm_revision);
 }
+
 const std::string& VersionInfo::revisionStatus() {
   CONSTRUCT_ON_FIRST_USE(std::string, build_scm_status);
 }
 
-std::string VersionInfo::version() {
-  return fmt::format("{}/{}/{}/{}/{}", revision(), BUILD_VERSION_NUMBER, revisionStatus(),
+const std::string& VersionInfo::version() {
+  CONSTRUCT_ON_FIRST_USE(std::string, fmt::format("{}/{}/{}/{}/{}", revision(), BUILD_VERSION_NUMBER, revisionStatus(),
 #ifdef NDEBUG
                      "RELEASE",
 #else
@@ -29,6 +30,6 @@ std::string VersionInfo::version() {
 #else
                      "no-ssl"
 #endif
-  );
+  ));
 }
 } // namespace Envoy

--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -19,17 +19,18 @@ const std::string& VersionInfo::revisionStatus() {
 }
 
 const std::string& VersionInfo::version() {
-  CONSTRUCT_ON_FIRST_USE(std::string, fmt::format("{}/{}/{}/{}/{}", revision(), BUILD_VERSION_NUMBER, revisionStatus(),
+  CONSTRUCT_ON_FIRST_USE(std::string, fmt::format("{}/{}/{}/{}/{}", revision(),
+                                                  BUILD_VERSION_NUMBER, revisionStatus(),
 #ifdef NDEBUG
-                     "RELEASE",
+                                                  "RELEASE",
 #else
-                     "DEBUG",
+                                                  "DEBUG",
 #endif
 #ifdef ENVOY_SSL_VERSION
-                     ENVOY_SSL_VERSION
+                                                  ENVOY_SSL_VERSION
 #else
-                     "no-ssl"
+                                                  "no-ssl"
 #endif
-  ));
+                                                  ));
 }
 } // namespace Envoy

--- a/source/common/common/version.h
+++ b/source/common/common/version.h
@@ -16,6 +16,6 @@ public:
   // Repository status (e.g. clean, modified).
   static const std::string& revisionStatus();
   // Repository information and build type.
-  static std::string version();
+  static const std::string& version();
 };
 } // namespace Envoy

--- a/source/common/signal/signal_action.cc
+++ b/source/common/signal/signal_action.cc
@@ -5,6 +5,7 @@
 #include <csignal>
 
 #include "common/common/assert.h"
+#include "common/common/version.h"
 
 namespace Envoy {
 
@@ -80,6 +81,10 @@ void SignalAction::installSigHandlers() {
   stack.ss_flags = 0;
 
   RELEASE_ASSERT(sigaltstack(&stack, &previous_altstack_) == 0, "");
+
+  // Make sure VersionInfo::version() is initialized so we don't allocate std::string in signal
+  // handlers.
+  RELEASE_ASSERT(!VersionInfo::version().empty(), "");
 
   int hidx = 0;
   for (const auto& sig : FATAL_SIGS) {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -18,7 +18,10 @@ envoy_cc_library(
         "abseil_symbolize",
     ],
     tags = ["backtrace"],
-    deps = ["//source/common/common:minimal_logger_lib"],
+    deps = [
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/common:version_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "common/common/logger.h"
+#include "common/common/version.h"
 
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
@@ -67,6 +68,7 @@ public:
    */
   void logTrace() {
     ENVOY_LOG(critical, "Backtrace (use tools/stack_decode.py to get line numbers):");
+    ENVOY_LOG(critical, "Envoy version: {}", VersionInfo::version());
 
     visitTrace([](int index, const char* symbol, void* address) {
       if (symbol != nullptr) {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -20,7 +20,10 @@ envoy_cc_test(
     name = "backtrace_test",
     srcs = ["backtrace_test.cc"],
     tags = ["backtrace"],
-    deps = ["//source/server:backtrace_lib"],
+    deps = [
+        "//source/server:backtrace_lib",
+        "//test/test_common:logging_lib",
+    ],
 )
 
 envoy_cc_test(

--- a/test/server/backtrace_test.cc
+++ b/test/server/backtrace_test.cc
@@ -1,5 +1,7 @@
 #include "server/backtrace.h"
 
+#include "test/test_common/logging.h"
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -9,7 +11,7 @@ TEST(Backward, Basic) {
   // logging a backtrace, and covers the added lines.
   BackwardsTrace tracer;
   tracer.capture();
-  tracer.logTrace();
+  EXPECT_LOG_CONTAINS("critical", "Envoy version:", tracer.logTrace());
 }
 
 TEST(Backward, InvalidUsageTest) {


### PR DESCRIPTION
Description:
Add envoy version stamp to backtrace logging so we don't have to ask the exact version of the backtrace.

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>