### PR TITLE
test: adjust memory limit for macOS

### DIFF
--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -342,7 +342,8 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // ----------  -----    -----------------   -----
   // 2019/09/09  8189     2739         3100   Initial per-host memory snapshot
   // 2019/09/10  8216     1283         1315   Use primitive counters for host stats
-  // 2019/10/01  8850     1299         1315   build: switch to libc++ by default
+  // 2019/11/01  8859     1299         1315   build: switch to libc++ by default
+  // 2019/11/12  8998     1299         1350   test: adjust memory limit for macOS
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -353,7 +354,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_host, 1299);
-  EXPECT_MEMORY_LE(m_per_host, 1315);
+  EXPECT_MEMORY_LE(m_per_host, 1350);
 }
 
 } // namespace


### PR DESCRIPTION
This test result `1332` on mac with `-c opt`. Also fixed typo.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>