### PR TITLE
lds: listener option transparent and freebind are not interpreted correctly

### DIFF
--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -51,10 +51,10 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
       listener_filters_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, listener_filters_timeout, 15000)),
       continue_on_listener_filters_timeout_(config.continue_on_listener_filters_timeout()) {
-  if (config.has_transparent()) {
+  if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, transparent, false)) {
     addListenSocketOptions(Network::SocketOptionFactory::buildIpTransparentOptions());
   }
-  if (config.has_freebind()) {
+  if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, freebind, false)) {
     addListenSocketOptions(Network::SocketOptionFactory::buildIpFreebindOptions());
   }
   if (!config.socket_options().empty()) {

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -3203,6 +3203,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TransparentFreebindListenerDisabl
     name: "TestListener"
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
+    transparent: false
+    freebind: false
     filter_chains:
     - filters:
   )EOF",


### PR DESCRIPTION
Description:
Currently when transparent and freebind are set to 'false' explicitly, they are
treated as 'true'.

Signed-off-by: lhuang8 <lhuang8@ebay.com>

Risk Level: low
Testing: //test/server:listener_manager_impl_test updated
Docs Changes:
Release Notes:
