### PR TITLE
dynamic forward proxy: allow host rewrite to take effect

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -652,6 +652,11 @@ public:
   virtual bool autoHostRewrite() const PURE;
 
   /**
+   * @return bool non empty if the :authority header should be overwritten with this value.
+   */
+  virtual const std::string& hostRewrite() const PURE;
+
+  /**
    * @return MetadataMatchCriteria* the metadata that a subset load balancer should match when
    * selecting an upstream host
    */

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -245,6 +245,7 @@ private:
     }
     const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
     bool autoHostRewrite() const override { return false; }
+    const std::string& hostRewrite() const override { return EMPTY_STRING; }
     bool includeVirtualHostRateLimits() const override { return true; }
     const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
     const Config::TypedMetadata& typedMetadata() const override { return typed_metadata_; }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -412,6 +412,7 @@ public:
   }
   const VirtualHost& virtualHost() const override { return vhost_; }
   bool autoHostRewrite() const override { return auto_host_rewrite_; }
+  const std::string& hostRewrite() const override { return host_rewrite_; }
   const std::multimap<std::string, std::string>& opaqueConfig() const override {
     return opaque_config_;
   }
@@ -516,6 +517,7 @@ private:
 
     const VirtualHost& virtualHost() const override { return parent_->virtualHost(); }
     bool autoHostRewrite() const override { return parent_->autoHostRewrite(); }
+    const std::string& hostRewrite() const override { return parent_->hostRewrite(); }
     bool includeVirtualHostRateLimits() const override {
       return parent_->includeVirtualHostRateLimits();
     }

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -62,6 +62,11 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::HeaderMap& headers, b
     default_port = 443;
   }
 
+  const auto& host_rewrite = route_entry->hostRewrite();
+  if (!host_rewrite.empty()) {
+    headers.Host()->value(host_rewrite);
+  }
+
   // See the comments in dns_cache.h for how loadDnsCacheEntry() handles hosts with embedded ports.
   // TODO(mattklein123): Because the filter and cluster have independent configuration, it is
   //                     not obvious to the user if something is misconfigured. We should see if

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -88,6 +88,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, upgradeMap()).WillByDefault(ReturnRef(upgrade_map_));
   ON_CALL(*this, hedgePolicy()).WillByDefault(ReturnRef(hedge_policy_));
   ON_CALL(*this, routeName()).WillByDefault(ReturnRef(route_name_));
+  ON_CALL(*this, hostRewrite()).WillByDefault(ReturnRef(host_rewrite_));
 }
 
 MockRouteEntry::~MockRouteEntry() = default;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -307,6 +307,7 @@ public:
   MOCK_CONST_METHOD0(virtualHostName, const std::string&());
   MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
   MOCK_CONST_METHOD0(autoHostRewrite, bool());
+  MOCK_CONST_METHOD0(hostRewrite, const std::string&());
   MOCK_CONST_METHOD0(opaqueConfig, const std::multimap<std::string, std::string>&());
   MOCK_CONST_METHOD0(includeVirtualHostRateLimits, bool());
   MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
@@ -334,6 +335,7 @@ public:
   testing::NiceMock<MockPathMatchCriterion> path_match_criterion_;
   envoy::api::v2::core::Metadata metadata_;
   UpgradeMap upgrade_map_;
+  std::string host_rewrite_;
 };
 
 class MockDecorator : public Decorator {


### PR DESCRIPTION
This is needed so that a route action, when using the dynamic
forward proxy, can set a host rewrite.

Fixes: #8607

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
