### PR TITLE
ci: Run the filter-example's HTTP filter test

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -85,7 +85,7 @@ if [ "$1" != "-nofetch" ]; then
   fi
 
   # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 616ec56fb7a673e285aed278cb0a44f23789806f)
+  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f af5aa34dc85b80646d9db12c5b901ef18cee9f45)
   sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
   cp -f "${ENVOY_SRCDIR}"/.bazelversion "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/.bazelversion
 fi

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -152,7 +152,7 @@ elif [[ "$CI_TARGET" == "bazel.asan" ]]; then
   echo "Building and testing envoy-filter-example tests..."
   pushd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} \
-    //:echo2_integration_test //:envoy_binary_test
+    //:echo2_integration_test //:envoy_binary_test //http-filter-example:http_filter_integration_test
   popd
   # Also validate that integration test traffic tapping (useful when debugging etc.)
   # works. This requires that we set TAP_PATH. We do this under bazel.asan to
@@ -178,7 +178,7 @@ elif [[ "$CI_TARGET" == "bazel.tsan" ]]; then
   echo "Building and testing envoy-filter-example tests..."
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} -c dbg --config=clang-tsan \
-    //:echo2_integration_test //:envoy_binary_test
+    //:echo2_integration_test //:envoy_binary_test //http-filter-example:http_filter_integration_test
   exit 0
 elif [[ "$CI_TARGET" == "bazel.dev" ]]; then
   setup_clang_toolchain

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -152,7 +152,7 @@ elif [[ "$CI_TARGET" == "bazel.asan" ]]; then
   echo "Building and testing envoy-filter-example tests..."
   pushd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} \
-    //:echo2_integration_test //:envoy_binary_test //http-filter-example:http_filter_integration_test
+    //:echo2_integration_test //http-filter-example:http_filter_integration_test //:envoy_binary_test
   popd
   # Also validate that integration test traffic tapping (useful when debugging etc.)
   # works. This requires that we set TAP_PATH. We do this under bazel.asan to
@@ -178,7 +178,7 @@ elif [[ "$CI_TARGET" == "bazel.tsan" ]]; then
   echo "Building and testing envoy-filter-example tests..."
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} -c dbg --config=clang-tsan \
-    //:echo2_integration_test //:envoy_binary_test //http-filter-example:http_filter_integration_test
+    //:echo2_integration_test //http-filter-example:http_filter_integration_test //:envoy_binary_test
   exit 0
 elif [[ "$CI_TARGET" == "bazel.dev" ]]; then
   setup_clang_toolchain


### PR DESCRIPTION
Description: This adds `//http-filter-example:http_filter_integration_test` as one of tests to be run on CI.
Risk Level: Low
Testing: includes a test from the filter-example repo
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>