### PR TITLE
udp: remove sendto/recvfrom

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -42,12 +42,6 @@ public:
   virtual SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) PURE;
 
   /**
-   * @see recv (man 2 recvfrom)
-   */
-  virtual SysCallSizeResult recvfrom(int sockfd, void* buffer, size_t length, int flags,
-                                     struct sockaddr* addr, socklen_t* addrlen) PURE;
-
-  /**
    * @see recvmsg (man 2 recvmsg)
    */
   virtual SysCallSizeResult recvmsg(int sockfd, struct msghdr* msg, int flags) PURE;
@@ -90,12 +84,6 @@ public:
    * @see man 2 socket
    */
   virtual SysCallIntResult socket(int domain, int type, int protocol) PURE;
-
-  /**
-   * @see man 2 sendto
-   */
-  virtual SysCallSizeResult sendto(int fd, const void* buffer, size_t size, int flags,
-                                   const sockaddr* addr, socklen_t addrlen) PURE;
 
   /**
    * @see man 2 sendmsg

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -61,15 +61,6 @@ public:
   virtual Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) PURE;
 
   /**
-   * Send buffer to address.
-   * @param slice points to the location of the data to be sent.
-   * @param to_address is the destination address.
-   * @return a Api::IoCallUint64Result with err_ = an Api::IoError instance or
-   * err_ = nullptr and rc_ = the bytes written for success.
-   */
-  virtual Api::IoCallUint64Result sendto(const Buffer::RawSlice& slice, int flags,
-                                         const Address::Instance& address) PURE;
-  /**
    * Send a message to the address.
    * @param slices points to the location of data to be sent.
    * @param num_slice indicates number of slices |slices| contains.

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -125,8 +125,7 @@ public:
 };
 
 /**
- * Utility struct that encapsulates the information from a udp socket's
- * recvfrom/recvmmsg call.
+ * Utility struct that encapsulates the information from a udp socket's recvmmsg call.
  */
 struct UdpRecvData {
   struct LocalPeerAddresses {

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -39,12 +39,6 @@ SysCallSizeResult OsSysCallsImpl::recv(int socket, void* buffer, size_t length, 
   return {rc, errno};
 }
 
-SysCallSizeResult OsSysCallsImpl::recvfrom(int sockfd, void* buffer, size_t length, int flags,
-                                           struct sockaddr* addr, socklen_t* addrlen) {
-  const ssize_t rc = ::recvfrom(sockfd, buffer, length, flags, addr, addrlen);
-  return {rc, errno};
-}
-
 SysCallSizeResult OsSysCallsImpl::recvmsg(int sockfd, struct msghdr* msg, int flags) {
   const ssize_t rc = ::recvmsg(sockfd, msg, flags);
   return {rc, errno};
@@ -80,12 +74,6 @@ SysCallIntResult OsSysCallsImpl::getsockopt(int sockfd, int level, int optname, 
 
 SysCallIntResult OsSysCallsImpl::socket(int domain, int type, int protocol) {
   const int rc = ::socket(domain, type, protocol);
-  return {rc, errno};
-}
-
-SysCallSizeResult OsSysCallsImpl::sendto(int fd, const void* buffer, size_t size, int flags,
-                                         const sockaddr* addr, socklen_t addrlen) {
-  const int rc = ::sendto(fd, buffer, size, flags, addr, addrlen);
   return {rc, errno};
 }
 

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -15,8 +15,6 @@ public:
   SysCallSizeResult writev(int fd, const iovec* iovec, int num_iovec) override;
   SysCallSizeResult readv(int fd, const iovec* iovec, int num_iovec) override;
   SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) override;
-  SysCallSizeResult recvfrom(int sockfd, void* buffer, size_t length, int flags,
-                             struct sockaddr* addr, socklen_t* addrlen) override;
   SysCallSizeResult recvmsg(int sockfd, struct msghdr* msg, int flags) override;
   SysCallIntResult close(int fd) override;
   SysCallIntResult ftruncate(int fd, off_t length) override;
@@ -28,8 +26,6 @@ public:
   SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
                               socklen_t* optlen) override;
   SysCallIntResult socket(int domain, int type, int protocol) override;
-  SysCallSizeResult sendto(int fd, const void* buffer, size_t size, int flags, const sockaddr* addr,
-                           socklen_t addrlen) override;
   SysCallSizeResult sendmsg(int fd, const msghdr* message, int flags) override;
   SysCallIntResult getsockname(int sockfd, sockaddr* addr, socklen_t* addrlen) override;
 };

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -73,17 +73,6 @@ Api::IoCallUint64Result IoSocketHandleImpl::writev(const Buffer::RawSlice* slice
   return sysCallResultToIoCallResult(result);
 }
 
-Api::IoCallUint64Result IoSocketHandleImpl::sendto(const Buffer::RawSlice& slice, int flags,
-                                                   const Address::Instance& address) {
-  const auto* address_base = dynamic_cast<const Address::InstanceBase*>(&address);
-  sockaddr* sock_addr = const_cast<sockaddr*>(address_base->sockAddr());
-
-  auto& os_syscalls = Api::OsSysCallsSingleton::get();
-  const Api::SysCallSizeResult result = os_syscalls.sendto(fd_, slice.mem_, slice.len_, flags,
-                                                           sock_addr, address_base->sockAddrLen());
-  return sysCallResultToIoCallResult(result);
-}
-
 Api::IoCallUint64Result IoSocketHandleImpl::sendmsg(const Buffer::RawSlice* slices,
                                                     uint64_t num_slice, int flags,
                                                     const Address::Ip* self_ip,

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -32,9 +32,6 @@ public:
 
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
 
-  Api::IoCallUint64Result sendto(const Buffer::RawSlice& slice, int flags,
-                                 const Address::Instance& address) override;
-
   Api::IoCallUint64Result sendmsg(const Buffer::RawSlice* slices, uint64_t num_slice, int flags,
                                   const Address::Ip* self_ip,
                                   const Address::Instance& peer_address) override;

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -33,14 +33,6 @@ public:
     }
     return io_handle_.writev(slices, num_slice);
   }
-  Api::IoCallUint64Result sendto(const Buffer::RawSlice& slice, int flags,
-                                 const Network::Address::Instance& address) override {
-    if (closed_) {
-      return Api::IoCallUint64Result(0, Api::IoErrorPtr(new Network::IoSocketError(EBADF),
-                                                        Network::IoSocketError::deleteIoError));
-    }
-    return io_handle_.sendto(slice, flags, address);
-  }
   Api::IoCallUint64Result sendmsg(const Buffer::RawSlice* slices, uint64_t num_slice, int flags,
                                   const Envoy::Network::Address::Ip* self_ip,
                                   const Network::Address::Instance& peer_address) override {

--- a/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
+++ b/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
@@ -139,8 +139,8 @@ TEST_P(ActiveQuicListenerTest, ReceiveFullQuicCHLO) {
   Buffer::RawSlice first_slice{reinterpret_cast<void*>(const_cast<char*>(encrypted_packet->data())),
                                encrypted_packet->length()};
   // Send a full CHLO to finish 0-RTT handshake.
-  auto send_rc =
-      client_socket_->ioHandle().sendto(first_slice, /*flags=*/0, *listen_socket_->localAddress());
+  auto send_rc = Network::Utility::writeToSocket(client_socket_->ioHandle(), &first_slice, 1,
+                                                 nullptr, *listen_socket_->localAddress());
   ASSERT_EQ(encrypted_packet->length(), send_rc.rc_);
 
   EXPECT_CALL(listener_config_, filterChainManager());

--- a/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
+++ b/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
@@ -53,10 +53,6 @@ TEST_F(QuicIoHandleWrapperTest, DelegateIoHandleCalls) {
   EXPECT_CALL(os_sys_calls_, close(1)).WillRepeatedly(Return(Api::SysCallIntResult{0, 0}));
 
   Network::Address::InstanceConstSharedPtr addr(new Network::Address::Ipv4Instance(12345));
-  EXPECT_CALL(os_sys_calls_, sendto(fd, data, 5u, 0, _, _))
-      .WillOnce(Return(Api::SysCallSizeResult{5u, 0}));
-  wrapper_->sendto(slice, 0, *addr);
-
   EXPECT_CALL(os_sys_calls_, sendmsg(fd, _, 0)).WillOnce(Return(Api::SysCallSizeResult{5u, 0}));
   wrapper_->sendmsg(&slice, 1, 0, /*self_ip=*/nullptr, *addr);
 
@@ -79,7 +75,6 @@ TEST_F(QuicIoHandleWrapperTest, DelegateIoHandleCalls) {
   // Following calls shouldn't be delegated.
   wrapper_->readv(5, &slice, 1);
   wrapper_->writev(&slice, 1);
-  wrapper_->sendto(slice, 0, *addr);
   wrapper_->sendmsg(&slice, 1, 0, /*self_ip=*/nullptr, *addr);
   wrapper_->recvmsg(&slice, 1, /*self_port=*/12345, output);
 }

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -65,10 +65,6 @@ public:
   MOCK_METHOD3(sendmsg, SysCallSizeResult(int fd, const msghdr* message, int flags));
   MOCK_METHOD3(readv, SysCallSizeResult(int, const iovec*, int));
   MOCK_METHOD4(recv, SysCallSizeResult(int socket, void* buffer, size_t length, int flags));
-  MOCK_METHOD6(recvfrom, SysCallSizeResult(int sockfd, void* buffer, size_t length, int flags,
-                                           struct sockaddr* addr, socklen_t* addrlen));
-  MOCK_METHOD6(sendto, SysCallSizeResult(int sockfd, const void* buffer, size_t length, int flags,
-                                         const struct sockaddr* addr, socklen_t addrlen));
   MOCK_METHOD3(recvmsg, SysCallSizeResult(int socket, struct msghdr* msg, int flags));
   MOCK_METHOD2(ftruncate, SysCallIntResult(int fd, off_t length));
   MOCK_METHOD6(mmap, SysCallPtrResult(void* addr, size_t length, int prot, int flags, int fd,

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -107,7 +107,7 @@ bool supportsIpVersion(const Address::IpVersion version);
  * @param type the type of socket to be bound.
  * @returns the address and the fd of the socket bound to that address.
  */
-std::pair<Address::InstanceConstSharedPtr, Network::IoHandlePtr>
+std::pair<Address::InstanceConstSharedPtr, IoHandlePtr>
 bindFreeLoopbackPort(Address::IpVersion version, Address::SocketType type);
 
 /**
@@ -133,7 +133,7 @@ public:
       : transport_socket_factory_(std::move(transport_socket_factory)) {}
 
   // Network::FilterChain
-  const Network::TransportSocketFactory& transportSocketFactory() const override {
+  const TransportSocketFactory& transportSocketFactory() const override {
     return *transport_socket_factory_;
   }
 
@@ -149,16 +149,23 @@ private:
 /**
  * Create an empty filter chain for testing purposes.
  * @param transport_socket_factory transport socket factory to use when creating transport sockets.
- * @return const Network::FilterChainSharedPtr filter chain.
+ * @return const FilterChainSharedPtr filter chain.
  */
-const Network::FilterChainSharedPtr
+const FilterChainSharedPtr
 createEmptyFilterChain(TransportSocketFactoryPtr&& transport_socket_factory);
 
 /**
  * Create an empty filter chain creating raw buffer sockets for testing purposes.
- * @return const Network::FilterChainSharedPtr filter chain.
+ * @return const FilterChainSharedPtr filter chain.
  */
-const Network::FilterChainSharedPtr createEmptyFilterChainWithRawBufferSockets();
+const FilterChainSharedPtr createEmptyFilterChainWithRawBufferSockets();
+
+/**
+ * Wrapper for Utility::readFromSocket() which reads a single datagram into the supplied
+ * UdpRecvData without worrying about the packet processor interface.
+ */
+Api::IoCallUint64Result readFromSocket(IoHandle& handle, const Address::Instance& local_address,
+                                       UdpRecvData& data);
 
 } // namespace Test
 } // namespace Network


### PR DESCRIPTION
We only use these APIs in tests and it's better to
unify around sendmsg/recvmsg with appropriate
wrappers.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
