### PR TITLE
check_and_fix_format.sh: spell fix: faild > failed

### DIFF
--- a/ci/check_and_fix_format.sh
+++ b/ci/check_and_fix_format.sh
@@ -9,7 +9,7 @@ function fix {
   ci/do_ci.sh fix_format
   ci/do_ci.sh fix_spelling
   ci/do_ci.sh fix_spelling_pedantic
-  echo "Format check faild, try apply following patch to fix:"
+  echo "Format check failed, try apply following patch to fix:"
   git diff HEAD | tee "${DIFF_OUTPUT}"
 
   exit 1


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: spell check fix
Risk Level: None
Testing: None
Docs Changes: None
Release Notes: `Simple spell fix on ci/check_and_fix_format.sh`
[Optional Fixes #Issue]
[Optional Deprecated:]
