### PR TITLE
test: deflake hds_integration_test

### DIFF
--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -358,17 +358,17 @@ TEST_P(HdsIntegrationTest, SingleEndpointTimeoutTcp) {
   server_health_check_specifier_.mutable_cluster_health_checks(0)
       ->mutable_health_checks(0)
       ->mutable_timeout()
-      ->set_nanos(100000000); // 0.1 seconds
+      ->set_nanos(500000000); // 0.5 seconds
 
   hds_stream_->startGrpcStream();
   hds_stream_->sendGrpcMessage(server_health_check_specifier_);
   test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
 
   // Envoys asks the endpoint if it's healthy
+  host_upstream_->set_allow_unexpected_disconnects(true);
   ASSERT_TRUE(host_upstream_->waitForRawConnection(host_fake_raw_connection_));
   ASSERT_TRUE(
       host_fake_raw_connection_->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
-  host_upstream_->set_allow_unexpected_disconnects(true);
 
   // No response from the endpoint
 
@@ -396,12 +396,12 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthyTcp) {
   test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
 
   // Envoy asks the endpoint if it's healthy
+  host_upstream_->set_allow_unexpected_disconnects(true);
   ASSERT_TRUE(host_upstream_->waitForRawConnection(host_fake_raw_connection_));
   ASSERT_TRUE(
       host_fake_raw_connection_->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
   AssertionResult result = host_fake_raw_connection_->write("Pong");
   RELEASE_ASSERT(result, result.message());
-  host_upstream_->set_allow_unexpected_disconnects(true);
 
   // Receive updates until the one we expect arrives
   waitForEndpointHealthResponse(envoy::api::v2::core::HealthStatus::HEALTHY);
@@ -431,12 +431,12 @@ TEST_P(HdsIntegrationTest, SingleEndpointUnhealthyTcp) {
   test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
 
   // Envoy asks the endpoint if it's healthy
+  host_upstream_->set_allow_unexpected_disconnects(true);
   ASSERT_TRUE(host_upstream_->waitForRawConnection(host_fake_raw_connection_));
   ASSERT_TRUE(
       host_fake_raw_connection_->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
   AssertionResult result = host_fake_raw_connection_->write("Voronoi");
   RELEASE_ASSERT(result, result.message());
-  host_upstream_->set_allow_unexpected_disconnects(true);
 
   // Receive updates until the one we expect arrives
   waitForEndpointHealthResponse(envoy::api::v2::core::HealthStatus::UNHEALTHY);
@@ -665,10 +665,10 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
 
   // Envoy sends a health check message to an endpoint
+  host2_upstream_->set_allow_unexpected_disconnects(true);
   ASSERT_TRUE(host2_upstream_->waitForHttpConnection(*dispatcher_, host2_fake_connection_));
   ASSERT_TRUE(host2_fake_connection_->waitForNewStream(*dispatcher_, host2_stream_));
   ASSERT_TRUE(host2_stream_->waitForEndStream(*dispatcher_));
-  host2_upstream_->set_allow_unexpected_disconnects(true);
 
   // Endpoint responds to the health check
   host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
@@ -717,10 +717,10 @@ TEST_P(HdsIntegrationTest, TestUpdateChangesTimer) {
 
   // A response should not be received until the new timer is completed
   ASSERT_FALSE(
-      hds_stream_->waitForGrpcMessage(*dispatcher_, response_, std::chrono::milliseconds(250)));
+      hds_stream_->waitForGrpcMessage(*dispatcher_, response_, std::chrono::milliseconds(100)));
   // Response should be received now
   ASSERT_TRUE(
-      hds_stream_->waitForGrpcMessage(*dispatcher_, response_, std::chrono::milliseconds(250)));
+      hds_stream_->waitForGrpcMessage(*dispatcher_, response_, std::chrono::milliseconds(400)));
 
   // Clean up connections
   cleanupHostConnections();


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Deflake hds_integration_test by:
- `set_allow_unexpected_disconnects` before wait for connection.
- adjust timeout so the HC is not closing connection before `waitForData`.

Risk Level: Low
Testing: `bazel test -c dbg --config=clang-tsan //test/integration:hds_integration_test --runs_per_test=1000`
Docs Changes: N/A
Release Notes: N/A
Fixes #6630, #8348 