### PR TITLE
buffer filter: add content-length when ending stream with trailers

### DIFF
--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -79,14 +79,8 @@ Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap& headers, 
 Http::FilterDataStatus BufferFilter::decodeData(Buffer::Instance& data, bool end_stream) {
   content_length_ += data.length();
   if (end_stream || settings_->disabled()) {
-    // request_headers_ is initialized iff plugin is enabled.
-    if (request_headers_ != nullptr && request_headers_->ContentLength() == nullptr) {
-      ASSERT(!settings_->disabled());
-      if (Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.buffer_filter_populate_content_length")) {
-        request_headers_->insertContentLength().value(content_length_);
-      }
-    }
+    maybeAddContentLength();
+
     return Http::FilterDataStatus::Continue;
   }
 
@@ -95,6 +89,16 @@ Http::FilterDataStatus BufferFilter::decodeData(Buffer::Instance& data, bool end
 }
 
 Http::FilterTrailersStatus BufferFilter::decodeTrailers(Http::HeaderMap&) {
+  maybeAddContentLength();
+
+  return Http::FilterTrailersStatus::Continue;
+}
+
+void BufferFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
+  callbacks_ = &callbacks;
+}
+
+void BufferFilter::maybeAddContentLength() {
   // request_headers_ is initialized iff plugin is enabled.
   if (request_headers_ != nullptr && request_headers_->ContentLength() == nullptr) {
     ASSERT(!settings_->disabled());
@@ -103,12 +107,6 @@ Http::FilterTrailersStatus BufferFilter::decodeTrailers(Http::HeaderMap&) {
       request_headers_->insertContentLength().value(content_length_);
     }
   }
-
-  return Http::FilterTrailersStatus::Continue;
-}
-
-void BufferFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
-  callbacks_ = &callbacks;
 }
 
 } // namespace BufferFilter

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -95,6 +95,15 @@ Http::FilterDataStatus BufferFilter::decodeData(Buffer::Instance& data, bool end
 }
 
 Http::FilterTrailersStatus BufferFilter::decodeTrailers(Http::HeaderMap&) {
+  // request_headers_ is initialized iff plugin is enabled.
+  if (request_headers_ != nullptr && request_headers_->ContentLength() == nullptr) {
+    ASSERT(!settings_->disabled());
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.buffer_filter_populate_content_length")) {
+      request_headers_->insertContentLength().value(content_length_);
+    }
+  }
+
   return Http::FilterTrailersStatus::Continue;
 }
 

--- a/source/extensions/filters/http/buffer/buffer_filter.h
+++ b/source/extensions/filters/http/buffer/buffer_filter.h
@@ -61,6 +61,7 @@ public:
 
 private:
   void initConfig();
+  void maybeAddContentLength();
 
   BufferFilterConfigSharedPtr config_;
   const BufferFilterSettings* settings_;

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -75,7 +75,8 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLengthOnTrailers) {
   codec_client_->sendData(*request_encoder_, "0123", false);
   codec_client_->sendData(*request_encoder_, "456", false);
   codec_client_->sendData(*request_encoder_, "789", false);
-  codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{});
+  Http::TestHeaderMapImpl request_trailers{{"request", "trailer"}};
+  codec_client_->sendTrailers(*request_encoder_, request_trailers);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -63,6 +63,34 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 }
 
+TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLengthOnTrailers) {
+  config_helper_.addFilter(ConfigHelper::DEFAULT_BUFFER_FILTER);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(Http::TestHeaderMapImpl{
+      {":method", "POST"}, {":scheme", "http"}, {":path", "/shelf"}, {":authority", "host"}});
+  request_encoder_ = &encoder_decoder.first;
+  IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
+  codec_client_->sendData(*request_encoder_, "0123", false);
+  codec_client_->sendData(*request_encoder_, "456", false);
+  codec_client_->sendData(*request_encoder_, "789", false);
+  codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{});
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  auto* content_length = upstream_request_->headers().ContentLength();
+  ASSERT_NE(content_length, nullptr);
+  EXPECT_EQ(content_length->value().getStringView(), "10");
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
 TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
   config_helper_.addFilter(ConfigHelper::SMALL_BUFFER_FILTER);
   initialize();

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -110,6 +110,22 @@ TEST_F(BufferFilterTest, ContentLengthPopulation) {
   EXPECT_EQ(headers.ContentLength()->value().getStringView(), "11");
 }
 
+TEST_F(BufferFilterTest, ContentLengthPopulationInTrailers) {
+  InSequence s;
+
+  Http::TestHeaderMapImpl headers;
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data1("hello");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.decodeData(data1, false));
+  ASSERT_EQ(headers.ContentLength(), nullptr);
+
+  Http::TestHeaderMapImpl trailers;
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(trailers));
+  ASSERT_NE(headers.ContentLength(), nullptr);
+  EXPECT_EQ(headers.ContentLength()->value().getStringView(), "5");
+}
+
 TEST_F(BufferFilterTest, ContentLengthPopulationAlreadyPresent) {
   InSequence s;
 


### PR DESCRIPTION
Description: https://github.com/envoyproxy/envoy/pull/7848 introduced content-length population in the buffer filter. However, it is only populated if the client stream ends on a data frame. This PR adds content-length population when closing the stream via trailers.
Risk Level: low - expanded functionality runtime guarded.
Testing: unit and integration tests.
Release Notes: I believe the current release notes added by https://github.com/envoyproxy/envoy/pull/7848 are still adequate.
