### PR TITLE
ratelimit: [#8565 Follow-up] [Perf] Allocate headers only if ratelimit service sends non-empty headers.

### DIFF
--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -101,6 +101,7 @@ message RateLimitResponse {
   // descriptors failed and/or what the currently configured limits are for all of them.
   repeated DescriptorStatus statuses = 2;
 
+  // A list of headers to add to the response
   // [#next-major-version: rename to response_headers_to_add]
   repeated api.v2.core.HeaderValue headers = 3;
 

--- a/api/envoy/service/ratelimit/v3alpha/rls.proto
+++ b/api/envoy/service/ratelimit/v3alpha/rls.proto
@@ -101,6 +101,7 @@ message RateLimitResponse {
   // descriptors failed and/or what the currently configured limits are for all of them.
   repeated DescriptorStatus statuses = 2;
 
+  // A list of headers to add to the response
   // [#next-major-version: rename to response_headers_to_add]
   repeated api.v3alpha.core.HeaderValue headers = 3;
 

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -73,15 +73,16 @@ void GrpcClientImpl::onSuccess(
     span.setTag(Constants::get().TraceStatus, Constants::get().TraceOk);
   }
 
-  Http::HeaderMapPtr response_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
+  Http::HeaderMapPtr response_headers_to_add, request_headers_to_add;
   if (!response->headers().empty()) {
+    response_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
     for (const auto& h : response->headers()) {
       response_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
 
-  Http::HeaderMapPtr request_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
   if (!response->request_headers_to_add().empty()) {
+    request_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
     for (const auto& h : response->request_headers_to_add()) {
       request_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -155,10 +155,11 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
                                            empty_stat_name,
                                            false};
     httpContext().codeStats().chargeResponseStat(info);
-    if (response_headers_to_add_) {
-      response_headers_to_add_->insertEnvoyRateLimited().value(
-          Http::Headers::get().EnvoyRateLimitedValues.True);
+    if (response_headers_to_add_ == nullptr) {
+      response_headers_to_add_ = std::make_unique<Http::HeaderMapImpl>();
     }
+    response_headers_to_add_->insertEnvoyRateLimited().value(
+        Http::Headers::get().EnvoyRateLimitedValues.True);
     break;
   }
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -155,8 +155,10 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
                                            empty_stat_name,
                                            false};
     httpContext().codeStats().chargeResponseStat(info);
-    response_headers_to_add_->insertEnvoyRateLimited().value(
-        Http::Headers::get().EnvoyRateLimitedValues.True);
+    if (response_headers_to_add_) {
+      response_headers_to_add_->insertEnvoyRateLimited().value(
+          Http::Headers::get().EnvoyRateLimitedValues.True);
+    }
     break;
   }
 


### PR DESCRIPTION
**Description**:
This is a follow up to [https://github.com/envoyproxy/envoy/pull/8565#discussion_r335727042](https://github.com/envoyproxy/envoy/pull/8565#discussion_r335727042)

- Allocate headers for callbacks only if ratelimit service sends non empty headers.
- Also, added back protobuf comment for response headers, which was overwritten.

**Risk Level**: Low
**Testing**:
    Passes "bazel test //test/..." in Linux

**Docs Changes**: protobuf documentation updated
