### PR TITLE
Makeuniquetest

### DIFF
--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
@@ -82,11 +82,6 @@ TEST(Http2PlatformTest, Http2Log) {
   HTTP2_DLOG_EVERY_N(ERROR, 2) << "DLOG_EVERY_N(ERROR, 2)";
 }
 
-TEST(Http2PlatformTest, Http2MakeUnique) {
-  auto p = http2::Http2MakeUnique<int>(4);
-  EXPECT_EQ(4, *p);
-}
-
 TEST(Http2PlatformTest, Http2Optional) {
   http2::Http2Optional<int> opt;
   EXPECT_FALSE(opt.has_value());

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -310,7 +310,7 @@ TEST_F(QuicPlatformTest, QuicUint128) {
 }
 
 TEST_F(QuicPlatformTest, QuicPtrUtil) {
-  p = QuicWrapUnique(new std::string("aaa"));
+  auto p = QuicWrapUnique(new std::string("aaa"));
   EXPECT_EQ("aaa", *p);
 }
 

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -310,9 +310,6 @@ TEST_F(QuicPlatformTest, QuicUint128) {
 }
 
 TEST_F(QuicPlatformTest, QuicPtrUtil) {
-  auto p = QuicMakeUnique<std::string>("abc");
-  EXPECT_EQ("abc", *p);
-
   p = QuicWrapUnique(new std::string("aaa"));
   EXPECT_EQ("aaa", *p);
 }

--- a/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
@@ -87,11 +87,6 @@ TEST(SpdyPlatformTest, SpdyLog) {
   SPDY_DVLOG_IF(4, false) << "DVLOG_IF(4, false)";
 }
 
-TEST(SpdyPlatformTest, SpdyMakeUnique) {
-  auto p = spdy::SpdyMakeUnique<int>(4);
-  EXPECT_EQ(4, *p);
-}
-
 TEST(SpdyPlatformTest, SpdyWrapUnique) {
   auto p = spdy::SpdyWrapUnique(new int(6));
   EXPECT_EQ(6, *p);


### PR DESCRIPTION
Signed-off-by: Bence Béky <bnc@google.com>

Description:
These platformized MakeUnique typedefs are being removed from QUICHE
platform because now every QUICHE embedder supports std::make_unique
from C++14.  Removing all usages (which all happen to be in tests) is to
prevent compile failures once that QUICHE change lands.

Risk Level: Low, test-only change.

Testing: n/a

Docs Changes: n/a

Release Notes: n/a