### PR TITLE
ci: azp repository_cache

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -15,6 +15,11 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
+  - task: CacheBeta@1
+    inputs:
+      key: 'format | ./WORKSPACE | **/*.bzl'
+      path: $(Build.StagingDirectory)/repository_cache
+
   - script: ci/run_envoy_docker.sh 'ci/check_and_fix_format.sh'
     workingDirectory: $(Build.SourcesDirectory)
     env:
@@ -55,6 +60,11 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
+  - task: CacheBeta@1
+    inputs:
+      key: '"$(CI_TARGET)" | ./WORKSPACE | **/*.bzl'
+      path: $(Build.StagingDirectory)/repository_cache
+
   - bash: |
       echo "disk space at beginning of build:"
       df -h

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -73,6 +73,7 @@ export BAZEL_QUERY_OPTIONS="${BAZEL_OPTIONS}"
 export BAZEL_BUILD_OPTIONS="--verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
   --local_cpu_resources=${NUM_CPUS} --show_task_finish --experimental_generate_json_trace_profile \
   --test_env=HOME --test_env=PYTHONUSERBASE --cache_test_results=no --test_output=all \
+  --repository_cache=${BUILD_DIR}/repository_cache --experimental_repository_cache_hardlinks \
   ${BAZEL_BUILD_EXTRA_OPTIONS} ${BAZEL_EXTRA_TEST_OPTIONS}"
 
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Cache bazel downloaded artifacts in azp, should make CI slightly faster and less download fail error.

Risk Level: Low
Testing: CI only

