### PR TITLE
ci: fix bazel.asan target.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -145,7 +145,7 @@ elif [[ "$CI_TARGET" == "bazel.debug.server_only" ]]; then
   exit 0
 elif [[ "$CI_TARGET" == "bazel.asan" ]]; then
   setup_clang_toolchain
-  BAZEL_BUILD_OPTIONS+="-c dbg --config=clang-asan \
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} -c dbg --config=clang-asan \
     --copt=-fsanitize=vptr,function --linkopt=-fsanitize=vptr,function \
     --linkopt=-l:libclang_rt.ubsan_standalone-x86_64.a \
     --linkopt=-l:libclang_rt.ubsan_standalone_cxx-x86_64.a \


### PR DESCRIPTION
BAZEL_BUILD_OPTIONS was expanded without a leading whitespace,
which broke builds with non-empty BAZEL_BUILD_EXTRA_OPTIONS.

Broken in #8631.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>