### PR TITLE
tls: shutdown all contexts when terminating server

### DIFF
--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -46,6 +46,12 @@ public:
    * context manager.
    */
   virtual PrivateKeyMethodManager& privateKeyMethodManager() PURE;
+
+  /**
+   * Remove any contexts in the context manager on shutdown.
+   *
+   */
+  virtual void shutdown() PURE;
 };
 
 using ContextManagerPtr = std::unique_ptr<ContextManager>;

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -71,6 +71,11 @@ void ContextManagerImpl::iterateContexts(std::function<void(const Envoy::Ssl::Co
   }
 }
 
+void ContextManagerImpl::shutdown() {
+  contexts_.clear();
+  ASSERT(contexts_.empty());
+}
+
 } // namespace Tls
 } // namespace TransportSockets
 } // namespace Extensions

--- a/source/extensions/transport_sockets/tls/context_manager_impl.h
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.h
@@ -39,6 +39,7 @@ public:
   Ssl::PrivateKeyMethodManager& privateKeyMethodManager() override {
     return private_key_method_manager_;
   };
+  void shutdown() override;
 
 private:
   void removeEmptyContexts();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -587,6 +587,9 @@ void InstanceImpl::terminate() {
   if (config_.clusterManager() != nullptr) {
     config_.clusterManager()->shutdown();
   }
+  if (ssl_context_manager_ != nullptr) {
+    ssl_context_manager_->shutdown();
+  }
   handler_.reset();
   thread_local_.shutdownThread();
   restarter_.shutdown();

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -31,6 +31,8 @@ class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
 
   Ssl::PrivateKeyMethodManager& privateKeyMethodManager() override { throwException(); }
 
+  void shutdown() override{};
+
 private:
   [[noreturn]] void throwException() {
     throw EnvoyException("SSL is not supported in this configuration");

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -30,6 +30,7 @@ public:
   MOCK_CONST_METHOD0(daysUntilFirstCertExpires, size_t());
   MOCK_METHOD1(iterateContexts, void(std::function<void(const Context&)> callback));
   MOCK_METHOD0(privateKeyMethodManager, Ssl::PrivateKeyMethodManager&());
+  MOCK_METHOD0(shutdown, void());
 };
 
 class MockConnectionInfo : public ConnectionInfo {

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5758799303933952
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5758799303933952
@@ -1,0 +1,67 @@
+static_resources {
+  listeners {
+    address {
+      pipe {
+        path: "&"
+      }
+    }
+    filter_chains {
+      tls_context {
+        session_ticket_keys_sds_secret_config {
+          sds_config {
+            api_config_source {
+              refresh_delay {
+                seconds: -1
+                nanos: -348270613
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  clusters {
+    name: "1"
+    type: STRICT_DNS
+    connect_timeout {
+      nanos: 2
+    }
+    lb_policy: RING_HASH
+    hosts {
+      socket_address {
+        address: "1.1.0.1"
+        port_value: 1
+      }
+    }
+    hosts {
+      socket_address {
+        address: "123.0.0.1"
+        named_port: ""
+      }
+    }
+    health_checks {
+      timeout {
+        nanos: 95
+      }
+      interval {
+        nanos: 4
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+      }
+      http_health_check {
+        host: "N"
+        path: "N"
+      }
+    }
+    tls_context {
+      common_tls_context {
+        tls_params {
+          cipher_suites: "ECDHE-ECDSA-AES256-SHA"
+        }
+      }
+    }
+    alt_stat_name: "google.com"
+  }
+}


### PR DESCRIPTION
When a server catches an Exception on initialization or is destructed, it calls `terminate()` to shutdown the listener manager, worker threads, and cluster manager among others. The `ContextManager` is also destroyed, but the destructor only removes contexts that are expired. This removes all contexts with a `shutdown()` method.

Fixes OSS-Fuzz Issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15760
Testing: Added crashing corpus

Signed-off-by: Asra Ali <asraa@google.com>
