### PR TITLE
docs: Use a portable shebang in build.sh

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . tools/shell_utils.sh
 


### PR DESCRIPTION
Description: `docs/build.sh` uses constructs from Bash 4 (such as the globstar shopt) which are not available to macOS users because `/bin/bash` is Bash 3. Use a portable shebang to start whichever bash appears first in `PATH`.
Risk Level: Low. 
Testing: Built the documentation on macOS Mojave and Ubuntu 16.04 and 18.04.
Docs Changes: N/A
Release Notes: N/A