### PR TITLE
clang-tidy: readability-identifier-naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks:          'abseil-*,
                   performance-*,
                   readability-braces-around-statements,
                   readability-container-size-empty,
+                  readability-identifier-naming,
                   readability-redundant-*'
 
 #TODO(lizan): grow this list, fix possible warnings and make more checks as error
@@ -42,6 +43,7 @@ WarningsAsErrors: 'abseil-duration-*,
                    performance-unnecessary-copy-initialization,
                    readability-braces-around-statements,
                    readability-container-size-empty,
+                   readability-identifier-naming,
                    readability-redundant-control-flow,
                    readability-redundant-member-init,
                    readability-redundant-smartptr-get,
@@ -56,3 +58,6 @@ CheckOptions:
 
   - key:             modernize-use-auto.MinTypeNameLength
     value:           '10'
+
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'

--- a/source/common/access_log/access_log_manager_impl.h
+++ b/source/common/access_log/access_log_manager_impl.h
@@ -62,7 +62,7 @@ private:
 class AccessLogFileImpl : public AccessLogFile {
 public:
   AccessLogFileImpl(Filesystem::FilePtr&& file, Event::Dispatcher& dispatcher,
-                    Thread::BasicLockable& lock, AccessLogFileStats& stats_,
+                    Thread::BasicLockable& lock, AccessLogFileStats& stats,
                     std::chrono::milliseconds flush_interval_msec,
                     Thread::ThreadFactory& thread_factory);
   ~AccessLogFileImpl() override;

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -511,11 +511,11 @@ uint32_t Primes::findPrimeLargerThan(uint32_t x) {
 }
 
 // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
-void WelfordStandardDeviation::update(double newValue) {
+void WelfordStandardDeviation::update(double new_value) {
   ++count_;
-  const double delta = newValue - mean_;
+  const double delta = new_value - mean_;
   mean_ += delta / count_;
-  const double delta2 = newValue - mean_;
+  const double delta2 = new_value - mean_;
   m2_ += delta * delta2;
 }
 

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -521,7 +521,7 @@ public:
    * Accumulates a new value into the standard deviation.
    * @param newValue the new value
    */
-  void update(double newValue);
+  void update(double new_value);
 
   /**
    * @return double the computed mean value.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -519,7 +519,7 @@ class WelfordStandardDeviation {
 public:
   /**
    * Accumulates a new value into the standard deviation.
-   * @param newValue the new value
+   * @param new_value the new value
    */
   void update(double new_value);
 

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -45,7 +45,7 @@ public:
    * Start writing stats once thread-local storage is ready to receive them (see
    * ThreadLocalStoreImpl::initializeThreading).
    */
-  void initializeStats(DispatcherStats* stats_);
+  void initializeStats(DispatcherStats* stats);
 
 private:
   static void onPrepare(evwatch*, const evwatch_prepare_cb_info* info, void* arg);

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -136,14 +136,14 @@ InstanceConstSharedPtr peerAddressFromFd(int fd) {
   return addressFromSockAddr(ss, ss_len);
 }
 
-IoHandlePtr InstanceBase::socketFromSocketType(SocketType socketType) const {
+IoHandlePtr InstanceBase::socketFromSocketType(SocketType socket_type) const {
 #if defined(__APPLE__)
   int flags = 0;
 #else
   int flags = SOCK_NONBLOCK;
 #endif
 
-  if (socketType == SocketType::Stream) {
+  if (socket_type == SocketType::Stream) {
     flags |= SOCK_STREAM;
   } else {
     flags |= SOCK_DGRAM;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -92,10 +92,10 @@ public:
 
   private:
     static HeaderCheckResult hasValidRetryFields(Http::HeaderEntry* header_entry,
-                                                 const ParseRetryFlagsFunc& parseFn) {
+                                                 const ParseRetryFlagsFunc& parse_fn) {
       HeaderCheckResult r;
       if (header_entry) {
-        const auto flags_and_validity = parseFn(header_entry->value().getStringView());
+        const auto flags_and_validity = parse_fn(header_entry->value().getStringView());
         r.valid_ = flags_and_validity.second;
         r.entry_ = header_entry;
       }

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -71,7 +71,7 @@ class TlsScope;
  */
 class ParentHistogramImpl : public MetricImpl<ParentHistogram> {
 public:
-  ParentHistogramImpl(StatName name, Store& parent, TlsScope& tlsScope,
+  ParentHistogramImpl(StatName name, Store& parent, TlsScope& tls_scope,
                       absl::string_view tag_extracted_name, const std::vector<Tag>& tags);
   ~ParentHistogramImpl() override;
 
@@ -213,7 +213,7 @@ public:
   void initializeThreading(Event::Dispatcher& main_thread_dispatcher,
                            ThreadLocal::Instance& tls) override;
   void shutdownThreading() override;
-  void mergeHistograms(PostMergeCb mergeCb) override;
+  void mergeHistograms(PostMergeCb merge_cb) override;
 
 private:
   template <class Stat> using StatMap = StatNameHashMap<Stat>;
@@ -339,7 +339,7 @@ private:
   std::string getTagsForName(const std::string& name, std::vector<Tag>& tags) const;
   void clearScopeFromCaches(uint64_t scope_id, const Event::PostCb& clean_central_cache);
   void releaseScopeCrossThread(ScopeImpl* scope);
-  void mergeInternal(PostMergeCb mergeCb);
+  void mergeInternal(PostMergeCb merge_cb);
   bool rejects(StatName name) const;
   bool rejectsAll() const { return stats_matcher_->rejectsAll(); }
   template <class StatMapClass, class StatListClass>

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -13,20 +13,20 @@ Extensions::NetworkFilters::Common::Redis::Client::DoNothingPoolCallbacks null_p
 
 RedisCluster::RedisCluster(
     const envoy::api::v2::Cluster& cluster,
-    const envoy::config::cluster::redis::RedisClusterConfig& redisCluster,
+    const envoy::config::cluster::redis::RedisClusterConfig& redis_cluster,
     NetworkFilters::Common::Redis::Client::ClientFactory& redis_client_factory,
-    Upstream::ClusterManager& clusterManager, Runtime::Loader& runtime, Api::Api& api,
+    Upstream::ClusterManager& cluster_manager, Runtime::Loader& runtime, Api::Api& api,
     Network::DnsResolverSharedPtr dns_resolver,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
     Stats::ScopePtr&& stats_scope, bool added_via_api,
     ClusterSlotUpdateCallBackSharedPtr lb_factory)
     : Upstream::BaseDynamicClusterImpl(cluster, runtime, factory_context, std::move(stats_scope),
                                        added_via_api),
-      cluster_manager_(clusterManager),
+      cluster_manager_(cluster_manager),
       cluster_refresh_rate_(std::chrono::milliseconds(
-          PROTOBUF_GET_MS_OR_DEFAULT(redisCluster, cluster_refresh_rate, 5000))),
+          PROTOBUF_GET_MS_OR_DEFAULT(redis_cluster, cluster_refresh_rate, 5000))),
       cluster_refresh_timeout_(std::chrono::milliseconds(
-          PROTOBUF_GET_MS_OR_DEFAULT(redisCluster, cluster_refresh_timeout, 3000))),
+          PROTOBUF_GET_MS_OR_DEFAULT(redis_cluster, cluster_refresh_timeout, 3000))),
       dispatcher_(factory_context.dispatcher()), dns_resolver_(std::move(dns_resolver)),
       dns_lookup_family_(Upstream::getDnsLookupFamilyFromCluster(cluster)),
       load_assignment_(cluster.has_load_assignment()

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -90,9 +90,9 @@ namespace Redis {
 class RedisCluster : public Upstream::BaseDynamicClusterImpl {
 public:
   RedisCluster(const envoy::api::v2::Cluster& cluster,
-               const envoy::config::cluster::redis::RedisClusterConfig& redisCluster,
+               const envoy::config::cluster::redis::RedisClusterConfig& redis_cluster,
                NetworkFilters::Common::Redis::Client::ClientFactory& client_factory,
-               Upstream::ClusterManager& clusterManager, Runtime::Loader& runtime, Api::Api& api,
+               Upstream::ClusterManager& cluster_manager, Runtime::Loader& runtime, Api::Api& api,
                Network::DnsResolverSharedPtr dns_resolver,
                Server::Configuration::TransportSocketFactoryContext& factory_context,
                Stats::ScopePtr&& stats_scope, bool added_via_api,

--- a/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
@@ -61,10 +61,10 @@ const std::vector<std::string> RequestParser::TRANSACT_OPERATIONS{"TransactGetIt
 const std::vector<std::string> RequestParser::TRANSACT_ITEM_OPERATIONS{"ConditionCheck", "Delete",
                                                                        "Get", "Put", "Update"};
 
-std::string RequestParser::parseOperation(const Http::HeaderMap& headerMap) {
+std::string RequestParser::parseOperation(const Http::HeaderMap& header_map) {
   std::string operation;
 
-  const Http::HeaderEntry* x_amz_target = headerMap.get(X_AMZ_TARGET);
+  const Http::HeaderEntry* x_amz_target = header_map.get(X_AMZ_TARGET);
   if (x_amz_target) {
     // Normally x-amz-target contains Version.Operation, e.g., DynamoDB_20160101.GetItem
     auto version_and_operation = StringUtil::splitToken(x_amz_target->value().getStringView(), ".");

--- a/source/extensions/filters/http/dynamo/dynamo_request_parser.h
+++ b/source/extensions/filters/http/dynamo/dynamo_request_parser.h
@@ -38,7 +38,7 @@ public:
    * Parse operation out of x-amz-target header.
    * @return empty string if operation cannot be parsed.
    */
-  static std::string parseOperation(const Http::HeaderMap& headerMap);
+  static std::string parseOperation(const Http::HeaderMap& header_map);
 
   /**
    * Parse table name out of data, based on the operation.

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -30,7 +30,7 @@ const std::string SquashFilter::ERROR_STATE = "error";
 
 SquashFilterConfig::SquashFilterConfig(
     const envoy::config::filter::http::squash::v2::Squash& proto_config,
-    Upstream::ClusterManager& clusterManager)
+    Upstream::ClusterManager& cluster_manager)
     : cluster_name_(proto_config.cluster()),
       attachment_json_(getAttachment(proto_config.attachment_template())),
       attachment_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, attachment_timeout, 60000)),
@@ -38,7 +38,7 @@ SquashFilterConfig::SquashFilterConfig(
           PROTOBUF_GET_MS_OR_DEFAULT(proto_config, attachment_poll_period, 1000)),
       request_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, request_timeout, 1000)) {
 
-  if (!clusterManager.get(cluster_name_)) {
+  if (!cluster_manager.get(cluster_name_)) {
     throw EnvoyException(
         fmt::format("squash filter: unknown cluster '{}' in squash config", cluster_name_));
   }

--- a/source/extensions/filters/http/squash/squash_filter.h
+++ b/source/extensions/filters/http/squash/squash_filter.h
@@ -20,7 +20,7 @@ namespace Squash {
 class SquashFilterConfig : protected Logger::Loggable<Logger::Id::config> {
 public:
   SquashFilterConfig(const envoy::config::filter::http::squash::v2::Squash& proto_config,
-                     Upstream::ClusterManager& clusterManager);
+                     Upstream::ClusterManager& cluster_manager);
   const std::string& clusterName() { return cluster_name_; }
   const std::string& attachmentJson() { return attachment_json_; }
   const std::chrono::milliseconds& attachmentTimeout() { return attachment_timeout_; }

--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -174,7 +174,7 @@ bool HttpPerRequestTapperImpl::onDestroyLog() {
 
 void HttpPerRequestTapperImpl::onBody(
     const Buffer::Instance& data, Extensions::Common::Tap::TraceWrapperPtr& buffered_streamed_body,
-    uint32_t maxBufferedBytes, MutableBodyChunk mutable_body_chunk,
+    uint32_t max_buffered_bytes, MutableBodyChunk mutable_body_chunk,
     MutableMessage mutable_message) {
   // TODO(mattklein123): Body matching.
   if (config_->streaming()) {
@@ -186,7 +186,7 @@ void HttpPerRequestTapperImpl::onBody(
       // If we have already started streaming, flush a body segment now.
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       TapCommon::Utility::addBufferToProtoBytes(
-          *(trace->mutable_http_streamed_trace_segment()->*mutable_body_chunk)(), maxBufferedBytes,
+          *(trace->mutable_http_streamed_trace_segment()->*mutable_body_chunk)(), max_buffered_bytes,
           data, 0, data.length());
       sink_handle_->submitTrace(std::move(trace));
     } else if (match_status.might_change_status_) {
@@ -196,8 +196,8 @@ void HttpPerRequestTapperImpl::onBody(
       }
       auto& body =
           *(buffered_streamed_body->mutable_http_streamed_trace_segment()->*mutable_body_chunk)();
-      ASSERT(body.as_bytes().size() <= maxBufferedBytes);
-      TapCommon::Utility::addBufferToProtoBytes(body, maxBufferedBytes - body.as_bytes().size(),
+      ASSERT(body.as_bytes().size() <= max_buffered_bytes);
+      TapCommon::Utility::addBufferToProtoBytes(body, max_buffered_bytes - body.as_bytes().size(),
                                                 data, 0, data.length());
     }
   } else {
@@ -205,8 +205,8 @@ void HttpPerRequestTapperImpl::onBody(
     makeBufferedFullTraceIfNeeded();
     auto& body =
         *(buffered_full_trace_->mutable_http_buffered_trace()->*mutable_message)()->mutable_body();
-    ASSERT(body.as_bytes().size() <= maxBufferedBytes);
-    TapCommon::Utility::addBufferToProtoBytes(body, maxBufferedBytes - body.as_bytes().size(), data,
+    ASSERT(body.as_bytes().size() <= max_buffered_bytes);
+    TapCommon::Utility::addBufferToProtoBytes(body, max_buffered_bytes - body.as_bytes().size(), data,
                                               0, data.length());
   }
 }

--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -186,8 +186,8 @@ void HttpPerRequestTapperImpl::onBody(
       // If we have already started streaming, flush a body segment now.
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       TapCommon::Utility::addBufferToProtoBytes(
-          *(trace->mutable_http_streamed_trace_segment()->*mutable_body_chunk)(), max_buffered_bytes,
-          data, 0, data.length());
+          *(trace->mutable_http_streamed_trace_segment()->*mutable_body_chunk)(),
+          max_buffered_bytes, data, 0, data.length());
       sink_handle_->submitTrace(std::move(trace));
     } else if (match_status.might_change_status_) {
       // If we might still match, start buffering the body up to our limit.
@@ -206,8 +206,8 @@ void HttpPerRequestTapperImpl::onBody(
     auto& body =
         *(buffered_full_trace_->mutable_http_buffered_trace()->*mutable_message)()->mutable_body();
     ASSERT(body.as_bytes().size() <= max_buffered_bytes);
-    TapCommon::Utility::addBufferToProtoBytes(body, max_buffered_bytes - body.as_bytes().size(), data,
-                                              0, data.length());
+    TapCommon::Utility::addBufferToProtoBytes(body, max_buffered_bytes - body.as_bytes().size(),
+                                              data, 0, data.length());
   }
 }
 

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -49,7 +49,7 @@ private:
 
   void onBody(const Buffer::Instance& data,
               Extensions::Common::Tap::TraceWrapperPtr& buffered_streamed_body,
-              uint32_t maxBufferedBytes, MutableBodyChunk mutable_body_chunk,
+              uint32_t max_buffered_bytes, MutableBodyChunk mutable_body_chunk,
               MutableMessage mutable_message);
 
   void makeBufferedFullTraceIfNeeded() {

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -61,9 +61,9 @@ public:
    * @param parserResolver supported parser resolver.
    * @param callbacks callbacks to be invoked (in order).
    */
-  RequestDecoder(const InitialParserFactory& factory, const RequestParserResolver& parserResolver,
+  RequestDecoder(const InitialParserFactory& factory, const RequestParserResolver& parser_resolver,
                  const std::vector<RequestCallbackSharedPtr> callbacks)
-      : AbstractMessageDecoder{callbacks}, factory_{factory}, parser_resolver_{parserResolver} {};
+      : AbstractMessageDecoder{callbacks}, factory_{factory}, parser_resolver_{parser_resolver} {};
 
 protected:
   RequestParserSharedPtr createStartParser() override;

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -58,7 +58,7 @@ public:
    * Visible for testing.
    * Allows injecting initial parser factory and parser resolver.
    * @param factory parser factory to be used when new message is to be processed.
-   * @param parserResolver supported parser resolver.
+   * @param parser_resolver supported parser resolver.
    * @param callbacks callbacks to be invoked (in order).
    */
   RequestDecoder(const InitialParserFactory& factory, const RequestParserResolver& parser_resolver,

--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -89,7 +89,7 @@ public:
   virtual bool operator==(const KillCursorsMessage& rhs) const PURE;
 
   virtual int32_t numberOfCursorIds() const PURE;
-  virtual void numberOfCursorIds(int32_t number_of_cursors_ids_) PURE;
+  virtual void numberOfCursorIds(int32_t number_of_cursors_ids) PURE;
   virtual const std::vector<int64_t>& cursorIds() const PURE;
   virtual void cursorIds(std::vector<int64_t>&& cursors_ids) PURE;
 };
@@ -163,11 +163,11 @@ public:
   virtual std::string database() const PURE;
   virtual void database(std::string database) PURE;
   virtual std::string commandName() const PURE;
-  virtual void commandName(std::string commandName) PURE;
+  virtual void commandName(std::string command_name) PURE;
   virtual const Bson::Document* metadata() const PURE;
   virtual void metadata(Bson::DocumentSharedPtr&& metadata) PURE;
   virtual const Bson::Document* commandArgs() const PURE;
-  virtual void commandArgs(Bson::DocumentSharedPtr&& commandArgs) PURE;
+  virtual void commandArgs(Bson::DocumentSharedPtr&& command_args) PURE;
   virtual const std::list<Bson::DocumentSharedPtr>& inputDocs() const PURE;
   virtual std::list<Bson::DocumentSharedPtr>& inputDocs() PURE;
 };
@@ -180,7 +180,7 @@ public:
   virtual const Bson::Document* metadata() const PURE;
   virtual void metadata(Bson::DocumentSharedPtr&& metadata) PURE;
   virtual const Bson::Document* commandReply() const PURE;
-  virtual void commandReply(Bson::DocumentSharedPtr&& commandReply) PURE;
+  virtual void commandReply(Bson::DocumentSharedPtr&& command_reply) PURE;
   virtual const std::list<Bson::DocumentSharedPtr>& outputDocs() const PURE;
   virtual std::list<Bson::DocumentSharedPtr>& outputDocs() PURE;
 };

--- a/source/extensions/tracers/zipkin/zipkin_core_types.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.h
@@ -238,7 +238,7 @@ public:
   /**
    * Sets the binary's annotation type.
    */
-  void setAnnotationType(AnnotationType annotationType) { annotation_type_ = annotationType; }
+  void setAnnotationType(AnnotationType annotation_type) { annotation_type_ = annotation_type; }
 
   /**
    * @return the annotation's endpoint attribute.

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -626,16 +626,16 @@ bool ContextImpl::verifySubjectAltName(X509* cert,
   return false;
 }
 
-bool ContextImpl::dNSNameMatch(const std::string& dNSName, const char* pattern) {
-  if (dNSName == pattern) {
+bool ContextImpl::dNSNameMatch(const std::string& d_ns_name, const char* pattern) {
+  if (d_ns_name == pattern) {
     return true;
   }
 
   size_t pattern_len = strlen(pattern);
   if (pattern_len > 1 && pattern[0] == '*' && pattern[1] == '.') {
-    if (dNSName.length() > pattern_len - 1) {
-      size_t off = dNSName.length() - pattern_len + 1;
-      return dNSName.compare(off, pattern_len - 1, pattern + 1) == 0;
+    if (d_ns_name.length() > pattern_len - 1) {
+      size_t off = d_ns_name.length() - pattern_len + 1;
+      return d_ns_name.compare(off, pattern_len - 1, pattern + 1) == 0;
     }
   }
 

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -579,7 +579,7 @@ bool ContextImpl::verifySubjectAltName(X509* cert,
       ASN1_STRING* str = san->d.dNSName;
       const char* dns_name = reinterpret_cast<const char*>(ASN1_STRING_data(str));
       for (auto& config_san : subject_alt_names) {
-        if (dNSNameMatch(config_san, dns_name)) {
+        if (dnsNameMatch(config_san, dns_name)) {
           return true;
         }
       }
@@ -626,16 +626,16 @@ bool ContextImpl::verifySubjectAltName(X509* cert,
   return false;
 }
 
-bool ContextImpl::dNSNameMatch(const std::string& d_ns_name, const char* pattern) {
-  if (d_ns_name == pattern) {
+bool ContextImpl::dnsNameMatch(const std::string& dns_name, const char* pattern) {
+  if (dns_name == pattern) {
     return true;
   }
 
   size_t pattern_len = strlen(pattern);
   if (pattern_len > 1 && pattern[0] == '*' && pattern[1] == '.') {
-    if (d_ns_name.length() > pattern_len - 1) {
-      size_t off = d_ns_name.length() - pattern_len + 1;
-      return d_ns_name.compare(off, pattern_len - 1, pattern + 1) == 0;
+    if (dns_name.length() > pattern_len - 1) {
+      size_t off = dns_name.length() - pattern_len + 1;
+      return dns_name.compare(off, pattern_len - 1, pattern + 1) == 0;
     }
   }
 

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -73,7 +73,7 @@ public:
    * @param pattern the pattern to match against (*.example.com)
    * @return true if the san matches pattern
    */
-  static bool dNSNameMatch(const std::string& dnsName, const char* pattern);
+  static bool dNSNameMatch(const std::string& dns_name, const char* pattern);
 
   SslStats& stats() { return stats_; }
 

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -69,11 +69,11 @@ public:
   /**
    * Determines whether the given name matches 'pattern' which may optionally begin with a wildcard.
    * NOTE:  public for testing
-   * @param san the subjectAltName to match
+   * @param dns_name the DNS name to match
    * @param pattern the pattern to match against (*.example.com)
    * @return true if the san matches pattern
    */
-  static bool dNSNameMatch(const std::string& dns_name, const char* pattern);
+  static bool dnsNameMatch(const std::string& dns_name, const char* pattern);
 
   SslStats& stats() { return stats_; }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -833,11 +833,11 @@ std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag
   return StringUtil::join(buf, ",");
 }
 
-std::string PrometheusStatsFormatter::metricName(const std::string& extractedName) {
+std::string PrometheusStatsFormatter::metricName(const std::string& extracted_name) {
   // Add namespacing prefix to avoid conflicts, as per best practice:
   // https://prometheus.io/docs/practices/naming/#metric-names
   // Also, naming conventions on https://prometheus.io/docs/concepts/data_model/
-  return sanitizeName(fmt::format("envoy_{0}", extractedName));
+  return sanitizeName(fmt::format("envoy_{0}", extracted_name));
 }
 
 uint64_t PrometheusStatsFormatter::statsAsPrometheus(

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -446,7 +446,7 @@ public:
   /**
    * Format the given metric name, prefixed with "envoy_".
    */
-  static std::string metricName(const std::string& extractedName);
+  static std::string metricName(const std::string& extracted_name);
 
 private:
   /**

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -118,7 +118,7 @@ static void BM_FindToken(benchmark::State& state) {
 }
 BENCHMARK(BM_FindToken);
 
-static bool nextToken(absl::string_view& str, char delim, bool stripWhitespace,
+static bool nextToken(absl::string_view& str, char delim, bool strip_whitespace,
                       absl::string_view* token) {
   while (!str.empty()) {
     absl::string_view::size_type pos = str.find(delim);
@@ -129,7 +129,7 @@ static bool nextToken(absl::string_view& str, char delim, bool stripWhitespace,
       *token = str.substr(0, pos);
       str.remove_prefix(pos + 1); // move past token and delim
     }
-    if (stripWhitespace) {
+    if (strip_whitespace) {
       *token = Envoy::StringUtil::trim(*token);
     }
     if (!token->empty()) {
@@ -143,8 +143,8 @@ static bool nextToken(absl::string_view& str, char delim, bool stripWhitespace,
 // a temp vector, but just iterates through the string_view, tokenizing, and matching against
 // the token we want. It appears to be about 2.5x to 3x faster on this testcase.
 static bool findTokenWithoutSplitting(absl::string_view str, char delim, absl::string_view token,
-                                      bool stripWhitespace) {
-  for (absl::string_view tok; nextToken(str, delim, stripWhitespace, &tok);) {
+                                      bool strip_whitespace) {
+  for (absl::string_view tok; nextToken(str, delim, strip_whitespace, &tok);) {
     if (tok == token) {
       return true;
     }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -856,7 +856,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(
-          Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
+          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
@@ -919,7 +919,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(
-          Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
+          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
@@ -998,7 +998,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(
-          Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
+          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
@@ -1077,7 +1077,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(
-          Invoke([&](const Tracing::Span& applyToSpan) -> void { EXPECT_EQ(span, &applyToSpan); }));
+          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -855,8 +855,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
-      .WillOnce(
-          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+      .WillOnce(Invoke(
+          [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
@@ -918,8 +918,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
-      .WillOnce(
-          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+      .WillOnce(Invoke(
+          [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
@@ -997,8 +997,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
-      .WillOnce(
-          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+      .WillOnce(Invoke(
+          [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",
@@ -1076,8 +1076,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
-      .WillOnce(
-          Invoke([&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+      .WillOnce(Invoke(
+          [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled",

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -53,9 +53,9 @@ enum record_type { A, AAAA };
 
 class TestDnsServerQuery {
 public:
-  TestDnsServerQuery(ConnectionPtr connection, const HostMap& hosts_A, const HostMap& hosts_AAAA,
+  TestDnsServerQuery(ConnectionPtr connection, const HostMap& hosts_a, const HostMap& hosts_aaaa,
                      const CNameMap& cnames, const std::chrono::seconds& record_ttl)
-      : connection_(std::move(connection)), hosts_A_(hosts_A), hosts_AAAA_(hosts_AAAA),
+      : connection_(std::move(connection)), hosts_A_(hosts_a), hosts_AAAA_(hosts_aaaa),
         cnames_(cnames), record_ttl_(record_ttl) {
     connection_->addReadFilter(Network::ReadFilterSharedPtr{new ReadFilter(*this)});
   }

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -155,8 +155,8 @@ protected:
     ON_CALL(random_, random()).WillByDefault(Return(0));
   }
 
-  void expectRedisResolve(bool createClient = false) {
-    if (createClient) {
+  void expectRedisResolve(bool create_client = false) {
+    if (create_client) {
       client_ = new Extensions::NetworkFilters::Common::Redis::Client::MockClient();
       EXPECT_CALL(*this, create_(_)).WillOnce(Return(client_));
       EXPECT_CALL(*client_, addConnectionCallbacks(_));

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -96,15 +96,15 @@ protected:
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, end_stream));
   }
 
-  void doResponseCompression(Http::TestHeaderMapImpl&& headers, bool withTrailers) {
+  void doResponseCompression(Http::TestHeaderMapImpl&& headers, bool with_trailers) {
     uint64_t content_length;
     ASSERT_TRUE(absl::SimpleAtoi(headers.get_("content-length"), &content_length));
     feedBuffer(content_length);
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
     EXPECT_EQ("", headers.get_("content-length"));
     EXPECT_EQ(Http::Headers::get().ContentEncodingValues.Gzip, headers.get_("content-encoding"));
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, !withTrailers));
-    if (withTrailers) {
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, !with_trailers));
+    if (with_trailers) {
       Buffer::OwnedImpl trailers_buffer;
       EXPECT_CALL(encoder_callbacks_, addEncodedData(_, true))
           .WillOnce(Invoke([&](Buffer::Instance& data, bool) { data_.move(data); }));

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -41,17 +41,17 @@ protected:
   ContextManagerImpl manager_{time_system_};
 };
 
-TEST_F(SslContextImplTest, TestdNSNameMatching) {
-  EXPECT_TRUE(ContextImpl::dNSNameMatch("lyft.com", "lyft.com"));
-  EXPECT_TRUE(ContextImpl::dNSNameMatch("a.lyft.com", "*.lyft.com"));
-  EXPECT_TRUE(ContextImpl::dNSNameMatch("a.b.lyft.com", "*.lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("foo.test.com", "*.lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("lyft.com", "*.lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("alyft.com", "*.lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("alyft.com", "*lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("lyft.com", "*lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("", "*lyft.com"));
-  EXPECT_FALSE(ContextImpl::dNSNameMatch("lyft.com", ""));
+TEST_F(SslContextImplTest, TestDnsNameMatching) {
+  EXPECT_TRUE(ContextImpl::dnsNameMatch("lyft.com", "lyft.com"));
+  EXPECT_TRUE(ContextImpl::dnsNameMatch("a.lyft.com", "*.lyft.com"));
+  EXPECT_TRUE(ContextImpl::dnsNameMatch("a.b.lyft.com", "*.lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("foo.test.com", "*.lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("lyft.com", "*.lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("alyft.com", "*.lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("alyft.com", "*lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("lyft.com", "*lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("", "*lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("lyft.com", ""));
 }
 
 TEST_F(SslContextImplTest, TestVerifySubjectAltNameDNSMatched) {

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -66,7 +66,7 @@ ToolConfig::ToolConfig(std::unique_ptr<Http::TestHeaderMapImpl> headers, int ran
 
 // static
 RouterCheckTool RouterCheckTool::create(const std::string& router_config_file,
-                                        const bool disableDeprecationCheck) {
+                                        const bool disable_deprecation_check) {
   // TODO(hennna): Allow users to load a full config and extract the route configuration from it.
   envoy::api::v2::RouteConfiguration route_config;
   auto stats = std::make_unique<Stats::IsolatedStoreImpl>();
@@ -76,7 +76,7 @@ RouterCheckTool RouterCheckTool::create(const std::string& router_config_file,
 
   auto factory_context = std::make_unique<NiceMock<Server::Configuration::MockFactoryContext>>();
   auto config = std::make_unique<Router::ConfigImpl>(route_config, *factory_context, false);
-  if (!disableDeprecationCheck) {
+  if (!disable_deprecation_check) {
     MessageUtil::checkForUnexpectedFields(route_config,
                                           ProtobufMessage::getStrictValidationVisitor(),
                                           &factory_context->runtime_loader_);

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -70,7 +70,7 @@ public:
    * config file.
    * */
   static RouterCheckTool create(const std::string& router_config_file,
-                                const bool disableDeprecationCheck);
+                                const bool disable_deprecation_check);
 
   /**
    * TODO(tonya11en): Use a YAML format for the expected routes. This will require a proto.

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -65,7 +65,7 @@ class RouterCheckTool : Logger::Loggable<Logger::Id::testing> {
 public:
   /**
    * @param router_config_file v2 router config file.
-   * @param disableDeprecationCheck flag to disable the RouteConfig deprecated field check
+   * @param disable_deprecation_check flag to disable the RouteConfig deprecated field check
    * @return RouterCheckTool a RouterCheckTool instance with member variables set by the router
    * config file.
    * */


### PR DESCRIPTION
Description: `readability-identifier-naming` enables the ability to ensure that letter-casing follows the style guide. This starts with just enabling for function/method parameters, which should always be `lower_case`.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>