### PR TITLE
config: add proxy version to bootstrap

### DIFF
--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -18,6 +18,7 @@ import "envoy/config/trace/v2/trace.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
 
@@ -148,6 +149,11 @@ message Bootstrap {
   // changes to this string, especially in multi-layer Envoy deployments or deployments using
   // extensions which are not upstream.
   string header_prefix = 18;
+
+  // Optional proxy version which will be used to set the value of :ref:`server.version statistic
+  // <server_statistics>` if specified. Envoy will not process this value, it will be sent as is to
+  // :ref:<stats sinks <envoy_api_msg_config.metrics.v2.StatsSink>.
+  google.protobuf.UInt64Value proxy_version = 19;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -153,7 +153,7 @@ message Bootstrap {
   // Optional proxy version which will be used to set the value of :ref:`server.version statistic
   // <server_statistics>` if specified. Envoy will not process this value, it will be sent as is to
   // :ref:<stats sinks <envoy_api_msg_config.metrics.v2.StatsSink>.
-  google.protobuf.UInt64Value proxy_version = 19;
+  google.protobuf.UInt64Value stats_server_version_override = 19;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
@@ -18,6 +18,7 @@ import "envoy/config/trace/v3alpha/trace.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
 
@@ -144,6 +145,11 @@ message Bootstrap {
   // changes to this string, especially in multi-layer Envoy deployments or deployments using
   // extensions which are not upstream.
   string header_prefix = 18;
+
+  // Optional proxy version which will be used to set the value of :ref:`server.version statistic
+  // <server_statistics>` if specified. Envoy will not process this value, it will be sent as is to
+  // :ref:<stats sinks <envoy_api_msg_config.metrics.v3alpha.StatsSink>.
+  google.protobuf.UInt64Value proxy_version = 19;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3alpha/bootstrap.proto
@@ -149,7 +149,7 @@ message Bootstrap {
   // Optional proxy version which will be used to set the value of :ref:`server.version statistic
   // <server_statistics>` if specified. Envoy will not process this value, it will be sent as is to
   // :ref:<stats sinks <envoy_api_msg_config.metrics.v3alpha.StatsSink>.
-  google.protobuf.UInt64Value proxy_version = 19;
+  google.protobuf.UInt64Value stats_server_version_override = 19;
 }
 
 // Administration interface :ref:`operations documentation

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -22,7 +22,7 @@ Server related statistics are rooted at *server.* with following statistics:
   state, Gauge, Current :ref:`State <envoy_api_enum_admin.v2alpha.ServerInfo.state>` of the Server.
   parent_connections, Gauge, Total connections of the old Envoy process on hot restart
   total_connections, Gauge, Total connections of both new and old Envoy processes
-  version, Gauge, Integer represented version number based on SCM revision or :ref:proxy_version` <envoy_api_field_config.bootstrap.v2.Bootstrap.header_prefix>` if set.
+  version, Gauge, Integer represented version number based on SCM revision or :ref:stats_server_version_override` <envoy_api_field_config.bootstrap.v2.Bootstrap.header_prefix>` if set.
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
   hot_restart_epoch, Gauge, Current hot restart epoch
   initialization_time_ms, Histogram, Total time taken for Envoy initialization in milliseconds. This is the time from server start-up until the worker threads are ready to accept new connections

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -22,7 +22,7 @@ Server related statistics are rooted at *server.* with following statistics:
   state, Gauge, Current :ref:`State <envoy_api_enum_admin.v2alpha.ServerInfo.state>` of the Server.
   parent_connections, Gauge, Total connections of the old Envoy process on hot restart
   total_connections, Gauge, Total connections of both new and old Envoy processes
-  version, Gauge, Integer represented version number based on SCM revision
+  version, Gauge, Integer represented version number based on SCM revision or :ref:proxy_version` <envoy_api_field_config.bootstrap.v2.Bootstrap.header_prefix>` if set.
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
   hot_restart_epoch, Gauge, Current hot restart epoch
   initialization_time_ms, Histogram, Total time taken for Envoy initialization in milliseconds. This is the time from server start-up until the worker threads are ready to accept new connections

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -109,7 +109,7 @@ Version history
   for each host, useful for DNS based clusters.
 * api: track and report requests issued since last load report.
 * build: releases are built with Clang and linked with LLD.
-* config: added :ref:proxy_version` <envoy_api_field_config.bootstrap.v2.Bootstrap.proxy_version>` in bootstrap, that can be used to override :ref:`server.version statistic <server_statistics>`.
+* config: added :ref:stats_server_version_override` <envoy_api_field_config.bootstrap.v2.Bootstrap.stats_server_version_override>` in bootstrap, that can be used to override :ref:`server.version statistic <server_statistics>`.
 * control-plane: management servers can respond with HTTP 304 to indicate that config is up to date for Envoy proxies polling a :ref:`REST API Config Type <envoy_api_field_core.ApiConfigSource.api_type>`
 * csrf: added support for whitelisting additional source origins.
 * dns: added support for getting DNS record TTL which is used by STRICT_DNS/LOGICAL_DNS cluster as DNS refresh rate.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -109,6 +109,7 @@ Version history
   for each host, useful for DNS based clusters.
 * api: track and report requests issued since last load report.
 * build: releases are built with Clang and linked with LLD.
+* config: added :ref:proxy_version` <envoy_api_field_config.bootstrap.v2.Bootstrap.proxy_version>` in bootstrap, that can be used to override :ref:`server.version statistic <server_statistics>`.
 * control-plane: management servers can respond with HTTP 304 to indicate that config is up to date for Envoy proxies polling a :ref:`REST API Config Type <envoy_api_field_core.ApiConfigSource.api_type>`
 * csrf: added support for whitelisting additional source origins.
 * dns: added support for getting DNS record TTL which is used by STRICT_DNS/LOGICAL_DNS cluster as DNS refresh rate.

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -309,10 +309,11 @@ void InstanceImpl::initialize(const Options& options,
 
   InstanceImpl::failHealthcheck(false);
 
-  // Check if bootstrap has proxy version set, if yes, we should use that as 'server.version' stat.
+  // Check if bootstrap has server version override set, if yes, we should use that as
+  // 'server.version' stat.
   uint64_t version_int;
-  if (bootstrap_.proxy_version().value() > 0) {
-    version_int = bootstrap_.proxy_version().value();
+  if (bootstrap_.stats_server_version_override().value() > 0) {
+    version_int = bootstrap_.stats_server_version_override().value();
   } else {
     if (!StringUtil::atoull(VersionInfo::revision().substr(0, 6).c_str(), version_int, 16)) {
       throw EnvoyException("compiled GIT SHA is invalid. Invalid build.");

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -309,12 +309,17 @@ void InstanceImpl::initialize(const Options& options,
 
   InstanceImpl::failHealthcheck(false);
 
+  // Check if bootstrap has proxy version set, if yes, we should use that as 'server.version' stat.
   uint64_t version_int;
-  if (!StringUtil::atoull(VersionInfo::revision().substr(0, 6).c_str(), version_int, 16)) {
-    throw EnvoyException("compiled GIT SHA is invalid. Invalid build.");
+  if (bootstrap_.proxy_version().value() > 0) {
+    version_int = bootstrap_.proxy_version().value();
+  } else {
+    if (!StringUtil::atoull(VersionInfo::revision().substr(0, 6).c_str(), version_int, 16)) {
+      throw EnvoyException("compiled GIT SHA is invalid. Invalid build.");
+    }
   }
-
   server_stats_->version_.set(version_int);
+
   bootstrap_.mutable_node()->set_build_version(VersionInfo::version());
 
   local_info_ = std::make_unique<LocalInfo::LocalInfoImpl>(

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -291,6 +291,7 @@ envoy_cc_test(
         ":node_bootstrap_no_admin_port.yaml",
         ":node_bootstrap_with_admin_socket_options.yaml",
         ":node_bootstrap_without_access_log.yaml",
+        ":proxy_version_bootstrap.yaml",
         ":runtime_bootstrap.yaml",
         ":runtime_test_data",
         ":static_validation_test_data",

--- a/test/server/proxy_version_bootstrap.yaml
+++ b/test/server/proxy_version_bootstrap.yaml
@@ -1,0 +1,14 @@
+node:
+  id: bootstrap_id
+  cluster: bootstrap_cluster
+  locality:
+    zone: bootstrap_zone
+    sub_zone: bootstrap_sub_zone
+  build_version: should_be_ignored
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0
+proxy_version: 100012001

--- a/test/server/proxy_version_bootstrap.yaml
+++ b/test/server/proxy_version_bootstrap.yaml
@@ -11,4 +11,4 @@ admin:
     socket_address:
       address: {{ ntop_ip_loopback_address }}
       port_value: 0
-proxy_version: 100012001
+stats_server_version_override: 100012001

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -316,6 +316,16 @@ TEST_P(ServerInstanceImplTest, StatsFlushWhenServerIsStillInitializing) {
   server_thread->join();
 }
 
+// Validates that the "server.version" is updated with proxy_version specified in bootstrap.
+TEST_P(ServerInstanceImplTest, ProxyVersionOveridesFromBootstrap) {
+  auto server_thread = startTestServer("test/server/proxy_version_bootstrap.yaml", true);
+
+  EXPECT_EQ(100012001, TestUtility::findGauge(stats_store_, "server.version")->value());
+
+  server_->dispatcher().post([&] { server_->shutdown(); });
+  server_thread->join();
+}
+
 TEST_P(ServerInstanceImplTest, EmptyShutdownLifecycleNotifications) {
   auto server_thread = startTestServer("test/server/node_bootstrap.yaml", false);
   server_->dispatcher().post([&] { server_->shutdown(); });

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -316,7 +316,7 @@ TEST_P(ServerInstanceImplTest, StatsFlushWhenServerIsStillInitializing) {
   server_thread->join();
 }
 
-// Validates that the "server.version" is updated with proxy_version specified in bootstrap.
+// Validates that the "server.version" is updated with stats_server_version_override from bootstrap.
 TEST_P(ServerInstanceImplTest, ProxyVersionOveridesFromBootstrap) {
   auto server_thread = startTestServer("test/server/proxy_version_bootstrap.yaml", true);
 


### PR DESCRIPTION
This PR adds a proxy version to bootstrap which will be used to set `server.version` metric.
Risk Level: Low, optional config
Testing: Added tests
Docs Changes: Updated
Release Notes: Updated

Fixes #8318 