### PR TITLE
tools: refactor .bzl to unify {protoxform,protodoc}.bzl.

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -51,7 +51,7 @@ pip3 install -r "${SCRIPT_DIR}"/requirements.txt
 rm -rf bazel-bin/external/envoy_api
 
 bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
-  tools/protodoc/protodoc.bzl%proto_doc_aspect --output_groups=rst --action_env=CPROFILE_ENABLED=1 \
+  tools/protodoc/protodoc.bzl%protodoc_aspect --output_groups=rst --action_env=CPROFILE_ENABLED=1 \
   --action_env=ENVOY_BLOB_SHA --spawn_strategy=standalone --host_force_python=PY3
 
 # We do ** matching below to deal with Bazel cache blah (source proto artifacts

--- a/tools/api_proto_plugin/plugin.bzl
+++ b/tools/api_proto_plugin/plugin.bzl
@@ -1,0 +1,89 @@
+# Borrowed from
+# https://github.com/bazelbuild/rules_go/blob/master/proto/toolchain.bzl. This
+# does some magic munging to remove workspace prefixes from output paths to
+# convert path as understood by Bazel into paths as understood by protoc.
+def _proto_path(proto):
+    """
+    The proto path is not really a file path
+    It's the path to the proto that was seen when the descriptor file was generated.
+    """
+    path = proto.path
+    root = proto.root.path
+    ws = proto.owner.workspace_root
+    if path.startswith(root):
+        path = path[len(root):]
+    if path.startswith("/"):
+        path = path[1:]
+    if path.startswith(ws):
+        path = path[len(ws):]
+    if path.startswith("/"):
+        path = path[1:]
+    return path
+
+def api_proto_plugin_impl(target, ctx, output_group, mnemonic, output_suffixes):
+    # Compute output files from the current proto_library node's dependencies.
+    transitive_outputs = depset(transitive = [dep.output_groups[output_group] for dep in ctx.rule.attr.deps])
+    proto_sources = target[ProtoInfo].direct_sources
+
+    # If this proto_library doesn't actually name any sources, e.g. //api:api,
+    # but just glues together other libs, we just need to follow the graph.
+    if not proto_sources:
+        return [OutputGroupInfo(**{output_group: transitive_outputs})]
+
+    # Figure out the set of import paths. Ideally we would use descriptor sets
+    # built by proto_library, which avoid having to do nasty path mangling, but
+    # these don't include source_code_info, which we need for comment
+    # extractions. See https://github.com/bazelbuild/bazel/issues/3971.
+    import_paths = []
+    for f in target[ProtoInfo].transitive_sources.to_list():
+        if f.root.path:
+            import_path = f.root.path + "/" + f.owner.workspace_root
+        else:
+            import_path = f.owner.workspace_root
+        if import_path:
+            import_paths += [import_path]
+
+    # The outputs live in the ctx.label's package root. We add some additional
+    # path information to match with protoc's notion of path relative locations.
+    outputs = []
+    for output_suffix in output_suffixes:
+        outputs += [ctx.actions.declare_file(ctx.label.name + "/" + _proto_path(f) +
+                                             output_suffix) for f in proto_sources]
+
+    # Create the protoc command-line args.
+    ctx_path = ctx.label.package + "/" + ctx.label.name
+    output_path = outputs[0].root.path + "/" + outputs[0].owner.workspace_root + "/" + ctx_path
+    args = ["-I./" + ctx.label.workspace_root]
+    args += ["-I" + import_path for import_path in import_paths]
+    args += ["--plugin=protoc-gen-api_proto_plugin=" + ctx.executable._api_proto_plugin.path, "--api_proto_plugin_out=" + output_path]
+    args += [_proto_path(src) for src in target[ProtoInfo].direct_sources]
+    ctx.actions.run(
+        executable = ctx.executable._protoc,
+        arguments = args,
+        inputs = target[ProtoInfo].transitive_sources,
+        tools = [ctx.executable._api_proto_plugin],
+        outputs = outputs,
+        mnemonic = mnemonic,
+        use_default_shell_env = True,
+    )
+
+    transitive_outputs = depset(outputs, transitive = [transitive_outputs])
+    return [OutputGroupInfo(**{output_group: transitive_outputs})]
+
+def api_proto_plugin_aspect(tool_label, aspect_impl):
+    return aspect(
+        attr_aspects = ["deps"],
+        attrs = {
+            "_protoc": attr.label(
+                default = Label("@com_google_protobuf//:protoc"),
+                executable = True,
+                cfg = "exec",
+            ),
+            "_api_proto_plugin": attr.label(
+                default = Label(tool_label),
+                executable = True,
+                cfg = "exec",
+            ),
+        },
+        implementation = aspect_impl,
+    )

--- a/tools/proto_format.sh
+++ b/tools/proto_format.sh
@@ -15,7 +15,7 @@ rm -rf bazel-bin/external/envoy_api
 # the precise set of protos we want to format, but as a starting place it seems
 # reasonable. In the future, we should change the logic here.
 bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
-  tools/protoxform/protoxform.bzl%proto_xform_aspect --output_groups=proto --action_env=CPROFILE_ENABLED=1 \
+  tools/protoxform/protoxform.bzl%protoxform_aspect --output_groups=proto --action_env=CPROFILE_ENABLED=1 \
   --spawn_strategy=standalone --host_force_python=PY3
 
 # Find all source protos.

--- a/tools/protodoc/protodoc.bzl
+++ b/tools/protodoc/protodoc.bzl
@@ -1,94 +1,15 @@
-# Borrowed from
-# https://github.com/bazelbuild/rules_go/blob/master/proto/toolchain.bzl. This
-# does some magic munging to remove workspace prefixes from output paths to
-# convert path as understood by Bazel into paths as understood by protoc.
-def _proto_path(proto):
-    """
-    The proto path is not really a file path
-    It's the path to the proto that was seen when the descriptor file was generated.
-    """
-    path = proto.path
-    root = proto.root.path
-    ws = proto.owner.workspace_root
-    if path.startswith(root):
-        path = path[len(root):]
-    if path.startswith("/"):
-        path = path[1:]
-    if path.startswith(ws):
-        path = path[len(ws):]
-    if path.startswith("/"):
-        path = path[1:]
-    return path
+load("//tools/api_proto_plugin:plugin.bzl", "api_proto_plugin_aspect", "api_proto_plugin_impl")
+
+def _protodoc_impl(target, ctx):
+    return api_proto_plugin_impl(target, ctx, "rst", "protodoc", [".rst"])
 
 # Bazel aspect (https://docs.bazel.build/versions/master/skylark/aspects.html)
 # that can be invoked from the CLI to produce docs via //tools/protodoc for
 # proto_library targets. Example use:
 #
-#   bazel build //api --aspects tools/protodoc/protodoc.bzl%proto_doc_aspect \
+#   bazel build //api --aspects tools/protodoc/protodoc.bzl%protodoc_aspect \
 #       --output_groups=rst
 #
 # The aspect builds the transitive docs, so any .proto in the dependency graph
 # get docs created.
-def _proto_doc_aspect_impl(target, ctx):
-    # Compute RST files from the current proto_library node's dependencies.
-    transitive_outputs = depset(transitive = [dep.output_groups["rst"] for dep in ctx.rule.attr.deps])
-    proto_sources = target[ProtoInfo].direct_sources
-
-    # If this proto_library doesn't actually name any sources, e.g. //api:api,
-    # but just glues together other libs, we just need to follow the graph.
-    if not proto_sources:
-        return [OutputGroupInfo(rst = transitive_outputs)]
-
-    # Figure out the set of import paths. Ideally we would use descriptor sets
-    # built by proto_library, which avoid having to do nasty path mangling, but
-    # these don't include source_code_info, which we need for comment
-    # extractions. See https://github.com/bazelbuild/bazel/issues/3971.
-    import_paths = []
-    for f in target[ProtoInfo].transitive_sources.to_list():
-        if f.root.path:
-            import_path = f.root.path + "/" + f.owner.workspace_root
-        else:
-            import_path = f.owner.workspace_root
-        if import_path:
-            import_paths += [import_path]
-
-    # The outputs live in the ctx.label's package root. We add some additional
-    # path information to match with protoc's notion of path relative locations.
-    outputs = [ctx.actions.declare_file(ctx.label.name + "/" + _proto_path(f) +
-                                        ".rst") for f in proto_sources]
-
-    # Create the protoc command-line args.
-    ctx_path = ctx.label.package + "/" + ctx.label.name
-    output_path = outputs[0].root.path + "/" + outputs[0].owner.workspace_root + "/" + ctx_path
-    args = ["-I./" + ctx.label.workspace_root]
-    args += ["-I" + import_path for import_path in import_paths]
-    args += ["--plugin=protoc-gen-protodoc=" + ctx.executable._protodoc.path, "--protodoc_out=" + output_path]
-    args += [_proto_path(src) for src in target[ProtoInfo].direct_sources]
-    ctx.actions.run(
-        executable = ctx.executable._protoc,
-        arguments = args,
-        inputs = target[ProtoInfo].transitive_sources,
-        tools = [ctx.executable._protodoc],
-        outputs = outputs,
-        mnemonic = "ProtoDoc",
-        use_default_shell_env = True,
-    )
-    transitive_outputs = depset(outputs, transitive = [transitive_outputs])
-    return [OutputGroupInfo(rst = transitive_outputs)]
-
-proto_doc_aspect = aspect(
-    attr_aspects = ["deps"],
-    attrs = {
-        "_protoc": attr.label(
-            default = Label("@com_google_protobuf//:protoc"),
-            executable = True,
-            cfg = "exec",
-        ),
-        "_protodoc": attr.label(
-            default = Label("//tools/protodoc"),
-            executable = True,
-            cfg = "exec",
-        ),
-    },
-    implementation = _proto_doc_aspect_impl,
-)
+protodoc_aspect = api_proto_plugin_aspect("//tools/protodoc", _protodoc_impl)

--- a/tools/protoxform/protoxform.bzl
+++ b/tools/protoxform/protoxform.bzl
@@ -1,98 +1,12 @@
-# TODO(htuch): this is a clone+modify from //tools/protodoc:protodoc.bzl.
-# Factor out common parts for this kind of API protoc aspect.
+load("//tools/api_proto_plugin:plugin.bzl", "api_proto_plugin_aspect", "api_proto_plugin_impl")
 
-# Borrowed from
-# https://github.com/bazelbuild/rules_go/blob/master/proto/toolchain.bzl. This
-# does some magic munging to remove workspace prefixes from output paths to
-# convert path as understood by Bazel into paths as understood by protoc.
-def _proto_path(proto):
-    """
-    The proto path is not really a file path
-    It's the path to the proto that was seen when the descriptor file was generated.
-    """
-    path = proto.path
-    root = proto.root.path
-    ws = proto.owner.workspace_root
-    if path.startswith(root):
-        path = path[len(root):]
-    if path.startswith("/"):
-        path = path[1:]
-    if path.startswith(ws):
-        path = path[len(ws):]
-    if path.startswith("/"):
-        path = path[1:]
-    return path
+def _protoxform_impl(target, ctx):
+    return api_proto_plugin_impl(target, ctx, "proto", "protoxform", [".v2.proto", ".v3alpha.proto"])
 
 # Bazel aspect (https://docs.bazel.build/versions/master/skylark/aspects.html)
 # that can be invoked from the CLI to perform API transforms via //tools/protoxform for
 # proto_library targets. Example use:
 #
-#   bazel build //api --aspects tools/protoxform/protoxform.bzl%proto_xform_aspect \
+#   bazel build //api --aspects tools/protoxform/protoxform.bzl%protoxform_aspect \
 #       --output_groups=proto
-def _proto_xform_aspect_impl(target, ctx):
-    # Compute .proto files from the current proto_library node's dependencies.
-    transitive_outputs = depset(transitive = [dep.output_groups["proto"] for dep in ctx.rule.attr.deps])
-    proto_sources = target[ProtoInfo].direct_sources
-
-    # If this proto_library doesn't actually name any sources, e.g. //api:api,
-    # but just glues together other libs, we just need to follow the graph.
-    if not proto_sources:
-        return [OutputGroupInfo(proto = transitive_outputs)]
-
-    # Figure out the set of import paths. Ideally we would use descriptor sets
-    # built by proto_library, which avoid having to do nasty path mangling, but
-    # these don't include source_code_info, which we need for comment
-    # extractions. See https://github.com/bazelbuild/bazel/issues/3971.
-    import_paths = []
-    for f in target[ProtoInfo].transitive_sources.to_list():
-        if f.root.path:
-            import_path = f.root.path + "/" + f.owner.workspace_root
-        else:
-            import_path = f.owner.workspace_root
-        if import_path:
-            import_paths += [import_path]
-
-    # The outputs live in the ctx.label's package root. We add some additional
-    # path information to match with protoc's notion of path relative locations.
-    api_versions = ["v2", "v3alpha"]
-    outputs = []
-    for api_version in api_versions:
-        outputs += [ctx.actions.declare_file(ctx.label.name + "/" + _proto_path(f) +
-                                             ".%s.proto" % api_version) for f in proto_sources]
-
-    # Create the protoc command-line args.
-    ctx_path = ctx.label.package + "/" + ctx.label.name
-    output_path = outputs[0].root.path + "/" + outputs[0].owner.workspace_root + "/" + ctx_path
-    args = ["-I./" + ctx.label.workspace_root]
-    args += ["-I" + import_path for import_path in import_paths]
-    args += ["--plugin=protoc-gen-protoxform=" + ctx.executable._protoxform.path, "--protoxform_out=" + output_path]
-    args += [_proto_path(src) for src in target[ProtoInfo].direct_sources]
-    ctx.actions.run(
-        executable = ctx.executable._protoc,
-        arguments = args,
-        inputs = target[ProtoInfo].transitive_sources,
-        tools = [ctx.executable._protoxform],
-        outputs = outputs,
-        mnemonic = "protoxform",
-        use_default_shell_env = True,
-    )
-
-    transitive_outputs = depset(outputs, transitive = [transitive_outputs])
-    return [OutputGroupInfo(proto = transitive_outputs)]
-
-proto_xform_aspect = aspect(
-    attr_aspects = ["deps"],
-    attrs = {
-        "_protoc": attr.label(
-            default = Label("@com_google_protobuf//:protoc"),
-            executable = True,
-            cfg = "exec",
-        ),
-        "_protoxform": attr.label(
-            default = Label("//tools/protoxform"),
-            executable = True,
-            cfg = "exec",
-        ),
-    },
-    implementation = _proto_xform_aspect_impl,
-)
+protoxform_aspect = api_proto_plugin_aspect("//tools/protoxform", _protoxform_impl)


### PR DESCRIPTION
This makes it much cheaper in terms of boiler plate to add a new API
protoc plugin based on the tools/api_proto_plugin framwork. This will be
used to support an additional plugin to perform API-wide type analysis,
generating a type upgrade map that will be consumed by protoxform and
the Envoy binary.

Part of #8082.

Risk level: Low
Testing: Rebuilt API with protoxform, docs with protodoc.

Signed-off-by: Harvey Tuch <htuch@google.com>