### PR TITLE
connection: pass socket options to the upstream socket.

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -634,7 +634,7 @@ ClientConnectionImpl::ClientConnectionImpl(
     const Network::Address::InstanceConstSharedPtr& source_address,
     Network::TransportSocketPtr&& transport_socket,
     const Network::ConnectionSocket::OptionsSharedPtr& options)
-    : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address),
+    : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address, options),
                      std::move(transport_socket), false) {
   // There are no meaningful socket options or source address semantics for
   // non-IP sockets, so skip.

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -175,9 +175,13 @@ public:
 // ConnectionSocket used with client connections.
 class ClientSocketImpl : public ConnectionSocketImpl {
 public:
-  ClientSocketImpl(const Address::InstanceConstSharedPtr& remote_address)
+  ClientSocketImpl(const Address::InstanceConstSharedPtr& remote_address, const OptionsSharedPtr& options)
       : ConnectionSocketImpl(remote_address->socket(Address::SocketType::Stream), nullptr,
-                             remote_address) {}
+                             remote_address) {
+    if (options) {
+      addOptions(options);
+    }
+  }
 };
 
 } // namespace Network

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -175,7 +175,8 @@ public:
 // ConnectionSocket used with client connections.
 class ClientSocketImpl : public ConnectionSocketImpl {
 public:
-  ClientSocketImpl(const Address::InstanceConstSharedPtr& remote_address, const OptionsSharedPtr& options)
+  ClientSocketImpl(const Address::InstanceConstSharedPtr& remote_address,
+                   const OptionsSharedPtr& options)
       : ConnectionSocketImpl(remote_address->socket(Address::SocketType::Stream), nullptr,
                              remote_address) {
     if (options) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -334,6 +334,10 @@ TEST_P(ConnectionImplTest, SocketOptions) {
       }));
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  ASSERT(upstream_connection_ != nullptr);
+  ASSERT(upstream_connection_->socketOptions() != nullptr);
+  ASSERT(upstream_connection_->socketOptions()->front() == option);
 }
 
 TEST_P(ConnectionImplTest, SocketOptionsFailureTest) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -335,6 +335,7 @@ TEST_P(ConnectionImplTest, SocketOptions) {
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
+  // Assert that upstream connection gets the socket options
   ASSERT(upstream_connection_ != nullptr);
   ASSERT(upstream_connection_->socketOptions() != nullptr);
   ASSERT(upstream_connection_->socketOptions()->front() == option);


### PR DESCRIPTION
Currently socket options are applied to the underlying upstream
socket, but the created upstream ClientSocket object does not get
these options. Change this by passing the SocketOptions to the
constructor of ClientSocketImpl class. This allows upstream extensions
(e.g., transport socket extensions) to introspect which socket options
were applied on the upstream socket and change their behavior
accordingly.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

Risk Level: Low (SocketOptions was nullptr on upstream connections before)
Testing: Existing unit test changed to test for regression
Docs Changes: none
Release Notes: none
