### PR TITLE
tools: fixing bugs in deprecate_version.py

### DIFF
--- a/tools/deprecate_version/deprecate_version.py
+++ b/tools/deprecate_version/deprecate_version.py
@@ -118,7 +118,7 @@ def CreateIssues(access_token, runtime_and_pr):
         repo.create_issue(title, body=body, assignees=[user.login], labels=labels)
       except github.GithubException as e:
         try:
-          body += '\ncc @' +  user.login
+          body += '\ncc @' + user.login
           repo.create_issue(title, body=body, labels=labels)
           print(('unable to assign issue %s to %s. Add them to the Envoy proxy org'
                  'and assign it their way.') % (title, user.login))

--- a/tools/deprecate_version/deprecate_version.py
+++ b/tools/deprecate_version/deprecate_version.py
@@ -117,10 +117,16 @@ def CreateIssues(access_token, runtime_and_pr):
       try:
         repo.create_issue(title, body=body, assignees=[user.login], labels=labels)
       except github.GithubException as e:
-        print(('GithubException while creating issue. This is typically because'
-               ' a user is not a member of envoyproxy org. Check that %s is in '
-               'the org.') % user.login)
-        raise
+        try:
+          body += '\ncc @' +  user.login
+          repo.create_issue(title, body=body, labels=labels)
+          print(('unable to assign issue %s to %s. Add them to the Envoy proxy org'
+                 'and assign it their way.') % (title, user.login))
+        except github.GithubException as e:
+          print(('GithubException while creating issue. This is typically because'
+                 ' a user is not a member of envoyproxy org. Check that %s is in '
+                 'the org.') % user.login)
+          raise
 
 
 def GetRuntimeAlreadyTrue():
@@ -158,6 +164,7 @@ def GetRuntimeAndPr():
       # If this runtime guard isn't true, ignore it for this release.
       if not runtime_guard in runtime_already_true:
         continue
+
       # For true runtime guards, walk the blame of the file they were added to,
       # to find the pr the feature was added.
       for commit, lines in repo.blame('HEAD', filename):
@@ -166,6 +173,8 @@ def GetRuntimeAndPr():
             pr = (int(re.search('\(#(\d+)\)', commit.message).group(1)))
             # Add the runtime guard and PR to the list to file issues about.
             features_to_flip.append((runtime_guard, pr))
+            # Make sure if grep finds multiple spots we only do the work one time.
+            runtime_already_true.remove(runtime_guard)
 
     else:
       print('no match in ' + str(line) + ' please address manually!')
@@ -178,7 +187,8 @@ if __name__ == '__main__':
 
   access_token = os.getenv('GH_ACCESS_TOKEN')
   if not access_token:
-    print('Missing GH_ACCESS_TOKEN')
+    print(
+        'Missing GH_ACCESS_TOKEN: see instructions in tools/deprecate_version/deprecate_version.py')
     sys.exit(1)
 
   CreateIssues(access_token, runtime_and_pr)

--- a/tools/deprecate_version/deprecate_version.py
+++ b/tools/deprecate_version/deprecate_version.py
@@ -123,9 +123,7 @@ def CreateIssues(access_token, runtime_and_pr):
           print(('unable to assign issue %s to %s. Add them to the Envoy proxy org'
                  'and assign it their way.') % (title, user.login))
         except github.GithubException as e:
-          print(('GithubException while creating issue. This is typically because'
-                 ' a user is not a member of envoyproxy org. Check that %s is in '
-                 'the org.') % user.login)
+          print('GithubException while creating issue.')
           raise
 
 


### PR DESCRIPTION
1) if a flag was mentioned in multiple places it would do the ownership work twice
2) the script crashed unless everyone was in the Envoy community.  One could add people and rerun if one had addition privs which most maintainers to not
3) pretty printing where the token instructions are since it saves me some cutting and pasting

Fixes #8844 
