### PR TITLE
Fix jwks_fetcher crash with missing jwks cluster for remote_jwks

### DIFF
--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -284,14 +284,18 @@ public:
         new FakeUpstream(0, GetParam().upstream_protocol, version_, timeSystem()));
   }
 
-  void initializeFilter() {
+  void initializeFilter(bool add_cluster) {
     config_helper_.addFilter(getFilterConfig(false));
 
-    config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
-      auto* jwks_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      jwks_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-      jwks_cluster->set_name("pubkey_cluster");
-    });
+    if (add_cluster) {
+      config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+        auto* jwks_cluster = bootstrap.mutable_static_resources()->add_clusters();
+        jwks_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+        jwks_cluster->set_name("pubkey_cluster");
+      });
+    } else {
+      config_helper_.skipPortUsageValidation();
+    }
 
     initialize();
   }
@@ -338,7 +342,7 @@ INSTANTIATE_TEST_SUITE_P(Protocols, RemoteJwksIntegrationTest,
 // With remote Jwks, this test verifies a request is passed with a good Jwt token
 // and a good public key fetched from a remote server.
 TEST_P(RemoteJwksIntegrationTest, WithGoodToken) {
-  initializeFilter();
+  initializeFilter(/*add_cluster=*/true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -373,7 +377,7 @@ TEST_P(RemoteJwksIntegrationTest, WithGoodToken) {
 // With remote Jwks, this test verifies a request is rejected even with a good Jwt token
 // when the remote jwks server replied with 500.
 TEST_P(RemoteJwksIntegrationTest, FetchFailedJwks) {
-  initializeFilter();
+  initializeFilter(/*add_cluster=*/true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -387,6 +391,26 @@ TEST_P(RemoteJwksIntegrationTest, FetchFailedJwks) {
 
   // Fails the jwks fetching.
   waitForJwksResponse("500", "");
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("401", response->headers().Status()->value().getStringView());
+
+  cleanup();
+}
+
+TEST_P(RemoteJwksIntegrationTest, FetchFailedMissingCluster) {
+  initializeFilter(/*add_cluster=*/false);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+      {"Authorization", "Bearer " + std::string(GoodToken)},
+  });
 
   response->waitForEndStream();
   ASSERT_TRUE(response->complete());


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>


Description:

If the cluster for remote_jwks is not configured.  jwks_fetcher will throw exception, since there is not exception catch in the data flow, it will crash the envoy.
Fix: check if cluster is configured, if not, failed the jwks fetch, and fail the request. not to crash envoy.

Risk Level: Low
Testing:  added a new integration test
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/8363
[Optional Deprecated:]
