### PR TITLE
config: Deprecate google.protobuf.Struct config members followup

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -110,7 +110,7 @@ message PrivateKeyProvider {
 
   // Private key method provider specific configuration.
   oneof config_type {
-    google.protobuf.Struct config = 2;
+    google.protobuf.Struct config = 2 [deprecated = true];
 
     google.protobuf.Any typed_config = 3;
   }

--- a/api/envoy/api/v2/listener/udp_listener_config.proto
+++ b/api/envoy/api/v2/listener/udp_listener_config.proto
@@ -23,7 +23,7 @@ message UdpListenerConfig {
   // Used to create a specific listener factory. To some factory, e.g.
   // "raw_udp_listener", config is not needed.
   oneof config_type {
-    google.protobuf.Struct config = 2;
+    google.protobuf.Struct config = 2 [deprecated = true];
 
     google.protobuf.Any typed_config = 3;
   }

--- a/api/envoy/api/v3alpha/auth/cert.proto
+++ b/api/envoy/api/v3alpha/auth/cert.proto
@@ -104,14 +104,16 @@ message TlsParameters {
 // (potentially asynchronous) signing and decryption operations. Some use cases for private key
 // methods would be TPM support and TLS acceleration.
 message PrivateKeyProvider {
+  reserved 2;
+
+  reserved "config";
+
   // Private key method provider name. The name must match a
   // supported private key method provider type.
   string provider_name = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // Private key method provider specific configuration.
   oneof config_type {
-    google.protobuf.Struct config = 2;
-
     google.protobuf.Any typed_config = 3;
   }
 }

--- a/api/envoy/api/v3alpha/listener/udp_listener_config.proto
+++ b/api/envoy/api/v3alpha/listener/udp_listener_config.proto
@@ -13,6 +13,10 @@ import "google/protobuf/struct.proto";
 // Listener :ref:`configuration overview <config_listeners>`
 
 message UdpListenerConfig {
+  reserved 2;
+
+  reserved "config";
+
   // Used to look up UDP listener factory, matches "raw_udp_listener" or
   // "quic_listener" to create a specific udp listener.
   // If not specified, treat as "raw_udp_listener".
@@ -21,8 +25,6 @@ message UdpListenerConfig {
   // Used to create a specific listener factory. To some factory, e.g.
   // "raw_udp_listener", config is not needed.
   oneof config_type {
-    google.protobuf.Struct config = 2;
-
     google.protobuf.Any typed_config = 3;
   }
 }

--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -245,7 +245,7 @@ message ExtensionFilter {
 
   // Custom configuration that depends on the filter being instantiated.
   oneof config_type {
-    google.protobuf.Struct config = 2;
+    google.protobuf.Struct config = 2 [deprecated = true];
 
     google.protobuf.Any typed_config = 3;
   }

--- a/api/envoy/config/filter/accesslog/v3alpha/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v3alpha/accesslog.proto
@@ -241,14 +241,16 @@ message GrpcStatusFilter {
 
 // Extension filter is statically registered at runtime.
 message ExtensionFilter {
+  reserved 2;
+
+  reserved "config";
+
   // The name of the filter implementation to instantiate. The name must
   // match a statically registered filter.
   string name = 1;
 
   // Custom configuration that depends on the filter being instantiated.
   oneof config_type {
-    google.protobuf.Struct config = 2;
-
     google.protobuf.Any typed_config = 3;
   }
 }

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1253,7 +1253,8 @@ name: envoy.file_access_log
 filter:
   extension_filter:
     name: test_header_filter
-    config:
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.filter.accesslog.v2.HeaderFilter
       header:
         name: test-header
 typed_config:
@@ -1326,8 +1327,10 @@ name: envoy.file_access_log
 filter:
   extension_filter:
     name: sample_extension_filter
-    config:
-      rate: 5
+    typed_config:
+      "@type": type.googleapis.com/google.protobuf.Struct
+      value:
+        rate: 5
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -1352,8 +1355,10 @@ name: envoy.file_access_log
 filter:
   extension_filter:
     name: unregistered_extension_filter
-    config:
-      foo: bar
+    typed_config:
+      "@type": type.googleapis.com/google.protobuf.Struct
+      value:
+        foo: bar
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4166,11 +4166,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncSignSuccess) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: false
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: false
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4198,11 +4200,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncDecryptSuccess) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: decrypt
-          sync_mode: false
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: decrypt
+            sync_mode: false
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4230,11 +4234,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderSyncSignSuccess) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4262,11 +4268,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderSyncDecryptSuccess) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: decrypt
-          sync_mode: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: decrypt
+            sync_mode: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4294,12 +4302,14 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncSignFailure) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: false
-          crypto_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: false
+            crypto_error: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4327,12 +4337,14 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderSyncSignFailure) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: true
-          crypto_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: true
+            crypto_error: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4360,11 +4372,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderSignFailure) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          method_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            method_error: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4392,11 +4406,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderDecryptFailure) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: decrypt
-          method_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: decrypt
+            method_error: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4424,11 +4440,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncSignCompleteFailure) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          async_method_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            async_method_error: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4457,11 +4475,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncDecryptCompleteFailure) {
         filename: "{{ test_tmpdir }}/unittestcert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: decrypt
-          async_method_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: decrypt
+            async_method_error: true
+            mode: rsa
     validation_context:
       trusted_ca:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
@@ -4503,11 +4523,13 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderMultiCertSuccess) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: false
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: false
+            mode: rsa
     - certificate_chain:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_cert.pem"
       private_key:
@@ -4541,20 +4563,24 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderMultiCertFail) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: false
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: false
+            mode: rsa
     - certificate_chain:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
-          expected_operation: sign
-          sync_mode: false
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
+            expected_operation: sign
+            sync_mode: false
+            mode: rsa
 )EOF";
 
   TestUtilOptions failing_test_options(client_ctx_yaml, server_ctx_yaml, false, GetParam());
@@ -4582,10 +4608,12 @@ TEST_P(SslSocketTest, EcdsaPrivateKeyProviderSuccess) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
-          expected_operation: sign
-          mode: ecdsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
+            expected_operation: sign
+            mode: ecdsa
 )EOF";
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
@@ -4615,20 +4643,24 @@ TEST_P(SslSocketTest, RsaAndEcdsaPrivateKeyProviderMultiCertSuccess) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: false
-          async_method_error: true
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: false
+            async_method_error: true
+            mode: rsa
     - certificate_chain:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
-          expected_operation: sign
-          mode: ecdsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
+            expected_operation: sign
+            mode: ecdsa
 )EOF";
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
   testUtil(test_options.setPrivateKeyMethodExpected(true));
@@ -4655,20 +4687,24 @@ TEST_P(SslSocketTest, RsaAndEcdsaPrivateKeyProviderMultiCertFail) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
-          expected_operation: sign
-          sync_mode: false
-          mode: rsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_tmpdir }}/unittestkey.pem"
+            expected_operation: sign
+            sync_mode: false
+            mode: rsa
     - certificate_chain:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_cert.pem"
       private_key_provider:
         provider_name: test
-        config:
-          private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
-          expected_operation: sign
-          async_method_error: true
-          mode: ecdsa
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
+            expected_operation: sign
+            async_method_error: true
+            mode: ecdsa
 )EOF";
   TestUtilOptions failing_test_options(client_ctx_yaml, server_ctx_yaml, false, GetParam());
   testUtil(failing_test_options.setPrivateKeyMethodExpected(true)

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
@@ -312,9 +312,13 @@ int TestPrivateKeyMethodProvider::ecdsaConnectionIndex() {
 }
 
 TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
-    const ProtobufWkt::Struct& config,
+    const ProtobufWkt::Any& typed_config,
     Server::Configuration::TransportSocketFactoryContext& factory_context) {
   std::string private_key_path;
+
+  auto config =
+                MessageUtil::anyConvert<ProtobufWkt::Struct>(
+              typed_config);
 
   for (auto& value_it : config.fields()) {
     auto& value = value_it.second;

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
@@ -316,9 +316,7 @@ TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
     Server::Configuration::TransportSocketFactoryContext& factory_context) {
   std::string private_key_path;
 
-  auto config =
-                MessageUtil::anyConvert<ProtobufWkt::Struct>(
-              typed_config);
+  auto config = MessageUtil::anyConvert<ProtobufWkt::Struct>(typed_config);
 
   for (auto& value_it : config.fields()) {
     auto& value = value_it.second;

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.h
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.h
@@ -60,7 +60,7 @@ private:
 class TestPrivateKeyMethodProvider : public virtual Ssl::PrivateKeyMethodProvider {
 public:
   TestPrivateKeyMethodProvider(
-      const ProtobufWkt::Struct& config,
+      const ProtobufWkt::Any& typed_config,
       Server::Configuration::TransportSocketFactoryContext& factory_context);
   // Ssl::PrivateKeyMethodProvider
   void registerPrivateKeyMethod(SSL* ssl, Ssl::PrivateKeyConnectionCallbacks& cb,
@@ -85,7 +85,7 @@ public:
   Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
       const envoy::api::v2::auth::PrivateKeyProvider& config,
       Server::Configuration::TransportSocketFactoryContext& factory_context) override {
-    return std::make_shared<TestPrivateKeyMethodProvider>(config.config(), factory_context);
+    return std::make_shared<TestPrivateKeyMethodProvider>(config.typed_config(), factory_context);
   }
 
   std::string name() const override { return std::string("test"); };


### PR DESCRIPTION
Deprecate google.protobuf.Struct config members in the following types:
envoy.api.v2.auth.PrivateKeyProvider
envoy.api.v2.listener.UdpListenerConfig
envoy.config.filter.accesslog.v2.ExtensionFilter

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Fixes: #8403 

Signed-off-by: Yan Avlasov <yavlasov@google.com>
