### PR TITLE
protobuf: remove MessageUtil::getJsonObjectFromMessage

### DIFF
--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -335,15 +335,6 @@ public:
                                               bool always_print_primitive_fields = false);
 
   /**
-   * Extract JSON object from a google.protobuf.Message.
-   * @param message message of type type.googleapis.com/google.protobuf.Message.
-   * @return Json::ObjectSharedPtr of JSON object or nullptr if unable to extract.
-   */
-  static Json::ObjectSharedPtr getJsonObjectFromMessage(const Protobuf::Message& message) {
-    return Json::Factory::loadFromString(MessageUtil::getJsonStringFromMessage(message));
-  }
-
-  /**
    * Utility method to create a Struct containing the passed in key/value strings.
    *
    * @param key the key to use to set the value

--- a/source/extensions/filters/network/dubbo_proxy/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/config.cc
@@ -137,10 +137,8 @@ void ConfigImpl::registerFilter(const DubboFilterConfig& proto_config) {
 
   ENVOY_LOG(debug, "    dubbo filter #{}", filter_factories_.size());
   ENVOY_LOG(debug, "      name: {}", string_name);
-
-  const Json::ObjectSharedPtr filter_config =
-      MessageUtil::getJsonObjectFromMessage(proto_config.config());
-  ENVOY_LOG(debug, "      config: {}", filter_config->asJsonString());
+  ENVOY_LOG(debug, "    config: {}",
+            MessageUtil::getJsonStringFromMessage(proto_config.config(), true));
 
   auto& factory =
       Envoy::Config::Utility::getAndCheckFactory<DubboFilters::NamedDubboFilterConfigFactory>(

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -386,10 +386,8 @@ void HttpConnectionManagerConfig::processFilter(
 
   ENVOY_LOG(debug, "    {} filter #{}", prefix, i);
   ENVOY_LOG(debug, "      name: {}", string_name);
-
-  const Json::ObjectSharedPtr filter_config =
-      MessageUtil::getJsonObjectFromMessage(proto_config.config());
-  ENVOY_LOG(debug, "    config: {}", filter_config->asJsonString());
+  ENVOY_LOG(debug, "    config: {}",
+            MessageUtil::getJsonStringFromMessage(proto_config.config(), true));
 
   // Now see if there is a factory that will accept the config.
   auto& factory =

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -159,11 +159,8 @@ void ConfigImpl::processFilter(
 
   ENVOY_LOG(debug, "    thrift filter #{}", filter_factories_.size());
   ENVOY_LOG(debug, "      name: {}", string_name);
-
-  const Json::ObjectSharedPtr filter_config =
-      MessageUtil::getJsonObjectFromMessage(proto_config.config());
-  ENVOY_LOG(debug, "      config: {}", filter_config->asJsonString());
-
+  ENVOY_LOG(debug, "    config: {}",
+            MessageUtil::getJsonStringFromMessage(proto_config.config(), true));
   auto& factory =
       Envoy::Config::Utility::getAndCheckFactory<ThriftFilters::NamedThriftFilterConfigFactory>(
           string_name);

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -77,9 +77,8 @@ std::vector<Network::FilterFactoryCb> ProdListenerComponentFactory::createNetwor
     const std::string& string_name = proto_config.name();
     ENVOY_LOG(debug, "  filter #{}:", i);
     ENVOY_LOG(debug, "    name: {}", string_name);
-    const Json::ObjectSharedPtr filter_config =
-        MessageUtil::getJsonObjectFromMessage(proto_config.config());
-    ENVOY_LOG(debug, "  config: {}", filter_config->asJsonString());
+    ENVOY_LOG(debug, "  config: {}",
+              MessageUtil::getJsonStringFromMessage(proto_config.config(), true));
 
     // Now see if there is a factory that will accept the config.
     auto& factory =
@@ -107,9 +106,8 @@ ProdListenerComponentFactory::createListenerFilterFactoryList_(
     const std::string& string_name = proto_config.name();
     ENVOY_LOG(debug, "  filter #{}:", i);
     ENVOY_LOG(debug, "    name: {}", string_name);
-    const Json::ObjectSharedPtr filter_config =
-        MessageUtil::getJsonObjectFromMessage(proto_config.config());
-    ENVOY_LOG(debug, "  config: {}", filter_config->asJsonString());
+    ENVOY_LOG(debug, "  config: {}",
+              MessageUtil::getJsonStringFromMessage(proto_config.config(), true));
 
     // Now see if there is a factory that will accept the config.
     auto& factory =
@@ -132,9 +130,8 @@ ProdListenerComponentFactory::createUdpListenerFilterFactoryList_(
     const std::string& string_name = proto_config.name();
     ENVOY_LOG(debug, "  filter #{}:", i);
     ENVOY_LOG(debug, "    name: {}", string_name);
-    const Json::ObjectSharedPtr filter_config =
-        MessageUtil::getJsonObjectFromMessage(proto_config.config());
-    ENVOY_LOG(debug, "  config: {}", filter_config->asJsonString());
+    ENVOY_LOG(debug, "  config: {}",
+              MessageUtil::getJsonStringFromMessage(proto_config.config(), true));
 
     // Now see if there is a factory that will accept the config.
     auto& factory =

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1307,10 +1307,11 @@ public:
                          Runtime::Loader&, Runtime::RandomGenerator&) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, Envoy::ProtobufMessage::getNullValidationVisitor(), *this);
-    const Json::ObjectSharedPtr filter_config =
-        MessageUtil::getJsonObjectFromMessage(*factory_config);
+
+    ProtobufWkt::Struct struct_config =
+        *dynamic_cast<const ProtobufWkt::Struct*>(factory_config.get());
     return std::make_unique<SampleExtensionFilter>(
-        static_cast<uint32_t>(filter_config->getInteger("rate")));
+        static_cast<uint32_t>(struct_config.fields().at("rate").number_value()));
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Part of removing Envoy::Json dependency from MessageUtil for #4705.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
