### PR TITLE
stats: Ignore end dot, silently removing them.

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -263,6 +263,16 @@ absl::string_view StringUtil::rtrim(absl::string_view source) {
 
 absl::string_view StringUtil::trim(absl::string_view source) { return ltrim(rtrim(source)); }
 
+absl::string_view StringUtil::removeTrailingCharacters(absl::string_view source, char ch) {
+  const absl::string_view::size_type pos = source.find_last_not_of(ch);
+  if (pos != absl::string_view::npos) {
+    source.remove_suffix(source.size() - pos - 1);
+  } else {
+    source.remove_suffix(source.size());
+  }
+  return source;
+}
+
 bool StringUtil::findToken(absl::string_view source, absl::string_view delimiters,
                            absl::string_view key_token, bool trim_whitespace) {
   const auto tokens = splitToken(source, delimiters, trim_whitespace);

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -222,6 +222,15 @@ public:
   static absl::string_view trim(absl::string_view source);
 
   /**
+   * Removes any specific trailing characters from the end of a string.
+   *
+   * @param source the string.
+   * @param ch the character to strip from the end of the string.
+   * @return a view of the string with the end characters removed.
+   */
+  static absl::string_view removeTrailingCharacters(absl::string_view source, char ch);
+
+  /**
    * Look up for an exactly token in a delimiter-separated string view.
    * @param source supplies the delimiter-separated string view.
    * @param multi-delimiter supplies chars used to split the delimiter-separated string view.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -222,10 +222,10 @@ public:
   static absl::string_view trim(absl::string_view source);
 
   /**
-   * Removes any specific trailing characters from the end of a string.
+   * Removes any specific trailing characters from the end of a string_view.
    *
-   * @param source the string.
-   * @param ch the character to strip from the end of the string.
+   * @param source the string_view.
+   * @param ch the character to strip from the end of the string_view.
    * @return a view of the string with the end characters removed.
    */
   static absl::string_view removeTrailingCharacters(absl::string_view source, char ch);

--- a/source/common/stats/fake_symbol_table_impl.h
+++ b/source/common/stats/fake_symbol_table_impl.h
@@ -142,7 +142,9 @@ private:
   }
 
   StoragePtr encodeHelper(absl::string_view name) const {
-    ASSERT(!absl::EndsWith(name, "."));
+    while (absl::EndsWith(name, ".")) {
+      name.remove_suffix(1);
+    }
     auto bytes = std::make_unique<Storage>(name.size() + StatNameSizeEncodingBytes);
     uint8_t* buffer = SymbolTableImpl::writeLengthReturningNext(name.size(), bytes.get());
     memcpy(buffer, name.data(), name.size());

--- a/source/common/stats/fake_symbol_table_impl.h
+++ b/source/common/stats/fake_symbol_table_impl.h
@@ -142,9 +142,7 @@ private:
   }
 
   StoragePtr encodeHelper(absl::string_view name) const {
-    while (absl::EndsWith(name, ".")) {
-      name.remove_suffix(1);
-    }
+    name = StringUtil::removeTrailingCharacters(name, '.');
     auto bytes = std::make_unique<Storage>(name.size() + StatNameSizeEncodingBytes);
     uint8_t* buffer = SymbolTableImpl::writeLengthReturningNext(name.size(), bytes.get());
     memcpy(buffer, name.data(), name.size());

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -376,7 +376,9 @@ void SymbolTableImpl::debugPrint() const {
 #endif
 
 SymbolTable::StoragePtr SymbolTableImpl::encode(absl::string_view name) {
-  ASSERT(!absl::EndsWith(name, "."));
+  while (absl::EndsWith(name, ".")) {
+    name.remove_suffix(1);
+  }
   Encoding encoding;
   addTokensToEncoding(name, encoding);
   auto bytes = std::make_unique<Storage>(encoding.bytesRequired());

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -7,6 +7,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/logger.h"
+#include "common/common/utility.h"
 
 #include "absl/strings/str_cat.h"
 
@@ -376,9 +377,7 @@ void SymbolTableImpl::debugPrint() const {
 #endif
 
 SymbolTable::StoragePtr SymbolTableImpl::encode(absl::string_view name) {
-  while (absl::EndsWith(name, ".")) {
-    name.remove_suffix(1);
-  }
+  name = StringUtil::removeTrailingCharacters(name, '.');
   Encoding encoding;
   addTokensToEncoding(name, encoding);
   auto bytes = std::make_unique<Storage>(encoding.bytesRequired());

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -315,8 +315,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
-    const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::
+operator!=(const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -315,8 +315,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::
-operator!=(const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
+    const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -223,6 +223,13 @@ TEST(StringUtil, StringViewRtrim) {
   EXPECT_EQ("", StringUtil::rtrim(""));
 }
 
+TEST(StringUtil, RemoveTrailingCharacters) {
+  EXPECT_EQ("", StringUtil::removeTrailingCharacters("......", '.'));
+  EXPECT_EQ("\t\f\v\n\rhello", StringUtil::removeTrailingCharacters("\t\f\v\n\rhello ", '.'));
+  EXPECT_EQ("\t\f\v\n\r a b", StringUtil::removeTrailingCharacters("\t\f\v\n\r a b.......", '.'));
+  EXPECT_EQ("", StringUtil::removeTrailingCharacters("", '.'));
+}
+
 TEST(StringUtil, StringViewTrim) {
   EXPECT_EQ("", StringUtil::trim("   "));
   EXPECT_EQ("hello", StringUtil::trim("\t\f\v\n\r  hello   "));

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -225,7 +225,7 @@ TEST(StringUtil, StringViewRtrim) {
 
 TEST(StringUtil, RemoveTrailingCharacters) {
   EXPECT_EQ("", StringUtil::removeTrailingCharacters("......", '.'));
-  EXPECT_EQ("\t\f\v\n\rhello", StringUtil::removeTrailingCharacters("\t\f\v\n\rhello ", '.'));
+  EXPECT_EQ("\t\f\v\n\rhello ", StringUtil::removeTrailingCharacters("\t\f\v\n\rhello ", '.'));
   EXPECT_EQ("\t\f\v\n\r a b", StringUtil::removeTrailingCharacters("\t\f\v\n\r a b.......", '.'));
   EXPECT_EQ("", StringUtil::removeTrailingCharacters("", '.'));
 }

--- a/test/common/stats/symbol_table_fuzz_test.cc
+++ b/test/common/stats/symbol_table_fuzz_test.cc
@@ -18,7 +18,15 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   while (provider.remaining_bytes() != 0) {
     std::string next_data = provider.ConsumeRandomLengthString(provider.remaining_bytes());
     StatName stat_name = pool.add(next_data);
-    FUZZ_ASSERT(next_data == symbol_table.toString(stat_name));
+
+    // We can add stat-names with trailing dots, but note that they will be
+    // trimmed by the Symbol Table implementation, so we must trim the input
+    // string before comparing.
+    absl::string_view trimmed_fuzz_data(next_data);
+    while (absl::EndsWith(trimmed_fuzz_data, ".")) {
+      trimmed_fuzz_data.remove_suffix(1);
+    }
+    FUZZ_ASSERT(trimmed_fuzz_data == symbol_table.toString(stat_name));
   }
 }
 

--- a/test/common/stats/symbol_table_fuzz_test.cc
+++ b/test/common/stats/symbol_table_fuzz_test.cc
@@ -22,10 +22,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
     // We can add stat-names with trailing dots, but note that they will be
     // trimmed by the Symbol Table implementation, so we must trim the input
     // string before comparing.
-    absl::string_view trimmed_fuzz_data(next_data);
-    while (absl::EndsWith(trimmed_fuzz_data, ".")) {
-      trimmed_fuzz_data.remove_suffix(1);
-    }
+    absl::string_view trimmed_fuzz_data = StringUtil::removeTrailingCharacters(next_data, '.');
     FUZZ_ASSERT(trimmed_fuzz_data == symbol_table.toString(stat_name));
   }
 }

--- a/test/common/stats/symbol_table_fuzz_test.cc
+++ b/test/common/stats/symbol_table_fuzz_test.cc
@@ -17,12 +17,6 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
 
   while (provider.remaining_bytes() != 0) {
     std::string next_data = provider.ConsumeRandomLengthString(provider.remaining_bytes());
-
-    // ending with a "." is not considered legal, so just skip.
-    if (!next_data.empty() && next_data[next_data.size() - 1] == '.') {
-      continue;
-    }
-
     StatName stat_name = pool.add(next_data);
     FUZZ_ASSERT(next_data == symbol_table.toString(stat_name));
   }

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -167,6 +167,13 @@ TEST_P(StatNameTest, TestSymbolConsistency) {
   EXPECT_EQ(vec_2[0], vec_1[1]);
 }
 
+TEST_P(StatNameTest, TestIgnoreTrailingDots) {
+  EXPECT_EQ("foo.bar", encodeDecode("foo.bar."));
+  EXPECT_EQ("foo.bar", encodeDecode("foo.bar..."));
+  EXPECT_EQ("", encodeDecode("."));
+  EXPECT_EQ("", encodeDecode(".."));
+}
+
 TEST_P(StatNameTest, TestSameValueOnPartialFree) {
   // This should hold true for components as well. Since "foo" persists even when "foo.bar" is
   // freed, we expect both instances of "foo" to have the same symbol.


### PR DESCRIPTION
Description: Earlier, when trying to get some consistency in how we spell stats prefixes throughout the codebase, I added in an assert that we never add a component of a stat-name with ".". However this (a) makes fuzzers unrelated to stats assert a lot and (b) is unclear whether we guard against this naming pattern everywhere we name stats.

Also of note, when considering stats as arrays of tokens joined by ".", we don't include a "." for an empty token -- those are removed the the array used for joining.

This should help clean up some of the fuzz issues found here: https://oss-fuzz.com/testcases?project=envoy&open=yes
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18721
