### PR TITLE
adaptive concurrency: Reset sample timer after minRTT calculation

### DIFF
--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
@@ -106,6 +106,7 @@ void GradientController::updateMinRTT() {
 
   min_rtt_calc_timer_->enableTimer(
       applyJitter(config_.minRTTCalcInterval(), config_.jitterPercent()));
+  sample_reset_timer_->enableTimer(config_.sampleRTTCalcInterval());
 }
 
 std::chrono::milliseconds GradientController::applyJitter(std::chrono::milliseconds interval,

--- a/test/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller_test.cc
@@ -488,6 +488,8 @@ min_rtt_calc_params:
   // random value > 10% of the interval.
   EXPECT_CALL(random_, random()).WillOnce(Return(15000));
   EXPECT_CALL(*rtt_timer, enableTimer(std::chrono::milliseconds(105000), _));
+  // Verify the sample timer is reset after the minRTT calculation occurs.
+  EXPECT_CALL(*sample_timer, enableTimer(std::chrono::milliseconds(123), _));
   for (int i = 0; i < 6; ++i) {
     tryForward(controller, true);
     controller->recordLatencySample(std::chrono::milliseconds(5));
@@ -525,6 +527,8 @@ min_rtt_calc_params:
 
   // Set the minRTT- this will trigger the timer for the next minRTT calculation.
   EXPECT_CALL(*rtt_timer, enableTimer(std::chrono::milliseconds(45000), _));
+  // Verify the sample timer is reset after the minRTT calculation occurs.
+  EXPECT_CALL(*sample_timer, enableTimer(std::chrono::milliseconds(123), _));
   for (int i = 0; i < 6; ++i) {
     tryForward(controller, true);
     controller->recordLatencySample(std::chrono::milliseconds(5));

--- a/test/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller_test.cc
@@ -470,8 +470,8 @@ min_rtt_calc_params:
 
   // Verify the configuration affects the timers that are kicked off.
   NiceMock<Event::MockDispatcher> fake_dispatcher;
-  auto sample_timer = new NiceMock<Event::MockTimer>;
-  auto rtt_timer = new NiceMock<Event::MockTimer>;
+  auto sample_timer = new Event::MockTimer();
+  auto rtt_timer = new Event::MockTimer();
 
   // Expect the sample timer to trigger start immediately upon controller creation.
   EXPECT_CALL(fake_dispatcher, createTimer_(_))
@@ -513,8 +513,8 @@ min_rtt_calc_params:
 
   // Verify the configuration affects the timers that are kicked off.
   NiceMock<Event::MockDispatcher> fake_dispatcher;
-  auto sample_timer = new NiceMock<Event::MockTimer>;
-  auto rtt_timer = new NiceMock<Event::MockTimer>;
+  auto sample_timer = new Event::MockTimer;
+  auto rtt_timer = new Event::MockTimer;
 
   // Expect the sample timer to trigger start immediately upon controller creation.
   EXPECT_CALL(fake_dispatcher, createTimer_(_))


### PR DESCRIPTION
This fixes a bug where the concurrency limit calculations were not occurring anymore after the minRTT (ideal round-trip time) was measured. 

During a minRTT calculation, the concurrency limit is dropped to 1 to measure the response time of an upstream. The time that the filter spends in this state is called the minRTT window. Periodically, the filter will use the measured minRTT value in a calculation of the new concurrency limit. The timer responsible for this concurrency limit recalculation is not enabled again if the filter is in a minRTT window, so we rely on the minRTT measurement to set the recalculation timer when finished. This was not occurring due to a bug introduced during a merge in a previous patch.

Relates to #7789