### PR TITLE
ext_authz: fail closed when status is unset

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,7 @@ Version history
 * build: official released binary is now built against libc++.
 * cluster: added :ref: `aggregate cluster <arch_overview_aggregate_cluster>` that allows load balancing between clusters.
 * ext_authz: added :ref:`configurable ability<envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate<envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the `ext_authz` service.
+* ext_authz: requests will be considered unauthorized if the authorization service does not set the status field of the CheckResponse message.
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by envoy.reloadable_features.connection_header_sanitization which defaults to true.
 * http: support :ref:`auto_host_rewrite_header<envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the dynamic forward proxy.

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -45,7 +45,8 @@ void GrpcClientImpl::check(RequestCallbacks& callbacks,
 void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v2::CheckResponse>&& response,
                                Tracing::Span& span) {
   ResponsePtr authz_response = std::make_unique<Response>(Response{});
-  if (response->status().code() == Grpc::Status::WellKnownGrpcStatus::Ok) {
+  if (response->has_status() &&
+      response->status().code() == Grpc::Status::WellKnownGrpcStatus::Ok) {
     span.setTag(TracingConstants::get().TraceStatus, TracingConstants::get().TraceOk);
     authz_response->status = CheckStatus::OK;
     if (response->has_ok_response()) {


### PR DESCRIPTION
Description: Currently if the status field of the CheckResponse message is unset, the request is permitted. This behavior is not documented or tested and could be charitably be described as "surprising." This PR changes the behavior to deny requests when status is unset and adds test coverage.
Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: Yes
