### PR TITLE
build: enable go-control-plane mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ workflows:
             tags:
               only: /^v.*/
       - api
+      - go_control_plane_mirror
       - filter_example_mirror
       - coverage
       - coverage_publish:


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
