### PR TITLE
tools: proto sync shebang line for portability

### DIFF
--- a/tools/proto_sync.py
+++ b/tools/proto_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Diff or copy protoxform artifacts from Bazel cache back to the source tree.
 


### PR DESCRIPTION
Signed-off-by: Yi Tang <ssnailtang@gmail.com>

Description: use `/usr/bin/env python3` for portability in `proto_sync.py`.
Risk Level: low

cc @htuch 