### PR TITLE
ext_authz: Fix spelling mistake in type definition

### DIFF
--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -21,14 +21,14 @@ namespace ExtAuthz {
 /**
  * Constant values used for tracing metadata.
  */
-struct TracingContantValues {
+struct TracingConstantValues {
   const std::string TraceStatus = "ext_authz_status";
   const std::string TraceUnauthz = "ext_authz_unauthorized";
   const std::string TraceOk = "ext_authz_ok";
   const std::string HttpStatus = "ext_authz_http_status";
 };
 
-using TracingConstants = ConstSingleton<TracingContantValues>;
+using TracingConstants = ConstSingleton<TracingConstantValues>;
 
 /**
  * Possible async results for a check call.


### PR DESCRIPTION
Description: Fix a spelling mistake ("Con[s]tant") introduced in 2f5f947f5cb11cc9cf4a8ad0be8aa1180cc4e4a1

Risk Level: Low
Testing: `git grep -i contant`
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Luke Shumaker <lukeshu@datawire.io>
