### PR TITLE
grpc_stats: add protobuf serialization to filter object

### DIFF
--- a/api/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
@@ -18,3 +18,12 @@ message FilterConfig {
   // counts.
   bool emit_filter_state = 1;
 }
+
+// gRPC statistics filter state object in protobuf form.
+message FilterObject {
+  // Count of request messages in the request stream.
+  uint64 request_message_count = 1;
+
+  // Count of response messages in the response stream.
+  uint64 response_message_count = 2;
+}

--- a/docs/root/configuration/http/http_filters/grpc_stats_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_stats_filter.rst
@@ -4,8 +4,10 @@ gRPC Statistics
 ===============
 
 * gRPC :ref:`architecture overview <arch_overview_grpc>`
-* :ref:`v2 API reference <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpFilter.name>`
+* :ref:`v2 API reference <envoy_api_msg_config.filter.http.grpc_stats.v2alpha.FilterConfig>`
 * This filter should be configured with the name *envoy.filters.http.grpc_stats*.
+* This filter can be enabled to emit a :ref:`filter state object
+  <envoy_api_msg_config.filter.http.grpc_stats.v2alpha.FilterObject>`
 
 This is a filter which enables telemetry of gRPC calls. Additionally, the
 filter detects message boundaries in streaming gRPC calls and emits the message

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.h
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.h
@@ -17,6 +17,13 @@ namespace GrpcStats {
 struct GrpcStatsObject : public StreamInfo::FilterState::Object {
   uint64_t request_message_count = 0;
   uint64_t response_message_count = 0;
+
+  ProtobufTypes::MessagePtr serializeAsProto() const override {
+    auto msg = std::make_unique<envoy::config::filter::http::grpc_stats::v2alpha::FilterObject>();
+    msg->set_request_message_count(request_message_count);
+    msg->set_response_message_count(response_message_count);
+    return msg;
+  }
 };
 
 class GrpcStatsFilterConfig

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -173,6 +173,13 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
                 .value());
   EXPECT_EQ(2U, data.request_message_count);
   EXPECT_EQ(3U, data.response_message_count);
+
+  auto filter_object =
+      dynamic_cast<envoy::config::filter::http::grpc_stats::v2alpha::FilterObject*>(
+          data.serializeAsProto().get());
+  EXPECT_NE(nullptr, filter_object);
+  EXPECT_EQ(2U, filter_object->request_message_count());
+  EXPECT_EQ(3U, filter_object->response_message_count());
 }
 
 } // namespace

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -175,11 +175,10 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
   EXPECT_EQ(3U, data.response_message_count);
 
   auto filter_object =
-      dynamic_cast<envoy::config::filter::http::grpc_stats::v2alpha::FilterObject*>(
+      *dynamic_cast<envoy::config::filter::http::grpc_stats::v2alpha::FilterObject*>(
           data.serializeAsProto().get());
-  EXPECT_NE(nullptr, filter_object);
-  EXPECT_EQ(2U, filter_object->request_message_count());
-  EXPECT_EQ(3U, filter_object->response_message_count());
+  EXPECT_EQ(2U, filter_object.request_message_count());
+  EXPECT_EQ(3U, filter_object.response_message_count());
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: serialize stream stats for telemetry
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none
[Optional Fixes #Issue]
[Optional Deprecated:]
