### PR TITLE
grpc: escape binary headers

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -152,6 +152,7 @@ envoy_cc_library(
         "//include/envoy/grpc:google_grpc_creds_interface",
         "//include/envoy/thread:thread_interface",
         "//include/envoy/thread_local:thread_local_interface",
+        "//source/common/common:base64_lib",
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",
         "//source/common/common:thread_annotations",

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -254,6 +254,8 @@ TEST_P(GrpcClientIntegrationTest, ServerInitialMetadata) {
   const TestMetadata initial_metadata = {
       {Http::LowerCaseString("foo"), "bar"},
       {Http::LowerCaseString("baz"), "blah"},
+      // This forces the binary encoding in gRPC library
+      {Http::LowerCaseString("binary-bin"), "help"},
   };
   stream->sendServerInitialMetadata(initial_metadata);
   stream->sendReply();

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -254,7 +254,6 @@ TEST_P(GrpcClientIntegrationTest, ServerInitialMetadata) {
   const TestMetadata initial_metadata = {
       {Http::LowerCaseString("foo"), "bar"},
       {Http::LowerCaseString("baz"), "blah"},
-      // This forces the binary encoding in gRPC library
       {Http::LowerCaseString("binary-bin"), "help"},
   };
   stream->sendServerInitialMetadata(initial_metadata);


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>
@PiotrSikora @htuch 

Description: escape base64-encoded binary metadata from gRPC library
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
