### PR TITLE
Apply correct dependencies to the google_grpc_context_lib

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_google_grpc_external_deps",
     "envoy_package",
     "envoy_select_google_grpc",
 )
@@ -162,13 +163,12 @@ envoy_cc_library(
     name = "google_grpc_context_lib",
     srcs = ["google_grpc_context.cc"],
     hdrs = ["google_grpc_context.h"],
-    external_deps = ["grpc"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:lock_guard_lib",
         "//source/common/common:macros",
         "//source/common/common:thread_lib",
-    ],
+    ] + envoy_google_grpc_external_deps(),
 )
 
 envoy_cc_library(

--- a/source/common/grpc/google_grpc_context.cc
+++ b/source/common/grpc/google_grpc_context.cc
@@ -7,7 +7,9 @@
 #include "common/common/macros.h"
 #include "common/common/thread.h"
 
+#ifdef ENVOY_GOOGLE_GRPC
 #include "grpcpp/grpcpp.h"
+#endif
 
 namespace Envoy {
 namespace Grpc {


### PR DESCRIPTION
Apply correct dependencies to the google_grpc_context_lib

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
