### PR TITLE
tools: making sure extensions have maintainer OWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,7 +33,7 @@ extensions/filters/common/original_src @snowp @klarose
 # tracers.datadog extension
 /*/extensions/tracers/datadog @cgilmour @palazzem @mattklein123
 # tracers.xray extension
-/*/extensions/tracers/xray @marcomagdy @lavignes @htuch
+/*/extensions/tracers/xray @marcomagdy @lavignes @mattklein123
 # mysql_proxy extension
 /*/extensions/filters/network/mysql_proxy @rshriram @venilnoronha @mattklein123
 # quic extension

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,9 +31,9 @@ extensions/filters/common/original_src @snowp @klarose
 # sni_cluster extension
 /*/extensions/filters/network/sni_cluster @rshriram @lizan
 # tracers.datadog extension
-/*/extensions/tracers/datadog @cgilmour @palazzem
+/*/extensions/tracers/datadog @cgilmour @palazzem @mattklein123
 # tracers.xray extension
-/*/extensions/tracers/xray @marcomagdy @lavignes
+/*/extensions/tracers/xray @marcomagdy @lavignes @htuch
 # mysql_proxy extension
 /*/extensions/filters/network/mysql_proxy @rshriram @venilnoronha @mattklein123
 # quic extension
@@ -57,9 +57,9 @@ extensions/filters/common/original_src @snowp @klarose
 # http inspector
 /*/extensions/filters/listener/http_inspector @yxue @PiotrSikora @lizan
 # attribute context
-/*/extensions/filters/common/expr @kyessenov @yangminzhu
+/*/extensions/filters/common/expr @kyessenov @yangminzhu @lizan
 # webassembly common extension
-/*/extensions/common/wasm @jplevyak @PiotrSikora
+/*/extensions/common/wasm @jplevyak @PiotrSikora @lizan
 # common crypto extension
 /*/extensions/common/crypto @lizan @PiotrSikora @bdecoste
 /*/extensions/filters/http/grpc_http1_bridge @snowp @jose

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -894,7 +894,7 @@ if __name__ == "__main__":
                                     "    {}".format(line))
             maintainer = len(set(owners).intersection(set(maintainers))) > 0
             if not maintainer:
-              error_messages.append("Extensions require at least 1 maintainer OWNER:\n"
+              error_messages.append("Extensions require at least one maintainer OWNER:\n"
                                     "    {}".format(line))
 
       return owned

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -875,6 +875,11 @@ if __name__ == "__main__":
   # error_messages.
   def ownedDirectories(error_messages):
     owned = []
+    maintainers = [
+        '@mattklein123', '@htuch', '@alyssawilk', '@zuercher', '@lizan', '@snowp', '@junr03',
+        '@dnoe', '@dio', '@jmarantz'
+    ]
+
     try:
       with open('./CODEOWNERS') as f:
         for line in f:
@@ -887,6 +892,15 @@ if __name__ == "__main__":
             if len(owners) < 2:
               error_messages.append("Extensions require at least 2 owners in CODEOWNERS:\n"
                                     "    {}".format(line))
+            maintainer = False
+            for owner in owners:
+              if owner in maintainers:
+                maintainer = True
+                break
+            if not maintainer:
+              error_messages.append("Extensions require at least 1 maintainer OWNER:\n"
+                                    "    {}".format(line))
+
       return owned
     except IOError:
       return []  # for the check format tests.

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -892,11 +892,7 @@ if __name__ == "__main__":
             if len(owners) < 2:
               error_messages.append("Extensions require at least 2 owners in CODEOWNERS:\n"
                                     "    {}".format(line))
-            maintainer = False
-            for owner in owners:
-              if owner in maintainers:
-                maintainer = True
-                break
+            maintainer = len(set(owners).intersection(set(maintainers))) > 0
             if not maintainer:
               error_messages.append("Extensions require at least 1 maintainer OWNER:\n"
                                     "    {}".format(line))


### PR DESCRIPTION
Adding an actual maintainer check in the check_format script, rather than assuming we'll catch it in review.
Back-adding the folks who merged extensions as OWNERS to those extensions.

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a