### PR TITLE
network: handle embedded nulls in unix domain socket

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -43,6 +43,13 @@ void validateIpv6Supported(const std::string& address) {
   }
 }
 
+// Returns the abstract path with embedded nulls replaces with '@'.
+std::string friendlyNameFromAbstractPath(const char* path, size_t num) {
+  std::string friendly_name(path, num);
+  std::replace(friendly_name.begin(), friendly_name.end(), '\0', '@');
+  return friendly_name;
+}
+
 } // namespace
 
 // Check if an IP family is supported on this machine.
@@ -341,10 +348,12 @@ PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len)
     address_length_ = ss_len - offsetof(struct sockaddr_un, sun_path);
   }
   address_ = *address;
-  friendly_name_ =
-      abstract_namespace_
-          ? fmt::format("@{}", absl::string_view(address_.sun_path + 1, address_length_ - 1))
-          : address_.sun_path;
+  if (abstract_namespace_) {
+    // Replace all null characters with '@' in friendly_name_.
+    friendly_name_ = friendlyNameFromAbstractPath(address_.sun_path, address_length_);
+  } else {
+    friendly_name_ = address->sun_path;
+  }
 }
 
 PipeInstance::PipeInstance(const std::string& pipe_path) : InstanceBase(Type::Pipe) {
@@ -355,15 +364,28 @@ PipeInstance::PipeInstance(const std::string& pipe_path) : InstanceBase(Type::Pi
   }
   memset(&address_, 0, sizeof(address_));
   address_.sun_family = AF_UNIX;
-  StringUtil::strlcpy(&address_.sun_path[0], pipe_path.c_str(), sizeof(address_.sun_path));
-  friendly_name_ = address_.sun_path;
-  if (address_.sun_path[0] == '@') {
+  if (pipe_path[0] == '@') {
+    // This indicates an abstract namespace.
+    // In this case, null bytes in the name have no special significance, and so we copy all
+    // characters of pipe_path to sun_path, including null bytes in the name. The pathname must also
+    // be null terminated. The friendly name is the address path with embedded nulls replaced with
+    // '@' for consistency with the first character.
 #if !defined(__linux__)
     throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
 #endif
     abstract_namespace_ = true;
-    address_length_ = strlen(address_.sun_path);
+    address_length_ = pipe_path.size();
+    memcpy(&address_.sun_path[0], pipe_path.data(), pipe_path.size());
     address_.sun_path[0] = '\0';
+    address_.sun_path[pipe_path.size()] = '\0';
+    friendly_name_ = friendlyNameFromAbstractPath(address_.sun_path, address_length_);
+  } else {
+    // Throw an error if the pipe path has an embedded null character.
+    if (pipe_path.size() != strlen(pipe_path.c_str())) {
+      throw EnvoyException("UNIX domain socket pathname contains embedded null characters");
+    }
+    StringUtil::strlcpy(&address_.sun_path[0], pipe_path.c_str(), sizeof(address_.sun_path));
+    friendly_name_ = address_.sun_path;
   }
 }
 

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -43,9 +43,9 @@ void validateIpv6Supported(const std::string& address) {
   }
 }
 
-// Returns the abstract path with embedded nulls replaces with '@'.
-std::string friendlyNameFromAbstractPath(const char* path, size_t num) {
-  std::string friendly_name(path, num);
+// Construsts a readable string with the embedded nulls in the abstract path replaced with '@'.
+std::string friendlyNameFromAbstractPath(absl::string_view path) {
+  std::string friendly_name(path.data(), path.size());
   std::replace(friendly_name.begin(), friendly_name.end(), '\0', '@');
   return friendly_name;
 }
@@ -350,7 +350,8 @@ PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len)
   address_ = *address;
   if (abstract_namespace_) {
     // Replace all null characters with '@' in friendly_name_.
-    friendly_name_ = friendlyNameFromAbstractPath(address_.sun_path, address_length_);
+    friendly_name_ =
+        friendlyNameFromAbstractPath(absl::string_view(address_.sun_path, address_length_));
   } else {
     friendly_name_ = address->sun_path;
   }
@@ -378,7 +379,8 @@ PipeInstance::PipeInstance(const std::string& pipe_path) : InstanceBase(Type::Pi
     memcpy(&address_.sun_path[0], pipe_path.data(), pipe_path.size());
     address_.sun_path[0] = '\0';
     address_.sun_path[pipe_path.size()] = '\0';
-    friendly_name_ = friendlyNameFromAbstractPath(address_.sun_path, address_length_);
+    friendly_name_ =
+        friendlyNameFromAbstractPath(absl::string_view(address_.sun_path, address_length_));
   } else {
     // Throw an error if the pipe path has an embedded null character.
     if (pipe_path.size() != strlen(pipe_path.c_str())) {

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -338,9 +338,9 @@ TEST(PipeInstanceTest, BadAddress) {
 
 // Validate that embedded nulls in abstract socket addresses are included and represented with '@'.
 TEST(PipeInstanceTest, EmbeddedNullAbstractNamespace) {
-#if defined(__linux__)
   std::string embedded_null("@/foo/bar");
   embedded_null[5] = '\0'; // Set embedded null.
+#if defined(__linux__)
   PipeInstance address(embedded_null);
   EXPECT_EQ("@/foo@bar", address.asString());
   EXPECT_EQ("@/foo@bar", address.asStringView());

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -336,6 +336,29 @@ TEST(PipeInstanceTest, BadAddress) {
                           "exceeds maximum UNIX domain socket path size");
 }
 
+// Validate that embedded nulls in abstract socket addresses are included and represented with '@'.
+TEST(PipeInstanceTest, EmbeddedNullAbstractNamespace) {
+#if defined(__linux__)
+  std::string embedded_null("@/foo/bar");
+  embedded_null[5] = '\0'; // Set embedded null.
+  PipeInstance address(embedded_null);
+  EXPECT_EQ("@/foo@bar", address.asString());
+  EXPECT_EQ("@/foo@bar", address.asStringView());
+  EXPECT_EQ(Type::Pipe, address.type());
+  EXPECT_EQ(nullptr, address.ip());
+#else
+  EXPECT_THROW(PipeInstance address(embedded_null), EnvoyException);
+#endif
+}
+
+// Reject embedded nulls in filesystem pathname addresses.
+TEST(PipeInstanceTest, EmbeddedNullPathError) {
+  std::string embedded_null("/foo/bar");
+  embedded_null[4] = '\0'; // Set embedded null.
+  EXPECT_THROW_WITH_REGEX(PipeInstance address(embedded_null), EnvoyException,
+                          "contains embedded null characters");
+}
+
 TEST(PipeInstanceTest, UnlinksExistingFile) {
   const auto bind_uds_socket = [](const std::string& path) {
     PipeInstance address(path);

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5118008002871296
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5118008002871296
@@ -1,0 +1,17 @@
+static_resources {   listeners {     name: "          "     address {       pipe {         path: "aa\000"       }     }     transparent {     }   } } stats_sinks {   typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\022*J.:*stateq {($ *stateq {($  cluster{s"
+  }
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\022*J.:*static_resourcAe csta  csta"
+  }
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "\022*J.:*stateq {($ *stateq {($  cluster{s"
+  }
+}

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5118008002871297
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5118008002871297
@@ -1,4 +1,4 @@
-static_resources {   listeners {     name: "          "     address {       pipe {         path: "\000"       }     }     transparent {     }   } } stats_sinks {   typed_config {
+static_resources {   listeners {     name: "          "     address {       pipe {         path: "aa\000"       }     }     transparent {     }   } } stats_sinks {   typed_config {
     type_url: "type.googleapis.com/envoy.api.v2.route.Route"
     value: "\022*J.:*stateq {($ *stateq {($  cluster{s"
   }


### PR DESCRIPTION
This PR rejects embedded nulls for pathname domain socket addresses, and handles them in abstract domain socket addresses. For abstract domain socket addresses, the `friendly_name_` replaces null bytes with '@' (for consistency with the first byte) so that log messages are preserved.

See http://man7.org/linux/man-pages/man7/unix.7.html.

Fixes OSS-Fuzz bug
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17984
(This was occurring due to null characters in the address resulting in an empty, but valid, address).
Testing: Added unit tests to test embedded nulls accepted and formatted with '@' in abstract namespace, and rejected for pathnames.

Signed-off-by: Asra Ali <asraa@google.com>

