### PR TITLE
protobuf: add back ubsan patch

### DIFF
--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -22,7 +22,7 @@ diff --git a/BUILD b/BUILD
 index 6665de94..55f28582 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -19,6 +19,6 @@ config_setting(
+@@ -19,7 +19,7 @@ config_setting(
  # ZLIB configuration
  ################################################################################
  

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -1,8 +1,28 @@
+diff --git a/src/google/protobuf/stubs/strutil.cc b/src/google/protobuf/stubs/strutil.cc
+index 3844fa6b8b..5486887295 100644
+--- a/src/google/protobuf/stubs/strutil.cc
++++ b/src/google/protobuf/stubs/strutil.cc
+@@ -1065,10 +1065,12 @@ char* FastUInt32ToBufferLeft(uint32 u, char* buffer) {
+ }
+ 
+ char* FastInt32ToBufferLeft(int32 i, char* buffer) {
+-  uint32 u = i;
++  uint32 u = 0;
+   if (i < 0) {
+     *buffer++ = '-';
+-    u = -i;
++    u -= i;
++  } else {
++    u = i;
+   }
+   return FastUInt32ToBufferLeft(u, buffer);
+ }
+
 diff --git a/BUILD b/BUILD
 index 6665de94..55f28582 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -19,7 +19,7 @@ config_setting(
+@@ -19,6 +19,6 @@ config_setting(
  # ZLIB configuration
  ################################################################################
  

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -506,7 +506,7 @@ def _com_google_protobuf():
         # The patch includes
         # https://github.com/protocolbuffers/protobuf/pull/6333 and also uses
         # foreign_cc build for zlib as its dependency.
-        # TODO(asraa): remove this when > protobuf 3.8.0 is released.
+        # TODO(asraa): remove this when protobuf 3.10 is released.
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:protobuf.patch"],
     )
@@ -520,7 +520,7 @@ def _com_google_protobuf():
         # The patch includes
         # https://github.com/protocolbuffers/protobuf/pull/6333 and also uses
         # foreign_cc build for zlib as its dependency.
-        # TODO(asraa): remove this when > protobuf 3.8.0 is released.
+        # TODO(asraa): remove this when protobuf 3.10 is released.
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:protobuf.patch"],
     )

--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5650952886943744
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5650952886943744
@@ -1,0 +1,11 @@
+config {
+  vhds {
+    config_source {
+      api_config_source {
+        request_timeout {
+          nanos: -2147483648
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds back protobuf patch fixing UBSAN error (https://github.com/protocolbuffers/protobuf/pull/6333). 
This was removed on updating protobuf to 3.9.1, but will be included in the protobuf 3.10 release.

Fixes OSS-Fuzz issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17759
Testing: Added corpus

