### PR TITLE
Fix TSAN warning from unlocked cross-thread read.

### DIFF
--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -28,7 +28,7 @@ bool DrainManagerImpl::drainClose() const {
     return true;
   }
 
-  if (!draining()) {
+  if (!draining_) {
     return false;
   }
 
@@ -52,6 +52,7 @@ void DrainManagerImpl::drainSequenceTick() {
 void DrainManagerImpl::startDrainSequence(std::function<void()> completion) {
   drain_sequence_completion_ = completion;
   ASSERT(!drain_tick_timer_);
+  draining_ = true;
   drain_tick_timer_ = server_.dispatcher().createTimer([this]() -> void { drainSequenceTick(); });
   drainSequenceTick();
 }

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -51,6 +51,7 @@ void DrainManagerImpl::drainSequenceTick() {
 
 void DrainManagerImpl::startDrainSequence(std::function<void()> completion) {
   drain_sequence_completion_ = completion;
+  ASSERT(!draining_);
   ASSERT(!drain_tick_timer_);
   draining_ = true;
   drain_tick_timer_ = server_.dispatcher().createTimer([this]() -> void { drainSequenceTick(); });

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -27,12 +27,12 @@ public:
   void startParentShutdownSequence() override;
 
 private:
-  bool draining() const { return drain_tick_timer_ != nullptr; }
   void drainSequenceTick();
 
   Instance& server_;
   const envoy::api::v2::Listener::DrainType drain_type_;
   Event::TimerPtr drain_tick_timer_;
+  std::atomic<bool> draining_{false};
   std::atomic<uint32_t> drain_time_completed_{};
   Event::TimerPtr parent_shutdown_timer_;
   std::function<void()> drain_sequence_completion_;


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Fix TSAN warning from unlocked cross-thread read.
Risk Level: Low
Testing: Unit tests.
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/8940
[Optional Deprecated:]
