### PR TITLE
test: deflake //test/integration:redirect_integration_test

### DIFF
--- a/test/integration/filters/pause_filter.cc
+++ b/test/integration/filters/pause_filter.cc
@@ -26,8 +26,9 @@ public:
     if (end_stream) {
       absl::WriterMutexLock m(&encode_lock_);
       number_of_decode_calls_ref_++;
-      if (number_of_decode_calls_ref_ == 2) {
-        // If this is the second stream to decode headers, force low watermark state.
+      // If this is the second stream to decode headers and we're at high watermark. force low
+      // watermark state
+      if (number_of_decode_calls_ref_ == 2 && connection()->aboveHighWatermark()) {
         connection()->onLowWatermark();
       }
     }
@@ -38,8 +39,9 @@ public:
     if (end_stream) {
       absl::WriterMutexLock m(&encode_lock_);
       number_of_encode_calls_ref_++;
-      if (number_of_encode_calls_ref_ == 1) {
-        // If this is the first stream to encode headers, force high watermark state.
+      // If this is the first stream to encode headers and we're not at high watermark, force high
+      // watermark state.
+      if (number_of_encode_calls_ref_ == 1 && !connection()->aboveHighWatermark()) {
         connection()->onHighWatermark();
       }
     }


### PR DESCRIPTION
Description:
Response body of this test may be big enough that it sometime trigger the watermark
callbacks on its own. Let's check the watermark state before TestPauseFilter
issuing watermark callbacks. Otherwise it may assert fail.

Risk Level: Low
Testing: Verified by --runs_per_test=100
Docs Changes: N/A
Release Notes: N/A
Fixes #9145 
