### PR TITLE
api: remove unused/deprecated type

### DIFF
--- a/api/envoy/config/filter/fault/v3alpha/fault.proto
+++ b/api/envoy/config/filter/fault/v3alpha/fault.proto
@@ -18,11 +18,6 @@ import "validate/validate.proto";
 // HTTP/gRPC/Mongo/Redis operation or delay proxying of TCP connections.
 // [#next-free-field: 6]
 message FaultDelay {
-  enum FaultDelayType {
-    // Unused and deprecated.
-    FIXED = 0;
-  }
-
   // Fault delays are controlled via an HTTP header (if applicable). See the
   // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.


### PR DESCRIPTION
Description: `FaultDelayType` was used for [a deprecated field](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/fault/v2/fault.proto#L34), which was removed due to the major version change.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A

cc @htuch 

Signed-off-by: Derek Argueta <dereka@pinterest.com>