### PR TITLE
RFC: register extension factory registries

### DIFF
--- a/include/envoy/registry/BUILD
+++ b/include/envoy/registry/BUILD
@@ -10,7 +10,10 @@ envoy_package()
 
 envoy_cc_library(
     name = "registry",
-    hdrs = ["registry.h"],
+    hdrs = [
+        "extensions_registry.h",
+        "registry.h",
+    ],
     deps = [
         "//source/common/common:assert_lib",
     ],

--- a/include/envoy/registry/extensions_registry.h
+++ b/include/envoy/registry/extensions_registry.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/common/exception.h"
+#include "envoy/common/pure.h"
+#include "envoy/registry/registry.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace Envoy {
+namespace Registry {
+
+/**
+ * Users of the ExtensionFactoryRegistryRegistry class must specialize
+ * this class to define a category name for their extension.
+ */
+template <class Base> class ExtensionFactoryRegistryCategory {
+public:
+  static std::string category();
+};
+
+/**
+ * Helper class to call `allFactoryNames` for a given type.
+ */
+class BaseExtensionFactoryRegistry {
+public:
+  virtual ~BaseExtensionFactoryRegistry() = default;
+  virtual std::string factoryNames() const PURE;
+};
+
+template <class Base> class ExtensionFactoryRegistry : public BaseExtensionFactoryRegistry {
+public:
+  using FactoryRegistry = Envoy::Registry::FactoryRegistry<Base>;
+
+  std::string factoryNames() const { return FactoryRegistry::allFactoryNames(); }
+};
+
+/**
+ * This is a registry of extension factory registries. The distinction between
+ * a factory registry and an extension factory registry is that an extension
+ * factory registry registers factories that are visible to user configuration
+ * through the build system and API.
+ */
+class ExtensionFactoryRegistryRegistry {
+public:
+  using MapType = absl::flat_hash_map<std::string, BaseExtensionFactoryRegistry*>;
+
+  static MapType& factories() {
+    static auto* factories = new MapType();
+    return *factories;
+  }
+
+  static void registerExtensionFactoryRegistry(BaseExtensionFactoryRegistry* factory,
+                                               absl::string_view name) {
+    auto result = factories().emplace(std::make_pair(name, factory));
+    if (!result.second) {
+      throw EnvoyException(fmt::format("Double registration for extension category: '{}'", name));
+    }
+  }
+};
+
+template <class Base> class RegisterExtensionFactoryRegistry {
+public:
+  RegisterExtensionFactoryRegistry() {
+    ExtensionFactoryRegistryRegistry::registerExtensionFactoryRegistry(
+        new ExtensionFactoryRegistry<Base>(), ExtensionFactoryRegistryCategory<Base>::category());
+  }
+};
+
+/**
+ * This needs to be used at global scope (i.e. not within a namespace).
+ */
+#define REGISTER_EXTENSION_FACTORY(BASE, CATEGORY)                                                 \
+  template <> std::string Envoy::Registry::ExtensionFactoryRegistryCategory<BASE>::category() {    \
+    return CATEGORY;                                                                               \
+  }                                                                                                \
+  static Envoy::Registry::RegisterExtensionFactoryRegistry<BASE> _extension
+
+} // namespace Registry
+} // namespace Envoy

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -7,6 +7,7 @@
 #include "envoy/config/filter/accesslog/v2/accesslog.pb.validate.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/http/header_map.h"
+#include "envoy/registry/extensions_registry.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/upstream.h"
 
@@ -286,3 +287,5 @@ AccessLogFactory::fromProto(const envoy::config::filter::accesslog::v2::AccessLo
 
 } // namespace AccessLog
 } // namespace Envoy
+
+REGISTER_EXTENSION_FACTORY(Envoy::Server::Configuration::AccessLogInstanceFactory, "access_logger");

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -14,6 +14,7 @@
 #include "envoy/event/signal.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/dns.h"
+#include "envoy/registry/extensions_registry.h"
 #include "envoy/server/options.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -247,6 +248,14 @@ void InstanceImpl::initialize(const Options& options,
                               ComponentFactory& component_factory, ListenerHooks& hooks) {
   ENVOY_LOG(info, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
             restarter_.version());
+
+  ENVOY_LOG(info, "registered extensions:");
+
+  for (const auto& ext : Envoy::Registry::ExtensionFactoryRegistryRegistry::factories()) {
+    ENVOY_LOG(info, "  {}: {}", ext.first, ext.second->factoryNames());
+  }
+
+  ENVOY_LOG(info, "done");
 
   ENVOY_LOG(info, "statically linked extensions:");
   ENVOY_LOG(info, "  access_loggers: {}",


### PR DESCRIPTION
Create a mechanism for registering extension factory registries in
yet another registry. This registry maps a category name to an
extension factory registry so that for each category, we can generate
a list of registered factory names.

Factory registried have to opt on (once) to this mechanism, in order
to support the use of factory registries that are not user-visible
at either build time or run time.

Subsequently, we can use this new factory to emit the named of
registered extension factories to the startup log and to the config
dump endpoint.

Signed-off-by: James Peach <jpeach@apache.org>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
