### PR TITLE
ratelimit: null initialize Filter::request_headers_ member

### DIFF
--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -138,7 +138,7 @@ private:
   Upstream::ClusterInfoConstSharedPtr cluster_;
   bool initiating_call_{};
   Http::HeaderMapPtr response_headers_to_add_;
-  Http::HeaderMap* request_headers_;
+  Http::HeaderMap* request_headers_{};
 };
 
 } // namespace RateLimitFilter


### PR DESCRIPTION
Description: Add missing null initialization of Filter::request_headers_ member introduced in #8565
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
