### PR TITLE
adaptive concurrency: Disregard healthchecks when sampling latencies

### DIFF
--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -254,27 +254,20 @@ TEST_F(AdaptiveConcurrencyFilterTest, EncodeHeadersValidTest) {
 }
 
 TEST_F(AdaptiveConcurrencyFilterTest, DisregardHealthChecks) {
-  auto mt = time_system_.monotonicTime();
-  time_system_.setMonotonicTime(mt + std::chrono::nanoseconds(123));
-
-  // Get the filter to record the request start time via decode.
-  Http::TestHeaderMapImpl request_headers;
-  EXPECT_CALL(*controller_, forwardingDecision())
-      .WillOnce(Return(RequestForwardingAction::Forward));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
-
-  const auto advance_time = std::chrono::nanoseconds(42);
-  mt = time_system_.monotonicTime();
-  time_system_.setMonotonicTime(mt + advance_time);
-
   StreamInfo::MockStreamInfo stream_info;
-  EXPECT_CALL(encoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info));
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info));
   EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(true));
+
+  Http::TestHeaderMapImpl request_headers;
+
+  // We do not expect a call to forwardingDecision() during decode.
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   Http::TestHeaderMapImpl response_headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
 
-  // We do not expect a call to recordLatencySample().
+  // We do not expect a call to recordLatencySample() as well.
 
   filter_->encodeComplete();
 }

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -110,7 +110,7 @@ enabled:
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   Http::TestHeaderMapImpl response_headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   filter_->encodeComplete();
 }
 
@@ -153,7 +153,7 @@ enabled:
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   Http::TestHeaderMapImpl response_headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   filter_->encodeComplete();
 }
 
@@ -226,7 +226,7 @@ TEST_F(AdaptiveConcurrencyFilterTest, OnDestroyCleanupTest) {
   time_system_.sleep(advance_time);
 
   Http::TestHeaderMapImpl response_headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   EXPECT_CALL(*controller_, recordLatencySample(advance_time));
   filter_->encodeComplete();
 
@@ -248,7 +248,7 @@ TEST_F(AdaptiveConcurrencyFilterTest, EncodeHeadersValidTest) {
   time_system_.setMonotonicTime(mt + advance_time);
 
   Http::TestHeaderMapImpl response_headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   EXPECT_CALL(*controller_, recordLatencySample(advance_time));
   filter_->encodeComplete();
 }
@@ -265,7 +265,7 @@ TEST_F(AdaptiveConcurrencyFilterTest, DisregardHealthChecks) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   Http::TestHeaderMapImpl response_headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
 
   // We do not expect a call to recordLatencySample() as well.
 


### PR DESCRIPTION
Changes latency sampling in the adaptive concurrency filter such that
health checking requests will not be sampled by the concurrency
controller. Health checks may potentially bias the sample aggregate to
lower latency measurements.


Partial progress to #8274