### PR TITLE
readme: add dependency to libc++1

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -46,6 +46,7 @@ for how to update or override dependencies.
        cmake \
        automake \
        autoconf \
+       libc++1 \
        make \
        ninja-build \
        curl \


### PR DESCRIPTION
Description: we now depend on libc++ so it needs to be installed on dev boxes.
Risk Level: low
Testing: none
Docs Changes: this is it
Release Notes: n/a
