### PR TITLE
ci: check casing of unions and structs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,5 +75,11 @@ CheckOptions:
   - key:             readability-identifier-naming.PrivateMemberSuffix
     value:           '_'
 
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+
   - key:             readability-identifier-naming.TypeAliasCase
+    value:           'CamelCase'
+
+  - key:             readability-identifier-naming.UnionCase
     value:           'CamelCase'


### PR DESCRIPTION
Description: unions and structs should be `CamelCase`. My local clang-tidy run did not find any violations so this should be a no-op.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A
part of #8656

Signed-off-by: Derek Argueta <dereka@pinterest.com>
