### PR TITLE
tls: select alpn override by upstream protocol

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
     srcs = ["application_protocol.cc"],
     hdrs = ["application_protocol.h"],
     deps = [
+        "//include/envoy/http:protocol_interface",
         "//include/envoy/stream_info:filter_state_interface",
         "//source/common/common:macros",
     ],

--- a/source/common/network/application_protocol.h
+++ b/source/common/network/application_protocol.h
@@ -16,13 +16,25 @@ using ApplicationProtocolOverride = absl::flat_hash_map<Http::Protocol, std::vec
  */
 class ApplicationProtocols : public StreamInfo::FilterState::Object {
 public:
-  explicit ApplicationProtocols(const ApplicationProtocolOverride& application_protocols_override)
-      : application_protocols_override_(application_protocols_override) {}
-  const ApplicationProtocolOverride& value() const { return application_protocols_override_; }
+  ApplicationProtocols(const ApplicationProtocolOverride& http_alpn_override,
+                       const std::vector<std::string>& tcp_alpn_override)
+      : http_alpn_override_(http_alpn_override), tcp_alpn_override_(tcp_alpn_override) {}
+
+  bool hasProtocol(const Http::Protocol& protocol) const {
+    return http_alpn_override_.count(protocol) > 0;
+  }
+
+  const std::vector<std::string>& value(const Http::Protocol& protocol) const {
+    return http_alpn_override_.at(protocol);
+  }
+
+  const std::vector<std::string>& value() const { return tcp_alpn_override_; }
+
   static const std::string& key();
 
 private:
-  const ApplicationProtocolOverride application_protocols_override_;
+  const ApplicationProtocolOverride http_alpn_override_;
+  const std::vector<std::string> tcp_alpn_override_;
 };
 
 } // namespace Network

--- a/source/common/network/application_protocol.h
+++ b/source/common/network/application_protocol.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include "envoy/http/protocol.h"
 #include "envoy/stream_info/filter_state.h"
+
+#include "absl/container/flat_hash_map.h"
 
 namespace Envoy {
 namespace Network {
+
+using ApplicationProtocolOverride = absl::flat_hash_map<Http::Protocol, std::vector<std::string>>;
 
 /**
  * ALPN to set in the upstream connection. Filters can use this one to override the ALPN in TLS
@@ -11,13 +16,13 @@ namespace Network {
  */
 class ApplicationProtocols : public StreamInfo::FilterState::Object {
 public:
-  explicit ApplicationProtocols(const std::vector<std::string>& application_protocols)
-      : application_protocols_(application_protocols) {}
-  const std::vector<std::string>& value() const { return application_protocols_; }
+  explicit ApplicationProtocols(const ApplicationProtocolOverride& application_protocols_override)
+      : application_protocols_override_(application_protocols_override) {}
+  const ApplicationProtocolOverride& value() const { return application_protocols_override_; }
   static const std::string& key();
 
 private:
-  const std::vector<std::string> application_protocols_;
+  const ApplicationProtocolOverride application_protocols_override_;
 };
 
 } // namespace Network

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -546,10 +546,14 @@ Http::ConnectionPool::Instance* Filter::getConnPool() {
   if (callbacks_->streamInfo().filterState().hasData<Network::ApplicationProtocols>(
           Network::ApplicationProtocols::key())) {
     const auto& alpn =
-        callbacks_->streamInfo().filterState().getDataReadOnly<Network::ApplicationProtocols>(
-            Network::ApplicationProtocols::key());
-    transport_socket_options_ = std::make_shared<Network::TransportSocketOptionsImpl>(
-        "", std::vector<std::string>{}, std::vector<std::string>{alpn.value()});
+        callbacks_->streamInfo()
+            .filterState()
+            .getDataReadOnly<Network::ApplicationProtocols>(Network::ApplicationProtocols::key())
+            .value();
+    if (alpn.count(protocol)) {
+      transport_socket_options_ = std::make_shared<Network::TransportSocketOptionsImpl>(
+          "", std::vector<std::string>{}, std::vector<std::string>{alpn.at(protocol)});
+    }
   }
 
   return config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), route_entry_->priority(),

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -847,15 +847,15 @@ void Filter::onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_
 
     callbacks_->streamInfo().setResponseFlag(response_flags);
 
-    callbacks_->sendLocalReply(code, body,
-                               [dropped, this](Http::HeaderMap& headers) {
-                                 if (dropped && !config_.suppress_envoy_headers_) {
-                                   headers.insertEnvoyOverloaded().value(
-                                       Http::Headers::get().EnvoyOverloadedValues.True);
-                                 }
-                                 modify_headers_(headers);
-                               },
-                               absl::nullopt, details);
+    callbacks_->sendLocalReply(
+        code, body,
+        [dropped, this](Http::HeaderMap& headers) {
+          if (dropped && !config_.suppress_envoy_headers_) {
+            headers.insertEnvoyOverloaded().value(Http::Headers::get().EnvoyOverloadedValues.True);
+          }
+          modify_headers_(headers);
+        },
+        absl::nullopt, details);
   }
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4244,7 +4244,7 @@ TEST_F(RouterTest, AlpnOverride) {
                                                      {Http::Protocol::Http2, {"baz", "qux"}}};
   callbacks_.streamInfo().filterState().setData(
       Network::ApplicationProtocols::key(),
-      std::make_unique<Network::ApplicationProtocols>(alpn_override),
+      std::make_unique<Network::ApplicationProtocols>(alpn_override, std::vector<std::string>{}),
       StreamInfo::FilterState::StateType::ReadOnly);
 
   EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _))
@@ -4285,7 +4285,7 @@ TEST_F(RouterTest, AlpnOverrideHttp2Upstream) {
 
   callbacks_.streamInfo().filterState().setData(
       Network::ApplicationProtocols::key(),
-      std::make_unique<Network::ApplicationProtocols>(alpn_override),
+      std::make_unique<Network::ApplicationProtocols>(alpn_override, std::vector<std::string>{}),
       StreamInfo::FilterState::StateType::ReadOnly);
 
   EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _))
@@ -4325,7 +4325,7 @@ TEST_F(RouterTest, AlpnOverrideEmptyAlpn) {
 
   callbacks_.streamInfo().filterState().setData(
       Network::ApplicationProtocols::key(),
-      std::make_unique<Network::ApplicationProtocols>(alpn_override),
+      std::make_unique<Network::ApplicationProtocols>(alpn_override, std::vector<std::string>{}),
       StreamInfo::FilterState::StateType::ReadOnly);
 
   EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _))

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1267,7 +1267,8 @@ TEST_F(TcpProxyRoutingTest, ApplicationProtocols) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   stream_info.filterState().setData(
       Network::ApplicationProtocols::key(),
-      std::make_unique<Network::ApplicationProtocols>(std::vector<std::string>{"foo", "bar"}),
+      std::make_unique<Network::ApplicationProtocols>(Network::ApplicationProtocolOverride{},
+                                                      std::vector<std::string>{"foo", "bar"}),
       StreamInfo::FilterState::StateType::ReadOnly);
 
   ON_CALL(connection_, streamInfo()).WillByDefault(ReturnRef(stream_info));


### PR DESCRIPTION
Signed-off-by: crazyxy <yxyan@google.com>

Description: select alpn override by upstream protocol
Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Fixes #Issue: Part of https://github.com/envoyproxy/envoy/issues/8197
