### PR TITLE
options: Allow OptionsImpl to be constructed from a vector

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -19,7 +19,7 @@
 
 namespace Envoy {
 namespace {
-std::vector<std::string> ToArgsVector(int argc, const char* const* argv) {
+std::vector<std::string> toArgsVector(int argc, const char* const* argv) {
   std::vector<std::string> args;
   for (int i = 0; i < argc; ++i) {
     args.emplace_back(argv[i]);
@@ -31,7 +31,7 @@ std::vector<std::string> ToArgsVector(int argc, const char* const* argv) {
 OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                          const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level)
-    : OptionsImpl(ToArgsVector(argc, argv), hot_restart_version_cb, default_log_level) {}
+    : OptionsImpl(toArgsVector(argc, argv), hot_restart_version_cb, default_log_level) {}
 
 OptionsImpl::OptionsImpl(std::vector<std::string> args,
                          const HotRestartVersionCb& hot_restart_version_cb,

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -18,7 +18,22 @@
 #include "tclap/CmdLine.h"
 
 namespace Envoy {
+namespace {
+std::vector<std::string> ToArgsVector(int argc, const char* const* argv) {
+  std::vector<std::string> args;
+  for (int i = 0; i < argc; ++i) {
+    args.emplace_back(argv[i]);
+  }
+  return args;
+}
+} // namespace
+
 OptionsImpl::OptionsImpl(int argc, const char* const* argv,
+                         const HotRestartVersionCb& hot_restart_version_cb,
+                         spdlog::level::level_enum default_log_level)
+    : OptionsImpl(ToArgsVector(argc, argv), hot_restart_version_cb, default_log_level) {}
+
+OptionsImpl::OptionsImpl(std::vector<std::string> args,
                          const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level)
     : signal_handling_enabled_(true) {
@@ -118,7 +133,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                                               "bool", cmd);
   cmd.setExceptionHandling(false);
   try {
-    cmd.parse(argc, argv);
+    cmd.parse(args);
     count_ = cmd.getArgList().size();
   } catch (TCLAP::ArgException& e) {
     try {

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -24,13 +24,23 @@ public:
   using HotRestartVersionCb = std::function<std::string(bool)>;
 
   /**
-   * @throw NoServingException if Envoy has already done everything specified by the argv (e.g.
+   * @throw NoServingException if Envoy has already done everything specified by the args (e.g.
    *        print the hot restart version) and it's time to exit without serving HTTP traffic. The
    *        caller should exit(0) after any necessary cleanup.
    * @throw MalformedArgvException if something is wrong with the arguments (invalid flag or flag
    *        value). The caller should call exit(1) after any necessary cleanup.
    */
   OptionsImpl(int argc, const char* const* argv, const HotRestartVersionCb& hot_restart_version_cb,
+              spdlog::level::level_enum default_log_level);
+
+  /**
+   * @throw NoServingException if Envoy has already done everything specified by the args (e.g.
+   *        print the hot restart version) and it's time to exit without serving HTTP traffic. The
+   *        caller should exit(0) after any necessary cleanup.
+   * @throw MalformedArgvException if something is wrong with the arguments (invalid flag or flag
+   *        value). The caller should call exit(1) after any necessary cleanup.
+   */
+  OptionsImpl(std::vector<std::string> args, const HotRestartVersionCb& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
   // Test constructor; creates "reasonable" defaults, but desired values should be set explicitly.

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -260,7 +260,7 @@ TEST_F(OptionsImplTest, OptionsFromArgv) {
 TEST_F(OptionsImplTest, OptionsFromArgvPrefix) {
   const std::array<const char*, 5> args{"envoy", "-c", "hello", "--admin-address-path", "goodbye"};
   std::unique_ptr<OptionsImpl> options = std::make_unique<OptionsImpl>(
-      args.size() - 2, // Pass in only a prefix of the args, cutting off the '--concurrency' part
+      args.size() - 2, // Pass in only a prefix of the args
       args.data(), [](bool) { return "1"; }, spdlog::level::warn);
   EXPECT_EQ("hello", options->configPath());
   // This should still have the default value since the extra arguments are

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -32,15 +32,12 @@ namespace {
 class OptionsImplTest : public testing::Test {
 
 public:
-  // Do the ugly work of turning a std::string into a char** and create an OptionsImpl. Args are
+  // Do the ugly work of turning a std::string into a vector and create an OptionsImpl. Args are
   // separated by a single space: no fancy quoting or escaping.
   std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
     std::vector<std::string> words = TestUtility::split(args, ' ');
-    std::vector<const char*> argv;
-    std::transform(words.cbegin(), words.cend(), std::back_inserter(argv),
-                   [](const std::string& arg) { return arg.c_str(); });
     return std::make_unique<OptionsImpl>(
-        argv.size(), argv.data(), [](bool) { return "1"; }, spdlog::level::warn);
+        std::move(words), [](bool) { return "1"; }, spdlog::level::warn);
   }
 };
 
@@ -250,6 +247,25 @@ TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
   // 5. use-fake-symbol-table - short-term override for rollout of real symbol-table implementation.
   // 6. hot restart version - print the hot restart version and exit.
   EXPECT_EQ(options->count() - 6, command_line_options->GetDescriptor()->field_count());
+}
+
+TEST_F(OptionsImplTest, OptionsFromArgv) {
+  const std::array<const char*, 3> args{"envoy", "-c", "hello"};
+  std::unique_ptr<OptionsImpl> options = std::make_unique<OptionsImpl>(
+      args.size(), args.data(), [](bool) { return "1"; }, spdlog::level::warn);
+  // Spot check that the arguments were parsed.
+  EXPECT_EQ("hello", options->configPath());
+}
+
+TEST_F(OptionsImplTest, OptionsFromArgvPrefix) {
+  const std::array<const char*, 5> args{"envoy", "-c", "hello", "--admin-address-path", "goodbye"};
+  std::unique_ptr<OptionsImpl> options = std::make_unique<OptionsImpl>(
+      args.size() - 2, // Pass in only a prefix of the args, cutting off the '--concurrency' part
+      args.data(), [](bool) { return "1"; }, spdlog::level::warn);
+  EXPECT_EQ("hello", options->configPath());
+  // This should still have the default value since the extra arguments are
+  // ignored.
+  EXPECT_EQ("", options->adminAddressPath());
 }
 
 TEST_F(OptionsImplTest, BadCliOption) {


### PR DESCRIPTION
This gives better type safety, and is no less efficient since the
overload of TCLAP::CmdLine::parse that takes in argc and argv performs
the same copy into a std::vector internally. Adding this constructor
gives more flexibility to creators of OptionsImpl instances.

Risk Level: low
Testing: ran unit tests
Docs Changes: n/a
Release Notes: n/a