### PR TITLE
clang-tidy: validate casing of private members

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -67,6 +67,12 @@ CheckOptions:
 
   - key:             readability-identifier-naming.ParameterCase
     value:           'lower_case'
-  
+
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+
   - key:             readability-identifier-naming.TypeAliasCase
     value:           'CamelCase'

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -35,8 +35,8 @@ public:
           rate_limit_settings.max_tokens_, time_source_, rate_limit_settings.fill_rate_);
       drain_request_timer_ = dispatcher.createTimer([this]() { callbacks_->onWriteable(); });
     }
-    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(retry_initial_delay_ms_,
-                                                                  retry_max_delay_ms_, random_);
+    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RETRY_INITIAL_DELAY_MS,
+                                                                  RETRY_MAX_DELAY_MS, random_);
   }
 
   void establishNewStream() {
@@ -129,8 +129,8 @@ private:
   GrpcStreamCallbacks<ResponseProto>* const callbacks_;
 
   // TODO(htuch): Make this configurable or some static.
-  const uint32_t retry_initial_delay_ms_ = 500;
-  const uint32_t retry_max_delay_ms_ = 30000; // Do not cross more than 30s
+  static constexpr uint32_t RETRY_INITIAL_DELAY_MS = 500;
+  static constexpr uint32_t RETRY_MAX_DELAY_MS = 30000; // Do not cross more than 30s
 
   Grpc::AsyncClient<RequestProto, ResponseProto> async_client_;
   Grpc::AsyncStream<RequestProto> stream_{};

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -35,8 +35,8 @@ public:
           rate_limit_settings.max_tokens_, time_source_, rate_limit_settings.fill_rate_);
       drain_request_timer_ = dispatcher.createTimer([this]() { callbacks_->onWriteable(); });
     }
-    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RETRY_INITIAL_DELAY_MS,
-                                                                  RETRY_MAX_DELAY_MS, random_);
+    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(retry_initial_delay_ms_,
+                                                                  retry_max_delay_ms_, random_);
   }
 
   void establishNewStream() {
@@ -129,8 +129,8 @@ private:
   GrpcStreamCallbacks<ResponseProto>* const callbacks_;
 
   // TODO(htuch): Make this configurable or some static.
-  const uint32_t RETRY_INITIAL_DELAY_MS = 500;
-  const uint32_t RETRY_MAX_DELAY_MS = 30000; // Do not cross more than 30s
+  const uint32_t retry_initial_delay_ms_ = 500;
+  const uint32_t retry_max_delay_ms_ = 30000; // Do not cross more than 30s
 
   Grpc::AsyncClient<RequestProto, ResponseProto> async_client_;
   Grpc::AsyncStream<RequestProto> stream_{};

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -36,7 +36,7 @@ public:
       drain_request_timer_ = dispatcher.createTimer([this]() { callbacks_->onWriteable(); });
     }
 
-    // TODO(htuch): Make this configurable or some static.
+    // TODO(htuch): Make this configurable.
     static constexpr uint32_t RetryInitialDelayMs = 500;
     static constexpr uint32_t RetryMaxDelayMs = 30000; // Do not cross more than 30s
     backoff_strategy_ =

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -39,8 +39,8 @@ public:
     // TODO(htuch): Make this configurable or some static.
     static constexpr uint32_t RetryInitialDelayMs = 500;
     static constexpr uint32_t RetryMaxDelayMs = 30000; // Do not cross more than 30s
-    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RetryInitialDelayMs,
-                                                                  RetryMaxDelayMs, random_);
+    backoff_strategy_ =
+        std::make_unique<JitteredBackOffStrategy>(RetryInitialDelayMs, RetryMaxDelayMs, random_);
   }
 
   void establishNewStream() {

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -35,8 +35,12 @@ public:
           rate_limit_settings.max_tokens_, time_source_, rate_limit_settings.fill_rate_);
       drain_request_timer_ = dispatcher.createTimer([this]() { callbacks_->onWriteable(); });
     }
-    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RETRY_INITIAL_DELAY_MS,
-                                                                  RETRY_MAX_DELAY_MS, random_);
+
+    // TODO(htuch): Make this configurable or some static.
+    static constexpr uint32_t RetryInitialDelayMs = 500;
+    static constexpr uint32_t RetryMaxDelayMs = 30000; // Do not cross more than 30s
+    backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RetryInitialDelayMs,
+                                                                  RetryMaxDelayMs, random_);
   }
 
   void establishNewStream() {
@@ -127,10 +131,6 @@ private:
   }
 
   GrpcStreamCallbacks<ResponseProto>* const callbacks_;
-
-  // TODO(htuch): Make this configurable or some static.
-  static constexpr uint32_t RETRY_INITIAL_DELAY_MS = 500;
-  static constexpr uint32_t RETRY_MAX_DELAY_MS = 30000; // Do not cross more than 30s
 
   Grpc::AsyncClient<RequestProto, ResponseProto> async_client_;
   Grpc::AsyncStream<RequestProto> stream_{};

--- a/source/common/http/codes.h
+++ b/source/common/http/codes.h
@@ -78,7 +78,6 @@ private:
   const Stats::StatName upstream_rq_5xx_;
   const Stats::StatName upstream_rq_unknown_;
   const Stats::StatName upstream_rq_completed_;
-  const Stats::StatName upstream_rq_time;
   const Stats::StatName upstream_rq_time_;
   const Stats::StatName vcluster_;
   const Stats::StatName vhost_;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -378,8 +378,8 @@ DiskLayer::DiskLayer(absl::string_view name, const std::string& path, Api::Api& 
 void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix, uint32_t depth,
                               Api::Api& api) {
   ENVOY_LOG(debug, "walking directory: {}", path);
-  if (depth > max_walk_depth_) {
-    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", max_walk_depth_));
+  if (depth > MAX_WALK_DEPTH) {
+    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", MAX_WALK_DEPTH));
   }
   // Check if this is an obviously bad path.
   if (api.fileSystem().illegalPath(path)) {

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -377,9 +377,12 @@ DiskLayer::DiskLayer(absl::string_view name, const std::string& path, Api::Api& 
 
 void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix, uint32_t depth,
                               Api::Api& api) {
+  // Maximum recursion depth for walkDirectory().
+  static constexpr uint32_t MaxWalkDepth = 16;
+
   ENVOY_LOG(debug, "walking directory: {}", path);
-  if (depth > MAX_WALK_DEPTH) {
-    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", MAX_WALK_DEPTH));
+  if (depth > MaxWalkDepth) {
+    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", MaxWalkDepth));
   }
   // Check if this is an obviously bad path.
   if (api.fileSystem().illegalPath(path)) {

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -378,8 +378,8 @@ DiskLayer::DiskLayer(absl::string_view name, const std::string& path, Api::Api& 
 void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix, uint32_t depth,
                               Api::Api& api) {
   ENVOY_LOG(debug, "walking directory: {}", path);
-  if (depth > MaxWalkDepth) {
-    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", MaxWalkDepth));
+  if (depth > max_walk_depth_) {
+    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", max_walk_depth_));
   }
   // Check if this is an obviously bad path.
   if (api.fileSystem().illegalPath(path)) {

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -182,7 +182,7 @@ private:
 
   const std::string path_;
   // Maximum recursion depth for walkDirectory().
-  const uint32_t max_walk_depth_ = 16;
+  static constexpr uint32_t MAX_WALK_DEPTH = 16;
   const Filesystem::WatcherPtr watcher_;
 };
 

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -181,8 +181,6 @@ private:
                      Api::Api& api);
 
   const std::string path_;
-  // Maximum recursion depth for walkDirectory().
-  static constexpr uint32_t MAX_WALK_DEPTH = 16;
   const Filesystem::WatcherPtr watcher_;
 };
 

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -182,7 +182,7 @@ private:
 
   const std::string path_;
   // Maximum recursion depth for walkDirectory().
-  const uint32_t MaxWalkDepth = 16;
+  const uint32_t max_walk_depth_ = 16;
   const Filesystem::WatcherPtr watcher_;
 };
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -25,8 +25,8 @@ HdsDelegate::HdsDelegate(Stats::Scope& scope, Grpc::RawAsyncClientPtr async_clie
       validation_visitor_(validation_visitor), api_(api) {
   health_check_request_.mutable_health_check_request()->mutable_node()->MergeFrom(
       local_info_.node());
-  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(retry_initial_delay_milliseconds_,
-                                                                retry_max_delay_milliseconds_, random_);
+  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(
+      retry_initial_delay_milliseconds_, retry_max_delay_milliseconds_, random_);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -26,7 +26,7 @@ HdsDelegate::HdsDelegate(Stats::Scope& scope, Grpc::RawAsyncClientPtr async_clie
   health_check_request_.mutable_health_check_request()->mutable_node()->MergeFrom(
       local_info_.node());
   backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(
-      retry_initial_delay_milliseconds_, retry_max_delay_milliseconds_, random_);
+      RETRY_INITIAL_DELAY_MILLISECONDS, retry_max_delay_milliseconds_, random_);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 
@@ -126,9 +126,9 @@ void HdsDelegate::processMessage(
     envoy::api::v2::Cluster cluster_config;
 
     cluster_config.set_name(cluster_health_check.cluster_name());
-    cluster_config.mutable_connect_timeout()->set_seconds(ClusterTimeoutSeconds);
+    cluster_config.mutable_connect_timeout()->set_seconds(CLUSTER_TIMEOUT_SECONDS);
     cluster_config.mutable_per_connection_buffer_limit_bytes()->set_value(
-        ClusterConnectionBufferLimitBytes);
+        CLUSTER_CONNECTION_BUFFER_LIMIT_BYTES);
 
     // Add endpoints to cluster
     for (const auto& locality_endpoints : cluster_health_check.locality_endpoints()) {

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -8,12 +8,12 @@ namespace Envoy {
 namespace Upstream {
 
 /**
-   * TODO(lilika): Add API knob for RetryInitialDelayMilliseconds
-   * and RetryMaxDelayMilliseconds, instead of hardcoding them.
-   *
-   * Parameters of the jittered backoff strategy that defines how often
-   * we retry to establish a stream to the management server
-   */
+ * TODO(lilika): Add API knob for RetryInitialDelayMilliseconds
+ * and RetryMaxDelayMilliseconds, instead of hardcoding them.
+ *
+ * Parameters of the jittered backoff strategy that defines how often
+ * we retry to establish a stream to the management server
+ */
 static constexpr uint32_t RetryInitialDelayMilliseconds = 1000;
 static constexpr uint32_t RetryMaxDelayMilliseconds = 30000;
 
@@ -35,8 +35,8 @@ HdsDelegate::HdsDelegate(Stats::Scope& scope, Grpc::RawAsyncClientPtr async_clie
       validation_visitor_(validation_visitor), api_(api) {
   health_check_request_.mutable_health_check_request()->mutable_node()->MergeFrom(
       local_info_.node());
-  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(
-      RetryInitialDelayMilliseconds, RetryMaxDelayMilliseconds, random_);
+  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RetryInitialDelayMilliseconds,
+                                                                RetryMaxDelayMilliseconds, random_);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -26,7 +26,7 @@ HdsDelegate::HdsDelegate(Stats::Scope& scope, Grpc::RawAsyncClientPtr async_clie
   health_check_request_.mutable_health_check_request()->mutable_node()->MergeFrom(
       local_info_.node());
   backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(
-      RETRY_INITIAL_DELAY_MILLISECONDS, retry_max_delay_milliseconds_, random_);
+      RETRY_INITIAL_DELAY_MILLISECONDS, RETRY_MAX_DELAY_MILLISECONDS, random_);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -182,16 +182,16 @@ private:
    * Parameters of the jittered backoff strategy that defines how often
    * we retry to establish a stream to the management server
    */
-  const uint32_t retry_initial_delay_milliseconds_ = 1000;
-  const uint32_t retry_max_delay_milliseconds_ = 30000;
+  static constexpr uint32_t RETRY_INITIAL_DELAY_MILLISECONDS = 1000;
+  static constexpr uint32_t RETRY_MAX_DELAY_MILLISECONDS = 30000;
 
   // Soft limit on size of the cluster’s connections read and write buffers.
-  static constexpr uint32_t ClusterConnectionBufferLimitBytes = 32768;
+  static constexpr uint32_t CLUSTER_CONNECTION_BUFFER_LIMIT_BYTES = 32768;
 
-  // TODO(lilika): Add API knob for ClusterTimeoutSeconds, instead of
+  // TODO(lilika): Add API knob for CLUSTER_TIMEOUT_SECONDS, instead of
   // hardcoding it.
   // The timeout for new network connections to hosts in the cluster.
-  static constexpr uint32_t ClusterTimeoutSeconds = 1;
+  static constexpr uint32_t CLUSTER_TIMEOUT_SECONDS = 1;
 
   // How often envoy reports the healthcheck results to the server
   uint32_t server_response_ms_ = 0;

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -175,23 +175,13 @@ private:
   Event::TimerPtr hds_retry_timer_;
   BackOffStrategyPtr backoff_strategy_;
 
-  /**
-   * TODO(lilika): Add API knob for RetryInitialDelayMilliseconds
-   * and RetryMaxDelayMilliseconds, instead of hardcoding them.
-   *
-   * Parameters of the jittered backoff strategy that defines how often
-   * we retry to establish a stream to the management server
-   */
-  static constexpr uint32_t RETRY_INITIAL_DELAY_MILLISECONDS = 1000;
-  static constexpr uint32_t RETRY_MAX_DELAY_MILLISECONDS = 30000;
-
   // Soft limit on size of the cluster’s connections read and write buffers.
-  static constexpr uint32_t CLUSTER_CONNECTION_BUFFER_LIMIT_BYTES = 32768;
+  static constexpr uint32_t ClusterConnectionBufferLimitBytes = 32768;
 
-  // TODO(lilika): Add API knob for CLUSTER_TIMEOUT_SECONDS, instead of
+  // TODO(lilika): Add API knob for ClusterTimeoutSeconds, instead of
   // hardcoding it.
   // The timeout for new network connections to hosts in the cluster.
-  static constexpr uint32_t CLUSTER_TIMEOUT_SECONDS = 1;
+  static constexpr uint32_t ClusterTimeoutSeconds = 1;
 
   // How often envoy reports the healthcheck results to the server
   uint32_t server_response_ms_ = 0;

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -154,7 +154,7 @@ private:
       stream_{};
   Event::Dispatcher& dispatcher_;
   Runtime::Loader& runtime_;
-  Envoy::Stats::Store& store_stats;
+  Envoy::Stats::Store& store_stats_;
   Ssl::ContextManager& ssl_context_manager_;
   Runtime::RandomGenerator& random_;
   ClusterInfoFactory& info_factory_;
@@ -182,8 +182,8 @@ private:
    * Parameters of the jittered backoff strategy that defines how often
    * we retry to establish a stream to the management server
    */
-  const uint32_t RetryInitialDelayMilliseconds = 1000;
-  const uint32_t RetryMaxDelayMilliseconds = 30000;
+  const uint32_t retry_initial_delay_milliseconds_ = 1000;
+  const uint32_t retry_max_delay_milliseconds_ = 30000;
 
   // Soft limit on size of the cluster’s connections read and write buffers.
   static constexpr uint32_t ClusterConnectionBufferLimitBytes = 32768;

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -156,8 +156,8 @@ public:
   }
 
   const SuccessRateMonitor& getSRMonitor(SuccessRateMonitorType type) const {
-    return (SuccessRateMonitorType::ExternalOrigin == type) ? external_origin_SR_monitor_
-                                                            : local_origin_SR_monitor_;
+    return (SuccessRateMonitorType::ExternalOrigin == type) ? external_origin_sr_monitor_
+                                                            : local_origin_sr_monitor_;
   }
 
   SuccessRateMonitor& getSRMonitor(SuccessRateMonitorType type) {
@@ -197,8 +197,8 @@ private:
   //   and for external origin failures when external/local events are split
   // - local origin: for local events when external/local events are split and
   //   not used when external/local events are not split.
-  SuccessRateMonitor external_origin_SR_monitor_;
-  SuccessRateMonitor local_origin_SR_monitor_;
+  SuccessRateMonitor external_origin_sr_monitor_;
+  SuccessRateMonitor local_origin_sr_monitor_;
 
   void putResultNoLocalExternalSplit(Result result, absl::optional<uint64_t> code);
   void putResultWithLocalExternalSplit(Result result, absl::optional<uint64_t> code);
@@ -396,17 +396,17 @@ private:
   EventLoggerSharedPtr event_logger_;
 
   // EjectionPair for external and local origin events.
-  // When external/local origin events are not split, external_origin_SR_num_ are used for
-  // both types of events: external and local. local_origin_SR_num_ is not used.
-  // When external/local origin events are split, external_origin_SR_num_ are used only
-  // for external events and local_origin_SR_num_ is used for local origin events.
-  EjectionPair external_origin_SR_num_;
-  EjectionPair local_origin_SR_num_;
+  // When external/local origin events are not split, external_origin_sr_num_ are used for
+  // both types of events: external and local. local_origin_sr_num_ is not used.
+  // When external/local origin events are split, external_origin_sr_num_ are used only
+  // for external events and local_origin_sr_num_ is used for local origin events.
+  EjectionPair external_origin_sr_num_;
+  EjectionPair local_origin_sr_num_;
 
   const EjectionPair& getSRNums(DetectorHostMonitor::SuccessRateMonitorType monitor_type) const {
     return (DetectorHostMonitor::SuccessRateMonitorType::ExternalOrigin == monitor_type)
-               ? external_origin_SR_num_
-               : local_origin_SR_num_;
+               ? external_origin_sr_num_
+               : local_origin_sr_num_;
   }
   EjectionPair& getSRNums(DetectorHostMonitor::SuccessRateMonitorType monitor_type) {
     return const_cast<EjectionPair&>(

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -121,8 +121,8 @@ public:
 
 private:
 #ifdef ENVOY_HANDLE_SIGNALS
-  Envoy::SignalAction handle_sigs;
-  Envoy::TerminateHandler log_on_terminate;
+  Envoy::SignalAction handle_sigs_;
+  Envoy::TerminateHandler log_on_terminate_;
 #endif
 
   PlatformImpl platform_impl_;

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -122,8 +122,8 @@ void HotRestartingBase::getPassedFdIfPresent(HotRestartMessage* out, msghdr* mes
   }
 }
 
-// While in use, recv_buf_ is always >= max_send_msg_size_. In between messages, it is kept empty, to be
-// grown back to max_send_msg_size_ at the start of the next message.
+// While in use, recv_buf_ is always >= max_send_msg_size_. In between messages, it is kept empty,
+// to be grown back to max_send_msg_size_ at the start of the next message.
 void HotRestartingBase::initRecvBufIfNewMessage() {
   if (recv_buf_.empty()) {
     ASSERT(cur_msg_recvd_bytes_ == 0);

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -60,7 +60,7 @@ void HotRestartingBase::sendHotRestartMessage(sockaddr_un& address,
   uint8_t* next_byte_to_send = send_buf.data();
   uint64_t sent = 0;
   while (sent < total_size) {
-    const uint64_t cur_chunk_size = std::min(max_send_msg_size_, total_size - sent);
+    const uint64_t cur_chunk_size = std::min(MAX_SEND_MSG_SIZE, total_size - sent);
     iovec iov[1];
     iov[0].iov_base = next_byte_to_send;
     iov[0].iov_len = cur_chunk_size;
@@ -122,13 +122,13 @@ void HotRestartingBase::getPassedFdIfPresent(HotRestartMessage* out, msghdr* mes
   }
 }
 
-// While in use, recv_buf_ is always >= max_send_msg_size_. In between messages, it is kept empty,
-// to be grown back to max_send_msg_size_ at the start of the next message.
+// While in use, recv_buf_ is always >= MAX_SEND_MSG_SIZE. In between messages, it is kept empty,
+// to be grown back to MAX_SEND_MSG_SIZE at the start of the next message.
 void HotRestartingBase::initRecvBufIfNewMessage() {
   if (recv_buf_.empty()) {
     ASSERT(cur_msg_recvd_bytes_ == 0);
     ASSERT(!expected_proto_length_.has_value());
-    recv_buf_.resize(max_send_msg_size_);
+    recv_buf_.resize(MAX_SEND_MSG_SIZE);
   }
 }
 
@@ -160,7 +160,7 @@ std::unique_ptr<HotRestartMessage> HotRestartingBase::receiveHotRestartMessage(B
   std::unique_ptr<HotRestartMessage> ret = nullptr;
   while (!ret) {
     iov[0].iov_base = recv_buf_.data() + cur_msg_recvd_bytes_;
-    iov[0].iov_len = max_send_msg_size_;
+    iov[0].iov_len = MAX_SEND_MSG_SIZE;
 
     // We always setup to receive an FD even though most messages do not pass one.
     memset(control_buffer, 0, CMSG_SPACE(sizeof(int)));
@@ -186,7 +186,7 @@ std::unique_ptr<HotRestartMessage> HotRestartingBase::receiveHotRestartMessage(B
 
       expected_proto_length_ = be64toh(*reinterpret_cast<uint64_t*>(recv_buf_.data()));
       // Expand the buffer from its default 4096 if this message is going to be longer.
-      if (expected_proto_length_.value() > max_send_msg_size_ - sizeof(uint64_t)) {
+      if (expected_proto_length_.value() > MAX_SEND_MSG_SIZE - sizeof(uint64_t)) {
         recv_buf_.resize(expected_proto_length_.value() + sizeof(uint64_t));
         cur_msg_recvd_bytes_ = recvmsg_rc;
       }

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -69,7 +69,7 @@ private:
   const uint64_t base_id_;
   int my_domain_socket_{-1};
 
-  const uint64_t MaxSendmsgSize = 4096;
+  const uint64_t max_send_msg_size_ = 4096;
 
   // State for the receiving half of the protocol.
   //

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -69,7 +69,7 @@ private:
   const uint64_t base_id_;
   int my_domain_socket_{-1};
 
-  const uint64_t max_send_msg_size_ = 4096;
+  static constexpr uint64_t MAX_SEND_MSG_SIZE = 4096;
 
   // State for the receiving half of the protocol.
   //

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -61,15 +61,13 @@ private:
   std::unique_ptr<envoy::HotRestartMessage> parseProtoAndResetState();
   void initRecvBufIfNewMessage();
 
-  // An int in [0, MAX_CONCURRENT_PROCESSES). As hot restarts happen, each next process gets the
+  // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
   // next of 0,1,2,0,1,...
   // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
   // this value to determine which domain socket name to treat as our parent, and which to treat as
   // our child. (E.g. if we are 2, 1 is parent and 0 is child).
   const uint64_t base_id_;
   int my_domain_socket_{-1};
-
-  static constexpr uint64_t MAX_SEND_MSG_SIZE = 4096;
 
   // State for the receiving half of the protocol.
   //

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -55,7 +55,7 @@ class TestDnsServerQuery {
 public:
   TestDnsServerQuery(ConnectionPtr connection, const HostMap& hosts_a, const HostMap& hosts_aaaa,
                      const CNameMap& cnames, const std::chrono::seconds& record_ttl)
-      : connection_(std::move(connection)), hosts_A_(hosts_a), hosts_AAAA_(hosts_aaaa),
+      : connection_(std::move(connection)), hosts_a_(hosts_a), hosts_aaaa_(hosts_aaaa),
         cnames_(cnames), record_ttl_(record_ttl) {
     connection_->addReadFilter(Network::ReadFilterSharedPtr{new ReadFilter(*this)});
   }
@@ -119,8 +119,8 @@ private:
         long name_len;
         // Get host name from query and use the name to lookup a record
         // in a host map. If the query type is of type A, then perform the lookup in
-        // the hosts_A_ host map. If the query type is of type AAAA, then perform the
-        // lookup in the hosts_AAAA_ host map.
+        // the hosts_a_ host map. If the query type is of type AAAA, then perform the
+        // lookup in the hosts_aaaa_ host map.
         char* name;
         ASSERT_EQ(ARES_SUCCESS, ares_expand_name(question, request, size_, &name, &name_len));
         const std::list<std::string>* ips = nullptr;
@@ -147,13 +147,13 @@ private:
         }
         ASSERT_TRUE(q_type == T_A || q_type == T_AAAA);
         if (q_type == T_A) {
-          auto it = parent_.hosts_A_.find(hostLookup);
-          if (it != parent_.hosts_A_.end()) {
+          auto it = parent_.hosts_a_.find(hostLookup);
+          if (it != parent_.hosts_a_.end()) {
             ips = &it->second;
           }
         } else {
-          auto it = parent_.hosts_AAAA_.find(hostLookup);
-          if (it != parent_.hosts_AAAA_.end()) {
+          auto it = parent_.hosts_aaaa_.find(hostLookup);
+          if (it != parent_.hosts_aaaa_.end()) {
             ips = &it->second;
           }
         }
@@ -248,8 +248,8 @@ private:
 
 private:
   ConnectionPtr connection_;
-  const HostMap& hosts_A_;
-  const HostMap& hosts_AAAA_;
+  const HostMap& hosts_a_;
+  const HostMap& hosts_aaaa_;
   const CNameMap& cnames_;
   const std::chrono::seconds& record_ttl_;
 };
@@ -265,16 +265,16 @@ public:
   }
 
   void onNewConnection(ConnectionPtr&& new_connection) override {
-    TestDnsServerQuery* query = new TestDnsServerQuery(std::move(new_connection), hosts_A_,
-                                                       hosts_AAAA_, cnames_, record_ttl_);
+    TestDnsServerQuery* query = new TestDnsServerQuery(std::move(new_connection), hosts_a_,
+                                                       hosts_aaaa_, cnames_, record_ttl_);
     queries_.emplace_back(query);
   }
 
   void addHosts(const std::string& hostname, const IpList& ip, const RecordType& type) {
     if (type == RecordType::A) {
-      hosts_A_[hostname] = ip;
+      hosts_a_[hostname] = ip;
     } else if (type == RecordType::AAAA) {
-      hosts_AAAA_[hostname] = ip;
+      hosts_aaaa_[hostname] = ip;
     }
   }
 
@@ -287,8 +287,8 @@ public:
 private:
   Event::Dispatcher& dispatcher_;
 
-  HostMap hosts_A_;
-  HostMap hosts_AAAA_;
+  HostMap hosts_a_;
+  HostMap hosts_aaaa_;
   CNameMap cnames_;
   std::chrono::seconds record_ttl_;
   // All queries are tracked so we can do resource reclamation when the test is

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -180,7 +180,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
   bool no_failures = true;
   for (const envoy::RouterCheckToolSchema::ValidationItem& check_config :
        validation_config.tests()) {
-    active_runtime = check_config.input().runtime();
+    active_runtime_ = check_config.input().runtime();
     headers_finalized_ = false;
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
@@ -450,7 +450,7 @@ void RouterCheckTool::printResults() {
 bool RouterCheckTool::runtimeMock(const std::string& key,
                                   const envoy::type::FractionalPercent& default_value,
                                   uint64_t random_value) {
-  return !active_runtime.empty() && active_runtime.compare(key) == 0 &&
+  return !active_runtime_.empty() && active_runtime_.compare(key) == 0 &&
          ProtobufPercentHelper::evaluateFractionalPercent(default_value, random_value);
 }
 

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -167,7 +167,7 @@ private:
   std::unique_ptr<Router::ConfigImpl> config_;
   std::unique_ptr<Stats::IsolatedStoreImpl> stats_;
   Api::ApiPtr api_;
-  std::string active_runtime;
+  std::string active_runtime_;
   Coverage coverage_;
 };
 


### PR DESCRIPTION
Description: standardize private class members as `lower_case_`.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>