### PR TITLE
Use shared instead of unique ptr to avoid conversion

### DIFF
--- a/source/extensions/filters/http/original_src/original_src_config_factory.cc
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.cc
@@ -16,7 +16,7 @@ Http::FilterFactoryCb OriginalSrcConfigFactory::createFilterFactoryFromProtoType
     const std::string&, Server::Configuration::FactoryContext&) {
   Config config(proto_config);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_unique<OriginalSrcFilter>(config));
+    callbacks.addStreamDecoderFilter(std::make_shared<OriginalSrcFilter>(config));
   };
 }
 


### PR DESCRIPTION
addStreamDecoderFilter() takes a shared ptr.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
