### PR TITLE
jwt_authn: Add support for tracing remote calls

### DIFF
--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -52,10 +52,11 @@ public:
     message->headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
     ENVOY_LOG(debug, "fetch pubkey from [uri = {}]: start", uri_->uri());
     auto options = Http::AsyncClient::RequestOptions()
-        .setTimeout(std::chrono::milliseconds(DurationUtil::durationToMilliseconds(uri.timeout())))
-        .setParentSpan(parent_span);
-    request_ = cm_.httpAsyncClientForCluster(uri.cluster())
-                   .send(std::move(message), *this, options);
+                       .setTimeout(std::chrono::milliseconds(
+                           DurationUtil::durationToMilliseconds(uri.timeout())))
+                       .setParentSpan(parent_span);
+    request_ =
+        cm_.httpAsyncClientForCluster(uri.cluster()).send(std::move(message), *this, options);
   }
 
   // HTTP async receive methods

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -54,7 +54,8 @@ public:
     auto options = Http::AsyncClient::RequestOptions()
                        .setTimeout(std::chrono::milliseconds(
                            DurationUtil::durationToMilliseconds(uri.timeout())))
-                       .setParentSpan(parent_span);
+                       .setParentSpan(parent_span)
+                       .setChildSpanName("JWT Remote PubKey Fetch");
     request_ =
         cm_.httpAsyncClientForCluster(uri.cluster()).send(std::move(message), *this, options);
   }

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -28,7 +28,7 @@ public:
     reset();
   }
 
-  void fetch(const ::envoy::api::v2::core::HttpUri& uri,
+  void fetch(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span,
              JwksFetcher::JwksReceiver& receiver) override {
     ENVOY_LOG(trace, "{}", __func__);
     ASSERT(!receiver_);
@@ -51,10 +51,11 @@ public:
     Http::MessagePtr message = Http::Utility::prepareHeaders(uri);
     message->headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
     ENVOY_LOG(debug, "fetch pubkey from [uri = {}]: start", uri_->uri());
+    auto options = Http::AsyncClient::RequestOptions()
+        .setTimeout(std::chrono::milliseconds(DurationUtil::durationToMilliseconds(uri.timeout())))
+        .setParentSpan(parent_span);
     request_ = cm_.httpAsyncClientForCluster(uri.cluster())
-                   .send(std::move(message), *this,
-                         Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(
-                             DurationUtil::durationToMilliseconds(uri.timeout()))));
+                   .send(std::move(message), *this, options);
   }
 
   // HTTP async receive methods

--- a/source/extensions/filters/http/common/jwks_fetcher.h
+++ b/source/extensions/filters/http/common/jwks_fetcher.h
@@ -58,9 +58,10 @@ public:
    * a callback or `cancel()` is invoked, no
    * additional `fetch()` may be issued.
    * @param uri the uri to retrieve the jwks from.
+   * @param parent_span the active span to create children under
    * @param receiver the receiver of the fetched JWKS or error.
    */
-  virtual void fetch(const ::envoy::api::v2::core::HttpUri& uri, JwksReceiver& receiver) PURE;
+  virtual void fetch(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span, JwksReceiver& receiver) PURE;
 
   /*
    * Factory method for creating a JwksFetcher.

--- a/source/extensions/filters/http/common/jwks_fetcher.h
+++ b/source/extensions/filters/http/common/jwks_fetcher.h
@@ -61,7 +61,8 @@ public:
    * @param parent_span the active span to create children under
    * @param receiver the receiver of the fetched JWKS or error.
    */
-  virtual void fetch(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span, JwksReceiver& receiver) PURE;
+  virtual void fetch(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span,
+                     JwksReceiver& receiver) PURE;
 
   /*
    * Factory method for creating a JwksFetcher.

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -43,6 +43,7 @@ envoy_cc_library(
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/stats:stats_macros",
         "//source/common/http:message_lib",
+        "//source/common/tracing:http_tracer_lib",
         "//source/extensions/filters/http/common:jwks_fetcher_lib",
     ],
 )

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -40,8 +40,9 @@ public:
   void onJwksSuccess(google::jwt_verify::JwksPtr&& jwks) override;
   void onJwksError(Failure reason) override;
   // Following functions are for Authenticator interface
-  void verify(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>&& tokens,
-              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) override;
+  void verify(Http::HeaderMap& headers, Tracing::Span& parent_span,
+              std::vector<JwtLocationConstPtr>&& tokens, SetPayloadCallback set_payload_cb,
+              AuthenticatorCallback callback) override;
   void onDestroy() override;
 
   TimeSource& timeSource() { return time_source_; }
@@ -92,7 +93,8 @@ private:
   TimeSource& time_source_;
 };
 
-void AuthenticatorImpl::verify(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>&& tokens,
+void AuthenticatorImpl::verify(Http::HeaderMap& headers, Tracing::Span& parent_span,
+                               std::vector<JwtLocationConstPtr>&& tokens,
                                SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
   ASSERT(!callback_);
   headers_ = &headers;

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -8,6 +8,7 @@
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"
 #include "common/protobuf/protobuf.h"
+#include "common/tracing/http_tracer_impl.h"
 
 #include "jwt_verify_lib/jwt.h"
 #include "jwt_verify_lib/verify.h"
@@ -80,7 +81,7 @@ private:
   // The HTTP request headers
   Http::HeaderMap* headers_{};
   // The active span for the request
-  Tracing::Span* parent_span_;
+  Tracing::Span* parent_span_{&Tracing::NullSpan::instance()};
   // the callback function to set payload
   SetPayloadCallback set_payload_cb_;
   // The on_done function.

--- a/source/extensions/filters/http/jwt_authn/authenticator.h
+++ b/source/extensions/filters/http/jwt_authn/authenticator.h
@@ -35,8 +35,9 @@ public:
 
   // Verify if headers satisfies the JWT requirements. Can be limited to single provider with
   // extract_param.
-  virtual void verify(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>&& tokens,
-                      SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) PURE;
+  virtual void verify(Http::HeaderMap& headers, Tracing::Span& parent_span,
+                      std::vector<JwtLocationConstPtr>&& tokens, SetPayloadCallback set_payload_cb,
+                      AuthenticatorCallback callback) PURE;
 
   // Called when the object is about to be destroyed.
   virtual void onDestroy() PURE;

--- a/source/extensions/filters/http/jwt_authn/authenticator.h
+++ b/source/extensions/filters/http/jwt_authn/authenticator.h
@@ -35,7 +35,7 @@ public:
 
   // Verify if headers satisfies the JWT requirements. Can be limited to single provider with
   // extract_param.
-  virtual void verify(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>&& tokens,
+  virtual void verify(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>&& tokens,
                       SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) PURE;
 
   // Called when the object is about to be destroyed.

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -40,7 +40,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   if (!verifier) {
     onComplete(Status::Ok);
   } else {
-    context_ = Verifier::createContext(headers, this);
+    context_ = Verifier::createContext(headers, decoder_callbacks_->activeSpan(), this);
     verifier->verify(context_);
   }
 

--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -312,7 +312,8 @@ VerifierConstPtr innerCreate(const JwtRequirement& requirement,
 
 } // namespace
 
-ContextSharedPtr Verifier::createContext(Http::HeaderMap& headers, Tracing::Span& parent_span, Callbacks* callback) {
+ContextSharedPtr Verifier::createContext(Http::HeaderMap& headers, Tracing::Span& parent_span,
+                                         Callbacks* callback) {
   return std::make_shared<ContextImpl>(headers, parent_span, callback);
 }
 

--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -27,10 +27,12 @@ struct CompletionState {
 
 class ContextImpl : public Verifier::Context {
 public:
-  ContextImpl(Http::HeaderMap& headers, Verifier::Callbacks* callback)
-      : headers_(headers), callback_(callback) {}
+  ContextImpl(Http::HeaderMap& headers, Tracing::Span& parent_span, Verifier::Callbacks* callback)
+      : headers_(headers), parent_span_(parent_span), callback_(callback) {}
 
   Http::HeaderMap& headers() const override { return headers_; }
+
+  Tracing::Span& parentSpan() const override { return parent_span_; }
 
   Verifier::Callbacks* callback() const override { return callback_; }
 
@@ -61,6 +63,7 @@ public:
 
 private:
   Http::HeaderMap& headers_;
+  Tracing::Span& parent_span_;
   Verifier::Callbacks* callback_;
   std::unordered_map<const Verifier*, CompletionState> completion_states_;
   std::vector<AuthenticatorPtr> auths_;
@@ -112,7 +115,7 @@ public:
     auto auth = auth_factory_.create(getAudienceChecker(), provider_name_, false);
     extractor_->sanitizePayloadHeaders(ctximpl.headers());
     auth->verify(
-        ctximpl.headers(), extractor_->extract(ctximpl.headers()),
+        ctximpl.headers(), ctximpl.parentSpan(), extractor_->extract(ctximpl.headers()),
         [&ctximpl](const std::string& name, const ProtobufWkt::Struct& payload) {
           ctximpl.addPayload(name, payload);
         },
@@ -162,7 +165,7 @@ public:
     auto auth = auth_factory_.create(nullptr, absl::nullopt, true);
     extractor_.sanitizePayloadHeaders(ctximpl.headers());
     auth->verify(
-        ctximpl.headers(), extractor_.extract(ctximpl.headers()),
+        ctximpl.headers(), ctximpl.parentSpan(), extractor_.extract(ctximpl.headers()),
         [&ctximpl](const std::string& name, const ProtobufWkt::Struct& payload) {
           ctximpl.addPayload(name, payload);
         },
@@ -309,8 +312,8 @@ VerifierConstPtr innerCreate(const JwtRequirement& requirement,
 
 } // namespace
 
-ContextSharedPtr Verifier::createContext(Http::HeaderMap& headers, Callbacks* callback) {
-  return std::make_shared<ContextImpl>(headers, callback);
+ContextSharedPtr Verifier::createContext(Http::HeaderMap& headers, Tracing::Span& parent_span, Callbacks* callback) {
+  return std::make_shared<ContextImpl>(headers, parent_span, callback);
 }
 
 VerifierConstPtr Verifier::create(const JwtRequirement& requirement,

--- a/source/extensions/filters/http/jwt_authn/verifier.h
+++ b/source/extensions/filters/http/jwt_authn/verifier.h
@@ -53,6 +53,13 @@ public:
     virtual Http::HeaderMap& headers() const PURE;
 
     /**
+     * Returns the active span wrapped in this context.
+     *
+     * @return the active span.
+     */
+    virtual Tracing::Span& parentSpan() const PURE;
+
+    /**
      * Returns the request callback wrapped in this context.
      *
      * @returns the request callback.
@@ -78,7 +85,7 @@ public:
       const AuthFactory& factory, const Extractor& extractor_for_allow_fail);
 
   // Factory method for creating verifier contexts.
-  static ContextSharedPtr createContext(Http::HeaderMap& headers, Callbacks* callback);
+  static ContextSharedPtr createContext(Http::HeaderMap& headers, Tracing::Span& parent_span, Callbacks* callback);
 };
 
 using ContextSharedPtr = std::shared_ptr<Verifier::Context>;

--- a/source/extensions/filters/http/jwt_authn/verifier.h
+++ b/source/extensions/filters/http/jwt_authn/verifier.h
@@ -85,7 +85,8 @@ public:
       const AuthFactory& factory, const Extractor& extractor_for_allow_fail);
 
   // Factory method for creating verifier contexts.
-  static ContextSharedPtr createContext(Http::HeaderMap& headers, Tracing::Span& parent_span, Callbacks* callback);
+  static ContextSharedPtr createContext(Http::HeaderMap& headers, Tracing::Span& parent_span,
+                                        Callbacks* callback);
 };
 
 using ContextSharedPtr = std::shared_ptr<Verifier::Context>;

--- a/test/extensions/filters/http/common/jwks_fetcher_test.cc
+++ b/test/extensions/filters/http/common/jwks_fetcher_test.cc
@@ -53,6 +53,7 @@ public:
   void SetUp() override { TestUtility::loadFromYaml(JwksUri, uri_); }
   HttpUri uri_;
   testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
+  NiceMock<Tracing::MockSpan> parent_span_;
 };
 
 // Test findByIssuer
@@ -66,7 +67,7 @@ TEST_F(JwksFetcherTest, TestGetSuccess) {
   EXPECT_CALL(receiver, onJwksError(testing::_)).Times(0);
 
   // Act
-  fetcher->fetch(uri_, receiver);
+  fetcher->fetch(uri_, parent_span_, receiver);
 }
 
 TEST_F(JwksFetcherTest, TestGet400) {
@@ -79,7 +80,7 @@ TEST_F(JwksFetcherTest, TestGet400) {
   EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network)).Times(1);
 
   // Act
-  fetcher->fetch(uri_, receiver);
+  fetcher->fetch(uri_, parent_span_, receiver);
 }
 
 TEST_F(JwksFetcherTest, TestGetNoBody) {
@@ -92,7 +93,7 @@ TEST_F(JwksFetcherTest, TestGetNoBody) {
   EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network)).Times(1);
 
   // Act
-  fetcher->fetch(uri_, receiver);
+  fetcher->fetch(uri_, parent_span_, receiver);
 }
 
 TEST_F(JwksFetcherTest, TestGetInvalidJwks) {
@@ -105,7 +106,7 @@ TEST_F(JwksFetcherTest, TestGetInvalidJwks) {
   EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::InvalidJwks)).Times(1);
 
   // Act
-  fetcher->fetch(uri_, receiver);
+  fetcher->fetch(uri_, parent_span_, receiver);
 }
 
 TEST_F(JwksFetcherTest, TestHttpFailure) {
@@ -119,7 +120,7 @@ TEST_F(JwksFetcherTest, TestHttpFailure) {
   EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network)).Times(1);
 
   // Act
-  fetcher->fetch(uri_, receiver);
+  fetcher->fetch(uri_, parent_span_, receiver);
 }
 
 TEST_F(JwksFetcherTest, TestCancel) {
@@ -134,7 +135,7 @@ TEST_F(JwksFetcherTest, TestCancel) {
   EXPECT_CALL(receiver, onJwksError(testing::_)).Times(0);
 
   // Act
-  fetcher->fetch(uri_, receiver);
+  fetcher->fetch(uri_, parent_span_, receiver);
   // Proper cancel
   fetcher->cancel();
   // Re-entrant cancel

--- a/test/extensions/filters/http/common/mock.h
+++ b/test/extensions/filters/http/common/mock.h
@@ -14,7 +14,8 @@ namespace Common {
 class MockJwksFetcher : public JwksFetcher {
 public:
   MOCK_METHOD0(cancel, void());
-  MOCK_METHOD3(fetch, void(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span, JwksReceiver& receiver));
+  MOCK_METHOD3(fetch, void(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span,
+                           JwksReceiver& receiver));
 };
 
 // A mock HTTP upstream.

--- a/test/extensions/filters/http/common/mock.h
+++ b/test/extensions/filters/http/common/mock.h
@@ -14,7 +14,7 @@ namespace Common {
 class MockJwksFetcher : public JwksFetcher {
 public:
   MOCK_METHOD0(cancel, void());
-  MOCK_METHOD2(fetch, void(const ::envoy::api::v2::core::HttpUri& uri, JwksReceiver& receiver));
+  MOCK_METHOD3(fetch, void(const ::envoy::api::v2::core::HttpUri& uri, Tracing::Span& parent_span, JwksReceiver& receiver));
 };
 
 // A mock HTTP upstream.

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -34,6 +34,7 @@ public:
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;
   MockVerifierCallbacks mock_cb_;
+  NiceMock<Tracing::MockSpan> parent_span_;
 };
 
 // tests rule that is just match no requires.
@@ -43,10 +44,10 @@ TEST_F(AllVerifierTest, TestAllAllow) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(2);
   auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer a"}};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
@@ -69,7 +70,7 @@ TEST_F(AllVerifierTest, TestAllowFailed) {
       {"b", "Prefix " + std::string(NonExistKidToken)},
       {"c", "Prefix "},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("a"));
   EXPECT_TRUE(headers.has("b"));

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -59,7 +59,8 @@ public:
       out_payload_ = payload;
     };
     auto tokens = filter_config_->getExtractor().extract(headers);
-    auth_->verify(headers, parent_span_, std::move(tokens), std::move(set_payload_cb), std::move(on_complete_cb));
+    auth_->verify(headers, parent_span_, std::move(tokens), std::move(set_payload_cb),
+                  std::move(on_complete_cb));
   }
 
   JwtAuthentication proto_config_;
@@ -78,10 +79,10 @@ public:
 // It also verifies Jwks cache with 10 JWT authentications, but only one Jwks fetch.
 TEST_F(AuthenticatorTest, TestOkJWTandCache) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   // Test OK pubkey and its cache
   for (int i = 0; i < 10; i++) {
@@ -101,10 +102,10 @@ TEST_F(AuthenticatorTest, TestForwardJwt) {
   (*proto_config_.mutable_providers())[std::string(ProviderName)].set_forward(true);
   CreateAuthenticator();
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   // Test OK pubkey and its cache
   auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
@@ -125,10 +126,10 @@ TEST_F(AuthenticatorTest, TestSetPayload) {
       "my_payload");
   CreateAuthenticator();
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   // Test OK pubkey and its cache
   auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
@@ -146,10 +147,10 @@ TEST_F(AuthenticatorTest, TestSetPayload) {
 // This test verifies the Jwt with non existing kid
 TEST_F(AuthenticatorTest, TestJwtWithNonExistKid) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   // Test OK pubkey and its cache
   auto headers =
@@ -249,10 +250,10 @@ TEST_F(AuthenticatorTest, TestIssuerNotFound) {
 // This test verifies that when Jwks fetching fails, JwksFetchFail status is returned.
 TEST_F(AuthenticatorTest, TestPubkeyFetchFail) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(
-          Invoke([](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksError(JwksFetcher::JwksReceiver::Failure::InvalidJwks);
-          }));
+      .WillOnce(Invoke([](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                          JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksError(JwksFetcher::JwksReceiver::Failure::InvalidJwks);
+      }));
 
   auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::JwksFetchFail, headers);
@@ -287,10 +288,10 @@ TEST_F(AuthenticatorTest, TestNoForwardPayloadHeader) {
   provider0.clear_forward_payload_header();
   CreateAuthenticator();
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::Ok, headers);
@@ -312,10 +313,10 @@ TEST_F(AuthenticatorTest, TestAllowFailedMultipleTokens) {
 
   CreateAuthenticator(nullptr, absl::nullopt);
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   auto headers = Http::TestHeaderMapImpl{
       {"a", "Bearer " + std::string(ExpiredToken)},
@@ -360,12 +361,12 @@ TEST_F(AuthenticatorTest, TestAllowFailedMultipleIssuers) {
   CreateAuthenticator(nullptr, absl::nullopt);
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
       .Times(2)
-      .WillRepeatedly(
-          Invoke([](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            ::google::jwt_verify::JwksPtr jwks = Jwks::createFrom(PublicKey, Jwks::JWKS);
-            EXPECT_TRUE(jwks->getStatus() == Status::Ok);
-            receiver.onJwksSuccess(std::move(jwks));
-          }));
+      .WillRepeatedly(Invoke([](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                                JwksFetcher::JwksReceiver& receiver) {
+        ::google::jwt_verify::JwksPtr jwks = Jwks::createFrom(PublicKey, Jwks::JWKS);
+        EXPECT_TRUE(jwks->getStatus() == Status::Ok);
+        receiver.onJwksSuccess(std::move(jwks));
+      }));
 
   auto headers = Http::TestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
@@ -386,10 +387,10 @@ TEST_F(AuthenticatorTest, TestCustomCheckAudience) {
       std::vector<std::string>{"invalid_service"});
   CreateAuthenticator(check_audience.get());
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(Invoke(
-          [this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            receiver.onJwksSuccess(std::move(jwks_));
-          }));
+      .WillOnce(Invoke([this](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
 
   auto headers =
       Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(InvalidAudToken)}};
@@ -402,11 +403,11 @@ TEST_F(AuthenticatorTest, TestCustomCheckAudience) {
 // This test verifies that when invalid JWKS is fetched, an JWKS error status is returned.
 TEST_F(AuthenticatorTest, TestInvalidPubkeyKey) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
-      .WillOnce(
-          Invoke([](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&, JwksFetcher::JwksReceiver& receiver) {
-            auto jwks = Jwks::createFrom(PublicKey, Jwks::PEM);
-            receiver.onJwksSuccess(std::move(jwks));
-          }));
+      .WillOnce(Invoke([](const ::envoy::api::v2::core::HttpUri&, Tracing::Span&,
+                          JwksFetcher::JwksReceiver& receiver) {
+        auto jwks = Jwks::createFrom(PublicKey, Jwks::PEM);
+        receiver.onJwksSuccess(std::move(jwks));
+      }));
 
   auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::JwksPemBadBase64, headers);

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -82,9 +82,9 @@ public:
   void createSyncMockAuthsAndVerifier(const StatusMap& statuses) {
     for (const auto& it : statuses) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
-      EXPECT_CALL(*mock_auth, doVerify(_, _, _, _))
+      EXPECT_CALL(*mock_auth, doVerify(_, _, _, _, _))
           .WillOnce(Invoke([issuer = it.first, status = it.second](
-                               Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
+                               Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*,
                                SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
             if (status == Status::Ok) {
               ProtobufWkt::Struct empty_struct;
@@ -115,9 +115,9 @@ public:
     std::unordered_map<std::string, AuthenticatorCallback> callbacks;
     for (const auto& provider : providers) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
-      EXPECT_CALL(*mock_auth, doVerify(_, _, _, _))
+      EXPECT_CALL(*mock_auth, doVerify(_, _, _, _, _))
           .WillOnce(Invoke(
-              [&callbacks, iss = provider](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
+              [&callbacks, iss = provider](Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*,
                                            SetPayloadCallback, AuthenticatorCallback callback) {
                 callbacks[iss] = std::move(callback);
               }));
@@ -135,6 +135,7 @@ public:
   NiceMock<MockAuthFactory> mock_factory_;
   ContextSharedPtr context_;
   NiceMock<MockExtractor> mock_extractor_;
+  NiceMock<Tracing::MockSpan> parent_span_;
 };
 
 // Deeply nested anys that ends in provider name
@@ -178,7 +179,7 @@ rules:
   auto headers = Http::TestHeaderMapImpl{
       {"sec-istio-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("sec-istio-auth-userinfo"));
 }
@@ -207,13 +208,13 @@ rules:
 )";
   TestUtility::loadFromYaml(config, proto_config_);
   auto mock_auth = std::make_unique<MockAuthenticator>();
-  EXPECT_CALL(*mock_auth, doVerify(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_auth, doVerify(_, _, _, _, _)).Times(0);
   mock_auths_["example_provider"] = std::move(mock_auth);
   createVerifier();
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
@@ -233,7 +234,7 @@ TEST_F(GroupVerifierTest, TestRequiresAll) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("example-auth-userinfo"));
   EXPECT_FALSE(headers.has("other-auth-userinfo"));
@@ -252,7 +253,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllBadFormat) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["example_provider"](Status::JwtBadFormat);
   // can keep invoking callback
@@ -276,7 +277,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllMissing) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["example_provider"](Status::Ok);
   callbacks["other_provider"](Status::JwtMissed);
@@ -300,7 +301,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllBothFailed) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("example-auth-userinfo"));
   EXPECT_FALSE(headers.has("other-auth-userinfo"));
@@ -322,7 +323,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyFirstAuthOK) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("example-auth-userinfo"));
   EXPECT_TRUE(headers.has("other-auth-userinfo"));
@@ -343,7 +344,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyLastAuthOk) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("example-auth-userinfo"));
   EXPECT_FALSE(headers.has("other-auth-userinfo"));
@@ -364,7 +365,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyAllAuthFailed) {
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("example-auth-userinfo"));
   EXPECT_FALSE(headers.has("other-auth-userinfo"));
@@ -382,7 +383,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllFirstAnyIsOk) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
@@ -400,7 +401,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllLastAnyIsOk) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
@@ -415,7 +416,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyIsOk) {
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_1"](Status::Ok);
   callbacks["provider_2"](Status::Ok);
@@ -432,7 +433,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyFailed) {
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwksFetchFail)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_1"](Status::JwksFetchFail);
   callbacks["provider_2"](Status::JwksFetchFail);
@@ -450,7 +451,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllFailed) {
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
@@ -465,7 +466,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyFirstAllIsOk) {
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_2"](Status::Ok);
   callbacks["provider_3"](Status::JwtMissed);
@@ -481,7 +482,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyLastAllIsOk) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_3"](Status::Ok);
   callbacks["provider_4"](Status::Ok);
@@ -497,7 +498,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllAreOk) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_1"](Status::Ok);
   callbacks["provider_2"](Status::Ok);
@@ -517,16 +518,16 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowAll) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"example_provider", "other_provider"});
   auto mock_auth = std::make_unique<MockAuthenticator>();
-  EXPECT_CALL(*mock_auth, doVerify(_, _, _, _))
+  EXPECT_CALL(*mock_auth, doVerify(_, _, _, _, _))
       .WillOnce(Invoke(
-          [&](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
+          [&](Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
               AuthenticatorCallback callback) { callbacks[allowfailed] = std::move(callback); }));
   EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
   mock_auths_[allowfailed] = std::move(mock_auth);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
 
   auto headers = Http::TestHeaderMapImpl{};
-  context_ = Verifier::createContext(headers, &mock_cb_);
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks[allowfailed](Status::Ok);
   // with requires any, if any inner verifier returns OK the whole any verifier should return OK.

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -116,11 +116,11 @@ public:
     for (const auto& provider : providers) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
       EXPECT_CALL(*mock_auth, doVerify(_, _, _, _, _))
-          .WillOnce(Invoke(
-              [&callbacks, iss = provider](Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*,
-                                           SetPayloadCallback, AuthenticatorCallback callback) {
-                callbacks[iss] = std::move(callback);
-              }));
+          .WillOnce(Invoke([&callbacks, iss = provider](
+                               Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*,
+                               SetPayloadCallback, AuthenticatorCallback callback) {
+            callbacks[iss] = std::move(callback);
+          }));
       EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
       mock_auths_[provider] = std::move(mock_auth);
     }
@@ -519,9 +519,10 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowAll) {
       std::vector<std::string>{"example_provider", "other_provider"});
   auto mock_auth = std::make_unique<MockAuthenticator>();
   EXPECT_CALL(*mock_auth, doVerify(_, _, _, _, _))
-      .WillOnce(Invoke(
-          [&](Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
-              AuthenticatorCallback callback) { callbacks[allowfailed] = std::move(callback); }));
+      .WillOnce(Invoke([&](Http::HeaderMap&, Tracing::Span&, std::vector<JwtLocationConstPtr>*,
+                           SetPayloadCallback, AuthenticatorCallback callback) {
+        callbacks[allowfailed] = std::move(callback);
+      }));
   EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
   mock_auths_[allowfailed] = std::move(mock_auth);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -24,11 +24,13 @@ public:
 
 class MockAuthenticator : public Authenticator {
 public:
-  MOCK_METHOD5(doVerify, void(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>* tokens,
+  MOCK_METHOD5(doVerify, void(Http::HeaderMap& headers, Tracing::Span& parent_span,
+                              std::vector<JwtLocationConstPtr>* tokens,
                               SetPayloadCallback set_payload_cb, AuthenticatorCallback callback));
 
-  void verify(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>&& tokens,
-              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) override {
+  void verify(Http::HeaderMap& headers, Tracing::Span& parent_span,
+              std::vector<JwtLocationConstPtr>&& tokens, SetPayloadCallback set_payload_cb,
+              AuthenticatorCallback callback) override {
     doVerify(headers, parent_span, &tokens, std::move(set_payload_cb), std::move(callback));
   }
 

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -24,12 +24,12 @@ public:
 
 class MockAuthenticator : public Authenticator {
 public:
-  MOCK_METHOD4(doVerify, void(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>* tokens,
+  MOCK_METHOD5(doVerify, void(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>* tokens,
                               SetPayloadCallback set_payload_cb, AuthenticatorCallback callback));
 
-  void verify(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>&& tokens,
+  void verify(Http::HeaderMap& headers, Tracing::Span& parent_span, std::vector<JwtLocationConstPtr>&& tokens,
               SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) override {
-    doVerify(headers, &tokens, std::move(set_payload_cb), std::move(callback));
+    doVerify(headers, parent_span, &tokens, std::move(set_payload_cb), std::move(callback));
   }
 
   MOCK_METHOD0(onDestroy, void());


### PR DESCRIPTION
Description: Add support for tracing remote calls made by the jwt_authn filter. Most changes are just passing down the `active_span` from `filter.cc` to `jwks_fetcher.cc`. Had to update a lot of tests with new function signatures.

Risk Level: Low, backwards compatible and does not change behavior if tracing is disabled

Testing: Unit tests to verify `active_span` is being passed down to `HttpAsyncClient`

Docs Changes: N/A

Release Notes: N/A