### PR TITLE
transport_socket: use same logic to construct transport socket options

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -4,7 +4,6 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_package",
-    "envoy_proto_library",
 )
 
 envoy_package()
@@ -281,7 +280,10 @@ envoy_cc_library(
     srcs = ["transport_socket_options_impl.cc"],
     hdrs = ["transport_socket_options_impl.h"],
     deps = [
+        ":application_protocol_lib",
+        ":upstream_server_name_lib",
         "//include/envoy/network:transport_socket_interface",
+        "//include/envoy/stream_info:filter_state_interface",
         "//source/common/common:scalar_to_byte_vector_lib",
         "//source/common/common:utility_lib",
     ],

--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -2,6 +2,8 @@
 
 #include "common/common/scalar_to_byte_vector.h"
 #include "common/common/utility.h"
+#include "common/network/application_protocol.h"
+#include "common/network/upstream_server_name.h"
 
 namespace Envoy {
 namespace Network {
@@ -16,5 +18,33 @@ void TransportSocketOptionsImpl::hashKey(std::vector<uint8_t>& key) const {
     }
   }
 }
+
+TransportSocketOptionsSharedPtr
+TransportSocketOptionsUtility::fromFilterState(const StreamInfo::FilterState& filter_state) {
+  absl::string_view server_name;
+  std::vector<std::string> application_protocols;
+  bool needs_transport_socket_options = false;
+  if (filter_state.hasData<UpstreamServerName>(UpstreamServerName::key())) {
+    const auto& upstream_server_name =
+        filter_state.getDataReadOnly<UpstreamServerName>(UpstreamServerName::key());
+    server_name = upstream_server_name.value();
+    needs_transport_socket_options = true;
+  }
+
+  if (filter_state.hasData<Network::ApplicationProtocols>(Network::ApplicationProtocols::key())) {
+    const auto& alpn = filter_state.getDataReadOnly<Network::ApplicationProtocols>(
+        Network::ApplicationProtocols::key());
+    application_protocols = alpn.value();
+    needs_transport_socket_options = true;
+  }
+
+  if (needs_transport_socket_options) {
+    return std::make_shared<Network::TransportSocketOptionsImpl>(
+        server_name, std::vector<std::string>{}, std::vector<std::string>{application_protocols});
+  } else {
+    return nullptr;
+  }
+}
+
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/transport_socket_options_impl.h
+++ b/source/common/network/transport_socket_options_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/network/transport_socket.h"
+#include "envoy/stream_info/filter_state.h"
 
 namespace Envoy {
 namespace Network {
@@ -32,6 +33,18 @@ private:
   const absl::optional<std::string> override_server_name_;
   const std::vector<std::string> override_verify_san_list_;
   const std::vector<std::string> override_alpn_list_;
+};
+
+class TransportSocketOptionsUtility {
+public:
+  /**
+   * Construct TransportSocketOptions from StreamInfo::FilterState, using UpstreamServerName
+   * and ApplicationProtocols key in the filter state.
+   * @returns TransportSocketOptionsSharedPtr a shared pointer to the transport socket options,
+   * nullptr if nothing is in the filter state.
+   */
+  static TransportSocketOptionsSharedPtr
+  fromFilterState(const StreamInfo::FilterState& stream_info);
 };
 
 } // namespace Network

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -573,14 +573,8 @@ Http::ConnectionPool::Instance* Filter::getConnPool() {
                                                                    : Http::Protocol::Http11;
   }
 
-  if (callbacks_->streamInfo().filterState().hasData<Network::ApplicationProtocols>(
-          Network::ApplicationProtocols::key())) {
-    const auto& alpn =
-        callbacks_->streamInfo().filterState().getDataReadOnly<Network::ApplicationProtocols>(
-            Network::ApplicationProtocols::key());
-    transport_socket_options_ = std::make_shared<Network::TransportSocketOptionsImpl>(
-        "", std::vector<std::string>{}, std::vector<std::string>{alpn.value()});
-  }
+  transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
+      callbacks_->streamInfo().filterState());
 
   return config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), route_entry_->priority(),
                                             protocol, this);

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -290,3 +290,12 @@ envoy_cc_test(
         "//source/common/network:address_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "transport_socket_options_impl_test",
+    srcs = ["transport_socket_options_impl_test.cc"],
+    deps = [
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/stream_info:filter_state_lib",
+    ],
+)

--- a/test/common/network/transport_socket_options_impl_test.cc
+++ b/test/common/network/transport_socket_options_impl_test.cc
@@ -1,0 +1,61 @@
+#include "common/network/application_protocol.h"
+#include "common/network/transport_socket_options_impl.h"
+#include "common/network/upstream_server_name.h"
+#include "common/stream_info/filter_state_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Network {
+namespace {
+
+class TransportSocketOptionsImplTest : public testing::Test {
+protected:
+  StreamInfo::FilterStateImpl filter_state_;
+};
+
+TEST_F(TransportSocketOptionsImplTest, Nullptr) {
+  EXPECT_EQ(nullptr, TransportSocketOptionsUtility::fromFilterState(filter_state_));
+  filter_state_.setData("random_key_has_no_effect",
+                        std::make_unique<UpstreamServerName>("www.example.com"),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+  EXPECT_EQ(nullptr, TransportSocketOptionsUtility::fromFilterState(filter_state_));
+}
+
+TEST_F(TransportSocketOptionsImplTest, UpstreamServer) {
+  filter_state_.setData(UpstreamServerName::key(),
+                        std::make_unique<UpstreamServerName>("www.example.com"),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+  auto transport_socket_options = TransportSocketOptionsUtility::fromFilterState(filter_state_);
+  EXPECT_EQ(absl::make_optional<std::string>("www.example.com"),
+            transport_socket_options->serverNameOverride());
+  EXPECT_TRUE(transport_socket_options->applicationProtocolListOverride().empty());
+}
+
+TEST_F(TransportSocketOptionsImplTest, ApplicationProtocols) {
+  std::vector<std::string> http_alpns{"h2", "http/1.1"};
+  filter_state_.setData(ApplicationProtocols::key(),
+                        std::make_unique<ApplicationProtocols>(http_alpns),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+  auto transport_socket_options = TransportSocketOptionsUtility::fromFilterState(filter_state_);
+  EXPECT_EQ(absl::nullopt, transport_socket_options->serverNameOverride());
+  EXPECT_EQ(http_alpns, transport_socket_options->applicationProtocolListOverride());
+}
+
+TEST_F(TransportSocketOptionsImplTest, Both) {
+  std::vector<std::string> http_alpns{"h2", "http/1.1"};
+  filter_state_.setData(UpstreamServerName::key(),
+                        std::make_unique<UpstreamServerName>("www.example.com"),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+  filter_state_.setData(ApplicationProtocols::key(),
+                        std::make_unique<ApplicationProtocols>(http_alpns),
+                        StreamInfo::FilterState::StateType::ReadOnly);
+  auto transport_socket_options = TransportSocketOptionsUtility::fromFilterState(filter_state_);
+  EXPECT_EQ(absl::make_optional<std::string>("www.example.com"),
+            transport_socket_options->serverNameOverride());
+  EXPECT_EQ(http_alpns, transport_socket_options->applicationProtocolListOverride());
+}
+
+} // namespace
+} // namespace Network
+} // namespace Envoy


### PR DESCRIPTION
Description:
Construct transport socket options from filter state:
- in tcp_proxy
- in http router

Risk Level: Low
Testing: CI, unittest
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
