### PR TITLE
clang-tidy: check casing on type aliases

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -64,3 +64,6 @@ CheckOptions:
 
   - key:             readability-identifier-naming.ParameterCase
     value:           'lower_case'
+  
+  - key:             readability-identifier-naming.TypeAliasCase
+    value:           'CamelCase'

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -109,7 +109,7 @@ struct HeterogeneousStringHash {
 
 struct HeterogeneousStringEqual {
   // See description for HeterogeneousStringHash::is_transparent.
-  using is_transparent = void; // NOLINT(readability-identifer-naming)
+  using is_transparent = void; // NOLINT(readability-identifier-naming)
 
   size_t operator()(absl::string_view a, absl::string_view b) const { return a == b; }
   size_t operator()(const SharedString& a, const SharedString& b) const { return *a == *b; }

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -101,7 +101,7 @@ struct HeterogeneousStringHash {
   // https://en.cppreference.com/w/cpp/utility/functional/less_void for an
   // official reference, and https://abseil.io/tips/144 for a description of
   // using it in the context of absl.
-  using is_transparent = void;
+  using is_transparent = void; // NOLINT(readability-identifier-naming)
 
   size_t operator()(absl::string_view a) const { return HashUtil::xxHash64(a); }
   size_t operator()(const SharedString& a) const { return HashUtil::xxHash64(*a); }
@@ -109,7 +109,7 @@ struct HeterogeneousStringHash {
 
 struct HeterogeneousStringEqual {
   // See description for HeterogeneousStringHash::is_transparent.
-  using is_transparent = void;
+  using is_transparent = void; // NOLINT(readability-identifer-naming)
 
   size_t operator()(absl::string_view a, absl::string_view b) const { return a == b; }
   size_t operator()(const SharedString& a, const SharedString& b) const { return *a == *b; }

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -79,7 +79,7 @@ public:
    * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
    * fine spdlog::info corresponds to LOGGER.info method.
    */
-  using levels = enum {
+  using Levels = enum {
     trace = spdlog::level::trace,
     debug = spdlog::level::debug,
     info = spdlog::level::info,

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -152,7 +152,7 @@ public:
    */
   struct CaseInsensitiveCompare {
     // Enable heterogeneous lookup (https://abseil.io/tips/144)
-    using is_transparent = void;
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
     bool operator()(absl::string_view lhs, absl::string_view rhs) const;
   };
 
@@ -163,7 +163,7 @@ public:
    */
   struct CaseInsensitiveHash {
     // Enable heterogeneous lookup (https://abseil.io/tips/144)
-    using is_transparent = void;
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
     uint64_t operator()(absl::string_view key) const;
   };
 

--- a/source/common/stats/allocator_impl.h
+++ b/source/common/stats/allocator_impl.h
@@ -36,13 +36,13 @@ public:
 
 private:
   struct HeapStatHash {
-    using is_transparent = void;
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
     size_t operator()(const Metric* a) const { return a->statName().hash(); }
     size_t operator()(StatName a) const { return a.hash(); }
   };
 
   struct HeapStatCompare {
-    using is_transparent = void;
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
     bool operator()(const Metric* a, const Metric* b) const {
       return a->statName() == b->statName();
     }

--- a/source/common/stats/symbol_table_impl.h
+++ b/source/common/stats/symbol_table_impl.h
@@ -565,7 +565,7 @@ struct HeterogeneousStatNameHash {
   // https://en.cppreference.com/w/cpp/utility/functional/less_void for an
   // official reference, and https://abseil.io/tips/144 for a description of
   // using it in the context of absl.
-  using is_transparent = void;
+  using is_transparent = void; // NOLINT(readability-identifier-naming)
 
   size_t operator()(StatName a) const { return a.hash(); }
   size_t operator()(const StatNameStorage& a) const { return a.statName().hash(); }
@@ -573,7 +573,7 @@ struct HeterogeneousStatNameHash {
 
 struct HeterogeneousStatNameEqual {
   // See description for HeterogeneousStatNameHash::is_transparent.
-  using is_transparent = void;
+  using is_transparent = void; // NOLINT(readability-identifier-naming)
 
   size_t operator()(StatName a, StatName b) const { return a == b; }
   size_t operator()(const StatNameStorage& a, const StatNameStorage& b) const {
@@ -594,7 +594,7 @@ class StatNameStorageSet {
 public:
   using HashSet =
       absl::flat_hash_set<StatNameStorage, HeterogeneousStatNameHash, HeterogeneousStatNameEqual>;
-  using iterator = HashSet::iterator;
+  using Iterator = HashSet::iterator;
 
   ~StatNameStorageSet();
 
@@ -616,12 +616,12 @@ public:
    * @param stat_name The stat_name to find.
    * @return the iterator pointing to the stat_name, or end() if not found.
    */
-  iterator find(StatName stat_name) { return hash_set_.find(stat_name); }
+  Iterator find(StatName stat_name) { return hash_set_.find(stat_name); }
 
   /**
    * @return the end-marker.
    */
-  iterator end() { return hash_set_.end(); }
+  Iterator end() { return hash_set_.end(); }
 
   /**
    * @param set the storage set to swap with.

--- a/source/extensions/common/wasm/wasm_vm.h
+++ b/source/extensions/common/wasm/wasm_vm.h
@@ -24,8 +24,12 @@ struct Word {
 };
 
 // Convert Word type for use by 32-bit VMs.
-template <typename T> struct ConvertWordTypeToUint32 { using type = T; };
-template <> struct ConvertWordTypeToUint32<Word> { using type = uint32_t; };
+template <typename T> struct ConvertWordTypeToUint32 {
+  using type = T; // NOLINT(readability-identifier-naming)
+};
+template <> struct ConvertWordTypeToUint32<Word> {
+  using type = uint32_t; // NOLINT(readability-identifier-naming)
+};
 
 // Convert Word-based function types for 32-bit VMs.
 template <typename F> struct ConvertFunctionTypeWordToUint32 {};
@@ -55,13 +59,14 @@ struct WasmFuncTypeHelper {};
 
 template <size_t N, class ReturnType, class ContextType, class ParamType, class... Args>
 struct WasmFuncTypeHelper<N, ReturnType, ContextType, ParamType, ReturnType(ContextType, Args...)> {
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using type = typename WasmFuncTypeHelper<N - 1, ReturnType, ContextType, ParamType,
                                            ReturnType(ContextType, Args..., ParamType)>::type;
 };
 
 template <class ReturnType, class ContextType, class ParamType, class... Args>
 struct WasmFuncTypeHelper<0, ReturnType, ContextType, ParamType, ReturnType(ContextType, Args...)> {
-  using type = ReturnType(ContextType, Args...);
+  using type = ReturnType(ContextType, Args...); // NOLINT(readability-identifier-naming)
 };
 
 template <size_t N, class ReturnType, class ContextType, class ParamType>

--- a/source/extensions/filters/network/kafka/parser.h
+++ b/source/extensions/filters/network/kafka/parser.h
@@ -43,7 +43,7 @@ using ParserSharedPtr = std::shared_ptr<Parser<MessageType, FailureDataType>>;
  */
 template <typename MessageType, typename FailureDataType> class ParseResponse {
 public:
-  using failure_type = FailureDataType;
+  using FailureType = FailureDataType;
 
   /**
    * Constructs a response that states that parser still needs data and should not be replaced.
@@ -99,8 +99,8 @@ public:
     data = {data.data() + min, data.size() - min};
     context_->remaining() -= min;
     if (0 == context_->remaining()) {
-      using failure_type = typename ResponseType::failure_type::element_type;
-      auto failure_data = std::make_shared<failure_type>(context_->asFailureData());
+      using FailureType = typename ResponseType::FailureType::element_type;
+      auto failure_data = std::make_shared<FailureType>(context_->asFailureData());
       return ResponseType::parseFailure(failure_data);
     } else {
       return ResponseType::stillWaiting();

--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -10,7 +10,9 @@ namespace {
 uint32_t makeRequestStreamId(uint32_t stream_id) { return htonl((stream_id << 1) | 1); }
 
 // All this templatized stuff is for the typesafe constexpr bitwise ORing of the "enum class" values
-template <typename First, typename... Rest> struct FirstArgType { using type = First; };
+template <typename First, typename... Rest> struct FirstArgType {
+  using type = First; // NOLINT(readability-identifier-naming)
+};
 
 template <typename Flag> constexpr uint8_t orFlags(Flag flag) { return static_cast<uint8_t>(flag); }
 

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -19,8 +19,8 @@ class Http2Frame {
 public:
   Http2Frame() = default;
 
-  using iterator = DataContainer::iterator;
-  using const_iterator = DataContainer::const_iterator;
+  using Iterator = DataContainer::iterator;
+  using ConstIterator = DataContainer::const_iterator;
 
   static constexpr size_t HeaderSize = 9;
   static const char Preamble[25];
@@ -110,10 +110,10 @@ public:
   size_t size() const { return data_.size(); }
   // Access to the raw frame bytes
   const uint8_t* data() const { return data_.data(); }
-  iterator begin() { return data_.begin(); }
-  iterator end() { return data_.end(); }
-  const_iterator begin() const { return data_.begin(); }
-  const_iterator end() const { return data_.end(); }
+  Iterator begin() { return data_.begin(); }
+  Iterator end() { return data_.end(); }
+  ConstIterator begin() const { return data_.begin(); }
+  ConstIterator end() const { return data_.end(); }
   bool empty() const { return data_.empty(); }
 
 private:

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -119,8 +119,8 @@ bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_jso
     std::string test_name = check_config->getString("test_name", "");
     tests_.emplace_back(test_name, std::vector<std::string>{});
     Json::ObjectSharedPtr validate = check_config->getObject("validate");
-    using checkerFunc = std::function<bool(ToolConfig&, const std::string&)>;
-    const std::unordered_map<std::string, checkerFunc> checkers = {
+    using CheckerFunc = std::function<bool(ToolConfig&, const std::string&)>;
+    const std::unordered_map<std::string, CheckerFunc> checkers = {
         {"cluster_name",
          [this](auto&... params) -> bool { return this->compareCluster(params...); }},
         {"virtual_cluster_name",
@@ -189,9 +189,9 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
     tests_.emplace_back(test_name, std::vector<std::string>{});
     const envoy::RouterCheckToolSchema::ValidationAssert& validate = check_config.validate();
 
-    using checkerFunc =
+    using CheckerFunc =
         std::function<bool(ToolConfig&, const envoy::RouterCheckToolSchema::ValidationAssert&)>;
-    checkerFunc checkers[] = {
+    CheckerFunc checkers[] = {
         [this](auto&... params) -> bool { return this->compareCluster(params...); },
         [this](auto&... params) -> bool { return this->compareVirtualCluster(params...); },
         [this](auto&... params) -> bool { return this->compareVirtualHost(params...); },


### PR DESCRIPTION
Description: verify `CamelCase` for `using FooBar = ...;` statements with some exceptions.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>