### PR TITLE
router check: add flag to enforce coverage failure threshold increases

### DIFF
--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -205,6 +205,7 @@ to the file where the coverage value is being set. This aids in making the requi
 changes to the coverage threshold.
 
 .. code:: bash
+
   > ENVOY_COV_CONFIG_FILE="run_cov.sh" bazel-bin/test/tools/router_check/router_check_tool --config-path ... --test-path ... --useproto --f 7 -i --covall
   Current route coverage: 6.2948%
   Failed due to stale coverage threshold.

--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -183,3 +183,29 @@ fields that could be tested.
   > bazel-bin/test/tools/router_check/router_check_tool --config-path ... --test-path ... --useproto --f 7 --covall
   Current route coverage: 6.2948%
   Failed to meet coverage requirement: 7%
+
+When the fail under flag is set an optional flag (`-i` or `--increase-cov`) can
+be included to enforce the minimum coverage threshold matches the current coverage.
+This prevents the enforced coverage value from becoming stale as new tests are added
+and ensures coverage regressions don't occur if the value is set below the current coverage.
+
+.. note::
+
+  This will only take effect if the fail under flag is set and the current coverage
+  requirement is met.
+
+.. code:: bash
+
+  > bazel-bin/test/tools/router_check/router_check_tool --config-path ... --test-path ... --useproto --f 7 -i --covall
+  Current route coverage: 6.2948%
+  Failed due to stale coverage threshold.
+
+Additionally, an optional environment variable can be set to display the path
+to the file where the coverage value is being set. This aids in making the required
+changes to the coverage threshold.
+
+.. code:: bash
+  > ENVOY_COV_CONFIG_FILE="run_cov.sh" bazel-bin/test/tools/router_check/router_check_tool --config-path ... --test-path ... --useproto --f 7 -i --covall
+  Current route coverage: 6.2948%
+  Failed due to stale coverage threshold.
+  Please increase the coverage failure threshold to 89.4231 in run_cov.sh

--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -184,9 +184,9 @@ fields that could be tested.
   Current route coverage: 6.2948%
   Failed to meet coverage requirement: 7%
 
-When the fail under flag is set an optional flag (`-i` or `--increase-cov`) can
-be included to enforce the minimum coverage threshold matches the current coverage.
-This prevents the enforced coverage value from becoming stale as new tests are added
+When the fail under flag is set an optional flag (`-i` or `--incr-cov-fail`) can
+be included to enforce the specified fail under coverage threshold matches the current coverage.
+This prevents the specified fail under test coverage value from becoming stale as new tests are added
 and ensures coverage regressions don't occur if the value is set below the current coverage.
 
 .. note::
@@ -198,15 +198,5 @@ and ensures coverage regressions don't occur if the value is set below the curre
 
   > bazel-bin/test/tools/router_check/router_check_tool --config-path ... --test-path ... --useproto --f 7 -i --covall
   Current route coverage: 6.2948%
-  Failed due to stale coverage threshold.
-
-Additionally, an optional environment variable can be set to display the path
-to the file where the coverage value is being set. This aids in making the required
-changes to the coverage threshold.
-
-.. code:: bash
-
-  > ENVOY_COV_CONFIG_FILE="run_cov.sh" bazel-bin/test/tools/router_check/router_check_tool --config-path ... --test-path ... --useproto --f 7 -i --covall
-  Current route coverage: 6.2948%
-  Failed due to stale coverage threshold.
-  Please increase the coverage failure threshold to 89.4231 in run_cov.sh
+  Failed due to stale coverage failure threshold.
+  Please increase the coverage failure threshold to match existing coverage of 89.4231%

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -75,6 +75,7 @@ Version history
 * router check tool: add deprecated field check.
 * router check tool: add flag for only printing results of failed tests.
 * router check tool: add support for outputting missing tests in the detailed coverage report.
+* router check tool: add flag to enforce coverage threshold is updated.
 * runtime: allow for the ability to parse boolean values.
 * runtime: allow for the ability to parse integers as double values and vice-versa.
 * sds: added :ref:`session_ticket_keys_sds_secret_config <envoy_api_field_auth.DownstreamTlsContext.session_ticket_keys_sds_secret_config>` for loading TLS Session Ticket Encryption Keys using SDS API.

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -474,6 +474,9 @@ Options::Options(int argc, char** argv) {
   TCLAP::ValueArg<double> fail_under("f", "fail-under",
                                      "Fail if test coverage is under a specified amount", false,
                                      0.0, "float", cmd);
+  TCLAP::SwitchArg increase_cov_threshold(
+      "i", "increase-cov", "If fail-under is set, enforce coverage threshold is increased", cmd,
+      false);
   TCLAP::SwitchArg comprehensive_coverage(
       "", "covall", "Measure coverage by checking all route fields", cmd, false);
   TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file.", false,
@@ -493,6 +496,7 @@ Options::Options(int argc, char** argv) {
   is_detailed_ = is_detailed.getValue();
   only_show_failures_ = only_show_failures.getValue();
   fail_under_ = fail_under.getValue();
+  increase_cov_threshold_ = increase_cov_threshold.getValue();
   comprehensive_coverage_ = comprehensive_coverage.getValue();
   disable_deprecation_check_ = disable_deprecation_check.getValue();
 

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -475,8 +475,8 @@ Options::Options(int argc, char** argv) {
                                      "Fail if test coverage is under a specified amount", false,
                                      0.0, "float", cmd);
   TCLAP::SwitchArg increase_cov_threshold(
-      "i", "increase-cov", "If fail-under is set, enforce coverage threshold is increased", cmd,
-      false);
+      "i", "incr-cov-fail",
+      "If fail-under is set, enforce specified test coverage threshold is increased", cmd, false);
   TCLAP::SwitchArg comprehensive_coverage(
       "", "covall", "Measure coverage by checking all route fields", cmd, false);
   TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file.", false,

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -204,6 +204,11 @@ public:
   double failUnder() const { return fail_under_; }
 
   /**
+   * @return true if required route coverage threshold should be increased.
+   */
+  bool increaseCovThreshold() const { return increase_cov_threshold_; }
+
+  /**
    * @return true if test coverage should be comprehensive.
    */
   bool comprehensiveCoverage() const { return comprehensive_coverage_; }
@@ -234,6 +239,7 @@ private:
   std::string unlabelled_test_path_;
   std::string unlabelled_config_path_;
   float fail_under_;
+  bool increase_cov_threshold_;
   bool comprehensive_coverage_;
   bool is_proto_;
   bool is_detailed_;

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -47,6 +47,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed due to stale coverage threshold." << std::endl;
         std::cerr << "Please increase the coverage failure threshold to " << current_coverage
                   << cov_file_path_msg << std::endl;
+        return EXIT_FAILURE;
       }
     }
   } catch (const Envoy::EnvoyException& ex) {

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -38,6 +38,16 @@ int main(int argc, char* argv[]) {
                   << std::endl;
         return EXIT_FAILURE;
       }
+      const auto cov_file_path = std::getenv("ENVOY_COV_CONFIG_FILE");
+      std::string cov_file_path_msg = "";
+      if (cov_file_path != nullptr) {
+        cov_file_path_msg = absl::StrCat(" in ", cov_file_path);
+      }
+      if (options.increaseCovThreshold() && current_coverage != options.failUnder()) {
+        std::cerr << "Failed due to stale coverage threshold." << std::endl;
+        std::cerr << "Please increase the coverage failure threshold to " << current_coverage
+                  << cov_file_path_msg << std::endl;
+      }
     }
   } catch (const Envoy::EnvoyException& ex) {
     std::cerr << ex.what() << std::endl;

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -40,8 +40,8 @@ int main(int argc, char* argv[]) {
       }
       if (options.increaseCovThreshold() && current_coverage != options.failUnder()) {
         std::cerr << "Failed due to stale coverage failure threshold." << std::endl;
-        std::cerr << "Please increase the coverage failure threshold to " << current_coverage
-                  << std::endl;
+        std::cerr << "Please increase the coverage failure threshold to match existing coverage of "
+                  << current_coverage << "%" << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -38,15 +38,10 @@ int main(int argc, char* argv[]) {
                   << std::endl;
         return EXIT_FAILURE;
       }
-      const auto cov_file_path = std::getenv("ENVOY_COV_CONFIG_FILE");
-      std::string cov_file_path_msg = "";
-      if (cov_file_path != nullptr) {
-        cov_file_path_msg = absl::StrCat(" in ", cov_file_path);
-      }
       if (options.increaseCovThreshold() && current_coverage != options.failUnder()) {
-        std::cerr << "Failed due to stale coverage threshold." << std::endl;
+        std::cerr << "Failed due to stale coverage failure threshold." << std::endl;
         std::cerr << "Please increase the coverage failure threshold to " << current_coverage
-                  << cov_file_path_msg << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
       }
     }

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -24,6 +24,27 @@ if [[ "${COVERAGE_OUTPUT}" != *"Current route coverage: "* ]] ; then
   exit 1
 fi
 
+# Testing increase coverage threshold flag - reason.
+COVERAGE_OUTPUT=$($COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
+echo "${COVERAGE_OUTPUT}"
+if [[ "${COVERAGE_OUTPUT}" != *"Failed due to stale coverage threshold."* ]] ; then
+  exit 1
+fi
+
+# Testing increase coverage threshold flag - increase request.
+COVERAGE_OUTPUT=$($COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
+echo "${COVERAGE_OUTPUT}"
+if [[ "${COVERAGE_OUTPUT}" != *"Please increase the coverage failure threshold to "* ]] ; then
+  exit 1
+fi
+
+
+# Testing increase coverage threshold flag - cov path env variable.
+COVERAGE_OUTPUT=$(ENVOY_COV_CONFIG_FILE="a_file" $COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
+if [[ "${COVERAGE_OUTPUT}" != *"increase the coverage failure threshold to "*" in a_file" ]] ; then
+  exit 1
+fi
+
 COMP_COVERAGE_CMD="${PATH_BIN} -c ${PATH_CONFIG}/ComprehensiveRoutes.yaml -t ${PATH_CONFIG}/ComprehensiveRoutes.golden.proto.json --details --useproto -f "
 COVERAGE_OUTPUT=$($COMP_COVERAGE_CMD "100" "--covall" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
 if [[ "${COVERAGE_OUTPUT}" != *"Current route coverage: 100%"* ]] ; then

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -26,14 +26,12 @@ fi
 
 # Testing increase coverage threshold flag - reason.
 COVERAGE_OUTPUT=$($COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
-echo "${COVERAGE_OUTPUT}"
 if [[ "${COVERAGE_OUTPUT}" != *"Failed due to stale coverage threshold."* ]] ; then
   exit 1
 fi
 
 # Testing increase coverage threshold flag - increase request.
 COVERAGE_OUTPUT=$($COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
-echo "${COVERAGE_OUTPUT}"
 if [[ "${COVERAGE_OUTPUT}" != *"Please increase the coverage failure threshold to "* ]] ; then
   exit 1
 fi
@@ -41,7 +39,7 @@ fi
 
 # Testing increase coverage threshold flag - cov path env variable.
 COVERAGE_OUTPUT=$(ENVOY_COV_CONFIG_FILE="a_file" $COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
-if [[ "${COVERAGE_OUTPUT}" != *"increase the coverage failure threshold to "*" in a_file" ]] ; then
+if [[ "${COVERAGE_OUTPUT}" != *"in a_file"* ]] ; then
   exit 1
 fi
 

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -26,7 +26,7 @@ fi
 
 # Testing increase coverage threshold flag - reason.
 COVERAGE_OUTPUT=$($COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
-if [[ "${COVERAGE_OUTPUT}" != *"Failed due to stale coverage threshold."* ]] ; then
+if [[ "${COVERAGE_OUTPUT}" != *"Failed due to stale coverage failure threshold."* ]] ; then
   exit 1
 fi
 
@@ -36,12 +36,6 @@ if [[ "${COVERAGE_OUTPUT}" != *"Please increase the coverage failure threshold t
   exit 1
 fi
 
-
-# Testing increase coverage threshold flag - cov path env variable.
-COVERAGE_OUTPUT=$(ENVOY_COV_CONFIG_FILE="a_file" $COVERAGE_CMD "1.0" "-i" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"
-if [[ "${COVERAGE_OUTPUT}" != *"in a_file"* ]] ; then
-  exit 1
-fi
 
 COMP_COVERAGE_CMD="${PATH_BIN} -c ${PATH_CONFIG}/ComprehensiveRoutes.yaml -t ${PATH_CONFIG}/ComprehensiveRoutes.golden.proto.json --details --useproto -f "
 COVERAGE_OUTPUT=$($COMP_COVERAGE_CMD "100" "--covall" 2>&1) || echo "${COVERAGE_OUTPUT:-no-output}"


### PR DESCRIPTION
Signed-off-by: Derek Schaller <d_a_schaller@yahoo.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Router check - add a flag to enforce that failure coverage threshold is increased during test runs. This ensure that the required coverage doesn't become stale over time.
Risk Level: Low
Testing: Included and manually tested.
Docs Changes: Included
Release Notes: Included
