### PR TITLE
Fix hot restart bug due to passed an fd without bind

### DIFF
--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -94,12 +94,8 @@ HotRestartingParent::Internal::getListenSocketsForChild(const HotRestartMessage:
   wrapped_reply.mutable_reply()->mutable_pass_listen_socket()->set_fd(-1);
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::resolveUrl(request.pass_listen_socket().address());
-  for (const auto& listener : server_->listenerManager().listeners()) {
-    if (listener.get().socket().socketType() == Network::Address::SocketType::Stream &&
-        !listener.get().bindToPort()) {
-      continue;
-    }
-
+  for (const auto& listener :
+       server_->listenerManager().listeners() && listener.get().bindToPort()) {
     if (*listener.get().socket().localAddress() == *addr) {
       wrapped_reply.mutable_reply()->mutable_pass_listen_socket()->set_fd(
           listener.get().socket().ioHandle().fd());

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -94,9 +94,8 @@ HotRestartingParent::Internal::getListenSocketsForChild(const HotRestartMessage:
   wrapped_reply.mutable_reply()->mutable_pass_listen_socket()->set_fd(-1);
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::resolveUrl(request.pass_listen_socket().address());
-  for (const auto& listener :
-       server_->listenerManager().listeners() && listener.get().bindToPort()) {
-    if (*listener.get().socket().localAddress() == *addr) {
+  for (const auto& listener : server_->listenerManager().listeners()) {
+    if (*listener.get().socket().localAddress() == *addr && listener.get().bindToPort()) {
       wrapped_reply.mutable_reply()->mutable_pass_listen_socket()->set_fd(
           listener.get().socket().ioHandle().fd());
       break;

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -95,6 +95,11 @@ HotRestartingParent::Internal::getListenSocketsForChild(const HotRestartMessage:
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::resolveUrl(request.pass_listen_socket().address());
   for (const auto& listener : server_->listenerManager().listeners()) {
+    if (listener.get().socket().socketType() == Network::Address::SocketType::Stream &&
+        !listener.get().bindToPort()) {
+      continue;
+    }
+
     if (*listener.get().socket().localAddress() == *addr) {
       wrapped_reply.mutable_reply()->mutable_pass_listen_socket()->set_fd(
           listener.get().socket().ioHandle().fd());

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -167,18 +167,16 @@ Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(
                                  : Network::Utility::UDP_SCHEME;
   const std::string addr = absl::StrCat(scheme, address->asString());
 
-  if (!bind_to_port && socket_type == Network::Address::SocketType::Stream) {
-    return std::make_shared<Network::TcpListenSocket>(address, options, bind_to_port);
-  }
-
-  const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
-  if (fd != -1) {
-    ENVOY_LOG(debug, "obtained socket for address {} from parent", addr);
-    Network::IoHandlePtr io_handle = std::make_unique<Network::IoSocketHandleImpl>(fd);
-    if (socket_type == Network::Address::SocketType::Stream) {
-      return std::make_shared<Network::TcpListenSocket>(std::move(io_handle), address, options);
-    } else {
-      return std::make_shared<Network::UdpListenSocket>(std::move(io_handle), address, options);
+  if (bind_to_port) {
+    const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
+    if (fd != -1) {
+      ENVOY_LOG(debug, "obtained socket for address {} from parent", addr);
+      Network::IoHandlePtr io_handle = std::make_unique<Network::IoSocketHandleImpl>(fd);
+      if (socket_type == Network::Address::SocketType::Stream) {
+        return std::make_shared<Network::TcpListenSocket>(std::move(io_handle), address, options);
+      } else {
+        return std::make_shared<Network::UdpListenSocket>(std::move(io_handle), address, options);
+      }
     }
   }
 

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -166,6 +166,11 @@ Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(
                                  ? Network::Utility::TCP_SCHEME
                                  : Network::Utility::UDP_SCHEME;
   const std::string addr = absl::StrCat(scheme, address->asString());
+
+  if (!bind_to_port && socket_type == Network::Address::SocketType::Stream) {
+    return std::make_shared<Network::TcpListenSocket>(address, options, bind_to_port);
+  }
+
   const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
   if (fd != -1) {
     ENVOY_LOG(debug, "obtained socket for address {} from parent", addr);
@@ -176,6 +181,7 @@ Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(
       return std::make_shared<Network::UdpListenSocket>(std::move(io_handle), address, options);
     }
   }
+
   if (socket_type == Network::Address::SocketType::Stream) {
     return std::make_shared<Network::TcpListenSocket>(address, options, bind_to_port);
   } else {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -202,6 +202,7 @@ envoy_cc_test(
         "//source/extensions/transport_sockets/tls:config",
         "//source/extensions/transport_sockets/tls:ssl_socket_lib",
         "//source/server:active_raw_udp_listener_config",
+        "//test/test_common:network_utility_lib",
         "//test/test_common:registry_lib",
     ],
 )

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -93,6 +93,7 @@ envoy_cc_test(
     deps = [
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
+        "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_mocks",
     ],
 )

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -20,6 +20,7 @@
 #include "extensions/transport_sockets/tls/ssl_socket.h"
 
 #include "test/server/utility.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
@@ -913,6 +914,45 @@ filter_chains:
   checkStats(2, 0, 1, 0, 1, 0);
 
   EXPECT_CALL(*listener_foo2, onDestroy());
+}
+
+TEST_F(ListenerManagerImplTest, BindToPortEqualToFalse) {
+  InSequence s;
+  EXPECT_CALL(*worker_, start(_));
+  manager_->startWorkers(guard_dog_);
+  const std::string listener_foo_yaml = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+deprecated_v1:
+    bind_to_port: false
+filter_chains:
+- filters: []
+  )EOF";
+  Api::OsSysCallsImpl os_syscall;
+  auto syscall_result = os_syscall.socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_GE(syscall_result.rc_, 0);
+  ListenerHandle* listener_foo = expectListenerCreate(true, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, false))
+      .WillOnce(
+          Invoke([this, &syscall_result](const Network::Address::InstanceConstSharedPtr& address,
+                                         Network::Address::SocketType socket_type,
+                                         const Network::Socket::OptionsSharedPtr& options,
+                                         bool bind_to_port) -> Network::SocketSharedPtr {
+            // When bind_to_port is equal to false, create socket fd directly, and do not get socket
+            // fd through hot restart.
+            NiceMock<Api::MockOsSysCalls> os_sys_calls;
+            TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls(&os_sys_calls);
+            ON_CALL(os_sys_calls, socket(AF_INET, _, 0))
+                .WillByDefault(Return(Api::SysCallIntResult{syscall_result.rc_, 0}));
+            return real_listener_factory_.createListenSocket(address, socket_type, options,
+                                                             bind_to_port);
+          }));
+  EXPECT_CALL(listener_foo->target_, initialize());
+  EXPECT_CALL(*listener_foo, onDestroy());
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), "", true));
 }
 
 TEST_F(ListenerManagerImplTest, CantBindSocket) {

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -37,7 +37,7 @@ public:
 
 class ListenerManagerImplTest : public testing::Test {
 protected:
-  ListenerManagerImplTest() : api_(Api::createApiForTest()) {
+  ListenerManagerImplTest() : api_(Api::createApiForTest()), real_listener_factory_(server_) {
     ON_CALL(server_, api()).WillByDefault(ReturnRef(*api_));
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
     manager_ =
@@ -217,6 +217,7 @@ protected:
   Network::Address::InstanceConstSharedPtr local_address_;
   Network::Address::InstanceConstSharedPtr remote_address_;
   std::unique_ptr<Network::MockConnectionSocket> socket_;
+  ProdListenerComponentFactory real_listener_factory_;
 };
 
 } // namespace Server

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -37,7 +37,7 @@ public:
 
 class ListenerManagerImplTest : public testing::Test {
 protected:
-  ListenerManagerImplTest() : api_(Api::createApiForTest()), real_listener_factory_(server_) {
+  ListenerManagerImplTest() : api_(Api::createApiForTest()) {
     ON_CALL(server_, api()).WillByDefault(ReturnRef(*api_));
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
     manager_ =
@@ -217,7 +217,6 @@ protected:
   Network::Address::InstanceConstSharedPtr local_address_;
   Network::Address::InstanceConstSharedPtr remote_address_;
   std::unique_ptr<Network::MockConnectionSocket> socket_;
-  ProdListenerComponentFactory real_listener_factory_;
 };
 
 } // namespace Server


### PR DESCRIPTION
When the 15001 listener appears at the same time, one of them will bind the socket and listening, and the other will not bind. In this case, the hot restart gets the socket of the previous process and may get the socket that is not listening.

Description: Fix hot restart bug due to passed an fd without bind
Risk Level: low
Testing:  Existing tests and new tests
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] #8427

