### PR TITLE
removing slow tests from fuzzit regression testing

### DIFF
--- a/ci/run_fuzzit.sh
+++ b/ci/run_fuzzit.sh
@@ -1,5 +1,19 @@
 #!/bin/bash -eux
 
+# helper function
+function contains() {
+    local n=$#
+    local value=${!n}
+    for ((i=1;i < $#;i++)) {
+        if [ "${!i}" == "${value}" ]; then
+            echo "y"
+            return 0
+        fi
+    }
+    echo "n"
+    return 1
+}
+
 # Dynamically source fuzzing targets
 declare -r FUZZER_TARGETS_CC=$(find . -name *_fuzz_test.cc)
 declare -r FUZZER_TARGETS="$(for t in ${FUZZER_TARGETS_CC}; do echo "${t:2:-3}"; done)"
@@ -17,10 +31,11 @@ done
 
 
 # run fuzzing regression or upload to Fuzzit for long running fuzzing job ($1 is either local-regression or fuzzing)
-wget -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.57/fuzzit_Linux_x86_64
+wget -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
 chmod a+x fuzzit
 
 PREFIX=$(realpath /build/tmp/_bazel_bazel/*/execroot/envoy/bazel-out/k8-fastbuild/bin)
+SLOW_TARGETS=("access-log-formatter" "h1-capture" "h1-capture-direct-response" "response-header" "request-header")
 for t in ${FILTERED_FUZZER_TARGETS}
 do
   TARGET_BASE="$(expr "$t" : '.*/\(.*\)_fuzz_test')"
@@ -29,5 +44,8 @@ do
   if [ $1 == "fuzzing" ]; then
     ./fuzzit create target --skip-if-exists --public-corpus envoyproxy/"${FUZZIT_TARGET_NAME}"
   fi
-  ./fuzzit create job --skip-if-not-exists --type $1 envoyproxy/"${FUZZIT_TARGET_NAME}" "${PREFIX}"/"${t}"_with_libfuzzer
+  # Skip slow targets for regression testing (this is still running in the cloud just won't run on Pull-Requests)
+  if [ $(contains "${SLOW_TARGETS[@]}" "${FUZZIT_TARGET_NAME}") == "n" ]; then
+    ./fuzzit create job --skip-if-not-exists --type $1 envoyproxy/"${FUZZIT_TARGET_NAME}" "${PREFIX}"/"${t}"_with_libfuzzer || exit 1
+  fi
 done


### PR DESCRIPTION
fix #8681 

@lizan I've removed access-log-formatter from regression testing - It's really slow and I think this should solve the problem. This fuzz target is still running in the cloud on every merge it just won't run on pull-request, anyway, I think it's not a big issue as the code targeted with this fuzz targeted rarely changes as far as I know.

Waiting for the CI to pass to check if this really solved the problem.

Description:
Risk Level: Low
Testing: not needed
[Optional Fixes #Issue]
#8681 

