### PR TITLE
fix gRPC crash due to uncaught exception

### DIFF
--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -62,13 +62,17 @@ grpc::Status
 FileBasedMetadataAuthenticator::GetMetadata(grpc::string_ref, grpc::string_ref,
                                             const grpc::AuthContext&,
                                             std::multimap<grpc::string, grpc::string>* metadata) {
-  std::string header_value = Envoy::Config::DataSource::read(config_.secret_data(), true, api_);
   std::string header_key = "authorization";
   std::string header_prefix = config_.header_prefix();
   if (!config_.header_key().empty()) {
     header_key = config_.header_key();
   }
-  metadata->insert(std::make_pair(header_key, header_prefix + header_value));
+  try {
+    std::string header_value = Envoy::Config::DataSource::read(config_.secret_data(), true, api_);
+    metadata->insert(std::make_pair(header_key, header_prefix + header_value));
+  } catch (const EnvoyException& e) {
+    return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
+  }
   return grpc::Status::OK;
 }
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

I struggled to test this with the test framework but got overwhelmed by its complexity.

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/8941
[Optional Deprecated:]
