### PR TITLE
Add a startup option to exit Envoy if it encounters a bind failure

### DIFF
--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -47,7 +47,7 @@ message ServerInfo {
   CommandLineOptions command_line_options = 6;
 }
 
-// [#next-free-field: 28]
+// [#next-free-field: 29]
 message CommandLineOptions {
   enum IpVersion {
     v4 = 0;
@@ -84,6 +84,9 @@ message CommandLineOptions {
 
   // See :option:`--reject-unknown-dynamic-fields` for details.
   bool reject_unknown_dynamic_fields = 26;
+
+  // See :option:`--server-exit-on-bind-failure` for details.
+  bool server_exit_on_bind_failure = 28;
 
   // See :option:`--admin-address-path` for details.
   string admin_address_path = 6;

--- a/api/envoy/admin/v3alpha/server_info.proto
+++ b/api/envoy/admin/v3alpha/server_info.proto
@@ -47,7 +47,7 @@ message ServerInfo {
   CommandLineOptions command_line_options = 6;
 }
 
-// [#next-free-field: 28]
+// [#next-free-field: 29]
 message CommandLineOptions {
   enum IpVersion {
     v4 = 0;
@@ -86,6 +86,9 @@ message CommandLineOptions {
 
   // See :option:`--reject-unknown-dynamic-fields` for details.
   bool reject_unknown_dynamic_fields = 26;
+
+  // See :option:`--server-exit-on-bind-failure` for details.
+  bool server_exit_on_bind_failure = 28;
 
   // See :option:`--admin-address-path` for details.
   string admin_address_path = 6;

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -8,6 +8,7 @@ Version history
 * buffer: remove old implementation
 * build: official released binary is now built against libc++.
 * cluster: added :ref: `aggregate cluster <arch_overview_aggregate_cluster>` that allows load balancing between clusters.
+* config: added support for :option:`--server-exit-on-bind-failure`, controlling whether the server will exit if it cannot start a listener on its configured address and port.
 * ext_authz: added :ref:`configurable ability<envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate<envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the `ext_authz` service.
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by envoy.reloadable_features.connection_header_sanitization which defaults to true.

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -260,6 +260,12 @@ following are the command line options that Envoy supports.
   and these occurrences are counted in the :ref:`server.dynamic_unknown_fields <server_statistics>`
   statistic.
 
+.. option:: --server--exit-on-bind-failure
+
+  *(optional)* This flag causes the server to exit if it cannot bind to an address and port for a given
+  listener. If this flag is not specified, and a bind failure occurs, the failed listener is essentially
+  ignored and the server continues to run.
+
 .. option:: --version
 
   *(optional)* This flag is used to display Envoy version and build information, e.g.

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -260,7 +260,7 @@ following are the command line options that Envoy supports.
   and these occurrences are counted in the :ref:`server.dynamic_unknown_fields <server_statistics>`
   statistic.
 
-.. option:: --server--exit-on-bind-failure
+.. option:: --server-exit-on-bind-failure
 
   *(optional)* This flag causes the server to exit if it cannot bind to an address and port for a given
   listener. If this flag is not specified, and a bind failure occurs, the failed listener is essentially

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -96,6 +96,11 @@ public:
   virtual bool rejectUnknownDynamicFields() const PURE;
 
   /**
+   * @return bool exit the server if a listener socket bind fails?
+   */
+  virtual bool serverExitOnBindFailure() const PURE;
+
+  /**
    * @return const std::string& the admin address output file.
    */
   virtual const std::string& adminAddressPath() const PURE;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -74,6 +74,10 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
                                                  "reject unknown fields in dynamic configuration",
                                                  cmd, false);
 
+  TCLAP::SwitchArg server_exit_on_bind_failure(
+      "", "server-exit-on-bind-failure",
+      "Exit the server if we cannot listen on a given address and port", cmd, false);
+
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
   TCLAP::ValueArg<std::string> local_address_ip_version("", "local-address-ip-version",
@@ -214,6 +218,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   allow_unknown_static_fields_ =
       allow_unknown_static_fields.getValue() || allow_unknown_fields.getValue();
   reject_unknown_dynamic_fields_ = reject_unknown_dynamic_fields.getValue();
+  server_exit_on_bind_failure_ = server_exit_on_bind_failure.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();
@@ -275,6 +280,7 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_config_yaml(configYaml());
   command_line_options->set_allow_unknown_static_fields(allow_unknown_static_fields_);
   command_line_options->set_reject_unknown_dynamic_fields(reject_unknown_dynamic_fields_);
+  command_line_options->set_server_exit_on_bind_failure(server_exit_on_bind_failure_);
   command_line_options->set_admin_address_path(adminAddressPath());
   command_line_options->set_component_log_level(component_log_level_str_);
   command_line_options->set_log_level(spdlog::level::to_string_view(logLevel()).data(),

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -91,6 +91,9 @@ public:
   void setRejectUnknownFieldsDynamic(bool reject_unknown_dynamic_fields) {
     reject_unknown_dynamic_fields_ = reject_unknown_dynamic_fields;
   }
+  void setServerExitOnBindFailure(bool server_exit_on_bind_failure) {
+    server_exit_on_bind_failure_ = server_exit_on_bind_failure;
+  }
   void setFakeSymbolTableEnabled(bool fake_symbol_table_enabled) {
     fake_symbol_table_enabled_ = fake_symbol_table_enabled;
   }
@@ -105,6 +108,7 @@ public:
   const std::string& configYaml() const override { return config_yaml_; }
   bool allowUnknownStaticFields() const override { return allow_unknown_static_fields_; }
   bool rejectUnknownDynamicFields() const override { return reject_unknown_dynamic_fields_; }
+  bool serverExitOnBindFailure() const override { return server_exit_on_bind_failure_; }
   const std::string& adminAddressPath() const override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() const override {
     return local_address_ip_version_;
@@ -146,6 +150,7 @@ private:
   std::string config_yaml_;
   bool allow_unknown_static_fields_{false};
   bool reject_unknown_dynamic_fields_{false};
+  bool server_exit_on_bind_failure_{false};
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;
   spdlog::level::level_enum log_level_;

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -32,7 +32,8 @@ namespace Server {
 OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
                                   Network::Address::IpVersion ip_version,
                                   bool allow_unknown_static_fields,
-                                  bool reject_unknown_dynamic_fields, uint32_t concurrency) {
+                                  bool reject_unknown_dynamic_fields, uint32_t concurrency,
+                                  bool server_exit_on_bind_failure) {
   OptionsImpl test_options("cluster_name", "node_name", "zone_name", spdlog::level::info);
 
   test_options.setConfigPath(config_path);
@@ -44,6 +45,7 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
   test_options.setAllowUnkownFields(allow_unknown_static_fields);
   test_options.setRejectUnknownFieldsDynamic(reject_unknown_dynamic_fields);
   test_options.setConcurrency(concurrency);
+  test_options.setServerExitOnBindFailure(server_exit_on_bind_failure);
 
   return test_options;
 }

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -35,7 +35,8 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
                                   Network::Address::IpVersion ip_version,
                                   bool allow_unknown_static_fields = false,
                                   bool reject_unknown_dynamic_fields = false,
-                                  uint32_t concurrency = 1);
+                                  uint32_t concurrency = 1,
+                                  bool server_exit_on_bind_failure = false);
 
 class TestDrainManager : public DrainManager {
 public:

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -28,6 +28,9 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
   ON_CALL(*this, rejectUnknownDynamicFields()).WillByDefault(Invoke([this] {
     return reject_unknown_dynamic_fields_;
   }));
+  ON_CALL(*this, serverExitOnBindFailure()).WillByDefault(Invoke([this] {
+    return server_exit_on_bind_failure_;
+  }));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -70,6 +70,7 @@ public:
   MOCK_CONST_METHOD0(configYaml, const std::string&());
   MOCK_CONST_METHOD0(allowUnknownStaticFields, bool());
   MOCK_CONST_METHOD0(rejectUnknownDynamicFields, bool());
+  MOCK_CONST_METHOD0(serverExitOnBindFailure, bool());
   MOCK_CONST_METHOD0(adminAddressPath, const std::string&());
   MOCK_CONST_METHOD0(localAddressIpVersion, Network::Address::IpVersion());
   MOCK_CONST_METHOD0(drainTime, std::chrono::seconds());
@@ -98,6 +99,7 @@ public:
   std::string config_yaml_;
   bool allow_unknown_static_fields_{};
   bool reject_unknown_dynamic_fields_{};
+  bool server_exit_on_bind_failure_{};
   std::string admin_address_path_;
   std::string service_cluster_name_;
   std::string service_node_name_;

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -231,6 +231,7 @@ TEST_F(OptionsImplTest, DefaultParams) {
   EXPECT_FALSE(command_line_options->cpuset_threads());
   EXPECT_FALSE(command_line_options->allow_unknown_static_fields());
   EXPECT_FALSE(command_line_options->reject_unknown_dynamic_fields());
+  EXPECT_FALSE(command_line_options->server_exit_on_bind_failure());
 }
 
 // Validates that the server_info proto is in sync with the options.


### PR DESCRIPTION
Use a startup option to instruct the server it should exit if it cannot bind to a dynamic listener socket.

Signed-off-by: Alvin Baptiste <alvinsb@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level: Low
Testing: Manual testing of the startup option, as well as `bazel test //test/...`
Docs Changes: Updated `cli.rst` to include new option.  Updated `version_history.rst`
Release Notes: N/A
Fixes: https://github.com/envoyproxy/envoy/issues/3395
