### PR TITLE
 tracing: Add option to http/async_client to name the child span

### DIFF
--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -11,6 +11,7 @@
 #include "common/protobuf/protobuf.h"
 
 #include "absl/types/optional.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Http {
@@ -220,15 +221,20 @@ public:
       parent_span_ = &parent_span;
       return *this;
     }
+    RequestOptions& setChildSpanName(const std::string& child_span_name) {
+      child_span_name_ = child_span_name;
+      return *this;
+    }
 
     // For gmock test
     bool operator==(const RequestOptions& src) const {
-      return StreamOptions::operator==(src) && parent_span_ == src.parent_span_;
+      return StreamOptions::operator==(src) && parent_span_ == src.parent_span_ && child_span_name_ == src.child_span_name_;
     }
 
     // The parent span that child spans are created under to trace egress requests/responses.
     // If not set, requests will not be traced.
     Tracing::Span* parent_span_{nullptr};
+    std::string child_span_name_{""};
   };
 
   /**

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -234,6 +234,9 @@ public:
     // The parent span that child spans are created under to trace egress requests/responses.
     // If not set, requests will not be traced.
     Tracing::Span* parent_span_{nullptr};
+    // The name to give to the child span that represents the async http request.
+    // If left empty and parent_span_ is set, then the default name will have the cluster name.
+    // Only used if parent_span_ is set.
     std::string child_span_name_{""};
   };
 

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -10,8 +10,8 @@
 
 #include "common/protobuf/protobuf.h"
 
-#include "absl/types/optional.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Http {
@@ -228,7 +228,8 @@ public:
 
     // For gmock test
     bool operator==(const RequestOptions& src) const {
-      return StreamOptions::operator==(src) && parent_span_ == src.parent_span_ && child_span_name_ == src.child_span_name_;
+      return StreamOptions::operator==(src) && parent_span_ == src.parent_span_ &&
+             child_span_name_ == src.child_span_name_;
     }
 
     // The parent span that child spans are created under to trace egress requests/responses.

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -10,7 +10,6 @@
 
 #include "common/protobuf/protobuf.h"
 
-#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -237,9 +237,9 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
     : AsyncStreamImpl(parent, *this, options), request_(std::move(request)), callbacks_(callbacks) {
 
   if (nullptr != options.parent_span_) {
-    child_span_ = options.parent_span_->spawnChild(Tracing::EgressConfig::get(),
-                                                   "async " + parent.cluster_->name() + " egress",
-                                                   parent.dispatcher().timeSource().systemTime());
+    const std::string child_span_name = options.child_span_name_.empty() ?
+        absl::StrCat("async ", parent.cluster_->name(), " egress") : options.child_span_name_;
+    child_span_ = options.parent_span_->spawnChild(Tracing::EgressConfig::get(), child_span_name, parent.dispatcher().timeSource().systemTime());
   } else {
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -237,9 +237,12 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
     : AsyncStreamImpl(parent, *this, options), request_(std::move(request)), callbacks_(callbacks) {
 
   if (nullptr != options.parent_span_) {
-    const std::string child_span_name = options.child_span_name_.empty() ?
-        absl::StrCat("async ", parent.cluster_->name(), " egress") : options.child_span_name_;
-    child_span_ = options.parent_span_->spawnChild(Tracing::EgressConfig::get(), child_span_name, parent.dispatcher().timeSource().systemTime());
+    const std::string child_span_name =
+        options.child_span_name_.empty()
+            ? absl::StrCat("async ", parent.cluster_->name(), " egress")
+            : options.child_span_name_;
+    child_span_ = options.parent_span_->spawnChild(Tracing::EgressConfig::get(), child_span_name,
+                                                   parent.dispatcher().timeSource().systemTime());
   } else {
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -83,6 +83,7 @@ public:
 class AsyncClientImplTracingTest : public AsyncClientImplTest {
 public:
   Tracing::MockSpan parent_span_;
+  const std::string child_span_name_{"Test Child Span Name"};
 };
 
 TEST_F(AsyncClientImplTest, BasicStream) {
@@ -185,6 +186,46 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
   expectSuccess(200);
 
   AsyncClient::RequestOptions options = AsyncClient::RequestOptions().setParentSpan(parent_span_);
+  client_.send(std::move(message_), callbacks_, options);
+
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
+  EXPECT_CALL(*child_span, finishSpan());
+
+  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  response_decoder_->decodeHeaders(std::move(response_headers), false);
+  response_decoder_->decodeData(data, true);
+}
+
+TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
+  Tracing::MockSpan* child_span{new Tracing::MockSpan()};
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
+  Buffer::Instance& data = *message_->body();
+
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](StreamDecoder& decoder,
+                           ConnectionPool::Callbacks& callbacks) -> ConnectionPool::Cancellable* {
+        callbacks.onPoolReady(stream_encoder_, cm_.conn_pool_.host_, stream_info_);
+        response_decoder_ = &decoder;
+        return nullptr;
+      }));
+
+  TestHeaderMapImpl copy(message_->headers());
+  copy.addCopy("x-envoy-internal", "true");
+  copy.addCopy("x-forwarded-for", "127.0.0.1");
+  copy.addCopy(":scheme", "http");
+
+  EXPECT_CALL(parent_span_, spawnChild_(_, child_span_name_, _))
+      .WillOnce(Return(child_span));
+  expectSuccess(200);
+
+  AsyncClient::RequestOptions options = AsyncClient::RequestOptions()
+      .setParentSpan(parent_span_)
+      .setChildSpanName(child_span_name_);
   client_.send(std::move(message_), callbacks_, options);
 
   EXPECT_CALL(*child_span,

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -219,13 +219,11 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   copy.addCopy("x-forwarded-for", "127.0.0.1");
   copy.addCopy(":scheme", "http");
 
-  EXPECT_CALL(parent_span_, spawnChild_(_, child_span_name_, _))
-      .WillOnce(Return(child_span));
+  EXPECT_CALL(parent_span_, spawnChild_(_, child_span_name_, _)).WillOnce(Return(child_span));
   expectSuccess(200);
 
-  AsyncClient::RequestOptions options = AsyncClient::RequestOptions()
-      .setParentSpan(parent_span_)
-      .setChildSpanName(child_span_name_);
+  AsyncClient::RequestOptions options =
+      AsyncClient::RequestOptions().setParentSpan(parent_span_).setChildSpanName(child_span_name_);
   client_.send(std::move(message_), callbacks_, options);
 
   EXPECT_CALL(*child_span,


### PR DESCRIPTION
Description: Add a `RequestOption` to allow naming the new `child_span_` created in `http/async_client`.

Risk Level: Low

Testing: Unit Test

Docs Changes: None

Release Notes:None