### PR TITLE
docs/best_practices/edge: fix `use_proxy_proto` location

### DIFF
--- a/docs/root/configuration/best_practices/edge.rst
+++ b/docs/root/configuration/best_practices/edge.rst
@@ -72,14 +72,14 @@ The following is a YAML example of the above recommendation.
             tls_certificates:
             - certificate_chain: { filename: "example_com_cert.pem" }
               private_key: { filename: "example_com_key.pem" }
+        # Uncomment if Envoy is behind a load balancer that exposes client IP address using the PROXY protocol.
+        # use_proxy_proto: true
         filters:
         - name: envoy.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: ingress_http
             use_remote_address: true
-            # Uncomment if Envoy is behind a load balancer that exposes client IP address using the PROXY protocol.
-            # use_proxy_proto: true
             common_http_protocol_options:
               idle_timeout: 3600s # 1 hour
             http2_protocol_options:


### PR DESCRIPTION
`use_proxy_proto` is part of the `listener.FilterChain` (not `HttpConnectionManager`)
https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener.proto#listener-filterchain

Signed-off-by: Dominik <dominik-k@mailbox.org>

Risk Level: None
Testing: Manually tested with `envoyproxy/envoy-alpine:v1.12.1` (Docker image)
Docs Changes: see description
Release Notes: docs: corrected use of `use_proxy_proto` in edge-proxy best-practice example

Fix for #8001

(Sorry for the doubled creation of this PR. Did it wrong (on #9079) with trying to fix to add my DCO. Sad that Github doesn't do it. But there's a [Github feature-request for automated DCO signoff](https://github.community/t5/How-to-use-Git-and-GitHub/Feature-request-DCO-signoff-through-Github-PR-s/td-p/24784), but with just 3 votes, yet.)