### PR TITLE
quiche: fix ActiveQuicListener construction seg fault

### DIFF
--- a/source/extensions/quic_listeners/quiche/active_quic_listener.h
+++ b/source/extensions/quic_listeners/quiche/active_quic_listener.h
@@ -44,11 +44,6 @@ public:
 private:
   friend class ActiveQuicListenerPeer;
 
-  ActiveQuicListener(Event::Dispatcher& dispatcher, Network::ConnectionHandler& parent,
-                     Network::Socket& listen_socket, std::unique_ptr<quic::QuicPacketWriter> writer,
-                     Network::UdpListenerPtr&& listener, Network::ListenerConfig& listener_config,
-                     const quic::QuicConfig& quic_config);
-
   Network::UdpListenerPtr udp_listener_;
   uint8_t random_seed_[16];
   std::unique_ptr<quic::QuicCryptoServerConfig> crypto_config_;


### PR DESCRIPTION
Change how ActiveQuicListener is constructed to avoid seg fault caused by unspecified argument evaluation order in different compilers. 

Currently, it only works if compiler evaluates them from left to right. Apparently clang and certain version of GCC do so, but evaluation order is not guaranteed cross all compilers. If no, shared_ptr is moved before being dereferenced.
 
Risk Level: low, code not is use
Testing: existing test
