### PR TITLE
build: statically link C++ stdlib in ASan builds.

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -91,7 +91,6 @@ def envoy_select_force_libcpp(if_libcpp, default = None):
 
 def envoy_stdlib_deps():
     return select({
-        "@envoy//bazel:asan_build": ["@envoy//bazel:dynamic_stdlib"],
         "@envoy//bazel:tsan_build": ["@envoy//bazel:dynamic_stdlib"],
         "//conditions:default": ["@envoy//bazel:static_stdlib"],
     })


### PR DESCRIPTION
While ThreadSanitizer doesn't support statically linking C++ stdlib:

  http://releases.llvm.org/8.0.1/tools/clang/docs/ThreadSanitizer.html
  "Libc/libstdc++ static linking is not supported."

AddressSanitizer supports it, but not static linkage (i.e. -static):

  http://releases.llvm.org/8.0.1/tools/clang/docs/AddressSanitizer.html
  "Static linking of executables is not supported."

with some known quirks:

  https://github.com/google/sanitizers/wiki/AddressSanitizer
  Q: My new() and delete() stacktraces are too short or do not make sense?
  A: This may happen when the C++ standard library is linked statically.
  Prebuilt libstdc++/libc++ often do not use frame pointers, and it breaks
  fast (frame-pointer-based) unwinding. Either switch to the shared library
  with the -shared-libstdc++ flag, or use ASAN_OPTIONS=fast_unwind_on_malloc=0.
  The latter could be very slow.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>