### PR TITLE
Update dependency and docs: jwt_verify_lib (add HS384, HS512 support)

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -170,10 +170,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/releases/download/cpp-3.2.0/msgpack-3.2.0.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "38a93926f362a330a2a4489ed799c260df0bc305417e2bb44d6745671d9641d7",
-        strip_prefix = "jwt_verify_lib-7e3191b0dcb72835aa63e308a53b541e7fda5458",
-        # 2019-09-23
-        urls = ["https://github.com/google/jwt_verify_lib/archive/7e3191b0dcb72835aa63e308a53b541e7fda5458.tar.gz"],
+        sha256 = "b42ad9d286e267b265080e97bacb99c27bce39db93a6c34be9575ddd9a3edd7a",
+        strip_prefix = "jwt_verify_lib-945805866007edb9d2760915abaa672ed8b7da86",
+        # 2019-10-07
+        urls = ["https://github.com/google/jwt_verify_lib/archive/945805866007edb9d2760915abaa672ed8b7da86.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "ef26268c54c8084d17654ba2ed5140bffeffd2a040a895ffb22a6cca3f6c613f",

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -8,7 +8,7 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
 .. attention::
-   ES256, HS256, RS256, RS384 and RS512 are supported for the JWT alg.
+   ES256, HS256, HS384, HS512, RS256, RS384 and RS512 are supported for the JWT alg.
 
 Configuration
 -------------


### PR DESCRIPTION
Signed-off-by: Ryan A. Chapman <ryan@rchapman.org>

Description: update jwt_verify_lib to support HS384 and HS512 tokens, also update documentation to show that Envoy now supports HS384 as well as HS512
Risk Level: low
Testing: upstream unit tests
Docs Changes: docs/root/configuration/http/http_filters/jwt_authn_filter.rst
Release Notes: none (should there be some?)