### PR TITLE
http conn: cleanup Connection interface #8419

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -290,11 +290,6 @@ public:
   virtual void setDelayedCloseTimeout(std::chrono::milliseconds timeout) PURE;
 
   /**
-   * @return std::chrono::milliseconds The delayed close timeout value.
-   */
-  virtual std::chrono::milliseconds delayedCloseTimeout() const PURE;
-
-  /**
    * @return std::string the failure reason of the underlying transport socket, if no failure
    *         occurred an empty string is returned.
    */

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -102,7 +102,7 @@ void ConnectionImpl::close(ConnectionCloseType type) {
 
   uint64_t data_to_write = write_buffer_->length();
   ENVOY_CONN_LOG(debug, "closing data_to_write={} type={}", *this, data_to_write, enumToInt(type));
-  const bool delayed_close_timeout_set = delayedCloseTimeout().count() > 0;
+  const bool delayed_close_timeout_set = delayed_close_timeout_.count() > 0;
   if (data_to_write == 0 || type == ConnectionCloseType::NoFlush ||
       !transport_socket_->canFlushClose()) {
     if (data_to_write > 0) {
@@ -589,7 +589,7 @@ void ConnectionImpl::onWriteReady() {
     ENVOY_CONN_LOG(debug, "write flush complete", *this);
     if (delayed_close_state_ == DelayedCloseState::CloseAfterFlushAndWait) {
       ASSERT(delayed_close_timer_ != nullptr);
-      delayed_close_timer_->enableTimer(delayedCloseTimeout());
+      delayed_close_timer_->enableTimer(delayed_close_timeout_);
     } else {
       ASSERT(bothSidesHalfClosed() || delayed_close_state_ == DelayedCloseState::CloseAfterFlush);
       closeSocket(ConnectionEvent::LocalClose);
@@ -597,7 +597,7 @@ void ConnectionImpl::onWriteReady() {
   } else {
     ASSERT(result.action_ == PostIoAction::KeepOpen);
     if (delayed_close_timer_ != nullptr) {
-      delayed_close_timer_->enableTimer(delayedCloseTimeout());
+      delayed_close_timer_->enableTimer(delayed_close_timeout_);
     }
     if (result.bytes_processed_ > 0) {
       for (BytesSentCb& cb : bytes_sent_callbacks_) {
@@ -644,9 +644,6 @@ bool ConnectionImpl::bothSidesHalfClosed() {
   return read_end_stream_ && write_end_stream_ && write_buffer_->length() == 0;
 }
 
-std::chrono::milliseconds ConnectionImpl::delayedCloseTimeout() const { 
-  return delayed_close_timeout_; 
-}
 void ConnectionImpl::onDelayedCloseTimeout() {
   delayed_close_timer_.reset();
   ENVOY_CONN_LOG(debug, "triggered delayed close", *this);
@@ -657,11 +654,11 @@ void ConnectionImpl::onDelayedCloseTimeout() {
 }
 
 void ConnectionImpl::initializeDelayedCloseTimer() {
-  const auto timeout = delayedCloseTimeout().count();
+  const auto timeout = delayed_close_timeout_.count();
   ASSERT(delayed_close_timer_ == nullptr && timeout > 0);
   delayed_close_timer_ = dispatcher_.createTimer([this]() -> void { onDelayedCloseTimeout(); });
   ENVOY_CONN_LOG(debug, "setting delayed close timer with timeout {} ms", *this, timeout);
-  delayed_close_timer_->enableTimer(delayedCloseTimeout());
+  delayed_close_timer_->enableTimer(delayed_close_timeout_);
 }
 
 absl::string_view ConnectionImpl::transportFailureReason() const {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -644,6 +644,9 @@ bool ConnectionImpl::bothSidesHalfClosed() {
   return read_end_stream_ && write_end_stream_ && write_buffer_->length() == 0;
 }
 
+std::chrono::milliseconds ConnectionImpl::delayedCloseTimeout() const { 
+  return delayed_close_timeout_; 
+}
 void ConnectionImpl::onDelayedCloseTimeout() {
   delayed_close_timer_.reset();
   ENVOY_CONN_LOG(debug, "triggered delayed close", *this);

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -130,7 +130,6 @@ public:
     ASSERT(delayed_close_timer_ == nullptr && ioHandle().isOpen());
     delayed_close_timeout_ = timeout;
   }
-  std::chrono::milliseconds delayedCloseTimeout() const override { return delayed_close_timeout_; }
 
 protected:
   void closeSocket(ConnectionEvent close_type);
@@ -175,6 +174,7 @@ private:
   // Returns true iff end of stream has been both written and read.
   bool bothSidesHalfClosed();
 
+  std::chrono::milliseconds delayedCloseTimeout() const;
   // Callback issued when a delayed close timeout triggers.
   void onDelayedCloseTimeout();
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -174,7 +174,6 @@ private:
   // Returns true iff end of stream has been both written and read.
   bool bothSidesHalfClosed();
 
-  std::chrono::milliseconds delayedCloseTimeout() const;
   // Callback issued when a delayed close timeout triggers.
   void onDelayedCloseTimeout();
 

--- a/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.cc
+++ b/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.cc
@@ -61,12 +61,6 @@ void QuicFilterManagerConnectionImpl::setDelayedCloseTimeout(std::chrono::millis
   }
 }
 
-std::chrono::milliseconds QuicFilterManagerConnectionImpl::delayedCloseTimeout() const {
-  // Not called outside of Network::ConnectionImpl.
-  // TODO(#8419): Try remove this interface from Network::Connection.
-  NOT_REACHED_GCOVR_EXCL_LINE;
-}
-
 const Network::ConnectionSocket::OptionsSharedPtr&
 QuicFilterManagerConnectionImpl::socketOptions() const {
   return quic_connection_->connectionSocket()->options();

--- a/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.h
+++ b/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.h
@@ -43,7 +43,6 @@ public:
     // No-op. TCP_NODELAY doesn't apply to UDP.
   }
   void setDelayedCloseTimeout(std::chrono::milliseconds timeout) override;
-  std::chrono::milliseconds delayedCloseTimeout() const override;
   void readDisable(bool /*disable*/) override { NOT_REACHED_GCOVR_EXCL_LINE; }
   void detectEarlyCloseWhenReadDisabled(bool /*value*/) override { NOT_REACHED_GCOVR_EXCL_LINE; }
   bool readEnabled() const override { return true; }

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -83,7 +83,6 @@ public:
   MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
   MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
   MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
-  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(transportFailureReason, absl::string_view());
 };
 
@@ -129,7 +128,6 @@ public:
   MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
   MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
   MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
-  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(transportFailureReason, absl::string_view());
 
   // Network::ClientConnection
@@ -178,7 +176,6 @@ public:
   MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
   MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
   MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
-  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(transportFailureReason, absl::string_view());
 
   // Network::FilterManagerConnection


### PR DESCRIPTION
Description: Remove Network::Connection::delayedCloseTimeout() from public interface
Risk Level: Low
Testing: Unit test, integration
Docs Changes: No
Release Notes: No
Fixes #8419 
