### PR TITLE
fix unstable test case UdpListenerImplTest.SendData

### DIFF
--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -411,8 +411,6 @@ TEST_P(UdpListenerImplTest, SendData) {
         client_socket_->ioHandle(), *client_socket_->localAddress(), data);
 
     bytes_read = result.rc_;
-    EXPECT_EQ(send_from_addr->asString(), data.addresses_.peer_->asString());
-
     if (bytes_read >= bytes_to_read || retry == 10 ||
         result.err_->getErrorCode() != Api::IoError::IoErrorCode::Again) {
       break;
@@ -423,6 +421,7 @@ TEST_P(UdpListenerImplTest, SendData) {
     ASSERT(bytes_read == 0);
   } while (true);
   EXPECT_EQ(bytes_to_read, bytes_read);
+  EXPECT_EQ(send_from_addr->asString(), data.addresses_.peer_->asString());
   EXPECT_EQ(data.buffer_->toString(), payload);
 }
 


### PR DESCRIPTION
Description:
If Network::Test::readFromSocket() return error code 'Again', `data.addresses_.peer_`
is null, `data.addresses_.peer_->asString()` causes crash because it dereferences
a null pointer.

This could happen in envoy-macos CI job. E.g https://dev.azure.com/cncf/envoy/_build/results?buildId=20576

Risk Level: Low
Testing: run fixed test case on Mac hundreds times, can't be reproduced anymore
Docs Changes:
Release Notes:

Signed-off-by: lhuang8 <lhuang8@ebay.com>
