### PR TITLE
Remove per-hop TE and Connection headers

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -514,6 +514,33 @@ int ConnectionImpl::onHeadersCompleteBase() {
       ENVOY_CONN_LOG(trace, "codec entering upgrade mode.", connection_);
       handling_upgrade_ = true;
     }
+  } else if (current_header_map_->Connection()) {
+    // Remove the TE header only if the header value is not "trailers", and it is
+    // nominated by the Connection header.  Per RFC7540 we should also remove the
+    // Connection header
+    //
+    // See https://github.com/envoyproxy/envoy/issues/8623
+    const auto tokens = absl::StrSplit(current_header_map_->Connection()->value().getStringView(), ',');
+    const std::string &te_header = Http::Headers::get().TE.get();
+
+    for (const auto& connection_header_token: tokens) {
+
+      if (connection_header_token.size() == te_header.size() &&
+          StringUtil::CaseInsensitiveCompare()(connection_header_token, te_header)) {
+
+        const auto& te_header_value = current_header_map_->TE()->value();
+        if (!te_header_value.empty() &&
+            !StringUtil::CaseInsensitiveCompare()(te_header_value.getStringView(),
+                                                  Http::Headers::get().TEValues.Trailers)) {
+
+            current_header_map_->removeConnection();
+            current_header_map_->remove(Http::Headers::get().TE);
+
+            ENVOY_CONN_LOG(trace, "removing unsupported \"TE: {}\" header", connection_, te_header_value.getStringView());
+        }
+        break;
+      }
+    }
   }
 
   int rc = onHeadersComplete(std::move(current_header_map_));

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -1067,4 +1067,69 @@ TEST_P(HeaderIntegrationTest, TestPathAndRouteOnNormalizedPath) {
           {":status", "200"},
       });
 }
+
+// Validates TE header is forwarded if it contains a supported value
+TEST_P(HeaderIntegrationTest, TestTeHeaderPassthrough) {
+  initializeFilter(HeaderMode::Append, false);
+  performRequest(
+      Http::TestHeaderMapImpl{
+          {":method", "GET"},
+          {":path", "/"},
+          {":scheme", "http"},
+          {":authority", "no-headers.com"},
+          {"x-request-foo", "downstram"},
+          {"connection", "te, close"},
+          {"te", "trailers"},
+      },
+      Http::TestHeaderMapImpl{
+          {":authority", "no-headers.com"},
+          {"x-request-foo", "downstram"},
+          {":path", "/"},
+          {":method", "GET"},
+          {"te", "trailers"},
+      },
+      Http::TestHeaderMapImpl{
+          {"server", "envoy"},
+          {"content-length", "0"},
+          {":status", "200"},
+          {"x-return-foo", "upstream"},
+      },
+      Http::TestHeaderMapImpl{
+          {"server", "envoy"},
+          {"x-return-foo", "upstream"},
+          {":status", "200"},
+      });
+}
+
+// Validates TE header is stripped if it contains an supported value
+TEST_P(HeaderIntegrationTest, TestTeHeaderSanitized) {
+  initializeFilter(HeaderMode::Append, false);
+  performRequest(
+      Http::TestHeaderMapImpl{
+          {":method", "GET"},
+          {":path", "/"},
+          {":scheme", "http"},
+          {":authority", "no-headers.com"},
+          {"x-request-foo", "downstram"},
+          {"connection", "te, close"},
+          {"te", "gzip"},
+      },
+      Http::TestHeaderMapImpl{
+          {":authority", "no-headers.com"},
+          {"x-request-foo", "downstram"},
+          {":path", "/"},
+          {":method", "GET"},
+      },
+      Http::TestHeaderMapImpl{
+          {"server", "envoy"},
+          {"content-length", "0"},
+          {":status", "200"},
+          {"x-return-foo", "upstream"},
+      },
+      Http::TestHeaderMapImpl{
+          {"server", "envoy"},
+          {"x-return-foo", "upstream"},
+          {":status", "200"},
+      });
+}
 } // namespace Envoy


### PR DESCRIPTION
- Remove the mentioned headers when TE contains an unsupported
  encoding.  The TE header must be nominated by the Connection
  header for any action to take place.

- Issue: https://github.com/envoyproxy/envoy/issues/8623

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
