### PR TITLE
ratelimit: Add rate limit upstream headers

### DIFF
--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -103,4 +103,7 @@ message RateLimitResponse {
 
   // A list of headers to add to the response
   repeated api.v2.core.HeaderValue headers = 3;
+
+  // A list of headers to add to the upstream server
+  repeated api.v2.core.HeaderValue upstream_headers = 4;
 }

--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -101,9 +101,9 @@ message RateLimitResponse {
   // descriptors failed and/or what the currently configured limits are for all of them.
   repeated DescriptorStatus statuses = 2;
 
-  // A list of headers to add to the response
+  // [#next-major-version: rename to response_headers]
   repeated api.v2.core.HeaderValue headers = 3;
 
-  // A list of headers to add to the upstream server
-  repeated api.v2.core.HeaderValue upstream_headers = 4;
+  // A list of headers to add to the request when forwarded
+  repeated api.v2.core.HeaderValue request_headers_to_add = 4;
 }

--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -101,7 +101,7 @@ message RateLimitResponse {
   // descriptors failed and/or what the currently configured limits are for all of them.
   repeated DescriptorStatus statuses = 2;
 
-  // [#next-major-version: rename to response_headers]
+  // [#next-major-version: rename to response_headers_to_add]
   repeated api.v2.core.HeaderValue headers = 3;
 
   // A list of headers to add to the request when forwarded

--- a/api/envoy/service/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/service/ratelimit/v3alpha/rls.proto
@@ -103,4 +103,7 @@ message RateLimitResponse {
 
   // A list of headers to add to the response
   repeated api.v3alpha.core.HeaderValue headers = 3;
+
+  // A list of headers to add to the upstream server
+  repeated api.v2.core.HeaderValue upstream_headers = 4;
 }

--- a/api/envoy/service/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/service/ratelimit/v3alpha/rls.proto
@@ -101,7 +101,7 @@ message RateLimitResponse {
   // descriptors failed and/or what the currently configured limits are for all of them.
   repeated DescriptorStatus statuses = 2;
 
-  // [#next-major-version: rename to response_headers]
+  // [#next-major-version: rename to response_headers_to_add]
   repeated api.v3alpha.core.HeaderValue headers = 3;
 
   // A list of headers to add to the request when forwarded

--- a/api/envoy/service/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/service/ratelimit/v3alpha/rls.proto
@@ -101,9 +101,9 @@ message RateLimitResponse {
   // descriptors failed and/or what the currently configured limits are for all of them.
   repeated DescriptorStatus statuses = 2;
 
-  // A list of headers to add to the response
+  // [#next-major-version: rename to response_headers]
   repeated api.v3alpha.core.HeaderValue headers = 3;
 
-  // A list of headers to add to the upstream server
-  repeated api.v3alpha.core.HeaderValue upstream_headers = 4;
+  // A list of headers to add to the request when forwarded
+  repeated api.v3alpha.core.HeaderValue request_headers_to_add = 4;
 }

--- a/api/envoy/service/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/service/ratelimit/v3alpha/rls.proto
@@ -105,5 +105,5 @@ message RateLimitResponse {
   repeated api.v3alpha.core.HeaderValue headers = 3;
 
   // A list of headers to add to the upstream server
-  repeated api.v2.core.HeaderValue upstream_headers = 4;
+  repeated api.v3alpha.core.HeaderValue upstream_headers = 4;
 }

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -39,10 +39,10 @@ public:
   virtual ~RequestCallbacks() = default;
 
   /**
-   * Called when a limit request is complete. The resulting status and
-   * response headers are supplied.
+   * Called when a limit request is complete. The resulting status,
+   * response headers and request headers to be forwarded to the upstream are supplied.
    */
-  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& headers,
+  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& response_headers,
                         Http::HeaderMapPtr&& request_headers_to_add) PURE;
 };
 

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -42,7 +42,7 @@ public:
    * Called when a limit request is complete. The resulting status,
    * response headers and request headers to be forwarded to the upstream are supplied.
    */
-  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& response_headers,
+  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& response_headers_to_add,
                         Http::HeaderMapPtr&& request_headers_to_add) PURE;
 };
 

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -42,7 +42,8 @@ public:
    * Called when a limit request is complete. The resulting status and
    * response headers are supplied.
    */
-  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) PURE;
+  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& headers,
+                        Http::HeaderMapPtr&& upstream_headers) PURE;
 };
 
 /**

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -43,7 +43,7 @@ public:
    * response headers are supplied.
    */
   virtual void complete(LimitStatus status, Http::HeaderMapPtr&& headers,
-                        Http::HeaderMapPtr&& upstream_headers) PURE;
+                        Http::HeaderMapPtr&& request_headers_to_add) PURE;
 };
 
 /**

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -42,7 +42,7 @@ public:
    * Called when a limit request is complete. The resulting status and
    * response headers are supplied.
    */
-  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& headers) PURE;
+  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) PURE;
 };
 
 /**

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -72,10 +72,10 @@ void GrpcClientImpl::onSuccess(
     span.setTag(Constants::get().TraceStatus, Constants::get().TraceOk);
   }
 
-  Http::HeaderMapPtr response_headers = std::make_unique<Http::HeaderMapImpl>();
+  Http::HeaderMapPtr response_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
   if (!response->headers().empty()) {
     for (const auto& h : response->headers()) {
-      response_headers->addCopy(Http::LowerCaseString(h.key()), h.value());
+      response_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
 
@@ -85,7 +85,8 @@ void GrpcClientImpl::onSuccess(
       request_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
-  callbacks_->complete(status, std::move(response_headers), std::move(request_headers_to_add));
+  callbacks_->complete(status, std::move(response_headers_to_add),
+                       std::move(request_headers_to_add));
   callbacks_ = nullptr;
 }
 

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -79,13 +79,13 @@ void GrpcClientImpl::onSuccess(
     }
   }
 
-  Http::HeaderMapPtr upstream_headers = std::make_unique<Http::HeaderMapImpl>();
-  if (response->upstream_headers_size()) {
-    for (const auto& h : response->upstream_headers()) {
-      upstream_headers->addCopy(Http::LowerCaseString(h.key()), h.value());
+  Http::HeaderMapPtr request_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
+  if (response->request_headers_to_add_size()) {
+    for (const auto& h : response->request_headers_to_add()) {
+      request_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
-  callbacks_->complete(status, std::move(headers), std::move(upstream_headers));
+  callbacks_->complete(status, std::move(headers), std::move(request_headers_to_add));
   callbacks_ = nullptr;
 }
 

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -72,20 +72,20 @@ void GrpcClientImpl::onSuccess(
     span.setTag(Constants::get().TraceStatus, Constants::get().TraceOk);
   }
 
-  Http::HeaderMapPtr headers = std::make_unique<Http::HeaderMapImpl>();
-  if (response->headers_size()) {
+  Http::HeaderMapPtr response_headers = std::make_unique<Http::HeaderMapImpl>();
+  if (!response->headers().empty()) {
     for (const auto& h : response->headers()) {
-      headers->addCopy(Http::LowerCaseString(h.key()), h.value());
+      response_headers->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
 
   Http::HeaderMapPtr request_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
-  if (response->request_headers_to_add_size()) {
+  if (!response->request_headers_to_add().empty()) {
     for (const auto& h : response->request_headers_to_add()) {
       request_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
-  callbacks_->complete(status, std::move(headers), std::move(request_headers_to_add));
+  callbacks_->complete(status, std::move(response_headers), std::move(request_headers_to_add));
   callbacks_ = nullptr;
 }
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -127,10 +127,10 @@ void Filter::onDestroy() {
 }
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
-                      Http::HeaderMapPtr&& response_headers,
+                      Http::HeaderMapPtr&& response_headers_to_add,
                       Http::HeaderMapPtr&& request_headers_to_add) {
   state_ = State::Complete;
-  response_headers_to_add_ = std::move(response_headers);
+  response_headers_to_add_ = std::move(response_headers_to_add);
   Http::HeaderMapPtr req_headers_to_add = std::move(request_headers_to_add);
   Stats::StatName empty_stat_name;
   Filters::Common::RateLimit::StatNames& stat_names = config_->statNames();

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -161,9 +161,9 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::Head
   if (status == Filters::Common::RateLimit::LimitStatus::OverLimit &&
       config_->runtime().snapshot().featureEnabled("ratelimit.http_filter_enforcing", 100)) {
     state_ = State::Responded;
-    callbacks_->sendLocalReply(Http::Code::TooManyRequests, "",
-                               [this](Http::HeaderMap& headers) { addHeaders(headers); },
-                               config_->rateLimitedGrpcStatus(), RcDetails::get().RateLimited);
+    callbacks_->sendLocalReply(
+        Http::Code::TooManyRequests, "", [this](Http::HeaderMap& headers) { addHeaders(headers); },
+        config_->rateLimitedGrpcStatus(), RcDetails::get().RateLimited);
     callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
   } else if (status == Filters::Common::RateLimit::LimitStatus::Error) {
     if (config_->failureModeAllow()) {

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -115,7 +115,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& headers) override;
+                Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override;
 
 private:
   void initiateCall(const Http::HeaderMap& headers);
@@ -124,6 +124,7 @@ private:
                                     const Router::RouteEntry* route_entry,
                                     const Http::HeaderMap& headers) const;
   void addHeaders(Http::HeaderMap& headers);
+  void addUpstreamHeaders();
   Http::Context& httpContext() { return config_->httpContext(); }
 
   enum class State { NotStarted, Calling, Complete, Responded };
@@ -135,6 +136,9 @@ private:
   Upstream::ClusterInfoConstSharedPtr cluster_;
   bool initiating_call_{};
   Http::HeaderMapPtr headers_to_add_;
+  Http::HeaderMapPtr upstream_headers_to_add_;
+  Http::HeaderMap* request_headers_;
+
 };
 
 } // namespace RateLimitFilter

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -115,7 +115,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
-                Http::HeaderMapPtr&& upstream_headers) override;
+                Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:
   void initiateCall(const Http::HeaderMap& headers);
@@ -123,7 +123,9 @@ private:
                                     std::vector<Envoy::RateLimit::Descriptor>& descriptors,
                                     const Router::RouteEntry* route_entry,
                                     const Http::HeaderMap& headers) const;
-  void addHeaders(Http::HeaderMap& headers);
+  void addResponseHeaders(Http::HeaderMap& headers);
+  void addRequestHeaders(Http::HeaderMapPtr& request_headers_to_add);
+
   Http::Context& httpContext() { return config_->httpContext(); }
 
   enum class State { NotStarted, Calling, Complete, Responded };
@@ -134,7 +136,7 @@ private:
   State state_{State::NotStarted};
   Upstream::ClusterInfoConstSharedPtr cluster_;
   bool initiating_call_{};
-  Http::HeaderMapPtr headers_to_add_;
+  Http::HeaderMapPtr response_headers_to_add_;
   Http::HeaderMap* request_headers_;
 };
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -115,7 +115,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& response_headers,
+                Http::HeaderMapPtr&& response_headers_to_add,
                 Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -114,8 +114,8 @@ public:
   void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override;
 
   // RateLimit::RequestCallbacks
-  void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override;
+  void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+                Http::HeaderMapPtr&& upstream_headers) override;
 
 private:
   void initiateCall(const Http::HeaderMap& headers);
@@ -124,7 +124,6 @@ private:
                                     const Router::RouteEntry* route_entry,
                                     const Http::HeaderMap& headers) const;
   void addHeaders(Http::HeaderMap& headers);
-  void addUpstreamHeaders();
   Http::Context& httpContext() { return config_->httpContext(); }
 
   enum class State { NotStarted, Calling, Complete, Responded };
@@ -136,9 +135,7 @@ private:
   Upstream::ClusterInfoConstSharedPtr cluster_;
   bool initiating_call_{};
   Http::HeaderMapPtr headers_to_add_;
-  Http::HeaderMapPtr upstream_headers_to_add_;
   Http::HeaderMap* request_headers_;
-
 };
 
 } // namespace RateLimitFilter

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -114,7 +114,8 @@ public:
   void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override;
 
   // RateLimit::RequestCallbacks
-  void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+  void complete(Filters::Common::RateLimit::LimitStatus status,
+                Http::HeaderMapPtr&& response_headers,
                 Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:
@@ -123,8 +124,8 @@ private:
                                     std::vector<Envoy::RateLimit::Descriptor>& descriptors,
                                     const Router::RouteEntry* route_entry,
                                     const Http::HeaderMap& headers) const;
-  void addResponseHeaders(Http::HeaderMap& headers);
-  void addRequestHeaders(Http::HeaderMapPtr& request_headers_to_add);
+  void populateResponseHeaders(Http::HeaderMap& response_headers);
+  void appendRequestHeaders(Http::HeaderMapPtr& request_headers_to_add);
 
   Http::Context& httpContext() { return config_->httpContext(); }
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -68,7 +68,7 @@ void Filter::onEvent(Network::ConnectionEvent event) {
   }
 }
 
-void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&&) {
+void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&&, Http::HeaderMapPtr&&) {
   status_ = Status::Complete;
   config_->stats().active_.dec();
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -68,7 +68,8 @@ void Filter::onEvent(Network::ConnectionEvent event) {
   }
 }
 
-void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&&, Http::HeaderMapPtr&&) {
+void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&&,
+                      Http::HeaderMapPtr&&) {
   status_ = Status::Complete;
   config_->stats().active_.dec();
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -91,8 +91,8 @@ public:
   void onBelowWriteBufferLowWatermark() override {}
 
   // RateLimit::RequestCallbacks
-  void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override;
+  void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+                Http::HeaderMapPtr&& upstream_headers) override;
 
 private:
   enum class Status { NotStarted, Calling, Complete };

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -92,7 +92,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
-                Http::HeaderMapPtr&& upstream_headers) override;
+                Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:
   enum class Status { NotStarted, Calling, Complete };

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -92,7 +92,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& headers) override;
+                Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override;
 
 private:
   enum class Status { NotStarted, Calling, Complete };

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -91,7 +91,8 @@ public:
   void onBelowWriteBufferLowWatermark() override {}
 
   // RateLimit::RequestCallbacks
-  void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+  void complete(Filters::Common::RateLimit::LimitStatus status,
+                Http::HeaderMapPtr&& response_headers_to_add,
                 Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -58,12 +58,12 @@ void Filter::onDestroy() {
 }
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
-                      Http::HeaderMapPtr&& response_headers,
+                      Http::HeaderMapPtr&& response_headers_to_add,
                       Http::HeaderMapPtr&& request_headers_to_add) {
   // TODO(zuercher): Store headers to append to a response. Adding them to a local reply (over
   // limit or error) is a matter of modifying the callbacks to allow it. Adding them to an upstream
   // response requires either response (aka encoder) filters or some other mechanism.
-  UNREFERENCED_PARAMETER(response_headers);
+  UNREFERENCED_PARAMETER(response_headers_to_add);
   UNREFERENCED_PARAMETER(request_headers_to_add);
 
   state_ = State::Complete;

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -58,7 +58,7 @@ void Filter::onDestroy() {
 }
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
-                      Http::HeaderMapPtr&& headers) {
+                      Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&&) {
   // TODO(zuercher): Store headers to append to a response. Adding them to a local reply (over
   // limit or error) is a matter of modifying the callbacks to allow it. Adding them to an upstream
   // response requires either response (aka encoder) filters or some other mechanism.

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -57,8 +57,8 @@ void Filter::onDestroy() {
   }
 }
 
-void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
-                      Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&&) {
+void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+                      Http::HeaderMapPtr&&) {
   // TODO(zuercher): Store headers to append to a response. Adding them to a local reply (over
   // limit or error) is a matter of modifying the callbacks to allow it. Adding them to an upstream
   // response requires either response (aka encoder) filters or some other mechanism.

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -57,12 +57,14 @@ void Filter::onDestroy() {
   }
 }
 
-void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
-                      Http::HeaderMapPtr&&) {
+void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
+                      Http::HeaderMapPtr&& response_headers,
+                      Http::HeaderMapPtr&& request_headers_to_add) {
   // TODO(zuercher): Store headers to append to a response. Adding them to a local reply (over
   // limit or error) is a matter of modifying the callbacks to allow it. Adding them to an upstream
   // response requires either response (aka encoder) filters or some other mechanism.
-  UNREFERENCED_PARAMETER(headers);
+  UNREFERENCED_PARAMETER(response_headers);
+  UNREFERENCED_PARAMETER(request_headers_to_add);
 
   state_ = State::Complete;
   Filters::Common::RateLimit::StatNames& stat_names = config_->statNames();

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -130,7 +130,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& headers) override;
+                Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override;
 
 private:
   void initiateCall(const ThriftProxy::MessageMetadata& metadata);

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -130,7 +130,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& response_headers,
+                Http::HeaderMapPtr&& response_headers_to_add,
                 Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -130,7 +130,7 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
-                Http::HeaderMapPtr&& upstream_headers) override;
+                Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:
   void initiateCall(const ThriftProxy::MessageMetadata& metadata);

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -129,8 +129,8 @@ public:
   ThriftProxy::FilterStatus setEnd() override { return ThriftProxy::FilterStatus::Continue; }
 
   // RateLimit::RequestCallbacks
-  void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override;
+  void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+                Http::HeaderMapPtr&& upstream_headers) override;
 
 private:
   void initiateCall(const ThriftProxy::MessageMetadata& metadata);

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -129,7 +129,8 @@ public:
   ThriftProxy::FilterStatus setEnd() override { return ThriftProxy::FilterStatus::Continue; }
 
   // RateLimit::RequestCallbacks
-  void complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&& headers,
+  void complete(Filters::Common::RateLimit::LimitStatus status,
+                Http::HeaderMapPtr&& response_headers,
                 Http::HeaderMapPtr&& request_headers_to_add) override;
 
 private:

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -412,7 +412,7 @@ stat_prefix: name
   EXPECT_CALL(factory_context.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
       .WillOnce(Return(&conn_pool));
 
-  request_callbacks->complete(Extensions::Filters::Common::RateLimit::LimitStatus::OK, nullptr);
+  request_callbacks->complete(Extensions::Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr);
 
   conn_pool.poolReady(upstream_connection);
 

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -412,7 +412,8 @@ stat_prefix: name
   EXPECT_CALL(factory_context.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
       .WillOnce(Return(&conn_pool));
 
-  request_callbacks->complete(Extensions::Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr);
+  request_callbacks->complete(Extensions::Filters::Common::RateLimit::LimitStatus::OK, nullptr,
+                              nullptr);
 
   conn_pool.poolReady(upstream_connection);
 

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -34,12 +34,12 @@ namespace {
 
 class MockRequestCallbacks : public RequestCallbacks {
 public:
-  void complete(LimitStatus status, Http::HeaderMapPtr&& headers,
+  void complete(LimitStatus status, Http::HeaderMapPtr&& response_headers_to_add,
                 Http::HeaderMapPtr&& request_headers_to_add) override {
-    complete_(status, headers.get(), request_headers_to_add.get());
+    complete_(status, response_headers_to_add.get(), request_headers_to_add.get());
   }
 
-  MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* headers,
+  MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* response_headers_to_add,
                                const Http::HeaderMap* request_headers_to_add));
 };
 

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -35,12 +35,12 @@ namespace {
 class MockRequestCallbacks : public RequestCallbacks {
 public:
   void complete(LimitStatus status, Http::HeaderMapPtr&& headers,
-                Http::HeaderMapPtr&& upstream_headers) override {
-    complete_(status, headers.get(), upstream_headers.get());
+                Http::HeaderMapPtr&& request_headers_to_add) override {
+    complete_(status, headers.get(), request_headers_to_add.get());
   }
 
   MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* headers,
-                               const Http::HeaderMap* upstream_headers));
+                               const Http::HeaderMap* request_headers_to_add));
 };
 
 class RateLimitGrpcClientTest : public testing::Test {

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -34,11 +34,13 @@ namespace {
 
 class MockRequestCallbacks : public RequestCallbacks {
 public:
-  void complete(LimitStatus status, Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override {
+  void complete(LimitStatus status, Http::HeaderMapPtr&& headers,
+                Http::HeaderMapPtr&& upstream_headers) override {
     complete_(status, headers.get(), upstream_headers.get());
   }
 
-  MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* headers, const Http::HeaderMap* upstream_headers));
+  MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* headers,
+                               const Http::HeaderMap* upstream_headers));
 };
 
 class RateLimitGrpcClientTest : public testing::Test {

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -34,11 +34,11 @@ namespace {
 
 class MockRequestCallbacks : public RequestCallbacks {
 public:
-  void complete(LimitStatus status, Http::HeaderMapPtr&& headers) override {
-    complete_(status, headers.get());
+  void complete(LimitStatus status, Http::HeaderMapPtr&& headers, Http::HeaderMapPtr&& upstream_headers) override {
+    complete_(status, headers.get(), upstream_headers.get());
   }
 
-  MOCK_METHOD2(complete_, void(LimitStatus status, const Http::HeaderMap* headers));
+  MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* headers, const Http::HeaderMap* upstream_headers));
 };
 
 class RateLimitGrpcClientTest : public testing::Test {
@@ -81,7 +81,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     response = std::make_unique<envoy::service::ratelimit::v2::RateLimitResponse>();
     response->set_overall_code(envoy::service::ratelimit::v2::RateLimitResponse_Code_OVER_LIMIT);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("over_limit")));
-    EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OverLimit, _));
+    EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OverLimit, _, _));
     client_.onSuccess(std::move(response), span_);
   }
 
@@ -100,7 +100,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     response = std::make_unique<envoy::service::ratelimit::v2::RateLimitResponse>();
     response->set_overall_code(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("ok")));
-    EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _));
+    EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _, _));
     client_.onSuccess(std::move(response), span_);
   }
 
@@ -117,7 +117,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
                   Tracing::NullSpan::instance());
 
     response = std::make_unique<envoy::service::ratelimit::v2::RateLimitResponse>();
-    EXPECT_CALL(request_callbacks_, complete_(LimitStatus::Error, _));
+    EXPECT_CALL(request_callbacks_, complete_(LimitStatus::Error, _, _));
     client_.onFailure(Grpc::Status::Unknown, "", span_);
   }
 }

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -26,10 +26,10 @@ using testing::_;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
+using testing::Not;
 using testing::Return;
 using testing::SetArgReferee;
 using testing::WithArgs;
-using testing::Not;
 
 namespace Envoy {
 namespace Extensions {
@@ -186,8 +186,9 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
               getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -230,8 +231,9 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithHeaders) {
               getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -277,8 +279,9 @@ TEST_F(HttpRateLimitFilterTest, ImmediateOkResponse) {
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -305,8 +308,9 @@ TEST_F(HttpRateLimitFilterTest, ImmediateErrorResponse) {
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -628,8 +632,9 @@ TEST_F(HttpRateLimitFilterTest, InternalRequestType) {
               getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -671,8 +676,9 @@ TEST_F(HttpRateLimitFilterTest, ExternalRequestType) {
               getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -711,8 +717,9 @@ TEST_F(HttpRateLimitFilterTest, ExcludeVirtualHost) {
               getApplicableRateLimit(0))
       .Times(0);
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -113,7 +113,7 @@ TEST_F(RateLimitFilterTest, OK) {
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
 
   EXPECT_CALL(filter_callbacks_, continueReading());
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 
@@ -140,7 +140,7 @@ TEST_F(RateLimitFilterTest, OverLimit) {
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(*client_, cancel()).Times(0);
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr, nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 
@@ -168,7 +168,7 @@ TEST_F(RateLimitFilterTest, OverLimitNotEnforcing) {
   EXPECT_CALL(filter_callbacks_.connection_, close(_)).Times(0);
   EXPECT_CALL(*client_, cancel()).Times(0);
   EXPECT_CALL(filter_callbacks_, continueReading());
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr, nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 
@@ -192,7 +192,7 @@ TEST_F(RateLimitFilterTest, Error) {
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
 
   EXPECT_CALL(filter_callbacks_, continueReading());
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 
@@ -232,7 +232,7 @@ TEST_F(RateLimitFilterTest, ImmediateOK) {
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
-            callbacks.complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr);
+            callbacks.complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr);
           })));
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
@@ -255,7 +255,7 @@ TEST_F(RateLimitFilterTest, ImmediateError) {
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
-            callbacks.complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr);
+            callbacks.complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr);
           })));
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
@@ -297,7 +297,7 @@ TEST_F(RateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -140,7 +140,8 @@ TEST_F(RateLimitFilterTest, OverLimit) {
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(*client_, cancel()).Times(0);
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,
+                               nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 
@@ -168,7 +169,8 @@ TEST_F(RateLimitFilterTest, OverLimitNotEnforcing) {
   EXPECT_CALL(filter_callbacks_.connection_, close(_)).Times(0);
   EXPECT_CALL(*client_, cancel()).Times(0);
   EXPECT_CALL(filter_callbacks_, continueReading());
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,
+                               nullptr);
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -207,8 +207,9 @@ TEST_F(ThriftRateLimitFilterTest, OkResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -236,8 +237,9 @@ TEST_F(ThriftRateLimitFilterTest, ImmediateOkResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -258,8 +260,9 @@ TEST_F(ThriftRateLimitFilterTest, ImmediateErrorResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                            {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo",
+                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                  {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -207,9 +207,8 @@ TEST_F(ThriftRateLimitFilterTest, OkResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo",
-                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                  {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                            {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
@@ -224,7 +223,7 @@ TEST_F(ThriftRateLimitFilterTest, OkResponse) {
   EXPECT_CALL(filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
       .Times(0);
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr);
 
   EXPECT_EQ(1U,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.ok").value());
@@ -237,13 +236,12 @@ TEST_F(ThriftRateLimitFilterTest, ImmediateOkResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo",
-                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                  {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                            {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
-            callbacks.complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr);
+            callbacks.complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr);
           })));
 
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
@@ -260,13 +258,12 @@ TEST_F(ThriftRateLimitFilterTest, ImmediateErrorResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(*client_, limit(_, "foo",
-                              testing::ContainerEq(std::vector<RateLimit::Descriptor>{
-                                  {{{"descriptor_key", "descriptor_value"}}}}),
+  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<RateLimit::Descriptor>{
+                                            {{{"descriptor_key", "descriptor_value"}}}}),
                               _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::RateLimit::RequestCallbacks& callbacks) -> void {
-            callbacks.complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr);
+            callbacks.complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr);
           })));
 
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
@@ -295,7 +292,7 @@ TEST_F(ThriftRateLimitFilterTest, ErrorResponse) {
   EXPECT_EQ(ThriftProxy::FilterStatus::StopIteration, filter_->messageBegin(request_metadata_));
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr);
 
   EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageEnd());
   EXPECT_CALL(filter_callbacks_.stream_info_,
@@ -332,7 +329,7 @@ TEST_F(ThriftRateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
       }));
   EXPECT_CALL(filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError));
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr);
 
   EXPECT_EQ(
       1U,
@@ -365,7 +362,8 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponse) {
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,
+                               nullptr);
 
   EXPECT_EQ(1U,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.over_limit")
@@ -397,7 +395,8 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponseWithHeaders) {
               setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
 
   Http::HeaderMapPtr h{new Http::TestHeaderMapImpl(*rl_headers)};
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, std::move(h));
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, std::move(h),
+                               nullptr);
 
   EXPECT_EQ(1U,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.over_limit")
@@ -421,7 +420,8 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponseRuntimeDisabled) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("ratelimit.thrift_filter_enforcing", 100))
       .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_, continueDecoding());
-  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr);
+  request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,
+                               nullptr);
 
   EXPECT_EQ(1U,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.over_limit")

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -125,13 +125,13 @@ public:
   }
 
   void sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code code,
-                             const Http::HeaderMapImpl& headers,
+                             const Http::HeaderMapImpl& response_headers,
                              const Http::HeaderMapImpl& request_headers_to_add) {
     ratelimit_request_->startGrpcStream();
     envoy::service::ratelimit::v2::RateLimitResponse response_msg;
     response_msg.set_overall_code(code);
 
-    headers.iterate(
+    response_headers.iterate(
         [](const Http::HeaderEntry& h, void* context) -> Http::HeaderMap::Iterate {
           auto header = static_cast<envoy::service::ratelimit::v2::RateLimitResponse*>(context)
                             ->mutable_headers()
@@ -211,15 +211,15 @@ TEST_P(RatelimitIntegrationTest, Ok) { basicFlow(); }
 TEST_P(RatelimitIntegrationTest, OkWithHeaders) {
   initiateClientConnection();
   waitForRatelimitRequest();
-  Http::TestHeaderMapImpl ratelimit_headers{{"x-ratelimit-limit", "1000"},
-                                            {"x-ratelimit-remaining", "500"}};
+  Http::TestHeaderMapImpl ratelimit_response_headers{{"x-ratelimit-limit", "1000"},
+                                                     {"x-ratelimit-remaining", "500"}};
   Http::TestHeaderMapImpl request_headers_to_add{{"x-ratelimit-done", "true"}};
 
-  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK, ratelimit_headers,
-                        request_headers_to_add);
+  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK,
+                        ratelimit_response_headers, request_headers_to_add);
   waitForSuccessfulUpstreamResponse();
 
-  ratelimit_headers.iterate(
+  ratelimit_response_headers.iterate(
       [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
         IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);
         Http::LowerCaseString lower_key{std::string(entry.key().getStringView())};
@@ -260,13 +260,13 @@ TEST_P(RatelimitIntegrationTest, OverLimit) {
 TEST_P(RatelimitIntegrationTest, OverLimitWithHeaders) {
   initiateClientConnection();
   waitForRatelimitRequest();
-  Http::TestHeaderMapImpl ratelimit_headers{
+  Http::TestHeaderMapImpl ratelimit_response_headers{
       {"x-ratelimit-limit", "1000"}, {"x-ratelimit-remaining", "0"}, {"retry-after", "33"}};
   sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OVER_LIMIT,
-                        ratelimit_headers, Http::HeaderMapImpl{});
+                        ratelimit_response_headers, Http::HeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
 
-  ratelimit_headers.iterate(
+  ratelimit_response_headers.iterate(
       [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
         IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);
         Http::LowerCaseString lower_key{std::string(entry.key().getStringView())};

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -125,7 +125,8 @@ public:
   }
 
   void sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code code,
-                             const Http::HeaderMapImpl& headers, const Http::HeaderMapImpl& upstream_headers) {
+                             const Http::HeaderMapImpl& headers,
+                             const Http::HeaderMapImpl& upstream_headers) {
     ratelimit_request_->startGrpcStream();
     envoy::service::ratelimit::v2::RateLimitResponse response_msg;
     response_msg.set_overall_code(code);
@@ -140,16 +141,16 @@ public:
           return Http::HeaderMap::Iterate::Continue;
         },
         &response_msg);
-    upstream_headers.iterate( 
-      [](const Http::HeaderEntry& h, void* context)->Http::HeaderMap::Iterate {
-        auto header = static_cast<envoy::service::ratelimit::v2::RateLimitResponse*>(context)
+    upstream_headers.iterate(
+        [](const Http::HeaderEntry& h, void* context) -> Http::HeaderMap::Iterate {
+          auto header = static_cast<envoy::service::ratelimit::v2::RateLimitResponse*>(context)
                             ->mutable_upstream_headers()
                             ->Add();
-        header->set_key(std::string(h.key().getStringView()));
-        header->set_value(std::string(h.value().getStringView()));
-        return Http::HeaderMap::Iterate::Continue;
-      },
-      &response_msg);
+          header->set_key(std::string(h.key().getStringView()));
+          header->set_value(std::string(h.value().getStringView()));
+          return Http::HeaderMap::Iterate::Continue;
+        },
+        &response_msg);
     ratelimit_request_->sendGrpcMessage(response_msg);
     ratelimit_request_->finishGrpcStream(Grpc::Status::Ok);
   }
@@ -214,8 +215,8 @@ TEST_P(RatelimitIntegrationTest, OkWithHeaders) {
                                             {"x-ratelimit-remaining", "500"}};
   Http::TestHeaderMapImpl upstream_headers{{"x-ratelimit-done", "true"}};
 
-  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK,
-                        ratelimit_headers, upstream_headers);
+  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK, ratelimit_headers,
+                        upstream_headers);
   waitForSuccessfulUpstreamResponse();
 
   ratelimit_headers.iterate(

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -125,13 +125,13 @@ public:
   }
 
   void sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code code,
-                             const Http::HeaderMapImpl& response_headers,
+                             const Http::HeaderMapImpl& response_headers_to_add,
                              const Http::HeaderMapImpl& request_headers_to_add) {
     ratelimit_request_->startGrpcStream();
     envoy::service::ratelimit::v2::RateLimitResponse response_msg;
     response_msg.set_overall_code(code);
 
-    response_headers.iterate(
+    response_headers_to_add.iterate(
         [](const Http::HeaderEntry& h, void* context) -> Http::HeaderMap::Iterate {
           auto header = static_cast<envoy::service::ratelimit::v2::RateLimitResponse*>(context)
                             ->mutable_headers()


### PR DESCRIPTION
**Description**:

- Ability to add custom upstream headers from ratelimit service/filter. 
- For LimitStatus::OK,  custom upstream headers are added if RLS service sends upstream headers.

**Risk Level**: Low

**Testing**: 
- Unit and integration tests added. 
- Verified with modified github.com/lyft/ratelimit service. 
- Passes "bazel test //test/..." in Linux

**Docs Changes**: protobuf documentation updated

**Release Notes**: ratelimit: support for adding custom headers to upstream server
from ratelimit service

** Issues: #6141 
