### PR TITLE
extensions: support disabling the grpc http1 reverse bridge filter per-route

### DIFF
--- a/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto
+++ b/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto
@@ -27,11 +27,7 @@ message FilterConfig {
 
 // gRPC reverse bridge filter configuration per virtualhost/route/weighted-cluster level.
 message FilterConfigPerRoute {
-  // It disables gRPC reverse bridge filter for this particular vhost or route.
+  // If true, disables gRPC reverse bridge filter for this particular vhost or route.
   // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
-  // The order is:
-  // - the routeEntry() (for config that's applied on weighted clusters)
-  // - the route
-  // - and finally from the virtual host object (routeEntry()->virtualhost()).
-  bool disabled = 1 [(validate.rules).bool = {const: true}];
+  bool disabled = 1;
 }

--- a/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto
+++ b/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto
@@ -24,3 +24,14 @@ message FilterConfig {
   // simple binary encoded protobuf.
   bool withhold_grpc_frames = 2;
 }
+
+// gRPC reverse bridge filter configuration per virtualhost/route/weighted-cluster level.
+message FilterConfigPerRoute {
+  // It disables gRPC reverse bridge filter for this particular vhost or route.
+  // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+  // The order is:
+  // - the routeEntry() (for config that's applied on weighted clusters)
+  // - the route
+  // - and finally from the virtual host object (routeEntry()->virtualhost()).
+  bool disabled = 1 [(validate.rules).bool = {const: true}];
+}

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -43,6 +43,7 @@ Version history
 * http: remove h2c upgrade headers for HTTP/1 as h2c upgrades are currently not supported.
 * http: absolute URL support is now on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
 * http: support :ref:`host rewrite <envoy_api_msg_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig>` in the dynamic forward proxy.
+* http: support :ref:`disable filter per route <envoy_api_msg_config.filter.http.grpc_http1_reverse_bridge.v2alpha1.FilterConfigPerRoute>` in the grpc http1 reverse bridge filter.
 * listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * listeners: added :ref:`connection balancer <envoy_api_field_Listener.connection_balance_config>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -43,7 +43,7 @@ Version history
 * http: remove h2c upgrade headers for HTTP/1 as h2c upgrades are currently not supported.
 * http: absolute URL support is now on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
 * http: support :ref:`host rewrite <envoy_api_msg_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig>` in the dynamic forward proxy.
-* http: support :ref:`disable filter per route <envoy_api_msg_config.filter.http.grpc_http1_reverse_bridge.v2alpha1.FilterConfigPerRoute>` in the grpc http1 reverse bridge filter.
+* http: support :ref:`disabling the filter per route <envoy_api_msg_config.filter.http.grpc_http1_reverse_bridge.v2alpha1.FilterConfigPerRoute>` in the grpc http1 reverse bridge filter.
 * listeners: added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
 * listeners: added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 * listeners: added :ref:`connection balancer <envoy_api_field_Listener.connection_balance_config>`

--- a/source/common/config/api_type_db.generated.pb_text
+++ b/source/common/config/api_type_db.generated.pb_text
@@ -4234,6 +4234,13 @@ types {
   }
 }
 types {
+  key: "envoy.config.filter.http.grpc_http1_reverse_bridge.v2alpha1.FilterConfigPerRoute"
+  value {
+    qualified_package: "envoy.config.filter.http.grpc_http1_reverse_bridge.v2alpha1"
+    proto_path: "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.proto"
+  }
+}
+types {
   key: "envoy.config.filter.http.gzip.v2.Gzip"
   value {
     qualified_package: "envoy.config.filter.http.gzip.v2"

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/BUILD
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/BUILD
@@ -19,8 +19,10 @@ envoy_cc_library(
         "//source/common/grpc:common_lib",
         "//source/common/grpc:status_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/http:utility_lib",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy_api//envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/http/grpc_http1_reverse_bridge/config.h"
 
+#include "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.validate.h"
 #include "envoy/registry/registry.h"
 
 #include "extensions/filters/http/grpc_http1_reverse_bridge/filter.h"
@@ -16,6 +17,13 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
     callbacks.addStreamFilter(
         std::make_unique<Filter>(config.content_type(), config.withhold_grpc_frames()));
   };
+}
+
+Router::RouteSpecificFilterConfigConstSharedPtr Config::createRouteSpecificFilterConfigTyped(
+    const envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute&
+        proto_config,
+    Server::Configuration::FactoryContext&) {
+  return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 
 /**

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -22,7 +22,7 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
 Router::RouteSpecificFilterConfigConstSharedPtr Config::createRouteSpecificFilterConfigTyped(
     const envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute&
         proto_config,
-    Server::Configuration::FactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {
   return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.h"
 #include "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.validate.h"
 #include "envoy/server/filter_config.h"
 
@@ -27,7 +28,8 @@ private:
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute&
           proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      ProtobufMessage::ValidationVisitor& validator) override;
 };
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -11,8 +11,10 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1ReverseBridge {
 
-class Config : public Common::FactoryBase<
-                   envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfig> {
+class Config
+    : public Common::FactoryBase<
+          envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfig,
+          envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute> {
 public:
   Config() : FactoryBase(HttpFilterNames::get().GrpcHttp1ReverseBridge) {}
 
@@ -20,6 +22,12 @@ public:
       const envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfig& config,
       const std::string& stat_prefix,
       Envoy::Server::Configuration::FactoryContext& context) override;
+
+private:
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute&
+          proto_config,
+      Server::Configuration::FactoryContext& context) override;
 };
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
@@ -41,6 +41,7 @@ private:
   // buffer we instead maintain our own.
   Buffer::OwnedImpl buffer_{};
 };
+
 class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
 public:
   FilterConfigPerRoute(
@@ -52,6 +53,7 @@ public:
 private:
   bool disabled_;
 };
+
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.validate.h"
+#include "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.h"
 #include "envoy/http/filter.h"
 
 #include "common/buffer/buffer_impl.h"

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.validate.h"
 #include "envoy/http/filter.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -39,6 +40,17 @@ private:
   // Normally we'd use the encoding buffer, but since we need to mutate the
   // buffer we instead maintain our own.
   Buffer::OwnedImpl buffer_{};
+};
+class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
+public:
+  FilterConfigPerRoute(
+      const envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute&
+          config)
+      : disabled_(config.disabled()) {}
+  bool disabled() const { return disabled_; }
+
+private:
+  bool disabled_;
 };
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -498,7 +498,7 @@ TEST_F(ReverseBridgeTest, GrpcRequestBadResponse) {
 }
 
 // Tests that the filter passes a GRPC request through without modification because it is disabled
-// per route
+// per route.
 TEST_F(ReverseBridgeTest, FilterConfigPerRouteDisabled) {
   initialize();
   decoder_callbacks_.is_grpc_request_ = true;
@@ -524,6 +524,95 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteDisabled) {
   EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "25"));
   EXPECT_THAT(headers,
               HeaderValueOf(Http::Headers::get().Path, "/testing.ExampleService/SendData"));
+}
+
+// Tests that a gRPC is downgraded to application/x-protobuf and upgraded back
+// to gRPC when the filter is enabled per route.
+TEST_F(ReverseBridgeTest, FilterConfigPerRouteEnabled) {
+  initialize();
+  decoder_callbacks_.is_grpc_request_ = true;
+
+  envoy::config::filter::http::grpc_http1_reverse_bridge::v2alpha1::FilterConfigPerRoute
+      filter_config_per_route;
+  filter_config_per_route.set_disabled(false);
+  FilterConfigPerRoute filterConfigPerRoute(filter_config_per_route);
+
+  ON_CALL(*decoder_callbacks_.route_,
+          perFilterConfig(HttpFilterNames::get().GrpcHttp1ReverseBridge))
+      .WillByDefault(testing::Return(&filterConfigPerRoute));
+
+  {
+    EXPECT_CALL(decoder_callbacks_, route()).Times(2);
+    EXPECT_CALL(decoder_callbacks_, clearRouteCache());
+    Http::TestHeaderMapImpl headers({{"content-type", "application/grpc"},
+                                     {"content-length", "25"},
+                                     {":path", "/testing.ExampleService/SendData"}});
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+
+    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
+    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "20"));
+    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+  }
+
+  {
+    // We should remove the first five bytes.
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcdefgh", 8);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
+    EXPECT_EQ("fgh", buffer.toString());
+  }
+
+  {
+    // Subsequent calls to decodeData should do nothing.
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcdefgh", 8);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
+    EXPECT_EQ("abcdefgh", buffer.toString());
+  }
+
+  {
+    Http::TestHeaderMapImpl trailers;
+    EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers));
+  }
+
+  Http::TestHeaderMapImpl headers(
+      {{":status", "200"}, {"content-length", "30"}, {"content-type", "application/x-protobuf"}});
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
+  EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "35"));
+
+  {
+    // First few calls should drain the buffer
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abc", 4);
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
+    EXPECT_EQ(0, buffer.length());
+  }
+  {
+    // First few calls should drain the buffer
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("def", 4);
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
+    EXPECT_EQ(0, buffer.length());
+  }
+  {
+    // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
+    Http::TestHeaderMapImpl trailers;
+    EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
+
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("ghj", 4);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, true));
+    EXPECT_EQ(17, buffer.length());
+    EXPECT_THAT(trailers, HeaderValueOf(Http::Headers::get().GrpcStatus, "0"));
+
+    Grpc::Decoder decoder;
+    std::vector<Grpc::Frame> frames;
+    decoder.decode(buffer, frames);
+
+    EXPECT_EQ(1, frames.size());
+    EXPECT_EQ(12, frames[0].length_);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Support disabling the filter per route in the grpc http1 reverse bridge filter.

Risk Level: low (adds per-filter config)
Testing: unit tests added
Docs: inline
Release Notes: updated
Fixes: #8052

Signed-off-by: Manuel Jurado <manuel.jurado@socialpoint.es>