### PR TITLE
quiche: remove unused include

### DIFF
--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
@@ -20,7 +20,6 @@
 #include "quiche/http2/platform/api/http2_logging.h"
 #include "quiche/http2/platform/api/http2_macros.h"
 #include "quiche/http2/platform/api/http2_optional.h"
-#include "quiche/http2/platform/api/http2_ptr_util.h"
 #include "quiche/http2/platform/api/http2_reconstruct_object.h"
 #include "quiche/http2/platform/api/http2_string_piece.h"
 #include "quiche/http2/test_tools/http2_random.h"


### PR DESCRIPTION
Signed-off-by: Bence Béky <bnc@google.com>

Description: Remove unused include from test file.
Risk Level: Low.  Test-only change.  Removed include only defines Http2MakeUnique, the only use of which has been removed at https://github.com/envoyproxy/envoy/pull/8534/files.
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
