### PR TITLE
Proof of Concept: Introduce ServerFactoryContext

### DIFF
--- a/include/envoy/config/config_provider.h
+++ b/include/envoy/config/config_provider.h
@@ -121,7 +121,7 @@ public:
     for (const auto* elem : config_protos) {
       ret_protos.push_back(static_cast<const P*>(elem));
     }
-    return ConfigProtoInfoVector<P>{ret_protos, getConfigVersion()};
+    return ConfigProtoInfoVector<P>{std::move(ret_protos), getConfigVersion()};
   }
 
   /**

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -56,6 +56,7 @@ public:
 };
 
 using RouteConfigProviderPtr = std::unique_ptr<RouteConfigProvider>;
+using RouteConfigProviderSharedPtr = std::shared_ptr<RouteConfigProvider>;
 
 } // namespace Router
 } // namespace Envoy

--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -36,7 +36,7 @@ public:
    * @param init_manager the Init::Manager used to coordinate initialization of a the underlying RDS
    * subscription.
    */
-  virtual RouteConfigProviderPtr createRdsRouteConfigProvider(
+  virtual RouteConfigProviderSharedPtr createRdsRouteConfigProvider(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
       Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
       Init::Manager& init_manager) PURE;

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -111,6 +111,8 @@ class FactoryContext : public virtual CommonFactoryContext {
 public:
   ~FactoryContext() override = default;
 
+  virtual FactoryContext* getServerContext() { return nullptr; }
+
   /**
    * @return AccessLogManager for use by the entire server.
    */

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -438,7 +438,7 @@ public:
    * config. Returned object will be stored in the loaded route configuration.
    */
   virtual Router::RouteSpecificFilterConfigConstSharedPtr
-  createRouteSpecificFilterConfig(const Protobuf::Message&, FactoryContext&) {
+  createRouteSpecificFilterConfig(const Protobuf::Message&, ServerFactoryContext&) {
     return nullptr;
   }
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -81,6 +81,12 @@ public:
   virtual ThreadLocal::SlotAllocator& threadLocal() PURE;
 
   /**
+   * @return ProtobufMessage::ValidationVisitor& validation visitor for filter configuration
+   *         messages.
+   */
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
+
+  /**
    * @return Server::Admin& the server's global admin HTTP endpoint.
    */
   virtual Server::Admin& admin() PURE;
@@ -89,12 +95,6 @@ public:
    * @return TimeSource& a reference to the time source.
    */
   virtual TimeSource& timeSource() PURE;
-
-  /**
-   * @return ProtobufMessage::ValidationVisitor& validation visitor for filter configuration
-   *         messages.
-   */
-  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
 
   /**
    * @return Api::Api& a reference to the api object.
@@ -188,7 +188,22 @@ public:
 };
 
 // Proof of Concept class
-class ServerFactoryContext : public virtual CommonFactoryContext {};
+class ServerFactoryContext : public virtual CommonFactoryContext {
+  // Hide and export only serverMessageValidationVisitor
+  // Will decide later
+  virtual ProtobufMessage::ValidationContext& messageValidationContext() {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  };
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  };
+
+public:
+  virtual ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+};
+
 class ServerFactoryCxtUtil {
 public:
   static ServerFactoryContext& generateServerFactoryContext(FactoryContext&) {

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -102,9 +102,6 @@ public:
   virtual Api::Api& api() PURE;
 };
 
-// Proof of Concept class
-class ServerFactoryContext : public virtual CommonFactoryContext {};
-
 /**
  * Context passed to network and HTTP filters to access server resources.
  * TODO(mattklein123): When we lock down visibility of the rest of the code, filters should only
@@ -188,6 +185,15 @@ public:
    * @return ProcessContext& a reference to the process context.
    */
   virtual ProcessContext& processContext() PURE;
+};
+
+// Proof of Concept class
+class ServerFactoryContext : public virtual CommonFactoryContext {};
+class ServerFactoryCxtUtil {
+public:
+  static ServerFactoryContext& generateServerFactoryContext(FactoryContext&) {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
 };
 
 class ListenerFactoryContext : public virtual FactoryContext {

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -261,13 +261,6 @@ public:
   virtual ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() PURE;
 };
 
-class ServerFactoryCxtUtil {
-public:
-  static ServerFactoryContext& generateServerFactoryContext(FactoryContext&) {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-};
-
 class ListenerFactoryContext : public virtual FactoryContext {
 public:
   /**

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -102,6 +102,9 @@ public:
   virtual Api::Api& api() PURE;
 };
 
+// Proof of Concept class
+class ServerFactoryContext : public virtual CommonFactoryContext {};
+
 /**
  * Context passed to network and HTTP filters to access server resources.
  * TODO(mattklein123): When we lock down visibility of the rest of the code, filters should only

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -254,11 +254,6 @@ public:
    * @return Api::Api& a reference to the api object.
    */
   virtual Api::Api& api() PURE;
-
-  /**
-   * @return ProtobufMessage::ValidationVisitor&
-   */
-  virtual ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() PURE;
 };
 
 class ListenerFactoryContext : public virtual FactoryContext {

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -102,6 +102,7 @@ public:
   virtual Api::Api& api() PURE;
 };
 
+class ServerFactoryContext;
 /**
  * Context passed to network and HTTP filters to access server resources.
  * TODO(mattklein123): When we lock down visibility of the rest of the code, filters should only
@@ -111,8 +112,7 @@ class FactoryContext : public virtual CommonFactoryContext {
 public:
   ~FactoryContext() override = default;
 
-  virtual FactoryContext* getServerContext() { return nullptr; }
-
+  virtual ServerFactoryContext& getServerFactoryContext(bool is_dynamic) const PURE;
   /**
    * @return AccessLogManager for use by the entire server.
    */
@@ -189,19 +189,76 @@ public:
 
 // Proof of Concept class
 class ServerFactoryContext : public virtual CommonFactoryContext {
-  // Hide and export only serverMessageValidationVisitor
-  // Will decide later
-  virtual ProtobufMessage::ValidationContext& messageValidationContext() {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  };
-  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  };
-
 public:
-  virtual ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  virtual ~ServerFactoryContext() = default;
+
+  /**
+   * @return Upstream::ClusterManager& singleton for use by the entire server.
+   */
+  virtual Upstream::ClusterManager& clusterManager() PURE;
+
+  /**
+   * @return Event::Dispatcher& the main thread's dispatcher. This dispatcher should be used
+   *         for all singleton processing.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
+   * @return information about the local environment the server is running in.
+   */
+  virtual const LocalInfo::LocalInfo& localInfo() const PURE;
+
+  /**
+   * @return RandomGenerator& the random generator for the server.
+   */
+  virtual Envoy::Runtime::RandomGenerator& random() PURE;
+
+  /**
+   * @return Runtime::Loader& the singleton runtime loader for the server.
+   */
+  virtual Envoy::Runtime::Loader& runtime() PURE;
+
+  /**
+   * @return Stats::Scope& the filter's stats scope.
+   */
+  virtual Stats::Scope& scope() PURE;
+
+  /**
+   * @return Singleton::Manager& the server-wide singleton manager.
+   */
+  virtual Singleton::Manager& singletonManager() PURE;
+
+  /**
+   * @return ThreadLocal::SlotAllocator& the thread local storage engine for the server. This is
+   *         used to allow runtime lockless updates to configuration, etc. across multiple threads.
+   */
+  virtual ThreadLocal::SlotAllocator& threadLocal() PURE;
+
+  /**
+   * @return ProtobufMessage::ValidationVisitor& validation visitor for filter configuration
+   *         messages.
+   */
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() PURE;
+
+  /**
+   * @return Server::Admin& the server's global admin HTTP endpoint.
+   */
+  virtual Server::Admin& admin() PURE;
+
+  /**
+   * @return TimeSource& a reference to the time source.
+   */
+  virtual TimeSource& timeSource() PURE;
+
+  /**
+   * @return Api::Api& a reference to the api object.
+   */
+  virtual Api::Api& api() PURE;
+
+  /**
+   * @return ProtobufMessage::ValidationVisitor&
+   */
+  virtual ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() PURE;
 };
 
 class ServerFactoryCxtUtil {

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -207,7 +207,7 @@ public:
   /**
    * @return information about the local environment the server is running in.
    */
-  virtual const LocalInfo::LocalInfo& localInfo() PURE;
+  virtual const LocalInfo::LocalInfo& localInfo() const PURE;
 
   /**
    * @return the time source used for the server.

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -224,6 +224,11 @@ public:
    *         messages.
    */
   virtual ProtobufMessage::ValidationContext& messageValidationContext() PURE;
+
+  /**
+   * @return Configuration::ServerFactoryContext& factory context for filters.
+   */
+  virtual Configuration::ServerFactoryContext& serverFactoryContext(bool is_dynamic) PURE;
 };
 
 } // namespace Server

--- a/source/common/init/target_impl.cc
+++ b/source/common/init/target_impl.cc
@@ -50,5 +50,36 @@ bool TargetImpl::ready() {
   return false;
 }
 
+SharedTargetImpl::SharedTargetImpl(absl::string_view name, InitializeFn fn)
+    : name_(fmt::format("shared target {}", name)),
+      fn_(std::make_shared<InternalInitalizeFn>([this, fn](WatcherHandlePtr watcher_handle) {
+        if (is_initialization_done_) {
+          watcher_handle->ready();
+        } else {
+          watcher_handles_.push_back(std::move(watcher_handle));
+          fn();
+        }
+      })) {}
+
+SharedTargetImpl::~SharedTargetImpl() { ENVOY_LOG(debug, "{} destroyed", name_); }
+
+absl::string_view SharedTargetImpl::name() const { return name_; }
+
+TargetHandlePtr SharedTargetImpl::createHandle(absl::string_view handle_name) const {
+  // Note: can't use std::make_unique here because TargetHandleImpl ctor is private.
+  return std::unique_ptr<TargetHandle>(
+      new TargetHandleImpl(handle_name, name_, std::weak_ptr<InternalInitalizeFn>(fn_)));
+}
+
+bool SharedTargetImpl::ready() {
+  is_initialization_done_ = true;
+  for (auto& watcher_handle : watcher_handles_) {
+    watcher_handle->ready();
+  }
+  // save heap and avoid repeatedly invoke
+  watcher_handles_.clear();
+  return true;
+}
+
 } // namespace Init
 } // namespace Envoy

--- a/source/common/init/target_impl.h
+++ b/source/common/init/target_impl.h
@@ -29,6 +29,8 @@ using InternalInitalizeFn = std::function<void(WatcherHandlePtr)>;
 class TargetHandleImpl : public TargetHandle, Logger::Loggable<Logger::Id::init> {
 private:
   friend class TargetImpl;
+  friend class SharedTargetImpl;
+
   TargetHandleImpl(absl::string_view handle_name, absl::string_view name,
                    std::weak_ptr<InternalInitalizeFn> fn);
 
@@ -83,6 +85,42 @@ private:
 
   // The callback function, called via TargetHandleImpl by the manager
   const std::shared_ptr<InternalInitalizeFn> fn_;
+};
+
+class SharedTargetImpl : public Target, Logger::Loggable<Logger::Id::init> {
+public:
+  /**
+   * @param name a human-readable target name, for logging / debugging
+   * @fn a callback function to invoke when `initialize` is called on the handle. Note that this
+   *     doesn't take a WatcherHandlePtr (like TargetFn does). Managing the watcher handle is done
+   *     internally to simplify usage.
+   */
+  SharedTargetImpl(absl::string_view name, InitializeFn fn);
+  ~SharedTargetImpl() override;
+
+  // Init::Target
+  absl::string_view name() const override;
+  TargetHandlePtr createHandle(absl::string_view handle_name) const override;
+
+  /**
+   * Signal to the init manager(s) that this target has finished initializing. This is safe to call
+   * any time. Calling it before initialization begins or after initialization has already ended
+   * will have no effect.
+   * @return true if the init manager received this call, false otherwise.
+   */
+  bool ready();
+
+private:
+  // Human-readable name for logging
+  const std::string name_;
+
+  // Handle to the ManagerImpl's internal watcher, to call when this target is initialized
+  std::vector<WatcherHandlePtr> watcher_handles_;
+
+  // The callback function, called via TargetHandleImpl by the manager
+  const std::shared_ptr<InternalInitalizeFn> fn_;
+
+  bool is_initialization_done_{false};
 };
 
 } // namespace Init

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -396,7 +396,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       strip_query_(route.redirect().strip_query()),
       hedge_policy_(buildHedgePolicy(vhost.hedgePolicy(), route.route())),
       retry_policy_(buildRetryPolicy(vhost.retryPolicy(), route.route(),
-                                     factory_context.messageValidationVisitor())),
+                                     factory_context.serverMessageValidationVisitor())),
       rate_limit_policy_(route.route().rate_limits()), shadow_policy_(route.route()),
       priority_(ConfigUtility::parsePriority(route.route().priority())),
       config_headers_(Http::HeaderUtility::buildHeaderDataVector(route.match().headers())),
@@ -840,9 +840,9 @@ RouteEntryImplBase::WeightedClusterEntry::perFilterConfig(const std::string& nam
   return cfg != nullptr ? cfg : DynamicRouteEntry::perFilterConfig(name);
 }
 
-PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost,
-                                           const envoy::api::v2::route::Route& route,
-                                           Server::Configuration::ServerFactoryContext& factory_context)
+PrefixRouteEntryImpl::PrefixRouteEntryImpl(
+    const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
+    Server::Configuration::ServerFactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context), prefix_(route.match().prefix()) {}
 
 void PrefixRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
@@ -900,9 +900,9 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
   return nullptr;
 }
 
-RegexRouteEntryImpl::RegexRouteEntryImpl(const VirtualHostImpl& vhost,
-                                         const envoy::api::v2::route::Route& route,
-                                         Server::Configuration::ServerFactoryContext& factory_context)
+RegexRouteEntryImpl::RegexRouteEntryImpl(
+    const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
+    Server::Configuration::ServerFactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context) {
   if (route.match().path_specifier_case() == envoy::api::v2::route::RouteMatch::kRegex) {
     regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher(route.match().regex());
@@ -1224,7 +1224,7 @@ createRouteSpecificFilterConfig(const std::string& name, const ProtobufWkt::Any&
       Server::Configuration::NamedHttpFilterConfigFactory>(name);
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   Envoy::Config::Utility::translateOpaqueConfig(
-      typed_config, config, factory_context.messageValidationVisitor(), *proto_config);
+      typed_config, config, factory_context.serverMessageValidationVisitor(), *proto_config);
   return factory.createRouteSpecificFilterConfig(*proto_config, factory_context);
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -368,7 +368,7 @@ const envoy::type::FractionalPercent& RouteTracingImpl::getOverallSampling() con
 
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                        const envoy::api::v2::route::Route& route,
-                                       Server::Configuration::FactoryContext& factory_context)
+                                       Server::Configuration::ServerFactoryContext& factory_context)
     : case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.match(), case_sensitive, true)),
       prefix_rewrite_(route.route().prefix_rewrite()), host_rewrite_(route.route().host_rewrite()),
       vhost_(vhost),
@@ -808,7 +808,7 @@ RouteEntryImplBase::perFilterConfig(const std::string& name) const {
 
 RouteEntryImplBase::WeightedClusterEntry::WeightedClusterEntry(
     const RouteEntryImplBase* parent, const std::string runtime_key,
-    Server::Configuration::FactoryContext& factory_context,
+    Server::Configuration::ServerFactoryContext& factory_context,
     const envoy::api::v2::route::WeightedCluster_ClusterWeight& cluster)
     : DynamicRouteEntry(parent, cluster.name()), runtime_key_(runtime_key),
       loader_(factory_context.runtime()),
@@ -842,7 +842,7 @@ RouteEntryImplBase::WeightedClusterEntry::perFilterConfig(const std::string& nam
 
 PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost,
                                            const envoy::api::v2::route::Route& route,
-                                           Server::Configuration::FactoryContext& factory_context)
+                                           Server::Configuration::ServerFactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context), prefix_(route.match().prefix()) {}
 
 void PrefixRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
@@ -863,7 +863,7 @@ RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::HeaderMap& headers
 
 PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
                                        const envoy::api::v2::route::Route& route,
-                                       Server::Configuration::FactoryContext& factory_context)
+                                       Server::Configuration::ServerFactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context), path_(route.match().path()) {}
 
 void PathRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
@@ -902,7 +902,7 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
 
 RegexRouteEntryImpl::RegexRouteEntryImpl(const VirtualHostImpl& vhost,
                                          const envoy::api::v2::route::Route& route,
-                                         Server::Configuration::FactoryContext& factory_context)
+                                         Server::Configuration::ServerFactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context) {
   if (route.match().path_specifier_case() == envoy::api::v2::route::RouteMatch::kRegex) {
     regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher(route.match().regex());
@@ -941,7 +941,7 @@ RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::HeaderMap& headers,
 
 VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtual_host,
                                  const ConfigImpl& global_route_config,
-                                 Server::Configuration::FactoryContext& factory_context,
+                                 Server::Configuration::ServerFactoryContext& factory_context,
                                  bool validate_clusters)
     : stat_name_pool_(factory_context.scope().symbolTable()),
       stat_name_(stat_name_pool_.add(virtual_host.name())),
@@ -1072,7 +1072,7 @@ const VirtualHostImpl* RouteMatcher::findWildcardVirtualHost(
 
 RouteMatcher::RouteMatcher(const envoy::api::v2::RouteConfiguration& route_config,
                            const ConfigImpl& global_route_config,
-                           Server::Configuration::FactoryContext& factory_context,
+                           Server::Configuration::ServerFactoryContext& factory_context,
                            bool validate_clusters) {
   for (const auto& virtual_host_config : route_config.virtual_hosts()) {
     VirtualHostSharedPtr virtual_host(new VirtualHostImpl(virtual_host_config, global_route_config,
@@ -1196,7 +1196,7 @@ VirtualHostImpl::virtualClusterFromEntries(const Http::HeaderMap& headers) const
 }
 
 ConfigImpl::ConfigImpl(const envoy::api::v2::RouteConfiguration& config,
-                       Server::Configuration::FactoryContext& factory_context,
+                       Server::Configuration::ServerFactoryContext& factory_context,
                        bool validate_clusters_default)
     : name_(config.name()), symbol_table_(factory_context.scope().symbolTable()),
       uses_vhds_(config.has_vhds()) {
@@ -1219,7 +1219,7 @@ namespace {
 RouteSpecificFilterConfigConstSharedPtr
 createRouteSpecificFilterConfig(const std::string& name, const ProtobufWkt::Any& typed_config,
                                 const ProtobufWkt::Struct& config,
-                                Server::Configuration::FactoryContext& factory_context) {
+                                Server::Configuration::ServerFactoryContext& factory_context) {
   auto& factory = Envoy::Config::Utility::getAndCheckFactory<
       Server::Configuration::NamedHttpFilterConfigFactory>(name);
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
@@ -1233,7 +1233,7 @@ createRouteSpecificFilterConfig(const std::string& name, const ProtobufWkt::Any&
 PerFilterConfigs::PerFilterConfigs(
     const Protobuf::Map<std::string, ProtobufWkt::Any>& typed_configs,
     const Protobuf::Map<std::string, ProtobufWkt::Struct>& configs,
-    Server::Configuration::FactoryContext& factory_context) {
+    Server::Configuration::ServerFactoryContext& factory_context) {
   if (!typed_configs.empty() && !configs.empty()) {
     throw EnvoyException("Only one of typed_configs or configs can be specified");
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -396,7 +396,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       strip_query_(route.redirect().strip_query()),
       hedge_policy_(buildHedgePolicy(vhost.hedgePolicy(), route.route())),
       retry_policy_(buildRetryPolicy(vhost.retryPolicy(), route.route(),
-                                     factory_context.serverMessageValidationVisitor())),
+                                     factory_context.messageValidationVisitor())),
       rate_limit_policy_(route.route().rate_limits()), shadow_policy_(route.route()),
       priority_(ConfigUtility::parsePriority(route.route().priority())),
       config_headers_(Http::HeaderUtility::buildHeaderDataVector(route.match().headers())),
@@ -1224,7 +1224,7 @@ createRouteSpecificFilterConfig(const std::string& name, const ProtobufWkt::Any&
       Server::Configuration::NamedHttpFilterConfigFactory>(name);
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   Envoy::Config::Utility::translateOpaqueConfig(
-      typed_config, config, factory_context.serverMessageValidationVisitor(), *proto_config);
+      typed_config, config, factory_context.messageValidationVisitor(), *proto_config);
   return factory.createRouteSpecificFilterConfig(*proto_config, factory_context);
 }
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -53,7 +53,7 @@ class PerFilterConfigs {
 public:
   PerFilterConfigs(const Protobuf::Map<std::string, ProtobufWkt::Any>& typed_configs,
                    const Protobuf::Map<std::string, ProtobufWkt::Struct>& configs,
-                   Server::Configuration::FactoryContext& factory_context);
+                   Server::Configuration::ServerFactoryContext& factory_context);
 
   const RouteSpecificFilterConfig* get(const std::string& name) const;
 
@@ -149,7 +149,7 @@ class VirtualHostImpl : public VirtualHost {
 public:
   VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtual_host,
                   const ConfigImpl& global_route_config,
-                  Server::Configuration::FactoryContext& factory_context, bool validate_clusters);
+                  Server::Configuration::ServerFactoryContext& factory_context, bool validate_clusters);
 
   RouteConstSharedPtr getRouteFromEntries(const Http::HeaderMap& headers,
                                           uint64_t random_value) const;
@@ -386,7 +386,7 @@ public:
    * @throw EnvoyException with reason if the route configuration contains any errors
    */
   RouteEntryImplBase(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
-                     Server::Configuration::FactoryContext& factory_context);
+                     Server::Configuration::ServerFactoryContext& factory_context);
 
   bool isDirectResponse() const { return direct_response_code_.has_value(); }
 
@@ -581,7 +581,7 @@ private:
   class WeightedClusterEntry : public DynamicRouteEntry {
   public:
     WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string rutime_key,
-                         Server::Configuration::FactoryContext& factory_context,
+                         Server::Configuration::ServerFactoryContext& factory_context,
                          const envoy::api::v2::route::WeightedCluster_ClusterWeight& cluster);
 
     uint64_t clusterWeight() const {
@@ -702,7 +702,7 @@ private:
 class PrefixRouteEntryImpl : public RouteEntryImplBase {
 public:
   PrefixRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
-                       Server::Configuration::FactoryContext& factory_context);
+                       Server::Configuration::ServerFactoryContext& factory_context);
 
   // Router::PathMatchCriterion
   const std::string& matcher() const override { return prefix_; }
@@ -724,7 +724,7 @@ private:
 class PathRouteEntryImpl : public RouteEntryImplBase {
 public:
   PathRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
-                     Server::Configuration::FactoryContext& factory_context);
+                     Server::Configuration::ServerFactoryContext& factory_context);
 
   // Router::PathMatchCriterion
   const std::string& matcher() const override { return path_; }
@@ -746,7 +746,7 @@ private:
 class RegexRouteEntryImpl : public RouteEntryImplBase {
 public:
   RegexRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
-                      Server::Configuration::FactoryContext& factory_context);
+                      Server::Configuration::ServerFactoryContext& factory_context);
 
   // Router::PathMatchCriterion
   const std::string& matcher() const override { return regex_str_; }
@@ -773,7 +773,7 @@ class RouteMatcher {
 public:
   RouteMatcher(const envoy::api::v2::RouteConfiguration& config,
                const ConfigImpl& global_http_config,
-               Server::Configuration::FactoryContext& factory_context, bool validate_clusters);
+               Server::Configuration::ServerFactoryContext& factory_context, bool validate_clusters);
 
   RouteConstSharedPtr route(const Http::HeaderMap& headers, uint64_t random_value) const;
 
@@ -809,7 +809,7 @@ private:
 class ConfigImpl : public Config {
 public:
   ConfigImpl(const envoy::api::v2::RouteConfiguration& config,
-             Server::Configuration::FactoryContext& factory_context,
+             Server::Configuration::ServerFactoryContext& factory_context,
              bool validate_clusters_default);
 
   const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -149,7 +149,8 @@ class VirtualHostImpl : public VirtualHost {
 public:
   VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtual_host,
                   const ConfigImpl& global_route_config,
-                  Server::Configuration::ServerFactoryContext& factory_context, bool validate_clusters);
+                  Server::Configuration::ServerFactoryContext& factory_context,
+                  bool validate_clusters);
 
   RouteConstSharedPtr getRouteFromEntries(const Http::HeaderMap& headers,
                                           uint64_t random_value) const;
@@ -773,7 +774,8 @@ class RouteMatcher {
 public:
   RouteMatcher(const envoy::api::v2::RouteConfiguration& config,
                const ConfigImpl& global_http_config,
-               Server::Configuration::ServerFactoryContext& factory_context, bool validate_clusters);
+               Server::Configuration::ServerFactoryContext& factory_context,
+               bool validate_clusters);
 
   RouteConstSharedPtr route(const Http::HeaderMap& headers, uint64_t random_value) const;
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -228,17 +228,17 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::createRdsRo
   // RdsRouteConfigSubscriptions are unique based on their serialized RDS config.
   const uint64_t manager_identifier = MessageUtil::hash(rds);
 
-
   auto it = dynamic_route_config_providers_.find(manager_identifier);
   if (it == dynamic_route_config_providers_.end()) {
     // std::make_shared does not work for classes with private constructors. There are ways
     // around it. However, since this is not a performance critical path we err on the side
     // of simplicity.
-    RdsRouteConfigSubscriptionSharedPtr subscription(new RdsRouteConfigSubscription(rds, manager_identifier, factory_context,
-                                                      stat_prefix, *this));
+    RdsRouteConfigSubscriptionSharedPtr subscription(new RdsRouteConfigSubscription(
+        rds, manager_identifier, factory_context, stat_prefix, *this));
     init_manager.add(subscription->init_target_);
-    std::shared_ptr<RdsRouteConfigProviderImpl> provider {new RdsRouteConfigProviderImpl(std::move(subscription), factory_context)};
-    dynamic_route_config_providers_.insert({manager_identifier, provider /* to_weak */}); 
+    std::shared_ptr<RdsRouteConfigProviderImpl> provider{
+        new RdsRouteConfigProviderImpl(std::move(subscription), factory_context)};
+    dynamic_route_config_providers_.insert({manager_identifier, provider /* to_weak */});
     return provider;
   } else {
     // Because the RouteConfigProviderManager's weak_ptrs only get cleaned up

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -65,7 +65,7 @@ RdsRouteConfigSubscription::RdsRouteConfigSubscription(
       stat_prefix_(stat_prefix), stats_({ALL_RDS_STATS(POOL_COUNTER(*scope_))}),
       route_config_provider_manager_(route_config_provider_manager),
       manager_identifier_(manager_identifier),
-      validation_visitor_(factory_context_.serverMessageValidationVisitor()) {
+      validation_visitor_(factory_context_.messageValidationVisitor()) {
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
           rds.config_source(),
@@ -73,7 +73,7 @@ RdsRouteConfigSubscription::RdsRouteConfigSubscription(
           *scope_, *this);
 
   config_update_info_ = std::make_unique<RouteConfigUpdateReceiverImpl>(
-      factory_context.timeSource(), factory_context.serverMessageValidationVisitor());
+      factory_context.timeSource(), factory_context.messageValidationVisitor());
 }
 
 RdsRouteConfigSubscription::~RdsRouteConfigSubscription() {

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -41,7 +41,7 @@ StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(
     const envoy::api::v2::RouteConfiguration& config,
     Server::Configuration::FactoryContext& factory_context,
     RouteConfigProviderManagerImpl& route_config_provider_manager)
-    : config_(new ConfigImpl(config, factory_context, true)), route_config_proto_{config},
+    : config_(new ConfigImpl(config, Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(factory_context), true)), route_config_proto_{config},
       last_updated_(factory_context.timeSource().systemTime()),
       route_config_provider_manager_(route_config_provider_manager) {
   route_config_provider_manager_.static_route_config_providers_.insert(this);
@@ -178,7 +178,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   ConfigConstSharedPtr initial_config;
   if (config_update_info_->configInfo().has_value()) {
     initial_config = std::make_shared<ConfigImpl>(config_update_info_->routeConfiguration(),
-                                                  factory_context_, false);
+                                                  Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(factory_context), false);
   } else {
     initial_config = std::make_shared<NullConfigImpl>();
   }
@@ -198,7 +198,7 @@ Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() {
 
 void RdsRouteConfigProviderImpl::onConfigUpdate() {
   ConfigConstSharedPtr new_config(
-      new ConfigImpl(config_update_info_->routeConfiguration(), factory_context_, false));
+      new ConfigImpl(config_update_info_->routeConfiguration(), Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(factory_context_), false));
   tls_->runOnAllThreads([new_config](ThreadLocal::ThreadLocalObjectSharedPtr previous)
                             -> ThreadLocal::ThreadLocalObjectSharedPtr {
     auto prev_config = std::dynamic_pointer_cast<ThreadLocalConfig>(previous);
@@ -210,7 +210,7 @@ void RdsRouteConfigProviderImpl::onConfigUpdate() {
 void RdsRouteConfigProviderImpl::validateConfig(
     const envoy::api::v2::RouteConfiguration& config) const {
   // TODO(lizan): consider cache the config here until onConfigUpdate.
-  ConfigImpl validation_config(config, factory_context_, false);
+  ConfigImpl validation_config(config, Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(factory_context_), false);
 }
 
 RouteConfigProviderManagerImpl::RouteConfigProviderManagerImpl(Server::Admin& admin) {

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -44,7 +44,7 @@ public:
    * @return RouteConfigProviderPtr a new route configuration provider based on the supplied proto
    *         configuration.
    */
-  static RouteConfigProviderPtr
+  static RouteConfigProviderSharedPtr
   create(const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
              config,
          Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
@@ -204,7 +204,7 @@ public:
   std::unique_ptr<envoy::admin::v2alpha::RoutesConfigDump> dumpRouteConfigs() const;
 
   // RouteConfigProviderManager
-  RouteConfigProviderPtr createRdsRouteConfigProvider(
+  RouteConfigProviderSharedPtr createRdsRouteConfigProvider(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
       Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
       Init::Manager& init_manager) override;
@@ -217,8 +217,8 @@ private:
   // TODO(jsedgwick) These two members are prime candidates for the owned-entry list/map
   // as in ConfigTracker. I.e. the ProviderImpls would have an EntryOwner for these lists
   // Then the lifetime management stuff is centralized and opaque.
-  std::unordered_map<uint64_t, std::weak_ptr<RdsRouteConfigSubscription>>
-      route_config_subscriptions_;
+  std::unordered_map<uint64_t, std::weak_ptr<RdsRouteConfigProviderImpl>>
+      dynamic_route_config_providers_;
   std::unordered_set<RouteConfigProvider*> static_route_config_providers_;
   Server::ConfigTracker::EntryOwnerPtr config_tracker_entry_;
 

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -112,6 +112,9 @@ public:
   }
   RouteConfigUpdatePtr& routeConfigUpdate() { return config_update_info_; }
 
+  // TODO(lambdai): return belonged RDSConfigProvider's init manager
+  Init::Manager& getRdsConfigInitManager() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+
 private:
   // Config::SubscriptionCallbacks
   void onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,
@@ -131,7 +134,8 @@ private:
 
   RdsRouteConfigSubscription(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
-      const uint64_t manager_identifier, Server::Configuration::FactoryContext& factory_context,
+      const uint64_t manager_identifier,
+      Server::Configuration::ServerFactoryContext& server_factory_context,
       const std::string& stat_prefix,
       RouteConfigProviderManagerImpl& route_config_provider_manager);
 
@@ -139,7 +143,7 @@ private:
 
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
   const std::string route_config_name_;
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::Configuration::ServerFactoryContext& factory_context_;
   // Server::Configuration::ServerFactoryContext& get_factory_context_;
   Init::SharedTargetImpl init_target_;
   Stats::ScopePtr scope_;

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -199,7 +199,7 @@ private:
 
   RdsRouteConfigSubscriptionSharedPtr subscription_;
   RouteConfigUpdatePtr& config_update_info_;
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::Configuration::ServerFactoryContext& factory_context_;
   ThreadLocal::SlotPtr tls_;
 
   friend class RouteConfigProviderManagerImpl;

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -140,7 +140,8 @@ private:
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
   const std::string route_config_name_;
   Server::Configuration::FactoryContext& factory_context_;
-  Init::TargetImpl init_target_;
+  // Server::Configuration::ServerFactoryContext& get_factory_context_;
+  Init::SharedTargetImpl init_target_;
   Stats::ScopePtr scope_;
   std::string stat_prefix_;
   RdsStats stats_;
@@ -178,6 +179,10 @@ public:
   SystemTime lastUpdated() const override { return config_update_info_->lastUpdated(); }
   void onConfigUpdate() override;
   void validateConfig(const envoy::api::v2::RouteConfiguration& config) const override;
+
+  Server::Configuration::ServerFactoryContext& getServerFactoryContext() {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
 
 private:
   struct ThreadLocalConfig : public ThreadLocal::ThreadLocalObject {

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -116,7 +116,7 @@ ScopedRdsConfigSubscription::RdsRouteConfigProviderHelper::RdsRouteConfigProvide
           parent_.route_config_provider_manager_
               .createRdsRouteConfigProvider(rds, parent_.factory_context_, parent_.stat_prefix_,
                                             init_manager)
-              .release())),
+              .get())),
       rds_update_callback_handle_(route_provider_->subscription().addUpdateCallback([this]() {
         // Subscribe to RDS update.
         parent_.onRdsConfigUpdate(scope_name_, route_provider_->subscription());

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -262,11 +262,9 @@ void ScopedRdsConfigSubscription::onRdsConfigUpdate(const std::string& scope_nam
          fmt::format("trying to update route config for non-existing scope {}", scope_name));
   auto new_scoped_route_info = std::make_shared<ScopedRouteInfo>(
       envoy::api::v2::ScopedRouteConfiguration(iter->second->configProto()),
-      std::make_shared<ConfigImpl>(
-          rds_subscription.routeConfigUpdate()->routeConfiguration(),
-          Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(
-              factory_context_),
-          false));
+      std::make_shared<ConfigImpl>(rds_subscription.routeConfigUpdate()->routeConfiguration(),
+                                   factory_context_.getServerFactoryContext(/*is_dynamic=*/false),
+                                   false));
   applyConfigUpdate([new_scoped_route_info](ConfigProvider::ConfigConstSharedPtr config)
                         -> ConfigProvider::ConfigConstSharedPtr {
     auto* thread_local_scoped_config =

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -263,7 +263,7 @@ void ScopedRdsConfigSubscription::onRdsConfigUpdate(const std::string& scope_nam
   auto new_scoped_route_info = std::make_shared<ScopedRouteInfo>(
       envoy::api::v2::ScopedRouteConfiguration(iter->second->configProto()),
       std::make_shared<ConfigImpl>(rds_subscription.routeConfigUpdate()->routeConfiguration(),
-                                   factory_context_, false));
+                                   Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(factory_context_), false));
   applyConfigUpdate([new_scoped_route_info](ConfigProvider::ConfigConstSharedPtr config)
                         -> ConfigProvider::ConfigConstSharedPtr {
     auto* thread_local_scoped_config =

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -262,8 +262,11 @@ void ScopedRdsConfigSubscription::onRdsConfigUpdate(const std::string& scope_nam
          fmt::format("trying to update route config for non-existing scope {}", scope_name));
   auto new_scoped_route_info = std::make_shared<ScopedRouteInfo>(
       envoy::api::v2::ScopedRouteConfiguration(iter->second->configProto()),
-      std::make_shared<ConfigImpl>(rds_subscription.routeConfigUpdate()->routeConfiguration(),
-                                   Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(factory_context_), false));
+      std::make_shared<ConfigImpl>(
+          rds_subscription.routeConfigUpdate()->routeConfiguration(),
+          Server::Configuration::ServerFactoryCxtUtil::generateServerFactoryContext(
+              factory_context_),
+          false));
   applyConfigUpdate([new_scoped_route_info](ConfigProvider::ConfigConstSharedPtr config)
                         -> ConfigProvider::ConfigConstSharedPtr {
     auto* thread_local_scoped_config =

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -168,6 +168,11 @@ private:
   absl::flat_hash_map<uint64_t, std::string> scope_name_by_hash_;
   // For creating RDS subscriptions.
   Server::Configuration::FactoryContext& factory_context_;
+  // Init::ManagerImpl init_manager;
+
+  // For notifying parent init manager
+  // Init::TargetImpl init_target;
+
   const std::string name_;
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
   const envoy::config::filter::network::http_connection_manager::v2::ScopedRoutes::ScopeKeyBuilder

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -19,7 +19,7 @@ namespace Router {
 
 // Implements callbacks to handle DeltaDiscovery protocol for VirtualHostDiscoveryService
 VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
-                                   Server::Configuration::FactoryContext& factory_context,
+                                   Server::Configuration::ServerFactoryContext& factory_context,
                                    const std::string& stat_prefix,
                                    std::unordered_set<RouteConfigProvider*>& route_config_providers)
     : config_update_info_(config_update_info),

--- a/source/common/router/vhds.h
+++ b/source/common/router/vhds.h
@@ -41,7 +41,7 @@ class VhdsSubscription : Envoy::Config::SubscriptionCallbacks,
                          Logger::Loggable<Logger::Id::router> {
 public:
   VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
-                   Server::Configuration::FactoryContext& factory_context,
+                   Server::Configuration::ServerFactoryContext& factory_context,
                    const std::string& stat_prefix,
                    std::unordered_set<RouteConfigProvider*>& route_config_providers);
   ~VhdsSubscription() override { init_target_.ready(); }

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -39,7 +39,7 @@ BufferFilterFactory::createFilterFactory(const Json::Object& json_config,
 Router::RouteSpecificFilterConfigConstSharedPtr
 BufferFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::config::filter::http::buffer::v2::BufferPerRoute& proto_config,
-    Server::Configuration::FactoryContext&) {
+    Server::Configuration::ServerFactoryContext&) {
   return std::make_shared<const BufferFilterSettings>(proto_config);
 }
 

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -31,7 +31,7 @@ private:
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::config::filter::http::buffer::v2::BufferPerRoute&,
-      Server::Configuration::FactoryContext&) override;
+      Server::Configuration::ServerFactoryContext&) override;
 };
 
 } // namespace BufferFilter

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -43,7 +43,7 @@ public:
                                   Server::Configuration::ServerFactoryContext& context) override {
     return createRouteSpecificFilterConfigTyped(
         MessageUtil::downcastAndValidate<const RouteConfigProto&>(
-            proto_config, context.serverMessageValidationVisitor()),
+            proto_config, context.messageValidationVisitor()),
         context);
   }
 

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -43,7 +43,7 @@ public:
                                   Server::Configuration::ServerFactoryContext& context) override {
     return createRouteSpecificFilterConfigTyped(
         MessageUtil::downcastAndValidate<const RouteConfigProto&>(
-            proto_config, context.messageValidationVisitor()),
+            proto_config, context.serverMessageValidationVisitor()),
         context);
   }
 

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -40,7 +40,7 @@ public:
 
   Router::RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfig(const Protobuf::Message& proto_config,
-                                  Server::Configuration::FactoryContext& context) override {
+                                  Server::Configuration::ServerFactoryContext& context) override {
     return createRouteSpecificFilterConfigTyped(
         MessageUtil::downcastAndValidate<const RouteConfigProto&>(
             proto_config, context.messageValidationVisitor()),
@@ -60,7 +60,7 @@ private:
 
   virtual Router::RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfigTyped(const RouteConfigProto&,
-                                       Server::Configuration::FactoryContext&) {
+                                       Server::Configuration::ServerFactoryContext&) {
     return nullptr;
   }
 

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -23,7 +23,7 @@ Http::FilterFactoryCb CsrfFilterFactory::createFilterFactoryFromProtoTyped(
 Router::RouteSpecificFilterConfigConstSharedPtr
 CsrfFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context) {
   return std::make_shared<const Csrf::CsrfPolicy>(policy, context.runtime());
 }
 

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -26,7 +26,7 @@ private:
                                     Server::Configuration::FactoryContext& context) override;
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace Csrf

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -61,7 +61,7 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
 Router::RouteSpecificFilterConfigConstSharedPtr
 ExtAuthzFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::config::filter::http::ext_authz::v2::ExtAuthzPerRoute& proto_config,
-    Server::Configuration::FactoryContext&) {
+    Server::Configuration::ServerFactoryContext&) {
   return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -28,7 +28,7 @@ private:
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::config::filter::http::ext_authz::v2::ExtAuthzPerRoute& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace ExtAuthz

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -34,7 +34,7 @@ FaultFilterFactory::createFilterFactory(const Json::Object& json_config,
 Router::RouteSpecificFilterConfigConstSharedPtr
 FaultFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::config::filter::http::fault::v2::HTTPFault& config,
-    Server::Configuration::FactoryContext&) {
+    Server::Configuration::ServerFactoryContext&) {
   return std::make_shared<const Fault::FaultSettings>(config);
 }
 

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -30,7 +30,7 @@ private:
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::config::filter::http::fault::v2::HTTPFault& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace Fault

--- a/source/extensions/filters/http/rbac/config.cc
+++ b/source/extensions/filters/http/rbac/config.cc
@@ -24,7 +24,7 @@ Http::FilterFactoryCb RoleBasedAccessControlFilterConfigFactory::createFilterFac
 Router::RouteSpecificFilterConfigConstSharedPtr
 RoleBasedAccessControlFilterConfigFactory::createRouteSpecificFilterConfigTyped(
     const envoy::config::filter::http::rbac::v2::RBACPerRoute& proto_config,
-    Server::Configuration::FactoryContext&) {
+    Server::Configuration::ServerFactoryContext&) {
   return std::make_shared<const RoleBasedAccessControlRouteSpecificFilterConfig>(proto_config);
 }
 

--- a/source/extensions/filters/http/rbac/config.h
+++ b/source/extensions/filters/http/rbac/config.h
@@ -28,7 +28,7 @@ private:
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::config::filter::http::rbac::v2::RBACPerRoute& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace RBACFilter

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -178,7 +178,7 @@ private:
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_;
   std::chrono::milliseconds request_timeout_;
-  Router::RouteConfigProviderPtr route_config_provider_;
+  Router::RouteConfigProviderSharedPtr route_config_provider_;
   Config::ConfigProviderPtr scoped_routes_config_provider_;
   std::chrono::milliseconds drain_timeout_;
   bool generate_request_id_;

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -52,7 +52,9 @@ ValidationInstance::ValidationInstance(const Options& options, Event::TimeSystem
       access_log_manager_(options.fileFlushIntervalMsec(), *api_, *dispatcher_, access_log_lock,
                           store),
       mutex_tracer_(nullptr), grpc_context_(stats_store_.symbolTable()),
-      http_context_(stats_store_.symbolTable()), time_system_(time_system) {
+      http_context_(stats_store_.symbolTable()), time_system_(time_system),
+      dynamic_server_context_(*this, /*is_dynamic=*/true),
+      static_server_context_(*this, /*is_dynamic=*/false) {
   try {
     initialize(options, local_address, component_factory);
   } catch (const EnvoyException& e) {

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -108,6 +108,10 @@ public:
     return validation_context_;
   }
 
+  Configuration::ServerFactoryContext& serverFactoryContext(bool is_dynamic) override {
+    return is_dynamic ? dynamic_server_context_ : static_server_context_;
+  }
+
   // Server::ListenerComponentFactory
   LdsApiPtr createLdsApi(const envoy::api::v2::core::ConfigSource& lds_config) override {
     return std::make_unique<LdsApiImpl>(lds_config, clusterManager(), initManager(), stats(),
@@ -193,6 +197,8 @@ private:
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;
   Event::TimeSystem& time_system_;
+  ServerFactoryContextImpl dynamic_server_context_;
+  ServerFactoryContextImpl static_server_context_;
 };
 
 } // namespace Server

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -96,7 +96,7 @@ public:
   Http::Context& httpContext() override { return http_context_; }
   ProcessContext& processContext() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
-  const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
+  const LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return api_->timeSource(); }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
 

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -192,7 +192,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                            ListenerManagerImpl& parent, const std::string& name, bool added_via_api,
                            bool workers_started, uint64_t hash,
                            ProtobufMessage::ValidationVisitor& validation_visitor)
-    : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
+    : parent_(parent), server_factory_context_(parent.server_factory_context_),
+      address_(Network::Address::resolveProtoAddress(config.address())),
       filter_chain_manager_(address_),
       socket_type_(Network::Utility::protobufAddressSocketType(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
@@ -341,6 +342,8 @@ ListenerImpl::~ListenerImpl() {
   init_watcher_.reset();
 }
 
+Configuration::FactoryContext* ListenerImpl::getServerContext() { return &server_factory_context_; }
+
 namespace {
 
 // Template function for creating a CIDR list entry for either source or destination address.
@@ -439,7 +442,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
                                          ListenerComponentFactory& listener_factory,
                                          WorkerFactory& worker_factory,
                                          bool enable_dispatcher_stats)
-    : server_(server), factory_(listener_factory),
+    : server_(server), server_factory_context_(server), factory_(listener_factory),
       scope_(server.stats().createScope("listener_manager.")), stats_(generateStats(*scope_)),
       config_tracker_entry_(server.admin().getConfigTracker().add(
           "listeners", [this] { return dumpListenerConfigs(); })),

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -192,8 +192,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                            ListenerManagerImpl& parent, const std::string& name, bool added_via_api,
                            bool workers_started, uint64_t hash,
                            ProtobufMessage::ValidationVisitor& validation_visitor)
-    : parent_(parent), server_factory_context_(parent.server_factory_context_),
-      address_(Network::Address::resolveProtoAddress(config.address())),
+    : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
       filter_chain_manager_(address_),
       socket_type_(Network::Utility::protobufAddressSocketType(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
@@ -342,7 +341,9 @@ ListenerImpl::~ListenerImpl() {
   init_watcher_.reset();
 }
 
-Configuration::FactoryContext* ListenerImpl::getServerContext() { return &server_factory_context_; }
+Configuration::ServerFactoryContext& ListenerImpl::getServerFactoryContext(bool is_dynamic) const {
+  return parent_.server_.serverFactoryContext(is_dynamic);
+}
 
 namespace {
 
@@ -442,7 +443,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
                                          ListenerComponentFactory& listener_factory,
                                          WorkerFactory& worker_factory,
                                          bool enable_dispatcher_stats)
-    : server_(server), server_factory_context_(server), factory_(listener_factory),
+    : server_(server), factory_(listener_factory),
       scope_(server.stats().createScope("listener_manager.")), stats_(generateStats(*scope_)),
       config_tracker_entry_(server.admin().getConfigTracker().add(
           "listeners", [this] { return dumpListenerConfigs(); })),

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -114,54 +114,6 @@ struct ListenerManagerStats {
   ALL_LISTENER_MANAGER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-class ServerFactoryContextImpl : public Configuration::FactoryContext {
-public:
-  explicit ServerFactoryContextImpl(Instance& server)
-      : server_(server), server_scope_(server_.stats().createScope("")) {}
-
-  // Server::Configuration::ListenerFactoryContext
-  AccessLog::AccessLogManager& accessLogManager() override { return server_.accessLogManager(); }
-  Upstream::ClusterManager& clusterManager() override { return server_.clusterManager(); }
-  Event::Dispatcher& dispatcher() override { return server_.dispatcher(); }
-  Grpc::Context& grpcContext() override { return server_.grpcContext(); }
-  bool healthCheckFailed() override { return server_.healthCheckFailed(); }
-  Tracing::HttpTracer& httpTracer() override { return httpContext().tracer(); }
-  Http::Context& httpContext() override { return server_.httpContext(); }
-  const LocalInfo::LocalInfo& localInfo() const override { return server_.localInfo(); }
-  Envoy::Runtime::RandomGenerator& random() override { return server_.random(); }
-  Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
-  Singleton::Manager& singletonManager() override { return server_.singletonManager(); }
-  OverloadManager& overloadManager() override { return server_.overloadManager(); }
-  ThreadLocal::Instance& threadLocal() override { return server_.threadLocal(); }
-  Admin& admin() override { return server_.admin(); }
-  TimeSource& timeSource() override { return api().timeSource(); }
-  Api::Api& api() override { return server_.api(); }
-  ServerLifecycleNotifier& lifecycleNotifier() override { return server_.lifecycleNotifier(); }
-  ProcessContext& processContext() override { return server_.processContext(); }
-
-  // ugly
-  virtual Stats::Scope& scope() override { return *server_scope_; }
-  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  virtual envoy::api::v2::core::TrafficDirection direction() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  virtual const Network::DrainDecision& drainDecision() override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  virtual Init::Manager& initManager() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  virtual Stats::Scope& listenerScope() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  virtual const envoy::api::v2::core::Metadata& listenerMetadata() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  virtual Configuration::FactoryContext* getServerContext() override { return this; }
-
-private:
-  Instance& server_;
-  Stats::ScopePtr server_scope_;
-};
-
 /**
  * Implementation of ListenerManager.
  */
@@ -188,7 +140,6 @@ public:
   Http::Context& httpContext() { return server_.httpContext(); }
 
   Instance& server_;
-  ServerFactoryContextImpl server_factory_context_;
   ListenerComponentFactory& factory_;
 
 private:
@@ -334,36 +285,30 @@ public:
 
   // Server::Configuration::ListenerFactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {
-    return server_factory_context_.accessLogManager();
+    return parent_.server_.accessLogManager();
   }
-  Upstream::ClusterManager& clusterManager() override {
-    return server_factory_context_.clusterManager();
-  }
-  Event::Dispatcher& dispatcher() override { return server_factory_context_.dispatcher(); }
-  Grpc::Context& grpcContext() override { return server_factory_context_.grpcContext(); }
-  bool healthCheckFailed() override { return server_factory_context_.healthCheckFailed(); }
+  Upstream::ClusterManager& clusterManager() override { return parent_.server_.clusterManager(); }
+  Event::Dispatcher& dispatcher() override { return parent_.server_.dispatcher(); }
+  Grpc::Context& grpcContext() override { return parent_.server_.grpcContext(); }
+  bool healthCheckFailed() override { return parent_.server_.healthCheckFailed(); }
   Tracing::HttpTracer& httpTracer() override { return httpContext().tracer(); }
-  Http::Context& httpContext() override { return server_factory_context_.httpContext(); }
-  const LocalInfo::LocalInfo& localInfo() const override {
-    return server_factory_context_.localInfo();
-  }
-  Envoy::Runtime::RandomGenerator& random() override { return server_factory_context_.random(); }
-  Envoy::Runtime::Loader& runtime() override { return server_factory_context_.runtime(); }
-  Singleton::Manager& singletonManager() override {
-    return server_factory_context_.singletonManager();
-  }
-  OverloadManager& overloadManager() override { return server_factory_context_.overloadManager(); }
-  ThreadLocal::Instance& threadLocal() override { return server_factory_context_.threadLocal(); }
-  Admin& admin() override { return server_factory_context_.admin(); }
+  Http::Context& httpContext() override { return parent_.server_.httpContext(); }
+  const LocalInfo::LocalInfo& localInfo() const override { return parent_.server_.localInfo(); }
+  Envoy::Runtime::RandomGenerator& random() override { return parent_.server_.random(); }
+  Envoy::Runtime::Loader& runtime() override { return parent_.server_.runtime(); }
+  Singleton::Manager& singletonManager() override { return parent_.server_.singletonManager(); }
+  OverloadManager& overloadManager() override { return parent_.server_.overloadManager(); }
+  ThreadLocal::Instance& threadLocal() override { return parent_.server_.threadLocal(); }
+  Admin& admin() override { return parent_.server_.admin(); }
   TimeSource& timeSource() override { return api().timeSource(); }
-  Api::Api& api() override { return server_factory_context_.api(); }
+  Api::Api& api() override { return parent_.server_.api(); }
   ServerLifecycleNotifier& lifecycleNotifier() override {
-    return server_factory_context_.lifecycleNotifier();
+    return parent_.server_.lifecycleNotifier();
   }
-  ProcessContext& processContext() override { return server_factory_context_.processContext(); }
+  ProcessContext& processContext() override { return parent_.server_.processContext(); }
 
   // Overrided Servers
-  virtual Configuration::FactoryContext* getServerContext() override;
+  Configuration::ServerFactoryContext& getServerFactoryContext(bool is_dynamic) const override;
   Network::DrainDecision& drainDecision() override { return *this; }
   Stats::Scope& scope() override { return *global_scope_; }
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
@@ -408,7 +353,6 @@ private:
   }
 
   ListenerManagerImpl& parent_;
-  ServerFactoryContextImpl& server_factory_context_;
 
   Network::Address::InstanceConstSharedPtr address_;
   FilterChainManagerImpl filter_chain_manager_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -74,7 +74,9 @@ InstanceImpl::InstanceImpl(const Options& options, Event::TimeSystem& time_syste
       mutex_tracer_(options.mutexTracingEnabled() ? &Envoy::MutexTracerImpl::getOrCreateTracer()
                                                   : nullptr),
       grpc_context_(store.symbolTable()), http_context_(store.symbolTable()),
-      process_context_(std::move(process_context)), main_thread_id_(std::this_thread::get_id()) {
+      process_context_(std::move(process_context)), main_thread_id_(std::this_thread::get_id()),
+      dynamic_server_context_(*this, /*is_dynamic=*/true),
+      static_server_context_(*this, /*is_dynamic=*/false) {
   try {
     if (!options.logPath().empty()) {
       try {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -147,7 +147,7 @@ class ServerFactoryContextImpl : public Configuration::ServerFactoryContext {
 public:
   explicit ServerFactoryContextImpl(Instance& server, bool is_dynamic)
       : server_(server), server_scope_(server_.stats().createScope("")),
-        validation_visitor_(is_dynamic_
+        validation_visitor_(is_dynamic
                                 ? server_.messageValidationContext().dynamicValidationVisitor()
                                 : server_.messageValidationContext().staticValidationVisitor()) {}
 
@@ -165,11 +165,6 @@ public:
   Admin& admin() override { return server_.admin(); }
   TimeSource& timeSource() override { return api().timeSource(); }
   Api::Api& api() override { return server_.api(); }
-
-  // TODO: delete it soon
-  ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() override {
-    return messageValidationVisitor();
-  }
 
 private:
   Instance& server_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -200,11 +200,8 @@ public:
   const LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }
 
-  // TODO(lambdai): implement it
-  Stats::Scope& scope() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  Stats::Scope& scope() override { return stats(); }
+
   std::chrono::milliseconds statsFlushInterval() const override {
     return config_.statsFlushInterval();
   }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -141,13 +141,47 @@ private:
   Event::SignalEventPtr sig_hup_;
 };
 
+class InstanceImpl;
+
+class ServerFactoryContextImpl : public Configuration::ServerFactoryContext {
+public:
+  explicit ServerFactoryContextImpl(Instance& server, bool is_dynamic_)
+      : server_(server), server_scope_(server_.stats().createScope("")),
+        validation_visitor_(is_dynamic_
+                                ? server_.messageValidationContext().dynamicValidationVisitor()
+                                : server_.messageValidationContext().staticValidationVisitor()) {}
+
+  Upstream::ClusterManager& clusterManager() override { return server_.clusterManager(); }
+  Event::Dispatcher& dispatcher() override { return server_.dispatcher(); }
+  const LocalInfo::LocalInfo& localInfo() const override { return server_.localInfo(); }
+  Envoy::Runtime::RandomGenerator& random() override { return server_.random(); }
+  Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
+  Stats::Scope& scope() override { return *server_scope_; }
+  Singleton::Manager& singletonManager() override { return server_.singletonManager(); }
+  ThreadLocal::Instance& threadLocal() override { return server_.threadLocal(); }
+  virtual ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    return validation_visitor_;
+  }
+  Admin& admin() override { return server_.admin(); }
+  TimeSource& timeSource() override { return api().timeSource(); }
+  Api::Api& api() override { return server_.api(); }
+
+  // TODO: delete it soon
+  ProtobufMessage::ValidationVisitor& serverMessageValidationVisitor() override {
+    return messageValidationVisitor();
+  }
+
+private:
+  Instance& server_;
+  Stats::ScopePtr server_scope_;
+  ProtobufMessage::ValidationVisitor& validation_visitor_;
+};
 /**
  * This is the actual full standalone server which stitches together various common components.
  */
 class InstanceImpl : Logger::Loggable<Logger::Id::main>,
                      public Instance,
-                     public ServerLifecycleNotifier,
-                     public Configuration::ServerFactoryContext {
+                     public ServerLifecycleNotifier {
 public:
   /**
    * @throw EnvoyException if initialization fails.
@@ -199,8 +233,9 @@ public:
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }
-
-  Stats::Scope& scope() override { return stats(); }
+  Configuration::ServerFactoryContext& serverFactoryContext(bool is_dynamic) override {
+    return is_dynamic ? dynamic_server_context_ : static_server_context_;
+  }
 
   std::chrono::milliseconds statsFlushInterval() const override {
     return config_.statsFlushInterval();
@@ -286,6 +321,9 @@ private:
   // initialization_time is a histogram for tracking the initialization time across hot restarts
   // whenever we have support for histogram merge across hot restarts.
   Stats::TimespanPtr initialization_timer_;
+
+  ServerFactoryContextImpl dynamic_server_context_;
+  ServerFactoryContextImpl static_server_context_;
 
   using LifecycleNotifierCallbacks = std::list<StageCallback>;
   using LifecycleNotifierCompletionCallbacks = std::list<StageCallbackWithCompletion>;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -145,7 +145,7 @@ class InstanceImpl;
 
 class ServerFactoryContextImpl : public Configuration::ServerFactoryContext {
 public:
-  explicit ServerFactoryContextImpl(Instance& server, bool is_dynamic_)
+  explicit ServerFactoryContextImpl(Instance& server, bool is_dynamic)
       : server_(server), server_scope_(server_.stats().createScope("")),
         validation_visitor_(is_dynamic_
                                 ? server_.messageValidationContext().dynamicValidationVisitor()

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -146,7 +146,8 @@ private:
  */
 class InstanceImpl : Logger::Loggable<Logger::Id::main>,
                      public Instance,
-                     public ServerLifecycleNotifier {
+                     public ServerLifecycleNotifier,
+                     public Configuration::ServerFactoryContext {
 public:
   /**
    * @throw EnvoyException if initialization fails.
@@ -196,9 +197,14 @@ public:
   Http::Context& httpContext() override { return http_context_; }
   ProcessContext& processContext() override { return *process_context_; }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
-  const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
+  const LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }
 
+  // TODO(lambdai): implement it
+  Stats::Scope& scope() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   std::chrono::milliseconds statsFlushInterval() const override {
     return config_.statsFlushInterval();
   }

--- a/test/common/init/BUILD
+++ b/test/common/init/BUILD
@@ -20,6 +20,7 @@ envoy_cc_test(
     name = "target_impl_test",
     srcs = ["target_impl_test.cc"],
     deps = [
+        "//source/common/init:manager_lib",
         "//test/mocks/init:init_mocks",
     ],
 )

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -108,7 +108,7 @@ public:
   NiceMock<Stats::MockStore> scope_;
   NiceMock<Server::MockInstance> server_;
   std::unique_ptr<RouteConfigProviderManagerImpl> route_config_provider_manager_;
-  RouteConfigProviderPtr rds_;
+  RouteConfigProviderSharedPtr rds_;
 };
 
 TEST_F(RdsImplTest, RdsAndStatic) {
@@ -280,7 +280,7 @@ public:
 
   envoy::config::filter::network::http_connection_manager::v2::Rds rds_;
   std::unique_ptr<RouteConfigProviderManagerImpl> route_config_provider_manager_;
-  RouteConfigProviderPtr provider_;
+  RouteConfigProviderSharedPtr provider_;
 };
 
 envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
@@ -415,12 +415,15 @@ virtual_hosts:
   factory_context_.cluster_manager_.subscription_factory_.callbacks_->onConfigUpdate(route_configs,
                                                                                      "1");
 
-  RouteConfigProviderPtr provider2 = route_config_provider_manager_->createRdsRouteConfigProvider(
-      rds_, factory_context_, "foo_prefix", factory_context_.initManager());
+  RouteConfigProviderSharedPtr provider2 =
+      route_config_provider_manager_->createRdsRouteConfigProvider(
+          rds_, factory_context_, "foo_prefix", factory_context_.initManager());
 
   // provider2 should have route config immediately after create
   EXPECT_TRUE(provider2->configInfo().has_value());
 
+  EXPECT_EQ(provider_.get(), provider2.get())
+      << "same rds config provider object should be generate";
   // So this means that both provider have same subscription.
   EXPECT_EQ(&dynamic_cast<RdsRouteConfigProviderImpl&>(*provider_).subscription(),
             &dynamic_cast<RdsRouteConfigProviderImpl&>(*provider2).subscription());
@@ -429,8 +432,9 @@ virtual_hosts:
   envoy::config::filter::network::http_connection_manager::v2::Rds rds2;
   rds2.set_route_config_name("foo_route_config");
   rds2.mutable_config_source()->set_path("bar_path");
-  RouteConfigProviderPtr provider3 = route_config_provider_manager_->createRdsRouteConfigProvider(
-      rds2, factory_context_, "foo_prefix", factory_context_.initManager());
+  RouteConfigProviderSharedPtr provider3 =
+      route_config_provider_manager_->createRdsRouteConfigProvider(
+          rds2, factory_context_, "foo_prefix", factory_context_.initManager());
   EXPECT_NE(provider3, provider_);
   factory_context_.cluster_manager_.subscription_factory_.callbacks_->onConfigUpdate(route_configs,
                                                                                      "provider3");

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -402,7 +402,7 @@ public:
   ~MockRouteConfigProviderManager() override;
 
   MOCK_METHOD4(createRdsRouteConfigProvider,
-               RouteConfigProviderPtr(
+               RouteConfigProviderSharedPtr(
                    const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
                    Server::Configuration::FactoryContext& factory_context,
                    const std::string& stat_prefix, Init::Manager& init_manager));


### PR DESCRIPTION
Description: 
Introduce `ServerFactoryContext` which is an implementation of `CommonFactoryContext`. Comparing to `ListenerFactoryContext`, `ServerFactoryContext` has a wider lifetime.
In this PR I also prove `ServerFactoryContext` would allow multiple listeners share a `RdsConfigProvider` and save huge of memory and CPU 
[x] Compile envoy-static with `ServerFactoryContext`: RdsConfigProvider, PerFilterConfig, Route, VhdsSubscription should use `ServerFactoryContext`
[ ] Safely implement ServerFactoryCxtUtil::generateServerFactoryContext
[ ] Server::Instance should implement `ServerFactoryContext`
[ ] RdsConfigProvider should own RdsSubscription
[ ] RdsConfigProvider should be able to notify multiple listeners and listeners could wait on RdsProvider in ready state
[ ] tons of broken tests due to signature change

Risk Level:
Testing:
Docs Changes:
Release Notes:
Fixes #8303
