### PR TITLE
grpc async client: add hash_policy option

### DIFF
--- a/include/envoy/grpc/BUILD
+++ b/include/envoy/grpc/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     deps = [
         ":status",
         "//include/envoy/buffer:buffer_interface",
+        "//include/envoy/http:async_client_interface",
         "//include/envoy/http:header_map_interface",
         "//include/envoy/tracing:http_tracer_interface",
         "//source/common/common:assert_lib",

--- a/include/envoy/grpc/async_client.h
+++ b/include/envoy/grpc/async_client.h
@@ -5,6 +5,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/grpc/status.h"
+#include "envoy/http/async_client.h"
 #include "envoy/http/header_map.h"
 #include "envoy/tracing/http_tracer.h"
 
@@ -150,7 +151,7 @@ public:
    * @param request serialized message.
    * @param callbacks the callbacks to be notified of RPC status.
    * @param parent_span the current parent tracing context.
-   * @param timeout supplies the request timeout.
+   * @param options the data struct to control the request sending.
    * @return a request handle or nullptr if no request could be started. NOTE: In this case
    *         onFailure() has already been called inline. The client owns the request and the
    *         handle should just be used to cancel.
@@ -158,7 +159,7 @@ public:
   virtual AsyncRequest* sendRaw(absl::string_view service_full_name, absl::string_view method_name,
                                 Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
                                 Tracing::Span& parent_span,
-                                const absl::optional<std::chrono::milliseconds>& timeout) PURE;
+                                const Http::AsyncClient::RequestOptions& options) PURE;
 
   /**
    * Start a gRPC stream asynchronously.
@@ -166,6 +167,7 @@ public:
    * @param service_full_name full name of the service (i.e. service_method.service()->full_name()).
    * @param method_name name of the method (i.e. service_method.name()).
    * @param callbacks the callbacks to be notified of stream status.
+   * @param options the data struct to control the stream.
    * @return a stream handle or nullptr if no stream could be started. NOTE: In this case
    *         onRemoteClose() has already been called inline. The client owns the stream and
    *         the handle can be used to send more messages or finish the stream. It is expected that
@@ -174,7 +176,8 @@ public:
    */
   virtual RawAsyncStream* startRaw(absl::string_view service_full_name,
                                    absl::string_view method_name,
-                                   RawAsyncStreamCallbacks& callbacks) PURE;
+                                   RawAsyncStreamCallbacks& callbacks,
+                                   const Http::AsyncClient::StreamOptions& options) PURE;
 };
 
 using RawAsyncClientPtr = std::unique_ptr<RawAsyncClient>;

--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -49,7 +49,7 @@ public:
       ENVOY_LOG(warn, "gRPC bidi stream for {} already exists!", service_method_.DebugString());
       return;
     }
-    stream_ = async_client_->start(service_method_, *this);
+    stream_ = async_client_->start(service_method_, *this, Http::AsyncClient::StreamOptions());
     if (stream_ == nullptr) {
       ENVOY_LOG(warn, "Unable to establish new stream");
       callbacks_->onEstablishmentFailure();

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -23,9 +23,10 @@ public:
   AsyncRequest* sendRaw(absl::string_view service_full_name, absl::string_view method_name,
                         Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
                         Tracing::Span& parent_span,
-                        const absl::optional<std::chrono::milliseconds>& timeout) override;
+                        const Http::AsyncClient::RequestOptions& options) override;
   RawAsyncStream* startRaw(absl::string_view service_full_name, absl::string_view method_name,
-                           RawAsyncStreamCallbacks& callbacks) override;
+                           RawAsyncStreamCallbacks& callbacks,
+                           const Http::AsyncClient::StreamOptions& options) override;
 
 private:
   Upstream::ClusterManager& cm_;
@@ -45,7 +46,7 @@ class AsyncStreamImpl : public RawAsyncStream,
 public:
   AsyncStreamImpl(AsyncClientImpl& parent, absl::string_view service_full_name,
                   absl::string_view method_name, RawAsyncStreamCallbacks& callbacks,
-                  const absl::optional<std::chrono::milliseconds>& timeout);
+                  const Http::AsyncClient::StreamOptions& options);
 
   virtual void initialize(bool buffer_body_for_retry);
 
@@ -79,7 +80,7 @@ private:
   std::string service_full_name_;
   std::string method_name_;
   RawAsyncStreamCallbacks& callbacks_;
-  const absl::optional<std::chrono::milliseconds>& timeout_;
+  Http::AsyncClient::StreamOptions options_;
   bool http_reset_{};
   Http::AsyncClient::Stream* stream_{};
   Decoder decoder_;
@@ -94,7 +95,7 @@ public:
   AsyncRequestImpl(AsyncClientImpl& parent, absl::string_view service_full_name,
                    absl::string_view method_name, Buffer::InstancePtr&& request,
                    RawAsyncRequestCallbacks& callbacks, Tracing::Span& parent_span,
-                   const absl::optional<std::chrono::milliseconds>& timeout);
+                   const Http::AsyncClient::RequestOptions& options);
 
   void initialize(bool buffer_body_for_retry) override;
 

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -95,13 +95,14 @@ GoogleAsyncClientImpl::~GoogleAsyncClientImpl() {
   }
 }
 
-AsyncRequest*
-GoogleAsyncClientImpl::sendRaw(absl::string_view service_full_name, absl::string_view method_name,
-                               Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
-                               Tracing::Span& parent_span,
-                               const absl::optional<std::chrono::milliseconds>& timeout) {
+AsyncRequest* GoogleAsyncClientImpl::sendRaw(absl::string_view service_full_name,
+                                             absl::string_view method_name,
+                                             Buffer::InstancePtr&& request,
+                                             RawAsyncRequestCallbacks& callbacks,
+                                             Tracing::Span& parent_span,
+                                             const Http::AsyncClient::RequestOptions& options) {
   auto* const async_request = new GoogleAsyncRequestImpl(
-      *this, service_full_name, method_name, std::move(request), callbacks, parent_span, timeout);
+      *this, service_full_name, method_name, std::move(request), callbacks, parent_span, options);
   std::unique_ptr<GoogleAsyncStreamImpl> grpc_stream{async_request};
 
   grpc_stream->initialize(true);
@@ -115,10 +116,10 @@ GoogleAsyncClientImpl::sendRaw(absl::string_view service_full_name, absl::string
 
 RawAsyncStream* GoogleAsyncClientImpl::startRaw(absl::string_view service_full_name,
                                                 absl::string_view method_name,
-                                                RawAsyncStreamCallbacks& callbacks) {
-  const absl::optional<std::chrono::milliseconds> no_timeout;
+                                                RawAsyncStreamCallbacks& callbacks,
+                                                const Http::AsyncClient::StreamOptions& options) {
   auto grpc_stream = std::make_unique<GoogleAsyncStreamImpl>(*this, service_full_name, method_name,
-                                                             callbacks, no_timeout);
+                                                             callbacks, options);
 
   grpc_stream->initialize(false);
   if (grpc_stream->call_failed()) {
@@ -129,13 +130,14 @@ RawAsyncStream* GoogleAsyncClientImpl::startRaw(absl::string_view service_full_n
   return active_streams_.front().get();
 }
 
-GoogleAsyncStreamImpl::GoogleAsyncStreamImpl(
-    GoogleAsyncClientImpl& parent, absl::string_view service_full_name,
-    absl::string_view method_name, RawAsyncStreamCallbacks& callbacks,
-    const absl::optional<std::chrono::milliseconds>& timeout)
+GoogleAsyncStreamImpl::GoogleAsyncStreamImpl(GoogleAsyncClientImpl& parent,
+                                             absl::string_view service_full_name,
+                                             absl::string_view method_name,
+                                             RawAsyncStreamCallbacks& callbacks,
+                                             const Http::AsyncClient::StreamOptions& options)
     : parent_(parent), tls_(parent_.tls_), dispatcher_(parent_.dispatcher_), stub_(parent_.stub_),
       service_full_name_(service_full_name), method_name_(method_name), callbacks_(callbacks),
-      timeout_(timeout) {}
+      options_(options) {}
 
 GoogleAsyncStreamImpl::~GoogleAsyncStreamImpl() {
   ENVOY_LOG(debug, "GoogleAsyncStreamImpl destruct");
@@ -149,9 +151,10 @@ GoogleAsyncStreamImpl::PendingMessage::PendingMessage(Buffer::InstancePtr reques
 void GoogleAsyncStreamImpl::initialize(bool /*buffer_body_for_retry*/) {
   parent_.stats_.streams_total_->inc();
   gpr_timespec abs_deadline =
-      timeout_ ? gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                              gpr_time_from_millis(timeout_.value().count(), GPR_TIMESPAN))
-               : gpr_inf_future(GPR_CLOCK_REALTIME);
+      options_.timeout
+          ? gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                         gpr_time_from_millis(options_.timeout.value().count(), GPR_TIMESPAN))
+          : gpr_inf_future(GPR_CLOCK_REALTIME);
   ctxt_.set_deadline(abs_deadline);
   // Fill service-wide initial metadata.
   for (const auto& header_value : parent_.initial_metadata_) {
@@ -387,8 +390,8 @@ void GoogleAsyncStreamImpl::cleanup() {
 GoogleAsyncRequestImpl::GoogleAsyncRequestImpl(
     GoogleAsyncClientImpl& parent, absl::string_view service_full_name,
     absl::string_view method_name, Buffer::InstancePtr request, RawAsyncRequestCallbacks& callbacks,
-    Tracing::Span& parent_span, const absl::optional<std::chrono::milliseconds>& timeout)
-    : GoogleAsyncStreamImpl(parent, service_full_name, method_name, *this, timeout),
+    Tracing::Span& parent_span, const Http::AsyncClient::RequestOptions& options)
+    : GoogleAsyncStreamImpl(parent, service_full_name, method_name, *this, options),
       request_(std::move(request)), callbacks_(callbacks) {
   current_span_ = parent_span.spawnChild(Tracing::EgressConfig::get(),
                                          "async " + parent.stat_prefix_ + " egress",

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -173,9 +173,10 @@ public:
   AsyncRequest* sendRaw(absl::string_view service_full_name, absl::string_view method_name,
                         Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
                         Tracing::Span& parent_span,
-                        const absl::optional<std::chrono::milliseconds>& timeout) override;
+                        const Http::AsyncClient::RequestOptions& options) override;
   RawAsyncStream* startRaw(absl::string_view service_full_name, absl::string_view method_name,
-                           RawAsyncStreamCallbacks& callbacks) override;
+                           RawAsyncStreamCallbacks& callbacks,
+                           const Http::AsyncClient::StreamOptions& options) override;
 
   TimeSource& timeSource() { return dispatcher_.timeSource(); }
 
@@ -207,7 +208,7 @@ class GoogleAsyncStreamImpl : public RawAsyncStream,
 public:
   GoogleAsyncStreamImpl(GoogleAsyncClientImpl& parent, absl::string_view service_full_name,
                         absl::string_view method_name, RawAsyncStreamCallbacks& callbacks,
-                        const absl::optional<std::chrono::milliseconds>& timeout);
+                        const Http::AsyncClient::StreamOptions& options);
   ~GoogleAsyncStreamImpl() override;
 
   virtual void initialize(bool buffer_body_for_retry);
@@ -272,7 +273,7 @@ private:
   std::string service_full_name_;
   std::string method_name_;
   RawAsyncStreamCallbacks& callbacks_;
-  const absl::optional<std::chrono::milliseconds>& timeout_;
+  const Http::AsyncClient::StreamOptions& options_;
   grpc::ClientContext ctxt_;
   std::unique_ptr<grpc::GenericClientAsyncReaderWriter> rw_;
   std::queue<PendingMessage> write_pending_queue_;
@@ -309,7 +310,7 @@ public:
   GoogleAsyncRequestImpl(GoogleAsyncClientImpl& parent, absl::string_view service_full_name,
                          absl::string_view method_name, Buffer::InstancePtr request,
                          RawAsyncRequestCallbacks& callbacks, Tracing::Span& parent_span,
-                         const absl::optional<std::chrono::milliseconds>& timeout);
+                         const Http::AsyncClient::RequestOptions& options);
 
   void initialize(bool buffer_body_for_retry) override;
 

--- a/source/common/grpc/typed_async_client.cc
+++ b/source/common/grpc/typed_async_client.cc
@@ -27,16 +27,18 @@ ProtobufTypes::MessagePtr parseMessageUntyped(ProtobufTypes::MessagePtr&& messag
 
 RawAsyncStream* startUntyped(RawAsyncClient* client,
                              const Protobuf::MethodDescriptor& service_method,
-                             RawAsyncStreamCallbacks& callbacks) {
-  return client->startRaw(service_method.service()->full_name(), service_method.name(), callbacks);
+                             RawAsyncStreamCallbacks& callbacks,
+                             const Http::AsyncClient::StreamOptions& options) {
+  return client->startRaw(service_method.service()->full_name(), service_method.name(), callbacks,
+                          options);
 }
 
 AsyncRequest* sendUntyped(RawAsyncClient* client, const Protobuf::MethodDescriptor& service_method,
                           const Protobuf::Message& request, RawAsyncRequestCallbacks& callbacks,
                           Tracing::Span& parent_span,
-                          const absl::optional<std::chrono::milliseconds>& timeout) {
+                          const Http::AsyncClient::RequestOptions& options) {
   return client->sendRaw(service_method.service()->full_name(), service_method.name(),
-                         Common::serializeMessage(request), callbacks, parent_span, timeout);
+                         Common::serializeMessage(request), callbacks, parent_span, options);
 }
 
 } // namespace Internal

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -16,11 +16,12 @@ ProtobufTypes::MessagePtr parseMessageUntyped(ProtobufTypes::MessagePtr&& messag
                                               Buffer::InstancePtr&& response);
 RawAsyncStream* startUntyped(RawAsyncClient* client,
                              const Protobuf::MethodDescriptor& service_method,
-                             RawAsyncStreamCallbacks& callbacks);
+                             RawAsyncStreamCallbacks& callbacks,
+                             const Http::AsyncClient::StreamOptions& options);
 AsyncRequest* sendUntyped(RawAsyncClient* client, const Protobuf::MethodDescriptor& service_method,
                           const Protobuf::Message& request, RawAsyncRequestCallbacks& callbacks,
                           Tracing::Span& parent_span,
-                          const absl::optional<std::chrono::milliseconds>& timeout);
+                          const Http::AsyncClient::RequestOptions& options);
 
 } // namespace Internal
 
@@ -100,13 +101,15 @@ public:
   virtual AsyncRequest* send(const Protobuf::MethodDescriptor& service_method,
                              const Protobuf::Message& request,
                              AsyncRequestCallbacks<Response>& callbacks, Tracing::Span& parent_span,
-                             const absl::optional<std::chrono::milliseconds>& timeout) {
+                             const Http::AsyncClient::RequestOptions& options) {
     return Internal::sendUntyped(client_.get(), service_method, request, callbacks, parent_span,
-                                 timeout);
+                                 options);
   }
   virtual AsyncStream<Request> start(const Protobuf::MethodDescriptor& service_method,
-                                     AsyncStreamCallbacks<Response>& callbacks) {
-    return AsyncStream<Request>(Internal::startUntyped(client_.get(), service_method, callbacks));
+                                     AsyncStreamCallbacks<Response>& callbacks,
+                                     const Http::AsyncClient::StreamOptions& options) {
+    return AsyncStream<Request>(
+        Internal::startUntyped(client_.get(), service_method, callbacks, options));
   }
 
   AsyncClient* operator->() { return this; }

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -64,7 +64,7 @@ void HdsDelegate::setHdsStreamResponseTimer() {
 
 void HdsDelegate::establishNewStream() {
   ENVOY_LOG(debug, "Establishing new gRPC bidi stream for {}", service_method_.DebugString());
-  stream_ = async_client_->start(service_method_, *this);
+  stream_ = async_client_->start(service_method_, *this, Http::AsyncClient::StreamOptions());
   if (stream_ == nullptr) {
     ENVOY_LOG(warn, "Unable to establish new stream");
     handleFailure();

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -29,7 +29,7 @@ void LoadStatsReporter::setRetryTimer() {
 
 void LoadStatsReporter::establishNewStream() {
   ENVOY_LOG(debug, "Establishing new gRPC bidi stream for {}", service_method_.DebugString());
-  stream_ = async_client_->start(service_method_, *this);
+  stream_ = async_client_->start(service_method_, *this, Http::AsyncClient::StreamOptions());
   if (stream_ == nullptr) {
     ENVOY_LOG(warn, "Unable to establish new stream");
     handleFailure();

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
@@ -66,7 +66,7 @@ void GrpcAccessLoggerImpl::flush() {
     stream_->stream_ =
         client_->start(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
                            "envoy.service.accesslog.v2.AccessLogService.StreamAccessLogs"),
-                       *stream_);
+                       *stream_, Http::AsyncClient::StreamOptions());
 
     auto* identifier = message_.mutable_identifier();
     *identifier->mutable_node() = local_info_.node();

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -38,7 +38,8 @@ void GrpcClientImpl::check(RequestCallbacks& callbacks,
   ASSERT(callbacks_ == nullptr);
   callbacks_ = &callbacks;
 
-  request_ = async_client_->send(service_method_, request, *this, parent_span, timeout_);
+  request_ = async_client_->send(service_method_, request, *this, parent_span,
+                                 Http::AsyncClient::RequestOptions().setTimeout(timeout_));
 }
 
 void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v2::CheckResponse>&& response,

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -56,7 +56,8 @@ void GrpcClientImpl::limit(RequestCallbacks& callbacks, const std::string& domai
   envoy::service::ratelimit::v2::RateLimitRequest request;
   createRequest(request, domain, descriptors);
 
-  request_ = async_client_->send(service_method_, request, *this, parent_span, timeout_);
+  request_ = async_client_->send(service_method_, request, *this, parent_span,
+                                 Http::AsyncClient::RequestOptions().setTimeout(timeout_));
 }
 
 void GrpcClientImpl::onSuccess(

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -23,7 +23,7 @@ void GrpcMetricsStreamerImpl::send(envoy::service::metrics::v2::StreamMetricsMes
   if (stream_ == nullptr) {
     stream_ = client_->start(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
                                  "envoy.service.metrics.v2.MetricsService.StreamMetrics"),
-                             *this);
+                             *this, Http::AsyncClient::StreamOptions());
     auto* identifier = message.mutable_identifier();
     *identifier->mutable_node() = local_info_.node();
   }

--- a/test/common/config/delta_subscription_impl_test.cc
+++ b/test/common/config/delta_subscription_impl_test.cc
@@ -143,7 +143,7 @@ TEST(DeltaSubscriptionImplFixturelessTest, NoGrpcStream) {
       xds_context, Config::TypeUrl::get().ClusterLoadAssignment, callbacks, stats,
       std::chrono::milliseconds(12345), false);
 
-  EXPECT_CALL(*async_client, startRaw(_, _, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*async_client, startRaw(_, _, _, _)).WillOnce(Return(nullptr));
 
   subscription->start({"name1"});
   subscription->updateResourceInterest({"name1", "name2"});

--- a/test/common/config/delta_subscription_test_harness.h
+++ b/test/common/config/delta_subscription_test_harness.h
@@ -40,7 +40,7 @@ public:
     subscription_ = std::make_unique<DeltaSubscriptionImpl>(
         xds_context_, Config::TypeUrl::get().ClusterLoadAssignment, callbacks_, stats_,
         init_fetch_timeout, false);
-    EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   }
 
   void doSubscriptionTearDown() override {

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -112,7 +112,7 @@ TEST_F(GrpcMuxImplTest, MultipleTypeUrlStreams) {
   InSequence s;
   auto foo_sub = grpc_mux_->subscribe("foo", {"x", "y"}, callbacks_);
   auto bar_sub = grpc_mux_->subscribe("bar", {}, callbacks_);
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage("foo", {"x", "y"}, "", true);
   expectSendMessage("bar", {}, "");
   grpc_mux_->start();
@@ -143,7 +143,7 @@ TEST_F(GrpcMuxImplTest, ResetStream) {
   auto foo_sub = grpc_mux_->subscribe("foo", {"x", "y"}, callbacks_);
   auto bar_sub = grpc_mux_->subscribe("bar", {}, callbacks_);
   auto baz_sub = grpc_mux_->subscribe("baz", {"z"}, callbacks_);
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage("foo", {"x", "y"}, "", true);
   expectSendMessage("bar", {}, "");
   expectSendMessage("baz", {"z"}, "");
@@ -157,7 +157,7 @@ TEST_F(GrpcMuxImplTest, ResetStream) {
   EXPECT_CALL(*timer, enableTimer(_, _));
   grpc_mux_->grpcStreamForTest().onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
   EXPECT_EQ(0, control_plane_connected_state_.value());
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage("foo", {"x", "y"}, "", true);
   expectSendMessage("bar", {}, "");
   expectSendMessage("baz", {"z"}, "");
@@ -173,7 +173,7 @@ TEST_F(GrpcMuxImplTest, PauseResume) {
   InSequence s;
   auto foo_sub = grpc_mux_->subscribe("foo", {"x", "y"}, callbacks_);
   grpc_mux_->pause("foo");
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   grpc_mux_->start();
   expectSendMessage("foo", {"x", "y"}, "", true);
   grpc_mux_->resume("foo");
@@ -197,7 +197,7 @@ TEST_F(GrpcMuxImplTest, TypeUrlMismatch) {
   InSequence s;
   auto foo_sub = grpc_mux_->subscribe("foo", {"x", "y"}, callbacks_);
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage("foo", {"x", "y"}, "", true);
   grpc_mux_->start();
 
@@ -234,7 +234,7 @@ TEST_F(GrpcMuxImplTest, WildcardWatch) {
   InSequence s;
   const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
   auto foo_sub = grpc_mux_->subscribe(type_url, {}, callbacks_);
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage(type_url, {}, "", true);
   grpc_mux_->start();
 
@@ -269,7 +269,7 @@ TEST_F(GrpcMuxImplTest, WatchDemux) {
   auto foo_sub = grpc_mux_->subscribe(type_url, {"x", "y"}, foo_callbacks);
   NiceMock<MockGrpcMuxCallbacks> bar_callbacks;
   auto bar_sub = grpc_mux_->subscribe(type_url, {"y", "z"}, bar_callbacks);
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   // Should dedupe the "x" resource.
   expectSendMessage(type_url, {"y", "z", "x"}, "", true);
   grpc_mux_->start();
@@ -348,7 +348,7 @@ TEST_F(GrpcMuxImplTest, MultipleWatcherWithEmptyUpdates) {
   NiceMock<MockGrpcMuxCallbacks> foo_callbacks;
   auto foo_sub = grpc_mux_->subscribe(type_url, {"x", "y"}, foo_callbacks);
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage(type_url, {"x", "y"}, "", true);
   grpc_mux_->start();
 
@@ -371,7 +371,7 @@ TEST_F(GrpcMuxImplTest, SingleWatcherWithEmptyUpdates) {
   NiceMock<MockGrpcMuxCallbacks> foo_callbacks;
   auto foo_sub = grpc_mux_->subscribe(type_url, {}, foo_callbacks);
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage(type_url, {}, "", true);
   grpc_mux_->start();
 
@@ -412,7 +412,7 @@ TEST_F(GrpcMuxImplTestWithMockTimeSystem, TooManyRequestsWithDefaultSettings) {
   setup();
 
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, false)).Times(AtLeast(99));
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
 
   const auto onReceiveMessage = [&](uint64_t burst) {
     for (uint64_t i = 0; i < burst; i++) {
@@ -465,7 +465,7 @@ TEST_F(GrpcMuxImplTestWithMockTimeSystem, TooManyRequestsWithEmptyRateLimitSetti
   setup(custom_rate_limit_settings);
 
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, false)).Times(AtLeast(99));
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
 
   const auto onReceiveMessage = [&](uint64_t burst) {
     for (uint64_t i = 0; i < burst; i++) {
@@ -521,7 +521,7 @@ TEST_F(GrpcMuxImplTest, TooManyRequestsWithCustomRateLimitSettings) {
   setup(custom_rate_limit_settings);
 
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, false)).Times(AtLeast(260));
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
 
   const auto onReceiveMessage = [&](uint64_t burst) {
     for (uint64_t i = 0; i < burst; i++) {
@@ -563,7 +563,7 @@ TEST_F(GrpcMuxImplTest, TooManyRequestsWithCustomRateLimitSettings) {
 TEST_F(GrpcMuxImplTest, UnwatchedTypeAcceptsEmptyResources) {
   setup();
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
 
   const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
 
@@ -600,7 +600,7 @@ TEST_F(GrpcMuxImplTest, UnwatchedTypeAcceptsEmptyResources) {
 TEST_F(GrpcMuxImplTest, UnwatchedTypeRejectsResources) {
   setup();
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
 
   const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
 

--- a/test/common/config/grpc_stream_test.cc
+++ b/test/common/config/grpc_stream_test.cc
@@ -47,14 +47,14 @@ TEST_F(GrpcStreamTest, EstablishStream) {
   EXPECT_FALSE(grpc_stream_.grpcStreamAvailable());
   // Successful establishment
   {
-    EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
     EXPECT_CALL(callbacks_, onStreamEstablished());
     grpc_stream_.establishNewStream();
     EXPECT_TRUE(grpc_stream_.grpcStreamAvailable());
   }
   // Idempotent
   {
-    EXPECT_CALL(*async_client_, startRaw(_, _, _)).Times(0);
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).Times(0);
     EXPECT_CALL(callbacks_, onStreamEstablished()).Times(0);
     grpc_stream_.establishNewStream();
     EXPECT_TRUE(grpc_stream_.grpcStreamAvailable());
@@ -63,7 +63,7 @@ TEST_F(GrpcStreamTest, EstablishStream) {
   EXPECT_FALSE(grpc_stream_.grpcStreamAvailable());
   // Successful re-establishment
   {
-    EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
     EXPECT_CALL(callbacks_, onStreamEstablished());
     grpc_stream_.establishNewStream();
     EXPECT_TRUE(grpc_stream_.grpcStreamAvailable());
@@ -73,7 +73,7 @@ TEST_F(GrpcStreamTest, EstablishStream) {
 // A failure in the underlying gRPC machinery should result in grpcStreamAvailable() false. Calling
 // sendMessage would segfault.
 TEST_F(GrpcStreamTest, FailToEstablishNewStream) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(nullptr));
   EXPECT_CALL(callbacks_, onEstablishmentFailure());
   grpc_stream_.establishNewStream();
   EXPECT_FALSE(grpc_stream_.grpcStreamAvailable());
@@ -82,7 +82,7 @@ TEST_F(GrpcStreamTest, FailToEstablishNewStream) {
 // Checks that sendMessage correctly passes a DiscoveryRequest down to the underlying gRPC
 // machinery.
 TEST_F(GrpcStreamTest, SendMessage) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   grpc_stream_.establishNewStream();
   envoy::api::v2::DiscoveryRequest request;
   request.set_response_nonce("grpc_stream_test_noncense");

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -13,7 +13,7 @@ class GrpcSubscriptionImplTest : public testing::Test, public GrpcSubscriptionTe
 // Validate that stream creation results in a timer based retry and can recover.
 TEST_F(GrpcSubscriptionImplTest, StreamCreationFailure) {
   InSequence s;
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(nullptr));
 
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_,
@@ -28,7 +28,7 @@ TEST_F(GrpcSubscriptionImplTest, StreamCreationFailure) {
   subscription_->updateResourceInterest({"cluster2"});
 
   // Retry and succeed.
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
 
   expectSendMessage({"cluster2"}, "", true);
   timer_cb_();
@@ -52,7 +52,7 @@ TEST_F(GrpcSubscriptionImplTest, RemoteStreamClose) {
   verifyControlPlaneStats(0);
 
   // Retry and succeed.
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({"cluster0", "cluster1"}, "", true);
   timer_cb_();
   EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0));

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -80,7 +80,7 @@ public:
   }
 
   void startSubscription(const std::set<std::string>& cluster_names) override {
-    EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
     last_cluster_names_ = cluster_names;
     expectSendMessage(last_cluster_names_, "", true);
     subscription_->start(cluster_names);

--- a/test/common/config/new_grpc_mux_impl_test.cc
+++ b/test/common/config/new_grpc_mux_impl_test.cc
@@ -75,7 +75,7 @@ TEST_F(NewGrpcMuxImplTest, DiscoveryResponseNonexistentSub) {
   const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
   grpc_mux_->addOrUpdateWatch(type_url, nullptr, {}, callbacks_, std::chrono::milliseconds(0));
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   grpc_mux_->start();
 
   {

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -42,7 +42,8 @@ TEST_F(EnvoyAsyncClientImplTest, StreamHttpStartFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
   ON_CALL(http_client_, start(_, _)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::GrpcStatus::Unavailable, ""));
-  auto grpc_stream = grpc_client_->start(*method_descriptor_, grpc_callbacks);
+  auto grpc_stream =
+      grpc_client_->start(*method_descriptor_, grpc_callbacks, Http::AsyncClient::StreamOptions());
   EXPECT_TRUE(grpc_stream == nullptr);
 }
 
@@ -67,7 +68,7 @@ TEST_F(EnvoyAsyncClientImplTest, RequestHttpStartFail) {
   EXPECT_CALL(*child_span, injectContext(_)).Times(0);
 
   auto* grpc_request = grpc_client_->send(*method_descriptor_, request_msg, grpc_callbacks,
-                                          active_span, absl::optional<std::chrono::milliseconds>());
+                                          active_span, Http::AsyncClient::RequestOptions());
   EXPECT_EQ(grpc_request, nullptr);
 }
 
@@ -93,7 +94,8 @@ TEST_F(EnvoyAsyncClientImplTest, StreamHttpSendHeadersFail) {
       }));
   EXPECT_CALL(grpc_callbacks, onReceiveTrailingMetadata_(_));
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::GrpcStatus::Internal, ""));
-  auto grpc_stream = grpc_client_->start(*method_descriptor_, grpc_callbacks);
+  auto grpc_stream =
+      grpc_client_->start(*method_descriptor_, grpc_callbacks, Http::AsyncClient::StreamOptions());
   EXPECT_TRUE(grpc_stream == nullptr);
 }
 
@@ -133,7 +135,7 @@ TEST_F(EnvoyAsyncClientImplTest, RequestHttpSendHeadersFail) {
   EXPECT_CALL(*child_span, finishSpan());
 
   auto* grpc_request = grpc_client_->send(*method_descriptor_, request_msg, grpc_callbacks,
-                                          active_span, absl::optional<std::chrono::milliseconds>());
+                                          active_span, Http::AsyncClient::RequestOptions());
   EXPECT_EQ(grpc_request, nullptr);
 }
 
@@ -144,7 +146,8 @@ TEST_F(EnvoyAsyncClientImplTest, StreamHttpClientException) {
   ON_CALL(cm_, get(_)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks,
               onRemoteClose(Status::GrpcStatus::Unavailable, "Cluster not available"));
-  auto grpc_stream = grpc_client_->start(*method_descriptor_, grpc_callbacks);
+  auto grpc_stream =
+      grpc_client_->start(*method_descriptor_, grpc_callbacks, Http::AsyncClient::StreamOptions());
   EXPECT_TRUE(grpc_stream == nullptr);
 }
 

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -79,7 +79,8 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, StreamHttpStartFail) {
   EXPECT_CALL(grpc_callbacks, onCreateInitialMetadata(_));
   EXPECT_CALL(grpc_callbacks, onReceiveTrailingMetadata_(_));
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::GrpcStatus::Unavailable, ""));
-  auto grpc_stream = grpc_client_->start(*method_descriptor_, grpc_callbacks);
+  auto grpc_stream =
+      grpc_client_->start(*method_descriptor_, grpc_callbacks, Http::AsyncClient::StreamOptions());
   EXPECT_TRUE(grpc_stream == nullptr);
 }
 
@@ -105,7 +106,7 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, RequestHttpStartFail) {
   EXPECT_CALL(*child_span, injectContext(_));
 
   auto* grpc_request = grpc_client_->send(*method_descriptor_, request_msg, grpc_callbacks,
-                                          active_span, absl::optional<std::chrono::milliseconds>());
+                                          active_span, Http::AsyncClient::RequestOptions());
   EXPECT_TRUE(grpc_request == nullptr);
 }
 

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -355,9 +355,8 @@ public:
                 setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
     EXPECT_CALL(*request->child_span_, injectContext(_));
 
-    request->grpc_request_ =
-        grpc_client_->send(*method_descriptor_, request_msg, *request, active_span,
-                           absl::optional<std::chrono::milliseconds>());
+    request->grpc_request_ = grpc_client_->send(*method_descriptor_, request_msg, *request,
+                                                active_span, Http::AsyncClient::RequestOptions());
     EXPECT_NE(request->grpc_request_, nullptr);
 
     if (!fake_connection_) {
@@ -391,7 +390,8 @@ public:
           }
         }));
 
-    stream->grpc_stream_ = grpc_client_->start(*method_descriptor_, *stream);
+    stream->grpc_stream_ =
+        grpc_client_->start(*method_descriptor_, *stream, Http::AsyncClient::StreamOptions());
     EXPECT_NE(stream->grpc_stream_, nullptr);
 
     if (!fake_connection_) {

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -140,7 +140,7 @@ TEST_F(HdsTest, HealthCheckRequest) {
       envoy::service::discovery::v2::Capability::TCP);
 
   EXPECT_CALL(local_info_, node()).WillOnce(ReturnRef(node_));
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(Grpc::ProtoBufferEq(request), false));
   createHdsDelegate();
 }
@@ -148,7 +148,7 @@ TEST_F(HdsTest, HealthCheckRequest) {
 // Test if processMessage processes endpoints from a HealthCheckSpecifier
 // message correctly
 TEST_F(HdsTest, TestProcessMessageEndpoints) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
   createHdsDelegate();
 
@@ -186,7 +186,7 @@ TEST_F(HdsTest, TestProcessMessageEndpoints) {
 // Test if processMessage processes health checks from a HealthCheckSpecifier
 // message correctly
 TEST_F(HdsTest, TestProcessMessageHealthChecks) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
   createHdsDelegate();
 
@@ -223,7 +223,7 @@ TEST_F(HdsTest, TestProcessMessageHealthChecks) {
 
 // Tests OnReceiveMessage given a minimal HealthCheckSpecifier message
 TEST_F(HdsTest, TestMinimalOnReceiveMessage) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
   createHdsDelegate();
 
@@ -239,7 +239,7 @@ TEST_F(HdsTest, TestMinimalOnReceiveMessage) {
 // Tests that SendResponse responds to the server in a timely fashion
 // given a minimal HealthCheckSpecifier message
 TEST_F(HdsTest, TestMinimalSendResponse) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
   createHdsDelegate();
 
@@ -256,7 +256,7 @@ TEST_F(HdsTest, TestMinimalSendResponse) {
 }
 
 TEST_F(HdsTest, TestStreamConnectionFailure) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _))
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
       .WillOnce(Return(nullptr))
       .WillOnce(Return(nullptr))
       .WillOnce(Return(nullptr))
@@ -288,7 +288,7 @@ TEST_F(HdsTest, TestStreamConnectionFailure) {
 // a HealthCheckSpecifier message that contains a single endpoint
 // which times out
 TEST_F(HdsTest, TestSendResponseOneEndpointTimeout) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
   createHdsDelegate();
 

--- a/test/common/upstream/load_stats_reporter_test.cc
+++ b/test/common/upstream/load_stats_reporter_test.cc
@@ -83,16 +83,16 @@ public:
 
 // Validate that stream creation results in a timer based retry.
 TEST_F(LoadStatsReporterTest, StreamCreationFailure) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(nullptr));
   EXPECT_CALL(*retry_timer_, enableTimer(_, _));
   createLoadStatsReporter();
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({});
   retry_timer_cb_();
 }
 
 TEST_F(LoadStatsReporterTest, TestPubSub) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
   createLoadStatsReporter();
   deliverLoadStatsResponse({"foo"});
@@ -110,7 +110,7 @@ TEST_F(LoadStatsReporterTest, TestPubSub) {
 
 // Validate treatment of existing clusters across updates.
 TEST_F(LoadStatsReporterTest, ExistingClusters) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   // Initially, we have no clusters to report on.
   expectSendMessage({});
   createLoadStatsReporter();
@@ -218,13 +218,13 @@ TEST_F(LoadStatsReporterTest, ExistingClusters) {
 
 // Validate that the client can recover from a remote stream closure via retry.
 TEST_F(LoadStatsReporterTest, RemoteStreamClose) {
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({});
   createLoadStatsReporter();
   EXPECT_CALL(*response_timer_, disableTimer());
   EXPECT_CALL(*retry_timer_, enableTimer(_, _));
   load_stats_reporter_->onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
-  EXPECT_CALL(*async_client_, startRaw(_, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({});
   retry_timer_cb_();
 }

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -44,14 +44,13 @@ public:
   void expectCallSend(envoy::service::auth::v2::CheckRequest& request) {
     EXPECT_CALL(*async_client_,
                 sendRaw(_, _, Grpc::ProtoBufferEq(request), Ref(*(client_.get())), _, _))
-        .WillOnce(Invoke(
-            [this](
-                absl::string_view service_full_name, absl::string_view method_name,
-                Buffer::InstancePtr&&, Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
-                const absl::optional<std::chrono::milliseconds>& timeout) -> Grpc::AsyncRequest* {
+        .WillOnce(
+            Invoke([this](absl::string_view service_full_name, absl::string_view method_name,
+                          Buffer::InstancePtr&&, Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                          const Http::AsyncClient::RequestOptions& options) -> Grpc::AsyncRequest* {
               EXPECT_EQ(use_alpha_ ? V2Alpha : V2, service_full_name);
               EXPECT_EQ("Check", method_name);
-              EXPECT_EQ(timeout_->count(), timeout->count());
+              EXPECT_EQ(timeout_->count(), options.timeout->count());
               return &async_request_;
             }));
   }

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -66,7 +66,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
         .WillOnce(
             Invoke([this](absl::string_view service_full_name, absl::string_view method_name,
                           Buffer::InstancePtr&&, Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
-                          const absl::optional<std::chrono::milliseconds>&) -> Grpc::AsyncRequest* {
+                          const Http::AsyncClient::RequestOptions&) -> Grpc::AsyncRequest* {
               std::string service_name = "envoy.service.ratelimit.v2.RateLimitService";
               EXPECT_EQ(service_name, service_full_name);
               EXPECT_EQ("ShouldRateLimit", method_name);

--- a/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
@@ -34,9 +34,10 @@ public:
   }
 
   void expectStreamStart(MockMetricsStream& stream, MetricsServiceCallbacks** callbacks_to_set) {
-    EXPECT_CALL(*async_client_, startRaw(_, _, _))
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
         .WillOnce(Invoke([&stream, callbacks_to_set](absl::string_view, absl::string_view,
-                                                     Grpc::RawAsyncStreamCallbacks& callbacks) {
+                                                     Grpc::RawAsyncStreamCallbacks& callbacks,
+                                                     const Http::AsyncClient::StreamOptions&) {
           *callbacks_to_set = dynamic_cast<MetricsServiceCallbacks*>(&callbacks);
           return &stream;
         }));
@@ -69,9 +70,10 @@ TEST_F(GrpcMetricsStreamerImplTest, BasicFlow) {
 TEST_F(GrpcMetricsStreamerImplTest, StreamFailure) {
   InSequence s;
 
-  EXPECT_CALL(*async_client_, startRaw(_, _, _))
-      .WillOnce(Invoke(
-          [](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& callbacks) {
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
+      .WillOnce(
+          Invoke([](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& callbacks,
+                    const Http::AsyncClient::StreamOptions&) {
             callbacks.onRemoteClose(Grpc::Status::Internal, "bad");
             return nullptr;
           }));

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -76,10 +76,11 @@ public:
                  AsyncRequest*(absl::string_view service_full_name, absl::string_view method_name,
                                Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
                                Tracing::Span& parent_span,
-                               const absl::optional<std::chrono::milliseconds>& timeout));
-  MOCK_METHOD3_T(startRaw,
+                               const Http::AsyncClient::RequestOptions& options));
+  MOCK_METHOD4_T(startRaw,
                  RawAsyncStream*(absl::string_view service_full_name, absl::string_view method_name,
-                                 RawAsyncStreamCallbacks& callbacks));
+                                 RawAsyncStreamCallbacks& callbacks,
+                                 const Http::AsyncClient::StreamOptions& options));
 };
 
 class MockAsyncClientFactory : public AsyncClientFactory {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>
(Follow up to https://github.com/envoyproxy/envoy/pull/8206)

Description: Propagate HTTP request/stream options to gRPC async client
Risk Level: low
Testing: unit
Docs Changes: none (internal refactor)
Release Notes: none