### PR TITLE
Update dependency and docs: jwt_verify_lib (add HS256 support)

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -160,10 +160,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/releases/download/cpp-3.2.0/msgpack-3.2.0.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "2d57d336239d5fe36a03849ddbea1bff09a1720e1c4a46bbb9743c71732b0d43",
-        strip_prefix = "jwt_verify_lib-0f14d43f20381cfae0469cb2309b2e220c0f0ea3",
-        # 2019-07-08
-        urls = ["https://github.com/google/jwt_verify_lib/archive/0f14d43f20381cfae0469cb2309b2e220c0f0ea3.tar.gz"],
+        sha256 = "38a93926f362a330a2a4489ed799c260df0bc305417e2bb44d6745671d9641d7",
+        strip_prefix = "jwt_verify_lib-7e3191b0dcb72835aa63e308a53b541e7fda5458",
+        # 2019-09-23
+        urls = ["https://github.com/google/jwt_verify_lib/archive/7e3191b0dcb72835aa63e308a53b541e7fda5458.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "ef26268c54c8084d17654ba2ed5140bffeffd2a040a895ffb22a6cca3f6c613f",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -162,7 +162,7 @@ REPOSITORY_LOCATIONS = dict(
     com_github_google_jwt_verify = dict(
         sha256 = "38a93926f362a330a2a4489ed799c260df0bc305417e2bb44d6745671d9641d7",
         strip_prefix = "jwt_verify_lib-7e3191b0dcb72835aa63e308a53b541e7fda5458",
-        # 2019-09-23
+        # 2019-09-23 
         urls = ["https://github.com/google/jwt_verify_lib/archive/7e3191b0dcb72835aa63e308a53b541e7fda5458.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -162,7 +162,7 @@ REPOSITORY_LOCATIONS = dict(
     com_github_google_jwt_verify = dict(
         sha256 = "38a93926f362a330a2a4489ed799c260df0bc305417e2bb44d6745671d9641d7",
         strip_prefix = "jwt_verify_lib-7e3191b0dcb72835aa63e308a53b541e7fda5458",
-        # 2019-09-23 
+        # 2019-09-23
         urls = ["https://github.com/google/jwt_verify_lib/archive/7e3191b0dcb72835aa63e308a53b541e7fda5458.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -8,7 +8,7 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
 .. attention::
-   Only ES256 and RS256 are supported for the JWT alg.
+   Only ES256, HS256, RS256, RS384, and RS512 are supported for the JWT alg.
 
 Configuration
 -------------

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -8,7 +8,7 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
 .. attention::
-   Only ES256, HS256, RS256, RS384, and RS512 are supported for the JWT alg.
+   ES256, HS256, RS256, RS384 and RS512 are supported for the JWT alg.
 
 Configuration
 -------------


### PR DESCRIPTION
Signed-off-by: Ryan A. Chapman <ryan@rchapman.org>

Description: update jwt_verify_lib to support HS256 tokens, also update documentation to show that Envoy now supports HS256 as well as RS384 and RS512 (see #8212)
Risk Level: low
Testing: upstream unit tests
Docs Changes: none
Release Notes: none (should there be some?)