### PR TITLE
protoxform: remove deprecated fields in v3alpha.

### DIFF
--- a/api/envoy/admin/v3alpha/server_info.proto
+++ b/api/envoy/admin/v3alpha/server_info.proto
@@ -63,7 +63,9 @@ message CommandLineOptions {
     InitOnly = 2;
   }
 
-  reserved 12;
+  reserved 12, 20, 21;
+
+  reserved "max_stats", "max_obj_name_len";
 
   // See :option:`--base-id` for details.
   uint64 base_id = 1;
@@ -121,11 +123,6 @@ message CommandLineOptions {
 
   // See :option:`--mode` for details.
   Mode mode = 19;
-
-  // max_stats and max_obj_name_len are now unused and have no effect.
-  uint64 max_stats = 20 [deprecated = true];
-
-  uint64 max_obj_name_len = 21 [deprecated = true];
 
   // See :option:`--disable-hot-restart` for details.
   bool disable_hot_restart = 22;

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -79,6 +79,10 @@ message Cluster {
   // Refer to :ref:`load balancer type <arch_overview_load_balancing_types>` architecture
   // overview section for information on each type.
   enum LbPolicy {
+    reserved 4;
+
+    reserved "ORIGINAL_DST_LB";
+
     // Refer to the :ref:`round robin load balancing
     // policy<arch_overview_load_balancing_types_round_robin>`
     // for an explanation.
@@ -98,16 +102,6 @@ message Cluster {
     // policy<arch_overview_load_balancing_types_random>`
     // for an explanation.
     RANDOM = 3;
-
-    // Refer to the :ref:`original destination load balancing
-    // policy<arch_overview_load_balancing_types_original_destination>`
-    // for an explanation.
-    //
-    // .. attention::
-    //
-    //   **This load balancing policy is deprecated**. Use CLUSTER_PROVIDED instead.
-    //
-    ORIGINAL_DST_LB = 4 [deprecated = true];
 
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
     // for an explanation.

--- a/api/envoy/api/v3alpha/core/config_source.proto
+++ b/api/envoy/api/v3alpha/core/config_source.proto
@@ -22,7 +22,7 @@ message ApiConfigSource {
   enum ApiType {
     // Ideally this would be 'reserved 0' but one can't reserve the default
     // value. Instead we throw an exception if this is ever used.
-    UNSUPPORTED_REST_LEGACY = 0 [deprecated = true];
+    DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE = 0 [deprecated = true];
 
     // REST-JSON v2 API. The `canonical JSON encoding
     // <https://developers.google.com/protocol-buffers/docs/proto3#json>`_ for

--- a/api/envoy/api/v3alpha/lds.proto
+++ b/api/envoy/api/v3alpha/lds.proto
@@ -70,7 +70,9 @@ message Listener {
     google.protobuf.BoolValue bind_to_port = 1;
   }
 
-  reserved 14;
+  reserved 14, 4;
+
+  reserved "use_original_dst";
 
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -90,23 +92,6 @@ message Listener {
   // Example using SNI for filter chain selection can be found in the
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
   repeated listener.FilterChain filter_chains = 3;
-
-  // If a connection is redirected using *iptables*, the port on which the proxy
-  // receives it might be different from the original destination address. When this flag is set to
-  // true, the listener hands off redirected connections to the listener associated with the
-  // original destination address. If there is no listener associated with the original destination
-  // address, the connection is handled by the listener that receives it. Defaults to false.
-  //
-  // .. attention::
-  //
-  //   This field is deprecated. Use :ref:`an original_dst <config_listener_filters_original_dst>`
-  //   :ref:`listener filter <envoy_api_field_Listener.listener_filters>` instead.
-  //
-  //   Note that hand off to another listener is *NOT* performed without this flag. Once
-  //   :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>` is implemented this flag
-  //   will be removed, as filter chain matching can be used to select a filter chain based on the
-  //   restored destination address.
-  google.protobuf.BoolValue use_original_dst = 4 [deprecated = true];
 
   // Soft limit on size of the listener’s new connection read and write buffers.
   // If unspecified, an implementation defined default is applied (1MiB).

--- a/api/envoy/api/v3alpha/route/route.proto
+++ b/api/envoy/api/v3alpha/route/route.proto
@@ -325,7 +325,9 @@ message RouteMatch {
   message GrpcRouteMatchOptions {
   }
 
-  reserved 5;
+  reserved 5, 3;
+
+  reserved "regex";
 
   oneof path_specifier {
     option (validate.required) = true;
@@ -337,24 +339,6 @@ message RouteMatch {
     // If specified, the route is an exact path rule meaning that the path must
     // exactly match the *:path* header once the query string is removed.
     string path = 2;
-
-    // If specified, the route is a regular expression rule meaning that the
-    // regex must match the *:path* header once the query string is removed. The entire path
-    // (without the query string) must match the regex. The rule will not match if only a
-    // subsequence of the *:path* header matches the regex. The regex grammar is defined `here
-    // <https://en.cppreference.com/w/cpp/regex/ecmascript>`_.
-    //
-    // Examples:
-    //
-    // * The regex ``/b[io]t`` matches the path */bit*
-    // * The regex ``/b[io]t`` matches the path */bot*
-    // * The regex ``/b[io]t`` does not match the path */bite*
-    // * The regex ``/b[io]t`` does not match the path */bit/bot*
-    //
-    // .. attention::
-    //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
-    //   untrusted input in all cases.
-    string regex = 3 [(validate.rules).string = {max_bytes: 1024}, deprecated = true];
 
     // If specified, the route is a regular expression rule meaning that the
     // regex must match the *:path* header once the query string is removed. The entire path
@@ -415,23 +399,9 @@ message RouteMatch {
 
 // [#comment:next free field: 11]
 message CorsPolicy {
-  // Specifies the origins that will be allowed to do CORS requests.
-  //
-  // An origin is allowed if either allow_origin or allow_origin_regex match.
-  //
-  // .. attention::
-  //  This field has been deprecated in favor of `allow_origin_string_match`.
-  repeated string allow_origin = 1 [deprecated = true];
+  reserved 1, 8, 7;
 
-  // Specifies regex patterns that match allowed origins.
-  //
-  // An origin is allowed if either allow_origin or allow_origin_regex match.
-  //
-  // .. attention::
-  //   This field has been deprecated in favor of `allow_origin_string_match` as it is not safe for
-  //   use with untrusted input in all cases.
-  repeated string allow_origin_regex = 8
-      [(validate.rules).repeated = {items {string {max_bytes: 1024}}}, deprecated = true];
+  reserved "allow_origin", "allow_origin_regex", "enabled";
 
   // Specifies string patterns that match allowed origins. An origin is allowed if any of the
   // string matchers match.
@@ -453,14 +423,6 @@ message CorsPolicy {
   google.protobuf.BoolValue allow_credentials = 6;
 
   oneof enabled_specifier {
-    // Specifies if CORS is enabled. Defaults to true. Only effective on route.
-    //
-    // .. attention::
-    //
-    //   **This field is deprecated**. Set the
-    //   :ref:`filter_enabled<envoy_api_field_route.CorsPolicy.filter_enabled>` field instead.
-    google.protobuf.BoolValue enabled = 7 [deprecated = true];
-
     // Specifies if CORS is enabled.
     //
     // More information on how this can be controlled via runtime can be found
@@ -510,23 +472,13 @@ message RouteAction {
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
   message RequestMirrorPolicy {
+    reserved 2;
+
+    reserved "runtime_key";
+
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.
     string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
-
-    // If not specified, all requests to the target cluster will be mirrored. If
-    // specified, Envoy will lookup the runtime key to get the % of requests to
-    // mirror. Valid values are from 0 to 10000, allowing for increments of
-    // 0.01% of requests to be mirrored. If the runtime key is specified in the
-    // configuration but not present in runtime, 0 is the default and thus 0% of
-    // requests will be mirrored.
-    //
-    // .. attention::
-    //
-    //   **This field is deprecated**. Set the
-    //   :ref:`runtime_fraction
-    //   <envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_fraction>` field instead.
-    string runtime_key = 2 [deprecated = true];
 
     // If both :ref:`runtime_key
     // <envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_key>` and this field are not
@@ -1095,20 +1047,9 @@ message Tracing {
 //    every application endpoint. This is both not easily maintainable and as well the matching and
 //    statistics output are not free.
 message VirtualCluster {
-  // Specifies a regex pattern to use for matching requests. The entire path of the request
-  // must match the regex. The regex grammar used is defined `here
-  // <https://en.cppreference.com/w/cpp/regex/ecmascript>`_.
-  //
-  // Examples:
-  //
-  // * The regex ``/rides/\d+`` matches the path */rides/0*
-  // * The regex ``/rides/\d+`` matches the path */rides/123*
-  // * The regex ``/rides/\d+`` does not match the path */rides/123/456*
-  //
-  // .. attention::
-  //   This field has been deprecated in favor of `headers` as it is not safe for use with
-  //   untrusted input in all cases.
-  string pattern = 1 [(validate.rules).string = {max_bytes: 1024}, deprecated = true];
+  reserved 1, 3;
+
+  reserved "pattern", "method";
 
   // Specifies a list of header matchers to use for matching requests. Each specified header must
   // match. The pseudo-headers `:path` and `:method` can be used to match the request path and
@@ -1119,13 +1060,6 @@ message VirtualCluster {
   // as the virtual host name are used when emitting statistics. The statistics are emitted by the
   // router filter and are documented :ref:`here <config_http_filters_router_stats>`.
   string name = 2 [(validate.rules).string = {min_bytes: 1}];
-
-  // Optionally specifies the HTTP method to match on. For example GET, PUT,
-  // etc.
-  //
-  // .. attention::
-  //   This field has been deprecated in favor of `headers`.
-  core.RequestMethod method = 3 [deprecated = true];
 }
 
 // Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
@@ -1287,7 +1221,9 @@ message RateLimit {
 //
 //  [#next-major-version: HeaderMatcher should be refactored to use StringMatcher.]
 message HeaderMatcher {
-  reserved 2, 3;
+  reserved 2, 3, 5;
+
+  reserved "regex_match";
 
   // Specifies the name of the header in the request.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
@@ -1296,22 +1232,6 @@ message HeaderMatcher {
   oneof header_match_specifier {
     // If specified, header match will be performed based on the value of the header.
     string exact_match = 4;
-
-    // If specified, this regex string is a regular expression rule which implies the entire request
-    // header value must match the regex. The rule will not match if only a subsequence of the
-    // request header value matches the regex. The regex grammar used in the value field is defined
-    // `here <https://en.cppreference.com/w/cpp/regex/ecmascript>`_.
-    //
-    // Examples:
-    //
-    // * The regex ``\d{3}`` matches the value *123*
-    // * The regex ``\d{3}`` does not match the value *1234*
-    // * The regex ``\d{3}`` does not match the value *123.456*
-    //
-    // .. attention::
-    //   This field has been deprecated in favor of `safe_regex_match` as it is not safe for use
-    //   with untrusted input in all cases.
-    string regex_match = 5 [(validate.rules).string = {max_bytes: 1024}, deprecated = true];
 
     // If specified, this regex string is a regular expression rule which implies the entire request
     // header value must match the regex. The rule will not match if only a subsequence of the
@@ -1364,26 +1284,13 @@ message HeaderMatcher {
 // Query parameter matching treats the query string of a request's :path header
 // as an ampersand-separated list of keys and/or key=value elements.
 message QueryParameterMatcher {
+  reserved 3, 4;
+
+  reserved "value", "regex";
+
   // Specifies the name of a key that must be present in the requested
   // *path*'s query string.
   string name = 1 [(validate.rules).string = {min_bytes: 1 max_bytes: 1024}];
-
-  // Specifies the value of the key. If the value is absent, a request
-  // that contains the key in its query string will match, whether the
-  // key appears with a value (e.g., "?debug=true") or not (e.g., "?debug")
-  //
-  // ..attention::
-  //   This field is deprecated. Use an `exact` match inside the `string_match` field.
-  string value = 3 [deprecated = true];
-
-  // Specifies whether the query parameter value is a regular expression.
-  // Defaults to false. The entire query parameter value (i.e., the part to
-  // the right of the equals sign in "key=value") must match the regex.
-  // E.g., the regex ``\d+$`` will match *123* but not *a123* or *123a*.
-  //
-  // ..attention::
-  //   This field is deprecated. Use a `safe_regex` match inside the `string_match` field.
-  google.protobuf.BoolValue regex = 4 [deprecated = true];
 
   oneof query_parameter_match_specifier {
     // Specifies whether a query parameter value should match against a string.

--- a/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
@@ -67,7 +67,9 @@ message Bootstrap {
     api.v3alpha.core.ApiConfigSource ads_config = 3;
   }
 
-  reserved 10;
+  reserved 10, 11;
+
+  reserved "runtime";
 
   // Node identity to present to the management server and for instance
   // identification purposes (e.g. in generated headers).
@@ -112,11 +114,6 @@ message Bootstrap {
   // Configuration for an external tracing provider. If not specified, no
   // tracing will be performed.
   trace.v3alpha.Tracing tracing = 9;
-
-  // Configuration for the runtime configuration provider (deprecated). If not
-  // specified, a “null” provider will be used which will result in all defaults
-  // being used.
-  Runtime runtime = 11 [deprecated = true];
 
   // Configuration for the runtime configuration provider. If not
   // specified, a “null” provider will be used which will result in all defaults

--- a/api/envoy/config/filter/fault/v3alpha/fault.proto
+++ b/api/envoy/config/filter/fault/v3alpha/fault.proto
@@ -28,10 +28,9 @@ message FaultDelay {
   message HeaderDelay {
   }
 
-  reserved 2;
+  reserved 2, 1;
 
-  // Unused and deprecated. Will be removed in the next release.
-  FaultDelayType type = 1 [deprecated = true];
+  reserved "type";
 
   oneof fault_delay_secifier {
     option (validate.required) = true;

--- a/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.proto
@@ -18,6 +18,10 @@ import "validate/validate.proto";
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 
 message ExtAuthz {
+  reserved 4;
+
+  reserved "use_alpha";
+
   // External authorization service configuration.
   oneof services {
     // gRPC service configuration (default timeout: 200ms).
@@ -40,12 +44,6 @@ message ExtAuthz {
   // Note that errors can be *always* tracked in the :ref:`stats
   // <config_http_filters_ext_authz_stats>`.
   bool failure_mode_allow = 2;
-
-  // Sets the package version the gRPC service should use. This is particularly
-  // useful when transitioning from alpha to release versions assuming that both definitions are
-  // semantically compatible. Deprecation note: This field is deprecated and should only be used for
-  // version upgrade. See release notes for more details.
-  bool use_alpha = 4 [deprecated = true];
 
   // Enables filter to buffer the client request body and send it within the authorization request.
   // A ``x-envoy-auth-partial-body: false|true`` metadata header will be added to the authorization

--- a/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.proto
@@ -87,14 +87,9 @@ message HttpConnectionManager {
       EGRESS = 1;
     }
 
-    // The span name will be derived from this field. If
-    // :ref:`traffic_direction <envoy_api_field_Listener.traffic_direction>` is
-    // specified on the parent listener, then it is used instead of this field.
-    //
-    // .. attention::
-    //  This field has been deprecated in favor of `traffic_direction`.
-    OperationName operation_name = 1
-        [(validate.rules).enum = {defined_only: true}, deprecated = true];
+    reserved 1;
+
+    reserved "operation_name";
 
     // A list of header names used to create tags for the active span. The header name is used to
     // populate the tag name, and the header value is used to populate the tag value. The tag is

--- a/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.proto
@@ -150,6 +150,10 @@ message RedisProxy {
       repeated RequestMirrorPolicy request_mirror_policy = 4;
     }
 
+    reserved 3;
+
+    reserved "catch_all_cluster";
+
     // List of prefix routes.
     repeated Route routes = 1;
 
@@ -158,31 +162,15 @@ message RedisProxy {
 
     // Optional catch-all route to forward commands that doesn't match any of the routes. The
     // catch-all route becomes required when no routes are specified.
-    // .. attention::
-    //
-    //   This field is deprecated. Use a :ref:`catch_all
-    //   route<envoy_api_field_config.filter.network.redis_proxy.v3alpha.RedisProxy.PrefixRoutes.catch_all_route>`
-    //   instead.
-    string catch_all_cluster = 3 [deprecated = true];
-
-    // Optional catch-all route to forward commands that doesn't match any of the routes. The
-    // catch-all route becomes required when no routes are specified.
     Route catch_all_route = 4;
   }
 
+  reserved 2;
+
+  reserved "cluster";
+
   // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
   string stat_prefix = 1 [(validate.rules).string = {min_bytes: 1}];
-
-  // Name of cluster from cluster manager. See the :ref:`configuration section
-  // <arch_overview_redis_configuration>` of the architecture overview for recommendations on
-  // configuring the backing cluster.
-  //
-  // .. attention::
-  //
-  //   This field is deprecated. Use a :ref:`catch_all
-  //   route<envoy_api_field_config.filter.network.redis_proxy.v3alpha.RedisProxy.PrefixRoutes.catch_all_route>`
-  //   instead.
-  string cluster = 2 [deprecated = true];
 
   // Network settings for the connection pool to the upstream clusters.
   ConnPoolSettings settings = 3 [(validate.rules).message = {required: true}];

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -22,6 +22,8 @@ message TcpProxy {
   // [#not-implemented-hide:] Deprecated.
   // TCP Proxy filter configuration using V1 format.
   message DeprecatedV1 {
+    option deprecated = true;
+
     // A TCP proxy route consists of a set of optional L4 criteria and the
     // name of a cluster. If a downstream connection matches all the
     // specified criteria, the cluster in the route is used for the

--- a/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.proto
@@ -19,59 +19,6 @@ import "validate/validate.proto";
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 
 message TcpProxy {
-  // [#not-implemented-hide:] Deprecated.
-  // TCP Proxy filter configuration using V1 format.
-  message DeprecatedV1 {
-    // A TCP proxy route consists of a set of optional L4 criteria and the
-    // name of a cluster. If a downstream connection matches all the
-    // specified criteria, the cluster in the route is used for the
-    // corresponding upstream connection. Routes are tried in the order
-    // specified until a match is found. If no match is found, the connection
-    // is closed. A route with no criteria is valid and always produces a
-    // match.
-    message TCPRoute {
-      // The cluster to connect to when a the downstream network connection
-      // matches the specified criteria.
-      string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
-
-      // An optional list of IP address subnets in the form
-      // “ip_address/xx”. The criteria is satisfied if the destination IP
-      // address of the downstream connection is contained in at least one of
-      // the specified subnets. If the parameter is not specified or the list
-      // is empty, the destination IP address is ignored. The destination IP
-      // address of the downstream connection might be different from the
-      // addresses on which the proxy is listening if the connection has been
-      // redirected.
-      repeated api.v3alpha.core.CidrRange destination_ip_list = 2;
-
-      // An optional string containing a comma-separated list of port numbers
-      // or ranges. The criteria is satisfied if the destination port of the
-      // downstream connection is contained in at least one of the specified
-      // ranges. If the parameter is not specified, the destination port is
-      // ignored. The destination port address of the downstream connection
-      // might be different from the port on which the proxy is listening if
-      // the connection has been redirected.
-      string destination_ports = 3;
-
-      // An optional list of IP address subnets in the form
-      // “ip_address/xx”. The criteria is satisfied if the source IP address
-      // of the downstream connection is contained in at least one of the
-      // specified subnets. If the parameter is not specified or the list is
-      // empty, the source IP address is ignored.
-      repeated api.v3alpha.core.CidrRange source_ip_list = 4;
-
-      // An optional string containing a comma-separated list of port numbers
-      // or ranges. The criteria is satisfied if the source port of the
-      // downstream connection is contained in at least one of the specified
-      // ranges. If the parameter is not specified, the source port is
-      // ignored.
-      string source_ports = 5;
-    }
-
-    // The route table for the filter. All filter instances must have a route
-    // table, even if it is empty.
-    repeated TCPRoute routes = 1 [(validate.rules).repeated = {min_items: 1}];
-  }
 
   // Allows for specification of multiple upstream clusters along with weights
   // that indicate the percentage of traffic to be forwarded to each cluster.
@@ -90,6 +37,10 @@ message TcpProxy {
     // Specifies one or more upstream clusters associated with the route.
     repeated ClusterWeight clusters = 1 [(validate.rules).repeated = {min_items: 1}];
   }
+
+  reserved 6;
+
+  reserved "deprecated_v1";
 
   // The prefix to use when emitting :ref:`statistics
   // <config_network_filters_tcp_proxy_stats>`.
@@ -133,9 +84,6 @@ message TcpProxy {
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by the this tcp_proxy.
   repeated accesslog.v3alpha.AccessLog access_log = 5;
-
-  // [#not-implemented-hide:] Deprecated.
-  DeprecatedV1 deprecated_v1 = 6 [deprecated = true];
 
   // The maximum number of unsuccessful connection attempts that will be made before
   // giving up. If the parameter is not specified, 1 connection attempt will be made.

--- a/api/envoy/config/trace/v3alpha/trace.proto
+++ b/api/envoy/config/trace/v3alpha/trace.proto
@@ -76,7 +76,7 @@ message ZipkinConfig {
     // Hence the motivation of adding HTTP_JSON_V1 as the default is to avoid a breaking change when
     // user upgrading Envoy with this change. Furthermore, we also immediately deprecate this field,
     // since in Zipkin realm this v1 version is considered to be not preferable anymore.]
-    HTTP_JSON_V1 = 0 [deprecated = true];
+    DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE = 0 [deprecated = true];
 
     // Zipkin API v2, JSON over HTTP.
     HTTP_JSON = 1;

--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -4,6 +4,7 @@ py_binary(
     name = "protoxform",
     srcs = [
         "migrate.py",
+        "options.py",
         "protoxform.py",
     ],
     python_version = "PY3",

--- a/tools/protoxform/options.py
+++ b/tools/protoxform/options.py
@@ -1,0 +1,27 @@
+# Manage internal options on messages/enums/fields/enum values.
+
+
+def AddHideOption(options):
+  """Mark message/enum/field/enum value as hidden.
+
+  Hidden messages are ignored when generating output.
+
+  Args:
+    options: MessageOptions/EnumOptions/FieldOptions/EnumValueOptions message.
+  """
+  hide_option = options.uninterpreted_option.add()
+  hide_option.name.add().name_part = 'protoxform_hide'
+
+
+def HasHideOption(options):
+  """Is message/enum/field/enum value hidden?
+
+  Hidden messages are ignored when generating output.
+
+  Args:
+    options: MessageOptions/EnumOptions/FieldOptions/EnumValueOptions message.
+  Returns:
+    Hidden status.
+  """
+  return any(
+      option.name[0].name_part == 'protoxform_hide' for option in options.uninterpreted_option)


### PR DESCRIPTION
We should start tagging messages with "option deprecated = true;" if we
want them to be auto-deprecated by protoxform going forward.

Risk level: Low (v3alpha is not used yet)
Testing: bazel test @envoy_api//..., manual diff inspection.

Signed-off-by: Harvey Tuch <htuch@google.com>