### PR TITLE
Fix Mongo stat separators

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -20,7 +20,7 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
 
   ASSERT(!proto_config.stat_prefix().empty());
 
-  const std::string stat_prefix = fmt::format("mongo.{}.", proto_config.stat_prefix());
+  const std::string stat_prefix = fmt::format("mongo.{}", proto_config.stat_prefix());
   AccessLogSharedPtr access_log;
   if (!proto_config.access_log().empty()) {
     access_log.reset(new AccessLog(proto_config.access_log(), context.accessLogManager(),

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -160,9 +160,10 @@ private:
   using ActiveQueryPtr = std::unique_ptr<ActiveQuery>;
 
   MongoProxyStats generateStats(const std::string& prefix, Stats::Scope& scope) {
-    return MongoProxyStats{ALL_MONGO_PROXY_STATS(POOL_COUNTER_PREFIX(scope, prefix),
-                                                 POOL_GAUGE_PREFIX(scope, prefix),
-                                                 POOL_HISTOGRAM_PREFIX(scope, prefix))};
+    const std::string dot_prefix = fmt::format("{}.", prefix);
+    return MongoProxyStats{ALL_MONGO_PROXY_STATS(POOL_COUNTER_PREFIX(scope, dot_prefix),
+                                                 POOL_GAUGE_PREFIX(scope, dot_prefix),
+                                                 POOL_HISTOGRAM_PREFIX(scope, dot_prefix))};
   }
 
   // Increment counters related to queries. 'names' is passed by non-const

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -62,7 +62,7 @@ public:
 
 class MongoProxyFilterTest : public testing::Test {
 public:
-  MongoProxyFilterTest() : mongo_stats_(std::make_shared<MongoStats>(store_, "test")) { setup(); }
+  MongoProxyFilterTest() { setup(); }
 
   void setup() {
     ON_CALL(runtime_.snapshot_, featureEnabled("mongo.proxy_enabled", 100))
@@ -82,9 +82,11 @@ public:
   }
 
   void initializeFilter(bool emit_dynamic_metadata = false) {
+    const std::string stat_prefix {"test"};
+    MongoStatsSharedPtr mongo_stats {std::make_shared<MongoStats>(store_, stat_prefix)};
     filter_ = std::make_unique<TestProxyFilter>(
-        "test.", store_, runtime_, access_log_, fault_config_, drain_decision_,
-        dispatcher_.timeSource(), emit_dynamic_metadata, mongo_stats_);
+        stat_prefix, store_, runtime_, access_log_, fault_config_, drain_decision_,
+        dispatcher_.timeSource(), emit_dynamic_metadata, mongo_stats);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 
@@ -114,7 +116,6 @@ public:
 
   Buffer::OwnedImpl fake_data_;
   NiceMock<TestStatStore> store_;
-  MongoStatsSharedPtr mongo_stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Envoy::AccessLog::MockAccessLogFile> file_{


### PR DESCRIPTION
Removes the trailing '.' from MongoStats stat_prefix format.
Inserting the separator happens when calling the POOL_*_PREFIX macros instead.

Risk Level: Low
Testing: Brought unit test init in line with factory method createFilterFactoryFromProtoTyped
Docs Changes: -
Release Notes: -
Fixes #8442 
