### PR TITLE
thrift: add option to strip service prefix from method name

### DIFF
--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -31,6 +31,11 @@ message Route {
 
   // Route request to some upstream cluster.
   RouteAction route = 2 [(validate.rules).message = {required: true}];
+
+  // Strip the service prefix from the method name, if there's a prefix. For
+  // example, the method call Service:method would end up being just method.
+  // Defaults to false.
+  bool strip_service_name = 3;
 }
 
 message RouteMatch {

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -31,11 +31,6 @@ message Route {
 
   // Route request to some upstream cluster.
   RouteAction route = 2 [(validate.rules).message = {required: true}];
-
-  // Strip the service prefix from the method name, if there's a prefix. For
-  // example, the method call Service:method would end up being just method.
-  // Defaults to false.
-  bool strip_service_name = 3;
 }
 
 message RouteMatch {
@@ -100,6 +95,11 @@ message RouteAction {
   // N.B. Thrift service or method name matching can be achieved by specifying a RequestHeaders
   // action with the header name ":method-name".
   repeated api.v2.route.RateLimit rate_limits = 4;
+
+  // Strip the service prefix from the method name, if there's a prefix. For
+  // example, the method call Service:method would end up being just method.
+  // Defaults to false.
+  bool strip_service_name = 5;
 }
 
 // Allows for specification of multiple upstream clusters along with weights that indicate the

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -69,6 +69,7 @@ message RouteMatch {
   repeated api.v2.route.HeaderMatcher headers = 4;
 }
 
+// [#next-free-field: 6]
 message RouteAction {
   oneof cluster_specifier {
     option (validate.required) = true;

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -99,7 +99,6 @@ message RouteAction {
 
   // Strip the service prefix from the method name, if there's a prefix. For
   // example, the method call Service:method would end up being just method.
-  // Defaults to false.
   bool strip_service_name = 5;
 }
 

--- a/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
@@ -31,6 +31,11 @@ message Route {
 
   // Route request to some upstream cluster.
   RouteAction route = 2 [(validate.rules).message = {required: true}];
+
+  // Strip the service prefix from the method name, if there's a prefix. For
+  // example, the method call Service:method would end up being just method.
+  // Defaults to false.
+  bool strip_service_name = 3;
 }
 
 message RouteMatch {

--- a/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
@@ -69,6 +69,7 @@ message RouteMatch {
   repeated api.v3alpha.route.HeaderMatcher headers = 4;
 }
 
+// [#next-free-field: 6]
 message RouteAction {
   oneof cluster_specifier {
     option (validate.required) = true;

--- a/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
@@ -99,7 +99,6 @@ message RouteAction {
 
   // Strip the service prefix from the method name, if there's a prefix. For
   // example, the method call Service:method would end up being just method.
-  // Defaults to false.
   bool strip_service_name = 5;
 }
 

--- a/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.proto
@@ -31,11 +31,6 @@ message Route {
 
   // Route request to some upstream cluster.
   RouteAction route = 2 [(validate.rules).message = {required: true}];
-
-  // Strip the service prefix from the method name, if there's a prefix. For
-  // example, the method call Service:method would end up being just method.
-  // Defaults to false.
-  bool strip_service_name = 3;
 }
 
 message RouteMatch {
@@ -100,6 +95,11 @@ message RouteAction {
   // N.B. Thrift service or method name matching can be achieved by specifying a RequestHeaders
   // action with the header name ":method-name".
   repeated api.v3alpha.route.RateLimit rate_limits = 4;
+
+  // Strip the service prefix from the method name, if there's a prefix. For
+  // example, the method call Service:method would end up being just method.
+  // Defaults to false.
+  bool strip_service_name = 5;
 }
 
 // Allows for specification of multiple upstream clusters along with weights that indicate the

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -92,6 +92,7 @@ Version history
 * tcp_proxy: the default :ref:`idle_timeout
   <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.idle_timeout>` is now 1 hour.
 * thrift_proxy: fix crashing bug on invalid transport/protocol framing
+* thrift_proxy: add support for stripping service name from method when using the multiplexed protocol.
 * tls: added verification of IP address SAN fields in certificates against configured SANs in the
 * tracing: added support to the Zipkin reporter for sending list of spans as Zipkin JSON v2 and protobuf message over HTTP.
   certificate validation context.
@@ -195,7 +196,9 @@ Version history
 * router: added a route name field to each http route in route.Route list
 * router: added several new variables for exposing information about the downstream TLS connection via :ref:`header
   formatters <config_http_conn_man_headers_custom_request_headers>`.
-* router: per try timeouts will no longer start before the downstream request has been received in full by the router.This ensures that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
+* router: per try
+    timeouts will no longer start before the downstream request has been received in full by the
+        router.This ensures that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
 * router: added :ref:`RouteAction's auto_host_rewrite_header <envoy_api_field_route.RouteAction.auto_host_rewrite_header>` to allow upstream host header substitution with some other header's value
 * router: added support for UPSTREAM_REMOTE_ADDRESS :ref:`header formatter
   <config_http_conn_man_headers_custom_request_headers>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -196,9 +196,7 @@ Version history
 * router: added a route name field to each http route in route.Route list
 * router: added several new variables for exposing information about the downstream TLS connection via :ref:`header
   formatters <config_http_conn_man_headers_custom_request_headers>`.
-* router: per try
-    timeouts will no longer start before the downstream request has been received in full by the
-        router.This ensures that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
+* router: per try timeouts will no longer start before the downstream request has been received in full by the router.This ensures that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
 * router: added :ref:`RouteAction's auto_host_rewrite_header <envoy_api_field_route.RouteAction.auto_host_rewrite_header>` to allow upstream host header substitution with some other header's value
 * router: added support for UPSTREAM_REMOTE_ADDRESS :ref:`header formatter
   <config_http_conn_man_headers_custom_request_headers>`.

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -37,6 +37,11 @@ public:
    * @return const RateLimitPolicy& the rate limit policy for the route.
    */
   virtual const RateLimitPolicy& rateLimitPolicy() const PURE;
+
+  /**
+   * @return bool should the service name prefix be stripped from the method.
+   */
+  virtual bool stripServiceName() const PURE;
 };
 
 /**
@@ -50,11 +55,6 @@ public:
    * @return the route entry or nullptr if there is no matching route for the request.
    */
   virtual const RouteEntry* routeEntry() const PURE;
-
-  /**
-   * @return bool should the service name prefix be stripped from the method.
-   */
-  virtual bool stripServiceName() const PURE;
 };
 
 using RouteConstSharedPtr = std::shared_ptr<const Route>;

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -50,6 +50,11 @@ public:
    * @return the route entry or nullptr if there is no matching route for the request.
    */
   virtual const RouteEntry* routeEntry() const PURE;
+
+  /**
+   * @return bool should the service name prefix be stripped from the method.
+   */
+  virtual bool stripServiceName() const PURE;
 };
 
 using RouteConstSharedPtr = std::shared_ptr<const Route>;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -25,7 +25,7 @@ RouteEntryImplBase::RouteEntryImplBase(
     : cluster_name_(route.route().cluster()),
       config_headers_(Http::HeaderUtility::buildHeaderDataVector(route.match().headers())),
       rate_limit_policy_(route.route().rate_limits()),
-      strip_service_name_(route.strip_service_name()) {
+      strip_service_name_(route.route().strip_service_name()) {
   if (route.route().has_metadata_match()) {
     const auto filter_it = route.route().metadata_match().filter_metadata().find(
         Envoy::Config::MetadataFilters::get().ENVOY_LB);
@@ -258,7 +258,7 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
 
   ENVOY_STREAM_LOG(debug, "router decoding request", *callbacks_);
 
-  if (route_->stripServiceName()) {
+  if (route_entry_->stripServiceName()) {
     const auto& method = metadata->methodName();
     const auto pos = method.find(':');
     if (pos != std::string::npos) {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -24,7 +24,8 @@ RouteEntryImplBase::RouteEntryImplBase(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
     : cluster_name_(route.route().cluster()),
       config_headers_(Http::HeaderUtility::buildHeaderDataVector(route.match().headers())),
-      rate_limit_policy_(route.route().rate_limits()) {
+      rate_limit_policy_(route.route().rate_limits()),
+      strip_service_name_(route.strip_service_name()) {
   if (route.route().has_metadata_match()) {
     const auto filter_it = route.route().metadata_match().filter_metadata().find(
         Envoy::Config::MetadataFilters::get().ENVOY_LB);
@@ -256,6 +257,14 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
   }
 
   ENVOY_STREAM_LOG(debug, "router decoding request", *callbacks_);
+
+  if (route_->stripServiceName()) {
+    const auto& method = metadata->methodName();
+    const auto pos = method.find(':');
+    if (pos != std::string::npos) {
+      metadata->setMethodName(method.substr(pos + 1));
+    }
+  }
 
   upstream_request_ =
       std::make_unique<UpstreamRequest>(*this, *conn_pool, metadata, transport, protocol);

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -42,6 +42,7 @@ public:
 
   // Router::Route
   const RouteEntry* routeEntry() const override;
+  bool stripServiceName() const override { return strip_service_name_; };
 
   virtual RouteConstSharedPtr matches(const MessageMetadata& metadata,
                                       uint64_t random_value) const PURE;
@@ -73,6 +74,7 @@ private:
 
     // Router::Route
     const RouteEntry* routeEntry() const override { return this; }
+    bool stripServiceName() const override { return parent_.stripServiceName(); }
 
   private:
     const RouteEntryImplBase& parent_;
@@ -88,6 +90,7 @@ private:
   uint64_t total_cluster_weight_;
   Envoy::Router::MetadataMatchCriteriaConstPtr metadata_match_criteria_;
   const RateLimitPolicyImpl rate_limit_policy_;
+  const bool strip_service_name_;
 };
 
 using RouteEntryImplBaseConstSharedPtr = std::shared_ptr<const RouteEntryImplBase>;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -39,10 +39,10 @@ public:
     return metadata_match_criteria_.get();
   }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
+  bool stripServiceName() const override { return strip_service_name_; };
 
   // Router::Route
   const RouteEntry* routeEntry() const override;
-  bool stripServiceName() const override { return strip_service_name_; };
 
   virtual RouteConstSharedPtr matches(const MessageMetadata& metadata,
                                       uint64_t random_value) const PURE;
@@ -71,10 +71,10 @@ private:
       return parent_.metadataMatchCriteria();
     }
     const RateLimitPolicy& rateLimitPolicy() const override { return parent_.rateLimitPolicy(); }
+    bool stripServiceName() const override { return parent_.stripServiceName(); }
 
     // Router::Route
     const RouteEntry* routeEntry() const override { return this; }
-    bool stripServiceName() const override { return parent_.stripServiceName(); }
 
   private:
     const RouteEntryImplBase& parent_;

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -318,6 +318,7 @@ public:
 
   // ThriftProxy::Router::Route
   MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
+  MOCK_CONST_METHOD0(stripServiceName, bool());
 
   NiceMock<MockRouteEntry> route_entry_;
 };

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -306,6 +306,7 @@ public:
   MOCK_CONST_METHOD0(metadataMatchCriteria, const Envoy::Router::MetadataMatchCriteria*());
   MOCK_CONST_METHOD0(tlsContextMatchCriteria, const Envoy::Router::TlsContextMatchCriteria*());
   MOCK_CONST_METHOD0(rateLimitPolicy, RateLimitPolicy&());
+  MOCK_CONST_METHOD0(stripServiceName, bool());
 
   std::string cluster_name_{"fake_cluster"};
   NiceMock<MockRateLimitPolicy> rate_limit_policy_;
@@ -318,7 +319,6 @@ public:
 
   // ThriftProxy::Router::Route
   MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
-  MOCK_CONST_METHOD0(stripServiceName, bool());
 
   NiceMock<MockRouteEntry> route_entry_;
 };

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -739,7 +739,8 @@ TEST_P(ThriftRouterFieldTypeTest, Call) {
   destroyRouter();
 }
 
-TEST_P(ThriftRouterFieldTypeTest, StripServiceName) {
+// Ensure the service name gets stripped when strip_service_name = true.
+TEST_P(ThriftRouterFieldTypeTest, StripServiceNameEnabled) {
   FieldType field_type = GetParam();
 
   initializeRouter();
@@ -749,6 +750,22 @@ TEST_P(ThriftRouterFieldTypeTest, StripServiceName) {
   completeRequest();
 
   EXPECT_EQ("method", metadata_->methodName());
+
+  returnResponse();
+  destroyRouter();
+}
+
+// Ensure the service name prefix isn't stripped when strip_service_name = false.
+TEST_P(ThriftRouterFieldTypeTest, StripServiceNameDisabled) {
+  FieldType field_type = GetParam();
+
+  initializeRouter();
+  startRequest(MessageType::Call, "Service:method", false);
+  connectUpstream();
+  sendTrivialStruct(field_type);
+  completeRequest();
+
+  EXPECT_EQ("Service:method", metadata_->methodName());
 
   returnResponse();
   destroyRouter();

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -107,12 +107,11 @@ public:
 
     EXPECT_CALL(callbacks_, route()).WillOnce(Return(route_ptr_));
     EXPECT_CALL(*route_, routeEntry()).WillOnce(Return(&route_entry_));
+    EXPECT_CALL(route_entry_, clusterName()).WillRepeatedly(ReturnRef(cluster_name_));
 
     if (strip_service_name) {
-      EXPECT_CALL(*route_, stripServiceName()).WillOnce(Return(true));
+      EXPECT_CALL(route_entry_, stripServiceName()).WillOnce(Return(true));
     }
-
-    EXPECT_CALL(route_entry_, clusterName()).WillRepeatedly(ReturnRef(cluster_name_));
 
     initializeMetadata(msg_type, method);
 


### PR DESCRIPTION
Fixes: #8738

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
