### PR TITLE
WiP: Replace ProtobufWkt::Message with correct namespace Protobuf::Message

### DIFF
--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -261,7 +261,7 @@ TEST(UtilityTest, PrepareDnsRefreshStrategy) {
   }
 }
 
-void packTypedStructIntoAny(ProtobufWkt::Any& typed_config, const ProtobufWkt::Message& inner) {
+void packTypedStructIntoAny(ProtobufWkt::Any& typed_config, const Protobuf::Message& inner) {
   udpa::type::v1::TypedStruct typed_struct;
   (*typed_struct.mutable_type_url()) =
       absl::StrCat("type.googleapis.com/", inner.GetDescriptor()->full_name());


### PR DESCRIPTION
Replace ProtobufWkt::Message with correct namespace Protobuf::Message

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
