### PR TITLE
Fix udp_listener_impl_test that fails to build with gcc

### DIFF
--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -409,14 +409,12 @@ TEST_P(UdpListenerImplTest, SendData) {
   do {
     Api::IoCallUint64Result result = Network::Test::readFromSocket(
         client_socket_->ioHandle(), *client_socket_->localAddress(), data);
-    if (result.rc_ >= 0) {
-      bytes_read = result.rc_;
-      EXPECT_EQ(send_from_addr->asString(), data.addresses_.peer_->asString());
-    } else if (retry == 10 || result.err_->getErrorCode() != Api::IoError::IoErrorCode::Again) {
-      break;
-    }
 
-    if (bytes_read >= bytes_to_read) {
+    bytes_read = result.rc_;
+    EXPECT_EQ(send_from_addr->asString(), data.addresses_.peer_->asString());
+
+    if (bytes_read >= bytes_to_read || retry == 10 ||
+        result.err_->getErrorCode() != Api::IoError::IoErrorCode::Again) {
       break;
     }
 


### PR DESCRIPTION
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Removing a >= 0 check on an unsigned int64 that is returned as a result of Network::Test::readFromSocket call in SendData test. Gcc compiler was failing to compile the test as the condition would never be false. 
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
