### PR TITLE
ext_authz: Make sure `injectContext` is called

### DIFF
--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -229,6 +229,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
     callbacks_ = nullptr;
     span_ = nullptr;
   } else {
+    span_->injectContext(message->headers());
     request_ = cm_.httpAsyncClientForCluster(cluster).send(
         std::move(message), *this,
         Http::AsyncClient::RequestOptions().setTimeout(config_->timeout()));

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -232,6 +232,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOk) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
 
   client_.check(request_callbacks_, request, active_span_);
 
@@ -257,6 +258,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeaders) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
   // Expect that header1 will be added and header2 correctly overwritten.
   EXPECT_CALL(async_client_, send_(AllOf(ContainsPairAsHeader(config_->headersToAdd().front()),
                                          ContainsPairAsHeader(config_->headersToAdd().back())),
@@ -286,6 +288,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAllowHeader) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
   client_.check(request_callbacks_, request, active_span_);
 
   const auto check_response_headers =
@@ -315,6 +318,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDenied) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
   client_.check(request_callbacks_, request, active_span_);
 
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_status"), Eq("ext_authz_unauthorized")));
@@ -337,6 +341,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedWithAllAttributes) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
 
   envoy::service::auth::v2::CheckRequest request;
   client_.check(request_callbacks_, request, active_span_);
@@ -362,6 +367,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
 
   envoy::service::auth::v2::CheckRequest request;
   client_.check(request_callbacks_, request, active_span_);
@@ -385,6 +391,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
 
   client_.check(request_callbacks_, request, active_span_);
 
@@ -405,6 +412,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
+
   client_.check(request_callbacks_, request, active_span_);
 
   EXPECT_CALL(request_callbacks_,
@@ -425,6 +434,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestErrorParsingStatusCode) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
 
   client_.check(request_callbacks_, request, active_span_);
 
@@ -443,6 +453,7 @@ TEST_F(ExtAuthzHttpClientTest, CancelledAuthorizationRequest) {
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+  EXPECT_CALL(*child_span, injectContext(_));
   EXPECT_CALL(async_client_, send_(_, _, _)).WillOnce(Return(&async_request_));
   client_.check(request_callbacks_, request, active_span_);
 


### PR DESCRIPTION
Description:
This patch makes sure active span `injectContext` is called before making the check request for the HTTP implementation of `ext_authz`.

Risk Level: Low
Testing: unit tests, manual validation against the repo by @enbohm (https://github.com/enbohm/envoy-tracing/pull/1).
Docs Changes: N/A
Release Notes: N/A
Fixes #6520

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
