### PR TITLE
wasm: rename envoy.wasm.vm.* to envoy.wasm.runtime.*.

### DIFF
--- a/source/extensions/common/wasm/null/null_vm.h
+++ b/source/extensions/common/wasm/null/null_vm.h
@@ -25,7 +25,7 @@ struct NullVm : public WasmVm {
   NullVm(const NullVm& other) : plugin_name_(other.plugin_name_) {}
 
   // WasmVm
-  absl::string_view vm() override { return WasmVmNames::get().Null; }
+  absl::string_view runtime() override { return WasmRuntimeNames::get().Null; }
   bool cloneable() override { return true; };
   WasmVmPtr clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;

--- a/source/extensions/common/wasm/wasm_vm.cc
+++ b/source/extensions/common/wasm/wasm_vm.cc
@@ -15,7 +15,7 @@ thread_local uint32_t effective_context_id_ = 0;
 
 WasmVmPtr createWasmVm(absl::string_view runtime) {
   if (runtime.empty()) {
-    throw WasmException("Failed to create WASM VM with unspecified runtime.");
+    throw WasmVmException("Failed to create WASM VM with unspecified runtime.");
   } else if (runtime == WasmRuntimeNames::get().Null) {
     return Null::createVm();
   } else {

--- a/source/extensions/common/wasm/wasm_vm.cc
+++ b/source/extensions/common/wasm/wasm_vm.cc
@@ -13,15 +13,15 @@ namespace Wasm {
 thread_local Envoy::Extensions::Common::Wasm::Context* current_context_ = nullptr;
 thread_local uint32_t effective_context_id_ = 0;
 
-WasmVmPtr createWasmVm(absl::string_view wasm_vm) {
-  if (wasm_vm.empty()) {
+WasmVmPtr createWasmVm(absl::string_view runtime) {
+  if (runtime.empty()) {
     throw WasmException("Failed to create WASM VM with unspecified runtime.");
-  } else if (wasm_vm == WasmVmNames::get().Null) {
+  } else if (runtime == WasmRuntimeNames::get().Null) {
     return Null::createVm();
   } else {
-    throw WasmException(fmt::format(
+    throw WasmVmException(fmt::format(
         "Failed to create WASM VM using {} runtime. Envoy was compiled without support for it.",
-        wasm_vm));
+        runtime));
   }
 }
 

--- a/source/extensions/common/wasm/wasm_vm.h
+++ b/source/extensions/common/wasm/wasm_vm.h
@@ -109,10 +109,10 @@ public:
 
   virtual ~WasmVm() = default;
   /**
-   * Return the VM identifier.
-   * @return one of WasmVmValues from well_known_names.h e.g. "envoy.wasm.vm.null".
+   * Return the runtime identifier.
+   * @return one of WasmRuntimeValues from well_known_names.h (e.g. "envoy.wasm.runtime.null").
    */
-  virtual absl::string_view vm() PURE;
+  virtual absl::string_view runtime() PURE;
 
   /**
    * Whether or not the VM implementation supports cloning. Cloning is VM system dependent.
@@ -322,8 +322,8 @@ struct SaveRestoreContext {
   uint32_t saved_effective_context_id_;
 };
 
-// Create a new low-level WASM VM of the give type (e.g. "envoy.wasm.vm.wavm").
-WasmVmPtr createWasmVm(absl::string_view vm);
+// Create a new low-level WASM VM using runtime of the given type (e.g. "envoy.wasm.runtime.wavm").
+WasmVmPtr createWasmVm(absl::string_view runtime);
 
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/common/wasm/well_known_names.h
+++ b/source/extensions/common/wasm/well_known_names.h
@@ -10,17 +10,17 @@ namespace Common {
 namespace Wasm {
 
 /**
- * Well-known wasm VM names.
- * NOTE: New wasm VMs should use the well known name: envoy.wasm.vm.name.
+ * Well-known wasm runtime names.
+ * NOTE: New wasm runtimes should use the well known name: envoy.wasm.runtime.name.
  */
-class WasmVmValues {
+class WasmRuntimeValues {
 public:
   // Null sandbox: modules must be compiled into envoy and registered name is given in the
   // DataSource.inline_string.
-  const std::string Null = "envoy.wasm.vm.null";
+  const std::string Null = "envoy.wasm.runtime.null";
 };
 
-using WasmVmNames = ConstSingleton<WasmVmValues>;
+using WasmRuntimeNames = ConstSingleton<WasmRuntimeValues>;
 
 } // namespace Wasm
 } // namespace Common

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -39,10 +39,10 @@ std::unique_ptr<Null::NullVmPlugin> PluginFactory::create() const {
   return result;
 }
 
-TEST(WasmVmTest, BadVmType) { EXPECT_THROW(createWasmVm("bad.vm"), WasmException); }
+TEST(WasmVmTest, BadVmType) { EXPECT_THROW(createWasmVm("bad.vm"), WasmVmException); }
 
 TEST(WasmVmTest, NullVmStartup) {
-  auto wasm_vm = createWasmVm("envoy.wasm.vm.null");
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null");
   EXPECT_TRUE(wasm_vm != nullptr);
   EXPECT_TRUE(wasm_vm->cloneable());
   auto wasm_vm_clone = wasm_vm->clone();
@@ -51,7 +51,7 @@ TEST(WasmVmTest, NullVmStartup) {
 }
 
 TEST(WasmVmTest, NullVmMemory) {
-  auto wasm_vm = createWasmVm("envoy.wasm.vm.null");
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null");
   EXPECT_EQ(wasm_vm->getMemorySize(), std::numeric_limits<uint64_t>::max());
   std::string d = "data";
   auto m = wasm_vm->getMemory(reinterpret_cast<uint64_t>(d.data()), d.size()).value();
@@ -78,7 +78,7 @@ TEST(WasmVmTest, NullVmMemory) {
 }
 
 TEST(WasmVmTest, NullVmStart) {
-  auto wasm_vm = createWasmVm("envoy.wasm.vm.null");
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null");
   EXPECT_TRUE(wasm_vm->load("test_null_vm_plugin", true));
   wasm_vm->link("test", false);
   // Test that context argument to start is pushed and that the effective_context_id_ is reset.

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -39,7 +39,16 @@ std::unique_ptr<Null::NullVmPlugin> PluginFactory::create() const {
   return result;
 }
 
-TEST(WasmVmTest, BadVmType) { EXPECT_THROW(createWasmVm("bad.vm"), WasmVmException); }
+TEST(WasmVmTest, NoRuntime) {
+  EXPECT_THROW_WITH_MESSAGE(createWasmVm(""), WasmVmException,
+                            "Failed to create WASM VM with unspecified runtime.");
+}
+
+TEST(WasmVmTest, BadRuntime) {
+  EXPECT_THROW_WITH_MESSAGE(createWasmVm("envoy.wasm.runtime.invalid"), WasmVmException,
+                            "Failed to create WASM VM using envoy.wasm.runtime.invalid runtime. "
+                            "Envoy was compiled without support for it.");
+}
 
 TEST(WasmVmTest, NullVmStartup) {
   auto wasm_vm = createWasmVm("envoy.wasm.runtime.null");


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>