### PR TITLE
grpc: move ifdefs out of headers.

### DIFF
--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -13,13 +13,16 @@ namespace Envoy {
 namespace Grpc {
 
 GoogleGrpcContext::GoogleGrpcContext() : instance_tracker_(instanceTracker()) {
+#ifdef ENVOY_GOOGLE_GRPC
   Thread::LockGuard lock(instance_tracker_.mutex_);
   if (++instance_tracker_.live_instances_ == 1) {
     grpc_init();
   }
+#endif
 }
 
 GoogleGrpcContext::~GoogleGrpcContext() {
+#ifdef ENVOY_GOOGLE_GRPC
   // Per https://github.com/grpc/grpc/issues/20303 it is OK to call
   // grpc_shutdown_blocking() as long as no one can concurrently call
   // grpc_init(). We use check_format.py to ensure that this file contains the
@@ -30,6 +33,7 @@ GoogleGrpcContext::~GoogleGrpcContext() {
   if (--instance_tracker_.live_instances_ == 0) {
     grpc_shutdown_blocking(); // Waiting for quiescence avoids non-determinism in tests.
   }
+#endif
 }
 
 GoogleGrpcContext::InstanceTracker& GoogleGrpcContext::instanceTracker() {

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -67,9 +67,10 @@ public:
 
 protected:
   ProcessWide process_wide_; // Process-wide state setup/teardown (excluding grpc).
-#ifdef ENVOY_GOOGLE_GRPC
+  // We instantiate this class regardless of ENVOY_GOOGLE_GRPC, to avoid having
+  // an ifdef in a header file exposed in a C++ library. It is too easy to have
+  // the ifdef be inconsistent across build-system boundaries.
   Grpc::GoogleGrpcContext google_grpc_context_;
-#endif
   const Envoy::OptionsImpl& options_;
   Server::ComponentFactory& component_factory_;
   Thread::ThreadFactory& thread_factory_;


### PR DESCRIPTION
Description: It is problematic to have ifdefs for fields in class definitions in a header file that's used at the boundary of Envoy as a library, such as main_common.h. This PR moves the ifdef into the .cc file so that the compilation of that module is the only one that needs to see the ifdef
Risk Level: low
Testing: //test/common/grpc/...
Docs Changes: n/a
Release Notes: n/a

