### PR TITLE
deps: update cel

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -279,10 +279,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://storage.googleapis.com/quiche-envoy-integration/4abb566fbbc63df8fe7c1ac30b21632b9eb18d0c.tar.gz"],
     ),
     com_google_cel_cpp = dict(
-        sha256 = "e21d11be5eca677fe79839d310ceffb2f950d9d03f7682af8c0d311e573a1302",
-        strip_prefix = "cel-cpp-d85f82972c2def6db9c90f3d9a23f56a0ac3caff",
-        # 2019-10-23
-        urls = ["https://github.com/google/cel-cpp/archive/d85f82972c2def6db9c90f3d9a23f56a0ac3caff.tar.gz"],
+        sha256 = "6b056207f6a069ee6e28f31010262585cf6090e6c889cb98da29715cf544ac7d",
+        strip_prefix = "cel-cpp-750fd9a3cbf4470ee46c8deef0a4701b4cc8b1ce",
+        # 2019-11-12
+        urls = ["https://github.com/google/cel-cpp/archive/750fd9a3cbf4470ee46c8deef0a4701b4cc8b1ce.tar.gz"],
     ),
     com_googlesource_code_re2 = dict(
         sha256 = "b0382aa7369f373a0148218f2df5a6afd6bfa884ce4da2dfb576b979989e615e",

--- a/source/extensions/filters/common/expr/BUILD
+++ b/source/extensions/filters/common/expr/BUILD
@@ -31,5 +31,6 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/stream_info:utility_lib",
         "@com_google_cel_cpp//eval/public:cel_value",
+        "@com_google_cel_cpp//eval/public:cel_value_producer",
     ],
 )

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -15,7 +15,7 @@ absl::optional<CelValue> convertHeaderEntry(const Http::HeaderEntry* header) {
   if (header == nullptr) {
     return {};
   }
-  return CelValue::CreateString(header->value().getStringView());
+  return CelValue::CreateStringView(header->value().getStringView());
 }
 
 absl::optional<CelValue> extractSslInfo(const Ssl::ConnectionInfo& ssl_info,
@@ -91,9 +91,9 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
       absl::string_view path = headers_.value_->Path()->value().getStringView();
       size_t query_offset = path.find('?');
       if (query_offset == absl::string_view::npos) {
-        return CelValue::CreateString(path);
+        return CelValue::CreateStringView(path);
       }
-      return CelValue::CreateString(path.substr(0, query_offset));
+      return CelValue::CreateStringView(path.substr(0, query_offset));
     } else if (value == Host) {
       return convertHeaderEntry(headers_.value_->Host());
     } else if (value == Scheme) {
@@ -163,7 +163,7 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
   if (value == Address) {
     auto upstream_host = info_.upstreamHost();
     if (upstream_host != nullptr && upstream_host->address() != nullptr) {
-      return CelValue::CreateString(upstream_host->address()->asStringView());
+      return CelValue::CreateStringView(upstream_host->address()->asStringView());
     }
   } else if (value == Port) {
     auto upstream_host = info_.upstreamHost();
@@ -188,9 +188,9 @@ absl::optional<CelValue> PeerWrapper::operator[](CelValue key) const {
   auto value = key.StringOrDie().value();
   if (value == Address) {
     if (local_) {
-      return CelValue::CreateString(info_.downstreamLocalAddress()->asStringView());
+      return CelValue::CreateStringView(info_.downstreamLocalAddress()->asStringView());
     } else {
-      return CelValue::CreateString(info_.downstreamRemoteAddress()->asStringView());
+      return CelValue::CreateStringView(info_.downstreamRemoteAddress()->asStringView());
     }
   } else if (value == Port) {
     if (local_) {

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -5,6 +5,7 @@
 #include "common/http/headers.h"
 
 #include "eval/public/cel_value.h"
+#include "eval/public/cel_value_producer.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -79,13 +80,15 @@ private:
   const Http::HeaderMap* value_;
 };
 
-class BaseWrapper : public google::api::expr::runtime::CelMap {
+class BaseWrapper : public google::api::expr::runtime::CelMap,
+                    public google::api::expr::runtime::CelValueProducer {
 public:
   int size() const override { return 0; }
   bool empty() const override { return false; }
   const google::api::expr::runtime::CelList* ListKeys() const override {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
+  CelValue Produce(ProtobufWkt::Arena*) override { return CelValue::CreateMap(this); }
 };
 
 class RequestWrapper : public BaseWrapper {
@@ -138,6 +141,17 @@ public:
 private:
   const StreamInfo::StreamInfo& info_;
   const bool local_;
+};
+
+class MetadataProducer : public google::api::expr::runtime::CelValueProducer {
+public:
+  MetadataProducer(const envoy::api::v2::core::Metadata& metadata) : metadata_(metadata) {}
+  CelValue Produce(ProtobufWkt::Arena* arena) override {
+    return CelValue::CreateMessage(&metadata_, arena);
+  }
+
+private:
+  const envoy::api::v2::core::Metadata& metadata_;
 };
 
 } // namespace Expr

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -11,6 +11,23 @@ namespace Filters {
 namespace Common {
 namespace Expr {
 
+ActivationPtr createActivation(const StreamInfo::StreamInfo& info,
+                               const Http::HeaderMap* request_headers,
+                               const Http::HeaderMap* response_headers,
+                               const Http::HeaderMap* response_trailers) {
+  auto activation = std::make_unique<Activation>();
+  activation->InsertValueProducer(Request, std::make_unique<RequestWrapper>(request_headers, info));
+  activation->InsertValueProducer(
+      Response, std::make_unique<ResponseWrapper>(response_headers, response_trailers, info));
+  activation->InsertValueProducer(Connection, std::make_unique<ConnectionWrapper>(info));
+  activation->InsertValueProducer(Upstream, std::make_unique<UpstreamWrapper>(info));
+  activation->InsertValueProducer(Source, std::make_unique<PeerWrapper>(info, false));
+  activation->InsertValueProducer(Destination, std::make_unique<PeerWrapper>(info, true));
+  activation->InsertValueProducer(Metadata,
+                                  std::make_unique<MetadataProducer>(info.dynamicMetadata()));
+  return activation;
+}
+
 BuilderPtr createBuilder(Protobuf::Arena* arena) {
   google::api::expr::runtime::InterpreterOptions options;
 
@@ -53,22 +70,8 @@ absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena* arena
                                   const Http::HeaderMap* request_headers,
                                   const Http::HeaderMap* response_headers,
                                   const Http::HeaderMap* response_trailers) {
-  google::api::expr::runtime::Activation activation;
-  const RequestWrapper request(request_headers, info);
-  const ResponseWrapper response(response_headers, response_trailers, info);
-  const ConnectionWrapper connection(info);
-  const UpstreamWrapper upstream(info);
-  const PeerWrapper source(info, false);
-  const PeerWrapper destination(info, true);
-  activation.InsertValue(Request, CelValue::CreateMap(&request));
-  activation.InsertValue(Response, CelValue::CreateMap(&response));
-  activation.InsertValue(Metadata, CelValue::CreateMessage(&info.dynamicMetadata(), arena));
-  activation.InsertValue(Connection, CelValue::CreateMap(&connection));
-  activation.InsertValue(Upstream, CelValue::CreateMap(&upstream));
-  activation.InsertValue(Source, CelValue::CreateMap(&source));
-  activation.InsertValue(Destination, CelValue::CreateMap(&destination));
-
-  auto eval_status = expr.Evaluate(activation, arena);
+  auto activation = createActivation(info, request_headers, response_headers, response_trailers);
+  auto eval_status = expr.Evaluate(*activation.get(), arena);
   if (!eval_status.ok()) {
     return {};
   }

--- a/source/extensions/filters/common/expr/evaluator.h
+++ b/source/extensions/filters/common/expr/evaluator.h
@@ -16,10 +16,19 @@ namespace Filters {
 namespace Common {
 namespace Expr {
 
+using Activation = google::api::expr::runtime::Activation;
+using ActivationPtr = std::unique_ptr<Activation>;
 using Builder = google::api::expr::runtime::CelExpressionBuilder;
 using BuilderPtr = std::unique_ptr<Builder>;
 using Expression = google::api::expr::runtime::CelExpression;
 using ExpressionPtr = std::unique_ptr<Expression>;
+
+// Creates an activation providing the common context attributes.
+// The activation lazily creates wrappers during an evaluation using the evaluation arena.
+ActivationPtr createActivation(const StreamInfo::StreamInfo& info,
+                               const Http::HeaderMap* request_headers,
+                               const Http::HeaderMap* response_headers,
+                               const Http::HeaderMap* response_trailers);
 
 // Creates an expression builder. The optional arena is used to enable constant folding
 // for intermediate evaluation results.

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -24,7 +24,7 @@ constexpr absl::string_view Undefined = "undefined";
 
 TEST(Context, EmptyHeadersAttributes) {
   HeadersWrapper headers(nullptr);
-  auto header = headers[CelValue::CreateString(Referer)];
+  auto header = headers[CelValue::CreateStringView(Referer)];
   EXPECT_FALSE(header.has_value());
   EXPECT_EQ(0, headers.size());
   EXPECT_TRUE(headers.empty());
@@ -51,7 +51,7 @@ TEST(Context, RequestAttributes) {
   EXPECT_FALSE(request.empty());
 
   {
-    auto value = request[CelValue::CreateString(Undefined)];
+    auto value = request[CelValue::CreateStringView(Undefined)];
     EXPECT_FALSE(value.has_value());
   }
 
@@ -61,69 +61,69 @@ TEST(Context, RequestAttributes) {
   }
 
   {
-    auto value = request[CelValue::CreateString(Scheme)];
+    auto value = request[CelValue::CreateStringView(Scheme)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("http", value.value().StringOrDie().value());
   }
   {
-    auto value = request[CelValue::CreateString(Host)];
+    auto value = request[CelValue::CreateStringView(Host)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("kittens.com", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(Path)];
+    auto value = request[CelValue::CreateStringView(Path)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("/meow?yes=1", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(UrlPath)];
+    auto value = request[CelValue::CreateStringView(UrlPath)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("/meow", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(Method)];
+    auto value = request[CelValue::CreateStringView(Method)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("POST", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(Referer)];
+    auto value = request[CelValue::CreateStringView(Referer)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("dogs.com", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(UserAgent)];
+    auto value = request[CelValue::CreateStringView(UserAgent)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("envoy-mobile", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(ID)];
+    auto value = request[CelValue::CreateStringView(ID)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("blah", value.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(Size)];
+    auto value = request[CelValue::CreateStringView(Size)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(10, value.value().Int64OrDie());
   }
 
   {
-    auto value = request[CelValue::CreateString(TotalSize)];
+    auto value = request[CelValue::CreateStringView(TotalSize)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     // this includes the headers size
@@ -131,28 +131,28 @@ TEST(Context, RequestAttributes) {
   }
 
   {
-    auto value = request[CelValue::CreateString(Time)];
+    auto value = request[CelValue::CreateStringView(Time)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsTimestamp());
     EXPECT_EQ("2018-04-03T23:06:09.123+00:00", absl::FormatTime(value.value().TimestampOrDie()));
   }
 
   {
-    auto value = request[CelValue::CreateString(Headers)];
+    auto value = request[CelValue::CreateStringView(Headers)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsMap());
     auto& map = *value.value().MapOrDie();
     EXPECT_FALSE(map.empty());
     EXPECT_EQ(8, map.size());
 
-    auto header = map[CelValue::CreateString(Referer)];
+    auto header = map[CelValue::CreateStringView(Referer)];
     EXPECT_TRUE(header.has_value());
     ASSERT_TRUE(header.value().IsString());
     EXPECT_EQ("dogs.com", header.value().StringOrDie().value());
   }
 
   {
-    auto value = request[CelValue::CreateString(Duration)];
+    auto value = request[CelValue::CreateStringView(Duration)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsDuration());
     EXPECT_EQ("15ms", absl::FormatDuration(value.value().DurationOrDie()));
@@ -171,14 +171,14 @@ TEST(Context, RequestFallbackAttributes) {
   EXPECT_CALL(info, bytesReceived()).WillRepeatedly(Return(10));
 
   {
-    auto value = request[CelValue::CreateString(Size)];
+    auto value = request[CelValue::CreateStringView(Size)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(10, value.value().Int64OrDie());
   }
 
   {
-    auto value = request[CelValue::CreateString(UrlPath)];
+    auto value = request[CelValue::CreateStringView(UrlPath)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("/meow", value.value().StringOrDie().value());
@@ -198,7 +198,7 @@ TEST(Context, ResponseAttributes) {
   EXPECT_CALL(info, responseFlags()).WillRepeatedly(Return(0x1));
 
   {
-    auto value = response[CelValue::CreateString(Undefined)];
+    auto value = response[CelValue::CreateStringView(Undefined)];
     EXPECT_FALSE(value.has_value());
   }
 
@@ -208,51 +208,51 @@ TEST(Context, ResponseAttributes) {
   }
 
   {
-    auto value = response[CelValue::CreateString(Size)];
+    auto value = response[CelValue::CreateStringView(Size)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(123, value.value().Int64OrDie());
   }
 
   {
-    auto value = response[CelValue::CreateString(Code)];
+    auto value = response[CelValue::CreateStringView(Code)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(404, value.value().Int64OrDie());
   }
 
   {
-    auto value = response[CelValue::CreateString(Headers)];
+    auto value = response[CelValue::CreateStringView(Headers)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsMap());
     auto& map = *value.value().MapOrDie();
     EXPECT_FALSE(map.empty());
     EXPECT_EQ(1, map.size());
 
-    auto header = map[CelValue::CreateString(header_name)];
+    auto header = map[CelValue::CreateStringView(header_name)];
     EXPECT_TRUE(header.has_value());
     ASSERT_TRUE(header.value().IsString());
     EXPECT_EQ("a", header.value().StringOrDie().value());
 
-    auto missing = map[CelValue::CreateString(Undefined)];
+    auto missing = map[CelValue::CreateStringView(Undefined)];
     EXPECT_FALSE(missing.has_value());
   }
 
   {
-    auto value = response[CelValue::CreateString(Trailers)];
+    auto value = response[CelValue::CreateStringView(Trailers)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsMap());
     auto& map = *value.value().MapOrDie();
     EXPECT_FALSE(map.empty());
     EXPECT_EQ(1, map.size());
 
-    auto header = map[CelValue::CreateString(trailer_name)];
+    auto header = map[CelValue::CreateString(&trailer_name)];
     EXPECT_TRUE(header.has_value());
     ASSERT_TRUE(header.value().IsString());
     EXPECT_EQ("b", header.value().StringOrDie().value());
   }
   {
-    auto value = response[CelValue::CreateString(Flags)];
+    auto value = response[CelValue::CreateStringView(Flags)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(0x1, value.value().Int64OrDie());
@@ -314,7 +314,7 @@ TEST(Context, ConnectionAttributes) {
   EXPECT_CALL(*upstream_ssl_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject_peer));
 
   {
-    auto value = connection[CelValue::CreateString(Undefined)];
+    auto value = connection[CelValue::CreateStringView(Undefined)];
     EXPECT_FALSE(value.has_value());
   }
 
@@ -324,7 +324,7 @@ TEST(Context, ConnectionAttributes) {
   }
 
   {
-    auto value = source[CelValue::CreateString(Undefined)];
+    auto value = source[CelValue::CreateStringView(Undefined)];
     EXPECT_FALSE(value.has_value());
   }
 
@@ -334,154 +334,154 @@ TEST(Context, ConnectionAttributes) {
   }
 
   {
-    auto value = destination[CelValue::CreateString(Address)];
+    auto value = destination[CelValue::CreateStringView(Address)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("1.2.3.4:123", value.value().StringOrDie().value());
   }
 
   {
-    auto value = destination[CelValue::CreateString(Port)];
+    auto value = destination[CelValue::CreateStringView(Port)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(123, value.value().Int64OrDie());
   }
 
   {
-    auto value = source[CelValue::CreateString(Address)];
+    auto value = source[CelValue::CreateStringView(Address)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("10.20.30.40:456", value.value().StringOrDie().value());
   }
 
   {
-    auto value = source[CelValue::CreateString(Port)];
+    auto value = source[CelValue::CreateStringView(Port)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(456, value.value().Int64OrDie());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(Address)];
+    auto value = upstream[CelValue::CreateStringView(Address)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("10.1.2.3:679", value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(Port)];
+    auto value = upstream[CelValue::CreateStringView(Port)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(679, value.value().Int64OrDie());
   }
 
   {
-    auto value = connection[CelValue::CreateString(MTLS)];
+    auto value = connection[CelValue::CreateStringView(MTLS)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsBool());
     EXPECT_TRUE(value.value().BoolOrDie());
   }
 
   {
-    auto value = connection[CelValue::CreateString(RequestedServerName)];
+    auto value = connection[CelValue::CreateStringView(RequestedServerName)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(sni_name, value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(TLSVersion)];
+    auto value = connection[CelValue::CreateStringView(TLSVersion)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(tls_version, value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(DNSSanLocalCertificate)];
+    auto value = connection[CelValue::CreateStringView(DNSSanLocalCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(dns_sans_local[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(DNSSanPeerCertificate)];
+    auto value = connection[CelValue::CreateStringView(DNSSanPeerCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(dns_sans_peer[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(URISanLocalCertificate)];
+    auto value = connection[CelValue::CreateStringView(URISanLocalCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(uri_sans_local[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(URISanPeerCertificate)];
+    auto value = connection[CelValue::CreateStringView(URISanPeerCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(uri_sans_peer[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(SubjectLocalCertificate)];
+    auto value = connection[CelValue::CreateStringView(SubjectLocalCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(subject_local, value.value().StringOrDie().value());
   }
 
   {
-    auto value = connection[CelValue::CreateString(SubjectPeerCertificate)];
+    auto value = connection[CelValue::CreateStringView(SubjectPeerCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(subject_peer, value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(TLSVersion)];
+    auto value = upstream[CelValue::CreateStringView(TLSVersion)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(tls_version, value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(DNSSanLocalCertificate)];
+    auto value = upstream[CelValue::CreateStringView(DNSSanLocalCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(dns_sans_local[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(DNSSanPeerCertificate)];
+    auto value = upstream[CelValue::CreateStringView(DNSSanPeerCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(dns_sans_peer[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(URISanLocalCertificate)];
+    auto value = upstream[CelValue::CreateStringView(URISanLocalCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(uri_sans_local[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(URISanPeerCertificate)];
+    auto value = upstream[CelValue::CreateStringView(URISanPeerCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(uri_sans_peer[0], value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(SubjectLocalCertificate)];
+    auto value = upstream[CelValue::CreateStringView(SubjectLocalCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(subject_local, value.value().StringOrDie().value());
   }
 
   {
-    auto value = upstream[CelValue::CreateString(SubjectPeerCertificate)];
+    auto value = upstream[CelValue::CreateStringView(SubjectPeerCertificate)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(subject_peer, value.value().StringOrDie().value());


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Update cel-cpp:
- use value producers to begin sharing the activation
- disambiguate CreateString vs CreateStringView

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
