### PR TITLE
api: final v1 cleanup

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -86,7 +86,7 @@ if [ "$1" != "-nofetch" ]; then
   fi
 
   # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f af5aa34dc85b80646d9db12c5b901ef18cee9f45)
+  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 03b45933284b332fd1df42cfb3270751fe543842)
   sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
   cp -f "${ENVOY_SRCDIR}"/.bazelversion "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/.bazelversion
 fi

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -156,7 +156,6 @@ envoy_cc_library(
         "//include/envoy/http:context_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/init:manager_interface",
-        "//include/envoy/json:json_object_interface",
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/network:drain_decision_interface",
         "//include/envoy/runtime:runtime_interface",

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -9,7 +9,6 @@
 #include "envoy/http/context.h"
 #include "envoy/http/filter.h"
 #include "envoy/init/manager.h"
-#include "envoy/json/json_object.h"
 #include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
@@ -312,13 +311,6 @@ public:
   ~NamedNetworkFilterConfigFactory() override = default;
 
   /**
-   * TODO(dereka): fully remove this method once envoy-filter-example is updated.
-   */
-  virtual Network::FilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) {
-    throw EnvoyException("v1 API is unsupported");
-  }
-
-  /**
    * Create a particular network filter factory implementation. If the implementation is unable to
    * produce a factory with the provided parameters, it should throw an EnvoyException. The returned
    * callback should always be initialized.
@@ -383,14 +375,6 @@ public:
 class NamedHttpFilterConfigFactory : public ProtocolOptionsFactory {
 public:
   ~NamedHttpFilterConfigFactory() override = default;
-
-  /**
-   * TODO(dereka): fully remove this method once envoy-filter-example is updated.
-   */
-  virtual Http::FilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
-                                                    FactoryContext&) {
-    throw EnvoyException("v1 API is unsupported");
-  }
 
   /**
    * Create a particular http filter factory implementation. If the implementation is unable to


### PR DESCRIPTION
Description: With the envoy-filter-example repository updated (https://github.com/envoyproxy/envoy-filter-example/pull/108), we can completely remove these methods. This *will* break builds using custom filters that have these method's `override`-en, but the fix is simply remove the `override` or (more preferable) just remove the methods entirely from each custom filter.
Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A (there was a release note included for https://github.com/envoyproxy/envoy/pull/8749, I don't think this warrants an additional note)

Signed-off-by: Derek Argueta <dereka@pinterest.com>