### PR TITLE
networking: added warning for stream reset on rs_too_large after headers sent

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -2251,6 +2251,7 @@ void ConnectionManagerImpl::ActiveStreamEncoderFilter::responseDataTooLarge() {
           parent_.is_head_request_);
       parent_.maybeEndEncode(parent_.state_.local_complete_);
     } else {
+      ENVOY_STREAM_LOG(debug, "Stream closed. Response data too large and headers have already been sent", *this);
       resetStream();
     }
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -2251,7 +2251,9 @@ void ConnectionManagerImpl::ActiveStreamEncoderFilter::responseDataTooLarge() {
           parent_.is_head_request_);
       parent_.maybeEndEncode(parent_.state_.local_complete_);
     } else {
-      ENVOY_STREAM_LOG(debug, "Stream closed. Response data too large and headers have already been sent", *this);
+      ENVOY_STREAM_LOG(
+          debug, "Resetting stream. Response data too large and headers have already been sent",
+          *this);
       resetStream();
     }
   }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3466,7 +3466,9 @@ TEST_F(HttpConnectionManagerImplTest, HitResponseBufferLimitsAfterHeaders) {
   EXPECT_CALL(*encoder_filters_[1], encodeData(_, false))
       .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
   EXPECT_CALL(stream_, resetStream(_));
-  decoder_filters_[0]->callbacks_->encodeData(fake_response, false);
+  EXPECT_LOG_CONTAINS("debug", "Stream closed. Response data too large and headers have already been sent",
+    decoder_filters_[0]->callbacks_->encodeData(fake_response, false);
+  );
 
   EXPECT_EQ(1U, stats_.named_.rs_too_large_.value());
 }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3466,9 +3466,9 @@ TEST_F(HttpConnectionManagerImplTest, HitResponseBufferLimitsAfterHeaders) {
   EXPECT_CALL(*encoder_filters_[1], encodeData(_, false))
       .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
   EXPECT_CALL(stream_, resetStream(_));
-  EXPECT_LOG_CONTAINS("debug", "Stream closed. Response data too large and headers have already been sent",
-    decoder_filters_[0]->callbacks_->encodeData(fake_response, false);
-  );
+  EXPECT_LOG_CONTAINS(
+      "debug", "Resetting stream. Response data too large and headers have already been sent",
+      decoder_filters_[0]->callbacks_->encodeData(fake_response, false););
 
   EXPECT_EQ(1U, stats_.named_.rs_too_large_.value());
 }


### PR DESCRIPTION
Signed-off-by: Paul <paul.caponetti@gmail.com>

Description: Added a warning log when a stream gets reset if a response is buffering, is too large, and headers have already been sent. 
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Fixes: #7430
