### PR TITLE
jwt_authn: bypass CORS preflight request

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -465,4 +465,9 @@ message JwtAuthentication {
   // The *rules* field above is checked first, if it could not find any matches,
   // check this one.
   FilterStateRule filter_state_rules = 3;
+
+  // When set to true, bypass the `CORS preflight request
+  // <http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ regardless of JWT
+  // requirements specified in the rules.
+  bool bypass_cors_preflight = 4;
 }

--- a/api/envoy/config/filter/http/jwt_authn/v3alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v3alpha/config.proto
@@ -465,4 +465,9 @@ message JwtAuthentication {
   // The *rules* field above is checked first, if it could not find any matches,
   // check this one.
   FilterStateRule filter_state_rules = 3;
+
+  // When set to true, bypass the `CORS preflight request
+  // <http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ regardless of JWT
+  // requirements specified in the rules.
+  bool bypass_cors_preflight = 4;
 }

--- a/docs/root/intro/arch_overview/security/jwt_authn_filter.rst
+++ b/docs/root/intro/arch_overview/security/jwt_authn_filter.rst
@@ -26,3 +26,6 @@ via HTTP/HTTPS.
 The JWT Authentication filter also supports to write the payloads of the successfully verified JWT
 to :ref:`Dynamic State <arch_overview_data_sharing_between_filters>` so that later filters could use
 it to make their own decisions based on the JWT payloads.
+
+The JWT Authentication filter will bypass the `CORS preflight request
+<http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ for JWT authentication.

--- a/docs/root/intro/arch_overview/security/jwt_authn_filter.rst
+++ b/docs/root/intro/arch_overview/security/jwt_authn_filter.rst
@@ -26,6 +26,3 @@ via HTTP/HTTPS.
 The JWT Authentication filter also supports to write the payloads of the successfully verified JWT
 to :ref:`Dynamic State <arch_overview_data_sharing_between_filters>` so that later filters could use
 it to make their own decisions based on the JWT payloads.
-
-The JWT Authentication filter will bypass the `CORS preflight request
-<http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ for JWT authentication.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -10,8 +10,8 @@ Version history
 * ext_authz: added :ref:`configurable ability<envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate<envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the `ext_authz` service.
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: support :ref:`auto_host_rewrite_header<envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the dynamic forward proxy.
-* lb_subset_config: new fallback policy for selectors: :ref:`KEYS_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`
 * jwt_authn: added :ref:`bypass_cors_preflight<envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.bypass_cors_preflight>` to allow bypassing the CORS preflight request.
+* lb_subset_config: new fallback policy for selectors: :ref:`KEYS_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -11,8 +11,7 @@ Version history
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: support :ref:`auto_host_rewrite_header<envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the dynamic forward proxy.
 * lb_subset_config: new fallback policy for selectors: :ref:`KEYS_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`
-* jwt_authn: added to bypass the CORS preflight request.
-* jwt_authn: added :ref:`bypass_cors_preflight<envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.bypass_cors_preflight>`_ to allow bypassing the CORS preflight request.
+* jwt_authn: added :ref:`bypass_cors_preflight<envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.bypass_cors_preflight>` to allow bypassing the CORS preflight request.
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -11,6 +11,7 @@ Version history
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: support :ref:`auto_host_rewrite_header<envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the dynamic forward proxy.
 * lb_subset_config: new fallback policy for selectors: :ref:`KEYS_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`
+* jwt_authn: added to bypass the CORS preflight request.
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,6 +12,7 @@ Version history
 * http: support :ref:`auto_host_rewrite_header<envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the dynamic forward proxy.
 * lb_subset_config: new fallback policy for selectors: :ref:`KEYS_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`
 * jwt_authn: added to bypass the CORS preflight request.
+* jwt_authn: added :ref:`bypass_cors_preflight<envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.bypass_cors_preflight>`_ to allow bypassing the CORS preflight request.
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -60,6 +60,7 @@ envoy_cc_library(
         ":filter_config_interface",
         ":matchers_lib",
         "//include/envoy/http:filter_interface",
+        "//source/common/http:headers_lib",
         "//source/extensions/filters/http:well_known_names",
     ],
 )

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -30,7 +30,7 @@ void Filter::onDestroy() {
   }
 }
 
-bool isCorsPreflightRequest(const Http::HeaderMap& headers) {
+bool isCORSPreflightRequest(const Http::HeaderMap& headers) {
   return headers.Method() &&
          headers.Method()->value().getStringView() == Http::Headers::get().MethodValues.Options &&
          headers.Origin() && !headers.Origin()->value().empty() &&
@@ -44,10 +44,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   state_ = Calling;
   stopped_ = false;
 
-  if (isCorsPreflightRequest(headers)) {
-    // The CORS preflight doesn't include user credentials, allow regardless of JWT policy.
+  if (config_->bypassCORSPreflightRequest() && isCORSPreflightRequest(headers)) {
+    // The CORS preflight doesn't include user credentials, bypass regardless of JWT requirements.
     // See http://www.w3.org/TR/cors/#cross-origin-request-with-preflight.
-    ENVOY_LOG(debug, "CORS preflight request allowed regardless of JWT policy");
+    ENVOY_LOG(debug, "CORS preflight request bypassed regardless of JWT requirements");
     stats_.cors_preflight_bypassed_.inc();
     onComplete(Status::Ok);
     return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -131,7 +131,7 @@ public:
                                  cm(), Common::JwksFetcher::create, timeSource());
   }
 
-  bool bypassCORSPreflightRequest() { return proto_config_.bypass_cors_preflight(); }
+  bool bypassCorsPreflightRequest() { return proto_config_.bypass_cors_preflight(); }
 
 private:
   JwtAuthnFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -47,7 +47,7 @@ private:
 #define ALL_JWT_AUTHN_FILTER_STATS(COUNTER)                                                        \
   COUNTER(allowed)                                                                                 \
   COUNTER(cors_preflight_bypassed)                                                                 \
-  COUNTER(denied)                                                                                  \
+  COUNTER(denied)
 // clang-format on
 
 /**
@@ -130,6 +130,8 @@ public:
     return Authenticator::create(check_audience, provider, allow_failed, getCache().getJwksCache(),
                                  cm(), Common::JwksFetcher::create, timeSource());
   }
+
+  bool bypassCORSPreflightRequest() { return proto_config_.bypass_cors_preflight(); }
 
 private:
   JwtAuthnFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -46,7 +46,8 @@ private:
 // clang-format off
 #define ALL_JWT_AUTHN_FILTER_STATS(COUNTER)                                                        \
   COUNTER(allowed)                                                                                 \
-  COUNTER(denied)
+  COUNTER(cors_preflight_bypassed)                                                                 \
+  COUNTER(denied)                                                                                  \
 // clang-format on
 
 /**

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -39,6 +39,7 @@ public:
 class FilterTest : public testing::Test {
 public:
   void SetUp() override {
+    proto_config_.set_bypass_cors_preflight(true);
     mock_config_ = ::std::make_shared<MockFilterConfig>(proto_config_, "", mock_context_);
 
     mock_verifier_ = std::make_unique<MockVerifier>();

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -82,6 +82,7 @@ rules:
     path: "/"
   requires:
     provider_name: "example_provider"
+bypass_cors_preflight: true
 )";
 
 // The name of provider for above config.


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Bypass the CORS preflight request in the JWT filter
Risk Level: Low
Testing: Added unit test and integration test
Docs Changes: n/a
Release Notes: Added `jwt_authn: added to bypass the CORS preflight request.`
Optional Fixes: https://github.com/istio/istio/issues/16171
[Optional Deprecated:]
