### PR TITLE
Add more tests for JWT allow_missing_or_failed

### DIFF
--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -68,7 +68,6 @@ MATCHER_P(JwtOutputWeird, jwt_header, "") {
   return !arg.has(jwt_header) && !arg.has(payload_header);
 }
 
-
 class AllVerifierTest : public testing::Test {
 public:
   void SetUp() override {
@@ -77,7 +76,6 @@ public:
       it.second.mutable_local_jwks()->set_inline_string(PublicKey);
     }
   }
-      // fmt::sprintf(kConfigTemplate, PublicKey, PublicKey), proto_config_); }
 
   void createVerifier() {
     filter_config_ = ::std::make_shared<FilterConfig>(proto_config_, "", mock_factory_ctx_);
@@ -114,7 +112,7 @@ TEST_F(AllVerifierTest, TestAllAllow) {
 // tests requires allow missing or failed. The `allow_missing_or_failed` is defined in a single
 // requirement by itself.
 class AllowFailedInSingleRequirementTest : public AllVerifierTest {
- protected:
+protected:
   void SetUp() override {
     AllVerifierTest::SetUp();
     proto_config_.mutable_rules(0)->mutable_requires()->mutable_allow_missing_or_failed();
@@ -131,9 +129,7 @@ TEST_F(AllowFailedInSingleRequirementTest, NoJwt) {
 
 TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, ExpiredToken}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
@@ -141,9 +137,7 @@ TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
 
 TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -151,10 +145,8 @@ TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
 
 TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken},
-      {kOtherHeader, OtherGoodToken}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -163,10 +155,7 @@ TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
 
 TEST_F(AllowFailedInSingleRequirementTest, GoodAndBadJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken},
-      {kOtherHeader, ExpiredToken}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -175,7 +164,7 @@ TEST_F(AllowFailedInSingleRequirementTest, GoodAndBadJwts) {
 
 // The `allow_missing_or_failed` is defined in an OR-list of requirments.
 class AllowFailedInOrListTest : public AllVerifierTest {
- protected:
+protected:
   void SetUp() override {
     AllVerifierTest::SetUp();
     const char allow_failed_yaml[] = R"(
@@ -198,9 +187,7 @@ TEST_F(AllowFailedInOrListTest, NoJwt) {
 
 TEST_F(AllowFailedInOrListTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, ExpiredToken}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
@@ -208,10 +195,8 @@ TEST_F(AllowFailedInOrListTest, BadJwt) {
 
 TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken},
-      {kOtherHeader, NonExistKidToken}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -220,10 +205,8 @@ TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
 
 TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken},
-      {kOtherHeader, OtherGoodToken}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -234,21 +217,19 @@ TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
 
 TEST_F(AllowFailedInOrListTest, BadAndGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, ExpiredToken},
-      {kOtherHeader, OtherGoodToken}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
-  // Note: the first (provider) requirement is failed, so the allow_missing_or_failed run and validate
-  // token by x-other (even though not require).
+  // Note: the first (provider) requirement is failed, so the allow_missing_or_failed run and
+  // validate token by x-other (even though not require).
   EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
 }
 
 // The `allow_missing_or_failed` is defined in an AND-list of requirments.
 class AllowFailedInAndListTest : public AllVerifierTest {
- protected:
+protected:
   void SetUp() override {
     AllVerifierTest::SetUp();
     const char allow_failed_yaml[] = R"(
@@ -271,9 +252,7 @@ TEST_F(AllowFailedInAndListTest, NoJwt) {
 
 TEST_F(AllowFailedInAndListTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, ExpiredToken}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
@@ -293,10 +272,8 @@ TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
 
 TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken},
-      {kOtherHeader, NonExistKidToken}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // Same as above, output payload is reset.
@@ -307,10 +284,8 @@ TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
 
 TEST_F(AllowFailedInAndListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, std::string(GoodToken)},
-      {kOtherHeader, std::string(OtherGoodToken)}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // Same as above, output payload is reset.
@@ -320,7 +295,7 @@ TEST_F(AllowFailedInAndListTest, TwoGoodJwts) {
 }
 
 class AllowFailedInAndOfOrListTest : public AllVerifierTest {
- protected:
+protected:
   void SetUp() override {
     AllVerifierTest::SetUp();
     const char allow_failed_yaml[] = R"(
@@ -349,9 +324,7 @@ TEST_F(AllowFailedInAndOfOrListTest, NoJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, std::string(ExpiredToken)}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
@@ -359,9 +332,7 @@ TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, GoodToken}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // Output payload is reset due to the second allow_missing_or_failed. Again, this is not
@@ -371,9 +342,7 @@ TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kOtherHeader, std::string(OtherGoodToken)}
-  };
+  auto headers = Http::TestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // Same here, payload for other token is reset.
@@ -382,10 +351,8 @@ TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, ExpiredToken},
-      {kOtherHeader, std::string(OtherGoodToken)}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
@@ -394,10 +361,8 @@ TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
-      {kExampleHeader, std::string(GoodToken)},
-      {kOtherHeader, std::string(OtherGoodToken)}
-  };
+  auto headers =
+      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -18,14 +18,79 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
+const char kConfigTemplate[] = R"(
+providers:
+  example_provider:
+    issuer: https://example.com
+    from_headers:
+    - name: "x-example"
+      value_prefix: ""
+    forward_payload_header: "x-example-payload"
+    local_jwks:
+      inline_string: ""
+  other_provider:
+    issuer: https://other.com
+    from_headers:
+    - name: "x-other"
+      value_prefix: ""
+    forward_payload_header: "x-other-payload"
+    local_jwks:
+      inline_string: ""
+rules:
+- match:
+    path: "/"
+)";
+
+// const char kExampleHeader[] = "x-example";
+const std::string kExampleHeader{"x-example"};
+const char kExamplePayloadHeader[] = "x-example-payload";
+const std::string kOtherHeader{"x-other"};
+const char kOtherPayloadHeader[] = "x-other-payload";
+
+
+// Returns true if the jwt_header is empty, and the jwt_header payload exists.
+// Based on the JWT provider setup for this test, this matcher is equivalent to JWT verification
+// was success.
+MATCHER_P(JwtOutputSuccess, jwt_header, "") {
+  auto payload_header = std::string(jwt_header) + "-payload";
+  return !arg.has(jwt_header) && arg.has(payload_header);
+}
+
+// Returns true if the jwt_header exists, and the jwt_header payload is empty.
+// Based on the JWT provider setup for this test, this matcher is equivalent to JWT verification
+// was failed.
+MATCHER_P(JwtOutputFailed, jwt_header, "") {
+  auto payload_header = jwt_header + "-payload";
+  return arg.has(jwt_header) && !arg.has(payload_header);
+}
+
+// Returns true if both jwt_header and jwt_header payload are empty.
+// This is probably an undesirable outcome of JWT validation and should be fixed in the future.
+// We will address this as part of https://github.com/envoyproxy/envoy/issues/8909
+MATCHER_P(JwtOutputWeird, jwt_header, "") {
+  auto payload_header = jwt_header + "-payload";
+  return !arg.has(jwt_header) && !arg.has(payload_header);
+}
+
+
 class AllVerifierTest : public testing::Test {
 public:
-  void SetUp() override { TestUtility::loadFromYaml(ExampleConfig, proto_config_); }
+  void SetUp() override {
+    TestUtility::loadFromYaml(kConfigTemplate, proto_config_);
+    for (auto& it : *(proto_config_.mutable_providers())) {
+      it.second.mutable_local_jwks()->set_inline_string(PublicKey);
+    }
+  }
+      // fmt::sprintf(kConfigTemplate, PublicKey, PublicKey), proto_config_); }
 
   void createVerifier() {
     filter_config_ = ::std::make_shared<FilterConfig>(proto_config_, "", mock_factory_ctx_);
     verifier_ = Verifier::create(proto_config_.rules(0).requires(), proto_config_.providers(),
                                  *filter_config_, filter_config_->getExtractor());
+  }
+
+  void modifyRequirement(const std::string& yaml) {
+    TestUtility::loadFromYaml(yaml, *proto_config_.mutable_rules(0)->mutable_requires());
   }
 
   JwtAuthentication proto_config_;
@@ -39,11 +104,10 @@ public:
 
 // tests rule that is just match no requires.
 TEST_F(AllVerifierTest, TestAllAllow) {
-  proto_config_.mutable_rules(0)->clear_requires();
   createVerifier();
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(2);
-  auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer a"}};
+  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, "a"}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   headers = Http::TestHeaderMapImpl{};
@@ -51,30 +115,300 @@ TEST_F(AllVerifierTest, TestAllAllow) {
   verifier_->verify(context_);
 }
 
-// tests requires allow missing or failed
-TEST_F(AllVerifierTest, TestAllowFailed) {
-  std::vector<std::string> names{"a", "b", "c"};
-  for (const auto& it : names) {
-    auto header =
-        (*proto_config_.mutable_providers())[std::string(ProviderName)].add_from_headers();
-    header->set_name(it);
-    header->set_value_prefix("Prefix ");
+// tests requires allow missing or failed. The `allow_missing_or_failed` is defined in a single
+// requirement by itself.
+class AllowFailedInSingleRequirementTest : public AllVerifierTest {
+ protected:
+  void SetUp() override {
+    AllVerifierTest::SetUp();
+    proto_config_.mutable_rules(0)->mutable_requires()->mutable_allow_missing_or_failed();
+    createVerifier();
   }
-  proto_config_.mutable_rules(0)->mutable_requires()->mutable_allow_missing_or_failed();
-  createVerifier();
-  MockUpstream mock_pubkey(mock_factory_ctx_.cluster_manager_, PublicKey);
+};
 
+TEST_F(AllowFailedInSingleRequirementTest, NoJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{};
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+}
+
+TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
-      {"a", "Prefix " + std::string(GoodToken)},
-      {"b", "Prefix " + std::string(NonExistKidToken)},
-      {"c", "Prefix "},
+      {kExampleHeader, ExpiredToken}
   };
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
-  EXPECT_FALSE(headers.has("a"));
-  EXPECT_TRUE(headers.has("b"));
-  EXPECT_TRUE(headers.has("c"));
+  EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
+}
+
+TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
+}
+
+TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken},
+      {kOtherHeader, OtherGoodToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
+  EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
+}
+
+TEST_F(AllowFailedInSingleRequirementTest, GoodAndBadJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken},
+      {kOtherHeader, ExpiredToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
+  EXPECT_THAT(headers, JwtOutputFailed(kOtherHeader));
+}
+
+// The `allow_missing_or_failed` is defined in an OR-list of requirments.
+class AllowFailedInOrListTest : public AllVerifierTest {
+ protected:
+  void SetUp() override {
+    AllVerifierTest::SetUp();
+    const char allow_failed_yaml[] = R"(
+requires_any:
+  requirements:
+  - provider_name: "example_provider"
+  - allow_missing_or_failed: {}
+)";
+    modifyRequirement(allow_failed_yaml);
+    createVerifier();
+  }
+};
+
+TEST_F(AllowFailedInOrListTest, NoJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{};
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+}
+
+TEST_F(AllowFailedInOrListTest, BadJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, ExpiredToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
+}
+
+TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken},
+      {kOtherHeader, NonExistKidToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
+  EXPECT_THAT(headers, JwtOutputFailed(kOtherHeader));
+}
+
+TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken},
+      {kOtherHeader, OtherGoodToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
+  // Note: the first (provider) requirement is satisfied, so the allow_missing_or_failed has not
+  // kicked in yet.
+  EXPECT_THAT(headers, JwtOutputFailed(kOtherHeader));
+}
+
+TEST_F(AllowFailedInOrListTest, BadAndGoodJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, ExpiredToken},
+      {kOtherHeader, OtherGoodToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
+  // Note: the first (provider) requirement is failed, so the allow_missing_or_failed run and validate
+  // token by x-other (even though not require).
+  EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
+}
+
+// The `allow_missing_or_failed` is defined in an AND-list of requirments.
+class AllowFailedInAndListTest : public AllVerifierTest {
+ protected:
+  void SetUp() override {
+    AllVerifierTest::SetUp();
+    const char allow_failed_yaml[] = R"(
+requires_all:
+  requirements:
+  - provider_name: "example_provider"
+  - allow_missing_or_failed: {}
+)";
+    modifyRequirement(allow_failed_yaml);
+    createVerifier();
+  }
+};
+
+TEST_F(AllowFailedInAndListTest, NoJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{};
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+}
+
+TEST_F(AllowFailedInAndListTest, BadJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, ExpiredToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
+}
+
+TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken},
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  // In AND-mode, the allow-missing-or-failed reset the output payload. This could be an undesired
+  // behavior.
+  EXPECT_FALSE(headers.has(kExampleHeader));
+  EXPECT_FALSE(headers.has(kExamplePayloadHeader));
+}
+
+TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken},
+      {kOtherHeader, NonExistKidToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  // Same as above, output payload is reset.
+  EXPECT_FALSE(headers.has(kExampleHeader));
+  EXPECT_FALSE(headers.has(kExamplePayloadHeader));
+  // The bad, non-required token won't affect the verification status though.
+  EXPECT_THAT(headers, JwtOutputFailed(kOtherHeader));
+}
+
+TEST_F(AllowFailedInAndListTest, TwoGoodJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, std::string(GoodToken)},
+      {kOtherHeader, std::string(OtherGoodToken)}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  // Same as above, output payload is reset.
+  EXPECT_FALSE(headers.has(kExampleHeader));
+  EXPECT_FALSE(headers.has(kExamplePayloadHeader));
+  // The *other* JWT is processed by allow_missing_or_failed, and actually output payload.
+  EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
+}
+
+class AllowFailedInAndOfOrListTest : public AllVerifierTest {
+ protected:
+  void SetUp() override {
+    AllVerifierTest::SetUp();
+    const char allow_failed_yaml[] = R"(
+requires_all:
+  requirements:
+  - requires_any:
+      requirements:
+      - provider_name: "example_provider"
+      - allow_missing_or_failed: {}
+  - requires_any:
+      requirements:
+      - provider_name: "other_provider"
+      - allow_missing_or_failed: {}
+)";
+    modifyRequirement(allow_failed_yaml);
+    createVerifier();
+  }
+};
+
+TEST_F(AllowFailedInAndOfOrListTest, NoJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{};
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+}
+
+TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, std::string(ExpiredToken)}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
+}
+
+TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, GoodToken}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  // Output payload is reset due to the second allow_missing_or_failed. Again, this is not
+  // a desirable state.
+  EXPECT_THAT(headers, JwtOutputWeird(kExampleHeader));
+}
+
+TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kOtherHeader, std::string(OtherGoodToken)}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  // Same here, payload for other token is reset.
+  EXPECT_THAT(headers, JwtOutputWeird(kOtherHeader));
+}
+
+TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, ExpiredToken},
+      {kOtherHeader, std::string(OtherGoodToken)}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputFailed(kExampleHeader));
+  EXPECT_THAT(headers, JwtOutputWeird(kOtherHeader));
+}
+
+TEST_F(AllowFailedInAndOfOrListTest, TwoGoodJwts) {
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  auto headers = Http::TestHeaderMapImpl{
+      {kExampleHeader, std::string(GoodToken)},
+      {kOtherHeader, std::string(OtherGoodToken)}
+  };
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+  EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
+  EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
@@ -18,7 +19,7 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
-const char kConfigTemplate[] = R"(
+constexpr char kConfigTemplate[] = R"(
 providers:
   example_provider:
     issuer: https://example.com
@@ -41,31 +42,31 @@ rules:
     path: "/"
 )";
 
-const std::string kExampleHeader{"x-example"};
-const std::string kOtherHeader{"x-other"};
+constexpr char kExampleHeader[] = "x-example";
+constexpr char kOtherHeader[] = "x-other";
 
 // Returns true if the jwt_header is empty, and the jwt_header payload exists.
 // Based on the JWT provider setup for this test, this matcher is equivalent to JWT verification
 // was success.
 MATCHER_P(JwtOutputSuccess, jwt_header, "") {
-  auto payload_header = std::string(jwt_header) + "-payload";
-  return !arg.has(jwt_header) && arg.has(payload_header);
+  auto payload_header = absl::StrCat(jwt_header, "-payload");
+  return !arg.has(std::string(jwt_header)) && arg.has(payload_header);
 }
 
 // Returns true if the jwt_header exists, and the jwt_header payload is empty.
 // Based on the JWT provider setup for this test, this matcher is equivalent to JWT verification
 // was failed.
 MATCHER_P(JwtOutputFailed, jwt_header, "") {
-  auto payload_header = jwt_header + "-payload";
-  return arg.has(jwt_header) && !arg.has(payload_header);
+  auto payload_header = absl::StrCat(jwt_header, "-payload");
+  return arg.has(std::string(jwt_header)) && !arg.has(payload_header);
 }
 
 // Returns true if both jwt_header and jwt_header payload are empty.
 // This is probably an undesirable outcome of JWT validation and should be fixed in the future.
 // We will address this as part of https://github.com/envoyproxy/envoy/issues/8909
 MATCHER_P(JwtOutputWeird, jwt_header, "") {
-  auto payload_header = jwt_header + "-payload";
-  return !arg.has(jwt_header) && !arg.has(payload_header);
+  auto payload_header = absl::StrCat(jwt_header, "-payload");
+  return !arg.has(std::string(jwt_header)) && !arg.has(payload_header);
 }
 
 class AllVerifierTest : public testing::Test {

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -41,12 +41,8 @@ rules:
     path: "/"
 )";
 
-// const char kExampleHeader[] = "x-example";
 const std::string kExampleHeader{"x-example"};
-const char kExamplePayloadHeader[] = "x-example-payload";
 const std::string kOtherHeader{"x-other"};
-const char kOtherPayloadHeader[] = "x-other-payload";
-
 
 // Returns true if the jwt_header is empty, and the jwt_header payload exists.
 // Based on the JWT provider setup for this test, this matcher is equivalent to JWT verification
@@ -292,8 +288,7 @@ TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
   verifier_->verify(context_);
   // In AND-mode, the allow-missing-or-failed reset the output payload. This could be an undesired
   // behavior.
-  EXPECT_FALSE(headers.has(kExampleHeader));
-  EXPECT_FALSE(headers.has(kExamplePayloadHeader));
+  EXPECT_THAT(headers, JwtOutputWeird(kExampleHeader));
 }
 
 TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
@@ -305,8 +300,7 @@ TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // Same as above, output payload is reset.
-  EXPECT_FALSE(headers.has(kExampleHeader));
-  EXPECT_FALSE(headers.has(kExamplePayloadHeader));
+  EXPECT_THAT(headers, JwtOutputWeird(kExampleHeader));
   // The bad, non-required token won't affect the verification status though.
   EXPECT_THAT(headers, JwtOutputFailed(kOtherHeader));
 }
@@ -320,8 +314,7 @@ TEST_F(AllowFailedInAndListTest, TwoGoodJwts) {
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // Same as above, output payload is reset.
-  EXPECT_FALSE(headers.has(kExampleHeader));
-  EXPECT_FALSE(headers.has(kExamplePayloadHeader));
+  EXPECT_THAT(headers, JwtOutputWeird(kExampleHeader));
   // The *other* JWT is processed by allow_missing_or_failed, and actually output payload.
   EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
 }

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -163,7 +163,7 @@ TEST_F(AllowFailedInSingleRequirementTest, GoodAndBadJwts) {
   EXPECT_THAT(headers, JwtOutputFailed(kOtherHeader));
 }
 
-// The `allow_missing_or_failed` is defined in an OR-list of requirments.
+// The `allow_missing_or_failed` is defined in an OR-list of requirements.
 class AllowFailedInOrListTest : public AllVerifierTest {
 protected:
   void SetUp() override {

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -228,7 +228,7 @@ TEST_F(AllowFailedInOrListTest, BadAndGoodJwts) {
   EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
 }
 
-// The `allow_missing_or_failed` is defined in an AND-list of requirments.
+// The `allow_missing_or_failed` is defined in an AND-list of requirements.
 class AllowFailedInAndListTest : public AllVerifierTest {
 protected:
   void SetUp() override {

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -440,7 +440,9 @@ std::string TestHeaderMapImpl::get_(const LowerCaseString& key) const {
   }
 }
 
-bool TestHeaderMapImpl::has(const std::string& key) const { return get(LowerCaseString(key)) != nullptr; }
+bool TestHeaderMapImpl::has(const std::string& key) const {
+  return get(LowerCaseString(key)) != nullptr;
+}
 
 bool TestHeaderMapImpl::has(const LowerCaseString& key) const { return get(key) != nullptr; }
 

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -440,9 +440,9 @@ std::string TestHeaderMapImpl::get_(const LowerCaseString& key) const {
   }
 }
 
-bool TestHeaderMapImpl::has(const std::string& key) { return get(LowerCaseString(key)) != nullptr; }
+bool TestHeaderMapImpl::has(const std::string& key) const { return get(LowerCaseString(key)) != nullptr; }
 
-bool TestHeaderMapImpl::has(const LowerCaseString& key) { return get(key) != nullptr; }
+bool TestHeaderMapImpl::has(const LowerCaseString& key) const { return get(key) != nullptr; }
 
 } // namespace Http
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -642,8 +642,8 @@ public:
   void remove(const std::string& key);
   std::string get_(const std::string& key) const;
   std::string get_(const LowerCaseString& key) const;
-  bool has(const std::string& key);
-  bool has(const LowerCaseString& key);
+  bool has(const std::string& key) const;
+  bool has(const LowerCaseString& key) const;
 };
 
 // Helper method to create a header map from an initializer list. Useful due to make_unique's


### PR DESCRIPTION
Description:
Add more unit tests to demonstrate the status quo behavior of JWT filter with `allow_missing_or_failed` requirement. Some behavior is arguably incorrect or confusing, though we will try not to fix it in this PR.

Related issues:
- https://github.com/envoyproxy/envoy/issues/8909

Risk Level: Low
Adding tests only.
Testing:
Add more unit tests for existing feature.
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
