### PR TITLE
stats: Add instructions in comments describing what to do if a stats memory test fails

### DIFF
--- a/source/docs/stats.md
+++ b/source/docs/stats.md
@@ -171,3 +171,32 @@ TBD
 ## Disabling statistics by substring or regex
 
 TBD
+
+## Stats Memory Tests
+
+Regardless of the underlying data structures used to implement statistics,
+memory usage will grow with the number of hosts and clusters. When a PR is
+issued that adds new per-host or per-cluster stats, this will have a
+multiplicative effect on consumed memory. This can become significant for
+deployments with O(10k) clusters or hosts.
+
+To improve visibility for this memory growth, there are [memory-usage
+integration
+tests](https://github.com/envoyproxy/envoy/blob/master/test/integration/stats_integration_test.cc).
+
+If a PR fails the tests in that file due to unexpected memory consumption, it
+gives the author and reviewer an opportunity to consider the cost/value of the
+new stats. If the test fails because the new byte-count is lower, then all
+that's needed is to lock in the improvement by updating the expected values. If
+the new per-cluster or per-host memory consumption is higher, then we must
+decide whether the value from the added stats justify the overhead for all Envoy
+deployments. In either case, we must update the golden values and add a comment
+to the table in the test indicating the memory impact of each PR.
+
+Developers trying to can iterate through changes in these tests locally with:
+
+```bash
+  bazel test -c opt --test_env=ENVOY_MEMORY_TEST_EXACT=true \
+      test/integration:stats_integration_test
+```
+

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -266,6 +266,10 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
   // On a local clang8/libstdc++/linux flow, the memory usage was observed in
   // June 2019 to be 64 bytes higher than it is in CI/release. Your mileage may
   // vary.
+  //
+  // If you encounter a failure here, please see
+  // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
+  // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 43340); // 104 bytes higher than a debug build.
   EXPECT_MEMORY_LE(m_per_cluster, 44000);
 }
@@ -306,6 +310,10 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // On a local clang8/libstdc++/linux flow, the memory usage was observed in
   // June 2019 to be 64 bytes higher than it is in CI/release. Your mileage may
   // vary.
+  //
+  // If you encounter a failure here, please see
+  // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
+  // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 34998); // 104 bytes higher than a debug build.
   EXPECT_MEMORY_LE(m_per_cluster, 36000);
 }
@@ -337,6 +345,10 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // 'release' builds, where we control the platform and tool-chain. So you
   // will need to find the correct value only after failing CI and looking
   // at the logs.
+  //
+  // If you encounter a failure here, please see
+  // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
+  // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_host, 1283);
   EXPECT_MEMORY_LE(m_per_host, 1315);
 }


### PR DESCRIPTION
Description: Adds comments in stats_integration_test describing how to resolve failures.
Risk Level: very low (comment change)
Testing: //test/integration:stats_integration_test
Docs Changes: n/a
Release Notes: n/a
Fixes: #7336 
