### PR TITLE
ci: move clang-tidy to azp

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -44,6 +44,8 @@ jobs:
         CI_TARGET: 'bazel.asan'
       tsan:
         CI_TARGET: 'bazel.tsan'
+      clang_tidy:
+        CI_TARGET: 'bazel.clang_tidy'
       gcc:
         CI_TARGET: 'bazel.gcc'
       compile_time_options:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,16 +104,6 @@ jobs:
            at: /build/envoy/generated
        - run: ci/coverage_publish.sh
 
-   clang_tidy:
-     executor: ubuntu-build
-     steps:
-       - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
-       - checkout
-       - run:
-           command:
-             ci/do_circle_ci.sh bazel.clang_tidy
-           no_output_timeout: 60m
-
    docs:
      executor: ubuntu-build
      steps:
@@ -146,7 +136,6 @@ workflows:
       - coverage
       - coverage_publish:
           requires: [coverage]
-      - clang_tidy
       - docs:
           filters:
             tags:


### PR DESCRIPTION
Testing: CI only

Signed-off-by: Lizan Zhou <lizan@tetrate.io>