### PR TITLE
Remove StringUtil::join.

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -362,15 +362,6 @@ size_t StringUtil::strlcpy(char* dst, const char* src, size_t size) {
   return strlen(src);
 }
 
-std::string StringUtil::join(const std::vector<std::string>& source, const std::string& delimiter) {
-  std::ostringstream buf;
-  std::copy(source.begin(), source.end(),
-            std::ostream_iterator<std::string>(buf, delimiter.c_str()));
-  std::string ret = buf.str();
-  // copy will always end with an extra delimiter, we remove it here.
-  return ret.substr(0, ret.length() - delimiter.length());
-}
-
 std::string StringUtil::subspan(absl::string_view source, size_t start, size_t end) {
   return std::string(source.data() + start, end - start);
 }

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -330,14 +330,6 @@ public:
   static size_t strlcpy(char* dst, const char* src, size_t size);
 
   /**
-   * Join elements of a vector into a string delimited by delimiter.
-   * @param source supplies the strings to join.
-   * @param delimiter supplies the delimiter to join them together.
-   * @return string combining elements of `source` with `delimiter` in between each element.
-   */
-  static std::string join(const std::vector<std::string>& source, const std::string& delimiter);
-
-  /**
    * Version of substr() that operates on a start and end index instead of a start index and a
    * length.
    * @return string substring starting at start, and ending right before end.

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -15,6 +15,8 @@
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
+#include "absl/strings/str_join.h"
+
 #include "ares.h"
 
 namespace Envoy {
@@ -48,7 +50,7 @@ DnsResolverImpl::DnsResolverImpl(
                                            resolver->ip()->addressAsString(),
                                            resolver->ip()->port()));
     }
-    const std::string resolvers_csv = StringUtil::join(resolver_addrs, ",");
+    const std::string resolvers_csv = absl::StrJoin(resolver_addrs, ",");
     int result = ares_set_servers_ports_csv(channel_, resolvers_csv.c_str());
     RELEASE_ASSERT(result == ARES_SUCCESS, "");
   }

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -16,7 +16,6 @@
 #include "common/network/utility.h"
 
 #include "absl/strings/str_join.h"
-
 #include "ares.h"
 
 namespace Envoy {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -15,6 +15,8 @@
 #include "common/protobuf/protobuf.h"
 #include "common/singleton/const_singleton.h"
 
+#include "absl/strings/str_join.h"
+
 // Obtain the value of a wrapped field (e.g. google.protobuf.UInt32Value) if set. Otherwise, return
 // the default value.
 #define PROTOBUF_GET_WRAPPED_OR_DEFAULT(message, field_name, default_value)                        \
@@ -120,7 +122,7 @@ class RepeatedPtrUtil {
 public:
   static std::string join(const Protobuf::RepeatedPtrField<std::string>& source,
                           const std::string& delimiter) {
-    return StringUtil::join(std::vector<std::string>(source.begin(), source.end()), delimiter);
+    return absl::StrJoin(std::vector<std::string>(source.begin(), source.end()), delimiter);
   }
 
   template <class ProtoType>

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -14,6 +14,7 @@
 #include "common/stream_info/utility.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -117,7 +118,7 @@ parseUpstreamMetadataField(absl::string_view params_str) {
     default:
       // Unsupported type or null value.
       ENVOY_LOG_MISC(debug, "unsupported value type for metadata [{}]",
-                     StringUtil::join(params, ", "));
+                     absl::StrJoin(params, ", "));
       return std::string();
     }
   };

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -13,6 +13,8 @@
 #include "common/init/manager_impl.h"
 #include "common/init/watcher_impl.h"
 
+#include "absl/strings/str_join.h"
+
 // Types are deeply nested under Envoy::Config::ConfigProvider; use 'using-directives' across all
 // ConfigProvider related types for consistency.
 using Envoy::Config::ConfigProvider;
@@ -255,7 +257,7 @@ void ScopedRdsConfigSubscription::onConfigUpdate(
   stats_.config_reload_.inc();
   if (!exception_msgs.empty()) {
     throw EnvoyException(fmt::format("Error adding/updating scoped route(s): {}",
-                                     StringUtil::join(exception_msgs, ", ")));
+                                     absl::StrJoin(exception_msgs, ", ")));
   }
 }
 

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -12,6 +12,8 @@
 #include "common/config/utility.h"
 #include "common/protobuf/utility.h"
 
+#include "absl/strings/str_join.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -101,7 +103,7 @@ void CdsApiImpl::onConfigUpdate(
   runInitializeCallbackIfAny();
   if (!exception_msgs.empty()) {
     throw EnvoyException(
-        fmt::format("Error adding/updating cluster(s) {}", StringUtil::join(exception_msgs, ", ")));
+        fmt::format("Error adding/updating cluster(s) {}", absl::StrJoin(exception_msgs, ", ")));
   }
 }
 

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -15,6 +15,8 @@
 #include "common/config/utility.h"
 #include "common/stats/symbol_table_impl.h"
 
+#include "absl/strings/str_join.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace StatSinks {
@@ -97,7 +99,7 @@ const std::string UdpStatsdSink::buildTagStr(const std::vector<Stats::Tag>& tags
   for (const Stats::Tag& tag : tags) {
     tag_strings.emplace_back(tag.name_ + ":" + tag.value_);
   }
-  return "|#" + StringUtil::join(tag_strings, ",");
+  return "|#" + absl::StrJoin(tag_strings, ",");
 }
 
 TcpStatsdSink::TcpStatsdSink(const LocalInfo::LocalInfo& local_info,

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -20,12 +20,11 @@
 
 #include "extensions/transport_sockets/tls/utility.h"
 
+#include "absl/strings/str_join.h"
 #include "openssl/evp.h"
 #include "openssl/hmac.h"
 #include "openssl/rand.h"
 #include "openssl/x509v3.h"
-
-#include "absl/strings/str_join.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -25,6 +25,8 @@
 #include "openssl/rand.h"
 #include "openssl/x509v3.h"
 
+#include "absl/strings/str_join.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
@@ -88,7 +90,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
       }
       throw EnvoyException(fmt::format("Failed to initialize cipher suites {}. The following "
                                        "ciphers were rejected when tried individually: {}",
-                                       config.cipherSuites(), StringUtil::join(bad_ciphers, ", ")));
+                                       config.cipherSuites(), absl::StrJoin(bad_ciphers, ", ")));
     }
 
     if (!SSL_CTX_set1_curves_list(ctx.ssl_ctx_.get(), config.ecdhCurves().c_str())) {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -880,7 +880,7 @@ std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag
   for (const Stats::Tag& tag : tags) {
     buf.push_back(fmt::format("{}=\"{}\"", sanitizeName(tag.name_), tag.value_));
   }
-  return StringUtil::join(buf, ",");
+  return absl::StrJoin(buf, ",");
 }
 
 std::string PrometheusStatsFormatter::metricName(const std::string& extracted_name) {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -11,6 +11,8 @@
 #include "common/config/utility.h"
 #include "common/protobuf/utility.h"
 
+#include "absl/strings/str_join.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -76,7 +78,7 @@ void LdsApiImpl::onConfigUpdate(
   init_target_.ready();
   if (!exception_msgs.empty()) {
     throw EnvoyException(fmt::format("Error adding/updating listener(s) {}",
-                                     StringUtil::join(exception_msgs, ", ")));
+                                     absl::StrJoin(exception_msgs, ", ")));
   }
 }
 

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -77,8 +77,8 @@ void LdsApiImpl::onConfigUpdate(
   }
   init_target_.ready();
   if (!exception_msgs.empty()) {
-    throw EnvoyException(fmt::format("Error adding/updating listener(s) {}",
-                                     absl::StrJoin(exception_msgs, ", ")));
+    throw EnvoyException(
+        fmt::format("Error adding/updating listener(s) {}", absl::StrJoin(exception_msgs, ", ")));
   }
 }
 

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -185,20 +185,6 @@ TEST(StringUtil, strlcpy) {
   }
 }
 
-TEST(StringUtil, join) {
-  EXPECT_EQ("hello,world", StringUtil::join({"hello", "world"}, ","));
-  EXPECT_EQ("hello", StringUtil::join({"hello"}, ","));
-  EXPECT_EQ("", StringUtil::join({}, ","));
-
-  EXPECT_EQ("helloworld", StringUtil::join({"hello", "world"}, ""));
-  EXPECT_EQ("hello", StringUtil::join({"hello"}, ""));
-  EXPECT_EQ("", StringUtil::join({}, ""));
-
-  EXPECT_EQ("hello,,world", StringUtil::join({"hello", "world"}, ",,"));
-  EXPECT_EQ("hello", StringUtil::join({"hello"}, ",,"));
-  EXPECT_EQ("", StringUtil::join({}, ",,"));
-}
-
 TEST(StringUtil, escape) {
   EXPECT_EQ(StringUtil::escape("hello world"), "hello world");
   EXPECT_EQ(StringUtil::escape("hello\nworld\n"), "hello\\nworld\\n");

--- a/test/common/stats/recent_lookups_test.cc
+++ b/test/common/stats/recent_lookups_test.cc
@@ -8,7 +8,6 @@
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/test/common/stats/recent_lookups_test.cc
+++ b/test/common/stats/recent_lookups_test.cc
@@ -7,6 +7,8 @@
 #include "test/test_common/logging.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -32,7 +34,7 @@ protected:
     for (const auto& item : items) {
       accum.push_back(absl::StrCat(item.second, ": ", item.first));
     }
-    return StringUtil::join(accum, " ");
+    return absl::StrJoin(accum, " ");
   }
 
   RecentLookups recent_lookups_;

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -13,7 +13,6 @@
 #include "absl/hash/hash_testing.h"
 #include "absl/strings/str_join.h"
 #include "absl/synchronization/blocking_counter.h"
-
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -11,7 +11,9 @@
 #include "test/test_common/utility.h"
 
 #include "absl/hash/hash_testing.h"
+#include "absl/strings/str_join.h"
 #include "absl/synchronization/blocking_counter.h"
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -604,7 +606,7 @@ TEST_P(StatNameTest, RecentLookups) {
     accum.emplace_back(absl::StrCat(count, ": ", name));
   });
   EXPECT_EQ(5, total);
-  std::string recent_lookups_str = StringUtil::join(accum, " ");
+  std::string recent_lookups_str = absl::StrJoin(accum, " ");
 
   EXPECT_EQ("1: direct.stat "
             "2: dynamic.stat1 " // Combines entries from set and symbol-table.

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -43,7 +43,6 @@
 
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -41,7 +41,9 @@
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -221,7 +223,7 @@ envoy::config::bootstrap::v2::Bootstrap parseBootstrapFromV2Yaml(const std::stri
 }
 
 std::string clustersJson(const std::vector<std::string>& clusters) {
-  return fmt::sprintf("\"clusters\": [%s]", StringUtil::join(clusters, ","));
+  return fmt::sprintf("\"clusters\": [%s]", absl::StrJoin(clusters, ","));
 }
 
 class ClusterManagerImplTest : public testing::Test {

--- a/test/extensions/filters/network/thrift_proxy/integration.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration.cc
@@ -5,6 +5,8 @@
 
 #include "test/test_common/environment.h"
 
+#include "absl/strings/str_join.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -75,7 +77,7 @@ void BaseThriftIntegrationTest::preparePayloads(const PayloadOptions& options,
                    [](const std::pair<std::string, std::string>& header) -> std::string {
                      return header.first + "=" + header.second;
                    });
-    args.push_back(StringUtil::join(headers, ","));
+    args.push_back(absl::StrJoin(headers, ","));
   }
 
   args.push_back(options.method_name_);

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -31,6 +31,8 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
+#include "absl/strings/str_join.h"
+
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -596,8 +598,8 @@ AssertionResult BaseIntegrationTest::compareSotwDiscoveryRequest(
   if (expected_resource_names != resource_names) {
     return AssertionFailure() << fmt::format(
                "resources {} do not match expected {} in {}",
-               fmt::join(resource_names.begin(), resource_names.end(), ","),
-               fmt::join(expected_resource_names.begin(), expected_resource_names.end(), ","),
+               absl::StrJoin(resource_names, ","),
+               absl::StrJoin(expected_resource_names, ","),
                discovery_request.DebugString());
   }
   if (expected_version != discovery_request.version_info()) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -32,7 +32,6 @@
 #include "test/test_common/network_utility.h"
 
 #include "absl/strings/str_join.h"
-
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -597,10 +596,8 @@ AssertionResult BaseIntegrationTest::compareSotwDiscoveryRequest(
                                                 discovery_request.resource_names().cend());
   if (expected_resource_names != resource_names) {
     return AssertionFailure() << fmt::format(
-               "resources {} do not match expected {} in {}",
-               absl::StrJoin(resource_names, ","),
-               absl::StrJoin(expected_resource_names, ","),
-               discovery_request.DebugString());
+               "resources {} do not match expected {} in {}", absl::StrJoin(resource_names, ","),
+               absl::StrJoin(expected_resource_names, ","), discovery_request.DebugString());
   }
   if (expected_version != discovery_request.version_info()) {
     return AssertionFailure() << fmt::format("version {} does not match expected {} in {}",


### PR DESCRIPTION
Description:

Abseil has a StrJoin, which does the same as StringUtils::join and
fmt::join. Replace all uses of these with absl::StrJoin.

Risk Level: Low
Testing: Bazel tests
Docs Changes: None
Release Notes: None
