### PR TITLE
remote data fetcher: copy URI instead of reference

### DIFF
--- a/source/common/config/remote_data_fetcher.h
+++ b/source/common/config/remote_data_fetcher.h
@@ -68,7 +68,7 @@ public:
 
 private:
   Upstream::ClusterManager& cm_;
-  const envoy::api::v2::core::HttpUri& uri_;
+  const envoy::api::v2::core::HttpUri uri_;
   const std::string content_hash_;
   RemoteDataFetcherCallback& callback_;
 

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -374,6 +374,57 @@ TEST_F(AsyncDataSourceTest, loadRemoteDataSourceExpectInvalidData) {
   EXPECT_CALL(init_watcher_, ready());
 }
 
+TEST_F(AsyncDataSourceTest, datasourceReleasedBeforeFetchingData) {
+  const std::string body = "hello world";
+  std::string async_data = "non-empty";
+  std::unique_ptr<Config::DataSource::RemoteAsyncDataProvider> provider;
+
+  {
+    AsyncDataSourcePb config;
+
+    std::string yaml = R"EOF(
+    remote:
+      http_uri:
+        uri: https://example.com/data
+        cluster: cluster_1
+      sha256:
+        b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+  )EOF";
+    TestUtility::loadFromYaml(yaml, config);
+    EXPECT_TRUE(config.has_remote());
+
+    EXPECT_CALL(cm_, httpAsyncClientForCluster("cluster_1")).WillOnce(ReturnRef(cm_.async_client_));
+    EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+        .WillOnce(
+            Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
+                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+              Http::MessagePtr response(new Http::ResponseMessageImpl(
+                  Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+              response->body() = std::make_unique<Buffer::OwnedImpl>(body);
+
+              callbacks.onSuccess(std::move(response));
+              return nullptr;
+            }));
+
+    EXPECT_CALL(init_manager_, add(_)).WillOnce(Invoke([this](const Init::Target& target) {
+      init_target_handle_ = target.createHandle("test");
+    }));
+
+    provider = std::make_unique<Config::DataSource::RemoteAsyncDataProvider>(
+        cm_, init_manager_, config.remote(), true, [&](const std::string& data) {
+          EXPECT_EQ(init_manager_.state(), Init::Manager::State::Initializing);
+          EXPECT_EQ(data, body);
+          async_data = data;
+        });
+  }
+
+  EXPECT_CALL(init_manager_, state()).WillOnce(Return(Init::Manager::State::Initializing));
+  EXPECT_CALL(init_watcher_, ready());
+  init_target_handle_->initialize(init_watcher_);
+  EXPECT_EQ(async_data, body);
+  EXPECT_NE(nullptr, provider.get());
+}
+
 } // namespace
 } // namespace Config
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Yan Xue <yxyan@google.com>

Description: copy URI instead of reference
Risk Level: Low
Testing: UT
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] Fix https://github.com/envoyproxy/envoy-wasm/issues/328
