### PR TITLE
stats: fix leak-into-pool for getDynamic("")

### DIFF
--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -478,17 +478,15 @@ StatName StatNameSet::getDynamic(absl::string_view token) {
     return iter->second;
   }
 
-  Stats::StatName stat_name = getBuiltin(token, StatName());
-  if (stat_name.empty()) {
+  {
     // Other tokens require holding a lock for our local cache.
     absl::MutexLock lock(&mutex_);
     Stats::StatName& stat_name_ref = dynamic_stat_names_[token];
     if (stat_name_ref.empty()) { // Note that builtin_stat_names_ already has one for "".
       stat_name_ref = pool_.add(token);
     }
-    stat_name = stat_name_ref;
+    return stat_name_ref;
   }
-  return stat_name;
 }
 
 } // namespace Stats

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -471,6 +471,13 @@ StatName StatNameSet::getBuiltin(absl::string_view token, StatName fallback) {
 }
 
 StatName StatNameSet::getDynamic(absl::string_view token) {
+  // We duplicate most of the getBuiltin implementation so that we can detect
+  // the difference between "not found" and "found empty stat name".
+  const auto iter = builtin_stat_names_.find(token);
+  if (iter != builtin_stat_names_.end()) {
+    return iter->second;
+  }
+
   Stats::StatName stat_name = getBuiltin(token, StatName());
   if (stat_name.empty()) {
     // Other tokens require holding a lock for our local cache.

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -557,6 +557,13 @@ TEST_P(StatNameTest, StatNameSet) {
   EXPECT_EQ("dynamic", table_->toString(dynamic));
   EXPECT_EQ(dynamic.data(), set->getDynamic("dynamic").data());
 
+  // Make sure blanks are always the same.
+  const Stats::StatName blank = set->getDynamic("");
+  EXPECT_EQ("", table_->toString(blank));
+  EXPECT_EQ(blank.data(), set->getDynamic("").data());
+  EXPECT_EQ(blank.data(), set->getDynamic("").data());
+  EXPECT_EQ(blank.data(), set->getDynamic(absl::string_view()).data());
+
   // There's another corner case for the same "dynamic" name from a
   // different set. Here we will get a different StatName object
   // out of the second set, though it will share the same underlying


### PR DESCRIPTION
Description: There was special case handling for this but it was not quite right, and it lacked a test. This caused a leak with empty tags in ip_tagging_filter.
Risk Level: low
Testing: //test/common/stats:symbol_table_impl_test
Docs Changes: n/a
Release Notes: n/a
