### PR TITLE
ci: hopefully deflake ASAN RBE

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -128,6 +128,13 @@ config_setting(
 )
 
 config_setting(
+    name = "dynamic_link_tests",
+    values = {
+        "define": "dynamic_link_tests=true",
+    },
+)
+
+config_setting(
     name = "disable_tcmalloc",
     values = {"define": "tcmalloc=disabled"},
 )

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -77,7 +77,7 @@ def envoy_external_dep_path(dep):
 
 def envoy_linkstatic():
     return select({
-        "@envoy//bazel:asan_build": 0,
+        "@envoy//bazel:dynamic_link_tests": 0,
         "//conditions:default": 1,
     })
 


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Suspecting dynamically linked tests are causing workers fail to read dependent libraries. Temporarily disable that while keep an option from command line.

Risk Level: Low
Testing:
Docs Changes:
Release Notes: