### PR TITLE
Use bool bitfields for ConnectionImpl

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -44,11 +44,9 @@ const std::string StreamEncoderImpl::LAST_CHUNK = "0\r\n\r\n";
 
 StreamEncoderImpl::StreamEncoderImpl(ConnectionImpl& connection,
                                      HeaderKeyFormatter* header_key_formatter)
-    : connection_(connection), header_key_formatter_(header_key_formatter) {
-  chunk_encoding_ = true;
-  processing_100_continue_ = false;
-  is_response_to_head_request_ = false;
-  is_content_length_allowed_ = true;
+    : connection_(connection), header_key_formatter_(header_key_formatter), chunk_encoding_(true),
+      processing_100_continue_(false), is_response_to_head_request_(false),
+      is_content_length_allowed_(true) {
   if (connection_.connection().aboveHighWatermark()) {
     runHighWatermarkCallbacks();
   }

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -366,6 +366,8 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
   output_buffer_.setWatermarks(connection.bufferLimit());
   http_parser_init(&parser_, type);
   parser_.data = this;
+  handling_upgrade_ = false;
+  reset_stream_called_ = false;
 }
 
 void ConnectionImpl::completeLastHeader() {

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -45,6 +45,10 @@ const std::string StreamEncoderImpl::LAST_CHUNK = "0\r\n\r\n";
 StreamEncoderImpl::StreamEncoderImpl(ConnectionImpl& connection,
                                      HeaderKeyFormatter* header_key_formatter)
     : connection_(connection), header_key_formatter_(header_key_formatter) {
+  chunk_encoding_ = true;
+  processing_100_continue_ = false;
+  is_response_to_head_request_ = false;
+  is_content_length_allowed_ = true;
   if (connection_.connection().aboveHighWatermark()) {
     runHighWatermarkCallbacks();
   }
@@ -356,13 +360,13 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
                                HeaderKeyFormatterPtr&& header_key_formatter)
     : connection_(connection), stats_{ALL_HTTP1_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http1."))},
       header_key_formatter_(std::move(header_key_formatter)),
-      output_buffer_([&]() -> void { this->onBelowLowWatermark(); },
-                     [&]() -> void { this->onAboveHighWatermark(); }),
-      max_headers_kb_(max_headers_kb), max_headers_count_(max_headers_count),
       strict_header_validation_(
           Runtime::runtimeFeatureEnabled("envoy.reloadable_features.strict_header_validation")),
       connection_header_sanitization_(Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.connection_header_sanitization")) {
+          "envoy.reloadable_features.connection_header_sanitization")),
+      output_buffer_([&]() -> void { this->onBelowLowWatermark(); },
+                     [&]() -> void { this->onAboveHighWatermark(); }),
+      max_headers_kb_(max_headers_kb), max_headers_count_(max_headers_count) {
   output_buffer_.setWatermarks(connection.bufferLimit());
   http_parser_init(&parser_, type);
   parser_.data = this;

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -357,9 +357,9 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
                                const uint32_t max_headers_count,
                                HeaderKeyFormatterPtr&& header_key_formatter)
     : connection_(connection), stats_{ALL_HTTP1_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http1."))},
-      header_key_formatter_(std::move(header_key_formatter)),
-      strict_header_validation_(
-          Runtime::runtimeFeatureEnabled("envoy.reloadable_features.strict_header_validation")),
+      header_key_formatter_(std::move(header_key_formatter)), handling_upgrade_(false),
+      reset_stream_called_(false), strict_header_validation_(Runtime::runtimeFeatureEnabled(
+                                       "envoy.reloadable_features.strict_header_validation")),
       connection_header_sanitization_(Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.connection_header_sanitization")),
       output_buffer_([&]() -> void { this->onBelowLowWatermark(); },
@@ -368,8 +368,6 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
   output_buffer_.setWatermarks(connection.bufferLimit());
   http_parser_init(&parser_, type);
   parser_.data = this;
-  handling_upgrade_ = false;
-  reset_stream_called_ = false;
 }
 
 void ConnectionImpl::completeLastHeader() {

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -96,10 +96,10 @@ private:
 
   void encodeFormattedHeader(absl::string_view key, absl::string_view value);
 
-  bool chunk_encoding_{true};
-  bool processing_100_continue_{false};
-  bool is_response_to_head_request_{false};
-  bool is_content_length_allowed_{true};
+  bool chunk_encoding_ : 1;
+  bool processing_100_continue_ : 1;
+  bool is_response_to_head_request_ : 1;
+  bool is_content_length_allowed_ : 1;
   const HeaderKeyFormatter* const header_key_formatter_;
 };
 
@@ -204,8 +204,11 @@ protected:
   http_parser parser_;
   HeaderMapPtr deferred_end_stream_headers_;
   Http::Code error_code_{Http::Code::BadRequest};
-  bool handling_upgrade_ : 1;
   const HeaderKeyFormatterPtr header_key_formatter_;
+  bool handling_upgrade_ : 1;
+  bool reset_stream_called_ : 1;
+  const bool strict_header_validation_ : 1;
+  const bool connection_header_sanitization_ : 1;
 
 private:
   enum class HeaderParsingState { Field, Value, Done };
@@ -300,16 +303,12 @@ private:
   HeaderParsingState header_parsing_state_{HeaderParsingState::Field};
   HeaderString current_header_field_;
   HeaderString current_header_value_;
-  bool reset_stream_called_ : 1;
   Buffer::WatermarkBuffer output_buffer_;
   Buffer::RawSlice reserved_iovec_;
   char* reserved_current_{};
   Protocol protocol_{Protocol::Http11};
   const uint32_t max_headers_kb_;
   const uint32_t max_headers_count_;
-
-  const bool strict_header_validation_ : 1;
-  const bool connection_header_sanitization_ : 1;
 };
 
 /**

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -96,11 +96,11 @@ private:
 
   void encodeFormattedHeader(absl::string_view key, absl::string_view value);
 
+  const HeaderKeyFormatter* const header_key_formatter_;
   bool chunk_encoding_ : 1;
   bool processing_100_continue_ : 1;
   bool is_response_to_head_request_ : 1;
   bool is_content_length_allowed_ : 1;
-  const HeaderKeyFormatter* const header_key_formatter_;
 };
 
 /**

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -204,7 +204,7 @@ protected:
   http_parser parser_;
   HeaderMapPtr deferred_end_stream_headers_;
   Http::Code error_code_{Http::Code::BadRequest};
-  bool handling_upgrade_{};
+  bool handling_upgrade_ : 1;
   const HeaderKeyFormatterPtr header_key_formatter_;
 
 private:
@@ -300,7 +300,7 @@ private:
   HeaderParsingState header_parsing_state_{HeaderParsingState::Field};
   HeaderString current_header_field_;
   HeaderString current_header_value_;
-  bool reset_stream_called_{};
+  bool reset_stream_called_ : 1;
   Buffer::WatermarkBuffer output_buffer_;
   Buffer::RawSlice reserved_iovec_;
   char* reserved_current_{};
@@ -308,8 +308,8 @@ private:
   const uint32_t max_headers_kb_;
   const uint32_t max_headers_count_;
 
-  const bool strict_header_validation_;
-  const bool connection_header_sanitization_;
+  const bool strict_header_validation_ : 1;
+  const bool connection_header_sanitization_ : 1;
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Chuong Vu <chuongv@google.com>

Simply refactor the bools to be bool bitfields as requested here https://github.com/envoyproxy/envoy/pull/8667#discussion_r349949608

@mattklein123 - You think it is worth doing it for the StreamEncoderImpl as well? If so I'll package it into this PR as well.
Description: Simple refactoring
Risk Level: Low
Testing: None
Docs Changes:
Release Notes: