### PR TITLE
Revert "Initialize cluster manager for runtime in validation check (#8986)"

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,7 +12,6 @@ Version history
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
-* server: fixed a bug in config validation for configs with runtime layers
 * tcp_proxy: added :ref:`ClusterWeight.metadata_match<envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.WeightedCluster.ClusterWeight.metadata_match>`
 * tcp_proxy: added :ref:`hash_policy<envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.hash_policy>`
 * tls: remove TLS 1.0 and 1.1 from client defaults

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -102,7 +102,6 @@ void ValidationInstance::initialize(const Options& options,
       dispatcher(), localInfo(), *secret_manager_, messageValidationContext(), *api_, http_context_,
       accessLogManager(), singletonManager(), time_system_);
   config_.initialize(bootstrap, *this, *cluster_manager_factory_);
-  runtime_loader_->initialize(clusterManager());
   http_context_.setTracer(config_.httpTracer());
   clusterManager().setInitializedCb([this]() -> void { init_manager_.initialize(init_watcher_); });
 }

--- a/test/server/runtime_bootstrap.yaml
+++ b/test/server/runtime_bootstrap.yaml
@@ -7,12 +7,3 @@ layered_runtime:
       disk_layer: { symlink_root: {{ test_rundir }}/test/server/test_data/runtime/primary }
     - name: overlay_disk_layer
       disk_layer: { symlink_root: {{ test_rundir }}/test/server/test_data/runtime/override, append_service_cluster: true }
-    - name: foobar
-      rtds_layer:
-        name: foobar
-        rtds_config:
-          api_config_source:
-            api_type: GRPC
-            grpc_services:
-              envoy_grpc:
-                cluster_name: xds_cluster

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -601,7 +601,6 @@ TEST_P(ServerInstanceImplTest, BootstrapRuntime) {
   EXPECT_EQ("bar", server_->runtime().snapshot().get("foo"));
   // This should access via the override/some_service overlay.
   EXPECT_EQ("fozz", server_->runtime().snapshot().get("fizz"));
-  EXPECT_EQ("foobar", server_->runtime().snapshot().getLayers()[3]->name());
 }
 
 // Validate that a runtime absent an admin layer will fail mutating operations


### PR DESCRIPTION
This reverts commit 50a8c42756442d2170a712a6c66a030708f7ebcb.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>

tsan and fuzzit is failing since this commit.