### PR TITLE
csrf: add PATCH to mutating methods

### DIFF
--- a/docs/root/configuration/http/http_filters/csrf_filter.rst
+++ b/docs/root/configuration/http/http_filters/csrf_filter.rst
@@ -27,7 +27,9 @@ a request originated from the same host.
 When the filter is evaluating a request, it ensures both pieces of information are present
 and compares their values. If the source origin is missing or the origins do not match
 the request is rejected. The exception to this being if the source origin has been
-added to the policy as valid.
+added to the policy as valid. Because CSRF attacks specifically target state-changing
+requests, the filter only acts on HTTP requests that have a state-changing method
+(POST, PUT, etc.).
 
   .. note::
     Due to differing functionality between browsers this filter will determine

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -23,6 +23,7 @@ Version history
 * config: async data access for local and remote data source.
 * config: changed the default value of :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>` from 0s to 15s. This is a change in behaviour in the sense that Envoy will move to the next initialization phase, even if the first config is not delivered in 15s. Refer to :ref:`initialization process <arch_overview_initialization>` for more details.
 * config: added stat :ref:`init_fetch_timeout <config_cluster_manager_cds>`.
+* csrf: add PATCH to supported methods.
 * dns: added support for configuring :ref:`dns_failure_refresh_rate <envoy_api_field_Cluster.dns_failure_refresh_rate>` to set the DNS refresh rate during failures.
 * ext_authz: added :ref:`configurable ability <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.metadata_context_namespaces>` to send dynamic metadata to the `ext_authz` service.
 * ext_authz: added tracing to the HTTP client.

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -232,9 +232,10 @@ public:
     const std::string Delete{"DELETE"};
     const std::string Get{"GET"};
     const std::string Head{"HEAD"};
+    const std::string Options{"OPTIONS"};
+    const std::string Patch{"PATCH"};
     const std::string Post{"POST"};
     const std::string Put{"PUT"};
-    const std::string Options{"OPTIONS"};
     const std::string Trace{"TRACE"};
   } MethodValues;
 

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -28,7 +28,7 @@ bool isModifyMethod(const Http::HeaderMap& headers) {
   const absl::string_view method_type = method->value().getStringView();
   const auto& method_values = Http::Headers::get().MethodValues;
   return (method_type == method_values.Post || method_type == method_values.Put ||
-          method_type == method_values.Delete);
+          method_type == method_values.Delete || method_type == method_values.Patch);
 }
 
 absl::string_view hostAndPort(const Http::HeaderEntry* header) {

--- a/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
@@ -157,6 +157,20 @@ TEST_P(CsrfFilterIntegrationTest, TestEnforcesDelete) {
   EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
 }
 
+TEST_P(CsrfFilterIntegrationTest, TestEnforcesPatch) {
+  config_helper_.addFilter(CSRF_FILTER_ENABLED_CONFIG);
+  Http::TestHeaderMapImpl headers = {{
+      {":method", "PATCH"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {"origin", "cross-origin"},
+      {"host", "test-origin"},
+  }};
+  const auto& response = sendRequest(headers);
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+}
+
 TEST_P(CsrfFilterIntegrationTest, TestRefererFallback) {
   config_helper_.addFilter(CSRF_FILTER_ENABLED_CONFIG);
   Http::TestHeaderMapImpl headers = {{":method", "DELETE"},

--- a/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
@@ -84,7 +84,7 @@ TEST_P(CsrfFilterIntegrationTest, TestCsrfSuccess) {
   }};
   const auto& response = sendRequestAndWaitForResponse(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("200"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "200");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestCsrfDisabled) {
@@ -98,7 +98,7 @@ TEST_P(CsrfFilterIntegrationTest, TestCsrfDisabled) {
   }};
   const auto& response = sendRequestAndWaitForResponse(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("200"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "200");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestNonMutationMethod) {
@@ -112,7 +112,7 @@ TEST_P(CsrfFilterIntegrationTest, TestNonMutationMethod) {
   }};
   const auto& response = sendRequestAndWaitForResponse(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("200"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "200");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestOriginMismatch) {
@@ -126,7 +126,7 @@ TEST_P(CsrfFilterIntegrationTest, TestOriginMismatch) {
   }};
   const auto& response = sendRequest(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "403");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestEnforcesPost) {
@@ -140,7 +140,7 @@ TEST_P(CsrfFilterIntegrationTest, TestEnforcesPost) {
   }};
   const auto& response = sendRequest(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "403");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestEnforcesDelete) {
@@ -154,7 +154,7 @@ TEST_P(CsrfFilterIntegrationTest, TestEnforcesDelete) {
   }};
   const auto& response = sendRequest(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "403");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestEnforcesPatch) {
@@ -168,7 +168,7 @@ TEST_P(CsrfFilterIntegrationTest, TestEnforcesPatch) {
   }};
   const auto& response = sendRequest(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "403");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestRefererFallback) {
@@ -180,7 +180,7 @@ TEST_P(CsrfFilterIntegrationTest, TestRefererFallback) {
                                      {"host", "test-origin"}};
   const auto& response = sendRequestAndWaitForResponse(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("200"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "200");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestMissingOrigin) {
@@ -189,7 +189,7 @@ TEST_P(CsrfFilterIntegrationTest, TestMissingOrigin) {
       {{":method", "DELETE"}, {":path", "/"}, {":scheme", "http"}, {"host", "test-origin"}}};
   const auto& response = sendRequest(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "403");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestShadowOnlyMode) {
@@ -203,7 +203,7 @@ TEST_P(CsrfFilterIntegrationTest, TestShadowOnlyMode) {
   }};
   const auto& response = sendRequestAndWaitForResponse(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("200"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "200");
 }
 
 TEST_P(CsrfFilterIntegrationTest, TestFilterAndShadowEnabled) {
@@ -217,7 +217,7 @@ TEST_P(CsrfFilterIntegrationTest, TestFilterAndShadowEnabled) {
   }};
   const auto& response = sendRequest(headers);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().Status()->value().getStringView(), absl::string_view("403"));
+  EXPECT_EQ(response->headers().Status()->value().getStringView(), "403");
 }
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Description: The CSRF filter acts on HTTP methods that can mutate data. HTTP PATCH ([RFC 5789](https://tools.ietf.org/html/rfc5789)) fits this description and should be considered for CSRF protection.
Risk Level: Low
Testing: added
Docs Changes: added
Release Notes: added

cc @dschaller 