### PR TITLE
ci: reduce azp runs

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -39,7 +39,6 @@ jobs:
       # (on Fuzzit) is not crashing envoy. This will help find bugs BEFORE merging and not after.
       fuzzit:
         CI_TARGET: 'bazel.fuzzit_regression'
-  dependsOn: [] # this removes the implicit dependency on previous stage and causes this to run in parallel.
   timeoutInMinutes: 360
   pool:
     vmImage: 'Ubuntu 16.04'

--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -21,7 +21,9 @@ jobs:
     displayName: "Run check format scripts"
 
 - job: bazel
+  dependsOn: ["format"]
   strategy:
+    maxParallel: 3
     matrix:
       release:
         CI_TARGET: 'bazel.release'
@@ -61,7 +63,7 @@ jobs:
     env:
       ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
       ENVOY_RBE: "true"
-      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=remote --jobs=100 --curses=no"
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=remote --jobs=$(RbeJobs) --curses=no"
       BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
       BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
@@ -116,7 +118,7 @@ jobs:
         FUZZIT_API_KEY: $(FuzzitApiKey)
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         ENVOY_RBE: "true"
-        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=remote --jobs=100 --curses=no"
+        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=remote --jobs=$(RbeJobs) --curses=no"
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
         GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)

--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -22,6 +22,8 @@ jobs:
 
 - job: bazel
   dependsOn: ["format"]
+  # For master builds, continue even if format fails
+  condition: or(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   strategy:
     maxParallel: 3
     matrix:


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
- Try optimize azp runs a bit, push jobs to azp config.
- Guard CI runs on PR with format.
- Reduce parallel runs to prevent overload RBE clusters.

Risk Level: Low
Testing: CI only
Docs Changes:
Release Notes: