### PR TITLE
upstream: ASSERT that transport socket callbacks are set at most once.

### DIFF
--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -8,6 +8,7 @@ namespace Envoy {
 namespace Network {
 
 void RawBufferSocket::setTransportSocketCallbacks(TransportSocketCallbacks& callbacks) {
+  ASSERT(!callbacks_);
   callbacks_ = &callbacks;
 }
 

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -22,6 +22,7 @@ TsiSocket::TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator ha
 TsiSocket::~TsiSocket() { ASSERT(!handshaker_); }
 
 void TsiSocket::setTransportSocketCallbacks(Envoy::Network::TransportSocketCallbacks& callbacks) {
+  ASSERT(!callbacks_);
   callbacks_ = &callbacks;
 
   noop_callbacks_ = std::make_unique<NoOpTransportSocketCallbacks>(callbacks);

--- a/source/extensions/transport_sockets/tap/tap.cc
+++ b/source/extensions/transport_sockets/tap/tap.cc
@@ -12,6 +12,7 @@ TapSocket::TapSocket(SocketTapConfigSharedPtr config,
     : config_(config), transport_socket_(std::move(transport_socket)) {}
 
 void TapSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) {
+  ASSERT(!tapper_);
   transport_socket_->setTransportSocketCallbacks(callbacks);
   tapper_ = config_ ? config_->createPerSocketTapper(callbacks.connection()) : nullptr;
 }


### PR DESCRIPTION
Description: Add ASSERTs to TransportSocket::setTransportSocketCallbacks implementations to verify that this method is called at most once, as implied by the API contract documented in envoy/network/transport_socket.h
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
