### PR TITLE
tools: rename deprecated call to logging.warn() to logging.warning().

### DIFF
--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -281,4 +281,4 @@ if __name__ == "__main__":
   if errors != 0:
     logging.error("%d FAILURES" % errors)
     exit(1)
-  logging.warn("PASS")
+  logging.warning("PASS")


### PR DESCRIPTION
Description: rename deprecated call to logging.warn() to logging.warning()
Risk Level: very low
Testing: ./tools/check_format_test_helper.py --log=WARN
Docs Changes: n/a
Release Notes: n/a

