### PR TITLE
build: initialize const vector explicitly

### DIFF
--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -144,9 +144,9 @@ private:
     }
     absl::optional<std::chrono::milliseconds> maxInterval() const override { return absl::nullopt; }
 
-    const std::vector<uint32_t> retriable_status_codes_;
-    const std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
-    const std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
+    const std::vector<uint32_t> retriable_status_codes_{};
+    const std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_{};
+    const std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_{};
   };
 
   struct NullShadowPolicy : public Router::ShadowPolicy {


### PR DESCRIPTION
Description: Fix build on fedora by initializing const vector explicitly. 
Risk Level: Low
Testing: compile, unit/integration test
Docs Changes: N/A
Release Notes: N/A