### PR TITLE
fuzz: a bunch of improvements to [new_]buffer_fuzz_test.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 /docs/root/intro/version_history.rst merge=union
 *.generated.pb_text linguist-generated=true
 *.generated.pb_text -diff -merge
+/test/**/*_corpus/* linguist-generated=true
+/test/**/*_corpus/* -diff -merge

--- a/test/common/buffer/buffer_corpus/case
+++ b/test/common/buffer/buffer_corpus/case
@@ -1,0 +1,594 @@
+actions { } actions { } actions { } actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer_fragment: 738197504
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_string: 1684078592
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  prepend_string: 65536
+}
+actions {
+}
+actions {
+  prepend_string: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}

--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5760708737761280
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5760708737761280
@@ -1,0 +1,2091 @@
+actions { } actions { } actions { } actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer_fragment: 738197504
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_string: 1684078592
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  prepend_string: 65536
+}
+actions {
+}
+actions {
+  prepend_string: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  read: 4
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  linearize: 0
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  read: 0
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  target_index: 5
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 5
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  read: 0
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 5
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 5
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 5
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  add_buffer: 1
+}
+actions {
+  write {
+  }
+}
+actions {
+}

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -31,11 +31,19 @@ constexpr uint32_t BufferCount = 3;
 // deallocation, just keep them around until the fuzz run is over.
 struct Context {
   std::vector<std::unique_ptr<Buffer::BufferFragmentImpl>> fragments_;
-  std::vector<std::unique_ptr<std::string>> strings_;
 };
 
-// Bound the maximum allocation size.
-constexpr uint32_t MaxAllocation = 2 * 1024 * 1024;
+// Bound the maximum allocation size per action. We want this to be able to at
+// least cover the span of multiple internal chunks. It looks like both
+// the new OwnedImpl and libevent have minimum chunks in O(a few kilobytes).
+// This makes sense in general, since you need to to minimize data structure
+// overhead. If we make this number too big, we risk spending a lot of time in
+// memcpy/memcmp and slowing down the fuzzer execution rate. The number below is
+// our current best compromise.
+constexpr uint32_t MaxAllocation = 16 * 1024;
+
+// Hard bound on total bytes allocated across the trace.
+constexpr uint32_t TotalMaxAllocation = 4 * MaxAllocation;
 
 uint32_t clampSize(uint32_t size, uint32_t max_alloc) {
   return std::min(size, std::min(MaxAllocation, max_alloc));
@@ -45,11 +53,26 @@ void releaseFragmentAllocation(const void* p, size_t, const Buffer::BufferFragme
   ::free(const_cast<void*>(p));
 }
 
-// Really simple string implementation of Buffer.
+// Test implementation of Buffer. Conceptually, this is just a string that we
+// can append/prepend to and consume bytes from the front of. However, naive
+// implementations with std::string involve lots of copying to support this, and
+// even std::stringbuf doesn't support cheap linearization. Instead we use a
+// flat array that takes advantage of the fact that the total number of bytes
+// allocated during fuzzing will be bounded by TotalMaxAllocation.
+//
+// The data structure is built around the concept of a large flat array of size
+// 2 * TotalMaxAllocation, with the initial start position set to the middle.
+// The goal is to make every mutating operation linear time, including
+// add() and prepend(), as well as supporting O(1) linearization (critical to
+// making it cheaper to compare results with the real buffer implementation).
+// We maintain a (start, length) pair and ensure via assertions that we never
+// walk off the edge; the caller should be guaranteeing this.
 class StringBuffer : public Buffer::Instance {
 public:
   void add(const void* data, uint64_t size) override {
-    data_ += std::string(std::string(static_cast<const char*>(data), size));
+    FUZZ_ASSERT(start_ + size_ + size <= data_.size());
+    ::memcpy(mutableEnd(), data, size);
+    size_ += size;
   }
 
   void addBufferFragment(Buffer::BufferFragment& fragment) override {
@@ -61,87 +84,112 @@ public:
 
   void add(const Buffer::Instance& data) override {
     const StringBuffer& src = dynamic_cast<const StringBuffer&>(data);
-    data_ += src.data_;
+    add(src.start(), src.size_);
   }
 
-  void prepend(absl::string_view data) override { data_ = std::string(data) + data_; }
+  void prepend(absl::string_view data) override {
+    FUZZ_ASSERT(start_ >= data.size());
+    start_ -= data.size();
+    size_ += data.size();
+    ::memcpy(mutableStart(), data.data(), data.size());
+  }
 
   void prepend(Instance& data) override {
     StringBuffer& src = dynamic_cast<StringBuffer&>(data);
-    data_ = src.data_ + data_;
-    src.data_.clear();
+    prepend(src.asStringView());
+    src.size_ = 0;
   }
 
   void commit(Buffer::RawSlice* iovecs, uint64_t num_iovecs) override {
     FUZZ_ASSERT(num_iovecs == 1);
-    FUZZ_ASSERT(tmp_buf_.get() == iovecs[0].mem_);
-    data_ += std::string(tmp_buf_.get(), iovecs[0].len_);
+    size_ += iovecs[0].len_;
   }
 
   void copyOut(size_t start, uint64_t size, void* data) const override {
-    ::memcpy(data, data_.data() + start, size);
+    ::memcpy(data, this->start() + start, size);
   }
 
-  void drain(uint64_t size) override { data_ = data_.substr(size); }
+  void drain(uint64_t size) override {
+    FUZZ_ASSERT(size <= size_);
+    start_ += size;
+    size_ -= size;
+  }
 
   uint64_t getRawSlices(Buffer::RawSlice* out, uint64_t out_size) const override {
-    FUZZ_ASSERT(out_size > 0);
+    if (out_size == 0) {
+      return 1;
+    }
     // Sketchy, but probably will work for test purposes.
-    out->mem_ = const_cast<char*>(data_.data());
-    out->len_ = data_.size();
+    out->mem_ = const_cast<char*>(start());
+    out->len_ = size_;
     return 1;
   }
 
-  uint64_t length() const override { return data_.size(); }
+  uint64_t length() const override { return size_; }
 
   void* linearize(uint32_t /*size*/) override {
     // Sketchy, but probably will work for test purposes.
-    return const_cast<char*>(data_.data());
+    return mutableStart();
   }
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }
 
   void move(Buffer::Instance& rhs, uint64_t length) override {
     StringBuffer& src = dynamic_cast<StringBuffer&>(rhs);
-    data_ += src.data_.substr(0, length);
-    src.data_ = src.data_.substr(length);
+    add(src.start(), length);
+    src.start_ += length;
+    src.size_ -= length;
   }
 
   Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override {
-    FUZZ_ASSERT(max_length <= MaxAllocation);
-    Buffer::RawSlice slice{tmp_buf_.get(), MaxAllocation};
+    FUZZ_ASSERT(start_ + size_ + max_length <= data_.size());
+    Buffer::RawSlice slice{mutableEnd(), max_length};
     Api::IoCallUint64Result result = io_handle.readv(max_length, &slice, 1);
     FUZZ_ASSERT(result.ok() && result.rc_ > 0);
-    data_ += std::string(tmp_buf_.get(), result.rc_);
+    size_ += result.rc_;
     return result;
   }
 
   uint64_t reserve(uint64_t length, Buffer::RawSlice* iovecs, uint64_t num_iovecs) override {
     FUZZ_ASSERT(num_iovecs > 0);
-    FUZZ_ASSERT(length <= MaxAllocation);
-    iovecs[0].mem_ = tmp_buf_.get();
+    FUZZ_ASSERT(start_ + size_ + length <= data_.size());
+    iovecs[0].mem_ = mutableEnd();
     iovecs[0].len_ = length;
     return 1;
   }
 
   ssize_t search(const void* data, uint64_t size, size_t start) const override {
-    return data_.find(std::string(static_cast<const char*>(data), size), start);
+    return asStringView().find({static_cast<const char*>(data), size}, start);
   }
 
-  bool startsWith(absl::string_view data) const override { return absl::StartsWith(data_, data); }
+  bool startsWith(absl::string_view data) const override {
+    return absl::StartsWith(asStringView(), data);
+  }
 
-  std::string toString() const override { return data_; }
+  std::string toString() const override { return std::string(data_.data() + start_, size_); }
 
   Api::IoCallUint64Result write(Network::IoHandle& io_handle) override {
-    const Buffer::RawSlice slice{const_cast<char*>(data_.data()), data_.size()};
+    const Buffer::RawSlice slice{const_cast<char*>(start()), size_};
     Api::IoCallUint64Result result = io_handle.writev(&slice, 1);
     FUZZ_ASSERT(result.ok());
-    data_ = data_.substr(result.rc_);
+    start_ += result.rc_;
+    size_ -= result.rc_;
     return result;
   }
 
-  std::string data_;
-  std::unique_ptr<char[]> tmp_buf_{new char[MaxAllocation]};
+  absl::string_view asStringView() const { return {start(), size_}; }
+
+  char* mutableStart() { return data_.data() + start_; }
+
+  const char* start() const { return data_.data() + start_; }
+
+  char* mutableEnd() { return mutableStart() + size_; }
+
+  const char* end() const { return start() + size_; }
+
+  std::array<char, 2 * TotalMaxAllocation> data_;
+  uint32_t start_{TotalMaxAllocation};
+  uint32_t size_{0};
 };
 
 using BufferList = std::vector<std::unique_ptr<Buffer::Instance>>;
@@ -163,21 +211,14 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     auto fragment =
         std::make_unique<Buffer::BufferFragmentImpl>(p, size, releaseFragmentAllocation);
     ctxt.fragments_.emplace_back(std::move(fragment));
-    const uint32_t previous_length = target_buffer.length();
-    const std::string new_value{static_cast<char*>(p), size};
     target_buffer.addBufferFragment(*ctxt.fragments_.back());
-    FUZZ_ASSERT(previous_length == target_buffer.search(new_value.data(), size, previous_length));
     break;
   }
   case test::common::buffer::Action::kAddString: {
     const uint32_t size = clampSize(action.add_string(), max_alloc);
     allocated += size;
-    auto string = std::make_unique<std::string>(size, insert_value);
-    ctxt.strings_.emplace_back(std::move(string));
-    const uint32_t previous_length = target_buffer.length();
-    target_buffer.add(absl::string_view(*ctxt.strings_.back()));
-    FUZZ_ASSERT(previous_length ==
-                target_buffer.search(ctxt.strings_.back()->data(), size, previous_length));
+    const std::string data(size, insert_value);
+    target_buffer.add(data);
     break;
   }
   case test::common::buffer::Action::kAddBuffer: {
@@ -186,20 +227,18 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
       break;
     }
     Buffer::Instance& source_buffer = *buffers[source_index];
-    const std::string source_contents = source_buffer.toString();
-    const uint32_t previous_length = target_buffer.length();
+    if (source_buffer.length() > max_alloc) {
+      break;
+    }
+    allocated += source_buffer.length();
     target_buffer.add(source_buffer);
-    FUZZ_ASSERT(previous_length == target_buffer.search(source_contents.data(),
-                                                        source_contents.size(), previous_length));
     break;
   }
   case test::common::buffer::Action::kPrependString: {
     const uint32_t size = clampSize(action.prepend_string(), max_alloc);
     allocated += size;
-    auto string = std::make_unique<std::string>(size, insert_value);
-    ctxt.strings_.emplace_back(std::move(string));
-    target_buffer.prepend(absl::string_view(*ctxt.strings_.back()));
-    FUZZ_ASSERT(target_buffer.search(ctxt.strings_.back()->data(), size, 0) == 0);
+    const std::string data(size, insert_value);
+    target_buffer.prepend(data);
     break;
   }
   case test::common::buffer::Action::kPrependBuffer: {
@@ -208,13 +247,14 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
       break;
     }
     Buffer::Instance& source_buffer = *buffers[source_index];
-    const std::string source_contents = source_buffer.toString();
+    if (source_buffer.length() > max_alloc) {
+      break;
+    }
+    allocated += source_buffer.length();
     target_buffer.prepend(source_buffer);
-    FUZZ_ASSERT(target_buffer.search(source_contents.data(), source_contents.size(), 0) == 0);
     break;
   }
   case test::common::buffer::Action::kReserveCommit: {
-    const uint32_t previous_length = target_buffer.length();
     const uint32_t reserve_length = clampSize(action.reserve_commit().reserve_length(), max_alloc);
     allocated += reserve_length;
     if (reserve_length == 0) {
@@ -245,19 +285,18 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
       slices[shrink_slice--].len_ = 0;
     }
     target_buffer.commit(slices, allocated_slices);
-    FUZZ_ASSERT(previous_length + target_length == target_buffer.length());
     break;
   }
   case test::common::buffer::Action::kCopyOut: {
     const uint32_t start =
         std::min(action.copy_out().start(), static_cast<uint32_t>(target_buffer.length()));
-    uint8_t copy_buffer[2 * 1024 * 1024];
     const uint32_t length =
-        std::min(static_cast<uint32_t>(target_buffer.length() - start),
-                 std::min(action.copy_out().length(), static_cast<uint32_t>(sizeof(copy_buffer))));
+        std::min(static_cast<uint32_t>(target_buffer.length() - start), action.copy_out().length());
+    // Make this static to avoid potential continuous ASAN inspired allocation.
+    static uint8_t copy_buffer[TotalMaxAllocation];
     target_buffer.copyOut(start, length, copy_buffer);
-    const std::string contents = target_buffer.toString();
-    FUZZ_ASSERT(::memcmp(copy_buffer, contents.data() + start, length) == 0);
+    const std::string data = target_buffer.toString();
+    FUZZ_ASSERT(::memcmp(copy_buffer, data.data() + start, length) == 0);
     break;
   }
   case test::common::buffer::Action::kDrain: {
@@ -272,12 +311,6 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     const uint32_t linearize_size =
         std::min(static_cast<uint32_t>(target_buffer.length()), action.linearize());
     target_buffer.linearize(linearize_size);
-    Buffer::RawSlice slices[1];
-    const uint64_t slices_used = target_buffer.getRawSlices(slices, 1);
-    if (linearize_size > 0) {
-      FUZZ_ASSERT(slices_used >= 1);
-      FUZZ_ASSERT(slices[0].len_ >= linearize_size);
-    }
     break;
   }
   case test::common::buffer::Action::kMove: {
@@ -288,9 +321,16 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     Buffer::Instance& source_buffer = *buffers[source_index];
     if (action.move().length() == 0) {
       target_buffer.move(source_buffer);
+      if (source_buffer.length() > max_alloc) {
+        break;
+      }
+      allocated += source_buffer.length();
     } else {
-      target_buffer.move(source_buffer, std::min(static_cast<uint32_t>(source_buffer.length()),
-                                                 action.move().length()));
+      const uint32_t source_length =
+          std::min(static_cast<uint32_t>(source_buffer.length()), action.move().length());
+      const uint32_t move_length = clampSize(max_alloc, source_length);
+      target_buffer.move(source_buffer, move_length);
+      allocated += move_length;
     }
     break;
   }
@@ -308,11 +348,9 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     std::string data(max_length, insert_value);
     const ssize_t rc = ::write(pipe_fds[1], data.data(), max_length);
     FUZZ_ASSERT(rc > 0);
-    const uint32_t previous_length = target_buffer.length();
     Api::IoCallUint64Result result = target_buffer.read(io_handle, max_length);
     FUZZ_ASSERT(result.rc_ == static_cast<uint64_t>(rc));
     FUZZ_ASSERT(::close(pipe_fds[1]) == 0);
-    FUZZ_ASSERT(previous_length == target_buffer.search(data.data(), rc, previous_length));
     break;
   }
   case test::common::buffer::Action::kWrite: {
@@ -341,6 +379,39 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     FUZZ_ASSERT(::close(pipe_fds[0]) == 0);
     break;
   }
+  case test::common::buffer::Action::kGetRawSlices: {
+    const uint64_t slices_needed = target_buffer.getRawSlices(nullptr, 0);
+    const uint64_t slices_tested =
+        std::min(slices_needed, static_cast<uint64_t>(action.get_raw_slices()));
+    if (slices_tested == 0) {
+      break;
+    }
+    std::vector<Buffer::RawSlice> raw_slices{slices_tested};
+    const uint64_t slices_obtained = target_buffer.getRawSlices(raw_slices.data(), slices_tested);
+    FUZZ_ASSERT(slices_obtained <= slices_needed);
+    uint64_t offset = 0;
+    const std::string data = target_buffer.toString();
+    for (const auto& raw_slices : raw_slices) {
+      FUZZ_ASSERT(::memcmp(raw_slices.mem_, data.data() + offset, raw_slices.len_) == 0);
+      offset += raw_slices.len_;
+    }
+    FUZZ_ASSERT(slices_needed != slices_tested || offset == target_buffer.length());
+    break;
+  }
+  case test::common::buffer::Action::kSearch: {
+    const std::string& content = action.search().content();
+    const uint32_t offset = action.search().offset();
+    const std::string data = target_buffer.toString();
+    FUZZ_ASSERT(target_buffer.search(content.data(), content.size(), offset) ==
+                static_cast<ssize_t>(target_buffer.toString().find(content, offset)));
+    break;
+  }
+  case test::common::buffer::Action::kStartsWith: {
+    const std::string data = target_buffer.toString();
+    FUZZ_ASSERT(target_buffer.startsWith(action.starts_with()) ==
+                (data.find(action.starts_with()) == 0));
+    break;
+  }
   default:
     // Maybe nothing is set?
     break;
@@ -351,29 +422,15 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
 
 } // namespace
 
-void BufferFuzz::bufferFuzz(const test::common::buffer::BufferFuzzTestCase& input, bool old_impl) {
-  ENVOY_LOG_MISC(trace, "Using {} buffer implementation", old_impl ? "old" : "new");
-  Buffer::OwnedImpl::useOldImpl(old_impl);
-  Context ctxt;
-  // Fuzzed buffers.
-  BufferList buffers;
-  // Shadow buffers based on StringBuffer.
-  BufferList linear_buffers;
-  for (uint32_t i = 0; i < BufferCount; ++i) {
-    buffers.emplace_back(new Buffer::OwnedImpl());
-    linear_buffers.emplace_back(new StringBuffer());
-  }
-
-  const uint64_t initial_allocated_bytes = Memory::Stats::totalCurrentlyAllocated();
-
+void executeActions(const test::common::buffer::BufferFuzzTestCase& input, BufferList& buffers,
+                    BufferList& linear_buffers, Context& ctxt) {
   // Soft bound on the available memory for allocation to avoid OOMs and
   // timeouts.
   uint32_t available_alloc = 2 * MaxAllocation;
-  constexpr auto max_actions = 1024;
+  constexpr auto max_actions = 128;
   for (int i = 0; i < std::min(max_actions, input.actions().size()); ++i) {
     const char insert_value = 'a' + i % 26;
     const auto& action = input.actions(i);
-    const uint64_t current_allocated_bytes = Memory::Stats::totalCurrentlyAllocated();
     ENVOY_LOG_MISC(debug, "Action {}", action.DebugString());
     const uint32_t allocated = bufferAction(ctxt, insert_value, available_alloc, buffers, action);
     const uint32_t linear_allocated =
@@ -388,38 +445,49 @@ void BufferFuzz::bufferFuzz(const test::common::buffer::BufferFuzzTestCase& inpu
       ENVOY_LOG_MISC(trace, "L: {}", linear_buffers[j]->toString());
     }
     // Verification pass, only non-mutating methods for buffers.
+    uint64_t current_allocated_bytes = 0;
     for (uint32_t j = 0; j < BufferCount; ++j) {
-      if (buffers[j]->toString() != linear_buffers[j]->toString()) {
+      // As an optimization, since we know that StringBuffer is just going to
+      // return the pointer to its std::string array, we can avoid the
+      // toString() copy here.
+      const uint64_t linear_buffer_length = linear_buffers[j]->length();
+      if (buffers[j]->toString() !=
+          absl::string_view(
+              static_cast<const char*>(linear_buffers[j]->linearize(linear_buffer_length)),
+              linear_buffer_length)) {
         ENVOY_LOG_MISC(debug, "Mismatched buffers at index {}", j);
         ENVOY_LOG_MISC(debug, "B: {}", buffers[j]->toString());
         ENVOY_LOG_MISC(debug, "L: {}", linear_buffers[j]->toString());
         FUZZ_ASSERT(false);
       }
-      FUZZ_ASSERT(buffers[j]->length() == linear_buffers[j]->length());
-      constexpr uint32_t max_slices = 16;
-      Buffer::RawSlice slices[max_slices];
-      buffers[j]->getRawSlices(slices, max_slices);
-      // This string should never appear (e.g. we don't synthesize _garbage as a
-      // pattern), verify that it's never found.
-      std::string garbage{"_garbage"};
-      FUZZ_ASSERT(buffers[j]->search(garbage.data(), garbage.size(), 0) == -1);
+      FUZZ_ASSERT(buffers[j]->length() == linear_buffer_length);
+      current_allocated_bytes += linear_buffer_length;
     }
-    ENVOY_LOG_MISC(debug, "[{} MB allocated total, {} MB since start]",
-                   current_allocated_bytes / (1024.0 * 1024),
-                   (current_allocated_bytes - initial_allocated_bytes) / (1024.0 * 1024));
+    ENVOY_LOG_MISC(debug, "[{} MB allocated total]", current_allocated_bytes / (1024.0 * 1024));
     // We bail out if buffers get too big, otherwise we will OOM the sanitizer.
     // We can't use Memory::Stats::totalCurrentlyAllocated() here as we don't
     // have tcmalloc in ASAN builds, so just do a simple count.
-    uint64_t total_length = 0;
-    for (const auto& buf : buffers) {
-      total_length += buf->length();
-    }
-    if (total_length > 4 * MaxAllocation) {
+    if (current_allocated_bytes > TotalMaxAllocation) {
       ENVOY_LOG_MISC(debug, "Terminating early with total buffer length {} to avoid OOM",
-                     total_length);
+                     current_allocated_bytes);
       break;
     }
   }
+}
+
+void BufferFuzz::bufferFuzz(const test::common::buffer::BufferFuzzTestCase& input, bool old_impl) {
+  ENVOY_LOG_MISC(trace, "Using {} buffer implementation", old_impl ? "old" : "new");
+  Buffer::OwnedImpl::useOldImpl(old_impl);
+  Context ctxt;
+  // Fuzzed buffers.
+  BufferList buffers;
+  // Shadow buffers based on StringBuffer.
+  BufferList linear_buffers;
+  for (uint32_t i = 0; i < BufferCount; ++i) {
+    buffers.emplace_back(new Buffer::OwnedImpl());
+    linear_buffers.emplace_back(new StringBuffer());
+  }
+  executeActions(input, buffers, linear_buffers, ctxt);
 }
 
 } // namespace Envoy

--- a/test/common/buffer/buffer_fuzz.proto
+++ b/test/common/buffer/buffer_fuzz.proto
@@ -19,6 +19,11 @@ message Move {
   uint32 length = 2;
 }
 
+message Search {
+  string content = 1;
+  uint32 offset = 2;
+}
+
 message Action {
   uint32 target_index = 1;
   oneof action_selector {
@@ -34,6 +39,9 @@ message Action {
     Move move = 11;
     uint32 read = 12;
     google.protobuf.Empty write = 13;
+    uint32 get_raw_slices = 14;
+    Search search = 15;
+    string starts_with = 16;
   }
 }
 

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -600,6 +600,7 @@ matcher
 matchers
 mcontext
 mem
+memcmp
 memcpy
 midp
 milli


### PR DESCRIPTION
Motivated by the timeout in
clusterfuzz-testcase-minimized-buffer_fuzz_test-5760708737761280 (>
25s), it was clear that there are some major inefficiencies in how we
fuzz the buffer implementations. This PR addresses them, namely:

* The StringBuffer implementation that was used for differential
  fuzzing (for correctness) was too simplistic, and had O(n^2)
  characteristics, e.g. each action that drained a single byte forced
  the buffer to be memcopied. Replaced with a fast flat array that takes
  advantage of the bounded nature of input in the fuzz test to achieve
  optimal operations, while remaining simple enough to grok.

* Various accessor operations, e.g. search, were previously tested next
  to mutating operations. This is kind of expensive, as we might double
  work, or turn an O(1) operation into O(n). Instead, these are now
  modeled as explicit actions.

* Used Linux perf events profiling to tune buffer and action bounds to
  improve performance. Went from > 50% of time spent in memcpy/memset to
  ~10% of time spent in the entire test code. The rest of the time is
  spent in libproto-mutator. This is in part because we use text vs.
  binary, and also because of a lack of -max_len on the fuzzer CLI.
  @asraa plans on following up on this in the future, as this is a
  general cross fuzzer concern in Envoy, we rely heavily on
  libproto-mutator.

The clusterfuzz-testcase-minimized-buffer_fuzz_test-5760708737761280
case now passes in milliseconds. With -max_len set to 512, we now
converge  new_buffer_fuzz_test after a while at 540/s, vs. previously at
30 exec/s (with Clang 9).

Also, some other technical debt pay down and bonus items:

* Fixed max allocation accounting in various places in bufferFuzz() and
  executeActions().

* Tell git and GitHub to treat corpus entries similar to binary; don't
  include them in language stats for the repo.

Risk level: Low (testing only)
Testing: Built and ran test locally for ~10 minutes, no crashes.

Signed-off-by: Harvey Tuch <htuch@google.com>