### PR TITLE
[grpc] Add gRPC patch to fix leak

### DIFF
--- a/bazel/grpc-direct-leak.patch
+++ b/bazel/grpc-direct-leak.patch
@@ -1,0 +1,22 @@
+From 7bdbe7ecbadaff7a902ea10259fd35535686d103 Mon Sep 17 00:00:00 2001
+From: yang-g <yangg@google.com>
+Date: Tue, 22 Oct 2019 10:17:40 -0700
+Subject: [PATCH] unref error when fail to load file
+
+---
+ .../lib/security/security_connector/load_system_roots_linux.cc  | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/core/lib/security/security_connector/load_system_roots_linux.cc b/src/core/lib/security/security_connector/load_system_roots_linux.cc
+index 82d5bf6bcdd..61b0b9be5b9 100644
+--- a/src/core/lib/security/security_connector/load_system_roots_linux.cc
++++ b/src/core/lib/security/security_connector/load_system_roots_linux.cc
+@@ -66,6 +66,8 @@ grpc_slice GetSystemRootCerts() {
+         grpc_load_file(kLinuxCertFiles[i], 1, &valid_bundle_slice);
+     if (error == GRPC_ERROR_NONE) {
+       return valid_bundle_slice;
++    } else {
++      GRPC_ERROR_UNREF(error);
+     }
+   }
+   return grpc_empty_slice();

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -681,6 +681,8 @@ def _com_github_grpc_grpc():
             "@envoy//bazel:grpc-protoinfo-3.patch",
             # Pre-integration of https://github.com/grpc/grpc/pull/18950
             "@envoy//bazel:grpc-rename-gettid.patch",
+            # Fixes https://github.com/grpc/grpc/issues/20640
+            "@envoy//bazel:grpc-direct-leak.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5702532346675200
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5702532346675200
@@ -1,0 +1,1 @@
+hds_config {   api_type: GRPC   grpc_services {     google_grpc {       target_uri: "ipv6:[::]:  8                         "       channel_credentials {         ssl_credentials {         }       }       stat_prefix: " "     }   } } 


### PR DESCRIPTION
This patches in https://github.com/grpc/grpc/pull/20735. This fixes a memory leak in grpc code when failing to load a file.

Fixes OSS-Fuzz issue
https://oss-fuzz.com/testcase-detail/5702532346675200

Signed-off-by: Asra Ali <asraa@google.com>