### PR TITLE
Use shared instead of unique ptr to avoid conversion

### DIFF
--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -14,7 +14,7 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
     const std::string&, Server::Configuration::FactoryContext&) {
   return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(
-        std::make_unique<Filter>(config.content_type(), config.withhold_grpc_frames()));
+        std::make_shared<Filter>(config.content_type(), config.withhold_grpc_frames()));
   };
 }
 


### PR DESCRIPTION
Another case of addStreamDecoderFilter() taking a unique ptr, missed
this one in the prev commit.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
