### PR TITLE
docs: fixed wrong reference to the idle_timeout field of the HTTP connection manager

### DIFF
--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -43,7 +43,7 @@ Version 1.12.0 (pending)
 
 1.11.2 (October 8, 2019)
 ========================
-* Use of :ref:`idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>` is deprecated. Use :ref:`idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>` instead.
+* Use of :ref:`idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>` is deprecated. Use :ref:`common_http_protocol_options <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>` instead.
 
 
 Version 1.11.0 (July 11, 2019)


### PR DESCRIPTION
Description: this PR fixes a mistake in the documentation whereby the field to use instead of the deprecated `idle_timeout` is referenced as `idle_timeout`. The link itself is correct, however, and points to `common_http_protocol_options`.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A