### PR TITLE
hds: use default interval if HealthCheckSpecifier message doesn't define one

### DIFF
--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -178,7 +178,7 @@ void HdsDelegate::onReceiveMessage(
   hds_clusters_.clear();
 
   // Set response
-  auto server_response_ms = PROTOBUF_GET_MS_REQUIRED(*message, interval);
+  auto server_response_ms = PROTOBUF_GET_MS_OR_DEFAULT(*message, interval, 1000);
 
   // Process the HealthCheckSpecifier message
   processMessage(std::move(message));

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -237,6 +237,22 @@ TEST_F(HdsTest, TestMinimalOnReceiveMessage) {
   hds_delegate_->onReceiveMessage(std::move(message));
 }
 
+// Tests OnReceiveMessage given a HealthCheckSpecifier message without interval field
+TEST_F(HdsTest, TestDefaultIntervalOnReceiveMessage) {
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
+  createHdsDelegate();
+
+  // Create Message
+  message = std::make_unique<envoy::service::discovery::v2::HealthCheckSpecifier>();
+  // notice that interval field is intentionally left undefined
+
+  // Process message
+  EXPECT_CALL(*server_response_timer_, enableTimer(std::chrono::milliseconds(1000), _))
+      .Times(AtLeast(1));
+  hds_delegate_->onReceiveMessage(std::move(message));
+}
+
 // Tests that SendResponse responds to the server in a timely fashion
 // given a minimal HealthCheckSpecifier message
 TEST_F(HdsTest, TestMinimalSendResponse) {


### PR DESCRIPTION
Description: Use default interval (1 second) if `HealthCheckSpecifier` message doesn't define one
Risk Level: Low
Testing: unit test, integration, manual testing
Docs Changes: N/A
Release Notes: N/A
Fixes #8863
