### PR TITLE
update cel-cpp

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -269,10 +269,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://storage.googleapis.com/quiche-envoy-integration/4abb566fbbc63df8fe7c1ac30b21632b9eb18d0c.tar.gz"],
     ),
     com_google_cel_cpp = dict(
-        sha256 = "f027c551d57d38fb9f0b5e4f21a2b0b8663987119e23b1fd8dfcc7588e9a2350",
-        strip_prefix = "cel-cpp-d9d02b20ab85da2444dbdd03410bac6822141364",
-        # 2019-08-15
-        urls = ["https://github.com/google/cel-cpp/archive/d9d02b20ab85da2444dbdd03410bac6822141364.tar.gz"],
+        sha256 = "e21d11be5eca677fe79839d310ceffb2f950d9d03f7682af8c0d311e573a1302",
+        strip_prefix = "cel-cpp-d85f82972c2def6db9c90f3d9a23f56a0ac3caff",
+        # 2019-10-23
+        urls = ["https://github.com/google/cel-cpp/archive/d85f82972c2def6db9c90f3d9a23f56a0ac3caff.tar.gz"],
     ),
     com_googlesource_code_re2 = dict(
         sha256 = "b0382aa7369f373a0148218f2df5a6afd6bfa884ce4da2dfb576b979989e615e",

--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -91,7 +91,6 @@ The following attributes are exposed to the language runtime:
    connection.tls_version, string, TLS version of the downstream TLS connection
    upstream.address, string, Upstream connection remote address
    upstream.port, int, Upstream connection remote port
-   upstream.mtls, bool, Indicates whether TLS is applied to the upstream connection and the peer ceritificate is presented
 
 
 Most attributes are optional and provide the default value based on the type of the attribute.

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -142,9 +142,6 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
         upstream_host->address()->ip() != nullptr) {
       return CelValue::CreateInt64(upstream_host->address()->ip()->port());
     }
-  } else if (value == MTLS) {
-    return CelValue::CreateBool(info_.upstreamSslConnection() != nullptr &&
-                                info_.upstreamSslConnection()->peerCertificatePresented());
   }
 
   return {};

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -14,9 +14,15 @@ namespace Expr {
 BuilderPtr createBuilder(Protobuf::Arena* arena) {
   google::api::expr::runtime::InterpreterOptions options;
 
-  // Conformance with spec/go runtimes requires this setting
-  options.partial_string_match = true;
+  // Security-oriented defaults
+  options.enable_comprehension = false;
+  options.enable_regex = true;
+  options.regex_max_program_size = 100;
+  options.enable_string_conversion = false;
+  options.enable_string_concat = false;
+  options.enable_list_concat = false;
 
+  // Enable constant folding (performance optimization)
   if (arena != nullptr) {
     options.constant_folding = true;
     options.constant_arena = arena;
@@ -24,7 +30,7 @@ BuilderPtr createBuilder(Protobuf::Arena* arena) {
 
   auto builder = google::api::expr::runtime::CreateCelExpressionBuilder(options);
   auto register_status =
-      google::api::expr::runtime::RegisterBuiltinFunctions(builder->GetRegistry());
+      google::api::expr::runtime::RegisterBuiltinFunctions(builder->GetRegistry(), options);
   if (!register_status.ok()) {
     throw EnvoyException(
         absl::StrCat("failed to register built-in functions: ", register_status.message()));

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -257,7 +257,6 @@ TEST(Context, ConnectionAttributes) {
   std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> upstream_host(
       new NiceMock<Envoy::Upstream::MockHostDescription>());
   auto downstream_ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
-  auto upstream_ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ConnectionWrapper connection(info);
   UpstreamWrapper upstream(info);
   PeerWrapper source(info, false);
@@ -273,11 +272,9 @@ TEST(Context, ConnectionAttributes) {
   EXPECT_CALL(info, downstreamLocalAddress()).WillRepeatedly(ReturnRef(local));
   EXPECT_CALL(info, downstreamRemoteAddress()).WillRepeatedly(ReturnRef(remote));
   EXPECT_CALL(info, downstreamSslConnection()).WillRepeatedly(Return(downstream_ssl_info));
-  EXPECT_CALL(info, upstreamSslConnection()).WillRepeatedly(Return(upstream_ssl_info));
   EXPECT_CALL(info, upstreamHost()).WillRepeatedly(Return(upstream_host));
   EXPECT_CALL(info, requestedServerName()).WillRepeatedly(ReturnRef(sni_name));
   EXPECT_CALL(*downstream_ssl_info, peerCertificatePresented()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*upstream_ssl_info, peerCertificatePresented()).WillRepeatedly(Return(true));
   const std::string tls_version = "TLSv1";
   EXPECT_CALL(*downstream_ssl_info, tlsVersion()).WillRepeatedly(ReturnRef(tls_version));
   EXPECT_CALL(*upstream_host, address()).WillRepeatedly(Return(upstream_address));
@@ -342,13 +339,6 @@ TEST(Context, ConnectionAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(679, value.value().Int64OrDie());
-  }
-
-  {
-    auto value = upstream[CelValue::CreateString(MTLS)];
-    EXPECT_TRUE(value.has_value());
-    ASSERT_TRUE(value.value().IsBool());
-    EXPECT_TRUE(value.value().BoolOrDie());
   }
 
   {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: update CEL runtime to tighten the complexity bounds:
- remove comprehension operators (forall, exists)
- remove list and string concat to avoid memory allocation
- limit RE2 regex max program size
- remove string conversion to avoid string allocation

Risk Level: low
Testing: unit tests
Docs Changes: remove upstream.mtls attribute due to ongoing #8464
Release Notes:
