### PR TITLE
Revert "use envoy_google_grpc_external_deps for google_grpc_context_l…

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_google_grpc_external_deps",
     "envoy_package",
     "envoy_select_google_grpc",
 )
@@ -163,12 +162,13 @@ envoy_cc_library(
     name = "google_grpc_context_lib",
     srcs = ["google_grpc_context.cc"],
     hdrs = ["google_grpc_context.h"],
+    external_deps = ["grpc"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:lock_guard_lib",
         "//source/common/common:macros",
         "//source/common/common:thread_lib",
-    ] + envoy_google_grpc_external_deps(),
+    ],
 )
 
 envoy_cc_library(

--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -7,9 +7,7 @@
 #include "common/common/macros.h"
 #include "common/common/thread.h"
 
-#ifdef ENVOY_GOOGLE_GRPC
 #include "grpcpp/grpcpp.h"
-#endif
 
 namespace Envoy {
 namespace Grpc {
@@ -17,9 +15,7 @@ namespace Grpc {
 GoogleGrpcContext::GoogleGrpcContext() : instance_tracker_(instanceTracker()) {
   Thread::LockGuard lock(instance_tracker_.mutex_);
   if (++instance_tracker_.live_instances_ == 1) {
-#ifdef ENVOY_GOOGLE_GRPC
     grpc_init();
-#endif
   }
 }
 
@@ -32,9 +28,7 @@ GoogleGrpcContext::~GoogleGrpcContext() {
   Thread::LockGuard lock(instance_tracker_.mutex_);
   ASSERT(instance_tracker_.live_instances_ > 0);
   if (--instance_tracker_.live_instances_ == 0) {
-#ifdef ENVOY_GOOGLE_GRPC
     grpc_shutdown_blocking(); // Waiting for quiescence avoids non-determinism in tests.
-#endif
   }
 }
 


### PR DESCRIPTION
…ib (#8380)"

This reverts commit 6d772458b1250c9f067f008a1a3c3dcfc1ce2a15.


Description: It is a wrong fix

Risk Level: None
Testing:  None
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue]
[Optional Deprecated:]
