### PR TITLE
[WIP] validate *x-envoy-expected-rq-timeout-ms* header value

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -164,6 +164,14 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
         request_headers.EnvoyExpectedRequestTimeoutMs();
     if (header_expected_timeout_entry) {
       trySetGlobalTimeout(header_expected_timeout_entry, timeout);
+      // In case timeout value is out of range,
+      // use *x-envoy-upstream-rq-timeout-ms* instead.
+      if (timeout.global_timeout_ < 0) {
+				Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
+				if (trySetGlobalTimeout(header_timeout_entry, timeout)) {
+					request_headers.removeEnvoyUpstreamRequestTimeoutMs();
+				}
+      }
     } else {
       Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -163,15 +163,17 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
     Http::HeaderEntry* header_expected_timeout_entry =
         request_headers.EnvoyExpectedRequestTimeoutMs();
     if (header_expected_timeout_entry) {
-      trySetGlobalTimeout(header_expected_timeout_entry, timeout);
       // In case timeout value is out of range,
       // use *x-envoy-upstream-rq-timeout-ms* instead.
-      if (timeout.global_timeout_ < 0) {
-				Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
-				if (trySetGlobalTimeout(header_timeout_entry, timeout)) {
-					request_headers.removeEnvoyUpstreamRequestTimeoutMs();
-				}
+      if (timeout.global_timeout_ < std::chrono::milliseconds(0)) {
+        Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
+        if (trySetGlobalTimeout(header_timeout_entry, timeout)) {
+          request_headers.removeEnvoyUpstreamRequestTimeoutMs();
+        }
+      } else {
+        trySetGlobalTimeout(header_expected_timeout_entry, timeout);
       }
+
     } else {
       Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
 

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -171,6 +171,37 @@ TEST_P(HttpTimeoutIntegrationTest, IgnoreTimeoutSetByEgressEnvoy) {
   EXPECT_EQ("504", response->headers().Status()->value().getStringView());
 }
 
+TEST_P(HttpTimeoutIntegrationTest, UseTimeoutSetByEgressEnvoy) {
+	enableRespectExpectedRqTimeout(true);
+	initialize();
+	codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+	auto encoder_decoder = codec_client_->startRequest(
+					Http::TestHeaderMapImpl{{":method", "POST"},
+																	{":path", "/test/long/url"},
+																	{":scheme", "http"},
+																	{":authority", "host"},
+																	{"x-forwarded-for", "10.0.0.1"},
+																	{"x-envoy-upstream-rq-timeout-ms", "20000"},
+																	{"x-envoy-expected-rq-timeout-ms", "-1"}});
+	auto response = std::move(encoder_decoder.second);
+	request_encoder_ = &encoder_decoder.first;
+	ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+	ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+	ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+	codec_client_->sendData(*request_encoder_, 0, true);
+	ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+	// Trigger global timeout, which i default timeout value (15s).
+	timeSystem().sleep(std::chrono::milliseconds(15001));
+	// Ensure we got a timeout downstream and canceled the upstream request.
+	response->waitForHeaders();
+	ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
+	codec_client_->close();
+	EXPECT_TRUE(upstream_request_->complete());
+	EXPECT_EQ(0U, upstream_request_->bodyLength());
+	EXPECT_TRUE(response->complete());
+	EXPECT_EQ("504", response->headers().Status()->value().getStringView());
+}
+
 // Regression test for https://github.com/envoyproxy/envoy/issues/7154 in which
 // resetStream() was only called after a response timeout for upstream requests
 // that had not received headers yet. This meant that decodeData might be

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -171,35 +171,35 @@ TEST_P(HttpTimeoutIntegrationTest, IgnoreTimeoutSetByEgressEnvoy) {
   EXPECT_EQ("504", response->headers().Status()->value().getStringView());
 }
 
-TEST_P(HttpTimeoutIntegrationTest, UseTimeoutSetByEgressEnvoy) {
-	enableRespectExpectedRqTimeout(true);
-	initialize();
-	codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-	auto encoder_decoder = codec_client_->startRequest(
-					Http::TestHeaderMapImpl{{":method", "POST"},
-																	{":path", "/test/long/url"},
-																	{":scheme", "http"},
-																	{":authority", "host"},
-																	{"x-forwarded-for", "10.0.0.1"},
-																	{"x-envoy-upstream-rq-timeout-ms", "20000"},
-																	{"x-envoy-expected-rq-timeout-ms", "-1"}});
-	auto response = std::move(encoder_decoder.second);
-	request_encoder_ = &encoder_decoder.first;
-	ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-	ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
-	ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
-	codec_client_->sendData(*request_encoder_, 0, true);
-	ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
-	// Trigger global timeout, which i default timeout value (15s).
-	timeSystem().sleep(std::chrono::milliseconds(15001));
-	// Ensure we got a timeout downstream and canceled the upstream request.
-	response->waitForHeaders();
-	ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
-	codec_client_->close();
-	EXPECT_TRUE(upstream_request_->complete());
-	EXPECT_EQ(0U, upstream_request_->bodyLength());
-	EXPECT_TRUE(response->complete());
-	EXPECT_EQ("504", response->headers().Status()->value().getStringView());
+TEST_P(HttpTimeoutIntegrationTest, ExpectedTimeoutOutOfRange) {
+  enableRespectExpectedRqTimeout(true);
+  initialize();
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestHeaderMapImpl{{":method", "POST"},
+                              {":path", "/test/long/url"},
+                              {":scheme", "http"},
+                              {":authority", "host"},
+                              {"x-forwarded-for", "10.0.0.1"},
+                              {"x-envoy-upstream-rq-timeout-ms", "20000"},
+                              {"x-envoy-expected-rq-timeout-ms", "-1"}});
+  auto response = std::move(encoder_decoder.second);
+  request_encoder_ = &encoder_decoder.first;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  codec_client_->sendData(*request_encoder_, 0, true);
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  // Trigger global timeout, which i default timeout value (15s).
+  timeSystem().sleep(std::chrono::milliseconds(15001));
+  // Ensure we got a timeout downstream and canceled the upstream request.
+  response->waitForHeaders();
+  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
+  codec_client_->close();
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("504", response->headers().Status()->value().getStringView());
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/7154 in which


### PR DESCRIPTION
Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>

For the case when respect_expected_rq_timeout is enabled and not valid (for example negative) value is set in x-envoy-expected-timeout-ms header, Envoy will use default timeout (15s) as upstream timeout (in case per try timeout is not specified). With this fix Envoy will fall back to timeout value from x-envoy-upstream-rq-timeout-ms header instead.

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Fixes #8586

