### PR TITLE
listener: clean up accept filter before creating connection

### DIFF
--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -264,6 +264,9 @@ void ConnectionHandlerImpl::ActiveTcpSocket::newConnection() {
       socket_->setDetectedTransportProtocol(
           Extensions::TransportSockets::TransportProtocolNames::get().RawBuffer);
     }
+    // Erase accept filter states because accept filters may not get the opportunity to clean up.
+    // Particularly the assigned events need to reset before assigning new events in the follow up.
+    accept_filters_.clear();
     // Create a new connection on this listener.
     listener_.newConnection(std::move(socket_));
   }

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -264,6 +264,8 @@ void ConnectionHandlerImpl::ActiveTcpSocket::newConnection() {
       socket_->setDetectedTransportProtocol(
           Extensions::TransportSockets::TransportProtocolNames::get().RawBuffer);
     }
+    // TODO(lambdai): add test cases
+    // TODO: Address issues in wider scope. See https://github.com/envoyproxy/envoy/issues/8925
     // Erase accept filter states because accept filters may not get the opportunity to clean up.
     // Particularly the assigned events need to reset before assigning new events in the follow up.
     accept_filters_.clear();

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -264,7 +264,7 @@ void ConnectionHandlerImpl::ActiveTcpSocket::newConnection() {
       socket_->setDetectedTransportProtocol(
           Extensions::TransportSockets::TransportProtocolNames::get().RawBuffer);
     }
-    // TODO(lambdai): add test cases
+    // TODO(lambdai): add integration test
     // TODO: Address issues in wider scope. See https://github.com/envoyproxy/envoy/issues/8925
     // Erase accept filter states because accept filters may not get the opportunity to clean up.
     // Particularly the assigned events need to reset before assigning new events in the follow up.

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -97,10 +97,10 @@ MockUdpListenerCallbacks::~MockUdpListenerCallbacks() = default;
 MockDrainDecision::MockDrainDecision() = default;
 MockDrainDecision::~MockDrainDecision() = default;
 
-MockListenerFilter::MockListenerFilter() = default;
-MockListenerFilter::~MockListenerFilter() {
-  die_();
+MockListenerFilter::MockListenerFilter() {
+  // ON_CALL(*this, die_()).WillByDefault(testing::Invoke([](){}));
 }
+MockListenerFilter::~MockListenerFilter() { die_(); }
 
 MockListenerFilterCallbacks::MockListenerFilterCallbacks() {
   ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -97,10 +97,8 @@ MockUdpListenerCallbacks::~MockUdpListenerCallbacks() = default;
 MockDrainDecision::MockDrainDecision() = default;
 MockDrainDecision::~MockDrainDecision() = default;
 
-MockListenerFilter::MockListenerFilter() {
-  // ON_CALL(*this, die_()).WillByDefault(testing::Invoke([](){}));
-}
-MockListenerFilter::~MockListenerFilter() { die_(); }
+MockListenerFilter::MockListenerFilter() = default;
+MockListenerFilter::~MockListenerFilter() { destroy_(); }
 
 MockListenerFilterCallbacks::MockListenerFilterCallbacks() {
   ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -98,7 +98,9 @@ MockDrainDecision::MockDrainDecision() = default;
 MockDrainDecision::~MockDrainDecision() = default;
 
 MockListenerFilter::MockListenerFilter() = default;
-MockListenerFilter::~MockListenerFilter() = default;
+MockListenerFilter::~MockListenerFilter() {
+  die_();
+}
 
 MockListenerFilterCallbacks::MockListenerFilterCallbacks() {
   ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -164,7 +164,7 @@ public:
   MockListenerFilter();
   ~MockListenerFilter() override;
 
-  MOCK_METHOD0(die_, void());
+  MOCK_METHOD0(destroy_, void());
   MOCK_METHOD1(onAccept, Network::FilterStatus(ListenerFilterCallbacks&));
 };
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -164,6 +164,7 @@ public:
   MockListenerFilter();
   ~MockListenerFilter() override;
 
+  MOCK_METHOD0(die_, void());
   MOCK_METHOD1(onAccept, Network::FilterStatus(ListenerFilterCallbacks&));
 };
 

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -361,7 +361,8 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
   EXPECT_CALL(test_listener2->socket_, localAddress()).WillRepeatedly(ReturnRef(alt_address));
   handler_->addListener(*test_listener2);
 
-  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  auto* test_filter = new NiceMock<Network::MockListenerFilter>();
+  EXPECT_CALL(*test_filter, die_()).Times(1);
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   bool redirected = false;
   EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -432,6 +433,7 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
   handler_->addListener(*test_listener2);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(*test_filter, die_()).Times(1);
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   bool redirected = false;
   EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -498,6 +500,7 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
         cb.socket().restoreLocalAddress(original_dst_address);
         return Network::FilterStatus::Continue;
       }));
+  EXPECT_CALL(*test_filter, die_()).Times(1);
   EXPECT_CALL(*accepted_socket, restoreLocalAddress(original_dst_address));
   EXPECT_CALL(*accepted_socket, localAddressRestored()).WillOnce(Return(true));
   EXPECT_CALL(*accepted_socket, localAddress()).WillRepeatedly(ReturnRef(original_dst_address));
@@ -529,6 +532,7 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
   handler_->addListener(*test_listener1);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(*test_filter, die_()).Times(1);
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(factory_, createListenerFilterChain(_))
       .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
@@ -586,6 +590,7 @@ TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
   handler_->addListener(*test_listener);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(*test_filter, die_()).Times(1);
   EXPECT_CALL(factory_, createListenerFilterChain(_))
       .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
         manager.addAcceptFilter(Network::ListenerFilterPtr{test_filter});
@@ -644,6 +649,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
 
   EXPECT_CALL(*timeout, disableTimer());
   timeout->invokeCallback();
+  EXPECT_CALL(*test_filter, die_()).Times(1);
   dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0UL, downstream_pre_cx_active.value());
   EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());
@@ -672,7 +678,7 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
   EXPECT_CALL(test_listener->socket_, localAddress());
   handler_->addListener(*test_listener);
 
-  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  Network::MockListenerFilter* test_filter = new NiceMock<Network::MockListenerFilter>();
   EXPECT_CALL(factory_, createListenerFilterChain(_))
       .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
         manager.addAcceptFilter(Network::ListenerFilterPtr{test_filter});
@@ -691,7 +697,7 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
   Stats::Gauge& downstream_pre_cx_active =
       stats_store_.gauge("downstream_pre_cx_active", Stats::Gauge::ImportMode::Accumulate);
   EXPECT_EQ(1UL, downstream_pre_cx_active.value());
-  EXPECT_CALL(*test_filter, die_()).Times(1);
+  EXPECT_CALL(*test_filter, die_()).Times(1).RetiresOnSaturation();
   // Barrier: test_filter must be destructed before findFilterChain
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(*timeout, disableTimer());
@@ -709,7 +715,6 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
 // Timeout is disabled once the listener filters complete.
 TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   InSequence s;
-
   TestListener* test_listener = addListener(1, true, false, "test_listener");
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
@@ -741,7 +746,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   Event::MockTimer* timeout = new Event::MockTimer(&dispatcher_);
   EXPECT_CALL(*timeout, enableTimer(std::chrono::milliseconds(15000), _));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
-
+  EXPECT_CALL(*test_filter, die_());
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(*timeout, disableTimer());
   listener_filter_cb->continueFilterChain(true);
@@ -778,6 +783,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
         return Network::FilterStatus::StopIteration;
       }));
   EXPECT_CALL(dispatcher_, createTimer_(_)).Times(0);
+  EXPECT_CALL(*test_filter, die_());
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
 
@@ -802,7 +808,6 @@ TEST_F(ConnectionHandlerTest, ListenerFilterReportError) {
 
   Network::MockListenerFilter* first_filter = new Network::MockListenerFilter();
   Network::MockListenerFilter* last_filter = new Network::MockListenerFilter();
-
   EXPECT_CALL(factory_, createListenerFilterChain(_))
       .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
         manager.addAcceptFilter(Network::ListenerFilterPtr{first_filter});
@@ -817,6 +822,8 @@ TEST_F(ConnectionHandlerTest, ListenerFilterReportError) {
       }));
   // The last filter won't be invoked
   EXPECT_CALL(*last_filter, onAccept(_)).Times(0);
+  EXPECT_CALL(*first_filter, die_()).Times(1);
+  EXPECT_CALL(*last_filter, die_()).Times(1);
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
 

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -691,7 +691,8 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
   Stats::Gauge& downstream_pre_cx_active =
       stats_store_.gauge("downstream_pre_cx_active", Stats::Gauge::ImportMode::Accumulate);
   EXPECT_EQ(1UL, downstream_pre_cx_active.value());
-
+  EXPECT_CALL(*test_filter, die_()).Times(1);
+  // Barrier: test_filter must be destructed before findFilterChain
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(*timeout, disableTimer());
   timeout->invokeCallback();


### PR DESCRIPTION
Signed-off-by: Yuchen Dai silentdai@gmail.com

Description:
When listener continue to accept connection on listener filter timeout, the OS socket fd could be owned by two separate FileEventImpl.
The destructing FileEventImpl cannot recover the intention of the alive FileEventImpl.

The observation is that EdgeTrigger flag is cleared and the fd will be LevelTriggered and the EPOLLOUT will be activated in each epoll_wait
immediately after the invoke.

Envoy worker thread owning that connecting will be consuming 1 cpu core in the repeated epoll_wait.

This PR is maintaining the immutability that at most one FileEventImpl could owns the fd so the assigned event always match the expectation
of FileEventImpl.

Before this PR
```
 # registered by tls_inspector
1573028637.322859 epoll_ctl(14, EPOLL_CTL_ADD, 26, {EPOLLIN|EPOLLRDHUP|EPOLLET, {u32=26, u64=26}}) = 0 
# registered by HCM
1573028637.419820 epoll_ctl(14, EPOLL_CTL_MOD, 26, {EPOLLIN|EPOLLOUT|EPOLLRDHUP|EPOLLET, {u32=26, u64=26}}) = 0         
# tls_inspector clean up, EPOLLET is cleared somehow
1573028637.420488 epoll_ctl(14, EPOLL_CTL_MOD, 26, {EPOLLIN|EPOLLOUT, {u32=26, u64=26}}) = 0                                                   

#repeated immediate return of epoll_wait, no write since the http write buffer is empty at the beginning
1573028637.420537 epoll_wait(14, [{EPOLLOUT, {u32=26, u64=26}}], 32, 24) = 1
```

With this PR
```
# registered by tls_inspector
1573030976.461595 epoll_ctl(14, EPOLL_CTL_ADD, 26, {EPOLLIN|EPOLLRDHUP|EPOLLET, {u32=26, u64=26}}) = 0 
# tls_inspector clean up  
1573030976.562546 epoll_ctl(14, EPOLL_CTL_DEL, 26, 0x7f1d914cd0a0) = 0                                                                                          
# registered by HCM, EPOLLET show up and leave there forever
1573030976.562986 epoll_ctl(14, EPOLL_CTL_ADD, 26, {EPOLLIN|EPOLLOUT|EPOLLET, {u32=26, u64=26}}) = 0                       
```

The proof that `EPOLLIN|EPOLLOUT` w/o EPOLLET is registered due to ~FileEventImpl
Below `fd 21 op 3 event_uaddr 5` is recognized as `epoll_ctl( ..., EPOLL_MOD, 21, { EPOLLIN|EPOLLOUT, {...}}) ` where EPOLLET (1 << 31) is missing. 
fd 21 is the English spelling of 26 since I capture the logs in different run.

```
fd 21 op 3 event_uaddr 5 0x7f443e11d24a : epoll_ctl 0xa/0x30 [/lib/x86_64-linux-gnu/libc-2.27.so]
 0x562790a619b2 : epoll_apply_one_change 0x172/0x570 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790a61356 : epoll_nochangelist_del 0xa6/0xb0 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790a53b1c : evmap_io_del_ 0x34c/0x3e0 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790a48d15 : event_del_nolock_ 0x2d5/0x490 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790a4e60c : event_del_ 0xac/0x100 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790a4cc2a : event_del 0x1a/0x20 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56279038c145 : Envoy::Event::ImplBase::~ImplBase() 0x15/0x30 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790366047 : Envoy::Event::FileEventImpl::~FileEventImpl() 0x47/0x60 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56279036607c : Envoy::Event::FileEventImpl::~FileEventImpl() 0x1c/0x30 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56278f7b8a5f : std::default_delete<Envoy::Event::FileEvent>::operator()(Envoy::Event::FileEvent*) const 0x2f/0x40 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56278f7b83a3 : std::unique_ptr<Envoy::Event::FileEvent, std::default_delete<Envoy::Event::FileEvent> >::~unique_ptr() 0x53/0x80 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56278f7d0187 : Envoy::Extensions::ListenerFilters::TlsInspector::Filter::~Filter() 0x47/0x70 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56278f7d01cc : Envoy::Extensions::ListenerFilters::TlsInspector::Filter::~Filter() 0x1c/0x30 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56278f7b23bf : std::default_delete<Envoy::Network::ListenerFilter>::operator()(Envoy::Network::ListenerFilter*) const 0x2f/0x40 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56278f7b1cd3 : std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> >::~unique_ptr() 0x53/0x80 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x562790350879 : void __gnu_cxx::new_allocator<std::_List_node<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > > >::destroy<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > >(std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> >*) 0x19/0x20 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x5627903507d0 : void std::allocator_traits<std::allocator<std::_List_node<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > > > >::destroy<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > >(std::allocator<std::_List_node<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > > >&, std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> >*) 0x20/0x30 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x56279035072e : std::__cxx11::_List_base<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> >, std::allocator<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > > >::_M_clear() 0x6e/0xa0 [/home/lambdai/workspace/tls/envoymaster1106.dbg]
 0x5627903505cf : std::__cxx11::list<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> >, std::allocator<std::unique_ptr<Envoy::Network::ListenerFilter, std::default_delete<Envoy::Network::ListenerFilter> > > >::clear() 0x1f/0x40 [/home/lambdai/workspace/tls/envoymaster1106.dbg]

```

Risk Level:
Testing:
Docs Changes:
Release Notes:
Fix istio/istio#18229