### PR TITLE
use envoy_google_grpc_external_deps for google_grpc_context_lib

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -3,8 +3,8 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
     "envoy_google_grpc_external_deps",
+    "envoy_package",
     "envoy_select_google_grpc",
 )
 

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_package",
+    "envoy_google_grpc_external_deps",
     "envoy_select_google_grpc",
 )
 
@@ -162,13 +163,12 @@ envoy_cc_library(
     name = "google_grpc_context_lib",
     srcs = ["google_grpc_context.cc"],
     hdrs = ["google_grpc_context.h"],
-    external_deps = ["grpc"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:lock_guard_lib",
         "//source/common/common:macros",
         "//source/common/common:thread_lib",
-    ],
+    ] + envoy_google_grpc_external_deps(),
 )
 
 envoy_cc_library(

--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -7,7 +7,9 @@
 #include "common/common/macros.h"
 #include "common/common/thread.h"
 
+#ifdef ENVOY_GOOGLE_GRPC
 #include "grpcpp/grpcpp.h"
+#endif
 
 namespace Envoy {
 namespace Grpc {
@@ -15,7 +17,9 @@ namespace Grpc {
 GoogleGrpcContext::GoogleGrpcContext() : instance_tracker_(instanceTracker()) {
   Thread::LockGuard lock(instance_tracker_.mutex_);
   if (++instance_tracker_.live_instances_ == 1) {
+#ifdef ENVOY_GOOGLE_GRPC
     grpc_init();
+#endif
   }
 }
 
@@ -28,7 +32,9 @@ GoogleGrpcContext::~GoogleGrpcContext() {
   Thread::LockGuard lock(instance_tracker_.mutex_);
   ASSERT(instance_tracker_.live_instances_ > 0);
   if (--instance_tracker_.live_instances_ == 0) {
+#ifdef ENVOY_GOOGLE_GRPC
     grpc_shutdown_blocking(); // Waiting for quiescence avoids non-determinism in tests.
+#endif
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Directly use "external_deps" in google_grpc_context_lib causing 
source/exe:envoy_main_common_lib not able to support target:gce 

Description:
Risk Level: None
Testing: None
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
