### PR TITLE
test flake: fix proxy protocol test

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -24,7 +24,7 @@ export ENVOY_BUILD_IMAGE="${IMAGE_NAME}:${IMAGE_ID}"
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
-docker run --storage-opt size=30G --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
+docker run --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build -v /var/run/docker.sock:/var/run/docker.sock ${GIT_VOLUME_OPTION} \
   -e BAZEL_BUILD_EXTRA_OPTIONS -e BAZEL_EXTRA_TEST_OPTIONS -e BAZEL_REMOTE_CACHE -e ENVOY_STDLIB -e BUILD_REASON \
   -e BAZEL_REMOTE_INSTANCE -e GCP_SERVICE_ACCOUNT_KEY -e NUM_CPUS -e ENVOY_RBE -e FUZZIT_API_KEY -e ENVOY_BUILD_IMAGE \

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -24,7 +24,7 @@ export ENVOY_BUILD_IMAGE="${IMAGE_NAME}:${IMAGE_ID}"
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
-docker run --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
+docker run --storage-opt size=30G --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build -v /var/run/docker.sock:/var/run/docker.sock ${GIT_VOLUME_OPTION} \
   -e BAZEL_BUILD_EXTRA_OPTIONS -e BAZEL_EXTRA_TEST_OPTIONS -e BAZEL_REMOTE_CACHE -e ENVOY_STDLIB -e BUILD_REASON \
   -e BAZEL_REMOTE_INSTANCE -e GCP_SERVICE_ACCOUNT_KEY -e NUM_CPUS -e ENVOY_RBE -e FUZZIT_API_KEY -e ENVOY_BUILD_IMAGE \

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -93,7 +93,7 @@ public:
   }
 
   void connect(bool read = true) {
-    int expected_callbacks = read ? 3 : 2;
+    int expected_callbacks = 2;
     auto maybeExitDispatcher = [&]() -> void {
       expected_callbacks--;
       if (expected_callbacks == 0) {
@@ -117,7 +117,6 @@ public:
             server_connection_ = &connection;
             connection.addConnectionCallbacks(server_callbacks_);
             connection.addReadFilter(read_filter_);
-            maybeExitDispatcher();
             return true;
           }));
     }

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -93,10 +93,19 @@ public:
   }
 
   void connect(bool read = true) {
+    int expected_callbacks = read ? 3 : 2;
+    auto maybeExitDispatcher = [&]() -> void {
+      expected_callbacks--;
+      if (expected_callbacks == 0) {
+        dispatcher_->exit();
+      }
+    };
+
     EXPECT_CALL(factory_, createListenerFilterChain(_))
         .WillOnce(Invoke([&](Network::ListenerFilterManager& filter_manager) -> bool {
           filter_manager.addAcceptFilter(
               std::make_unique<Filter>(std::make_shared<Config>(listenerScope())));
+          maybeExitDispatcher();
           return true;
         }));
     conn_->connect();
@@ -108,11 +117,12 @@ public:
             server_connection_ = &connection;
             connection.addConnectionCallbacks(server_callbacks_);
             connection.addReadFilter(read_filter_);
+            maybeExitDispatcher();
             return true;
           }));
     }
     EXPECT_CALL(connection_callbacks_, onEvent(Network::ConnectionEvent::Connected))
-        .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher_->exit(); }));
+        .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { maybeExitDispatcher(); }));
     dispatcher_->run(Event::Dispatcher::RunType::Block);
   }
 


### PR DESCRIPTION
The client and listener events on connection are not strictly ordered
(at least not on macOS), so make sure that all expected events fire
before triggering the dispatcher exit.

Risk Level: low, test-only change
Testing: 2000x iterations, no failures
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
