### PR TITLE
Allow configuration of incomplete streams for Autonomous Upstream

### DIFF
--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -294,8 +294,8 @@ void BaseIntegrationTest::createUpstreams() {
   for (uint32_t i = 0; i < fake_upstreams_count_; ++i) {
     auto endpoint = upstream_address_fn_(i);
     if (autonomous_upstream_) {
-      fake_upstreams_.emplace_back(
-          new AutonomousUpstream(endpoint, upstream_protocol_, *time_system_));
+      fake_upstreams_.emplace_back(new AutonomousUpstream(
+          endpoint, upstream_protocol_, *time_system_, autonomous_allow_incomplete_streams_));
     } else {
       fake_upstreams_.emplace_back(new FakeUpstream(endpoint, upstream_protocol_, *time_system_,
                                                     enable_half_close_, udp_fake_upstream_));

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -369,6 +369,10 @@ protected:
   // If true, use AutonomousUpstream for fake upstreams.
   bool autonomous_upstream_{false};
 
+  // If true, allow incomplete streams in AutonomousUpstream
+  // This does nothing if autonomous_upstream_ is false
+  bool autonomous_allow_incomplete_streams_{false};
+
   bool enable_half_close_{false};
 
   // Whether the default created fake upstreams are UDP listeners.

--- a/test/integration/transport_socket_match_integration_test.cc
+++ b/test/integration/transport_socket_match_integration_test.cc
@@ -144,11 +144,11 @@ require_client_certificate: true
       if (isTLSUpstream(i)) {
         fake_upstreams_.emplace_back(new AutonomousUpstream(
             createUpstreamSslContext(), endpoint->ip()->port(), FakeHttpConnection::Type::HTTP1,
-            endpoint->ip()->version(), timeSystem()));
+            endpoint->ip()->version(), timeSystem(), false));
       } else {
         fake_upstreams_.emplace_back(new AutonomousUpstream(
             Network::Test::createRawBufferSocketFactory(), endpoint->ip()->port(),
-            FakeHttpConnection::Type::HTTP1, endpoint->ip()->version(), timeSystem()));
+            FakeHttpConnection::Type::HTTP1, endpoint->ip()->version(), timeSystem(), false));
       }
     }
   }


### PR DESCRIPTION
This allows integration tests to toggle to check if the stream should be
closed.

Also removed one unused constructor

Signed-off-by: Chuong Vu <chuongv@google.com>

Description: This allows integration tests to toggle to check if the stream should be
closed.
Risk Level: Low

