### PR TITLE
http: fix ssl_redirect on external

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -70,23 +70,23 @@ HeaderUtility::HeaderData::HeaderData(const Json::Object& config)
         return header_matcher;
       }()) {}
 
-void HeaderUtility::getAllOfHeader(const Http::HeaderMap& headers, absl::string_view key,
+void HeaderUtility::getAllOfHeader(const HeaderMap& headers, absl::string_view key,
                                    std::vector<absl::string_view>& out) {
   auto args = std::make_pair(LowerCaseString(std::string(key)), &out);
 
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> Envoy::Http::HeaderMap::Iterate {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         auto key_ret =
             static_cast<std::pair<LowerCaseString, std::vector<absl::string_view>*>*>(context);
         if (header.key() == key_ret->first.get().c_str()) {
           key_ret->second->emplace_back(header.value().getStringView());
         }
-        return Envoy::Http::HeaderMap::Iterate::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       &args);
 }
 
-bool HeaderUtility::matchHeaders(const Http::HeaderMap& request_headers,
+bool HeaderUtility::matchHeaders(const HeaderMap& request_headers,
                                  const std::vector<HeaderDataPtr>& config_headers) {
   // No headers to match is considered a match.
   if (!config_headers.empty()) {
@@ -100,9 +100,8 @@ bool HeaderUtility::matchHeaders(const Http::HeaderMap& request_headers,
   return true;
 }
 
-bool HeaderUtility::matchHeaders(const Http::HeaderMap& request_headers,
-                                 const HeaderData& header_data) {
-  const Http::HeaderEntry* header = request_headers.get(header_data.name_);
+bool HeaderUtility::matchHeaders(const HeaderMap& request_headers, const HeaderData& header_data) {
+  const HeaderEntry* header = request_headers.get(header_data.name_);
 
   if (header == nullptr) {
     return header_data.invert_match_ && header_data.header_match_type_ == HeaderMatchType::Present;
@@ -144,17 +143,23 @@ bool HeaderUtility::headerIsValid(const absl::string_view header_value) {
                                      header_value.size()) != 0);
 }
 
-void HeaderUtility::addHeaders(Http::HeaderMap& headers, const Http::HeaderMap& headers_to_add) {
+void HeaderUtility::addHeaders(HeaderMap& headers, const HeaderMap& headers_to_add) {
   headers_to_add.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-        Http::HeaderString k;
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
+        HeaderString k;
         k.setCopy(header.key().getStringView());
-        Http::HeaderString v;
+        HeaderString v;
         v.setCopy(header.value().getStringView());
-        static_cast<Http::HeaderMapImpl*>(context)->addViaMove(std::move(k), std::move(v));
-        return Http::HeaderMap::Iterate::Continue;
+        static_cast<HeaderMapImpl*>(context)->addViaMove(std::move(k), std::move(v));
+        return HeaderMap::Iterate::Continue;
       },
       &headers);
+}
+
+bool HeaderUtility::isEnvoyInternalRequest(const HeaderMap& headers) {
+  const HeaderEntry* internal_request_header = headers.EnvoyInternalRequest();
+  return internal_request_header &&
+         internal_request_header->value() == Headers::get().EnvoyInternalRequestValues.True;
 }
 
 } // namespace Http

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -103,6 +103,11 @@ public:
    * @param headers_to_add supplies the headers to be added
    */
   static void addHeaders(HeaderMap& headers, const HeaderMap& headers_to_add);
+
+  /**
+   * @brief a helper function to determine if the headers represent an envoy internal request
+   */
+  static bool isEnvoyInternalRequest(const HeaderMap& headers);
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1003,7 +1003,8 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& 
   if (ssl_requirements_ == SslRequirements::ALL && forwarded_proto_header->value() != "https") {
     return SSL_REDIRECT_ROUTE;
   } else if (ssl_requirements_ == SslRequirements::EXTERNAL_ONLY &&
-             forwarded_proto_header->value() != "https" && !headers.EnvoyInternalRequest()) {
+             forwarded_proto_header->value() != "https" &&
+             not Http::HeaderUtility::isEnvoyInternalRequest(headers)) {
     return SSL_REDIRECT_ROUTE;
   }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -286,12 +286,9 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
   ASSERT(response_status_code == Http::Utility::getResponseStatus(response_headers));
   if (config_.emit_dynamic_stats_ && !callbacks_->streamInfo().healthCheck()) {
     const Http::HeaderEntry* upstream_canary_header = response_headers.EnvoyUpstreamCanary();
-    const Http::HeaderEntry* internal_request_header = downstream_headers_->EnvoyInternalRequest();
-
     const bool is_canary = (upstream_canary_header && upstream_canary_header->value() == "true") ||
                            (upstream_host ? upstream_host->canary() : false);
-    const bool internal_request =
-        internal_request_header && internal_request_header->value() == "true";
+    const bool internal_request = Http::HeaderUtility::isEnvoyInternalRequest(*downstream_headers_);
 
     Stats::StatName upstream_zone = upstreamZone(upstream_host);
     Http::CodeStats::ResponseStatInfo info{config_.scope_,
@@ -1213,12 +1210,8 @@ void Filter::onUpstreamComplete(UpstreamRequest& upstream_request) {
     Event::Dispatcher& dispatcher = callbacks_->dispatcher();
     std::chrono::milliseconds response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
         dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
-
     upstream_request.upstream_host_->outlierDetector().putResponseTime(response_time);
-
-    const Http::HeaderEntry* internal_request_header = downstream_headers_->EnvoyInternalRequest();
-    const bool internal_request =
-        internal_request_header && internal_request_header->value() == "true";
+    const bool internal_request = Http::HeaderUtility::isEnvoyInternalRequest(*downstream_headers_);
 
     Http::CodeStats& code_stats = httpContext().codeStats();
     Http::CodeStats::ResponseTimingInfo info{config_.scope_,

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -26,9 +26,7 @@ struct RcDetailsValues {
 using RcDetails = ConstSingleton<RcDetailsValues>;
 
 void Filter::initiateCall(const Http::HeaderMap& headers) {
-  bool is_internal_request =
-      headers.EnvoyInternalRequest() && (headers.EnvoyInternalRequest()->value() == "true");
-
+  bool is_internal_request = Http::HeaderUtility::isEnvoyInternalRequest(headers);
   if ((is_internal_request && config_->requestType() == FilterRequestType::External) ||
       (!is_internal_request && config_->requestType() == FilterRequestType::Internal)) {
     return;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -128,7 +128,7 @@ public:
                                                        random_, local_info_)
             ->asString();
     ConnectionManagerUtility::mutateTracingRequestHeader(headers, runtime_, config_, &route_);
-    ret.internal_ = headers.EnvoyInternalRequest() != nullptr;
+    ret.internal_ = HeaderUtility::isEnvoyInternalRequestheaders(headers);
     return ret;
   }
 


### PR DESCRIPTION
Description: ssl_redirect on external only is not doing as declared
The reason is  that it doesn't determines whether the request is internal in the common approach.
Expect: check the header exists and the value is "true" as everywhere else in the code base.

Risk Level: HIGH, maybe. Since ssl_redirect on EXTERNAL_ONLY may see different(but correct!) behavior. 

Testing:
Docs Changes:
Signed-off-by: Yuchen Dai <silentdai@gmail.com>