### PR TITLE
tls: expose upstream TLS properties in access log

### DIFF
--- a/docs/root/configuration/observability/access_log.rst
+++ b/docs/root/configuration/observability/access_log.rst
@@ -436,3 +436,81 @@ The following command operators are supported:
   TCP
     The validity end date of the client certificate used to establish the downstream TLS connection.
 
+%UPSTREAM_LOCAL_URI_SAN%
+  HTTP
+    The URIs present in the SAN of the local certificate used to establish the upstream TLS connection.
+  TCP
+    The URIs present in the SAN of the local certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_URI_SAN%
+  HTTP
+    The URIs present in the SAN of the peer certificate used to establish the upstream TLS connection.
+  TCP
+    The URIs present in the SAN of the peer certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_LOCAL_SUBJECT%
+  HTTP
+    The subject present in the local certificate used to establish the upstream TLS connection.
+  TCP
+    The subject present in the local certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_SUBJECT%
+  HTTP
+    The subject present in the peer certificate used to establish the upstream TLS connection.
+  TCP
+    The subject present in the peer certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_ISSUER%
+  HTTP
+    The issuer present in the peer certificate used to establish the upstream TLS connection.
+  TCP
+    The issuer present in the peer certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_TLS_SESSION_ID%
+  HTTP
+    The session ID for the established upstream TLS connection.
+  TCP
+    The session ID for the established upstream TLS connection.
+
+%UPSTREAM_TLS_CIPHER%
+  HTTP
+    The OpenSSL name for the set of ciphers used to establish the upstream TLS connection.
+  TCP
+    The OpenSSL name for the set of ciphers used to establish the upstream TLS connection.
+
+%UPSTREAM_TLS_VERSION%
+  HTTP
+    The TLS version (e.g., ``TLSv1.2``, ``TLSv1.3``) used to establish the upstream TLS connection.
+  TCP
+    The TLS version (e.g., ``TLSv1.2``, ``TLSv1.3``) used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_FINGERPRINT_256%
+  HTTP
+    The hex-encoded SHA256 fingerprint of the client certificate used to establish the upstream TLS connection.
+  TCP
+    The hex-encoded SHA256 fingerprint of the client certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_SERIAL%
+  HTTP
+    The serial number of the client certificate used to establish the upstream TLS connection.
+  TCP
+    The serial number of the client certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_CERT%
+  HTTP
+    The client certificate in the URL-encoded PEM format used to establish the upstream TLS connection.
+  TCP
+    The client certificate in the URL-encoded PEM format used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_CERT_V_START%
+  HTTP
+    The validity start date of the client certificate used to establish the upstream TLS connection.
+  TCP
+    The validity start date of the client certificate used to establish the upstream TLS connection.
+
+%UPSTREAM_PEER_CERT_V_END%
+  HTTP
+    The validity end date of the client certificate used to establish the upstream TLS connection.
+  TCP
+    The validity end date of the client certificate used to establish the upstream TLS connection.
+

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -29,8 +29,8 @@ const std::regex& getStartTimeNewlinePattern(){
     CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n")};
 const std::regex& getNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "\n")};
 
-// Helper that handles the case when the downstream ConnectionInfo is missing or if the desired value is
-// empty.
+// Helper that handles the case when the downstream ConnectionInfo is missing or if the desired
+// value is empty.
 StreamInfoFormatter::FieldExtractor downstreamSslInfoStringExtractor(
     std::function<std::string(const Ssl::ConnectionInfo& connection_info)> string_extractor) {
   return [string_extractor](const StreamInfo::StreamInfo& stream_info) {
@@ -47,8 +47,8 @@ StreamInfoFormatter::FieldExtractor downstreamSslInfoStringExtractor(
   };
 }
 
-// Helper that handles the case when the upstream ConnectionInfo is missing or if the desired value is
-// empty.
+// Helper that handles the case when the upstream ConnectionInfo is missing or if the desired value
+// is empty.
 StreamInfoFormatter::FieldExtractor upstreamSslInfoStringExtractor(
     std::function<std::string(const Ssl::ConnectionInfo& connection_info)> string_extractor) {
   return [string_extractor](const StreamInfo::StreamInfo& stream_info) {

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -563,6 +563,328 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
         .WillRepeatedly(ReturnRef(upstream_transport_failure_reason));
     EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
   }
+
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_URI_SAN");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::vector<std::string> sans{"san"};
+    EXPECT_CALL(*connection_info, uriSanPeerCertificate()).WillRepeatedly(Return(sans));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("san", upstream_format.format(header, header, header, stream_info));
+  }
+
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_URI_SAN");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::vector<std::string> sans{"san1", "san2"};
+    EXPECT_CALL(*connection_info, uriSanPeerCertificate()).WillRepeatedly(Return(sans));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("san1,san2", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_URI_SAN");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, uriSanPeerCertificate())
+        .WillRepeatedly(Return(std::vector<std::string>()));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_URI_SAN");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_URI_SAN");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::vector<std::string> sans{"san"};
+    EXPECT_CALL(*connection_info, uriSanLocalCertificate()).WillRepeatedly(Return(sans));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("san", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_URI_SAN");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::vector<std::string> sans{"san1", "san2"};
+    EXPECT_CALL(*connection_info, uriSanLocalCertificate()).WillRepeatedly(Return(sans));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("san1,san2", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_URI_SAN");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, uriSanLocalCertificate())
+        .WillRepeatedly(Return(std::vector<std::string>()));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_URI_SAN");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_SUBJECT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::string subject_local = "subject";
+    EXPECT_CALL(*connection_info, subjectLocalCertificate())
+        .WillRepeatedly(ReturnRef(subject_local));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("subject", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_SUBJECT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, subjectLocalCertificate())
+        .WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_LOCAL_SUBJECT");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SUBJECT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::string subject_peer = "subject";
+    EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject_peer));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("subject", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SUBJECT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SUBJECT");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_SESSION_ID");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::string session_id = "deadbeef";
+    EXPECT_CALL(*connection_info, sessionId()).WillRepeatedly(ReturnRef(session_id));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("deadbeef", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_SESSION_ID");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, sessionId()).WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_SESSION_ID");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_CIPHER");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, ciphersuiteString())
+        .WillRepeatedly(Return("TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+              upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_CIPHER");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, ciphersuiteString()).WillRepeatedly(Return(""));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_CIPHER");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_VERSION");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    std::string tlsVersion = "TLSv1.2";
+    EXPECT_CALL(*connection_info, tlsVersion()).WillRepeatedly(ReturnRef(tlsVersion));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("TLSv1.2", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_VERSION");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, tlsVersion()).WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_TLS_VERSION");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_FINGERPRINT_256");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    std::string expected_sha = "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f";
+    EXPECT_CALL(*connection_info, sha256PeerCertificateDigest())
+        .WillRepeatedly(ReturnRef(expected_sha));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ(expected_sha, upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_FINGERPRINT_256");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    std::string expected_sha;
+    EXPECT_CALL(*connection_info, sha256PeerCertificateDigest())
+        .WillRepeatedly(ReturnRef(expected_sha));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_FINGERPRINT_256");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SERIAL");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::string serial_number = "b8b5ecc898f2124a";
+    EXPECT_CALL(*connection_info, serialNumberPeerCertificate())
+        .WillRepeatedly(ReturnRef(serial_number));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("b8b5ecc898f2124a", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SERIAL");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, serialNumberPeerCertificate())
+        .WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SERIAL");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_ISSUER");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::string issuer_peer =
+        "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
+    EXPECT_CALL(*connection_info, issuerPeerCertificate()).WillRepeatedly(ReturnRef(issuer_peer));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
+              upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_ISSUER");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, issuerPeerCertificate()).WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_ISSUER");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SUBJECT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    const std::string subject_peer =
+        "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
+    EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject_peer));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
+              upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SUBJECT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(EMPTY_STRING));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_SUBJECT");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    std::string expected_cert = "<some cert>";
+    EXPECT_CALL(*connection_info, urlEncodedPemEncodedPeerCertificate())
+        .WillRepeatedly(ReturnRef(expected_cert));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ(expected_cert, upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    std::string expected_cert = "";
+    EXPECT_CALL(*connection_info, urlEncodedPemEncodedPeerCertificate())
+        .WillRepeatedly(ReturnRef(expected_cert));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT_V_START");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    absl::Time abslStartTime =
+        TestUtility::parseTime("Dec 18 01:50:34 2018 GMT", "%b %e %H:%M:%S %Y GMT");
+    SystemTime startTime = absl::ToChronoTime(abslStartTime);
+    EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(startTime));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("2018-12-18T01:50:34.000Z",
+              upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT_V_START");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(absl::nullopt));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT_V_START");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT_V_END");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    absl::Time abslEndTime =
+        TestUtility::parseTime("Dec 17 01:50:34 2020 GMT", "%b %e %H:%M:%S %Y GMT");
+    SystemTime endTime = absl::ToChronoTime(abslEndTime);
+    EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(endTime));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("2020-12-17T01:50:34.000Z",
+              upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT_V_END");
+    auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
+    EXPECT_CALL(*connection_info, expirationPeerCertificate())
+        .WillRepeatedly(Return(absl::nullopt));
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, upstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    StreamInfoFormatter upstream_format("UPSTREAM_PEER_CERT_V_END");
+    EXPECT_EQ("-", upstream_format.format(header, header, header, stream_info));
+  }
 }
 
 TEST(AccessLogFormatterTest, requestHeaderFormatter) {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: Add access log extraction functions for use in the access log.
Risk Level: low
Testing: unit tests
Docs Changes: updated access log documentation
Release Notes: added upstream TLS info to the access log

/cc @incfly 