### PR TITLE
Handle redirects when fetching AWS IAM metadata

### DIFF
--- a/source/extensions/filters/http/common/aws/utility.cc
+++ b/source/extensions/filters/http/common/aws/utility.cc
@@ -110,6 +110,7 @@ absl::optional<std::string> Utility::metadataFetcher(const std::string& host,
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, TIMEOUT.count());
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
   std::string buffer;
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);


### PR DESCRIPTION
Fixes: #8325

Description: By default cURL does not follow redirects. When fetching AWS IAM credentials, some endpoints may opt to redirect instead of handling paths with trailing slashes. In general, we should be following any redirect from these endpoints for maximum compatibility.
Risk Level: LOW

Signed-off-by: Scott LaVigne <lavignes@amazon.com>
