### PR TITLE
Initialize cluster manager for runtime in validation check

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,6 +12,7 @@ Version history
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
+* server: fixed a bug in config validation for configs with runtime layers
 * tcp_proxy: added :ref:`ClusterWeight.metadata_match<envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.WeightedCluster.ClusterWeight.metadata_match>`
 * tcp_proxy: added :ref:`hash_policy<envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.hash_policy>`
 * tls: remove TLS 1.0 and 1.1 from client defaults

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -102,6 +102,7 @@ void ValidationInstance::initialize(const Options& options,
       dispatcher(), localInfo(), *secret_manager_, messageValidationContext(), *api_, http_context_,
       accessLogManager(), singletonManager(), time_system_);
   config_.initialize(bootstrap, *this, *cluster_manager_factory_);
+  runtime_loader_->initialize(clusterManager());
   http_context_.setTracer(config_.httpTracer());
   clusterManager().setInitializedCb([this]() -> void { init_manager_.initialize(init_watcher_); });
 }

--- a/test/server/runtime_bootstrap.yaml
+++ b/test/server/runtime_bootstrap.yaml
@@ -7,3 +7,12 @@ layered_runtime:
       disk_layer: { symlink_root: {{ test_rundir }}/test/server/test_data/runtime/primary }
     - name: overlay_disk_layer
       disk_layer: { symlink_root: {{ test_rundir }}/test/server/test_data/runtime/override, append_service_cluster: true }
+    - name: foobar
+      rtds_layer:
+        name: foobar
+        rtds_config:
+          api_config_source:
+            api_type: GRPC
+            grpc_services:
+              envoy_grpc:
+                cluster_name: xds_cluster

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -601,6 +601,7 @@ TEST_P(ServerInstanceImplTest, BootstrapRuntime) {
   EXPECT_EQ("bar", server_->runtime().snapshot().get("foo"));
   // This should access via the override/some_service overlay.
   EXPECT_EQ("fozz", server_->runtime().snapshot().get("fizz"));
+  EXPECT_EQ("foobar", server_->runtime().snapshot().getLayers()[3]->name());
 }
 
 // Validate that a runtime absent an admin layer will fail mutating operations


### PR DESCRIPTION
Description: In validation mode, the runtime loader's cluster manager was null, leading to a segfault when validation was run on configs with `rtds_layer` specified. This change initializes the runtime loader with the same cluster manager used in the rest of config validation.
Risk Level: Low
Testing: I tested this by building envoy locally and running the binary on a config containing rtds_layer. Without the line I added in source/server/config_validation/server.cc, running Envoy in validation mode on the config leads to a segfault. With it, it returns 'OK'.
I updated an existing test file as well to show that the rtds_layer gets initialized and parsed correctly; however, the initialize function in server_test.cc behaves differently from the initialize function in server.cc and will succeed without my change.
Docs Changes: N/A
Release Notes: included
Fixes #8977 
[Optional Deprecated:]
