### PR TITLE
Make the build setup script more robust.

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -85,8 +85,8 @@ export BAZEL_BUILD_OPTIONS="--verbose_failures ${BAZEL_OPTIONS} --action_env=HOM
 
 if [ "$1" != "-nofetch" ]; then
   # Setup Envoy consuming project.
-  if [[ ! -a "${ENVOY_FILTER_EXAMPLE_SRCDIR}" ]]
-  then
+  if [[ ! -d "${ENVOY_FILTER_EXAMPLE_SRCDIR}/.git" ]]; then
+    rm -rf "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
     git clone https://github.com/envoyproxy/envoy-filter-example.git "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   fi
 


### PR DESCRIPTION
*Description:*

If `ci/build_setup.sh` is killed at an inopportune time, it can
have created the filter checkout directory but not cloned the git
repository to it. This leads to hard-to-debug failures.
The (partial) fix is to check for the git metadata directory before
assuming it is OK.

*Risk Level:* Low
*Testing:* Ran ci script in Docker.
*Docs Changes:* N/A
*Release Notes:* N/A

