### PR TITLE
common: remove the unnecessary free inside common::Crypto::Utility::verifySignature. 

### DIFF
--- a/source/extensions/common/crypto/utility_impl.cc
+++ b/source/extensions/common/crypto/utility_impl.cc
@@ -57,7 +57,6 @@ const VerificationOutput UtilityImpl::verifySignature(absl::string_view hash, Cr
   EVP_PKEY* pkey = pkey_wrapper->getEVP_PKEY();
 
   if (pkey == nullptr) {
-    free(pkey_wrapper);
     return {false, "Failed to initialize digest verify."};
   }
 

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -109,7 +109,8 @@ TEST(UtilityTest, TestVerifySignature) {
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("unknown is not supported.", result.error_message_);
 
-  PublicKeyObject* empty_crypto = new PublicKeyObject();
+  PublicKeyObject* empty_crypto = static_cast<PublicKeyObject*>(malloc(sizeof(PublicKeyObject)));
+  new (empty_crypto) PublicKeyObject();
   result = UtilitySingleton::get().verifySignature(hash_func, *empty_crypto, sig, text);
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("Failed to initialize digest verify.", result.error_message_);

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -109,8 +109,7 @@ TEST(UtilityTest, TestVerifySignature) {
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("unknown is not supported.", result.error_message_);
 
-  PublicKeyObject* empty_crypto = static_cast<PublicKeyObject*>(malloc(sizeof(PublicKeyObject)));
-  new (empty_crypto) PublicKeyObject();
+  auto empty_crypto = std::make_unique<PublicKeyObject>();
   result = UtilitySingleton::get().verifySignature(hash_func, *empty_crypto, sig, text);
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("Failed to initialize digest verify.", result.error_message_);


### PR DESCRIPTION
Signed-off-by: Xin Zhuang <stevenzzz@google.com>

Description: Remove the unnecessary free inside verifySignature, the function should not free memory held by a referenced parameter.  

Risk Level: LOW
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Fixes: #8286