### PR TITLE
ci: fix three clang-tidy master errors

### DIFF
--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -121,7 +121,7 @@ public:
    * @param address network address to bind and listen on.
    * @param listener_scope stats scope for the listener being started,
    */
-  virtual void startHttpListener(const std::string& access_log_path_,
+  virtual void startHttpListener(const std::string& access_log_path,
                                  const std::string& address_out_path,
                                  Network::Address::InstanceConstSharedPtr address,
                                  const Network::Socket::OptionsSharedPtr& socket_options,

--- a/source/extensions/quic_listeners/quiche/platform/quic_stack_trace_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_stack_trace_impl.h
@@ -6,6 +6,9 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
+#include <sstream>
+#include <string>
+
 #include "server/backtrace.h"
 
 namespace quic {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -46,7 +46,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::ByRef;
 using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;


### PR DESCRIPTION
Description:
Fix these three errors currently on the master branch
```
/home/dereka/.cache/bazel/_bazel_dereka/b4e08c1eaa8adbb40db2e2ca7ea0cbf2/execroot/envoy/include/envoy/server/admin.h:124:53: error: invalid case style for parameter 'access_log_path_' [readability-identifier-naming,-warnings-as-errors]
source/extensions/quic_listeners/quiche/platform/quic_stack_trace_impl.h:16:22: error: implicit instantiation of undefined template 'std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >' [clang-diagnostic-error]
/home/dereka/.cache/bazel/_bazel_dereka/b4e08c1eaa8adbb40db2e2ca7ea0cbf2/execroot/envoy/test/common/upstream/cluster_manager_impl_test.cc:49:16: error: using decl 'ByRef' is unused [misc-unused-using-decls,-warnings-as-errors]
```
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Derek Argueta <dereka@pinterest.com>