### PR TITLE
Add check_spelling bash script to pre-push hook

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -65,6 +65,11 @@ do
       fi
 
       echo "  Checking spelling for $i"
+      "$SCRIPT_DIR"/check_spelling.sh check $i
+      if [[ $? -ne 0 ]]; then
+        exit 1
+      fi
+
       "$SCRIPT_DIR"/check_spelling_pedantic.py check $i
       if [[ $? -ne 0 ]]; then
         exit 1


### PR DESCRIPTION
circle-ci runs both, the python script and the bash script.
The python checker misses words that are caught by the bash script. So, we need to run both.

Signed-off-by: Marco Magdy <mmagdy@gmail.com>

Description: (see above)
Risk Level: medium
Testing: manual test
