### PR TITLE
upstream: fix bounds in refresh rate

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -622,12 +622,13 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
   // this value is used as the cluster’s DNS refresh
-  // rate. If this setting is not specified, the value defaults to 5000ms. For
-  // cluster types other than
+  // rate. The value configured must be greater than 0ms. If this setting is not specified, the
+  // value defaults to 5000ms. For cluster types other than
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  google.protobuf.Duration dns_refresh_rate = 16 [(validate.rules).duration = {gt {}}];
+  google.protobuf.Duration dns_refresh_rate = 16
+      [(validate.rules).duration = {gt {nanos: 1000000}}];
 
   // If the DNS failure refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -622,7 +622,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
   // this value is used as the cluster’s DNS refresh
-  // rate. The value configured must be greater than 0ms. If this setting is not specified, the
+  // rate. The value configured must be at least 1ms. If this setting is not specified, the
   // value defaults to 5000ms. For cluster types other than
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -618,7 +618,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.LOGICAL_DNS>`,
   // this value is used as the cluster’s DNS refresh
-  // rate. The value configured must be greater than 0ms. If this setting is not specified, the
+  // rate. The value configured must be at least 1ms. If this setting is not specified, the
   // value defaults to 5000ms. For cluster types other than
   // :ref:`STRICT_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.LOGICAL_DNS>`

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -618,12 +618,13 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.LOGICAL_DNS>`,
   // this value is used as the cluster’s DNS refresh
-  // rate. If this setting is not specified, the value defaults to 5000ms. For
-  // cluster types other than
+  // rate. The value configured must be greater than 0ms. If this setting is not specified, the
+  // value defaults to 5000ms. For cluster types other than
   // :ref:`STRICT_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.LOGICAL_DNS>`
   // this setting is ignored.
-  google.protobuf.Duration dns_refresh_rate = 16 [(validate.rules).duration = {gt {}}];
+  google.protobuf.Duration dns_refresh_rate = 16
+      [(validate.rules).duration = {gt {nanos: 1000000}}];
 
   // If the DNS failure refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_api.v3alpha.Cluster.DiscoveryType.STRICT_DNS>`,

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5665941383282688
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5665941383282688
@@ -1,0 +1,1 @@
+static_resources {   clusters {     name: " "     type: STRICT_DNS     connect_timeout {       nanos: 4     }     dns_refresh_rate {       nanos: 4     }   } } 


### PR DESCRIPTION
The DNS refresh rate must be greater than zero. However, `PROTOBUF_GET_MS_OR_DEFAULT` grabs the configured value and rounds down to calculate the milliseconds for the refresh rate. Because of this, the bound should be greater than 1000000 nanoseconds to avoid rounding down to zero.

Also added a comment to the config that the value must be greater than zero. 

Fixes OSS-Fuzz Issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17772
Testing: Corpus entry added

Signed-off-by: Asra Ali <asraa@google.com>

