### PR TITLE
ci: fix master clang-tidy run

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -52,12 +52,12 @@ LLVM_PREFIX=$(llvm-config --prefix)
 if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
   echo "Running full clang-tidy..."
   "${LLVM_PREFIX}/share/clang/run-clang-tidy.py"
-elif [[ -z "${CIRCLE_PR_NUMBER}" && "$CIRCLE_BRANCH" == "master" ]]; then
-  echo "On master branch, running clang-tidy-diff against previous commit..."
+elif [[ "${BUILD_REASON}" != "PullRequest" ]]; then
+  echo "Running clang-tidy-diff against previous commit..."
   git diff HEAD^ | filter_excludes | "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" -p 1
 else
   echo "Running clang-tidy-diff against master branch..."
   git fetch https://github.com/envoyproxy/envoy.git master
-  git diff $(git merge-base HEAD FETCH_HEAD)..HEAD | filter_excludes | \
+  git diff "${SYSTEM_PULLREQUEST_TARGETBRANCH:-refs/heads/master}..HEAD" | filter_excludes | \
      "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" -p 1
 fi

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -28,6 +28,7 @@ docker run --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build -v /var/run/docker.sock:/var/run/docker.sock ${GIT_VOLUME_OPTION} \
   -e BAZEL_BUILD_EXTRA_OPTIONS -e BAZEL_EXTRA_TEST_OPTIONS -e BAZEL_REMOTE_CACHE -e ENVOY_STDLIB -e BUILD_REASON \
   -e BAZEL_REMOTE_INSTANCE -e GCP_SERVICE_ACCOUNT_KEY -e NUM_CPUS -e ENVOY_RBE -e FUZZIT_API_KEY -e ENVOY_BUILD_IMAGE \
+  -e SYSTEM_PULLREQUEST_TARGETBRANCH \
   -v "$PWD":/source --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${ENVOY_BUILD_IMAGE}" \
   /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home \
   --home-dir /source envoybuild && usermod -a -G pcap envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Use TargetBranch for clang-tidy diff: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml

Risk Level:
Testing:
Docs Changes:
Release Notes:
