### PR TITLE
csrf filter: fix casing of additional origins method

### DIFF
--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -126,7 +126,7 @@ bool CsrfFilter::isValid(const absl::string_view source_origin, Http::HeaderMap&
     return true;
   }
 
-  for (const auto& additional_origin : policy_->additional_origins()) {
+  for (const auto& additional_origin : policy_->additionalOrigins()) {
     if (additional_origin->match(source_origin)) {
       return true;
     }

--- a/source/extensions/filters/http/csrf/csrf_filter.h
+++ b/source/extensions/filters/http/csrf/csrf_filter.h
@@ -37,7 +37,7 @@ public:
   CsrfPolicy(const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
              Runtime::Loader& runtime)
       : policy_(policy), runtime_(runtime) {
-    for (const auto& additional_origin : policy.additionalOrigins()) {
+    for (const auto& additional_origin : policy.additional_origins()) {
       additional_origins_.emplace_back(
           std::make_unique<Matchers::StringMatcherImpl>(additional_origin));
     }

--- a/source/extensions/filters/http/csrf/csrf_filter.h
+++ b/source/extensions/filters/http/csrf/csrf_filter.h
@@ -37,7 +37,7 @@ public:
   CsrfPolicy(const envoy::config::filter::http::csrf::v2::CsrfPolicy& policy,
              Runtime::Loader& runtime)
       : policy_(policy), runtime_(runtime) {
-    for (const auto& additional_origin : policy.additional_origins()) {
+    for (const auto& additional_origin : policy.additionalOrigins()) {
       additional_origins_.emplace_back(
           std::make_unique<Matchers::StringMatcherImpl>(additional_origin));
     }
@@ -58,7 +58,7 @@ public:
                                               shadow_enabled.default_value());
   }
 
-  const std::vector<Matchers::StringMatcherPtr>& additional_origins() const {
+  const std::vector<Matchers::StringMatcherPtr>& additionalOrigins() const {
     return additional_origins_;
   };
 


### PR DESCRIPTION
Signed-off-by: Derek Schaller <d_a_schaller@yahoo.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Fix casing of additional origins method in CSRF http filter
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A as this is an internal styling change
