### PR TITLE
config: register deprecated names for transport sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ BROWSE
 /build_*
 *.bzlc
 .cache
+.clangd
 .classpath
 .clwb/
 /ci/bazel-*

--- a/docs/root/operations/traffic_tapping.rst
+++ b/docs/root/operations/traffic_tapping.rst
@@ -45,7 +45,7 @@ or cluster. For a plain text socket this might look like:
                 file_per_tap:
                   path_prefix: /some/tap/path
       transport_socket:
-        name: raw_buffer
+        name: envoy.transport_sockets.raw_buffer
 
 For a TLS socket, this will be:
 
@@ -64,7 +64,7 @@ For a TLS socket, this will be:
                 file_per_tap:
                   path_prefix: /some/tap/path
       transport_socket:
-        name: ssl
+        name: envoy.transport_sockets.tls
         config: <TLS context>
 
 where the TLS context configuration replaces any existing :ref:`downstream

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -35,7 +35,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
 
   const absl::string_view transport_protocol = socket.detectedTransportProtocol();
   if (!transport_protocol.empty() &&
-      transport_protocol != TransportSockets::TransportSocketNames::get().RawBuffer) {
+      transport_protocol != TransportSockets::TransportProtocolNames::get().RawBuffer) {
     ENVOY_LOG(trace, "http inspector: cannot inspect http protocol with transport socket {}",
               transport_protocol);
     return Network::FilterStatus::Continue;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -220,7 +220,8 @@ ParseState Filter::parseClientHello(const void* data, size_t len) {
       } else {
         config_->stats().alpn_not_found_.inc();
       }
-      cb_->socket().setDetectedTransportProtocol(TransportSockets::TransportSocketNames::get().Tls);
+      cb_->socket().setDetectedTransportProtocol(
+          TransportSockets::TransportProtocolNames::get().Tls);
     } else {
       config_->stats().tls_not_found_.inc();
     }

--- a/source/extensions/filters/network/dubbo_proxy/protocol.h
+++ b/source/extensions/filters/network/dubbo_proxy/protocol.h
@@ -129,6 +129,7 @@ public:
  * ProtocolFactoryBase provides a template for a trivial NamedProtocolConfigFactory.
  */
 template <class ProtocolImpl> class ProtocolFactoryBase : public NamedProtocolConfigFactory {
+public:
   ProtocolPtr createProtocol(SerializationType serialization_type) override {
     auto protocol = std::make_unique<ProtocolImpl>();
     protocol->initSerializer(serialization_type);

--- a/source/extensions/filters/network/dubbo_proxy/router/route.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/route.h
@@ -100,6 +100,7 @@ public:
  */
 template <class RouteMatcherImpl>
 class RouteMatcherFactoryBase : public NamedRouteMatcherConfigFactory {
+public:
   RouteMatcherPtr createRouteMatcher(const RouteConfigurations& route_configs,
                                      Server::Configuration::FactoryContext& context) override {
     return std::make_unique<RouteMatcherImpl>(route_configs, context);

--- a/source/extensions/filters/network/dubbo_proxy/serializer.h
+++ b/source/extensions/filters/network/dubbo_proxy/serializer.h
@@ -110,6 +110,7 @@ public:
  * SerializerFactoryBase provides a template for a trivial NamedSerializerConfigFactory.
  */
 template <class SerializerImpl> class SerializerFactoryBase : public NamedSerializerConfigFactory {
+public:
   SerializerPtr createSerializer() override { return std::make_unique<SerializerImpl>(); }
 
   std::string name() override { return name_; }

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -529,6 +529,7 @@ public:
  * ProtocolFactoryBase provides a template for a trivial NamedProtocolConfigFactory.
  */
 template <class ProtocolImpl> class ProtocolFactoryBase : public NamedProtocolConfigFactory {
+public:
   ProtocolPtr createProtocol() override { return std::move(std::make_unique<ProtocolImpl>()); }
 
   std::string name() override { return name_; }

--- a/source/extensions/filters/network/thrift_proxy/transport.h
+++ b/source/extensions/filters/network/thrift_proxy/transport.h
@@ -113,6 +113,7 @@ public:
  * TransportFactoryBase provides a template for a trivial NamedTransportConfigFactory.
  */
 template <class TransportImpl> class TransportFactoryBase : public NamedTransportConfigFactory {
+public:
   TransportPtr createTransport() override { return std::move(std::make_unique<TransportImpl>()); }
 
   std::string name() override { return name_; }

--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.cc
@@ -36,7 +36,7 @@ bool EnvoyQuicServerConnection::OnPacketHeader(const quic::QuicPacketHeader& hea
   // Self address should be initialized by now. It's time to install filters.
   connectionSocket()->setLocalAddress(quicAddressToEnvoyAddressInstance(self_address()));
   connectionSocket()->setDetectedTransportProtocol(
-      Extensions::TransportSockets::TransportSocketNames::get().Quic);
+      Extensions::TransportSockets::TransportProtocolNames::get().Quic);
   ASSERT(filter_chain_ == nullptr);
   filter_chain_ = listener_config_.filterChainManager().findFilterChain(*connectionSocket());
   if (filter_chain_ == nullptr) {

--- a/source/extensions/transport_sockets/raw_buffer/config.cc
+++ b/source/extensions/transport_sockets/raw_buffer/config.cc
@@ -23,10 +23,10 @@ ProtobufTypes::MessagePtr RawBufferSocketFactory::createEmptyConfigProto() {
 }
 
 REGISTER_FACTORY(UpstreamRawBufferSocketFactory,
-                 Server::Configuration::UpstreamTransportSocketConfigFactory);
+                 Server::Configuration::UpstreamTransportSocketConfigFactory){"raw_buffer"};
 
 REGISTER_FACTORY(DownstreamRawBufferSocketFactory,
-                 Server::Configuration::DownstreamTransportSocketConfigFactory);
+                 Server::Configuration::DownstreamTransportSocketConfigFactory){"raw_buffer"};
 
 } // namespace RawBuffer
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/tls/config.cc
+++ b/source/extensions/transport_sockets/tls/config.cc
@@ -29,7 +29,7 @@ ProtobufTypes::MessagePtr UpstreamSslSocketFactory::createEmptyConfigProto() {
 }
 
 REGISTER_FACTORY(UpstreamSslSocketFactory,
-                 Server::Configuration::UpstreamTransportSocketConfigFactory);
+                 Server::Configuration::UpstreamTransportSocketConfigFactory){"tls"};
 
 Network::TransportSocketFactoryPtr DownstreamSslSocketFactory::createTransportSocketFactory(
     const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext& context,
@@ -47,7 +47,7 @@ ProtobufTypes::MessagePtr DownstreamSslSocketFactory::createEmptyConfigProto() {
 }
 
 REGISTER_FACTORY(DownstreamSslSocketFactory,
-                 Server::Configuration::DownstreamTransportSocketConfigFactory);
+                 Server::Configuration::DownstreamTransportSocketConfigFactory){"tls"};
 
 Ssl::ContextManagerPtr SslContextManagerFactory::createContextManager(TimeSource& time_source) {
   return std::make_unique<ContextManagerImpl>(time_source);

--- a/source/extensions/transport_sockets/well_known_names.h
+++ b/source/extensions/transport_sockets/well_known_names.h
@@ -16,12 +16,25 @@ class TransportSocketNameValues {
 public:
   const std::string Alts = "envoy.transport_sockets.alts";
   const std::string Tap = "envoy.transport_sockets.tap";
-  const std::string RawBuffer = "raw_buffer";
-  const std::string Tls = "tls";
-  const std::string Quic = "quic";
+  const std::string RawBuffer = "envoy.transport_sockets.raw_buffer";
+  const std::string Tls = "envoy.transport_sockets.tls";
+  const std::string Quic = "envoy.transport_sockets.quic";
 };
 
 using TransportSocketNames = ConstSingleton<TransportSocketNameValues>;
+
+/**
+ * Well-known transport protocol names.
+ */
+class TransportProtocolNameValues {
+public:
+  const std::string Tls = "tls";
+  const std::string RawBuffer = "raw_buffer";
+  const std::string Quic = "quic";
+};
+
+// TODO(lizan): Find a better place to have this singleton.
+using TransportProtocolNames = ConstSingleton<TransportProtocolNameValues>;
 
 } // namespace TransportSockets
 } // namespace Extensions

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -257,7 +257,7 @@ void ConnectionHandlerImpl::ActiveSocket::newConnection() {
     // Set default transport protocol if none of the listener filters did it.
     if (socket_->detectedTransportProtocol().empty()) {
       socket_->setDetectedTransportProtocol(
-          Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
+          Extensions::TransportSockets::TransportProtocolNames::get().RawBuffer);
     }
     // Create a new connection on this listener.
     listener_.newConnection(std::move(socket_));

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -426,10 +426,10 @@ void ConfigHelper::setTapTransportSocket(const std::string& tap_path, const std:
     RELEASE_ASSERT(!tls_config, "");
     inner_transport_socket.MergeFrom(transport_socket);
   } else if (tls_config.has_value()) {
-    inner_transport_socket.set_name("tls");
+    inner_transport_socket.set_name("envoy.transport_sockets.tls");
     inner_transport_socket.mutable_config()->MergeFrom(tls_config.value());
   } else {
-    inner_transport_socket.set_name("raw_buffer");
+    inner_transport_socket.set_name("envoy.transport_sockets.raw_buffer");
   }
   // Configure outer tap transport socket.
   transport_socket.set_name("envoy.transport_sockets.tap");

--- a/test/extensions/quic_listeners/quiche/envoy_quic_dispatcher_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_dispatcher_test.cc
@@ -157,7 +157,7 @@ TEST_P(EnvoyQuicDispatcherTest, CreateNewConnectionUponCHLO) {
   EXPECT_CALL(filter_chain_manager, findFilterChain(_))
       .WillOnce(Invoke([&](const Network::ConnectionSocket& socket) {
         EXPECT_EQ(*listen_socket_->localAddress(), *socket.localAddress());
-        EXPECT_EQ(Extensions::TransportSockets::TransportSocketNames::get().Quic,
+        EXPECT_EQ(Extensions::TransportSockets::TransportProtocolNames::get().Quic,
                   socket.detectedTransportProtocol());
         EXPECT_EQ(peer_addr, envoyAddressInstanceToQuicSocketAddress(socket.remoteAddress()));
         return &filter_chain;

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
@@ -354,7 +354,7 @@ TEST_P(EnvoyQuicServerSessionTest, InitializeFilterChain) {
                   *socket.remoteAddress());
         EXPECT_EQ(*quicAddressToEnvoyAddressInstance(self_address), *socket.localAddress());
         EXPECT_EQ(listener_config_.socket().ioHandle().fd(), socket.ioHandle().fd());
-        EXPECT_EQ(Extensions::TransportSockets::TransportSocketNames::get().Quic,
+        EXPECT_EQ(Extensions::TransportSockets::TransportProtocolNames::get().Quic,
                   socket.detectedTransportProtocol());
         return &filter_chain;
       }));

--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -22,7 +22,7 @@ filter_chains:
     transport_protocol: "quic"
   filters: []
   transport_socket:
-    name: quic
+    name: envoy.transport_sockets.quic
     config:
       common_tls_context:
         tls_certificates:


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Addresses #8540. Will do deprecation check in follow up.

Risk Level: Med around transport protocol / transport socket names.
Testing: CI, unittest
Docs Changes: N/A
Release Notes: N/A
