### PR TITLE
build: ignore go-control-plane mirror git commit error code

### DIFF
--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -97,11 +97,8 @@ def publishGoProtobufs(repo, sha):
   git(repo, 'config', 'user.name', USER_NAME)
   git(repo, 'config', 'user.email', USER_EMAIL)
   git(repo, 'add', 'envoy')
-  try:
-    git(repo, 'commit', '-s', '-m', MIRROR_MSG + sha)
-    git(repo, 'push', 'origin', BRANCH)
-  except:
-    print('Failed to commit changes, skipping push')
+  git(repo, 'commit', '--allow-empty', '-s', '-m', MIRROR_MSG + sha)
+  git(repo, 'push', 'origin', BRANCH)
 
 
 if __name__ == "__main__":

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -97,8 +97,11 @@ def publishGoProtobufs(repo, sha):
   git(repo, 'config', 'user.name', USER_NAME)
   git(repo, 'config', 'user.email', USER_EMAIL)
   git(repo, 'add', 'envoy')
-  git(repo, 'commit', '-s', '-m', MIRROR_MSG + sha)
-  git(repo, 'push', 'origin', BRANCH)
+  try:
+    git(repo, 'commit', '-s', '-m', MIRROR_MSG + sha)
+    git(repo, 'push', 'origin', BRANCH)
+  except:
+    print('Failed to commit changes, skipping push')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

This fixes post-submit when there are no changes to the API.
cc @zuercher 

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
