### PR TITLE
test: set idle_timeout in common_http_protocol options

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -511,7 +511,7 @@ void ConfigHelper::setDownstreamHttpIdleTimeout(std::chrono::milliseconds timeou
   addConfigModifier(
       [timeout](
           envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm) {
-        hcm.mutable_idle_timeout()->MergeFrom(
+        hcm.mutable_common_http_protocol_options()->mutable_idle_timeout()->MergeFrom(
             ProtobufUtil::TimeUtil::MillisecondsToDuration(timeout.count()));
       });
 }


### PR DESCRIPTION
This fixes compile_time_options by setting `idle_timeout` in `common_http_protocol_options`, rather than using the deprecated `idle_timeout` field in the HCM config.

Signed-off-by: Asra Ali <asraa@google.com>

