### PR TITLE
event_base: remove event_base ptr from FileEventImpl

### DIFF
--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -12,13 +12,12 @@ namespace Event {
 
 FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, int fd, FileReadyCb cb,
                              FileTriggerType trigger, uint32_t events)
-    : cb_(cb), base_(&dispatcher.base()), fd_(fd), trigger_(trigger) {
+    : cb_(cb), fd_(fd), trigger_(trigger) {
 #ifdef WIN32
   RELEASE_ASSERT(trigger_ == FileTriggerType::Level,
                  "libevent does not support edge triggers on Windows");
 #endif
-  assignEventBase(&dispatcher.base());
-  assignEvents(events);
+  assignEvents(events, &dispatcher.base());
   event_add(&raw_event_, nullptr);
 }
 
@@ -40,16 +39,10 @@ void FileEventImpl::activate(uint32_t events) {
   event_active(&raw_event_, libevent_events, 0);
 }
 
-void FileEventImpl::assignEventBase(event_base* base) {
-  // we cannot use below
-  // ASSERT(-1 !=event_base_set(base, &raw_event_));
-  raw_event_.ev_base = base;
-}
-
-void FileEventImpl::assignEvents(uint32_t events) {
-  ASSERT(base_ == event_get_base(&raw_event_));
+void FileEventImpl::assignEvents(uint32_t events, event_base* base) {
+  ASSERT(base != nullptr);
   event_assign(
-      &raw_event_, base_, fd_,
+      &raw_event_, base, fd_,
       EV_PERSIST | (trigger_ == FileTriggerType::Level ? 0 : EV_ET) |
           (events & FileReadyType::Read ? EV_READ : 0) |
           (events & FileReadyType::Write ? EV_WRITE : 0) |
@@ -76,8 +69,10 @@ void FileEventImpl::assignEvents(uint32_t events) {
 }
 
 void FileEventImpl::setEnabled(uint32_t events) {
+  auto* base = event_get_base(&raw_event_);
+  ASSERT(base != nullptr);
   event_del(&raw_event_);
-  assignEvents(events);
+  assignEvents(events, base);
   event_add(&raw_event_, nullptr);
 }
 

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -41,17 +41,13 @@ void FileEventImpl::activate(uint32_t events) {
 }
 
 void FileEventImpl::assignEventBase(event_base* base) {
-  //  ASSERT(-1 !=event_base_set(base, &raw_event_));
+  // we cannot use below
+  // ASSERT(-1 !=event_base_set(base, &raw_event_));
   raw_event_.ev_base = base;
 }
 
 void FileEventImpl::assignEvents(uint32_t events) {
-  {
-    event_base* base_out;
-    event_get_assignment(&raw_event_, &base_out, nullptr, nullptr, nullptr, nullptr);
-    ASSERT(base_ == base_out);
-  }
-
+  ASSERT(base_ == event_get_base(&raw_event_));
   event_assign(
       &raw_event_, base_, fd_,
       EV_PERSIST | (trigger_ == FileTriggerType::Level ? 0 : EV_ET) |

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -70,7 +70,6 @@ void FileEventImpl::assignEvents(uint32_t events, event_base* base) {
 
 void FileEventImpl::setEnabled(uint32_t events) {
   auto* base = event_get_base(&raw_event_);
-  ASSERT(base != nullptr);
   event_del(&raw_event_);
   assignEvents(events, base);
   event_add(&raw_event_, nullptr);

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -24,6 +24,9 @@ public:
   void setEnabled(uint32_t events) override;
 
 private:
+  // TODO(lambdai): remove it once verification is done.
+  void assignEventBase(event_base* base);
+
   void assignEvents(uint32_t events);
 
   FileReadyCb cb_;

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -24,13 +24,9 @@ public:
   void setEnabled(uint32_t events) override;
 
 private:
-  // TODO(lambdai): remove it once verification is done.
-  void assignEventBase(event_base* base);
-
-  void assignEvents(uint32_t events);
+  void assignEvents(uint32_t events, event_base* base);
 
   FileReadyCb cb_;
-  event_base* base_;
   int fd_;
   FileTriggerType trigger_;
 };


### PR DESCRIPTION
Inspired by my experiment fighting with event.
envoy never migrate from FileEvent to another event_base. Notes the ownership of fd could be moved.
Since `base_` always holds the value of `event_get_base(&raw_event_)`, remove the `base_` field and save 8 bytes on major 64bit platforms.


