### PR TITLE
yaml: re-implement yaml conversion without rapidjson

### DIFF
--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -14,13 +14,12 @@ envoy_cc_library(
     hdrs = ["json_loader.h"],
     external_deps = [
         "rapidjson",
-        "yaml_cpp",
     ],
     deps = [
-        "//include/envoy/api:api_interface",
         "//include/envoy/json:json_object_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
         "//source/common/common:utility_lib",
+        "//source/common/protobuf:utility_lib",
     ],
 )

--- a/source/common/json/json_loader.h
+++ b/source/common/json/json_loader.h
@@ -3,7 +3,6 @@
 #include <list>
 #include <string>
 
-#include "envoy/api/api.h"
 #include "envoy/json/json_object.h"
 
 namespace Envoy {
@@ -12,19 +11,9 @@ namespace Json {
 class Factory {
 public:
   /**
-   * Constructs a Json Object from a file.
-   */
-  static ObjectSharedPtr loadFromFile(const std::string& file_path, Api::Api& api);
-
-  /**
    * Constructs a Json Object from a string.
    */
   static ObjectSharedPtr loadFromString(const std::string& json);
-
-  /**
-   * Constructs a Json Object from a YAML string.
-   */
-  static ObjectSharedPtr loadFromYamlString(const std::string& yaml);
 };
 
 } // namespace Json

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -51,7 +51,10 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["protobuf"],
+    external_deps = [
+        "protobuf",
+        "yaml_cpp",
+    ],
     deps = [
         ":message_validator_lib",
         ":protobuf",
@@ -61,7 +64,6 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
         "//source/common/common:utility_lib",
-        "//source/common/json:json_loader_lib",
         "@envoy_api//envoy/type:pkg_cc_proto",
     ],
 )

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -6,7 +6,6 @@
 
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
-#include "common/json/json_loader.h"
 #include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/protobuf.h"
 
@@ -37,6 +36,76 @@ void blockFormat(YAML::Node node) {
       blockFormat(it.second);
     }
   }
+}
+
+ProtobufWkt::Value parseYamlNode(const YAML::Node& node) {
+  ProtobufWkt::Value value;
+  switch (node.Type()) {
+  case YAML::NodeType::Null:
+    value.set_null_value(ProtobufWkt::NULL_VALUE);
+    break;
+  case YAML::NodeType::Scalar: {
+    if (node.Tag() == "!") {
+      value.set_string_value(node.as<std::string>());
+      break;
+    }
+    bool bool_value;
+    if (YAML::convert<bool>::decode(node, bool_value)) {
+      value.set_bool_value(bool_value);
+      break;
+    }
+    int64_t int_value;
+    if (YAML::convert<int64_t>::decode(node, int_value)) {
+      if (static_cast<int64_t>(static_cast<double>(int_value)) == int_value) {
+        value.set_number_value(int_value);
+      } else {
+        // Proto3 JSON mapping allows use string for integer, this still has to be converted from
+        // int_value to support 0x and 0o literals.
+        value.set_string_value(std::to_string(int_value));
+      }
+      break;
+    }
+    double double_value;
+    if (YAML::convert<double>::decode(node, double_value)) {
+      value.set_number_value(double_value);
+      break;
+    }
+    // Otherwise, fall back on string.
+    value.set_string_value(node.as<std::string>());
+    break;
+  }
+  case YAML::NodeType::Sequence: {
+    auto& list_values = *value.mutable_list_value()->mutable_values();
+    for (const auto& it : node) {
+      *list_values.Add() = parseYamlNode(it);
+    }
+    break;
+  }
+  case YAML::NodeType::Map: {
+    auto& struct_fields = *value.mutable_struct_value()->mutable_fields();
+    for (const auto& it : node) {
+      struct_fields[it.first.as<std::string>()] = parseYamlNode(it.second);
+    }
+    break;
+  }
+  case YAML::NodeType::Undefined:
+    throw EnvoyException("Undefined YAML value");
+  }
+  return value;
+}
+
+void jsonConvertInternal(const Protobuf::Message& source,
+                         ProtobufMessage::ValidationVisitor& validation_visitor,
+                         Protobuf::Message& dest) {
+  Protobuf::util::JsonPrintOptions json_options;
+  json_options.preserve_proto_field_names = true;
+  std::string json;
+  const auto status = Protobuf::util::MessageToJsonString(source, &json, json_options);
+  if (!status.ok()) {
+    throw EnvoyException(fmt::format("Unable to convert protobuf message to JSON string: {} {}",
+                                     status.ToString(), source.DebugString()));
+  }
+  MessageUtil::loadFromJson(json, dest, validation_visitor);
 }
 
 } // namespace
@@ -140,14 +209,19 @@ void MessageUtil::loadFromJson(const std::string& json, ProtobufWkt::Struct& mes
 
 void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& message,
                                ProtobufMessage::ValidationVisitor& validation_visitor) {
-  const auto loaded_object = Json::Factory::loadFromYamlString(yaml);
-  // Load the message if the loaded object has type Object or Array.
-  if (loaded_object->isObject() || loaded_object->isArray()) {
-    const std::string json = loaded_object->asJsonString();
-    loadFromJson(json, message, validation_visitor);
+  ProtobufWkt::Value value = ValueUtil::loadFromYaml(yaml);
+  if (value.kind_case() == ProtobufWkt::Value::kStructValue ||
+      value.kind_case() == ProtobufWkt::Value::kListValue) {
+    jsonConvertInternal(value, validation_visitor, message);
     return;
   }
   throw EnvoyException("Unable to convert YAML as JSON: " + yaml);
+}
+
+void MessageUtil::loadFromYaml(const std::string& yaml, ProtobufWkt::Struct& message) {
+  // No need to validate if converting to a Struct, since there are no unknown
+  // fields possible.
+  return loadFromYaml(yaml, message, ProtobufMessage::getNullValidationVisitor());
 }
 
 void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message,
@@ -342,24 +416,6 @@ std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& messa
   return json;
 }
 
-namespace {
-
-void jsonConvertInternal(const Protobuf::Message& source,
-                         ProtobufMessage::ValidationVisitor& validation_visitor,
-                         Protobuf::Message& dest) {
-  Protobuf::util::JsonPrintOptions json_options;
-  json_options.preserve_proto_field_names = true;
-  std::string json;
-  const auto status = Protobuf::util::MessageToJsonString(source, &json, json_options);
-  if (!status.ok()) {
-    throw EnvoyException(fmt::format("Unable to convert protobuf message to JSON string: {} {}",
-                                     status.ToString(), source.DebugString()));
-  }
-  MessageUtil::loadFromJson(json, dest, validation_visitor);
-}
-
-} // namespace
-
 void MessageUtil::jsonConvert(const Protobuf::Message& source, ProtobufWkt::Struct& dest) {
   // Any proto3 message can be transformed to Struct, so there is no need to check for unknown
   // fields. There is one catch; Duration/Timestamp etc. which have non-object canonical JSON
@@ -421,6 +477,22 @@ std::string MessageUtil::CodeEnumToString(ProtobufUtil::error::Code code) {
     return "DATA_LOSS";
   default:
     return "";
+  }
+}
+
+ProtobufWkt::Value ValueUtil::loadFromYaml(const std::string& yaml) {
+  try {
+    return parseYamlNode(YAML::Load(yaml));
+  } catch (YAML::ParserException& e) {
+    throw EnvoyException(e.what());
+  } catch (YAML::BadConversion& e) {
+    throw EnvoyException(e.what());
+  } catch (std::exception& e) {
+    // There is a potentially wide space of exceptions thrown by the YAML parser,
+    // and enumerating them all may be difficult. Envoy doesn't work well with
+    // unhandled exceptions, so we capture them and record the exception name in
+    // the Envoy Exception text.
+    throw EnvoyException(fmt::format("Unexpected YAML exception: {}", +e.what()));
   }
 }
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -4,14 +4,12 @@
 
 #include "envoy/api/api.h"
 #include "envoy/common/exception.h"
-#include "envoy/json/json_object.h"
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/type/percent.pb.h"
 
 #include "common/common/hash.h"
 #include "common/common/utility.h"
-#include "common/json/json_loader.h"
 #include "common/protobuf/protobuf.h"
 #include "common/singleton/const_singleton.h"
 
@@ -216,6 +214,7 @@ public:
   static void loadFromJson(const std::string& json, ProtobufWkt::Struct& message);
   static void loadFromYaml(const std::string& yaml, Protobuf::Message& message,
                            ProtobufMessage::ValidationVisitor& validation_visitor);
+  static void loadFromYaml(const std::string& yaml, ProtobufWkt::Struct& message);
   static void loadFromFile(const std::string& path, Protobuf::Message& message,
                            ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api);
 
@@ -353,6 +352,11 @@ public:
 class ValueUtil {
 public:
   static std::size_t hash(const ProtobufWkt::Value& value) { return MessageUtil::hash(value); }
+
+  /**
+   * Load YAML string into ProtobufWkt::Value.
+   */
+  static ProtobufWkt::Value loadFromYaml(const std::string& yaml);
 
   /**
    * Compare two ProtobufWkt::Values for equality.

--- a/source/extensions/filters/http/squash/squash_filter.h
+++ b/source/extensions/filters/http/squash/squash_filter.h
@@ -5,6 +5,7 @@
 #include "envoy/config/filter/http/squash/v2/squash.pb.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/filter.h"
+#include "envoy/json/json_object.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/common/logger.h"

--- a/test/common/json/json_fuzz_test.cc
+++ b/test/common/json/json_fuzz_test.cc
@@ -23,6 +23,16 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
     ProtobufWkt::Struct message2;
     MessageUtil::loadFromJson(MessageUtil::getJsonStringFromMessage(message), message2);
     FUZZ_ASSERT(TestUtility::protoEqual(message, message2));
+
+    // MessageUtil::getYamlStringFromMessage automatically convert types, so we have to do another
+    // round-trip.
+    std::string yaml = MessageUtil::getYamlStringFromMessage(message);
+    ProtobufWkt::Struct yaml_message;
+    MessageUtil::loadFromYaml(yaml, yaml_message);
+
+    ProtobufWkt::Struct message3;
+    MessageUtil::loadFromYaml(MessageUtil::getYamlStringFromMessage(yaml_message), message3);
+    FUZZ_ASSERT(TestUtility::protoEqual(yaml_message, message3));
   } catch (const Envoy::EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Failed due to {}", e.what());
   }

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -20,7 +20,6 @@ protected:
 };
 
 TEST_F(JsonLoaderTest, Basic) {
-  EXPECT_THROW(Factory::loadFromFile("bad_file", *api_), Exception);
   EXPECT_THROW(Factory::loadFromString("{"), Exception);
 
   {
@@ -373,64 +372,6 @@ TEST_F(JsonLoaderTest, AsString) {
     }
     return true;
   });
-}
-
-TEST_F(JsonLoaderTest, AsJsonString) {
-  // We can't do simply equality of asJsonString(), since there is a reliance on internal ordering,
-  // e.g. of map traversal, in the output.
-  const std::string json_string = "{\"name1\": \"value1\", \"name2\": true}";
-  const ObjectSharedPtr json = Factory::loadFromString(json_string);
-  const ObjectSharedPtr json2 = Factory::loadFromString(json->asJsonString());
-  EXPECT_EQ("value1", json2->getString("name1"));
-  EXPECT_TRUE(json2->getBoolean("name2"));
-}
-
-TEST_F(JsonLoaderTest, YamlScalar) {
-  EXPECT_EQ(true, Factory::loadFromYamlString("true")->asBoolean());
-  EXPECT_EQ("true", Factory::loadFromYamlString("\"true\"")->asString());
-  EXPECT_EQ(1, Factory::loadFromYamlString("1")->asInteger());
-  EXPECT_EQ("1", Factory::loadFromYamlString("\"1\"")->asString());
-  EXPECT_DOUBLE_EQ(1.0, Factory::loadFromYamlString("1.0")->asDouble());
-  EXPECT_EQ("1.0", Factory::loadFromYamlString("\"1.0\"")->asString());
-}
-
-TEST_F(JsonLoaderTest, YamlObject) {
-  {
-    const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("[foo, bar]");
-    std::vector<Json::ObjectSharedPtr> output = json->asObjectArray();
-    EXPECT_EQ(2, output.size());
-    EXPECT_EQ("foo", output[0]->asString());
-    EXPECT_EQ("bar", output[1]->asString());
-  }
-  {
-    const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("foo: bar");
-    EXPECT_EQ("bar", json->getString("foo"));
-  }
-  {
-    const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("Null");
-    EXPECT_TRUE(json->isNull());
-  }
-}
-
-TEST_F(JsonLoaderTest, YamlAsJsonString) {
-  const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("");
-  EXPECT_EQ(json->asJsonString(), "null");
-}
-
-TEST_F(JsonLoaderTest, BadYamlException) {
-  std::string bad_yaml = R"EOF(
-admin:
-  access_log_path: /dev/null
-  address:
-    socket_address:
-      address: {{ ntop_ip_loopback_address }}
-      port_value: 0
-)EOF";
-
-  EXPECT_THROW_WITH_REGEX(Json::Factory::loadFromYamlString(bad_yaml), EnvoyException,
-                          "bad conversion");
-  EXPECT_THROW_WITHOUT_REGEX(Json::Factory::loadFromYamlString(bad_yaml), EnvoyException,
-                             "Unexpected YAML exception");
 }
 
 } // namespace

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -357,6 +357,42 @@ TEST_F(ProtobufUtilityTest, ValueUtilHash) {
   EXPECT_NE(ValueUtil::hash(v), 0);
 }
 
+TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlScalar) {
+  EXPECT_EQ(ValueUtil::loadFromYaml("null").ShortDebugString(), "null_value: NULL_VALUE");
+  EXPECT_EQ(ValueUtil::loadFromYaml("true").ShortDebugString(), "bool_value: true");
+  EXPECT_EQ(ValueUtil::loadFromYaml("1").ShortDebugString(), "number_value: 1");
+  EXPECT_EQ(ValueUtil::loadFromYaml("9223372036854775807").ShortDebugString(),
+            "string_value: \"9223372036854775807\"");
+  EXPECT_EQ(ValueUtil::loadFromYaml("\"foo\"").ShortDebugString(), "string_value: \"foo\"");
+  EXPECT_EQ(ValueUtil::loadFromYaml("foo").ShortDebugString(), "string_value: \"foo\"");
+  {
+    ProtobufWkt::Value v = ValueUtil::loadFromYaml("1.0");
+    EXPECT_DOUBLE_EQ(1.0, v.number_value());
+  }
+}
+
+TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlObject) {
+  EXPECT_EQ(ValueUtil::loadFromYaml("[foo, bar]").ShortDebugString(),
+            "list_value { values { string_value: \"foo\" } values { string_value: \"bar\" } }");
+  EXPECT_EQ(ValueUtil::loadFromYaml("foo: bar").ShortDebugString(),
+            "struct_value { fields { key: \"foo\" value { string_value: \"bar\" } } }");
+}
+
+TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlException) {
+  std::string bad_yaml = R"EOF(
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0
+)EOF";
+
+  EXPECT_THROW_WITH_REGEX(ValueUtil::loadFromYaml(bad_yaml), EnvoyException, "bad conversion");
+  EXPECT_THROW_WITHOUT_REGEX(ValueUtil::loadFromYaml(bad_yaml), EnvoyException,
+                             "Unexpected YAML exception");
+}
+
 TEST_F(ProtobufUtilityTest, HashedValue) {
   ProtobufWkt::Value v1, v2, v3;
   v1.set_string_value("s");

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4502,8 +4502,8 @@ virtual_hosts:
   EXPECT_THROW_WITH_REGEX(
       TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
       EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set. Cannot set 'prefix' for type "
-      "oneof");
+      "invalid value oneof field 'path_specifier' is already set. Cannot set '(prefix|path)' for "
+      "type oneof");
 }
 
 TEST_F(BadHttpRouteConfigurationsTest, BadRouteEntryConfigMissingPathSpecifier) {
@@ -4539,8 +4539,8 @@ virtual_hosts:
   EXPECT_THROW_WITH_REGEX(
       TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
       EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set. Cannot set 'prefix' for type "
-      "oneof");
+      "invalid value oneof field 'path_specifier' is already set. Cannot set '(prefix|regex)' for "
+      "type oneof");
 }
 
 TEST_F(BadHttpRouteConfigurationsTest, BadRouteEntryConfigNoAction) {
@@ -4576,8 +4576,8 @@ virtual_hosts:
   EXPECT_THROW_WITH_REGEX(
       TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
       EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set. Cannot set 'path' for type "
-      "oneof");
+      "invalid value oneof field 'path_specifier' is already set. Cannot set '(path|regex)' for "
+      "type oneof");
 }
 
 TEST_F(BadHttpRouteConfigurationsTest, BadRouteEntryConfigPrefixAndPathAndRegex) {

--- a/test/integration/filter_manager_integration_test.cc
+++ b/test/integration/filter_manager_integration_test.cc
@@ -93,8 +93,7 @@ protected:
 
           auto* filter_chain = l->mutable_filter_chains(0);
           auto* filter_list_back = filter_chain->add_filters();
-          const std::string json = Json::Factory::loadFromYamlString(filter_yaml)->asJsonString();
-          TestUtility::loadFromJson(json, *filter_list_back);
+          TestUtility::loadFromYaml(filter_yaml, *filter_list_back);
 
           // Now move it to the front.
           for (int i = filter_chain->filters_size() - 1; i > 0; --i) {

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -334,8 +334,7 @@ typed_config:
       "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
       path: /dev/null
   )EOF";
-        const std::string json = Json::Factory::loadFromYamlString(yaml_string)->asJsonString();
-        TestUtility::loadFromJson(json, *hcm.mutable_http_filters(1));
+        TestUtility::loadFromYaml(yaml_string, *hcm.mutable_http_filters(1));
       });
 
   // As with ProtocolIntegrationTest.HittingEncoderFilterLimit use a filter

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -353,9 +353,7 @@ TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
         auto* foo_upgrade = hcm.add_upgrade_configs();
         foo_upgrade->set_upgrade_type("foo");
         auto* filter_list_back = foo_upgrade->add_filters();
-        const std::string json =
-            Json::Factory::loadFromYamlString("name: envoy.router")->asJsonString();
-        TestUtility::loadFromJson(json, *filter_list_back);
+        TestUtility::loadFromYaml("name: envoy.router", *filter_list_back);
       });
   initialize();
 

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -109,9 +109,17 @@ RouterCheckTool::RouterCheckTool(
       .WillByDefault(testing::Invoke(this, &RouterCheckTool::runtimeMock));
 }
 
+Json::ObjectSharedPtr loadFromFile(const std::string& file_path, Api::Api& api) {
+  std::string contents = api.fileSystem().fileReadToEnd(file_path);
+  if (absl::EndsWith(file_path, ".yaml")) {
+    contents = MessageUtil::getJsonStringFromMessage(ValueUtil::loadFromYaml(contents));
+  }
+  return Json::Factory::loadFromString(contents);
+}
+
 // TODO(jyotima): Remove this code path once the json schema code path is deprecated.
 bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_json) {
-  Json::ObjectSharedPtr loader = Json::Factory::loadFromFile(expected_route_json, *api_);
+  Json::ObjectSharedPtr loader = loadFromFile(expected_route_json, *api_);
   loader->validateSchema(Json::ToolSchema::routerCheckSchema());
   bool no_failures = true;
   for (const Json::ObjectSharedPtr& check_config : loader->asObjectArray()) {


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
Use ProtobufWkt::Value to do YAML parsing. Part of #4705.

Risk Level: Med
Testing: unit test, fuzz
Docs Changes: N/A
Release Notes: N/A
