### PR TITLE
Added a warning when read buffer exceeds configured limit to aid in debugging

### DIFF
--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -113,7 +113,11 @@ public:
   void raiseEvent(ConnectionEvent event) override;
   // Should the read buffer be drained?
   bool shouldDrainReadBuffer() override {
-    return read_buffer_limit_ > 0 && read_buffer_.length() >= read_buffer_limit_;
+    if (read_buffer_limit_ > 0 && read_buffer_.length() >= read_buffer_limit_) {
+      ENVOY_CONN_LOG(warn, "read buffer size exceeded limit", *this);
+      return true;
+    }
+    return false;
   }
   // Mark read buffer ready to read in the event loop. This is used when yielding following
   // shouldDrainReadBuffer().


### PR DESCRIPTION
Signed-off-by: Paul Caponetti <pcaponetti@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Added a warning when read buffer exceeds configured limit to aid in debugging.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Fixes: #7430