### PR TITLE
adaptive concurrency: Increase minRTT measurement pinned concurrency

### DIFF
--- a/api/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.proto
+++ b/api/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.proto
@@ -57,6 +57,9 @@ message GradientControllerConfig {
     // Example: If the interval is 10s and the jitter is 15%, the next window will begin
     // somewhere in the range (10s - 11.5s).
     type.Percent jitter = 3;
+
+    // The concurrency limit set while measuring the minRTT. Defaults to 3.
+    google.protobuf.UInt32Value min_concurrency = 4 [(validate.rules).uint32 = {gt: 0}];
   }
 
   // The percentile to use when summarizing aggregated samples. Defaults to p50.

--- a/api/envoy/config/filter/http/adaptive_concurrency/v3alpha/adaptive_concurrency.proto
+++ b/api/envoy/config/filter/http/adaptive_concurrency/v3alpha/adaptive_concurrency.proto
@@ -57,6 +57,9 @@ message GradientControllerConfig {
     // Example: If the interval is 10s and the jitter is 15%, the next window will begin
     // somewhere in the range (10s - 11.5s).
     type.v3alpha.Percent jitter = 3;
+
+    // The concurrency limit set while measuring the minRTT. Defaults to 3.
+    google.protobuf.UInt32Value min_concurrency = 4 [(validate.rules).uint32 = {gt: 0}];
   }
 
   // The percentile to use when summarizing aggregated samples. Defaults to p50.

--- a/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
+++ b/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
@@ -33,7 +33,7 @@ time (minRTT) for an upstream.
 Calculating the minRTT
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The minRTT is periodically measured by only allowing a single outstanding request at a time to an
+The minRTT is periodically measured by only allowing a very low outstanding request count to an
 upstream cluster and measuring the latency under these ideal conditions. The length of this minRTT
 calculation window is variable depending on the number of requests the filter is configured to
 aggregate to represent the expected latency of an upstream.
@@ -41,8 +41,8 @@ aggregate to represent the expected latency of an upstream.
 A configurable *jitter* value is used to randomly delay the start of the minRTT calculation window
 by some amount of time. This is not necessary and can be disabled; however, it is recommended to
 prevent all hosts in a cluster from being in a minRTT calculation window (and having a concurrency
-limit of 1) at the same time. The jitter helps negate the effect of the minRTT calculation on the
-downstream success rate if retries are enabled.
+limit of 3 by default) at the same time. The jitter helps negate the effect of the minRTT
+calculation on the downstream success rate if retries are enabled.
 
 It is possible that there is a noticeable increase in request 503s during the minRTT measurement
 window because of the potentially significant drop in the concurrency limit. This is expected and it
@@ -170,6 +170,9 @@ adaptive_concurrency.gradient_controller.sample_aggregate_percentile
     Overrides the percentile value used to represent the collection of latency samples in
     calculations. A value of `95` indicates the 95th percentile. The runtime value specified is
     clamped to the range [0,100].
+
+adaptive_concurrency.gradient_controller.min_concurrency
+    Overrides the concurrency that is pinned while measuring the minRTT.
 
 Statistics
 ----------

--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
@@ -40,7 +40,10 @@ GradientControllerConfig::GradientControllerConfig(
       max_gradient_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config.concurrency_limit_params(),
                                                     max_gradient, 2.0)),
       sample_aggregate_percentile_(
-          PROTOBUF_PERCENT_TO_DOUBLE_OR_DEFAULT(proto_config, sample_aggregate_percentile, 50)) {}
+          PROTOBUF_PERCENT_TO_DOUBLE_OR_DEFAULT(proto_config, sample_aggregate_percentile, 50)),
+      min_concurrency_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config.min_rtt_calc_params(), min_concurrency, 3))
+  {}
 
 GradientController::GradientController(GradientControllerConfig config,
                                        Event::Dispatcher& dispatcher, Runtime::Loader&,
@@ -48,7 +51,7 @@ GradientController::GradientController(GradientControllerConfig config,
                                        Runtime::RandomGenerator& random)
     : config_(std::move(config)), dispatcher_(dispatcher), scope_(scope),
       stats_(generateStats(scope_, stats_prefix)), random_(random), deferred_limit_value_(1),
-      num_rq_outstanding_(0), concurrency_limit_(1),
+      num_rq_outstanding_(0), concurrency_limit_(config_.minConcurrency()),
       latency_sample_hist_(hist_fast_alloc(), hist_free) {
   min_rtt_calc_timer_ = dispatcher_.createTimer([this]() -> void { enterMinRTTSamplingWindow(); });
 
@@ -82,13 +85,13 @@ GradientControllerStats GradientController::generateStats(Stats::Scope& scope,
 void GradientController::enterMinRTTSamplingWindow() {
   absl::MutexLock ml(&sample_mutation_mtx_);
 
-  stats_.min_rtt_calculation_active_.set(1);
+  stats_.min_rtt_calculation_active_.set(config_.minConcurrency());
 
   // Set the minRTT flag to indicate we're gathering samples to update the value. This will
   // prevent the sample window from resetting until enough requests are gathered to complete the
   // recalculation.
   deferred_limit_value_.store(concurrencyLimit());
-  updateConcurrencyLimit(1);
+  updateConcurrencyLimit(config_.minConcurrency());
 
   // Throw away any latency samples from before the recalculation window as it may not represent
   // the minRTT.

--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
@@ -41,9 +41,8 @@ GradientControllerConfig::GradientControllerConfig(
                                                     max_gradient, 2.0)),
       sample_aggregate_percentile_(
           PROTOBUF_PERCENT_TO_DOUBLE_OR_DEFAULT(proto_config, sample_aggregate_percentile, 50)),
-      min_concurrency_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config.min_rtt_calc_params(), min_concurrency, 3))
-  {}
+      min_concurrency_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config.min_rtt_calc_params(),
+                                                       min_concurrency, 3)) {}
 
 GradientController::GradientController(GradientControllerConfig config,
                                        Event::Dispatcher& dispatcher, Runtime::Loader&,

--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h
@@ -90,8 +90,7 @@ public:
   }
 
   uint32_t minConcurrency() const {
-    return runtime_.snapshot().getInteger(RuntimeKeys::get().MinConcurrencyKey,
-                                          min_concurrency_);
+    return runtime_.snapshot().getInteger(RuntimeKeys::get().MinConcurrencyKey, min_concurrency_);
   }
 
 private:
@@ -110,7 +109,7 @@ private:
         "adaptive_concurrency.gradient_controller.sample_aggregate_percentile";
     const std::string JitterPercentKey = "adaptive_concurrency.gradient_controller.jitter";
     const std::string MinConcurrencyKey =
-      "adaptive_concurrency.gradient_controller.min_concurrency";
+        "adaptive_concurrency.gradient_controller.min_concurrency";
   };
 
   using RuntimeKeys = ConstSingleton<RuntimeKeyValues>;
@@ -153,10 +152,10 @@ using GradientControllerConfigSharedPtr = std::shared_ptr<GradientControllerConf
  *
  * The algorithm:
  * ==============
- * An ideal round-trip time (minRTT) is measured periodically by only allowing a single outstanding
- * request at a time and measuring the round-trip time to the upstream. This information is then
- * used in the calculation of a number called the gradient, using time-sampled latencies
- * (sampleRTT):
+ * An ideal round-trip time (minRTT) is measured periodically by only allowing a small number of
+ * outstanding requests at a time and measuring the round-trip time to the upstream. This
+ * information is then used in the calculation of a number called the gradient, using time-sampled
+ * latencies (sampleRTT):
  *
  *     gradient = minRTT / sampleRTT
  *
@@ -181,14 +180,14 @@ using GradientControllerConfigSharedPtr = std::shared_ptr<GradientControllerConf
  * concept of mutually exclusive sampling windows.
  *
  * When the gradient controller is instantiated, it starts inside of a minRTT calculation window
- * (indicated by inMinRTTSamplingWindow() returning true) and the concurrency limit is pinned to 1.
- * This window lasts until the configured number of requests is received, the minRTT value is
- * updated, and the minRTT value is set by a single worker thread. To prevent sampleRTT calculations
- * from triggering during this window, the update window mutex is held. Since it's necessary for a
- * worker thread to know which update window update window mutex is held for, they check the state
- * of inMinRTTSamplingWindow() after each sample. When the minRTT calculation is complete, a timer
- * is set to trigger the next minRTT sampling window by the worker thread who updates the minRTT
- * value.
+ * (indicated by inMinRTTSamplingWindow() returning true) and the concurrency limit is pinned to the
+ * configured min_concurrency. This window lasts until the configured number of requests is
+ * received, the minRTT value is updated, and the minRTT value is set by a single worker thread. To
+ * prevent sampleRTT calculations from triggering during this window, the update window mutex is
+ * held. Since it's necessary for a worker thread to know which update window update window mutex is
+ * held for, they check the state of inMinRTTSamplingWindow() after each sample. When the minRTT
+ * calculation is complete, a timer is set to trigger the next minRTT sampling window by the worker
+ * thread who updates the minRTT value.
  *
  * If the controller is not in a minRTT sampling window, it's possible that the controller is in a
  * sampleRTT calculation window. In this, all of the latency samples are consolidated into a

--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h
@@ -89,6 +89,11 @@ public:
     return std::max(0.0, std::min(val, 100.0)) / 100.0;
   }
 
+  uint32_t minConcurrency() const {
+    return runtime_.snapshot().getInteger(RuntimeKeys::get().MinConcurrencyKey,
+                                          min_concurrency_);
+  }
+
 private:
   class RuntimeKeyValues {
   public:
@@ -104,6 +109,8 @@ private:
     const std::string SampleAggregatePercentileKey =
         "adaptive_concurrency.gradient_controller.sample_aggregate_percentile";
     const std::string JitterPercentKey = "adaptive_concurrency.gradient_controller.jitter";
+    const std::string MinConcurrencyKey =
+      "adaptive_concurrency.gradient_controller.min_concurrency";
   };
 
   using RuntimeKeys = ConstSingleton<RuntimeKeyValues>;
@@ -130,6 +137,9 @@ private:
 
   // The percentile value considered when processing samples.
   const double sample_aggregate_percentile_;
+
+  // The concurrency limit set while measuring the minRTT.
+  const uint32_t min_concurrency_;
 };
 using GradientControllerConfigSharedPtr = std::shared_ptr<GradientControllerConfig>;
 

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_integration_test.h
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_integration_test.h
@@ -19,6 +19,7 @@ typed_config:
     min_rtt_calc_params:
       interval: 30s
       request_count: 50
+      min_concurrency: 1
 )EOF";
 
 const std::string CONCURRENCY_LIMIT_GAUGE_NAME =

--- a/test/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller_test.cc
@@ -96,6 +96,7 @@ min_rtt_calc_params:
     value: 13.2
   interval: 31s
   request_count: 52
+  min_concurrency: 8
 )EOF";
 
   auto config = makeConfig(yaml, runtime_);
@@ -107,6 +108,7 @@ min_rtt_calc_params:
   EXPECT_EQ(config.maxGradient(), 2.1);
   EXPECT_EQ(config.sampleAggregatePercentile(), .425);
   EXPECT_EQ(config.jitterPercent(), .132);
+  EXPECT_EQ(config.minConcurrency(), 8);
 }
 
 TEST_F(GradientControllerConfigTest, Clamping) {
@@ -156,6 +158,7 @@ min_rtt_calc_params:
   interval:
     seconds: 31
   request_count: 52
+  min_concurrency: 7
 )EOF";
 
   auto config = makeConfig(yaml, runtime_);
@@ -180,6 +183,9 @@ min_rtt_calc_params:
 
   EXPECT_CALL(runtime_.snapshot_, getDouble(_, 13.2)).WillOnce(Return(15.5));
   EXPECT_EQ(config.jitterPercent(), .155);
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger(_, 7)).WillOnce(Return(9));
+  EXPECT_EQ(config.(), 9);
 }
 
 TEST_F(GradientControllerConfigTest, DefaultValuesTest) {
@@ -199,6 +205,7 @@ min_rtt_calc_params:
   EXPECT_EQ(config.maxGradient(), 2.0);
   EXPECT_EQ(config.sampleAggregatePercentile(), .5);
   EXPECT_EQ(config.jitterPercent(), .15);
+  EXPECT_EQ(config.minConcurrency(), 3);
 }
 
 TEST_F(GradientControllerTest, MinRTTLogicTest) {
@@ -214,17 +221,19 @@ min_rtt_calc_params:
     value: 0.0
   interval: 30s
   request_count: 50
+  min_concurrency: 4
 )EOF";
 
   auto controller = makeController(yaml);
   const auto min_rtt = std::chrono::milliseconds(13);
 
-  // The controller should be measuring minRTT upon creation, so the concurrency window is 1.
+  // The controller should be measuring minRTT upon creation, so the concurrency window is 4 (the
+  // min concurrency).
   EXPECT_EQ(
-      1,
+      4,
       stats_.gauge("test_prefix.min_rtt_calculation_active", Stats::Gauge::ImportMode::Accumulate)
           .value());
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 4);
   tryForward(controller, true);
   tryForward(controller, false);
   tryForward(controller, false);
@@ -232,7 +241,7 @@ min_rtt_calc_params:
 
   // 49 more requests should cause the minRTT to be done calculating.
   for (int i = 0; i < 49; ++i) {
-    EXPECT_EQ(controller->concurrencyLimit(), 1);
+    EXPECT_EQ(controller->concurrencyLimit(), 4);
     tryForward(controller, true);
     tryForward(controller, false);
     controller->recordLatencySample(min_rtt);
@@ -312,7 +321,7 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // Force a minRTT of 5ms.
   advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));
@@ -322,7 +331,7 @@ min_rtt_calc_params:
   // Ensure that the concurrency window increases on its own due to the headroom calculation.
   time_system_.sleep(std::chrono::milliseconds(101));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_GT(controller->concurrencyLimit(), 1);
+  EXPECT_GT(controller->concurrencyLimit(), 3);
 
   // Make it seem as if the recorded latencies are consistently lower than the measured minRTT.
   // Ensure that it grows.
@@ -366,7 +375,7 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // Force a minRTT of 5 seconds.
   advancePastMinRTTStage(controller, yaml, std::chrono::seconds(5));
@@ -403,7 +412,7 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // Get initial minRTT measurement out of the way.
   advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));
@@ -426,11 +435,11 @@ min_rtt_calc_params:
   // Wait until the minRTT recalculation is triggered again and verify the limit drops.
   time_system_.sleep(std::chrono::seconds(31));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // 49 more requests should cause the minRTT to be done calculating.
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(controller->concurrencyLimit(), 1);
+    EXPECT_EQ(controller->concurrencyLimit(), 3);
     tryForward(controller, true);
     controller->recordLatencySample(std::chrono::milliseconds(13));
   }
@@ -455,7 +464,7 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // Get initial minRTT measurement out of the way.
   advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));
@@ -476,12 +485,12 @@ min_rtt_calc_params:
   // Wait until the minRTT recalculation is triggered again and verify the limit drops.
   time_system_.sleep(std::chrono::seconds(31));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // Verify sample recalculation doesn't occur during the minRTT window.
   time_system_.sleep(std::chrono::milliseconds(101));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 }
 
 TEST_F(GradientControllerTest, NoSamplesTest) {
@@ -500,7 +509,7 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
-  EXPECT_EQ(controller->concurrencyLimit(), 1);
+  EXPECT_EQ(controller->concurrencyLimit(), 3);
 
   // Get minRTT measurement out of the way.
   advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));


### PR DESCRIPTION
This patch increases the concurrency limit that is pinned during a minRTT calculation from 1 to 3 and makes this value configurable. The change is motivated by the high likelihood of triggering retry overflows when measuring the minRTT upon first enabling the adaptive concurrency filter.