### PR TITLE
Allow router_check to be included

### DIFF
--- a/test/tools/router_check/BUILD
+++ b/test/tools/router_check/BUILD
@@ -12,7 +12,6 @@ envoy_package()
 
 envoy_cc_test_binary(
     name = "router_check_tool",
-    srcs = ["router_check.cc"],
     deps = [":router_check_main_lib"],
 )
 
@@ -23,6 +22,7 @@ envoy_cc_test_library(
         "coverage.h",
         "router.cc",
         "router.h",
+        "router_check.cc",
     ],
     copts = ["-DHAVE_LONG_LONG"],
     external_deps = ["tclap"],


### PR DESCRIPTION
Description: Allow router_check tool to be included.
Risk Level: Low
Testing:
Docs Changes: None
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
