### PR TITLE
build: not refer @envoy//api at all

### DIFF
--- a/bazel/api_binding.bzl
+++ b/bazel/api_binding.bzl
@@ -10,12 +10,12 @@ def _default_envoy_api_impl(ctx):
         "tools",
     ]
     for d in api_dirs:
-        ctx.symlink(ctx.path(ctx.attr.api).dirname.get_child(d), d)
+        ctx.symlink(ctx.path(ctx.attr.envoy_root).dirname.get_child("api").get_child(d), d)
 
 _default_envoy_api = repository_rule(
     implementation = _default_envoy_api_impl,
     attrs = {
-        "api": attr.label(default = "@envoy//api:BUILD"),
+        "envoy_root": attr.label(default = "@envoy//:BUILD"),
     },
 )
 


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Fixes #8455 

Risk Level: Low
Testing: Tested last_green bazel build at 886c0a4d5b69022b0329e30d07bbe7a274e31aa0.
Docs Changes: N/A
Release Notes: N/A
