### PR TITLE
ci: fix clang-tidy

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -70,7 +70,7 @@ elif [[ "${BUILD_REASON}" != "PullRequest" ]]; then
 else
   echo "Running clang-tidy-diff against master branch..."
   git fetch https://github.com/envoyproxy/envoy.git master
-  git diff "${SYSTEM_PULLREQUEST_TARGETBRANCH:-refs/heads/master}..HEAD" | filter_excludes | \
+  git diff "$(git merge-base HEAD FETCH_HEAD)..HEAD" | filter_excludes | \
     "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary=${CLANG_TIDY} \
       -p 1

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -69,8 +69,7 @@ elif [[ "${BUILD_REASON}" != "PullRequest" ]]; then
       -p 1
 else
   echo "Running clang-tidy-diff against master branch..."
-  git fetch https://github.com/envoyproxy/envoy.git master
-  git diff "${SYSTEM_PULLREQUEST_TARGETBRANCH}" | filter_excludes | \
+  git diff "remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}" | filter_excludes | \
     "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary=${CLANG_TIDY} \
       -p 1

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 ENVOY_SRCDIR=${ENVOY_SRCDIR:-$(cd $(dirname $0)/.. && pwd)}
 

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -70,7 +70,7 @@ elif [[ "${BUILD_REASON}" != "PullRequest" ]]; then
 else
   echo "Running clang-tidy-diff against master branch..."
   git fetch https://github.com/envoyproxy/envoy.git master
-  git diff "$(git merge-base HEAD FETCH_HEAD)..HEAD" | filter_excludes | \
+  git diff "${SYSTEM_PULLREQUEST_TARGETBRANCH}" | filter_excludes | \
     "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary=${CLANG_TIDY} \
       -p 1

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -28,6 +28,7 @@ docker run --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build -v /var/run/docker.sock:/var/run/docker.sock ${GIT_VOLUME_OPTION} \
   -e BAZEL_BUILD_EXTRA_OPTIONS -e BAZEL_EXTRA_TEST_OPTIONS -e BAZEL_REMOTE_CACHE -e ENVOY_STDLIB -e BUILD_REASON \
   -e BAZEL_REMOTE_INSTANCE -e GCP_SERVICE_ACCOUNT_KEY -e NUM_CPUS -e ENVOY_RBE -e FUZZIT_API_KEY -e ENVOY_BUILD_IMAGE \
+  -e SYSTEM_PULLREQUEST_TARGETBRANCH \
   -v "$PWD":/source --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${ENVOY_BUILD_IMAGE}" \
   /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home \
   --home-dir /source envoybuild && usermod -a -G pcap envoybuild && su envoybuild -c \"cd source && $*\""

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -28,7 +28,6 @@ docker run --rm ${DOCKER_TTY_OPTION} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build -v /var/run/docker.sock:/var/run/docker.sock ${GIT_VOLUME_OPTION} \
   -e BAZEL_BUILD_EXTRA_OPTIONS -e BAZEL_EXTRA_TEST_OPTIONS -e BAZEL_REMOTE_CACHE -e ENVOY_STDLIB -e BUILD_REASON \
   -e BAZEL_REMOTE_INSTANCE -e GCP_SERVICE_ACCOUNT_KEY -e NUM_CPUS -e ENVOY_RBE -e FUZZIT_API_KEY -e ENVOY_BUILD_IMAGE \
-  -e SYSTEM_PULLREQUEST_TARGETBRANCH \
   -v "$PWD":/source --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${ENVOY_BUILD_IMAGE}" \
   /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home \
   --home-dir /source envoybuild && usermod -a -G pcap envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
clang-tidy is currently yielding:
```
...
Running clang-tidy-diff against master branch...
From https://github.com/envoyproxy/envoy
 * branch            master     -> FETCH_HEAD
fatal: ambiguous argument 'master..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
No relevant changes found.
```
on all PRs. This reverts a small part of https://github.com/envoyproxy/envoy/pull/8965 to go back to using the base commit (the commit from which the PR was split off from) for `git diff`.

Signed-off-by: Derek Argueta <dereka@pinterest.com>