### PR TITLE
Update dependency and docs: jwt_verify_lib (add ES384, ES512 support)

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -174,10 +174,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/releases/download/cpp-3.2.0/msgpack-3.2.0.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "b42ad9d286e267b265080e97bacb99c27bce39db93a6c34be9575ddd9a3edd7a",
-        strip_prefix = "jwt_verify_lib-945805866007edb9d2760915abaa672ed8b7da86",
-        # 2019-10-07
-        urls = ["https://github.com/google/jwt_verify_lib/archive/945805866007edb9d2760915abaa672ed8b7da86.tar.gz"],
+        sha256 = "480ff74bcdea9e177a803feb8f797c76abd38a80ec27d93b64f4d56e7cfd28a1",
+        strip_prefix = "jwt_verify_lib-9f10e2d60d42edeb6662e185707a7d6a4ebc5604",
+        # 2019-10-24
+        urls = ["https://github.com/google/jwt_verify_lib/archive/9f10e2d60d42edeb6662e185707a7d6a4ebc5604.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "ef26268c54c8084d17654ba2ed5140bffeffd2a040a895ffb22a6cca3f6c613f",

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -8,7 +8,7 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
 .. attention::
-   ES256, HS256, HS384, HS512, RS256, RS384 and RS512 are supported for the JWT alg.
+   ES256, ES384, ES512, HS256, HS384, HS512, RS256, RS384 and RS512 are supported for the JWT alg.
 
 Configuration
 -------------


### PR DESCRIPTION
Signed-off-by: Ryan A. Chapman ryan@rchapman.org

Description: update jwt_verify_lib to support ES384 and ES512 tokens, also update documentation to show that Envoy now supports ES384 as well as ES512
Risk Level: low
Testing: upstream unit tests
Docs Changes: docs/root/configuration/http/http_filters/jwt_authn_filter.rst
Release Notes: none (should there be some?)