### PR TITLE
proto_sync: improve error message.

### DIFF
--- a/tools/proto_sync.py
+++ b/tools/proto_sync.py
@@ -52,7 +52,8 @@ class RequiresReformatError(ProtoSyncError):
 
   def __init__(self, message):
     super(RequiresReformatError, self).__init__(
-        '%s; either run ./ci/do_ci.sh fix_format or %s fix to reformat.\n' % (message, sys.argv[0]))
+        '%s; either run ./ci/do_ci.sh fix_format or ./tools/proto_format.sh fix to reformat.\n' %
+        message)
 
 
 def LabelPaths(label, src_suffix):


### PR DESCRIPTION
It was previously pointing at proto_sync.py, which is misleading, it's
necessary to run the full tools/proto_format.sh for a proto fix.

Signed-off-by: Harvey Tuch <htuch@google.com>