### PR TITLE
listener: improve draining listener removal logs

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -407,7 +407,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
   // Start the drain sequence which completes when the listener's drain manager has completed
   // draining at whatever the server configured drain times are.
   draining_it->listener_->localDrainManager().startDrainSequence([this, draining_it]() -> void {
-    draining_it->listener_->debugLog("removing listener");
+    draining_it->listener_->debugLog("removing draining listener");
     for (const auto& worker : workers_) {
       // Once the drain time has completed via the drain manager's timer, we tell the workers
       // to remove the listener.
@@ -417,7 +417,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
         // while filters might still be using its context (stats, etc.).
         server_.dispatcher().post([this, draining_it]() -> void {
           if (--draining_it->workers_pending_removal_ == 0) {
-            draining_it->listener_->debugLog("listener removal complete");
+            draining_it->listener_->debugLog("draining listener removal complete");
             draining_listeners_.erase(draining_it);
             stats_.total_listeners_draining_.set(draining_listeners_.size());
           }


### PR DESCRIPTION
listener removal logs for draining listeners is little confusing - make it obvious in the log that it is removing draining lsitener
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes:  N/A