### PR TITLE
flags: add a note to --drain-time-s that it applies to LDS

### DIFF
--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -315,8 +315,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
-    const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::
+operator!=(const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -315,8 +315,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::
-operator!=(const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
+    const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -87,8 +87,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   TCLAP::ValueArg<uint32_t> file_flush_interval_msec("", "file-flush-interval-msec",
                                                      "Interval for log flushing in msec", false,
                                                      10000, "uint32_t", cmd);
-  TCLAP::ValueArg<uint32_t> drain_time_s("", "drain-time-s", "Hot restart drain time in seconds",
-                                         false, 600, "uint32_t", cmd);
+  TCLAP::ValueArg<uint32_t> drain_time_s("", "drain-time-s",
+                                         "Hot restart and LDS removal drain time in seconds", false,
+                                         600, "uint32_t", cmd);
   TCLAP::ValueArg<uint32_t> parent_shutdown_time_s("", "parent-shutdown-time-s",
                                                    "Hot restart parent shutdown time in seconds",
                                                    false, 900, "uint32_t", cmd);


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>
Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
