### PR TITLE
build: fix spell checker on macOS

### DIFF
--- a/tools/check_spelling_pedantic.py
+++ b/tools/check_spelling_pedantic.py
@@ -535,9 +535,12 @@ def execute(files, dictionary_file, fix):
 
 
 if __name__ == "__main__":
-  # Force UTF-8 across all open and popen calls. Use 'C' as the language
-  # to handle hosts where en_US is not recognized (e.g. CI).
-  locale.setlocale(locale.LC_ALL, ['C', 'UTF-8'])
+  # Force UTF-8 across all open and popen calls. Fallback to 'C' as the
+  # language to handle hosts where en_US is not recognized (e.g. CI).
+  try:
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+  except:
+    locale.setlocale(locale.LC_ALL, 'C.UTF-8')
 
   default_dictionary = os.path.join(TOOLS_DIR, 'spelling_dictionary.txt')
 

--- a/tools/check_spelling_pedantic.py
+++ b/tools/check_spelling_pedantic.py
@@ -537,7 +537,7 @@ def execute(files, dictionary_file, fix):
 if __name__ == "__main__":
   # Force UTF-8 across all open and popen calls. Use 'C' as the language
   # to handle hosts where en_US is not recognized (e.g. CI).
-  locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+  locale.setlocale(locale.LC_ALL, ['C', 'UTF-8'])
 
   default_dictionary = os.path.join(TOOLS_DIR, 'spelling_dictionary.txt')
 


### PR DESCRIPTION
Use alternate invocation for setlocale that sucessfully sets a language
agnostic UTF-8 encoding as the locale.

Risk Level: low
Testing: n/a
Doc Changes: n/a
Release Notes: n/a
Fixes: #8742

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
