### PR TITLE
Ensure the command are lower case for RedisLoadBalancerContext

### DIFF
--- a/source/extensions/clusters/redis/BUILD
+++ b/source/extensions/clusters/redis/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         ":crc16_lib",
         "//include/envoy/upstream:thread_local_cluster_interface",
         "//include/envoy/upstream:upstream_interface",
+        "//source/common/common:to_lower_table_lib",
         "//source/common/upstream:upstream_includes",
         "//source/common/upstream:upstream_lib",
         "//source/extensions/clusters:well_known_names",

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -161,8 +161,8 @@ Upstream::HostConstSharedPtr RedisClusterLoadBalancerFactory::RedisClusterLoadBa
   return shard->master();
 }
 
-namespace {
-bool isReadRequest(const NetworkFilters::Common::Redis::RespValue& request) {
+bool RedisLoadBalancerContextImpl::isReadRequest(
+    const NetworkFilters::Common::Redis::RespValue& request) {
   if (request.type() != NetworkFilters::Common::Redis::RespType::Array) {
     return false;
   }
@@ -171,9 +171,15 @@ bool isReadRequest(const NetworkFilters::Common::Redis::RespValue& request) {
       first.type() != NetworkFilters::Common::Redis::RespType::BulkString) {
     return false;
   }
-  return NetworkFilters::Common::Redis::SupportedCommands::isReadCommand(first.asString());
+  std::string to_lower_string(first.asString());
+  toLowerTable().toLowerCase(to_lower_string);
+  return NetworkFilters::Common::Redis::SupportedCommands::isReadCommand(to_lower_string);
 }
-} // namespace
+
+const ToLowerTable& RedisLoadBalancerContextImpl::toLowerTable() {
+  static auto* table = new ToLowerTable();
+  return *table;
+}
 
 RedisLoadBalancerContextImpl::RedisLoadBalancerContextImpl(
     const std::string& key, bool enabled_hashtagging, bool is_redis_cluster,

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -96,6 +96,9 @@ public:
 private:
   absl::string_view hashtag(absl::string_view v, bool enabled);
 
+  static const ToLowerTable& toLowerTable();
+  static bool isReadRequest(const NetworkFilters::Common::Redis::RespValue& request);
+
   const absl::optional<uint64_t> hash_key_;
   const bool is_read_;
   const NetworkFilters::Common::Redis::Client::ReadPolicy read_policy_;

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -407,6 +407,46 @@ TEST_F(RedisLoadBalancerContextImplTest, Basic) {
   EXPECT_EQ(NetworkFilters::Common::Redis::Client::ReadPolicy::Master, context2.readPolicy());
 }
 
+TEST_F(RedisLoadBalancerContextImplTest, UpperCaseCommand) {
+  // Simple read command
+  std::vector<NetworkFilters::Common::Redis::RespValue> get_foo(2);
+  get_foo[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  get_foo[0].asString() = "GET";
+  get_foo[1].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  get_foo[1].asString() = "foo";
+
+  NetworkFilters::Common::Redis::RespValue get_request;
+  get_request.type(NetworkFilters::Common::Redis::RespType::Array);
+  get_request.asArray().swap(get_foo);
+
+  RedisLoadBalancerContextImpl context1("foo", true, true, get_request,
+                                        NetworkFilters::Common::Redis::Client::ReadPolicy::Master);
+
+  EXPECT_EQ(absl::optional<uint64_t>(44950), context1.computeHashKey());
+  EXPECT_EQ(true, context1.isReadCommand());
+  EXPECT_EQ(NetworkFilters::Common::Redis::Client::ReadPolicy::Master, context1.readPolicy());
+
+  // Simple write command
+  std::vector<NetworkFilters::Common::Redis::RespValue> set_foo(3);
+  set_foo[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  set_foo[0].asString() = "SET";
+  set_foo[1].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  set_foo[1].asString() = "foo";
+  set_foo[2].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  set_foo[2].asString() = "bar";
+
+  NetworkFilters::Common::Redis::RespValue set_request;
+  set_request.type(NetworkFilters::Common::Redis::RespType::Array);
+  set_request.asArray().swap(set_foo);
+
+  RedisLoadBalancerContextImpl context2("foo", true, true, set_request,
+                                        NetworkFilters::Common::Redis::Client::ReadPolicy::Master);
+
+  EXPECT_EQ(absl::optional<uint64_t>(44950), context2.computeHashKey());
+  EXPECT_EQ(false, context2.isReadCommand());
+  EXPECT_EQ(NetworkFilters::Common::Redis::Client::ReadPolicy::Master, context2.readPolicy());
+}
+
 TEST_F(RedisLoadBalancerContextImplTest, UnsupportedCommand) {
   std::vector<NetworkFilters::Common::Redis::RespValue> unknown(1);
   unknown[0].type(NetworkFilters::Common::Redis::RespType::Integer);


### PR DESCRIPTION
Description: Found a similar issue with #8530 in the RedisLoadBalancerContext.  The redis command needs to be lower case when we determine if it's a read command.
Risk Level: Low
Testing: Add unit test
Docs Changes: N/A
Release Notes: N/A
