### PR TITLE
clang-tidy: check casing on class names

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -59,6 +59,9 @@ CheckOptions:
   - key:             modernize-use-auto.MinTypeNameLength
     value:           '10'
 
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+
   - key:             readability-identifier-naming.EnumCase
     value:           'CamelCase'
 

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -22,8 +22,12 @@ def _tcmalloc_external_deps(repository):
 # passed to cc_library should be specified with this function. Note: this exists to ensure that
 # all envoy targets pass through an envoy-declared skylark function where they can be modified
 # before being passed to a native bazel function.
-def envoy_basic_cc_library(name, **kargs):
-    native.cc_library(name = name, **kargs)
+def envoy_basic_cc_library(name, deps = [], external_deps = [], **kargs):
+    native.cc_library(
+        name = name,
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps],
+        **kargs
+    )
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -86,6 +86,10 @@ envoy_cc_library(
 envoy_basic_cc_library(
     name = "fmt_lib",
     hdrs = ["fmt.h"],
+    external_deps = [
+        "abseil_strings",
+        "fmtlib",
+    ],
     include_prefix = envoy_include_prefix(package_name()),
 )
 

--- a/source/common/common/fmt.h
+++ b/source/common/common/fmt.h
@@ -12,6 +12,7 @@ namespace fmt {
 // formatted with the same format specifiers available to std::string.
 // TODO(zuercher): Once absl::string_view is replaced with std::string_view, this can be removed
 // as fmtlib handles std::string_view natively.
+// NOLINTNEXTLINE(readability-identifier-naming)
 template <> struct formatter<absl::string_view> : formatter<string_view> {
   auto format(absl::string_view absl_string_view, fmt::format_context& ctx) -> decltype(ctx.out()) {
     string_view fmt_string_view(absl_string_view.data(), absl_string_view.size());

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -87,7 +87,7 @@ TEST(Logger, logAsStatement) {
 }
 
 TEST(Logger, checkLoggerLevel) {
-  class logTestClass : public Logger::Loggable<Logger::Id::misc> {
+  class LogTestClass : public Logger::Loggable<Logger::Id::misc> {
   public:
     void setLevel(const spdlog::level::level_enum level) { ENVOY_LOGGER().set_level(level); }
     uint32_t executeAtTraceLevel() {
@@ -101,7 +101,7 @@ TEST(Logger, checkLoggerLevel) {
     }
   };
 
-  logTestClass testObj;
+  LogTestClass testObj;
 
   // Set Loggers severity low
   testObj.setLevel(spdlog::level::trace);

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -101,14 +101,14 @@ TEST(Logger, checkLoggerLevel) {
     }
   };
 
-  LogTestClass testObj;
+  LogTestClass test_obj;
 
   // Set Loggers severity low
-  testObj.setLevel(spdlog::level::trace);
-  EXPECT_THAT(testObj.executeAtTraceLevel(), testing::Eq(1));
+  test_obj.setLevel(spdlog::level::trace);
+  EXPECT_THAT(test_obj.executeAtTraceLevel(), testing::Eq(1));
 
-  testObj.setLevel(spdlog::level::info);
-  EXPECT_THAT(testObj.executeAtTraceLevel(), testing::Eq(2));
+  test_obj.setLevel(spdlog::level::info);
+  EXPECT_THAT(test_obj.executeAtTraceLevel(), testing::Eq(2));
 }
 
 TEST(RegistryTest, LoggerWithName) {


### PR DESCRIPTION
Description: verify `CamelCase` for class names.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>