### PR TITLE
api: mark endpoint_name as not implemented

### DIFF
--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -126,6 +126,7 @@ message ClusterLoadAssignment {
   repeated endpoint.LocalityLbEndpoints endpoints = 2;
 
   // Map of named endpoints that can be referenced in LocalityLbEndpoints.
+  // [#not-implemented-hide:]
   map<string, endpoint.Endpoint> named_endpoints = 5;
 
   // Load balancing policy settings.

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -57,6 +57,7 @@ message LbEndpoint {
   oneof host_identifier {
     Endpoint endpoint = 1;
 
+    // [#not-implemented-hide:]
     string endpoint_name = 5;
   }
 

--- a/api/envoy/api/v3alpha/eds.proto
+++ b/api/envoy/api/v3alpha/eds.proto
@@ -126,6 +126,7 @@ message ClusterLoadAssignment {
   repeated endpoint.LocalityLbEndpoints endpoints = 2;
 
   // Map of named endpoints that can be referenced in LocalityLbEndpoints.
+  // [#not-implemented-hide:]
   map<string, endpoint.Endpoint> named_endpoints = 5;
 
   // Load balancing policy settings.

--- a/api/envoy/api/v3alpha/endpoint/endpoint.proto
+++ b/api/envoy/api/v3alpha/endpoint/endpoint.proto
@@ -57,6 +57,7 @@ message LbEndpoint {
   oneof host_identifier {
     Endpoint endpoint = 1;
 
+    // [#not-implemented-hide:]
     string endpoint_name = 5;
   }
 


### PR DESCRIPTION
This has not been implemented, so hide the API from the docs.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Related to #4280 
