### PR TITLE
Enforce hashtagging for Redis clusters

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -47,6 +47,7 @@ Version history
 * redis: added :ref:`enable_command_stats <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_command_stats>` to enable :ref:`per command statistics <arch_overview_redis_cluster_command_stats>` for upstream clusters.
 * redis: added :ref:`read_policy <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.read_policy>` to allow reading from redis replicas for Redis Cluster deployments.
 * redis: fix a bug where the redis health checker ignored the upstream auth password.
+* redis: enable_hashtaging is always enabled when the upstream uses open source Redis cluster protocol.
 * regex: introduce new :ref:`RegexMatcher <envoy_api_msg_type.matcher.RegexMatcher>` type that
   provides a safe regex implementation for untrusted user input. This type is now used in all
   configuration that processes user provided input. See :ref:`deprecated configuration details

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -176,12 +176,11 @@ bool isReadRequest(const NetworkFilters::Common::Redis::RespValue& request) {
 } // namespace
 
 RedisLoadBalancerContextImpl::RedisLoadBalancerContextImpl(
-    const std::string& key, bool enabled_hashtagging, bool use_crc16,
+    const std::string& key, bool enabled_hashtagging, bool is_redis_cluster,
     const NetworkFilters::Common::Redis::RespValue& request,
     NetworkFilters::Common::Redis::Client::ReadPolicy read_policy)
-    : hash_key_(use_crc16
-                    ? Crc16::crc16(hashtag(key, use_crc16 || enabled_hashtagging))
-                    : MurmurHash::murmurHash2_64(hashtag(key, use_crc16 || enabled_hashtagging))),
+    : hash_key_(is_redis_cluster ? Crc16::crc16(hashtag(key, true))
+                                 : MurmurHash::murmurHash2_64(hashtag(key, enabled_hashtagging))),
       is_read_(isReadRequest(request)), read_policy_(read_policy) {}
 
 // Inspired by the redis-cluster hashtagging algorithm

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -179,8 +179,9 @@ RedisLoadBalancerContextImpl::RedisLoadBalancerContextImpl(
     const std::string& key, bool enabled_hashtagging, bool use_crc16,
     const NetworkFilters::Common::Redis::RespValue& request,
     NetworkFilters::Common::Redis::Client::ReadPolicy read_policy)
-    : hash_key_(use_crc16 ? Crc16::crc16(hashtag(key, enabled_hashtagging))
-                          : MurmurHash::murmurHash2_64(hashtag(key, enabled_hashtagging))),
+    : hash_key_(use_crc16
+                    ? Crc16::crc16(hashtag(key, use_crc16 || enabled_hashtagging))
+                    : MurmurHash::murmurHash2_64(hashtag(key, use_crc16 || enabled_hashtagging))),
       is_read_(isReadRequest(request)), read_policy_(read_policy) {}
 
 // Inspired by the redis-cluster hashtagging algorithm

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -67,6 +67,16 @@ public:
 class RedisLoadBalancerContextImpl : public RedisLoadBalancerContext,
                                      public Upstream::LoadBalancerContextBase {
 public:
+  /**
+   * The load balancer context for Redis requests. Note that use_crc16 implies using Redis cluster
+   * which require us to always enable hashtagging.
+   * @param key specify the key for the Redis request.
+   * @param enabled_hashtagging specify whether to enable hashtagging, this will always be true if
+   * use_crc16 is true.
+   * @param use_crc16 specify whether to use crc16.
+   * @param request specify the Redis request.
+   * @param read_policy specify the read policy.
+   */
   RedisLoadBalancerContextImpl(const std::string& key, bool enabled_hashtagging, bool use_crc16,
                                const NetworkFilters::Common::Redis::RespValue& request,
                                NetworkFilters::Common::Redis::Client::ReadPolicy read_policy =

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -68,16 +68,18 @@ class RedisLoadBalancerContextImpl : public RedisLoadBalancerContext,
                                      public Upstream::LoadBalancerContextBase {
 public:
   /**
-   * The load balancer context for Redis requests. Note that use_crc16 implies using Redis cluster
-   * which require us to always enable hashtagging.
+   * The load balancer context for Redis requests. Note that is_redis_cluster implies using Redis
+   * cluster which require us to always enable hashtagging.
    * @param key specify the key for the Redis request.
    * @param enabled_hashtagging specify whether to enable hashtagging, this will always be true if
-   * use_crc16 is true.
-   * @param use_crc16 specify whether to use crc16.
+   * is_redis_cluster is true.
+   * @param is_redis_cluster specify whether this is a request for redis cluster, if true the key
+   * will be hashed using crc16.
    * @param request specify the Redis request.
    * @param read_policy specify the read policy.
    */
-  RedisLoadBalancerContextImpl(const std::string& key, bool enabled_hashtagging, bool use_crc16,
+  RedisLoadBalancerContextImpl(const std::string& key, bool enabled_hashtagging,
+                               bool is_redis_cluster,
                                const NetworkFilters::Common::Redis::RespValue& request,
                                NetworkFilters::Common::Redis::Client::ReadPolicy read_policy =
                                    NetworkFilters::Common::Redis::Client::ReadPolicy::Master);

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -208,9 +208,9 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key,
     return nullptr;
   }
 
-  const bool use_crc16 = is_redis_cluster_;
-  Clusters::Redis::RedisLoadBalancerContextImpl lb_context(
-      key, parent_.config_.enableHashtagging(), use_crc16, request, parent_.config_.readPolicy());
+  Clusters::Redis::RedisLoadBalancerContextImpl lb_context(key, parent_.config_.enableHashtagging(),
+                                                           is_redis_cluster_, request,
+                                                           parent_.config_.readPolicy());
   Upstream::HostConstSharedPtr host = cluster_->loadBalancer().chooseHost(&lb_context);
   if (!host) {
     return nullptr;

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -423,6 +423,28 @@ TEST_F(RedisLoadBalancerContextImplTest, UnsupportedCommand) {
   EXPECT_EQ(NetworkFilters::Common::Redis::Client::ReadPolicy::Master, context3.readPolicy());
 }
 
+TEST_F(RedisLoadBalancerContextImplTest, EnforceHashTag) {
+  std::vector<NetworkFilters::Common::Redis::RespValue> set_foo(3);
+  set_foo[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  set_foo[0].asString() = "set";
+  set_foo[1].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  set_foo[1].asString() = "{foo}bar";
+  set_foo[2].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  set_foo[2].asString() = "bar";
+
+  NetworkFilters::Common::Redis::RespValue set_request;
+  set_request.type(NetworkFilters::Common::Redis::RespType::Array);
+  set_request.asArray().swap(set_foo);
+
+  // Enable_hash tagging should be ignored when use_crc16 is true. This is treated like "foo"
+  RedisLoadBalancerContextImpl context2("{foo}bar", false, true, set_request,
+                                        NetworkFilters::Common::Redis::Client::ReadPolicy::Master);
+
+  EXPECT_EQ(absl::optional<uint64_t>(44950), context2.computeHashKey());
+  EXPECT_EQ(false, context2.isReadCommand());
+  EXPECT_EQ(NetworkFilters::Common::Redis::Client::ReadPolicy::Master, context2.readPolicy());
+}
+
 } // namespace Redis
 } // namespace Clusters
 } // namespace Extensions

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -436,7 +436,8 @@ TEST_F(RedisLoadBalancerContextImplTest, EnforceHashTag) {
   set_request.type(NetworkFilters::Common::Redis::RespType::Array);
   set_request.asArray().swap(set_foo);
 
-  // Enable_hash tagging should be ignored when use_crc16 is true. This is treated like "foo"
+  // Enable_hash tagging should be override when is_redis_cluster is true. This is treated like
+  // "foo"
   RedisLoadBalancerContextImpl context2("{foo}bar", false, true, set_request,
                                         NetworkFilters::Common::Redis::Client::ReadPolicy::Master);
 


### PR DESCRIPTION
Description: When mirroring traffic from a non-hashtagging-enabled cluster to a cluster that supports OSS Redis Cluster protocol, we need to ensure hashtagging is enabled on the OSS Redis Cluster.  Otherwise there will be a lot of redirection traffic. 
Risk Level: Low
Testing: Added unit test
Docs Changes: N/A
Release Notes: Yes