### PR TITLE
Replace deprecated thread annotations macros

### DIFF
--- a/source/common/common/perf_annotation.h
+++ b/source/common/common/perf_annotation.h
@@ -136,7 +136,7 @@ private:
 
   // Maps {category, description} to DurationStats.
 #if PERF_THREAD_SAFE
-  DurationStatsMap duration_stats_map_ GUARDED_BY(mutex_);
+  DurationStatsMap duration_stats_map_ ABSL_GUARDED_BY(mutex_);
   Thread::MutexBasicLockable mutex_;
 #else
   DurationStatsMap duration_stats_map_;

--- a/source/common/grpc/context_impl.h
+++ b/source/common/grpc/context_impl.h
@@ -56,8 +56,8 @@ private:
 
   Stats::SymbolTable& symbol_table_;
   mutable Thread::MutexBasicLockable mutex_;
-  Stats::StatNamePool stat_name_pool_ GUARDED_BY(mutex_);
-  StringMap<Stats::StatName> stat_name_map_ GUARDED_BY(mutex_);
+  Stats::StatNamePool stat_name_pool_ ABSL_GUARDED_BY(mutex_);
+  StringMap<Stats::StatName> stat_name_map_ ABSL_GUARDED_BY(mutex_);
   const Stats::StatName grpc_;
   const Stats::StatName grpc_web_;
   const Stats::StatName success_;

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -295,7 +295,7 @@ private:
   // Queue of completed (op, ok) passed from completionThread() to
   // handleOpCompletion().
   std::deque<std::pair<GoogleAsyncTag::Operation, bool>>
-      completed_ops_ GUARDED_BY(completed_ops_lock_);
+      completed_ops_ ABSL_GUARDED_BY(completed_ops_lock_);
   Thread::MutexBasicLockable completed_ops_lock_;
 
   friend class GoogleAsyncClientImpl;


### PR DESCRIPTION
Clean-up stragglers that were not included in the original commit.
Abseil thread annotation macros are now prefixed by ABSL_.

There is no semantic change; this is just a rename.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
