### PR TITLE
test: deflake //test/extensions/access_loggers/grpc:tcp_grpc_access_log_integration_test

### DIFF
--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -143,6 +143,8 @@ TEST_P(TcpGrpcAccessLogIntegrationTest, BasicAccessLogFlow) {
   ASSERT_TRUE(fake_upstream_connection->write("", true));
   tcp_client->waitForHalfClose();
   tcp_client->write("", true);
+
+  ASSERT_TRUE(fake_upstream_connection->waitForData(3));
   ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
 


### PR DESCRIPTION
Risk Level: Low
Testing: CI, local with runs_per_test=1000
Docs Changes: N/A
Release Notes: N/A
Fixes #8879

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
