### PR TITLE
build: Fix msan use-of-unitialized-value in router

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -445,11 +445,14 @@ void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
 }
 
 absl::string_view RouteEntryImplBase::processRequestHost(const Http::HeaderMap& headers,
-                                                         const absl::string_view& new_scheme,
-                                                         const absl::string_view& new_port) const {
+                                                         absl::string_view new_scheme,
+                                                         absl::string_view new_port) const {
 
   absl::string_view request_host = headers.Host()->value().getStringView();
   size_t host_end;
+  if (request_host.empty()) {
+    return request_host;
+  }
   // Detect if IPv6 URI
   if (request_host[0] == '[') {
     host_end = request_host.rfind("]:");

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -423,9 +423,8 @@ public:
 
   // Router::DirectResponseEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
-  absl::string_view processRequestHost(const Http::HeaderMap& headers,
-                                       const absl::string_view& new_scheme,
-                                       const absl::string_view& new_port) const;
+  absl::string_view processRequestHost(const Http::HeaderMap& headers, absl::string_view new_scheme,
+                                       absl::string_view new_port) const;
   void rewritePathHeader(Http::HeaderMap&, bool) const override {}
   Http::Code responseCode() const override { return direct_response_code_.value(); }
   const std::string& responseBody() const override { return direct_response_body_; }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Sending an HTTP/1.1 request with an empty host to an Envoy with redirect configured causes a use-of-unitialized-value when processing the request host.
This was caught running msan in google.

Also fixes unneeded `const absl::string_view&` parameters

Risk level: Low

05888==WARNING: MemorySanitizer: use-of-uninitialized-value
  | #0 0x5622c8c8062a in Envoy::Router::RouteEntryImplBase::processRequestHost(Envoy::Http::HeaderMap const&, absl::string_view const&, absl::string_view const&) const third_party/envoy/src/source/common/router/config_impl.cc:590:7
  | #1 0x5622c8c80cb2 in Envoy::Router::RouteEntryImplBase::newPath(Envoy::Http::HeaderMap const&) const third_party/envoy/src/source/common/router/config_impl.cc:646:18
  | #2 0x5622c8c81b07 in non-virtual thunk to Envoy::Router::RouteEntryImplBase::newPath(Envoy::Http::HeaderMap const&) const third_party/envoy/src/source/common/router/config_impl.cc
  | #3 0x5622c8c61723 in Envoy::Router::Filter::decodeHeaders(Envoy::Http::HeaderMap&, bool)::$_1::operator()(Envoy::Http::HeaderMap&) const third_party/envoy/src/source/common/router/router.cc:366:50
  | #4 0x5622c79f8df7 in Envoy::Http::ConnectionManagerImpl::ActiveStream::sendLocalReply(bool, Envoy::Http::Code, absl::string_view, std::__msan::function<void (Envoy::Http::HeaderMap&)> const&, bool, std::__msan::optional<Envoy::Grpc::Status::GrpcStatus>, absl::string_view)::$_5::operator()(std::__msan::unique_ptr<Envoy::Http::HeaderMap, std::__msan::default_delete<Envoy::Http::HeaderMap> >&&, bool) const third_party/envoy/src/source/common/http/conn_manager_impl.cc:1303:11


