### PR TITLE
tls: add local certificate presented flag for mTLS detection

### DIFF
--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -24,6 +24,11 @@ public:
   virtual bool peerCertificatePresented() const PURE;
 
   /**
+   * @return bool whether the local certificate is presented.
+   **/
+  virtual bool localCertificatePresented() const PURE;
+
+  /**
    * @return std::string the URIs in the SAN field of the local certificate. Returns {} if there is
    *         no local certificate, or no SAN field, or no URI.
    **/

--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -24,7 +24,8 @@ public:
   virtual bool peerCertificatePresented() const PURE;
 
   /**
-   * @return bool whether the local certificate is presented.
+   * @return bool whether the local certificate is requested on the client by the server. This
+   * flag is always true on the server.
    **/
   virtual bool localCertificatePresented() const PURE;
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -112,6 +112,7 @@ absl::optional<CelValue> ConnectionWrapper::operator[](CelValue key) const {
   auto value = key.StringOrDie().value();
   if (value == MTLS) {
     return CelValue::CreateBool(info_.downstreamSslConnection() != nullptr &&
+                                info_.downstreamSslConnection()->localCertificatePresented() &&
                                 info_.downstreamSslConnection()->peerCertificatePresented());
   } else if (value == RequestedServerName) {
     return CelValue::CreateString(info_.requestedServerName());
@@ -144,7 +145,8 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
     }
   } else if (value == MTLS) {
     return CelValue::CreateBool(info_.upstreamSslConnection() != nullptr &&
-                                info_.upstreamSslConnection()->peerCertificatePresented());
+                                info_.upstreamSslConnection()->localCertificatePresented()) &&
+           info_.upstreamSslConnection()->peerCertificatePresented();
   }
 
   return {};

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -145,8 +145,8 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
     }
   } else if (value == MTLS) {
     return CelValue::CreateBool(info_.upstreamSslConnection() != nullptr &&
-                                info_.upstreamSslConnection()->localCertificatePresented()) &&
-           info_.upstreamSslConnection()->peerCertificatePresented();
+                                info_.upstreamSslConnection()->localCertificatePresented() &&
+                                info_.upstreamSslConnection()->peerCertificatePresented());
   }
 
   return {};

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -306,6 +306,11 @@ bool SslSocketInfo::peerCertificatePresented() const {
   return cert != nullptr;
 }
 
+bool SslSocketInfo::localCertificatePresented() const {
+  bssl::UniquePtr<X509> cert(SSL_get_certificate(ssl_.get()));
+  return cert != nullptr;
+}
+
 std::vector<std::string> SslSocketInfo::uriSanLocalCertificate() const {
   if (!cached_uri_san_local_certificate_.empty()) {
     return cached_uri_san_local_certificate_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -307,7 +307,7 @@ bool SslSocketInfo::peerCertificatePresented() const {
 }
 
 bool SslSocketInfo::localCertificatePresented() const {
-  bssl::UniquePtr<X509> cert(SSL_get_certificate(ssl_.get()));
+  X509* cert = SSL_get_certificate(ssl_.get());
   return cert != nullptr;
 }
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -47,6 +47,7 @@ public:
 
   // Ssl::ConnectionInfo
   bool peerCertificatePresented() const override;
+  bool localCertificatePresented() const override;
   std::vector<std::string> uriSanLocalCertificate() const override;
   const std::string& sha256PeerCertificateDigest() const override;
   const std::string& serialNumberPeerCertificate() const override;

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -43,7 +43,7 @@ enum class SocketState { PreHandshake, HandshakeInProgress, HandshakeComplete, S
 
 class SslSocketInfo : public Envoy::Ssl::ConnectionInfo {
 public:
-  SslSocketInfo(bssl::UniquePtr<SSL> ssl) : ssl_(std::move(ssl)) {}
+  SslSocketInfo(bssl::UniquePtr<SSL> ssl, InitialState state);
 
   // Ssl::ConnectionInfo
   bool peerCertificatePresented() const override;
@@ -84,6 +84,7 @@ private:
   mutable std::vector<std::string> cached_dns_san_local_certificate_;
   mutable std::string cached_session_id_;
   mutable std::string cached_tls_version_;
+  bool local_cert_presented = false;
 };
 
 class SslSocket : public Network::TransportSocket,

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -277,7 +277,9 @@ TEST(Context, ConnectionAttributes) {
   EXPECT_CALL(info, upstreamHost()).WillRepeatedly(Return(upstream_host));
   EXPECT_CALL(info, requestedServerName()).WillRepeatedly(ReturnRef(sni_name));
   EXPECT_CALL(*downstream_ssl_info, peerCertificatePresented()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*downstream_ssl_info, localCertificatePresented()).WillRepeatedly(Return(true));
   EXPECT_CALL(*upstream_ssl_info, peerCertificatePresented()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*upstream_ssl_info, localCertificatePresented()).WillRepeatedly(Return(true));
   const std::string tls_version = "TLSv1";
   EXPECT_CALL(*downstream_ssl_info, tlsVersion()).WillRepeatedly(ReturnRef(tls_version));
   EXPECT_CALL(*upstream_host, address()).WillRepeatedly(Return(upstream_address));

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -808,6 +808,7 @@ TEST_P(SslSocketTest, GetCertDigest) {
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
   testUtil(test_options.setExpectedDigest(TEST_NO_SAN_CERT_HASH)
+               .setExpectLocalCertPresented()
                .setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL));
 }
 
@@ -879,6 +880,7 @@ TEST_P(SslSocketTest, GetCertDigestServerCertWithIntermediateCA) {
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
   testUtil(test_options.setExpectedDigest(TEST_NO_SAN_CERT_HASH)
+               .setExpectLocalCertPresented()
                .setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL));
 }
 
@@ -935,6 +937,7 @@ TEST_P(SslSocketTest, GetUriWithUriSan) {
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
   testUtil(test_options.setExpectedClientCertUri("spiffe://lyft.com/test-team")
+               .setExpectLocalCertPresented()
                .setExpectedSerialNumber(TEST_SAN_URI_CERT_SERIAL));
 }
 
@@ -1089,6 +1092,7 @@ TEST_P(SslSocketTest, GetUriWithLocalUriSan) {
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
   testUtil(test_options.setExpectedLocalUri("spiffe://lyft.com/test-team")
+               .setExpectLocalCertPresented()
                .setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL));
 }
 
@@ -3761,7 +3765,8 @@ TEST_P(SslSocketTest, RevokedCertificateCRLInTrustedCA) {
 )EOF";
   TestUtilOptions successful_test_options(successful_client_ctx_yaml, server_ctx_yaml, true,
                                           GetParam());
-  testUtil(successful_test_options.setExpectedSerialNumber(TEST_SAN_DNS2_CERT_SERIAL));
+  testUtil(successful_test_options.setExpectedSerialNumber(TEST_SAN_DNS2_CERT_SERIAL)
+               .setExpectLocalCertPresented());
 }
 
 TEST_P(SslSocketTest, GetRequestedServerName) {
@@ -4246,7 +4251,7 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncSignSuccess) {
 
   TestUtilOptions successful_test_options(successful_client_ctx_yaml, server_ctx_yaml, true,
                                           GetParam());
-  testUtil(successful_test_options.setPrivateKeyMethodExpected(true));
+  testUtil(successful_test_options.setPrivateKeyMethodExpected(true).setExpectLocalCertPresented());
 }
 
 // Test asynchronous decryption (RSA).
@@ -4342,7 +4347,7 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderSyncDecryptSuccess) {
 
   TestUtilOptions successful_test_options(successful_client_ctx_yaml, server_ctx_yaml, true,
                                           GetParam());
-  testUtil(successful_test_options.setPrivateKeyMethodExpected(true));
+  testUtil(successful_test_options.setPrivateKeyMethodExpected(true).setExpectLocalCertPresented());
 }
 
 // Test asynchronous signing (ECDHE) failure (invalid signature).

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -343,6 +343,7 @@ void testUtil(const TestUtilOptions& options) {
                   server_connection->ssl()->subjectPeerCertificate());
       }
       if (!options.expectedLocalSubject().empty()) {
+        EXPECT_TRUE(server_connection->ssl()->localCertificatePresented());
         EXPECT_EQ(options.expectedLocalSubject(),
                   server_connection->ssl()->subjectLocalCertificate());
       }

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -38,6 +38,7 @@ public:
   ~MockConnectionInfo() override;
 
   MOCK_CONST_METHOD0(peerCertificatePresented, bool());
+  MOCK_CONST_METHOD0(localCertificatePresented, bool());
   MOCK_CONST_METHOD0(uriSanLocalCertificate, std::vector<std::string>());
   MOCK_CONST_METHOD0(sha256PeerCertificateDigest, const std::string&());
   MOCK_CONST_METHOD0(serialNumberPeerCertificate, const std::string&());


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: add a boolean flag to report whether a local cert is presented. This is useful for upstream mTLS detection. 
Risk Level: low
Testing: unit tests updated
Docs Changes: none
Release Notes: none
