### PR TITLE
fuzz: fix false positive in new_buffer_fuzz_test.

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-new_buffer_fuzz_test-5714377684025344
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-new_buffer_fuzz_test-5714377684025344
@@ -1,0 +1,469 @@
+actions {
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  read: 9476
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  target_index: 256
+  read: 1
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 2
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 4
+  move {
+  }
+}
+actions {
+  target_index: 2
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 2
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  target_index: 2
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 8
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+}
+actions {
+  move {
+    source_index: 8
+  }
+}
+actions {
+  target_index: 5
+  move {
+  }
+}
+actions {
+  add_string: 1646279268
+}
+actions {
+  target_index: 2
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 8
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  target_index: 4
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 2
+  move {
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 1
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 2
+  move {
+  }
+}
+actions {
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 1
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 4
+  move {
+  }
+}
+actions {
+  target_index: 4
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 4
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 8
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 1
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  target_index: 1
+}
+actions {
+  target_index: 4
+  move {
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}
+actions {
+  move {
+    source_index: 4
+  }
+}

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -322,8 +322,8 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
       if (source_buffer.length() > max_alloc) {
         break;
       }
-      target_buffer.move(source_buffer);
       allocated += source_buffer.length();
+      target_buffer.move(source_buffer);
     } else {
       const uint32_t source_length =
           std::min(static_cast<uint32_t>(source_buffer.length()), action.move().length());


### PR DESCRIPTION
This was bad accounting of moved buffer size.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18452.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>