### PR TITLE
Ensure the commands are lower case in Redis request mirroring

### DIFF
--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -19,7 +19,10 @@ bool MirrorPolicyImpl::shouldMirror(const std::string& command) const {
     return false;
   }
 
-  if (exclude_read_commands_ && Common::Redis::SupportedCommands::isReadCommand(command)) {
+  std::string to_lower_string(command);
+  to_lower_table_.toLowerCase(to_lower_string);
+
+  if (exclude_read_commands_ && Common::Redis::SupportedCommands::isReadCommand(to_lower_string)) {
     return false;
   }
 

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -41,6 +41,7 @@ private:
   const bool exclude_read_commands_;
   ConnPool::InstanceSharedPtr upstream_;
   Runtime::Loader& runtime_;
+  const ToLowerTable to_lower_table_;
 };
 
 class Prefix : public Route {

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -203,6 +203,8 @@ TEST(MirrorPolicyImplTest, ShouldMirrorDefault) {
 
   EXPECT_EQ(true, policy.shouldMirror("get"));
   EXPECT_EQ(true, policy.shouldMirror("set"));
+  EXPECT_EQ(true, policy.shouldMirror("GET"));
+  EXPECT_EQ(true, policy.shouldMirror("SET"));
 }
 
 TEST(MirrorPolicyImplTest, MissingUpstream) {
@@ -214,6 +216,8 @@ TEST(MirrorPolicyImplTest, MissingUpstream) {
 
   EXPECT_EQ(false, policy.shouldMirror("get"));
   EXPECT_EQ(false, policy.shouldMirror("set"));
+  EXPECT_EQ(false, policy.shouldMirror("GET"));
+  EXPECT_EQ(false, policy.shouldMirror("SET"));
 }
 
 TEST(MirrorPolicyImplTest, ExcludeReadCommands) {
@@ -227,6 +231,8 @@ TEST(MirrorPolicyImplTest, ExcludeReadCommands) {
 
   EXPECT_EQ(false, policy.shouldMirror("get"));
   EXPECT_EQ(true, policy.shouldMirror("set"));
+  EXPECT_EQ(false, policy.shouldMirror("GET"));
+  EXPECT_EQ(true, policy.shouldMirror("SET"));
 }
 
 TEST(MirrorPolicyImplTest, DeterminedByRuntimeFraction) {
@@ -245,18 +251,22 @@ TEST(MirrorPolicyImplTest, DeterminedByRuntimeFraction) {
   EXPECT_CALL(
       runtime.snapshot_,
       featureEnabled("runtime_key", Matcher<const envoy::type::FractionalPercent&>(Percent(50))))
-      .Times(2)
+      .Times(4)
       .WillRepeatedly(Return(true));
   EXPECT_EQ(true, policy.shouldMirror("get"));
   EXPECT_EQ(true, policy.shouldMirror("set"));
+  EXPECT_EQ(true, policy.shouldMirror("GET"));
+  EXPECT_EQ(true, policy.shouldMirror("SET"));
 
   EXPECT_CALL(
       runtime.snapshot_,
       featureEnabled("runtime_key", Matcher<const envoy::type::FractionalPercent&>(Percent(50))))
-      .Times(2)
+      .Times(4)
       .WillRepeatedly(Return(false));
   EXPECT_EQ(false, policy.shouldMirror("get"));
   EXPECT_EQ(false, policy.shouldMirror("set"));
+  EXPECT_EQ(false, policy.shouldMirror("GET"));
+  EXPECT_EQ(false, policy.shouldMirror("SET"));
 }
 
 } // namespace RedisProxy


### PR DESCRIPTION
Description: We need to lower case the command name when we're deciding if we want to mirror the command.
Risk Level: Low
Testing: Added unit test
Docs Changes: N/A
Release Notes: N/A