### PR TITLE
http: add explicit const header method

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -350,6 +350,7 @@ private:
  */
 #define DEFINE_INLINE_HEADER(name)                                                                 \
   virtual const HeaderEntry* name() const PURE;                                                    \
+  virtual const HeaderEntry* const##name() const PURE;                                             \
   virtual HeaderEntry* name() PURE;                                                                \
   virtual HeaderEntry& insert##name() PURE;                                                        \
   virtual void remove##name() PURE;

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -25,6 +25,7 @@ namespace Http {
 #define DEFINE_INLINE_HEADER_FUNCS(name)                                                           \
 public:                                                                                            \
   const HeaderEntry* name() const override { return inline_headers_.name##_; }                     \
+  const HeaderEntry* const##name() const override { return name(); }                               \
   HeaderEntry* name() override {                                                                   \
     cached_byte_size_.reset();                                                                     \
     return inline_headers_.name##_;                                                                \

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -36,7 +36,7 @@ Http::FilterHeadersStatus CorsFilter::decodeHeaders(Http::HeaderMap& headers, bo
     return Http::FilterHeadersStatus::Continue;
   }
 
-  origin_ = headers.Origin();
+  origin_ = headers.constOrigin();
   if (origin_ == nullptr || origin_->value().empty()) {
     return Http::FilterHeadersStatus::Continue;
   }
@@ -53,13 +53,13 @@ Http::FilterHeadersStatus CorsFilter::decodeHeaders(Http::HeaderMap& headers, bo
 
   is_cors_request_ = true;
 
-  const auto method = headers.Method();
+  const auto method = headers.constMethod();
   if (method == nullptr ||
       method->value().getStringView() != Http::Headers::get().MethodValues.Options) {
     return Http::FilterHeadersStatus::Continue;
   }
 
-  const auto requestMethod = headers.AccessControlRequestMethod();
+  const auto requestMethod = headers.constAccessControlRequestMethod();
   if (requestMethod == nullptr || requestMethod->value().empty()) {
     return Http::FilterHeadersStatus::Continue;
   }

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -376,6 +376,27 @@ TEST(HeaderMapImplTest, InlineInsert) {
   EXPECT_EQ("hello", headers.get(Headers::get().Host)->value().getStringView());
 }
 
+TEST(HeaderMapImplTest, ConstGetter) {
+  HeaderMapImpl headers;
+  headers.insertHost().value(std::string("hello"));
+  EXPECT_GT(headers.refreshByteSize(), 0);
+  EXPECT_TRUE(headers.byteSize().has_value());
+
+  // const header map getter method  will not invalidate the byte cache
+  const auto& const_headers = headers;
+  const_headers.Host();
+  EXPECT_TRUE(const_headers.byteSize().has_value());
+
+  // Non const header map will default invalidate the size cache
+  headers.Host();
+  EXPECT_FALSE(headers.byteSize().has_value());
+
+  // const method will not invalidate the size cache
+  EXPECT_GT(headers.refreshByteSize(), 0);
+  headers.constHost();
+  EXPECT_TRUE(headers.byteSize().has_value());
+}
+
 // Utility function for testing byteSize() against a manual byte count.
 uint64_t countBytesForTest(const HeaderMapImpl& headers) {
   uint64_t byte_size = 0;


### PR DESCRIPTION
There are cases that we have a non-const reference of HeaderMap but we want to invoke const getter. See https://github.com/envoyproxy/envoy/pull/8531#discussion_r334188725

Adding constPath() to avoid the ugly `const_cast<const Http::HeaderMap&>(headers).Path()`

CC @asraa 

Signed-off-by: Yuchen Dai <silentdai@gmail.com>
