### PR TITLE
fuzz: fix move max alloc handling in buffer_fuzz_test.

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5664992304562176
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5664992304562176
@@ -1,0 +1,182 @@
+actions {   target_index:       4 } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 1
+  read: 32249
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  read: 1
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  add_string: 32249
+}
+actions {
+}
+actions {
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+}
+actions {
+  move {
+    source_index: 1
+  }
+}

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -318,15 +318,18 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     }
     Buffer::Instance& source_buffer = *buffers[source_index];
     if (action.move().length() == 0) {
-      target_buffer.move(source_buffer);
       if (source_buffer.length() > max_alloc) {
         break;
       }
+      target_buffer.move(source_buffer);
       allocated += source_buffer.length();
     } else {
       const uint32_t source_length =
           std::min(static_cast<uint32_t>(source_buffer.length()), action.move().length());
       const uint32_t move_length = clampSize(max_alloc, source_length);
+      if (move_length == 0) {
+        break;
+      }
       target_buffer.move(source_buffer, move_length);
       allocated += move_length;
     }


### PR DESCRIPTION
Hopefully the last of these issues, was triggering asserts in
ClusterFuzz.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18354

Risk level: Low (test only)
Testing: Failing corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>