### PR TITLE
metrics service: static registration macro

### DIFF
--- a/source/extensions/stat_sinks/metrics_service/config.h
+++ b/source/extensions/stat_sinks/metrics_service/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/registry/registry.h"
 #include "envoy/server/instance.h"
 
 #include "server/configuration_impl.h"
@@ -22,6 +23,8 @@ public:
 
   std::string name() override;
 };
+
+DECLARE_FACTORY(MetricsServiceSinkFactory);
 
 } // namespace MetricsService
 } // namespace StatSinks


### PR DESCRIPTION
Description: Using #7185 to allow the metrics service to be used in a static library.
Risk Level: low
Testing: locally compiled and ran as static library

Signed-off-by: Jose Nino <jnino@lyft.com>