### PR TITLE
Add option to access upstream connection

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -336,9 +336,9 @@ public:
   };
 
   /**
-   * This method returns a Upstream::ClusterInfoConstSharedPtr given construction parameters.
+   * This method returns a Upstream::ClusterInfoSharedPtr given construction parameters.
    */
-  virtual Upstream::ClusterInfoConstSharedPtr
+  virtual Upstream::ClusterInfoSharedPtr
   createClusterInfo(const CreateClusterInfoParams& params) PURE;
 };
 

--- a/include/envoy/upstream/thread_local_cluster.h
+++ b/include/envoy/upstream/thread_local_cluster.h
@@ -26,7 +26,7 @@ public:
    * @return ClusterInfoConstSharedPtr the info for this cluster. The info is safe to store beyond
    * the lifetime of the ThreadLocalCluster instance itself.
    */
-  virtual ClusterInfoConstSharedPtr info() PURE;
+  virtual ClusterInfoSharedPtr info() PURE;
 
   /**
    * @return LoadBalancer& the backing load balancer.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -869,6 +869,16 @@ public:
   virtual Http::Protocol
   upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_protocol) const PURE;
 
+  /**
+   * Sets value of upstream connection.
+   */
+  virtual void upstreamConnection(Network::Connection& connection) PURE;
+
+  /**
+   * @return pointer to upstream connection.
+   */
+  virtual Network::Connection* upstreamConnection() const PURE;
+
 protected:
   /**
    * Invoked by extensionProtocolOptionsTyped.
@@ -882,6 +892,7 @@ protected:
 };
 
 using ClusterInfoConstSharedPtr = std::shared_ptr<const ClusterInfo>;
+using ClusterInfoSharedPtr = std::shared_ptr<ClusterInfo>;
 
 class HealthChecker;
 
@@ -905,6 +916,7 @@ public:
    * @return the information about this upstream cluster.
    */
   virtual ClusterInfoConstSharedPtr info() const PURE;
+  virtual ClusterInfoSharedPtr info() PURE;
 
   /**
    * @return a pointer to the cluster's outlier detector. If an outlier detector has not been

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1143,7 +1143,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::getHttpConnPoolsContainer(
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
-    ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
+    ThreadLocalClusterManagerImpl& parent, ClusterInfoSharedPtr cluster,
     const LoadBalancerFactorySharedPtr& lb_factory)
     : parent_(parent), lb_factory_(lb_factory), cluster_info_(cluster),
       http_async_client_(cluster, parent.parent_.stats_, parent.thread_local_dispatcher_,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -301,7 +301,7 @@ private:
         std::unordered_map<Network::ClientConnection*, std::unique_ptr<TcpConnContainer>>;
 
     struct ClusterEntry : public ThreadLocalCluster {
-      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
+      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoSharedPtr cluster,
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry() override;
 
@@ -313,7 +313,7 @@ private:
 
       // Upstream::ThreadLocalCluster
       const PrioritySet& prioritySet() override { return priority_set_; }
-      ClusterInfoConstSharedPtr info() override { return cluster_info_; }
+      ClusterInfoSharedPtr info() override { return cluster_info_; }
       LoadBalancer& loadBalancer() override { return *lb_; }
 
       ThreadLocalClusterManagerImpl& parent_;
@@ -324,7 +324,7 @@ private:
       LoadBalancerFactorySharedPtr lb_factory_;
       // Current active LB.
       LoadBalancerPtr lb_;
-      ClusterInfoConstSharedPtr cluster_info_;
+      ClusterInfoSharedPtr cluster_info_;
       Http::AsyncClientImpl http_async_client_;
     };
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -233,7 +233,7 @@ HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
 
 ClusterSharedPtr HdsCluster::create() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
-ClusterInfoConstSharedPtr
+ClusterInfoSharedPtr
 ProdClusterInfoFactory::createClusterInfo(const CreateClusterInfoParams& params) {
   Envoy::Stats::ScopePtr scope =
       params.stats_.createScope(fmt::format("cluster.{}.", params.cluster_.name()));

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -25,7 +25,7 @@ namespace Upstream {
 
 class ProdClusterInfoFactory : public ClusterInfoFactory, Logger::Loggable<Logger::Id::upstream> {
 public:
-  ClusterInfoConstSharedPtr createClusterInfo(const CreateClusterInfoParams& params) override;
+  ClusterInfoSharedPtr createClusterInfo(const CreateClusterInfoParams& params) override;
 };
 
 // TODO(lilika): Add HdsClusters to the /clusters endpoint to get detailed stats about each HC host.
@@ -53,6 +53,7 @@ public:
   void setOutlierDetector(const Outlier::DetectorSharedPtr& outlier_detector);
   HealthChecker* healthChecker() override { return health_checker_.get(); }
   ClusterInfoConstSharedPtr info() const override { return info_; }
+  ClusterInfoSharedPtr info() override { return info_; }
   Outlier::Detector* outlierDetector() override { return outlier_detector_.get(); }
   const Outlier::Detector* outlierDetector() const override { return outlier_detector_.get(); }
   void initialize(std::function<void()> callback) override;
@@ -80,7 +81,7 @@ private:
   bool added_via_api_;
 
   HostVectorSharedPtr initial_hosts_;
-  ClusterInfoConstSharedPtr info_;
+  ClusterInfoSharedPtr info_;
   std::vector<Upstream::HealthCheckerSharedPtr> health_checkers_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
 };

--- a/source/common/upstream/logical_host.h
+++ b/source/common/upstream/logical_host.h
@@ -11,7 +11,7 @@ namespace Upstream {
  */
 class LogicalHost : public HostImpl {
 public:
-  LogicalHost(const ClusterInfoConstSharedPtr& cluster, const std::string& hostname,
+  LogicalHost(const ClusterInfoSharedPtr& cluster, const std::string& hostname,
               const Network::Address::InstanceConstSharedPtr& address,
               const envoy::api::v2::endpoint::LocalityLbEndpoints& locality_lb_endpoint,
               const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -66,7 +66,7 @@ class HostDescriptionImpl : virtual public HostDescription,
                             protected Logger::Loggable<Logger::Id::upstream> {
 public:
   HostDescriptionImpl(
-      ClusterInfoConstSharedPtr cluster, const std::string& hostname,
+      ClusterInfoSharedPtr cluster, const std::string& hostname,
       Network::Address::InstanceConstSharedPtr dest_address,
       const envoy::api::v2::core::Metadata& metadata,
       const envoy::api::v2::core::Locality& locality,
@@ -98,7 +98,7 @@ public:
     metadata_ = std::make_shared<envoy::api::v2::core::Metadata>(new_metadata);
   }
 
-  const ClusterInfo& cluster() const override { return *cluster_; }
+  ClusterInfo& cluster() const override { return *cluster_; }
   HealthCheckHostMonitor& healthChecker() const override {
     if (health_checker_) {
       return *health_checker_;
@@ -136,7 +136,7 @@ private:
                                 const envoy::api::v2::core::Metadata& metadata);
 
 protected:
-  ClusterInfoConstSharedPtr cluster_;
+  ClusterInfoSharedPtr cluster_;
   const std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
   Network::Address::InstanceConstSharedPtr health_check_address_;
@@ -159,7 +159,7 @@ class HostImpl : public HostDescriptionImpl,
                  public Host,
                  public std::enable_shared_from_this<HostImpl> {
 public:
-  HostImpl(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
+  HostImpl(ClusterInfoSharedPtr cluster, const std::string& hostname,
            Network::Address::InstanceConstSharedPtr address,
            const envoy::api::v2::core::Metadata& metadata, uint32_t initial_weight,
            const envoy::api::v2::core::Locality& locality,
@@ -229,7 +229,7 @@ public:
 
 protected:
   static Network::ClientConnectionPtr
-  createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& cluster,
+  createConnection(Event::Dispatcher& dispatcher, ClusterInfo& cluster,
                    const Network::Address::InstanceConstSharedPtr& address,
                    Network::TransportSocketFactory& socket_factory,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
@@ -580,6 +580,11 @@ public:
   Http::Protocol
   upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_protocol) const override;
 
+  void upstreamConnection(Network::Connection& connection) override {
+    upstream_connection_ = &connection;
+  }
+  Network::Connection* upstreamConnection() const override { return upstream_connection_; }
+
 private:
   struct ResourceManagers {
     ResourceManagers(const envoy::api::v2::Cluster& config, Runtime::Loader& runtime,
@@ -629,6 +634,7 @@ private:
   const absl::optional<envoy::api::v2::Cluster::CustomClusterType> cluster_type_;
   const std::unique_ptr<Server::Configuration::CommonFactoryContext> factory_context_;
   std::vector<Network::FilterFactoryCb> filter_factories_;
+  Network::Connection* upstream_connection_;
 };
 
 /**
@@ -688,6 +694,7 @@ public:
   // Upstream::Cluster
   HealthChecker* healthChecker() override { return health_checker_.get(); }
   ClusterInfoConstSharedPtr info() const override { return info_; }
+  ClusterInfoSharedPtr info() override { return info_; }
   Outlier::Detector* outlierDetector() override { return outlier_detector_.get(); }
   const Outlier::Detector* outlierDetector() const override { return outlier_detector_.get(); }
   void initialize(std::function<void()> callback) override;
@@ -729,8 +736,8 @@ protected:
   Init::WatcherImpl init_watcher_;
 
   Runtime::Loader& runtime_;
-  ClusterInfoConstSharedPtr info_; // This cluster info stores the stats scope so it must be
-                                   // initialized first and destroyed last.
+  ClusterInfoSharedPtr info_; // This cluster info stores the stats scope so it must be
+                              // initialized first and destroyed last.
   HealthCheckerSharedPtr health_checker_;
   Outlier::DetectorSharedPtr outlier_detector_;
 

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -141,7 +141,7 @@ private:
   // A redis node in the Redis cluster.
   class RedisHost : public Upstream::HostImpl {
   public:
-    RedisHost(Upstream::ClusterInfoConstSharedPtr cluster, const std::string& hostname,
+    RedisHost(Upstream::ClusterInfoSharedPtr cluster, const std::string& hostname,
               Network::Address::InstanceConstSharedPtr address, RedisCluster& parent, bool master)
         : Upstream::HostImpl(cluster, hostname, address, parent.lbEndpoint().metadata(),
                              parent.lbEndpoint().load_balancing_weight().value(),

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -315,8 +315,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
-    const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::
+operator!=(const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -315,8 +315,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::
-operator!=(const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
+    const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -60,7 +60,7 @@ inline envoy::api::v2::Cluster defaultStaticCluster(const std::string& name) {
   return parseClusterFromV2Json(defaultStaticClusterJson(name));
 }
 
-inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
+inline HostSharedPtr makeTestHost(ClusterInfoSharedPtr cluster, const std::string& url,
                                   uint32_t weight = 1) {
   return HostSharedPtr{new HostImpl(
       cluster, "", Network::Utility::resolveUrl(url),
@@ -69,7 +69,7 @@ inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::
       envoy::api::v2::core::HealthStatus::UNKNOWN)};
 }
 
-inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
+inline HostSharedPtr makeTestHost(ClusterInfoSharedPtr cluster, const std::string& url,
                                   const envoy::api::v2::core::Metadata& metadata,
                                   uint32_t weight = 1) {
   return HostSharedPtr{
@@ -80,7 +80,7 @@ inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::
 }
 
 inline HostSharedPtr
-makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
+makeTestHost(ClusterInfoSharedPtr cluster, const std::string& url,
              const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config,
              uint32_t weight = 1) {
   return HostSharedPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
@@ -89,7 +89,7 @@ makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                     envoy::api::v2::core::HealthStatus::UNKNOWN)};
 }
 
-inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,
+inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoSharedPtr cluster,
                                                              const std::string& url) {
   return HostDescriptionConstSharedPtr{new HostDescriptionImpl(
       cluster, "", Network::Utility::resolveUrl(url),

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -110,6 +110,8 @@ public:
   MOCK_CONST_METHOD0(eds_service_name, absl::optional<std::string>());
   MOCK_CONST_METHOD1(createNetworkFilterChain, void(Network::Connection&));
   MOCK_CONST_METHOD1(upstreamHttpProtocol, Http::Protocol(absl::optional<Http::Protocol>));
+  MOCK_CONST_METHOD0(upstreamConnection, Network::Connection*());
+  MOCK_METHOD1(upstreamConnection, void(Network::Connection&));
 
   std::string name_{"fake_cluster"};
   absl::optional<std::string> eds_service_name_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -165,6 +165,7 @@ public:
   // Upstream::Cluster
   MOCK_METHOD0(healthChecker, HealthChecker*());
   MOCK_CONST_METHOD0(info, ClusterInfoConstSharedPtr());
+  MOCK_METHOD0(info, ClusterInfoSharedPtr());
   MOCK_METHOD0(outlierDetector, Outlier::Detector*());
   MOCK_CONST_METHOD0(outlierDetector, const Outlier::Detector*());
   MOCK_METHOD1(initialize, void(std::function<void()> callback));
@@ -234,7 +235,7 @@ public:
 
   // Upstream::ThreadLocalCluster
   MOCK_METHOD0(prioritySet, const PrioritySet&());
-  MOCK_METHOD0(info, ClusterInfoConstSharedPtr());
+  MOCK_METHOD0(info, ClusterInfoSharedPtr());
   MOCK_METHOD0(loadBalancer, LoadBalancer&());
 
   NiceMock<MockClusterMockPrioritySet> cluster_;
@@ -400,7 +401,7 @@ public:
   MockClusterInfoFactory();
   ~MockClusterInfoFactory() override;
 
-  MOCK_METHOD1(createClusterInfo, ClusterInfoConstSharedPtr(const CreateClusterInfoParams&));
+  MOCK_METHOD1(createClusterInfo, ClusterInfoSharedPtr(const CreateClusterInfoParams&));
 };
 
 class MockRetryHostPredicate : public RetryHostPredicate {


### PR DESCRIPTION
We have upstream filters now, and thus need a way to access upstream connection by downstream filters to access filterstate/streaminfo on upstream connection.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:Add option to access upstream connection
Risk Level:Low
Testing:Added unite test for TCP
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
