### PR TITLE
test: fix and add mock ProtoBufferEq matchers

### DIFF
--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -124,14 +124,35 @@ MATCHER_P2(ProtoBufferEqIgnoringField, expected, ignored_field, "") {
     *result_listener << "\nParse of buffer failed\n";
     return false;
   }
-  auto equal = ::Envoy::TestUtility::protoEqualIgnoringField(proto, expected, ignored_field);
+  const bool equal = ::Envoy::TestUtility::protoEqualIgnoringField(proto, expected, ignored_field);
   if (!equal) {
     std::string but_ignoring = absl::StrCat("(but ignoring ", ignored_field, ")");
     *result_listener << "\n"
+                     << TestUtility::addLeftAndRightPadding("Expected proto:") << "\n"
+                     << TestUtility::addLeftAndRightPadding(but_ignoring) << "\n"
+                     << expected.DebugString()
+                     << TestUtility::addLeftAndRightPadding("is not equal to actual proto:") << "\n"
+                     << proto.DebugString()
+                     << TestUtility::addLeftAndRightPadding("") // line full of padding
+                     << "\n";
+  }
+  return equal;
+}
+
+MATCHER_P(ProtoBufferEqIgnoreRepeatedFieldOrdering, expected, "") {
+  typename std::remove_const<decltype(expected)>::type proto;
+  if (!proto.ParseFromArray(static_cast<char*>(arg->linearize(arg->length())), arg->length())) {
+    *result_listener << "\nParse of buffer failed\n";
+    return false;
+  }
+  const bool equal =
+      ::Envoy::TestUtility::protoEqual(proto, expected, /*ignore_repeated_field_ordering=*/true);
+  if (!equal) {
+    *result_listener << "\n"
                      << "=======================Expected proto:===========================\n"
-                     << expected.DebugString() << " " << but_ignoring
+                     << expected.DebugString()
                      << "------------------is not equal to actual proto:------------------\n"
-                     << proto.DebugString() << " " << but_ignoring
+                     << proto.DebugString()
                      << "=================================================================\n";
   }
   return equal;


### PR DESCRIPTION
Fix ProtoBufferEqIgnoringField's formatting, add ProtoBufferEqIgnoreRepeatedFieldOrdering.
Both are similar to the test/test_common/utility versions.

Risk Level: none
Testing: only changes format of test failure error messages