### PR TITLE
config: replace use of protobuf UnpackTo with MessageUtil::unpackTo.

### DIFF
--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -267,7 +267,7 @@ void Utility::translateOpaqueConfig(const ProtobufWkt::Any& typed_config,
 
     if (type == typed_struct_type) {
       udpa::type::v1::TypedStruct typed_struct;
-      typed_config.UnpackTo(&typed_struct);
+      MessageUtil::unpackTo(typed_config, typed_struct);
       // if out_proto is expecting Struct, return directly
       if (out_proto.GetDescriptor()->full_name() == struct_type) {
         out_proto.CopyFrom(typed_struct.value());
@@ -282,10 +282,10 @@ void Utility::translateOpaqueConfig(const ProtobufWkt::Any& typed_config,
       }
     } // out_proto is expecting Struct, unpack directly
     else if (type != struct_type || out_proto.GetDescriptor()->full_name() == struct_type) {
-      typed_config.UnpackTo(&out_proto);
+      MessageUtil::unpackTo(typed_config, out_proto);
     } else {
       ProtobufWkt::Struct struct_config;
-      typed_config.UnpackTo(&struct_config);
+      MessageUtil::unpackTo(typed_config, struct_config);
       MessageUtil::jsonConvert(struct_config, validation_visitor, out_proto);
     }
   }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -429,6 +429,14 @@ std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& messa
   return json;
 }
 
+void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message) {
+  if (!any_message.UnpackTo(&message)) {
+    throw EnvoyException(fmt::format("Unable to unpack as {}: {}",
+                                     message.GetDescriptor()->full_name(),
+                                     any_message.DebugString()));
+  }
+}
+
 void MessageUtil::jsonConvert(const Protobuf::Message& source, ProtobufWkt::Struct& dest) {
   // Any proto3 message can be transformed to Struct, so there is no need to check for unknown
   // fields. There is one catch; Duration/Timestamp etc. which have non-object canonical JSON

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -281,18 +281,32 @@ public:
   }
 
   /**
+   * Convert from google.protobuf.Any to a typed message. This should be used
+   * instead of the inbuilt UnpackTo as it performs validation of results.
+   *
+   * @param any_message source google.protobuf.Any message.
+   * @param message destination to unpack to.
+   *
+   * @throw EnvoyException if the message does not unpack.
+   */
+  static inline void unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message) {
+    if (!any_message.UnpackTo(&message)) {
+      throw EnvoyException(fmt::format("Unable to unpack as {}: {}",
+                                       message.GetDescriptor()->full_name(),
+                                       any_message.DebugString()));
+    }
+  }
+
+  /**
    * Convert from google.protobuf.Any to a typed message.
    * @param message source google.protobuf.Any message.
-   * @param validation_visitor message validation visitor instance.
    *
    * @return MessageType the typed message inside the Any.
    */
   template <class MessageType>
   static inline MessageType anyConvert(const ProtobufWkt::Any& message) {
     MessageType typed_message;
-    if (!message.UnpackTo(&typed_message)) {
-      throw EnvoyException("Unable to unpack " + message.DebugString());
-    }
+    unpackTo(message, typed_message);
     return typed_message;
   };
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -289,13 +289,7 @@ public:
    *
    * @throw EnvoyException if the message does not unpack.
    */
-  static inline void unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message) {
-    if (!any_message.UnpackTo(&message)) {
-      throw EnvoyException(fmt::format("Unable to unpack as {}: {}",
-                                       message.GetDescriptor()->full_name(),
-                                       any_message.DebugString()));
-    }
-  }
+  static void unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message);
 
   /**
    * Convert from google.protobuf.Any to a typed message.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -753,7 +753,7 @@ ClusterInfoImpl::ClusterInfoImpl(
         Server::Configuration::NamedUpstreamNetworkFilterConfigFactory>(string_name);
     auto message = factory.createEmptyConfigProto();
     if (!proto_config.typed_config().value().empty()) {
-      proto_config.typed_config().UnpackTo(message.get());
+      MessageUtil::unpackTo(proto_config.typed_config(), *message);
     }
     Network::FilterFactoryCb callback =
         factory.createFilterFactoryFromProto(*message, *factory_context_);

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -261,6 +261,20 @@ TEST(UtilityTest, PrepareDnsRefreshStrategy) {
   }
 }
 
+// Validate that an opaque config of the wrong type throws during conversion.
+TEST(UtilityTest, AnyWrongType) {
+  ProtobufWkt::Duration source_duration;
+  source_duration.set_seconds(42);
+  ProtobufWkt::Any typed_config;
+  typed_config.PackFrom(source_duration);
+  ProtobufWkt::Timestamp out;
+  EXPECT_THROW_WITH_REGEX(
+      Utility::translateOpaqueConfig(typed_config, ProtobufWkt::Struct(),
+                                     ProtobufMessage::getStrictValidationVisitor(), out),
+      EnvoyException,
+      R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\] .*)");
+}
+
 void packTypedStructIntoAny(ProtobufWkt::Any& typed_config, const Protobuf::Message& inner) {
   udpa::type::v1::TypedStruct typed_struct;
   (*typed_struct.mutable_type_url()) =

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -428,13 +428,27 @@ TEST_F(ProtobufUtilityTest, HashedValueStdHash) {
   EXPECT_NE(set.find(hv3), set.end());
 }
 
+// MessageUtility::anyConvert() with the wrong type throws.
 TEST_F(ProtobufUtilityTest, AnyConvertWrongType) {
   ProtobufWkt::Duration source_duration;
   source_duration.set_seconds(42);
   ProtobufWkt::Any source_any;
   source_any.PackFrom(source_duration);
-  EXPECT_THROW_WITH_REGEX(TestUtility::anyConvert<ProtobufWkt::Timestamp>(source_any),
-                          EnvoyException, "Unable to unpack .*");
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::anyConvert<ProtobufWkt::Timestamp>(source_any), EnvoyException,
+      R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\] .*)");
+}
+
+// MessageUtility::unpackTo() with the wrong type throws.
+TEST_F(ProtobufUtilityTest, UnpackToWrongType) {
+  ProtobufWkt::Duration source_duration;
+  source_duration.set_seconds(42);
+  ProtobufWkt::Any source_any;
+  source_any.PackFrom(source_duration);
+  ProtobufWkt::Timestamp dst;
+  EXPECT_THROW_WITH_REGEX(
+      MessageUtil::unpackTo(source_any, dst), EnvoyException,
+      R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\] .*)");
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertSuccess) {

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -307,6 +307,10 @@ def whitelistedForGrpcInit(file_path):
   return file_path in GRPC_INIT_WHITELIST
 
 
+def whitelistedForUnpackTo(file_path):
+  return file_path.startswith("./test") or file_path == "./source/common/protobuf/utility.h"
+
+
 def findSubstringAndReturnError(pattern, file_path, error_message):
   text = readFile(file_path)
   if pattern in text:
@@ -499,6 +503,9 @@ def checkSourceLine(line, file_path, reportError):
        "std::chrono::system_clock::now" in line or "std::chrono::steady_clock::now" in line or \
        "std::this_thread::sleep_for" in line or hasCondVarWaitFor(line):
       reportError("Don't reference real-world time sources from production code; use injection")
+  if not whitelistedForUnpackTo(file_path):
+    if "UnpackTo" in line:
+      reportError("Don't use UnpackTo() directly, use MessageUtil::unpackTo() instead")
   # Check that we use the absl::Time library
   if "std::get_time" in line:
     if "test/" in file_path:

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -308,7 +308,9 @@ def whitelistedForGrpcInit(file_path):
 
 
 def whitelistedForUnpackTo(file_path):
-  return file_path.startswith("./test") or file_path == "./source/common/protobuf/utility.h"
+  return file_path.startswith("./test") or file_path in [
+      "./source/common/protobuf/utility.cc", "./source/common/protobuf/utility.h"
+  ]
 
 
 def findSubstringAndReturnError(pattern, file_path, error_message):

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -180,6 +180,8 @@ def runChecks():
   errors += checkUnfixableError("real_time_system.cc", real_time_inject_error)
   errors += checkUnfixableError("system_clock.cc", real_time_inject_error)
   errors += checkUnfixableError("steady_clock.cc", real_time_inject_error)
+  errors += checkUnfixableError(
+      "unpack_to.cc", "Don't use UnpackTo() directly, use MessageUtil::unpackTo() instead")
   errors += checkUnfixableError("condvar_wait_for.cc", real_time_inject_error)
   errors += checkUnfixableError("sleep.cc", real_time_inject_error)
   errors += checkUnfixableError("std_atomic_free_functions.cc", "std::atomic_*")

--- a/tools/testdata/check_format/unpack_to.cc
+++ b/tools/testdata/check_format/unpack_to.cc
@@ -1,0 +1,9 @@
+namespace Envoy {
+
+int foo() {
+  ProtobufWky::Any bar;
+  Protobuf::Message baz;
+  bar.UnpackTo(baz);
+}
+
+} // namespace Envoy


### PR DESCRIPTION
Previously, we were missing a number of checks on the return of
UnpackTo(). This was dangerous, since Any conversion might fail, with
the result being that later config validations returned confusing error
messages (e.g. due to an empty message).

This PR switches all uses of UnpackTo() to a checked
MessageUtil::unpackTo(), which also provides helpful type information in
the exception.

Risk level: Low
Testing: Unit tests, also fixed above observed issue in v3 integration
  tests I'm working on.

Signed-off-by: Harvey Tuch <htuch@google.com>