### PR TITLE
test: modify some macros to reduce number of uncovered lines reported

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -25,9 +25,10 @@ static const std::string UnspecifiedValueString = "-";
 namespace {
 
 // Matches newline pattern in a StartTimeFormatter format string.
-const std::regex& getStartTimeNewlinePattern(){
-    CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n")};
-const std::regex& getNewlinePattern(){CONSTRUCT_ON_FIRST_USE(std::regex, "\n")};
+const std::regex& getStartTimeNewlinePattern() {
+  CONSTRUCT_ON_FIRST_USE(std::regex, "%[-_0^#]*[1-9]*n");
+}
+const std::regex& getNewlinePattern() { CONSTRUCT_ON_FIRST_USE(std::regex, "\n"); }
 
 // Helper that handles the case when the ConnectionInfo is missing or if the desired value is
 // empty.

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -105,9 +105,11 @@ void invokeDebugAssertionFailureRecordAction_ForAssertMacroUseOnly();
  * Indicate a panic situation and exit.
  */
 #define PANIC(X)                                                                                   \
-  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::assert), critical,        \
-                      "panic: {}", X);                                                             \
-  abort();
+  do {                                                                                             \
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::assert), critical,      \
+                        "panic: {}", X);                                                           \
+    abort();                                                                                       \
+  } while (false)
 
 // NOT_IMPLEMENTED_GCOVR_EXCL_LINE is for overridden functions that are expressly not implemented.
 // The macro name includes "GCOVR_EXCL_LINE" to exclude the macro's usage from code coverage

--- a/source/common/common/macros.h
+++ b/source/common/common/macros.h
@@ -30,12 +30,16 @@ namespace Envoy {
  * See https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use.
  */
 #define CONSTRUCT_ON_FIRST_USE(type, ...)                                                          \
-  static const type* objectptr = new type{__VA_ARGS__};                                            \
-  return *objectptr;
+  do {                                                                                             \
+    static const type* objectptr = new type{__VA_ARGS__};                                          \
+    return *objectptr;                                                                             \
+  } while (0)
 
 #define MUTABLE_CONSTRUCT_ON_FIRST_USE(type, ...)                                                  \
-  static type* objectptr = new type{__VA_ARGS__};                                                  \
-  return *objectptr;
+  do {                                                                                             \
+    static type* objectptr = new type{__VA_ARGS__};                                                \
+    return *objectptr;                                                                             \
+  } while (0)
 
 /**
  * Have a generic fall-through for different versions of C++

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -270,7 +270,7 @@ FilterUtility::StrictHeaderChecker::checkHeader(Http::HeaderMap& headers,
                                &Router::RetryStateImpl::parseRetryGrpcOn);
   }
   // Should only validate headers for which we have implemented a validator.
-  NOT_REACHED_GCOVR_EXCL_LINE
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Stats::StatName Filter::upstreamZone(Upstream::HostDescriptionConstSharedPtr upstream_host) {

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -90,7 +90,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
         Event::FileTriggerType::Edge, Event::FileReadyType::Read | Event::FileReadyType::Closed);
     return Network::FilterStatus::StopIteration;
   }
-  NOT_REACHED_GCOVR_EXCL_LINE
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 ParseState Filter::onRead() {
@@ -119,7 +119,7 @@ ParseState Filter::onRead() {
     done(true);
     return ParseState::Done;
   }
-  NOT_REACHED_GCOVR_EXCL_LINE
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 ParseState Filter::parseHttpHeader(absl::string_view data) {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -112,7 +112,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
         Event::FileTriggerType::Edge, Event::FileReadyType::Read | Event::FileReadyType::Closed);
     return Network::FilterStatus::StopIteration;
   }
-  NOT_REACHED_GCOVR_EXCL_LINE
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void Filter::onALPN(const unsigned char* data, unsigned int len) {

--- a/source/server/config_validation/api.cc
+++ b/source/server/config_validation/api.cc
@@ -16,7 +16,7 @@ Event::DispatcherPtr ValidationImpl::allocateDispatcher() {
 }
 
 Event::DispatcherPtr ValidationImpl::allocateDispatcher(Buffer::WatermarkFactoryPtr&&) {
-  NOT_REACHED_GCOVR_EXCL_LINE
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 } // namespace Api


### PR DESCRIPTION
Compiler macros that define statements with semicolons, when followed
by an additional semicolon, have the side-effect of producing a line of
code considered unreachable by llvm-cov. This change modifies the
macros to avoid this, which makes code coverage numbers slightly more
accurate.

Risk Level: low
Testing: n/a
Doc Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>