### PR TITLE
Expand $GOPATH in tools/check_format.py.

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -74,8 +74,10 @@ STD_REGEX_WHITELIST = ("./source/common/common/utility.cc", "./source/common/com
 GRPC_INIT_WHITELIST = ("./source/common/grpc/google_grpc_context.cc")
 
 CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-9")
-BUILDIFIER_PATH = os.getenv("BUILDIFIER_BIN", "$GOPATH/bin/buildifier")
-BUILDOZER_PATH = os.getenv("BUILDOZER_BIN", "$GOPATH/bin/buildozer")
+BUILDIFIER_PATH = os.getenv("BUILDIFIER_BIN") or (os.path.expandvars("$GOPATH/bin/buildifier") if
+                                                os.getenv("GOPATH") else shutil.which("buildozer"))
+BUILDOZER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer") if
+                                                os.getenv("GOPATH") else shutil.which("buildozer"))
 ENVOY_BUILD_FIXER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),
                                       "envoy_build_fixer.py")
 HEADER_ORDER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "header_order.py")

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -75,7 +75,7 @@ GRPC_INIT_WHITELIST = ("./source/common/grpc/google_grpc_context.cc")
 
 CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-9")
 BUILDIFIER_PATH = os.getenv("BUILDIFIER_BIN") or (os.path.expandvars("$GOPATH/bin/buildifier") if
-                                                os.getenv("GOPATH") else shutil.which("buildozer"))
+                                                os.getenv("GOPATH") else shutil.which("buildifier"))
 BUILDOZER_PATH = os.getenv("BUILDOZER_BIN") or (os.path.expandvars("$GOPATH/bin/buildozer") if
                                                 os.getenv("GOPATH") else shutil.which("buildozer"))
 ENVOY_BUILD_FIXER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),


### PR DESCRIPTION
`tools/check_format.py` doesn't expand $GOPATH when defaulting the
Bazel build tools. Copy the expansion from `docs/generate_extension_db.py`
and apply it to buildifier and buildozer.

Signed-off-by: James Peach <jpeach@apache.org>

Risk Level: Low
Testing: Ran script
Docs Changes: N/A
Release Notes: N/A
