### PR TITLE
http: change ":no-chunks" pseudo-header to "no-chunks" header.

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -133,7 +133,7 @@ public:
   const LowerCaseString LastModified{"last-modified"};
   const LowerCaseString Location{"location"};
   const LowerCaseString Method{":method"};
-  const LowerCaseString NoChunks{":no-chunks"};
+  const LowerCaseString NoChunks{"no-chunks"};
   const LowerCaseString Origin{"origin"};
   const LowerCaseString OtSpanContext{"x-ot-span-context"};
   const LowerCaseString Path{":path"};

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1391,8 +1391,8 @@ most_specific_header_mutations_wins: true
 
 // Validate that we can't add :-prefixed request headers.
 TEST_F(RouteMatcherTest, TestRequestHeadersToAddNoPseudoHeader) {
-  for (const std::string& header : {":path", ":authority", ":method", ":scheme", ":status",
-                                    ":protocol", ":no-chunks", ":status"}) {
+  for (const std::string& header :
+       {":path", ":authority", ":method", ":scheme", ":status", ":protocol"}) {
     const std::string yaml = fmt::format(R"EOF(
 name: foo
 virtual_hosts:
@@ -1417,8 +1417,8 @@ virtual_hosts:
 
 // Validate that we can't remove :-prefixed request headers.
 TEST_F(RouteMatcherTest, TestRequestHeadersToRemoveNoPseudoHeader) {
-  for (const std::string& header : {":path", ":authority", ":method", ":scheme", ":status",
-                                    ":protocol", ":no-chunks", ":status", "host"}) {
+  for (const std::string& header :
+       {":path", ":authority", ":method", ":scheme", ":status", ":protocol", "host"}) {
     const std::string yaml = fmt::format(R"EOF(
 name: foo
 virtual_hosts:


### PR DESCRIPTION
It appears that we've added a custom "Envoy only" pseudo-header,
which is clearly forbidden by the HTTP/2 spec.

It's only used by the Hystrix Dashboard Event Stream, so presumably
it's not widely used, but it's been breaking some intermediaries.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>