### PR TITLE
config: C++ library to wrap API type database.

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -22,6 +22,31 @@ envoy_cc_library(
     ],
 )
 
+# Pack API type database text file into a char* string that can be referenced
+# at the C++ level.
+genrule(
+    name = "api_type_db_genrule",
+    srcs = ["api_type_db.generated.pb_text"],
+    outs = ["api_type_db_def.generated.cc"],
+    cmd = """
+      (echo 'namespace Envoy { namespace Config { const char* ApiTypeDbPbText = R\"EOF('; \\
+          cat $(SRCS); echo ')EOF\";}}') > $@
+    """,
+)
+
+envoy_cc_library(
+    name = "api_type_db_lib",
+    srcs = [
+        "api_type_db.cc",
+        "api_type_db_def.generated.cc",
+    ],
+    hdrs = ["api_type_db.h"],
+    deps = [
+        "//source/common/protobuf",
+        "//tools/type_whisperer:api_type_db_proto_cc_proto",
+    ],
+)
+
 envoy_cc_library(
     name = "base_json_lib",
     srcs = ["base_json.cc"],

--- a/source/common/config/api_type_db.cc
+++ b/source/common/config/api_type_db.cc
@@ -1,0 +1,38 @@
+#include "common/config/api_type_db.h"
+
+#include "common/protobuf/protobuf.h"
+
+#include "tools/type_whisperer/api_type_db.pb.h"
+
+namespace Envoy {
+namespace Config {
+
+extern const char* ApiTypeDbPbText;
+
+namespace {
+
+tools::type_whisperer::TypeDb* loadApiTypeDb() {
+  tools::type_whisperer::TypeDb* api_type_db = new tools::type_whisperer::TypeDb;
+  if (Protobuf::TextFormat::ParseFromString(ApiTypeDbPbText, api_type_db)) {
+    return api_type_db;
+  }
+  return nullptr;
+}
+
+const tools::type_whisperer::TypeDb& getApiTypeDb() {
+  static tools::type_whisperer::TypeDb* api_type_db = loadApiTypeDb();
+  return *api_type_db;
+}
+
+} // namespace
+
+absl::optional<std::string> ApiTypeDb::getProtoPathForType(const std::string& type_name) {
+  auto it = getApiTypeDb().types().find(type_name);
+  if (it == getApiTypeDb().types().end()) {
+    return absl::nullopt;
+  }
+  return it->second.proto_path();
+}
+
+} // namespace Config
+} // namespace Envoy

--- a/source/common/config/api_type_db.h
+++ b/source/common/config/api_type_db.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Config {
+
+// We don't expose the raw API type database to consumers, as this requires RTTI
+// and this may be linked in environments where RTTI is not available (e.g.
+// libtooling binaries).
+class ApiTypeDb {
+public:
+  /**
+   * Obtain the API directory relative path for the .proto for a given API type.
+   * @param type_name fully qualified dot separated type name, e.g.
+   *   envoy.type.Int64Range.
+   * @return absl::optional<std::string> the corresponding proto path if found
+   *   in the type DB, otherwise nullopt.
+   */
+  static absl::optional<std::string> getProtoPathForType(const std::string& type_name);
+};
+
+} // namespace Config
+} // namespace Envoy

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -17,6 +17,14 @@ load("//bazel:repositories.bzl", "NOBORINGSSL_SKIP_TARGETS", "PPC_SKIP_TARGETS")
 envoy_package()
 
 envoy_cc_test(
+    name = "api_type_db_test",
+    srcs = ["api_type_db_test.cc"],
+    deps = [
+        "//source/common/config:api_type_db_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "delta_subscription_impl_test",
     srcs = ["delta_subscription_impl_test.cc"],
     deps = [

--- a/test/common/config/api_type_db_test.cc
+++ b/test/common/config/api_type_db_test.cc
@@ -1,0 +1,21 @@
+#include "common/config/api_type_db.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Config {
+namespace {
+
+TEST(ApiTypeDb, GetProtoPathForTypeUnknown) {
+  const auto unknown_type_path = ApiTypeDb::getProtoPathForType("foo");
+  EXPECT_EQ(absl::nullopt, unknown_type_path);
+}
+
+TEST(ApiTypeDb, GetProtoPathForTypeKnown) {
+  const auto known_type_path = ApiTypeDb::getProtoPathForType("envoy.type.Int64Range");
+  EXPECT_EQ("envoy/type/range.proto", *known_type_path);
+}
+
+} // namespace
+} // namespace Config
+} // namespace Envoy


### PR DESCRIPTION
This can be used inside the Envoy main binary as well as with libtooling
binaries that want access to the type database.

Risk level: Low (not used)
Testing: Unit test added, validated against some experimental local
  libtooling binaries (based on #8597) that the type DB is usable via
  this mechanism.

Part of #8082.

Signed-off-by: Harvey Tuch <htuch@google.com>