### PR TITLE
Make it easier to run the clang-tidy script.

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -2,8 +2,15 @@
 
 set -e
 
+ENVOY_SRCDIR=${ENVOY_SRCDIR:-$(cd $(dirname $0)/.. && pwd)}
+
+LLVM_CONFIG=${LLVM_CONFIG:-llvm-config}
+LLVM_PREFIX=${LLVM_PREFIX:-$(${LLVM_CONFIG} --prefix)}
+CLANG_TIDY=${CLANG_TIDY:-$(${LLVM_CONFIG} --bindir)/clang-tidy}
+CLANG_APPLY_REPLACEMENTS=${CLANG_APPLY_REPLACEMENTS:-$(${LLVM_CONFIG} --bindir)/clang-apply-replacements}
+
 # Quick syntax check of .clang-tidy.
-clang-tidy -dump-config > /dev/null 2> clang-tidy-config-errors.txt
+${CLANG_TIDY} -dump-config > /dev/null 2> clang-tidy-config-errors.txt
 if [[ -s clang-tidy-config-errors.txt ]]; then
   cat clang-tidy-config-errors.txt
   rm clang-tidy-config-errors.txt
@@ -47,17 +54,24 @@ function filter_excludes() {
   exclude_testdata | exclude_chromium_url | exclude_win32_impl
 }
 
-LLVM_PREFIX=$(llvm-config --prefix)
 
 if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
   echo "Running full clang-tidy..."
-  "${LLVM_PREFIX}/share/clang/run-clang-tidy.py"
+  "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
+    -clang-tidy-binary=${CLANG_TIDY} \
+    -clang-apply-replacements-binary=${CLANG_APPLY_REPLACEMENTS} \
+    ${APPLY_CLANG_TIDY_FIXES:+-fix}
 elif [[ "${BUILD_REASON}" != "PullRequest" ]]; then
   echo "Running clang-tidy-diff against previous commit..."
-  git diff HEAD^ | filter_excludes | "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" -p 1
+  git diff HEAD^ | filter_excludes | \
+    "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
+      -clang-tidy-binary=${CLANG_TIDY} \
+      -p 1
 else
   echo "Running clang-tidy-diff against master branch..."
   git fetch https://github.com/envoyproxy/envoy.git master
   git diff "${SYSTEM_PULLREQUEST_TARGETBRANCH:-refs/heads/master}..HEAD" | filter_excludes | \
-     "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" -p 1
+    "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
+      -clang-tidy-binary=${CLANG_TIDY} \
+      -p 1
 fi


### PR DESCRIPTION
*Description:*

Make it easier to run the `ci/run_clang_tidy.sh` script with a
non-default clang by defaulting script variables and allowing
the user to override tool paths.

*Risk Level:* Low
*Testing:* Ran the script
*Docs Changes:* N/A
*Release Notes:* N/A
