### PR TITLE
release: flipping flags

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -348,6 +348,7 @@ void ConnectionImpl::StreamImpl::onMetadataDecoded(MetadataMapPtr&& metadata_map
 
 namespace {
 
+// TOOD(yanavlasov, PiotrSikora) fix up tests with this true
 const char InvalidHttpMessagingOverrideKey[] =
     "envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging";
 const char MaxOutboundFramesOverrideKey[] =

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -348,7 +348,6 @@ void ConnectionImpl::StreamImpl::onMetadataDecoded(MetadataMapPtr&& metadata_map
 
 namespace {
 
-// TOOD(yanavlasov, PiotrSikora) fix up tests with this true
 const char InvalidHttpMessagingOverrideKey[] =
     "envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging";
 const char MaxOutboundFramesOverrideKey[] =

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -25,6 +25,9 @@ namespace Runtime {
 constexpr const char* runtime_features[] = {
     // Enabled
     "envoy.reloadable_features.test_feature_true",
+    "envoy.reloadable_features.strict_header_validation",
+    "envoy.reloadable_features.http2_protocol_options.max_inbound_priority_frames_per_stream",
+    "envoy.reloadable_features.http2_protocol_options.max_outbound_frames",
     "envoy.reloadable_features.buffer_filter_populate_content_length",
     "envoy.reloadable_features.trusted_forwarded_proto",
     "envoy.reloadable_features.outlier_detection_support_for_grpc_status",

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -26,8 +26,6 @@ constexpr const char* runtime_features[] = {
     // Enabled
     "envoy.reloadable_features.test_feature_true",
     "envoy.reloadable_features.strict_header_validation",
-    "envoy.reloadable_features.http2_protocol_options.max_inbound_priority_frames_per_stream",
-    "envoy.reloadable_features.http2_protocol_options.max_outbound_frames",
     "envoy.reloadable_features.buffer_filter_populate_content_length",
     "envoy.reloadable_features.trusted_forwarded_proto",
     "envoy.reloadable_features.outlier_detection_support_for_grpc_status",

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -433,6 +433,9 @@ TEST_F(Http1ServerConnectionImplTest, HeaderInvalidCharsRejection) {
 // Regression test for http-parser allowing embedded NULs in header values,
 // verify we reject them.
 TEST_F(Http1ServerConnectionImplTest, HeaderEmbeddedNulRejection) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.strict_header_validation", "false"}});
   initialize();
 
   InSequence sequence;


### PR DESCRIPTION
Flipping the following flags to true by default:
    "envoy.reloadable_features.strict_header_validation",

Not flipping 
  "envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging"  
 because it's supposed to remain false, but filed a follow-up bug for tooling
ditto
    "envoy.reloadable_features.http2_protocol_options.max_inbound_priority_frames_per_stream",
    "envoy.reloadable_features.http2_protocol_options.max_outbound_frames",
as they aren't even booleans.

Risk Level: Medium
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
