### PR TITLE
ci: mirror .pb.go to envoyproxy/go-control-plane.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,21 @@ jobs:
        - add_ssh_keys:
            fingerprints:
              - "fb:f3:fe:be:1c:b2:ec:b6:25:f9:7b:a6:87:54:02:8c"
-             - "9d:3b:fe:7c:09:3b:ce:a9:6a:de:de:41:fb:6b:52:62"
        - run: ci/api_mirror.sh
-       - run: ci/go_mirror.sh
        - store_artifacts:
            path: /build/envoy/generated
            destination: /
+
+   go_control_plane_mirror:
+     executor: ubuntu-build
+     steps:
+       - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
+       - checkout
+       - run: ci/do_circle_ci.sh bazel.api
+       - add_ssh_keys:
+           fingerprints:
+             - "9d:3b:fe:7c:09:3b:ce:a9:6a:de:de:41:fb:6b:52:62"
+       - run: ci/go_mirror.sh
 
    filter_example_mirror:
      executor: ubuntu-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,9 @@ jobs:
        - add_ssh_keys:
            fingerprints:
              - "fb:f3:fe:be:1c:b2:ec:b6:25:f9:7b:a6:87:54:02:8c"
+             - "9d:3b:fe:7c:09:3b:ce:a9:6a:de:de:41:fb:6b:52:62"
        - run: ci/api_mirror.sh
+       - run: ci/go_mirror.sh
        - store_artifacts:
            path: /build/envoy/generated
            destination: /


### PR DESCRIPTION
This reverts "ci: temporarily disable go_mirror while figuring out SSH keys (#8311)",
commit 98c35eff10ad170d550fb5ecfc2c6b3637418c0c. I've added a new key pair and set this up in both
Circle and GitHub, so pushes should now work.

Signed-off-by: Harvey Tuch <htuch@google.com>