### PR TITLE
examples: fix the broken link to the Redis proxy filter

### DIFF
--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,6 +1,4 @@
-In this example, we show how a [Redis filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/network_filters/redis_proxy_filter) can be used with the Envoy proxy. The Envoy proxy [configuration](./envoy.yaml) includes a redis filter that routes egress requests to redis server.
-
-
+In this example, we show how a [Redis filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/redis_proxy_filter) can be used with the Envoy proxy. The Envoy proxy [configuration](./envoy.yaml) includes a redis filter that routes egress requests to redis server.
 
 # Usage
 1. `docker-compose pull`


### PR DESCRIPTION
Description: Link to the Redis proxy filter documentation page returns a 404. This PR updates the broken link to the correct one.
Risk Level: Low
Testing: manually checked the link
Docs Changes: N/A
Release Notes: N/A
