### PR TITLE
Fixed BUILDIFIER_PATH and BUILDOZER_PATH env var expansion in check_format.py and envoy_build_fixer.py scripts

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -13,6 +13,7 @@ import stat
 import sys
 import traceback
 import shutil
+import paths
 
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/", "./bazel-", "./.cache",
                      "./source/extensions/extensions_build_config.bzl",
@@ -75,8 +76,8 @@ STD_REGEX_WHITELIST = ("./source/common/common/utility.cc", "./source/common/com
 GRPC_INIT_WHITELIST = ("./source/common/grpc/google_grpc_context.cc")
 
 CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-9")
-BUILDIFIER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildifier") if os.getenv("GOPATH") else shutil.which("buildifier"))
-BUILDOZER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer") if os.getenv("GOPATH") else shutil.which("buildozer"))
+BUILDIFIER_PATH = paths.getBuildifier()
+BUILDOZER_PATH = paths.getBuildozer()
 ENVOY_BUILD_FIXER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),
                                       "envoy_build_fixer.py")
 HEADER_ORDER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "header_order.py")

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -12,6 +12,7 @@ import subprocess
 import stat
 import sys
 import traceback
+import shutil
 
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/", "./bazel-", "./.cache",
                      "./source/extensions/extensions_build_config.bzl",
@@ -74,8 +75,8 @@ STD_REGEX_WHITELIST = ("./source/common/common/utility.cc", "./source/common/com
 GRPC_INIT_WHITELIST = ("./source/common/grpc/google_grpc_context.cc")
 
 CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-9")
-BUILDIFIER_PATH = os.getenv("BUILDIFIER_BIN", "$GOPATH/bin/buildifier")
-BUILDOZER_PATH = os.getenv("BUILDOZER_BIN", "$GOPATH/bin/buildozer")
+BUILDIFIER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildifier") if os.getenv("GOPATH") else shutil.which("buildifier"))
+BUILDOZER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer") if os.getenv("GOPATH") else shutil.which("buildozer"))
 ENVOY_BUILD_FIXER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),
                                       "envoy_build_fixer.py")
 HEADER_ORDER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "header_order.py")

--- a/tools/envoy_build_fixer.py
+++ b/tools/envoy_build_fixer.py
@@ -13,10 +13,10 @@ import re
 import subprocess
 import sys
 import tempfile
-import shutil
+import paths
 
 # Where does Buildozer live?
-BUILDOZER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer") if os.getenv("GOPATH") else shutil.which("buildozer"))
+BUILDOZER_PATH = paths.getBuildozer()
 
 # Canonical Envoy license.
 LICENSE_STRING = 'licenses(["notice"])  # Apache 2\n\n'

--- a/tools/envoy_build_fixer.py
+++ b/tools/envoy_build_fixer.py
@@ -13,9 +13,10 @@ import re
 import subprocess
 import sys
 import tempfile
+import shutil
 
 # Where does Buildozer live?
-BUILDOZER_PATH = os.getenv('BUILDOZER_BIN', '$GOPATH/bin/buildozer')
+BUILDOZER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer") if os.getenv("GOPATH") else shutil.which("buildozer"))
 
 # Canonical Envoy license.
 LICENSE_STRING = 'licenses(["notice"])  # Apache 2\n\n'

--- a/tools/paths.py
+++ b/tools/paths.py
@@ -1,0 +1,13 @@
+import os
+import os.path
+import shutil
+
+
+def getBuildifier():
+  return os.getenv("BUILDIFIER_BIN") or (os.path.expandvars("$GOPATH/bin/buildifier")
+                                         if os.getenv("GOPATH") else shutil.which("buildifier"))
+
+
+def getBuildozer():
+  return os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer")
+                                        if os.getenv("GOPATH") else shutil.which("buildozer"))


### PR DESCRIPTION
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Fixes BUILDIFIER_PATH and BUILDOZER_PATH env var expansion when scripts have to fall back on $GOLANG path. Python's os.getenv returns string in the "default value" parameter verbatim, which results in scipts not finding buildozer and buildifier binaries.
Risk Level: low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
