### PR TITLE
Quiche changes to avoid gcc flags on Windows

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -108,7 +108,10 @@ envoy_cc_library(
     name = "http2_constants_lib",
     srcs = ["quiche/http2/http2_constants.cc"],
     hdrs = ["quiche/http2/http2_constants.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -117,7 +120,10 @@ envoy_cc_library(
     name = "http2_structures_lib",
     srcs = ["quiche/http2/http2_structures.cc"],
     hdrs = ["quiche/http2/http2_structures.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -129,7 +135,10 @@ envoy_cc_library(
     name = "http2_decoder_decode_buffer_lib",
     srcs = ["quiche/http2/decoder/decode_buffer.cc"],
     hdrs = ["quiche/http2/decoder/decode_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -138,7 +147,10 @@ envoy_cc_library(
     name = "http2_decoder_decode_http2_structures_lib",
     srcs = ["quiche/http2/decoder/decode_http2_structures.cc"],
     hdrs = ["quiche/http2/decoder/decode_http2_structures.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -152,7 +164,10 @@ envoy_cc_library(
     name = "http2_decoder_decode_status_lib",
     srcs = ["quiche/http2/decoder/decode_status.cc"],
     hdrs = ["quiche/http2/decoder/decode_status.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -161,7 +176,10 @@ envoy_cc_library(
     name = "http2_decoder_frame_decoder_state_lib",
     srcs = ["quiche/http2/decoder/frame_decoder_state.cc"],
     hdrs = ["quiche/http2/decoder/frame_decoder_state.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -181,7 +199,10 @@ envoy_cc_library(
         "quiche/http2/decoder/frame_decoder_state.h",
         "quiche/http2/decoder/http2_frame_decoder.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -212,7 +233,10 @@ envoy_cc_library(
     name = "http2_decoder_frame_decoder_listener_lib",
     srcs = ["quiche/http2/decoder/http2_frame_decoder_listener.cc"],
     hdrs = ["quiche/http2/decoder/http2_frame_decoder_listener.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -224,7 +248,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_altsvc_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/altsvc_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/altsvc_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -241,7 +268,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_continuation_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/continuation_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/continuation_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -258,7 +288,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_data_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/data_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/data_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -275,7 +308,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_goaway_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/goaway_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/goaway_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -292,7 +328,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_headers_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/headers_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/headers_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -309,7 +348,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_ping_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/ping_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/ping_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -326,7 +368,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_priority_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/priority_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/priority_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -343,7 +388,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_push_promise_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/push_promise_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/push_promise_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -360,7 +408,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_rst_stream_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/rst_stream_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/rst_stream_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -377,7 +428,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_settings_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/settings_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/settings_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -394,7 +448,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_unknown_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/unknown_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/unknown_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -411,7 +468,10 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_window_update_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/window_update_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/window_update_payload_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -429,7 +489,10 @@ envoy_cc_library(
     name = "http2_decoder_structure_decoder_lib",
     srcs = ["quiche/http2/decoder/http2_structure_decoder.cc"],
     hdrs = ["quiche/http2/decoder/http2_structure_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -444,7 +507,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_block_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_block_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_block_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -459,7 +525,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -477,7 +546,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_listener.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_hpack_hpack_constants_lib",
@@ -490,7 +562,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_state_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_state.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_state.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -508,7 +583,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_string_buffer_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_string_buffer.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_string_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_hpack_huffman_hpack_huffman_decoder_lib",
@@ -520,7 +598,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_tables_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_tables.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_tables.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -535,7 +616,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_entry_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_entry_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_entry_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -552,7 +636,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_entry_decoder_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_entry_decoder_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_entry_decoder_listener.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_hpack_hpack_constants_lib",
@@ -564,7 +651,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_entry_type_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_entry_type_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_entry_type_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -579,7 +669,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_string_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_string_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_string_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -593,7 +686,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_string_decoder_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_string_decoder_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_string_decoder_listener.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -602,7 +698,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_whole_entry_buffer_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_whole_entry_buffer.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_whole_entry_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_hpack_decoder_hpack_decoder_string_buffer_lib",
@@ -617,7 +716,10 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_whole_entry_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_whole_entry_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_whole_entry_listener.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_hpack_decoder_hpack_decoder_string_buffer_lib",
@@ -630,7 +732,10 @@ envoy_cc_library(
     name = "http2_hpack_huffman_hpack_huffman_decoder_lib",
     srcs = ["quiche/http2/hpack/huffman/hpack_huffman_decoder.cc"],
     hdrs = ["quiche/http2/hpack/huffman/hpack_huffman_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -639,7 +744,10 @@ envoy_cc_library(
     name = "http2_hpack_huffman_hpack_huffman_encoder_lib",
     srcs = ["quiche/http2/hpack/huffman/hpack_huffman_encoder.cc"],
     hdrs = ["quiche/http2/hpack/huffman/hpack_huffman_encoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_hpack_huffman_huffman_spec_tables_lib",
@@ -651,7 +759,10 @@ envoy_cc_library(
     name = "http2_hpack_huffman_huffman_spec_tables_lib",
     srcs = ["quiche/http2/hpack/huffman/huffman_spec_tables.cc"],
     hdrs = ["quiche/http2/hpack/huffman/huffman_spec_tables.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
 )
 
@@ -659,7 +770,10 @@ envoy_cc_library(
     name = "http2_hpack_hpack_constants_lib",
     srcs = ["quiche/http2/hpack/http2_hpack_constants.cc"],
     hdrs = ["quiche/http2/hpack/http2_hpack_constants.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -674,7 +788,10 @@ envoy_cc_library(
     name = "http2_hpack_hpack_string_lib",
     srcs = ["quiche/http2/hpack/hpack_string.cc"],
     hdrs = ["quiche/http2/hpack/hpack_string.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -683,7 +800,10 @@ envoy_cc_library(
     name = "http2_hpack_varint_hpack_varint_decoder_lib",
     srcs = ["quiche/http2/hpack/varint/hpack_varint_decoder.cc"],
     hdrs = ["quiche/http2/hpack/varint/hpack_varint_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -696,7 +816,10 @@ envoy_cc_library(
     name = "http2_hpack_varint_hpack_varint_encoder_lib",
     srcs = ["quiche/http2/hpack/varint/hpack_varint_encoder.cc"],
     hdrs = ["quiche/http2/hpack/varint/hpack_varint_encoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -763,7 +886,10 @@ envoy_cc_library(
     name = "spdy_core_alt_svc_wire_format_lib",
     srcs = ["quiche/spdy/core/spdy_alt_svc_wire_format.cc"],
     hdrs = ["quiche/spdy/core/spdy_alt_svc_wire_format.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [":spdy_platform"],
@@ -789,7 +915,10 @@ envoy_cc_library(
         "quiche/spdy/core/spdy_frame_builder.h",
         "quiche/spdy/core/spdy_framer.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_platform",
@@ -808,7 +937,10 @@ envoy_cc_library(
     name = "spdy_core_frame_reader_lib",
     srcs = ["quiche/spdy/core/spdy_frame_reader.cc"],
     hdrs = ["quiche/spdy/core/spdy_frame_reader.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":spdy_core_protocol_lib",
@@ -820,7 +952,10 @@ envoy_cc_library(
     name = "spdy_core_header_block_lib",
     srcs = ["quiche/spdy/core/spdy_header_block.cc"],
     hdrs = ["quiche/spdy/core/spdy_header_block.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
@@ -832,7 +967,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "spdy_core_headers_handler_interface_lib",
     hdrs = ["quiche/spdy/core/spdy_headers_handler_interface.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [":spdy_platform"],
@@ -842,7 +980,10 @@ envoy_cc_library(
     name = "spdy_core_http2_deframer_lib",
     srcs = ["quiche/spdy/core/http2_frame_decoder_adapter.cc"],
     hdrs = ["quiche/spdy/core/http2_frame_decoder_adapter.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -910,7 +1051,10 @@ envoy_cc_library(
         "quiche/spdy/core/hpack/hpack_output_stream.h",
         "quiche/spdy/core/hpack/hpack_static_table.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":spdy_core_protocol_lib",
@@ -922,7 +1066,10 @@ envoy_cc_library(
     name = "spdy_core_hpack_hpack_decoder_adapter_lib",
     srcs = ["quiche/spdy/core/hpack/hpack_decoder_adapter.cc"],
     hdrs = ["quiche/spdy/core/hpack/hpack_decoder_adapter.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -958,7 +1105,10 @@ envoy_cc_library(
         "quiche/spdy/core/spdy_bitmasks.h",
         "quiche/spdy/core/spdy_protocol.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
@@ -982,7 +1132,10 @@ envoy_cc_test_library(
     name = "spdy_core_test_utils_lib",
     srcs = ["quiche/spdy/core/spdy_test_utils.cc"],
     hdrs = ["quiche/spdy/core/spdy_test_utils.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [
         ":spdy_core_header_block_lib",
@@ -996,7 +1149,10 @@ envoy_cc_test_library(
 envoy_cc_library(
     name = "spdy_core_zero_copy_output_buffer_lib",
     hdrs = ["quiche/spdy/core/zero_copy_output_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
 )
 
@@ -1117,7 +1273,10 @@ envoy_cc_library(
     name = "quic_platform_ip_address",
     srcs = ["quiche/quic/platform/api/quic_ip_address.cc"],
     hdrs = ["quiche/quic/platform/api/quic_ip_address.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1156,7 +1315,10 @@ envoy_cc_library(
     name = "quic_platform_socket_address",
     srcs = ["quiche/quic/platform/api/quic_socket_address.cc"],
     hdrs = ["quiche/quic/platform/api/quic_socket_address.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1258,7 +1420,10 @@ envoy_cc_library(
     name = "quic_core_ack_listener_interface_lib",
     srcs = ["quiche/quic/core/quic_ack_listener_interface.cc"],
     hdrs = ["quiche/quic/core/quic_ack_listener_interface.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1298,7 +1463,10 @@ envoy_cc_library(
     name = "quic_core_bandwidth_lib",
     srcs = ["quiche/quic/core/quic_bandwidth.cc"],
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1347,7 +1515,10 @@ envoy_cc_library(
     name = "quic_core_config_lib",
     srcs = ["quiche/quic/core/quic_config.cc"],
     hdrs = ["quiche/quic/core/quic_config.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1367,7 +1538,10 @@ envoy_cc_library(
     name = "quic_core_congestion_control_bandwidth_sampler_lib",
     srcs = ["quiche/quic/core/congestion_control/bandwidth_sampler.cc"],
     hdrs = ["quiche/quic/core/congestion_control/bandwidth_sampler.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1386,7 +1560,10 @@ envoy_cc_library(
     name = "quic_core_congestion_control_bbr_lib",
     srcs = ["quiche/quic/core/congestion_control/bbr_sender.cc"],
     hdrs = ["quiche/quic/core/congestion_control/bbr_sender.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1409,7 +1586,10 @@ envoy_cc_library(
     name = "quic_core_congestion_control_general_loss_algorithm_lib",
     srcs = ["quiche/quic/core/congestion_control/general_loss_algorithm.cc"],
     hdrs = ["quiche/quic/core/congestion_control/general_loss_algorithm.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1428,7 +1608,10 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/loss_detection_interface.h",
         "quiche/quic/core/congestion_control/send_algorithm_interface.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1453,7 +1636,10 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/loss_detection_interface.h",
         "quiche/quic/core/congestion_control/send_algorithm_interface.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1475,7 +1661,10 @@ envoy_cc_library(
     name = "quic_core_congestion_control_pacing_sender_lib",
     srcs = ["quiche/quic/core/congestion_control/pacing_sender.cc"],
     hdrs = ["quiche/quic/core/congestion_control/pacing_sender.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1492,7 +1681,10 @@ envoy_cc_library(
     name = "quic_core_congestion_control_rtt_stats_lib",
     srcs = ["quiche/quic/core/congestion_control/rtt_stats.cc"],
     hdrs = ["quiche/quic/core/congestion_control/rtt_stats.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1512,7 +1704,10 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/hybrid_slow_start.h",
         "quiche/quic/core/congestion_control/prr_sender.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1534,7 +1729,10 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/cubic_bytes.h",
         "quiche/quic/core/congestion_control/tcp_cubic_sender_bytes.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1555,7 +1753,10 @@ envoy_cc_library(
     name = "quic_core_congestion_control_uber_loss_algorithm_lib",
     srcs = ["quiche/quic/core/congestion_control/uber_loss_algorithm.cc"],
     hdrs = ["quiche/quic/core/congestion_control/uber_loss_algorithm.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_congestion_control_general_loss_algorithm_lib"],
@@ -1564,7 +1765,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_congestion_control_windowed_filter_lib",
     hdrs = ["quiche/quic/core/congestion_control/windowed_filter.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_time_lib"],
@@ -1574,7 +1778,10 @@ envoy_cc_library(
     name = "quic_core_connection_lib",
     srcs = ["quiche/quic/core/quic_connection.cc"],
     hdrs = ["quiche/quic/core/quic_connection.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1608,7 +1815,10 @@ envoy_cc_library(
     name = "quic_core_connection_stats_lib",
     srcs = ["quiche/quic/core/quic_connection_stats.cc"],
     hdrs = ["quiche/quic/core/quic_connection_stats.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1623,7 +1833,10 @@ envoy_cc_library(
     name = "quic_core_constants_lib",
     srcs = ["quiche/quic/core/quic_constants.cc"],
     hdrs = ["quiche/quic/core/quic_constants.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1671,7 +1884,10 @@ envoy_cc_library(
         "quiche/quic/core/crypto/quic_crypto_server_config.h",
         "quiche/quic/core/crypto/transport_parameters.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = [
         "ssl",
         "zlib",
@@ -1761,7 +1977,10 @@ envoy_cc_library(
         "quiche/quic/core/crypto/quic_decrypter.h",
         "quiche/quic/core/crypto/quic_encrypter.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -1798,7 +2017,10 @@ envoy_cc_library(
         "quiche/quic/core/crypto/proof_source.h",
         "quiche/quic/core/crypto/quic_crypto_proof.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1814,7 +2036,10 @@ envoy_cc_library(
     name = "quic_core_crypto_random_lib",
     srcs = ["quiche/quic/core/crypto/quic_random.cc"],
     hdrs = ["quiche/quic/core/crypto/quic_random.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -1834,7 +2059,10 @@ envoy_cc_library(
         "quiche/quic/core/crypto/tls_connection.h",
         "quiche/quic/core/crypto/tls_server_connection.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -1854,7 +2082,10 @@ envoy_cc_library(
         "quiche/quic/core/quic_data_reader.h",
         "quiche/quic/core/quic_data_writer.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1871,7 +2102,10 @@ envoy_cc_library(
     name = "quic_core_error_codes_lib",
     srcs = ["quiche/quic/core/quic_error_codes.cc"],
     hdrs = ["quiche/quic/core/quic_error_codes.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1882,7 +2116,10 @@ envoy_cc_library(
     name = "quic_core_framer_lib",
     srcs = ["quiche/quic/core/quic_framer.cc"],
     hdrs = ["quiche/quic/core/quic_framer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1951,7 +2188,10 @@ envoy_cc_library(
         "quiche/quic/core/frames/quic_streams_blocked_frame.h",
         "quiche/quic/core/frames/quic_window_update_frame.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1969,7 +2209,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_http_http_constants_lib",
     hdrs = ["quiche/quic/core/http/http_constants.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     deps = [":quic_core_types_lib"],
 )
@@ -1990,7 +2233,10 @@ envoy_cc_library(
         "quiche/quic/core/http/quic_spdy_client_session_base.h",
         "quiche/quic/core/http/quic_spdy_client_stream.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2013,7 +2259,10 @@ envoy_cc_library(
     name = "quic_core_http_header_list_lib",
     srcs = ["quiche/quic/core/http/quic_header_list.cc"],
     hdrs = ["quiche/quic/core/http/quic_header_list.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2030,7 +2279,10 @@ envoy_cc_library(
     name = "quic_core_http_http_decoder_lib",
     srcs = ["quiche/quic/core/http/http_decoder.cc"],
     hdrs = ["quiche/quic/core/http/http_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2046,7 +2298,10 @@ envoy_cc_library(
     name = "quic_core_http_http_encoder_lib",
     srcs = ["quiche/quic/core/http/http_encoder.cc"],
     hdrs = ["quiche/quic/core/http/http_encoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2060,7 +2315,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_http_http_frames_lib",
     hdrs = ["quiche/quic/core/http/http_frames.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2073,7 +2331,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_http_spdy_server_push_utils_header",
     hdrs = ["quiche/quic/core/http/spdy_server_push_utils.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2103,7 +2364,10 @@ envoy_cc_library(
         "quiche/quic/core/http/quic_spdy_session.h",
         "quiche/quic/core/http/quic_spdy_stream.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2140,7 +2404,10 @@ envoy_cc_library(
     name = "quic_core_http_spdy_stream_body_buffer_lib",
     srcs = ["quiche/quic/core/http/quic_spdy_stream_body_buffer.cc"],
     hdrs = ["quiche/quic/core/http/quic_spdy_stream_body_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2154,7 +2421,10 @@ envoy_cc_library(
     name = "quic_core_http_spdy_utils_lib",
     srcs = ["quiche/quic/core/http/spdy_utils.cc"],
     hdrs = ["quiche/quic/core/http/spdy_utils.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2169,7 +2439,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_interval_lib",
     hdrs = ["quiche/quic/core/quic_interval.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2178,7 +2451,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_interval_set_lib",
     hdrs = ["quiche/quic/core/quic_interval_set.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2213,7 +2489,10 @@ envoy_cc_library(
     name = "quic_core_packet_creator_lib",
     srcs = ["quiche/quic/core/quic_packet_creator.cc"],
     hdrs = ["quiche/quic/core/quic_packet_creator.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2234,7 +2513,10 @@ envoy_cc_library(
     name = "quic_core_packet_generator_lib",
     srcs = ["quiche/quic/core/quic_packet_generator.cc"],
     hdrs = ["quiche/quic/core/quic_packet_generator.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2268,7 +2550,10 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_writer.h",
         "quiche/quic/core/quic_packet_writer_wrapper.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2289,7 +2574,10 @@ envoy_cc_library(
         "quiche/quic/core/quic_packets.h",
         "quiche/quic/core/quic_write_blocked_list.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2327,7 +2615,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_process_packet_interface_lib",
     hdrs = ["quiche/quic/core/quic_process_packet_interface.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2352,7 +2643,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_constants_lib",
     srcs = ["quiche/quic/core/qpack/qpack_constants.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_constants.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2362,7 +2656,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2379,7 +2676,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_encoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_encoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_encoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2400,7 +2700,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_header_table_lib",
     srcs = ["quiche/quic/core/qpack/qpack_header_table.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_header_table.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2414,7 +2717,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_instruction_decoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_instruction_decoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_instruction_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2429,7 +2735,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_instruction_encoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_instruction_encoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_instruction_encoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2444,7 +2753,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_progressive_decoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_progressive_decoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_progressive_decoder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2463,7 +2775,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_required_insert_count_lib",
     srcs = ["quiche/quic/core/qpack/qpack_required_insert_count.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_required_insert_count.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2472,7 +2787,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_qpack_qpack_utils_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_utils.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_qpack_qpack_stream_sender_delegate_lib"],
@@ -2482,7 +2800,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_encoder_stream_sender_lib",
     srcs = ["quiche/quic/core/qpack/qpack_encoder_stream_sender.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_encoder_stream_sender.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2497,7 +2818,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_encoder_stream_receiver_lib",
     srcs = ["quiche/quic/core/qpack/qpack_encoder_stream_receiver.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_encoder_stream_receiver.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2514,7 +2838,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoder_stream_sender_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoder_stream_sender.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoder_stream_sender.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2530,7 +2857,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoder_stream_receiver_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoder_stream_receiver.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoder_stream_receiver.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2548,7 +2878,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_static_table_lib",
     srcs = ["quiche/quic/core/qpack/qpack_static_table.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_static_table.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2560,7 +2893,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_qpack_qpack_stream_receiver_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_stream_receiver.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2570,7 +2906,10 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoded_headers_accumulator_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoded_headers_accumulator.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoded_headers_accumulator.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2586,7 +2925,10 @@ envoy_cc_library(
     name = "quic_core_qpack_value_splitting_header_list_lib",
     srcs = ["quiche/quic/core/qpack/value_splitting_header_list.cc"],
     hdrs = ["quiche/quic/core/qpack/value_splitting_header_list.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2605,7 +2947,7 @@ envoy_cc_library(
 #         "quiche/quic/core/qpack/qpack_receive_stream.h",
 #         "quiche/quic/core/qpack/qpack_send_stream.h",
 #     ],
-#     copts = quiche_copt,
+#     copts = select({"@envoy//bazel:windows_x86_64": [], "//conditions:default": quiche_copt}),
 #     repository = "@envoy",
 #     deps = [
 #         ":quic_core_http_spdy_session_lib",
@@ -2618,7 +2960,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_qpack_qpack_stream_sender_delegate_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_stream_sender_delegate.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2628,7 +2973,10 @@ envoy_cc_library(
     name = "quic_core_received_packet_manager_lib",
     srcs = ["quiche/quic/core/quic_received_packet_manager.cc"],
     hdrs = ["quiche/quic/core/quic_received_packet_manager.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2646,7 +2994,10 @@ envoy_cc_library(
     name = "quic_core_sent_packet_manager_lib",
     srcs = ["quiche/quic/core/quic_sent_packet_manager.cc"],
     hdrs = ["quiche/quic/core/quic_sent_packet_manager.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2692,7 +3043,10 @@ envoy_cc_library(
         "quiche/quic/core/quic_buffered_packet_store.h",
         "quiche/quic/core/quic_dispatcher.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2757,7 +3111,10 @@ envoy_cc_library(
         "quiche/quic/core/tls_server_handshaker.h",
         "quiche/quic/core/uber_quic_stream_id_manager.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -2822,7 +3179,10 @@ envoy_cc_library(
     name = "quic_core_stream_send_buffer_lib",
     srcs = ["quiche/quic/core/quic_stream_send_buffer.cc"],
     hdrs = ["quiche/quic/core/quic_stream_send_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2842,7 +3202,10 @@ envoy_cc_library(
     name = "quic_core_stream_sequencer_buffer_lib",
     srcs = ["quiche/quic/core/quic_stream_sequencer_buffer.cc"],
     hdrs = ["quiche/quic/core/quic_stream_sequencer_buffer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2859,7 +3222,10 @@ envoy_cc_library(
     name = "quic_core_sustained_bandwidth_recorder_lib",
     srcs = ["quiche/quic/core/quic_sustained_bandwidth_recorder.cc"],
     hdrs = ["quiche/quic/core/quic_sustained_bandwidth_recorder.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2874,7 +3240,10 @@ envoy_cc_library(
     name = "quic_core_tag_lib",
     srcs = ["quiche/quic/core/quic_tag.cc"],
     hdrs = ["quiche/quic/core/quic_tag.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2895,7 +3264,10 @@ envoy_cc_library(
     name = "quic_core_time_wait_list_manager_lib",
     srcs = ["quiche/quic/core/quic_time_wait_list_manager.cc"],
     hdrs = ["quiche/quic/core/quic_time_wait_list_manager.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2915,7 +3287,10 @@ envoy_cc_library(
     name = "quic_core_transmission_info_lib",
     srcs = ["quiche/quic/core/quic_transmission_info.cc"],
     hdrs = ["quiche/quic/core/quic_transmission_info.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2938,7 +3313,10 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_number.h",
         "quiche/quic/core/quic_types.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -2955,7 +3333,10 @@ envoy_cc_library(
     name = "quic_core_uber_received_packet_manager_lib",
     srcs = ["quiche/quic/core/uber_received_packet_manager.cc"],
     hdrs = ["quiche/quic/core/uber_received_packet_manager.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2969,7 +3350,10 @@ envoy_cc_library(
     name = "quic_core_unacked_packet_map_lib",
     srcs = ["quiche/quic/core/quic_unacked_packet_map.cc"],
     hdrs = ["quiche/quic/core/quic_unacked_packet_map.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2986,7 +3370,10 @@ envoy_cc_library(
     name = "quic_core_utils_lib",
     srcs = ["quiche/quic/core/quic_utils.cc"],
     hdrs = ["quiche/quic/core/quic_utils.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3006,7 +3393,10 @@ envoy_cc_library(
     name = "quic_core_version_manager_lib",
     srcs = ["quiche/quic/core/quic_version_manager.cc"],
     hdrs = ["quiche/quic/core/quic_version_manager.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3019,7 +3409,10 @@ envoy_cc_library(
     name = "quic_core_versions_lib",
     srcs = ["quiche/quic/core/quic_versions.cc"],
     hdrs = ["quiche/quic/core/quic_versions.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3035,7 +3428,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_config_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_config_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_config_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3049,7 +3445,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_framer_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_framer_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_framer_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3064,7 +3463,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_mock_clock_lib",
     srcs = ["quiche/quic/test_tools/mock_clock.cc"],
     hdrs = ["quiche/quic/test_tools/mock_clock.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3077,7 +3479,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_mock_random_lib",
     srcs = ["quiche/quic/test_tools/mock_random.cc"],
     hdrs = ["quiche/quic/test_tools/mock_random.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_crypto_random_lib"],
@@ -3087,7 +3492,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_packet_generator_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_packet_generator_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_packet_generator_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3101,7 +3509,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_sent_packet_manager_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_sent_packet_manager_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_sent_packet_manager_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3116,7 +3527,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_simple_quic_framer_lib",
     srcs = ["quiche/quic/test_tools/simple_quic_framer.cc"],
     hdrs = ["quiche/quic/test_tools/simple_quic_framer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3131,7 +3545,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_stream_send_buffer_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_stream_send_buffer_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_stream_send_buffer_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_stream_send_buffer_lib"],
@@ -3141,7 +3558,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_stream_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_stream_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_stream_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3171,7 +3591,10 @@ envoy_cc_test_library(
         "quiche/quic/test_tools/quic_dispatcher_peer.h",
         "quiche/quic/test_tools/quic_test_utils.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -3216,7 +3639,10 @@ envoy_cc_test_library(
     name = "quic_test_tools_unacked_packet_map_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_unacked_packet_map_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_unacked_packet_map_peer.h"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_unacked_packet_map_lib"],
@@ -3256,7 +3682,10 @@ envoy_cc_test_library(
         ],
         "//conditions:default": [],
     }),
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":epoll_server_platform"],
@@ -3298,7 +3727,10 @@ envoy_cc_test(
         "@envoy//bazel:linux": ["quiche/epoll_server/simple_epoll_server_test.cc"],
         "//conditions:default": [],
     }),
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":epoll_server_lib"],
@@ -3307,7 +3739,10 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_common_test",
     srcs = ["quiche/common/simple_linked_hash_map_test.cc"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3346,7 +3781,10 @@ envoy_cc_library(
     hdrs = [
         "quiche/quic/platform/api/quic_mem_slice_span.h",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3372,7 +3810,10 @@ envoy_cc_library(
 envoy_cc_test(
     name = "spdy_core_header_block_test",
     srcs = ["quiche/spdy/core/spdy_header_block_test.cc"],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3393,7 +3834,10 @@ envoy_cc_test(
         "quiche/quic/platform/api/quic_string_utils_test.cc",
         "quiche/quic/platform/api/quic_text_utils_test.cc",
     ],
-    copts = quiche_copt,
+    copts = select({
+        "@envoy//bazel:windows_x86_64": [],
+        "//conditions:default": quiche_copt,
+    }),
     repository = "@envoy",
     tags = ["nofips"],
     deps = [

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -52,16 +52,19 @@ genrule(
 
 # These options are only used to suppress errors in brought-in QUICHE tests.
 # Use #pragma GCC diagnostic ignored in integration code to suppress these errors.
-quiche_copt = [
-    # Remove these after upstream fix.
-    "-Wno-unused-parameter",
-    "-Wno-unused-function",
-    "-Wno-type-limits",
-    # quic_inlined_frame.h uses offsetof() to optimize memory usage in frames.
-    "-Wno-invalid-offsetof",
-    "-Wno-type-limits",
-    "-Wno-return-type",
-]
+quiche_copts = select({
+    "@envoy//bazel:windows_x86_64": [],
+    "//conditions:default": [
+        # Remove these after upstream fix.
+        "-Wno-unused-parameter",
+        "-Wno-unused-function",
+        "-Wno-type-limits",
+        # quic_inlined_frame.h uses offsetof() to optimize memory usage in frames.
+        "-Wno-invalid-offsetof",
+        "-Wno-type-limits",
+        "-Wno-return-type",
+    ],
+})
 
 envoy_cc_test_library(
     name = "http2_platform_reconstruct_object",
@@ -108,10 +111,7 @@ envoy_cc_library(
     name = "http2_constants_lib",
     srcs = ["quiche/http2/http2_constants.cc"],
     hdrs = ["quiche/http2/http2_constants.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -120,10 +120,7 @@ envoy_cc_library(
     name = "http2_structures_lib",
     srcs = ["quiche/http2/http2_structures.cc"],
     hdrs = ["quiche/http2/http2_structures.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -135,10 +132,7 @@ envoy_cc_library(
     name = "http2_decoder_decode_buffer_lib",
     srcs = ["quiche/http2/decoder/decode_buffer.cc"],
     hdrs = ["quiche/http2/decoder/decode_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -147,10 +141,7 @@ envoy_cc_library(
     name = "http2_decoder_decode_http2_structures_lib",
     srcs = ["quiche/http2/decoder/decode_http2_structures.cc"],
     hdrs = ["quiche/http2/decoder/decode_http2_structures.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -164,10 +155,7 @@ envoy_cc_library(
     name = "http2_decoder_decode_status_lib",
     srcs = ["quiche/http2/decoder/decode_status.cc"],
     hdrs = ["quiche/http2/decoder/decode_status.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -176,10 +164,7 @@ envoy_cc_library(
     name = "http2_decoder_frame_decoder_state_lib",
     srcs = ["quiche/http2/decoder/frame_decoder_state.cc"],
     hdrs = ["quiche/http2/decoder/frame_decoder_state.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -199,10 +184,7 @@ envoy_cc_library(
         "quiche/http2/decoder/frame_decoder_state.h",
         "quiche/http2/decoder/http2_frame_decoder.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -233,10 +215,7 @@ envoy_cc_library(
     name = "http2_decoder_frame_decoder_listener_lib",
     srcs = ["quiche/http2/decoder/http2_frame_decoder_listener.cc"],
     hdrs = ["quiche/http2/decoder/http2_frame_decoder_listener.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -248,10 +227,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_altsvc_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/altsvc_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/altsvc_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -268,10 +244,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_continuation_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/continuation_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/continuation_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -288,10 +261,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_data_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/data_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/data_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -308,10 +278,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_goaway_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/goaway_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/goaway_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -328,10 +295,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_headers_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/headers_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/headers_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -348,10 +312,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_ping_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/ping_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/ping_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -368,10 +329,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_priority_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/priority_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/priority_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -388,10 +346,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_push_promise_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/push_promise_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/push_promise_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -408,10 +363,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_rst_stream_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/rst_stream_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/rst_stream_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -428,10 +380,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_settings_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/settings_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/settings_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -448,10 +397,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_unknown_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/unknown_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/unknown_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -468,10 +414,7 @@ envoy_cc_library(
     name = "http2_decoder_payload_decoders_window_update_payload_decoder_lib",
     srcs = ["quiche/http2/decoder/payload_decoders/window_update_payload_decoder.cc"],
     hdrs = ["quiche/http2/decoder/payload_decoders/window_update_payload_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -489,10 +432,7 @@ envoy_cc_library(
     name = "http2_decoder_structure_decoder_lib",
     srcs = ["quiche/http2/decoder/http2_structure_decoder.cc"],
     hdrs = ["quiche/http2/decoder/http2_structure_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -507,10 +447,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_block_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_block_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_block_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -525,10 +462,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -546,10 +480,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_listener.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_hpack_hpack_constants_lib",
@@ -562,10 +493,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_state_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_state.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_state.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -583,10 +511,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_string_buffer_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_string_buffer.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_string_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_hpack_huffman_hpack_huffman_decoder_lib",
@@ -598,10 +523,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_decoder_tables_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_decoder_tables.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder_tables.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -616,10 +538,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_entry_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_entry_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_entry_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -636,10 +555,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_entry_decoder_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_entry_decoder_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_entry_decoder_listener.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_hpack_hpack_constants_lib",
@@ -651,10 +567,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_entry_type_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_entry_type_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_entry_type_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -669,10 +582,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_string_decoder_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_string_decoder.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_string_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -686,10 +596,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_string_decoder_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_string_decoder_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_string_decoder_listener.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -698,10 +605,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_whole_entry_buffer_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_whole_entry_buffer.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_whole_entry_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_hpack_decoder_hpack_decoder_string_buffer_lib",
@@ -716,10 +620,7 @@ envoy_cc_library(
     name = "http2_hpack_decoder_hpack_whole_entry_listener_lib",
     srcs = ["quiche/http2/hpack/decoder/hpack_whole_entry_listener.cc"],
     hdrs = ["quiche/http2/hpack/decoder/hpack_whole_entry_listener.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_hpack_decoder_hpack_decoder_string_buffer_lib",
@@ -732,10 +633,7 @@ envoy_cc_library(
     name = "http2_hpack_huffman_hpack_huffman_decoder_lib",
     srcs = ["quiche/http2/hpack/huffman/hpack_huffman_decoder.cc"],
     hdrs = ["quiche/http2/hpack/huffman/hpack_huffman_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -744,10 +642,7 @@ envoy_cc_library(
     name = "http2_hpack_huffman_hpack_huffman_encoder_lib",
     srcs = ["quiche/http2/hpack/huffman/hpack_huffman_encoder.cc"],
     hdrs = ["quiche/http2/hpack/huffman/hpack_huffman_encoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_hpack_huffman_huffman_spec_tables_lib",
@@ -759,10 +654,7 @@ envoy_cc_library(
     name = "http2_hpack_huffman_huffman_spec_tables_lib",
     srcs = ["quiche/http2/hpack/huffman/huffman_spec_tables.cc"],
     hdrs = ["quiche/http2/hpack/huffman/huffman_spec_tables.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
 )
 
@@ -770,10 +662,7 @@ envoy_cc_library(
     name = "http2_hpack_hpack_constants_lib",
     srcs = ["quiche/http2/hpack/http2_hpack_constants.cc"],
     hdrs = ["quiche/http2/hpack/http2_hpack_constants.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -788,10 +677,7 @@ envoy_cc_library(
     name = "http2_hpack_hpack_string_lib",
     srcs = ["quiche/http2/hpack/hpack_string.cc"],
     hdrs = ["quiche/http2/hpack/hpack_string.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -800,10 +686,7 @@ envoy_cc_library(
     name = "http2_hpack_varint_hpack_varint_decoder_lib",
     srcs = ["quiche/http2/hpack/varint/hpack_varint_decoder.cc"],
     hdrs = ["quiche/http2/hpack/varint/hpack_varint_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -816,10 +699,7 @@ envoy_cc_library(
     name = "http2_hpack_varint_hpack_varint_encoder_lib",
     srcs = ["quiche/http2/hpack/varint/hpack_varint_encoder.cc"],
     hdrs = ["quiche/http2/hpack/varint/hpack_varint_encoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":http2_platform"],
 )
@@ -886,10 +766,7 @@ envoy_cc_library(
     name = "spdy_core_alt_svc_wire_format_lib",
     srcs = ["quiche/spdy/core/spdy_alt_svc_wire_format.cc"],
     hdrs = ["quiche/spdy/core/spdy_alt_svc_wire_format.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [":spdy_platform"],
@@ -915,10 +792,7 @@ envoy_cc_library(
         "quiche/spdy/core/spdy_frame_builder.h",
         "quiche/spdy/core/spdy_framer.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_platform",
@@ -937,10 +811,7 @@ envoy_cc_library(
     name = "spdy_core_frame_reader_lib",
     srcs = ["quiche/spdy/core/spdy_frame_reader.cc"],
     hdrs = ["quiche/spdy/core/spdy_frame_reader.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":spdy_core_protocol_lib",
@@ -952,10 +823,7 @@ envoy_cc_library(
     name = "spdy_core_header_block_lib",
     srcs = ["quiche/spdy/core/spdy_header_block.cc"],
     hdrs = ["quiche/spdy/core/spdy_header_block.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
@@ -967,10 +835,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "spdy_core_headers_handler_interface_lib",
     hdrs = ["quiche/spdy/core/spdy_headers_handler_interface.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [":spdy_platform"],
@@ -980,10 +845,7 @@ envoy_cc_library(
     name = "spdy_core_http2_deframer_lib",
     srcs = ["quiche/spdy/core/http2_frame_decoder_adapter.cc"],
     hdrs = ["quiche/spdy/core/http2_frame_decoder_adapter.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_constants_lib",
@@ -1051,10 +913,7 @@ envoy_cc_library(
         "quiche/spdy/core/hpack/hpack_output_stream.h",
         "quiche/spdy/core/hpack/hpack_static_table.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":spdy_core_protocol_lib",
@@ -1066,10 +925,7 @@ envoy_cc_library(
     name = "spdy_core_hpack_hpack_decoder_adapter_lib",
     srcs = ["quiche/spdy/core/hpack/hpack_decoder_adapter.cc"],
     hdrs = ["quiche/spdy/core/hpack/hpack_decoder_adapter.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":http2_decoder_decode_buffer_lib",
@@ -1105,10 +961,7 @@ envoy_cc_library(
         "quiche/spdy/core/spdy_bitmasks.h",
         "quiche/spdy/core/spdy_protocol.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
@@ -1132,10 +985,7 @@ envoy_cc_test_library(
     name = "spdy_core_test_utils_lib",
     srcs = ["quiche/spdy/core/spdy_test_utils.cc"],
     hdrs = ["quiche/spdy/core/spdy_test_utils.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [
         ":spdy_core_header_block_lib",
@@ -1149,10 +999,7 @@ envoy_cc_test_library(
 envoy_cc_library(
     name = "spdy_core_zero_copy_output_buffer_lib",
     hdrs = ["quiche/spdy/core/zero_copy_output_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
 )
 
@@ -1273,10 +1120,7 @@ envoy_cc_library(
     name = "quic_platform_ip_address",
     srcs = ["quiche/quic/platform/api/quic_ip_address.cc"],
     hdrs = ["quiche/quic/platform/api/quic_ip_address.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1315,10 +1159,7 @@ envoy_cc_library(
     name = "quic_platform_socket_address",
     srcs = ["quiche/quic/platform/api/quic_socket_address.cc"],
     hdrs = ["quiche/quic/platform/api/quic_socket_address.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1420,10 +1261,7 @@ envoy_cc_library(
     name = "quic_core_ack_listener_interface_lib",
     srcs = ["quiche/quic/core/quic_ack_listener_interface.cc"],
     hdrs = ["quiche/quic/core/quic_ack_listener_interface.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1463,10 +1301,7 @@ envoy_cc_library(
     name = "quic_core_bandwidth_lib",
     srcs = ["quiche/quic/core/quic_bandwidth.cc"],
     hdrs = ["quiche/quic/core/quic_bandwidth.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1515,10 +1350,7 @@ envoy_cc_library(
     name = "quic_core_config_lib",
     srcs = ["quiche/quic/core/quic_config.cc"],
     hdrs = ["quiche/quic/core/quic_config.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1538,10 +1370,7 @@ envoy_cc_library(
     name = "quic_core_congestion_control_bandwidth_sampler_lib",
     srcs = ["quiche/quic/core/congestion_control/bandwidth_sampler.cc"],
     hdrs = ["quiche/quic/core/congestion_control/bandwidth_sampler.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1560,10 +1389,7 @@ envoy_cc_library(
     name = "quic_core_congestion_control_bbr_lib",
     srcs = ["quiche/quic/core/congestion_control/bbr_sender.cc"],
     hdrs = ["quiche/quic/core/congestion_control/bbr_sender.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1586,10 +1412,7 @@ envoy_cc_library(
     name = "quic_core_congestion_control_general_loss_algorithm_lib",
     srcs = ["quiche/quic/core/congestion_control/general_loss_algorithm.cc"],
     hdrs = ["quiche/quic/core/congestion_control/general_loss_algorithm.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1608,10 +1431,7 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/loss_detection_interface.h",
         "quiche/quic/core/congestion_control/send_algorithm_interface.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1636,10 +1456,7 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/loss_detection_interface.h",
         "quiche/quic/core/congestion_control/send_algorithm_interface.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1661,10 +1478,7 @@ envoy_cc_library(
     name = "quic_core_congestion_control_pacing_sender_lib",
     srcs = ["quiche/quic/core/congestion_control/pacing_sender.cc"],
     hdrs = ["quiche/quic/core/congestion_control/pacing_sender.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1681,10 +1495,7 @@ envoy_cc_library(
     name = "quic_core_congestion_control_rtt_stats_lib",
     srcs = ["quiche/quic/core/congestion_control/rtt_stats.cc"],
     hdrs = ["quiche/quic/core/congestion_control/rtt_stats.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1704,10 +1515,7 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/hybrid_slow_start.h",
         "quiche/quic/core/congestion_control/prr_sender.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1729,10 +1537,7 @@ envoy_cc_library(
         "quiche/quic/core/congestion_control/cubic_bytes.h",
         "quiche/quic/core/congestion_control/tcp_cubic_sender_bytes.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1753,10 +1558,7 @@ envoy_cc_library(
     name = "quic_core_congestion_control_uber_loss_algorithm_lib",
     srcs = ["quiche/quic/core/congestion_control/uber_loss_algorithm.cc"],
     hdrs = ["quiche/quic/core/congestion_control/uber_loss_algorithm.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_congestion_control_general_loss_algorithm_lib"],
@@ -1765,10 +1567,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_congestion_control_windowed_filter_lib",
     hdrs = ["quiche/quic/core/congestion_control/windowed_filter.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_time_lib"],
@@ -1778,10 +1577,7 @@ envoy_cc_library(
     name = "quic_core_connection_lib",
     srcs = ["quiche/quic/core/quic_connection.cc"],
     hdrs = ["quiche/quic/core/quic_connection.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1815,10 +1611,7 @@ envoy_cc_library(
     name = "quic_core_connection_stats_lib",
     srcs = ["quiche/quic/core/quic_connection_stats.cc"],
     hdrs = ["quiche/quic/core/quic_connection_stats.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -1833,10 +1626,7 @@ envoy_cc_library(
     name = "quic_core_constants_lib",
     srcs = ["quiche/quic/core/quic_constants.cc"],
     hdrs = ["quiche/quic/core/quic_constants.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -1884,10 +1674,7 @@ envoy_cc_library(
         "quiche/quic/core/crypto/quic_crypto_server_config.h",
         "quiche/quic/core/crypto/transport_parameters.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = [
         "ssl",
         "zlib",
@@ -1977,10 +1764,7 @@ envoy_cc_library(
         "quiche/quic/core/crypto/quic_decrypter.h",
         "quiche/quic/core/crypto/quic_encrypter.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -2017,10 +1801,7 @@ envoy_cc_library(
         "quiche/quic/core/crypto/proof_source.h",
         "quiche/quic/core/crypto/quic_crypto_proof.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2036,10 +1817,7 @@ envoy_cc_library(
     name = "quic_core_crypto_random_lib",
     srcs = ["quiche/quic/core/crypto/quic_random.cc"],
     hdrs = ["quiche/quic/core/crypto/quic_random.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -2059,10 +1837,7 @@ envoy_cc_library(
         "quiche/quic/core/crypto/tls_connection.h",
         "quiche/quic/core/crypto/tls_server_connection.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -2082,10 +1857,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_data_reader.h",
         "quiche/quic/core/quic_data_writer.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2102,10 +1874,7 @@ envoy_cc_library(
     name = "quic_core_error_codes_lib",
     srcs = ["quiche/quic/core/quic_error_codes.cc"],
     hdrs = ["quiche/quic/core/quic_error_codes.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2116,10 +1885,7 @@ envoy_cc_library(
     name = "quic_core_framer_lib",
     srcs = ["quiche/quic/core/quic_framer.cc"],
     hdrs = ["quiche/quic/core/quic_framer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2188,10 +1954,7 @@ envoy_cc_library(
         "quiche/quic/core/frames/quic_streams_blocked_frame.h",
         "quiche/quic/core/frames/quic_window_update_frame.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2209,10 +1972,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_http_http_constants_lib",
     hdrs = ["quiche/quic/core/http/http_constants.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     deps = [":quic_core_types_lib"],
 )
@@ -2233,10 +1993,7 @@ envoy_cc_library(
         "quiche/quic/core/http/quic_spdy_client_session_base.h",
         "quiche/quic/core/http/quic_spdy_client_stream.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2259,10 +2016,7 @@ envoy_cc_library(
     name = "quic_core_http_header_list_lib",
     srcs = ["quiche/quic/core/http/quic_header_list.cc"],
     hdrs = ["quiche/quic/core/http/quic_header_list.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2279,10 +2033,7 @@ envoy_cc_library(
     name = "quic_core_http_http_decoder_lib",
     srcs = ["quiche/quic/core/http/http_decoder.cc"],
     hdrs = ["quiche/quic/core/http/http_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2298,10 +2049,7 @@ envoy_cc_library(
     name = "quic_core_http_http_encoder_lib",
     srcs = ["quiche/quic/core/http/http_encoder.cc"],
     hdrs = ["quiche/quic/core/http/http_encoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2315,10 +2063,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_http_http_frames_lib",
     hdrs = ["quiche/quic/core/http/http_frames.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2331,10 +2076,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_http_spdy_server_push_utils_header",
     hdrs = ["quiche/quic/core/http/spdy_server_push_utils.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2364,10 +2106,7 @@ envoy_cc_library(
         "quiche/quic/core/http/quic_spdy_session.h",
         "quiche/quic/core/http/quic_spdy_stream.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2404,10 +2143,7 @@ envoy_cc_library(
     name = "quic_core_http_spdy_stream_body_buffer_lib",
     srcs = ["quiche/quic/core/http/quic_spdy_stream_body_buffer.cc"],
     hdrs = ["quiche/quic/core/http/quic_spdy_stream_body_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2421,10 +2157,7 @@ envoy_cc_library(
     name = "quic_core_http_spdy_utils_lib",
     srcs = ["quiche/quic/core/http/spdy_utils.cc"],
     hdrs = ["quiche/quic/core/http/spdy_utils.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2439,10 +2172,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_interval_lib",
     hdrs = ["quiche/quic/core/quic_interval.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2451,10 +2181,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_interval_set_lib",
     hdrs = ["quiche/quic/core/quic_interval_set.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2489,10 +2216,7 @@ envoy_cc_library(
     name = "quic_core_packet_creator_lib",
     srcs = ["quiche/quic/core/quic_packet_creator.cc"],
     hdrs = ["quiche/quic/core/quic_packet_creator.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2513,10 +2237,7 @@ envoy_cc_library(
     name = "quic_core_packet_generator_lib",
     srcs = ["quiche/quic/core/quic_packet_generator.cc"],
     hdrs = ["quiche/quic/core/quic_packet_generator.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2550,10 +2271,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_writer.h",
         "quiche/quic/core/quic_packet_writer_wrapper.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -2574,10 +2292,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_packets.h",
         "quiche/quic/core/quic_write_blocked_list.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2615,10 +2330,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_process_packet_interface_lib",
     hdrs = ["quiche/quic/core/quic_process_packet_interface.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2643,10 +2355,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_constants_lib",
     srcs = ["quiche/quic/core/qpack/qpack_constants.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_constants.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2656,10 +2365,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2676,10 +2382,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_encoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_encoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_encoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2700,10 +2403,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_header_table_lib",
     srcs = ["quiche/quic/core/qpack/qpack_header_table.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_header_table.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2717,10 +2417,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_instruction_decoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_instruction_decoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_instruction_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2735,10 +2432,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_instruction_encoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_instruction_encoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_instruction_encoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2753,10 +2447,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_progressive_decoder_lib",
     srcs = ["quiche/quic/core/qpack/qpack_progressive_decoder.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_progressive_decoder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2775,10 +2466,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_required_insert_count_lib",
     srcs = ["quiche/quic/core/qpack/qpack_required_insert_count.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_required_insert_count.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2787,10 +2475,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_qpack_qpack_utils_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_utils.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_qpack_qpack_stream_sender_delegate_lib"],
@@ -2800,10 +2485,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_encoder_stream_sender_lib",
     srcs = ["quiche/quic/core/qpack/qpack_encoder_stream_sender.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_encoder_stream_sender.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2818,10 +2500,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_encoder_stream_receiver_lib",
     srcs = ["quiche/quic/core/qpack/qpack_encoder_stream_receiver.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_encoder_stream_receiver.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2838,10 +2517,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoder_stream_sender_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoder_stream_sender.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoder_stream_sender.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2857,10 +2533,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoder_stream_receiver_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoder_stream_receiver.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoder_stream_receiver.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2878,10 +2551,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_static_table_lib",
     srcs = ["quiche/quic/core/qpack/qpack_static_table.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_static_table.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2893,10 +2563,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_qpack_qpack_stream_receiver_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_stream_receiver.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2906,10 +2573,7 @@ envoy_cc_library(
     name = "quic_core_qpack_qpack_decoded_headers_accumulator_lib",
     srcs = ["quiche/quic/core/qpack/qpack_decoded_headers_accumulator.cc"],
     hdrs = ["quiche/quic/core/qpack/qpack_decoded_headers_accumulator.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2925,10 +2589,7 @@ envoy_cc_library(
     name = "quic_core_qpack_value_splitting_header_list_lib",
     srcs = ["quiche/quic/core/qpack/value_splitting_header_list.cc"],
     hdrs = ["quiche/quic/core/qpack/value_splitting_header_list.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2947,7 +2608,7 @@ envoy_cc_library(
 #         "quiche/quic/core/qpack/qpack_receive_stream.h",
 #         "quiche/quic/core/qpack/qpack_send_stream.h",
 #     ],
-#     copts = select({"@envoy//bazel:windows_x86_64": [], "//conditions:default": quiche_copt}),
+#     copts = quiche_copts,
 #     repository = "@envoy",
 #     deps = [
 #         ":quic_core_http_spdy_session_lib",
@@ -2960,10 +2621,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_core_qpack_qpack_stream_sender_delegate_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_stream_sender_delegate.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_platform_base"],
@@ -2973,10 +2631,7 @@ envoy_cc_library(
     name = "quic_core_received_packet_manager_lib",
     srcs = ["quiche/quic/core/quic_received_packet_manager.cc"],
     hdrs = ["quiche/quic/core/quic_received_packet_manager.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -2994,10 +2649,7 @@ envoy_cc_library(
     name = "quic_core_sent_packet_manager_lib",
     srcs = ["quiche/quic/core/quic_sent_packet_manager.cc"],
     hdrs = ["quiche/quic/core/quic_sent_packet_manager.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3043,10 +2695,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_buffered_packet_store.h",
         "quiche/quic/core/quic_dispatcher.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3111,10 +2760,7 @@ envoy_cc_library(
         "quiche/quic/core/tls_server_handshaker.h",
         "quiche/quic/core/uber_quic_stream_id_manager.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -3179,10 +2825,7 @@ envoy_cc_library(
     name = "quic_core_stream_send_buffer_lib",
     srcs = ["quiche/quic/core/quic_stream_send_buffer.cc"],
     hdrs = ["quiche/quic/core/quic_stream_send_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3202,10 +2845,7 @@ envoy_cc_library(
     name = "quic_core_stream_sequencer_buffer_lib",
     srcs = ["quiche/quic/core/quic_stream_sequencer_buffer.cc"],
     hdrs = ["quiche/quic/core/quic_stream_sequencer_buffer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3222,10 +2862,7 @@ envoy_cc_library(
     name = "quic_core_sustained_bandwidth_recorder_lib",
     srcs = ["quiche/quic/core/quic_sustained_bandwidth_recorder.cc"],
     hdrs = ["quiche/quic/core/quic_sustained_bandwidth_recorder.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3240,10 +2877,7 @@ envoy_cc_library(
     name = "quic_core_tag_lib",
     srcs = ["quiche/quic/core/quic_tag.cc"],
     hdrs = ["quiche/quic/core/quic_tag.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3264,10 +2898,7 @@ envoy_cc_library(
     name = "quic_core_time_wait_list_manager_lib",
     srcs = ["quiche/quic/core/quic_time_wait_list_manager.cc"],
     hdrs = ["quiche/quic/core/quic_time_wait_list_manager.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3287,10 +2918,7 @@ envoy_cc_library(
     name = "quic_core_transmission_info_lib",
     srcs = ["quiche/quic/core/quic_transmission_info.cc"],
     hdrs = ["quiche/quic/core/quic_transmission_info.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3313,10 +2941,7 @@ envoy_cc_library(
         "quiche/quic/core/quic_packet_number.h",
         "quiche/quic/core/quic_types.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -3333,10 +2958,7 @@ envoy_cc_library(
     name = "quic_core_uber_received_packet_manager_lib",
     srcs = ["quiche/quic/core/uber_received_packet_manager.cc"],
     hdrs = ["quiche/quic/core/uber_received_packet_manager.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3350,10 +2972,7 @@ envoy_cc_library(
     name = "quic_core_unacked_packet_map_lib",
     srcs = ["quiche/quic/core/quic_unacked_packet_map.cc"],
     hdrs = ["quiche/quic/core/quic_unacked_packet_map.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3370,10 +2989,7 @@ envoy_cc_library(
     name = "quic_core_utils_lib",
     srcs = ["quiche/quic/core/quic_utils.cc"],
     hdrs = ["quiche/quic/core/quic_utils.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3393,10 +3009,7 @@ envoy_cc_library(
     name = "quic_core_version_manager_lib",
     srcs = ["quiche/quic/core/quic_version_manager.cc"],
     hdrs = ["quiche/quic/core/quic_version_manager.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3409,10 +3022,7 @@ envoy_cc_library(
     name = "quic_core_versions_lib",
     srcs = ["quiche/quic/core/quic_versions.cc"],
     hdrs = ["quiche/quic/core/quic_versions.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3428,10 +3038,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_config_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_config_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_config_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3445,10 +3052,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_framer_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_framer_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_framer_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3463,10 +3067,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_mock_clock_lib",
     srcs = ["quiche/quic/test_tools/mock_clock.cc"],
     hdrs = ["quiche/quic/test_tools/mock_clock.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3479,10 +3080,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_mock_random_lib",
     srcs = ["quiche/quic/test_tools/mock_random.cc"],
     hdrs = ["quiche/quic/test_tools/mock_random.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_crypto_random_lib"],
@@ -3492,10 +3090,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_packet_generator_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_packet_generator_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_packet_generator_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3509,10 +3104,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_sent_packet_manager_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_sent_packet_manager_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_sent_packet_manager_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3527,10 +3119,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_simple_quic_framer_lib",
     srcs = ["quiche/quic/test_tools/simple_quic_framer.cc"],
     hdrs = ["quiche/quic/test_tools/simple_quic_framer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3545,10 +3134,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_stream_send_buffer_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_stream_send_buffer_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_stream_send_buffer_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_stream_send_buffer_lib"],
@@ -3558,10 +3144,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_stream_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_stream_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_stream_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3591,10 +3174,7 @@ envoy_cc_test_library(
         "quiche/quic/test_tools/quic_dispatcher_peer.h",
         "quiche/quic/test_tools/quic_test_utils.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -3639,10 +3219,7 @@ envoy_cc_test_library(
     name = "quic_test_tools_unacked_packet_map_peer_lib",
     srcs = ["quiche/quic/test_tools/quic_unacked_packet_map_peer.cc"],
     hdrs = ["quiche/quic/test_tools/quic_unacked_packet_map_peer.h"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":quic_core_unacked_packet_map_lib"],
@@ -3682,10 +3259,7 @@ envoy_cc_test_library(
         ],
         "//conditions:default": [],
     }),
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":epoll_server_platform"],
@@ -3727,10 +3301,7 @@ envoy_cc_test(
         "@envoy//bazel:linux": ["quiche/epoll_server/simple_epoll_server_test.cc"],
         "//conditions:default": [],
     }),
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [":epoll_server_lib"],
@@ -3739,10 +3310,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_common_test",
     srcs = ["quiche/common/simple_linked_hash_map_test.cc"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3781,10 +3349,7 @@ envoy_cc_library(
     hdrs = [
         "quiche/quic/platform/api/quic_mem_slice_span.h",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
@@ -3810,10 +3375,7 @@ envoy_cc_library(
 envoy_cc_test(
     name = "spdy_core_header_block_test",
     srcs = ["quiche/spdy/core/spdy_header_block_test.cc"],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
@@ -3834,10 +3396,7 @@ envoy_cc_test(
         "quiche/quic/platform/api/quic_string_utils_test.cc",
         "quiche/quic/platform/api/quic_text_utils_test.cc",
     ],
-    copts = select({
-        "@envoy//bazel:windows_x86_64": [],
-        "//conditions:default": quiche_copt,
-    }),
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -208,7 +208,10 @@ envoy_cc_library(
     name = "quic_platform_mem_slice_span_impl_lib",
     srcs = ["quic_mem_slice_span_impl.cc"],
     hdrs = ["quic_mem_slice_span_impl.h"],
-    copts = ["-Wno-unused-parameter"],
+    copts = select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": ["-Wno-unused-parameter"],
+    }),
     tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
@@ -223,10 +226,13 @@ envoy_cc_library(
     name = "quic_platform_mem_slice_storage_impl_lib",
     srcs = ["quic_mem_slice_storage_impl.cc"],
     hdrs = ["quic_mem_slice_storage_impl.h"],
-    copts = [
-        "-Wno-error=invalid-offsetof",
-        "-Wno-unused-parameter",
-    ],
+    copts = select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": [
+            "-Wno-error=invalid-offsetof",
+            "-Wno-unused-parameter",
+        ],
+    }),
     tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
Description:
The `-w` flags are not recognized by msvc.

Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>
Signed-off-by: William Rowe <wrowe@pivotal.io>

Risk Level: Low
Testing: Local on Windows
Docs Changes: None
Release Notes: None

