### PR TITLE
Fix #8672 placed in the wrong version_history section

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,7 @@ Version history
 * access log: added FILTER_STATE :ref:`access log formatters <config_access_log_format>` and gRPC access logger.
 * api: remove all support for v1
 * build: official released binary is now built against libc++.
+* logger: added `--log-format-escaped` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 * tcp_proxy: added :ref:`hash_policy<envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.hash_policy>`
@@ -67,7 +68,6 @@ Version history
 * listeners: added :ref:`connection balancer <envoy_api_field_Listener.connection_balance_config>`
   configuration for TCP listeners.
 * listeners: listeners now close the listening socket as part of the draining stage as soon as workers stop accepting their connections.
-* logger: added `--log-format-escaped` command line option to escape newline characters in application logs.
 * lua: extended `httpCall()` and `respond()` APIs to accept headers with entry values that can be a string or table of strings.
 * lua: extended `dynamicMetadata:set()` to allow setting complex values.
 * metrics_service: added support for flushing histogram buckets.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,7 +6,7 @@ Version history
 * access log: added FILTER_STATE :ref:`access log formatters <config_access_log_format>` and gRPC access logger.
 * api: remove all support for v1
 * build: official released binary is now built against libc++.
-* logger: added `--log-format-escaped` command line option to escape newline characters in application logs.
+* logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 * tcp_proxy: added :ref:`hash_policy<envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.hash_policy>`


### PR DESCRIPTION
Description: #8672 did not make it in `1.12.0`, but `version_history.rst` has this placed incorrectly.

Risk Level: Low

Testing: N/A

Docs Changes: N/A

Release Notes: Modified `version_history.rst`

Signed-off-by: Teju Nareddy <nareddyt@google.com>