### PR TITLE
Bump upstream components

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -22,15 +22,15 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/envoyproxy/envoy-build-tools/archive/4433e52437af6936d0af95ebc3b16b4b6df38618.tar.gz"],
     ),
     boringssl = dict(
-        sha256 = "c712766ddc844de2a38e686e1cdd7288795e9a6fe7f699c6636f1b76703db84e",
-        strip_prefix = "boringssl-265728decec4370cd02b941f72fba9f0735e2923",
+        sha256 = "891352824e0f7977bc0c291b8c65076e3ed23630334841b93f346f12d4484b06",
+        strip_prefix = "boringssl-5565939d4203234ddc742c02241ce4523e7b3beb",
         # To update BoringSSL, which tracks Chromium releases:
         # 1. Open https://omahaproxy.appspot.com/ and note <current_version> of linux/beta release.
         # 2. Open https://chromium.googlesource.com/chromium/src/+/refs/tags/<current_version>/DEPS and note <boringssl_revision>.
         # 3. Find a commit in BoringSSL's "master-with-bazel" branch that merges <boringssl_revision>.
         #
-        # chromium-77.0.3865.35 (BETA)
-        urls = ["https://github.com/google/boringssl/archive/265728decec4370cd02b941f72fba9f0735e2923.tar.gz"],
+        # chromium-78.0.3904.21 (BETA)
+        urls = ["https://github.com/google/boringssl/archive/5565939d4203234ddc742c02241ce4523e7b3beb.tar.gz"],
     ),
     boringssl_fips = dict(
         sha256 = "b12ad676ee533824f698741bd127f6fbc82c46344398a6d78d25e62c6c418c73",
@@ -64,9 +64,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/circonus-labs/libcircllhist/archive/63a16dd6f2fc7bc841bb17ff92be8318df60e2e1.tar.gz"],
     ),
     com_github_cyan4973_xxhash = dict(
-        sha256 = "b34792646d5e19964bb7bba24f06cb13aecaac623ab91a54da08aa19d3686d7e",
-        strip_prefix = "xxHash-0.7.0",
-        urls = ["https://github.com/Cyan4973/xxHash/archive/v0.7.0.tar.gz"],
+        sha256 = "77876fa31d3132c8c22b81cb219eac5b1f035637d5ca48bad617380043e21ffd",
+        strip_prefix = "xxHash-6137bfc606e08c791fccab835928de7e5ed41308",
+        # 2019-07-11
+        urls = ["https://github.com/Cyan4973/xxHash/archive/6137bfc606e08c791fccab835928de7e5ed41308.tar.gz"],
     ),
     com_github_envoyproxy_sqlparser = dict(
         sha256 = "425dfee0c4fe9aff8acf2365cde3dd2ba7fb878d2ba37562d33920e34c40c05e",
@@ -89,10 +90,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz"],
     ),
     com_github_google_libprotobuf_mutator = dict(
-        sha256 = "97b3639630040f41c45f45838ab00b78909e6b4cb69c8028e01302bea5b79495",
-        strip_prefix = "libprotobuf-mutator-c3d2faf04a1070b0b852b0efdef81e1a81ba925e",
-        # 2018-03-06
-        urls = ["https://github.com/google/libprotobuf-mutator/archive/c3d2faf04a1070b0b852b0efdef81e1a81ba925e.tar.gz"],
+        sha256 = "f45c3ad82376d891cd0bcaa7165e83efd90e0014b00aebf0cbaf07eb05a1d3f9",
+        strip_prefix = "libprotobuf-mutator-d1fe8a7d8ae18f3d454f055eba5213c291986f21",
+        # 2019-07-10
+        urls = ["https://github.com/google/libprotobuf-mutator/archive/d1fe8a7d8ae18f3d454f055eba5213c291986f21.tar.gz"],
     ),
     com_github_gperftools_gperftools = dict(
         # TODO(cmluciano): Bump to release 2.8

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -64,10 +64,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/circonus-labs/libcircllhist/archive/63a16dd6f2fc7bc841bb17ff92be8318df60e2e1.tar.gz"],
     ),
     com_github_cyan4973_xxhash = dict(
-        sha256 = "77876fa31d3132c8c22b81cb219eac5b1f035637d5ca48bad617380043e21ffd",
-        strip_prefix = "xxHash-6137bfc606e08c791fccab835928de7e5ed41308",
-        # 2019-07-11
-        urls = ["https://github.com/Cyan4973/xxHash/archive/6137bfc606e08c791fccab835928de7e5ed41308.tar.gz"],
+        sha256 = "afa29766cfc0448ff4a1fd9f2c47e02c48d50be5b79749925d15d545008c3f81",
+        strip_prefix = "xxHash-v0.7.1",
+        urls = ["https://github.com/Cyan4973/xxHash/archive/v0.7.1.tar.gz"],
     ),
     com_github_envoyproxy_sqlparser = dict(
         sha256 = "425dfee0c4fe9aff8acf2365cde3dd2ba7fb878d2ba37562d33920e34c40c05e",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -65,7 +65,7 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_github_cyan4973_xxhash = dict(
         sha256 = "afa29766cfc0448ff4a1fd9f2c47e02c48d50be5b79749925d15d545008c3f81",
-        strip_prefix = "xxHash-v0.7.1",
+        strip_prefix = "xxHash-0.7.1",
         urls = ["https://github.com/Cyan4973/xxHash/archive/v0.7.1.tar.gz"],
     ),
     com_github_envoyproxy_sqlparser = dict(


### PR DESCRIPTION
Description:
Windows fixes upstream in BoringSSL
Windows fixes upstream in xxHash
Windows fixes upstream in libprotobuf_mutator

Signed-off-by: William Rowe <wrowe@pivotal.io>
Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>

Risk Level: Low
Testing: Local on Windows
Docs Changes: None
Release Notes: None

