### PR TITLE
server: provide server health status when stats disabled

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1,6 +1,5 @@
 #include "server/server.h"
 
-#include <atomic>
 #include <csignal>
 #include <cstdint>
 #include <functional>
@@ -135,8 +134,8 @@ void InstanceImpl::drainListeners() {
 }
 
 void InstanceImpl::failHealthcheck(bool fail) {
-  live_ = !fail;
-  server_stats_->live_.set(live_);
+  live_.store(!fail);
+  server_stats_->live_.set(live_.load());
 }
 
 MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store) {
@@ -213,7 +212,7 @@ void InstanceImpl::flushStatsInternal() {
   }
 }
 
-bool InstanceImpl::healthCheckFailed() { return !live_; }
+bool InstanceImpl::healthCheckFailed() { return !live_.load(); }
 
 InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
     envoy::config::bootstrap::v2::Bootstrap& bootstrap, const Options& options,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -55,9 +55,9 @@ InstanceImpl::InstanceImpl(
     ComponentFactory& component_factory, Runtime::RandomGeneratorPtr&& random_generator,
     ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory,
     Filesystem::Instance& file_system, std::unique_ptr<ProcessContext> process_context)
-    : init_manager_(init_manager), workers_started_(false), shutdown_(false), options_(options),
-      validation_context_(options_.allowUnknownStaticFields(),
-                          !options.rejectUnknownDynamicFields()),
+    : init_manager_(init_manager), workers_started_(false), live_(false), shutdown_(false),
+      options_(options), validation_context_(options_.allowUnknownStaticFields(),
+                                             !options.rejectUnknownDynamicFields()),
       time_source_(time_system), restarter_(restarter), start_time_(time(nullptr)),
       original_start_time_(start_time_), stats_store_(store), thread_local_(tls),
       api_(new Api::Impl(thread_factory, store, time_system, file_system,
@@ -134,7 +134,10 @@ void InstanceImpl::drainListeners() {
   drain_manager_->startDrainSequence(nullptr);
 }
 
-void InstanceImpl::failHealthcheck(bool fail) { server_stats_->live_.set(!fail); }
+void InstanceImpl::failHealthcheck(bool fail) {
+  live_ = !fail;
+  server_stats_->live_.set(live_);
+}
 
 MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store) {
   snapped_counters_ = store.counters();
@@ -210,7 +213,7 @@ void InstanceImpl::flushStatsInternal() {
   }
 }
 
-bool InstanceImpl::healthCheckFailed() { return server_stats_->live_.value() == 0; }
+bool InstanceImpl::healthCheckFailed() { return !live_; }
 
 InstanceUtil::BootstrapVersion InstanceUtil::loadBootstrapConfig(
     envoy::config::bootstrap::v2::Bootstrap& bootstrap, const Options& options,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -260,6 +260,7 @@ private:
   // - There may be active connections referencing it.
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   bool workers_started_;
+  bool live_;
   bool shutdown_;
   const Options& options_;
   ProtobufMessage::ProdValidationContextImpl validation_context_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -260,7 +261,7 @@ private:
   // - There may be active connections referencing it.
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   bool workers_started_;
-  bool live_;
+  std::atomic<bool> live_;
   bool shutdown_;
   const Options& options_;
   ProtobufMessage::ProdValidationContextImpl validation_context_;

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -293,9 +293,7 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_EQ("200", request("admin", "GET", "/runtime", response));
   EXPECT_EQ("application/json", ContentType(response));
 
-  response = request("/runtime_modify?foo=bar&foo1=bar1", "POST");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/runtime_modify?foo=bar&foo1=bar1", response));
 
   EXPECT_EQ("200", request("admin", "GET", "/runtime?format=json", response));
   EXPECT_EQ("application/json", ContentType(response));

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -17,6 +17,10 @@
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
 
+using testing::Eq;
+using testing::HasSubstr;
+using testing::Not;
+
 namespace Envoy {
 
 INSTANTIATE_TEST_SUITE_P(Protocols, IntegrationAdminTest,
@@ -28,30 +32,14 @@ INSTANTIATE_TEST_SUITE_P(Protocols, IntegrationAdminTest,
 TEST_P(IntegrationAdminTest, HealthCheck) {
   initialize();
 
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "POST", "/healthcheck", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  BufferingStreamDecoderPtr response;
+  EXPECT_EQ("200", request("http", "POST", "/healthcheck", response));
 
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/healthcheck/fail",
-                                                "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/healthcheck/fail", response));
+  EXPECT_EQ("503", request("http", "GET", "/healthcheck", response));
 
-  response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("503", response->headers().Status()->value().getStringView());
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/healthcheck/ok", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/healthcheck/ok", response));
+  EXPECT_EQ("200", request("http", "GET", "/healthcheck", response));
 }
 
 TEST_P(IntegrationAdminTest, HealthCheckWithoutServerStats) {
@@ -59,101 +47,54 @@ TEST_P(IntegrationAdminTest, HealthCheckWithoutServerStats) {
   stats_matcher.mutable_exclusion_list()->add_patterns()->set_prefix("server.");
   initialize(stats_matcher);
 
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "POST", "/healthcheck", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  BufferingStreamDecoderPtr response;
+  EXPECT_EQ("200", request("http", "POST", "/healthcheck", response));
+  EXPECT_EQ("200", request("admin", "GET", "/stats", response));
+  EXPECT_THAT(response->body(), Not(HasSubstr("server.")));
 
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_THAT(response->body(), testing::Not(testing::HasSubstr("server.")));
+  EXPECT_EQ("200", request("admin", "POST", "/healthcheck/fail", response));
+  EXPECT_EQ("503", request("http", "GET", "/healthcheck", response));
+  EXPECT_EQ("200", request("admin", "GET", "/stats", response));
+  EXPECT_THAT(response->body(), Not(HasSubstr("server.")));
 
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/healthcheck/fail",
-                                                "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("503", response->headers().Status()->value().getStringView());
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_THAT(response->body(), testing::Not(testing::HasSubstr("server.")));
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/healthcheck/ok", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_THAT(response->body(), testing::Not(testing::HasSubstr("server.")));
+  EXPECT_EQ("200", request("admin", "POST", "/healthcheck/ok", response));
+  EXPECT_EQ("200", request("http", "GET", "/healthcheck", response));
+  EXPECT_EQ("200", request("admin", "GET", "/stats", response));
+  EXPECT_THAT(response->body(), Not(HasSubstr("server.")));
 }
 
 TEST_P(IntegrationAdminTest, HealthCheckWithBufferFilter) {
   config_helper_.addFilter(ConfigHelper::DEFAULT_BUFFER_FILTER);
   initialize();
 
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/healthcheck", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  BufferingStreamDecoderPtr response;
+  EXPECT_EQ("200", request("http", "GET", "/healthcheck", response));
 }
 
 TEST_P(IntegrationAdminTest, AdminLogging) {
   initialize();
 
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "POST", "/logging", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  BufferingStreamDecoderPtr response;
+  EXPECT_EQ("200", request("admin", "POST", "/logging", response));
 
   // Bad level
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/logging?level=blah",
-                                                "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("404", request("admin", "POST", "/logging?level=blah", response));
 
   // Bad logger
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/logging?blah=info",
-                                                "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("404", request("admin", "POST", "/logging?blah=info", response));
 
   // This is going to stomp over custom log levels that are set on the command line.
-  response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "POST", "/logging?level=warning", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/logging?level=warning", response));
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
     EXPECT_EQ("warning", logger.levelString());
   }
 
-  response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "POST", "/logging?assert=trace", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/logging?assert=trace", response));
   EXPECT_EQ(spdlog::level::trace, Logger::Registry::getLog(Logger::Id::assert).level());
 
   spdlog::string_view_t level_name = spdlog::level::level_string_views[default_log_level_];
-  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST",
-                                                fmt::format("/logging?level={}", level_name), "",
-                                                downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200",
+            request("admin", "POST", fmt::format("/logging?level={}", level_name), response));
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
     EXPECT_EQ(level_name, logger.levelString());
   }
@@ -175,207 +116,143 @@ TEST_P(IntegrationAdminTest, Admin) {
   Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
   initialize();
 
-  auto request = [this](absl::string_view request,
-                        absl::string_view method) -> BufferingStreamDecoderPtr {
-    return IntegrationUtil::makeSingleRequest(lookupPort("admin"), std::string(method),
-                                              std::string(request), "", downstreamProtocol(),
-                                              version_);
-  };
-
-  BufferingStreamDecoderPtr response = request("/notfound", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().Status()->value().getStringView());
+  BufferingStreamDecoderPtr response;
+  EXPECT_EQ("404", request("admin", "GET", "/notfound", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
   EXPECT_NE(std::string::npos, response->body().find("invalid path. admin commands are:"))
       << response->body();
 
-  response = request("/help", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/help", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
   EXPECT_NE(std::string::npos, response->body().find("admin commands are:")) << response->body();
 
-  response = request("/", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/", response));
   EXPECT_EQ("text/html; charset=UTF-8", ContentType(response));
   EXPECT_NE(std::string::npos, response->body().find("<title>Envoy Admin</title>"))
       << response->body();
 
-  response = request("/server_info", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/server_info", response));
   EXPECT_EQ("application/json", ContentType(response));
 
-  response = request("/ready", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/ready", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/stats", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
   // Our first attempt to get recent lookups will get the error message as they
   // are off by default.
-  response = request("/stats/recentlookups", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats/recentlookups", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
   EXPECT_THAT(response->body(), testing::HasSubstr("Lookup tracking is not enabled"));
 
   // Now enable recent-lookups tracking and check that we get a count.
-  request("/stats/recentlookups/enable", "POST");
-  response = request("/stats/recentlookups", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/stats/recentlookups/enable", response));
+  EXPECT_EQ("200", request("admin", "GET", "/stats/recentlookups", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
   EXPECT_TRUE(absl::StartsWith(response->body(), "   Count Lookup\n")) << response->body();
   EXPECT_LT(30, response->body().size());
 
   // Now disable recent-lookups tracking and check that we get the error again.
-  request("/stats/recentlookups/disable", "POST");
-  response = request("/stats/recentlookups", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/stats/recentlookups/disable", response));
+  EXPECT_EQ("200", request("admin", "GET", "/stats/recentlookups", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
   EXPECT_THAT(response->body(), testing::HasSubstr("Lookup tracking is not enabled"));
 
-  response = request("/stats?usedonly", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?usedonly", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
   // Testing a filter with no matches
-  response = request("/stats?filter=foo", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?filter=foo", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
   // Testing a filter with matches
-  response = request("/stats?filter=server", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?filter=server", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/stats?filter=server&usedonly", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?filter=server&usedonly", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/stats?format=json&usedonly", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?format=json&usedonly", response));
   EXPECT_EQ("application/json", ContentType(response));
   validateStatsJson(response->body(), 0);
 
-  response = request("/stats?format=blah", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("404", request("admin", "GET", "/stats?format=blah", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/stats?format=json", "GET");
-  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?format=json", response));
   EXPECT_EQ("application/json", ContentType(response));
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   validateStatsJson(response->body(), 1);
 
   // Filtering stats by a regex with one match should return just that match.
-  response = request("/stats?format=json&filter=^server\\.version$", "GET");
-  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200",
+            request("admin", "GET", "/stats?format=json&filter=^server\\.version$", response));
   EXPECT_EQ("application/json", ContentType(response));
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   validateStatsJson(response->body(), 0);
-  EXPECT_THAT(response->body(),
-              testing::Eq("{\"stats\":[{\"name\":\"server.version\",\"value\":0}]}"));
+  EXPECT_THAT(response->body(), Eq("{\"stats\":[{\"name\":\"server.version\",\"value\":0}]}"));
 
   // Filtering stats by a non-full-string regex should also return just that match.
-  response = request("/stats?format=json&filter=server\\.version", "GET");
-  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", request("admin", "GET", "/stats?format=json&filter=server\\.version", response));
   EXPECT_EQ("application/json", ContentType(response));
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   validateStatsJson(response->body(), 0);
-  EXPECT_THAT(response->body(),
-              testing::Eq("{\"stats\":[{\"name\":\"server.version\",\"value\":0}]}"));
+  EXPECT_THAT(response->body(), Eq("{\"stats\":[{\"name\":\"server.version\",\"value\":0}]}"));
 
   // Filtering stats by a regex with no matches (".*not_intended_to_appear.*") should return a
   // valid, empty, stats array.
-  response = request("/stats?format=json&filter=not_intended_to_appear", "GET");
-  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200",
+            request("admin", "GET", "/stats?format=json&filter=not_intended_to_appear", response));
   EXPECT_EQ("application/json", ContentType(response));
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   validateStatsJson(response->body(), 0);
-  EXPECT_THAT(response->body(), testing::Eq("{\"stats\":[]}"));
+  EXPECT_THAT(response->body(), Eq("{\"stats\":[]}"));
 
-  response = request("/stats?format=prometheus", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr(
-                  "envoy_http_downstream_rq_xx{envoy_response_code_class=\"4\",envoy_http_conn_"
-                  "manager_prefix=\"admin\"} 2\n"));
-  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE envoy_http_downstream_rq_xx counter\n"));
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr(
-                  "envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class=\"4\","
-                  "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr("# TYPE envoy_cluster_upstream_cx_active gauge\n"));
+  EXPECT_EQ("200", request("admin", "GET", "/stats?format=prometheus", response));
   EXPECT_THAT(
       response->body(),
-      testing::HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cluster_0\"} 0\n"));
-
-  response = request("/stats/prometheus", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr(
-                  "envoy_http_downstream_rq_xx{envoy_response_code_class=\"4\",envoy_http_conn_"
-                  "manager_prefix=\"admin\"} 2\n"));
-  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE envoy_http_downstream_rq_xx counter\n"));
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr(
-                  "envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class=\"4\","
-                  "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr("# TYPE envoy_cluster_upstream_cx_active gauge\n"));
+      HasSubstr("envoy_http_downstream_rq_xx{envoy_response_code_class=\"4\",envoy_http_conn_"
+                "manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), HasSubstr("# TYPE envoy_http_downstream_rq_xx counter\n"));
   EXPECT_THAT(
       response->body(),
-      testing::HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cluster_0\"} 0\n"));
+      HasSubstr("envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class=\"4\","
+                "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), HasSubstr("# TYPE envoy_cluster_upstream_cx_active gauge\n"));
+  EXPECT_THAT(response->body(),
+              HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cluster_0\"} 0\n"));
 
-  response = request("/clusters", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_THAT(response->body(), testing::HasSubstr("added_via_api"));
+  EXPECT_EQ("200", request("admin", "GET", "/stats/prometheus", response));
+  EXPECT_THAT(
+      response->body(),
+      HasSubstr("envoy_http_downstream_rq_xx{envoy_response_code_class=\"4\",envoy_http_conn_"
+                "manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), HasSubstr("# TYPE envoy_http_downstream_rq_xx counter\n"));
+  EXPECT_THAT(
+      response->body(),
+      HasSubstr("envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class=\"4\","
+                "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), HasSubstr("# TYPE envoy_cluster_upstream_cx_active gauge\n"));
+  EXPECT_THAT(response->body(),
+              HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cluster_0\"} 0\n"));
+
+  EXPECT_EQ("200", request("admin", "GET", "/clusters", response));
+  EXPECT_THAT(response->body(), HasSubstr("added_via_api"));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/clusters?format=json", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/clusters?format=json", response));
   EXPECT_EQ("application/json", ContentType(response));
   EXPECT_NO_THROW(Json::Factory::loadFromString(response->body()));
 
-  response = request("/cpuprofiler", "POST");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("400", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("400", request("admin", "POST", "/cpuprofiler", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/hot_restart_version", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/hot_restart_version", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  response = request("/reset_counters", "POST");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/reset_counters", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
-  request("/stats/recentlookups/enable", "POST");
-  request("/stats/recentlookups/clear", "POST");
-  response = request("/stats/recentlookups", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/stats/recentlookups/enable", response));
+  EXPECT_EQ("200", request("admin", "POST", "/stats/recentlookups/clear", response));
+  EXPECT_EQ("200", request("admin", "GET", "/stats/recentlookups", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
 
   // TODO(#8324): "http1.metadata_not_supported_error" should not still be in
@@ -410,23 +287,17 @@ TEST_P(IntegrationAdminTest, Admin) {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
-  response = request("/certs", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/certs", response));
   EXPECT_EQ("application/json", ContentType(response));
 
-  response = request("/runtime", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/runtime", response));
   EXPECT_EQ("application/json", ContentType(response));
 
   response = request("/runtime_modify?foo=bar&foo1=bar1", "POST");
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 
-  response = request("/runtime?format=json", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/runtime?format=json", response));
   EXPECT_EQ("application/json", ContentType(response));
 
   Json::ObjectSharedPtr json = Json::Factory::loadFromString(response->body());
@@ -436,21 +307,17 @@ TEST_P(IntegrationAdminTest, Admin) {
   auto foo1_obj = entries->getObject("foo1");
   EXPECT_EQ("bar1", foo1_obj->getString("final_value"));
 
-  response = request("/listeners", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/listeners", response));
   EXPECT_EQ("text/plain; charset=UTF-8", ContentType(response));
   auto listeners = test_server_->server().listenerManager().listeners();
   auto listener_it = listeners.cbegin();
   for (; listener_it != listeners.end(); ++listener_it) {
-    EXPECT_THAT(response->body(), testing::HasSubstr(fmt::format(
-                                      "{}::{}", listener_it->get().name(),
+    EXPECT_THAT(response->body(),
+                HasSubstr(fmt::format("{}::{}", listener_it->get().name(),
                                       listener_it->get().socket().localAddress()->asString())));
   }
 
-  response = request("/listeners?format=json", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/listeners?format=json", response));
   EXPECT_EQ("application/json", ContentType(response));
 
   json = Json::Factory::loadFromString(response->body());
@@ -468,9 +335,7 @@ TEST_P(IntegrationAdminTest, Admin) {
               socket_address->getInteger("port_value"));
   }
 
-  response = request("/config_dump", "GET");
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "GET", "/config_dump", response));
   EXPECT_EQ("application/json", ContentType(response));
   json = Json::Factory::loadFromString(response->body());
   size_t index = 0;
@@ -564,11 +429,8 @@ TEST_P(IntegrationAdminTest, AdminOnDestroyCallbacks) {
       test_server_->server().admin().addHandler("/foo/bar", "hello", callback, true, false));
 
   // As part of the request, on destroy() should be called and the on_destroy_callback invoked.
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/foo/bar", "", downstreamProtocol(), version_);
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  BufferingStreamDecoderPtr response;
+  EXPECT_EQ("200", request("admin", "GET", "/foo/bar", response));
   // Check that the added callback was invoked.
   EXPECT_EQ(test, false);
 
@@ -583,19 +445,14 @@ TEST_P(IntegrationAdminTest, AdminCpuProfilerStart) {
   });
 
   initialize();
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "POST", "/cpuprofiler?enable=y", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
+  BufferingStreamDecoderPtr response;
 #ifdef PROFILER_AVAILABLE
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/cpuprofiler?enable=y", response));
 #else
-  EXPECT_EQ("500", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("500", request("admin", "POST", "/cpuprofiler?enable=y", response));
 #endif
 
-  response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "POST", "/cpuprofiler?enable=n", "", downstreamProtocol(), version_);
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("200", request("admin", "POST", "/cpuprofiler?enable=n", response));
 }
 
 class IntegrationAdminIpv4Ipv6Test : public testing::Test, public HttpIntegrationTest {
@@ -669,21 +526,21 @@ TEST_P(StatsMatcherIntegrationTest, ExcludePrefixServerDot) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_prefix("server.");
   initialize();
   makeRequest();
-  EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("server.")));
+  EXPECT_THAT(response_->body(), Not(HasSubstr("server.")));
 }
 
 TEST_P(StatsMatcherIntegrationTest, DEPRECATED_FEATURE_TEST(ExcludeRequests)) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_regex(".*requests.*");
   initialize();
   makeRequest();
-  EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("requests")));
+  EXPECT_THAT(response_->body(), Not(HasSubstr("requests")));
 }
 
 TEST_P(StatsMatcherIntegrationTest, DEPRECATED_FEATURE_TEST(ExcludeExact)) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_exact("server.concurrency");
   initialize();
   makeRequest();
-  EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("server.concurrency")));
+  EXPECT_THAT(response_->body(), Not(HasSubstr("server.concurrency")));
 }
 
 TEST_P(StatsMatcherIntegrationTest, DEPRECATED_FEATURE_TEST(ExcludeMultipleExact)) {
@@ -691,8 +548,8 @@ TEST_P(StatsMatcherIntegrationTest, DEPRECATED_FEATURE_TEST(ExcludeMultipleExact
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_regex(".*live");
   initialize();
   makeRequest();
-  EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("server.concurrency")));
-  EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("server.live")));
+  EXPECT_THAT(response_->body(), Not(HasSubstr("server.concurrency")));
+  EXPECT_THAT(response_->body(), Not(HasSubstr("server.live")));
 }
 
 // TODO(ambuc): Find a cleaner way to test this. This test has an unfortunate compromise:

--- a/test/integration/integration_admin_test.h
+++ b/test/integration/integration_admin_test.h
@@ -15,6 +15,14 @@ public:
     HttpIntegrationTest::initialize();
   }
 
+  void initialize(envoy::config::metrics::v2::StatsMatcher stats_matcher) {
+    config_helper_.addConfigModifier(
+        [stats_matcher](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
+          *bootstrap.mutable_stats_config()->mutable_stats_matcher() = stats_matcher;
+        });
+    initialize();
+  }
+
   /**
    *  Destructor for an individual test.
    */

--- a/test/integration/integration_admin_test.h
+++ b/test/integration/integration_admin_test.h
@@ -23,6 +23,14 @@ public:
     initialize();
   }
 
+  absl::string_view request(const std::string port_key, const std::string method,
+                            const std::string endpoint, BufferingStreamDecoderPtr& response) {
+    response = IntegrationUtil::makeSingleRequest(lookupPort(port_key), method, endpoint, "",
+                                                  downstreamProtocol(), version_);
+    EXPECT_TRUE(response->complete());
+    return response->headers().Status()->value().getStringView();
+  }
+
   /**
    *  Destructor for an individual test.
    */


### PR DESCRIPTION
Description: This fixes a bug where the server health check returns an incorrect response when server stats are disabled i.e. due to relying on the `server.live` gauge.
Risk Level: Low
Testing: Added a new test
Docs Changes: N/A
Release Notes: N/A
Fixes #8473