### PR TITLE
Add TimerImpl::enableHRTimer - take two

### DIFF
--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -43,6 +43,15 @@ public:
                            const ScopeTrackedObject* object = nullptr) PURE;
 
   /**
+   * Enable a pending high resolution timeout. If a timeout is already pending, it will be reset to
+   * the new timeout.
+   *
+   * @param us supplies the duration of the alarm in microseconds.
+   * @param object supplies an optional scope for the duration of the alarm.
+   */
+  virtual void enableHRTimer(const std::chrono::microseconds& us,
+                             const ScopeTrackedObject* object = nullptr) PURE;
+  /**
    * Return whether the timer is currently armed.
    */
   virtual bool enabled() PURE;

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -9,7 +9,7 @@
 namespace Envoy {
 namespace Event {
 
-void TimerUtils::millisecondsToTimeval(const std::chrono::milliseconds& d, timeval& tv) {
+void TimerUtils::microsecondsToTimeval(const std::chrono::microseconds& d, timeval& tv) {
   std::chrono::seconds secs = std::chrono::duration_cast<std::chrono::seconds>(d);
   std::chrono::microseconds usecs = std::chrono::duration_cast<std::chrono::microseconds>(d - secs);
 
@@ -38,12 +38,17 @@ TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Dispatcher& dispat
 void TimerImpl::disableTimer() { event_del(&raw_event_); }
 
 void TimerImpl::enableTimer(const std::chrono::milliseconds& d, const ScopeTrackedObject* object) {
+  enableHRTimer(d, object);
+}
+
+void TimerImpl::enableHRTimer(const std::chrono::microseconds& d,
+                              const ScopeTrackedObject* object = nullptr) {
   object_ = object;
   if (d.count() == 0) {
     event_active(&raw_event_, EV_TIMEOUT, 0);
   } else {
     timeval tv;
-    TimerUtils::millisecondsToTimeval(d, tv);
+    TimerUtils::microsecondsToTimeval(d, tv);
     event_add(&raw_event_, &tv);
   }
 }

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -9,14 +9,6 @@
 namespace Envoy {
 namespace Event {
 
-void TimerUtils::microsecondsToTimeval(const std::chrono::microseconds& d, timeval& tv) {
-  std::chrono::seconds secs = std::chrono::duration_cast<std::chrono::seconds>(d);
-  std::chrono::microseconds usecs = std::chrono::duration_cast<std::chrono::microseconds>(d - secs);
-
-  tv.tv_sec = secs.count();
-  tv.tv_usec = usecs.count();
-}
-
 TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Dispatcher& dispatcher)
     : cb_(cb), dispatcher_(dispatcher) {
   ASSERT(cb_);
@@ -38,17 +30,23 @@ TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Dispatcher& dispat
 void TimerImpl::disableTimer() { event_del(&raw_event_); }
 
 void TimerImpl::enableTimer(const std::chrono::milliseconds& d, const ScopeTrackedObject* object) {
-  enableHRTimer(d, object);
+  timeval tv;
+  TimerUtils::durationToTimeval(d, tv);
+  internalEnableTimer(tv, object);
 }
 
 void TimerImpl::enableHRTimer(const std::chrono::microseconds& d,
                               const ScopeTrackedObject* object = nullptr) {
+  timeval tv;
+  TimerUtils::durationToTimeval(d, tv);
+  internalEnableTimer(tv, object);
+}
+
+void TimerImpl::internalEnableTimer(const timeval& tv, const ScopeTrackedObject* object) {
   object_ = object;
-  if (d.count() == 0) {
+  if (tv.tv_sec == 0 && tv.tv_usec == 0) {
     event_active(&raw_event_, EV_TIMEOUT, 0);
   } else {
-    timeval tv;
-    TimerUtils::microsecondsToTimeval(d, tv);
     event_add(&raw_event_, &tv);
   }
 }

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -16,7 +16,7 @@ namespace Event {
  */
 class TimerUtils {
 public:
-  static void millisecondsToTimeval(const std::chrono::milliseconds& d, timeval& tv);
+  static void microsecondsToTimeval(const std::chrono::microseconds& d, timeval& tv);
 };
 
 /**
@@ -29,6 +29,9 @@ public:
   // Timer
   void disableTimer() override;
   void enableTimer(const std::chrono::milliseconds& d, const ScopeTrackedObject* scope) override;
+  void enableHRTimer(const std::chrono::microseconds& us,
+                     const ScopeTrackedObject* object) override;
+
   bool enabled() override;
 
 private:

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -19,9 +19,9 @@ public:
   /**
    * Intended for consumption by enable(HR)Timer, this method is templated method to avoid implicit
    * duration conversions for its input arguments. This lets us have an opportunity to check bounds
-   * before doing any conversions. When the passed in duration exceeds INT32_T max days, the output
-   * will be clipped to yield INT32_MAX days worth of seconds and 0 microseconds for the output
-   * argument. Throws an EnvoyException on negative duration input.
+   * before doing any conversions. When the passed in duration exceeds INT32_MAX max seconds, the
+   * output will be clipped to yield INT32_MAX seconds and 0 microseconds for the
+   * output argument. Throws an EnvoyException on negative duration input.
    * @tparam Duration std::chrono duration type, e.g. seconds, milliseconds, ...
    * @param d duration value
    * @param tv output parameter that will be updated

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -19,9 +19,9 @@ public:
   /**
    * Intended for consumption by enable(HR)Timer, this method is templated method to avoid implicit
    * duration conversions for its input arguments. This lets us have an opportunity to check bounds
-   * before doing any conversions. When the passed in duration exceeds UINT32_T max days, the output
+   * before doing any conversions. When the passed in duration exceeds INT32_T max days, the output
    * will be clipped to yield INT32_MAX days worth of seconds and 0 microseconds for the output
-   * argument. ASSERTS on negative duration input.
+   * argument. Throws an EnvoyException on negative duration input.
    * @tparam Duration std::chrono duration type, e.g. seconds, milliseconds, ...
    * @param d duration value
    * @param tv output parameter that will be updated

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -31,10 +31,6 @@ public:
       throw EnvoyException(
           fmt::format("Negative duration passed to durationToTimeval(): {}", d.count()));
     };
-    // We need to worry about:
-    // - overflowing tv
-    // - overflowing when doing narrowing conversions, e.g. seconds -> nanoseconds
-    // - practically, do we ever want to sleep for a super large amount of time?
     constexpr int64_t clip_to = INT32_MAX; // 136.102208 years
     auto secs = std::chrono::duration_cast<std::chrono::seconds>(d);
     if (secs.count() > clip_to) {

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -20,11 +20,11 @@ public:
    * Intended for consumption by enable(HR)Timer, this method is templated method to avoid implicit
    * duration conversions for its input arguments. This lets us have an opportunity to check bounds
    * before doing any conversions. When the passed in duration exceeds UINT32_T max days, the output
-   * timeval will be clipped to yield INT32_MAX days worth of seconds and and 0 usecs for the
-   * timeval output argument. ASSERTS on negative duration input.
+   * will be clipped to yield INT32_MAX days worth of seconds and 0 microseconds for the output
+   * argument. ASSERTS on negative duration input.
    * @tparam Duration std::chrono duration type, e.g. seconds, milliseconds, ...
    * @param d duration value
-   * @param tv timeval to update
+   * @param tv output parameter that will be updated
    */
   template <typename Duration> static void durationToTimeval(const Duration& d, timeval& tv) {
     if (d.count() < 0) {
@@ -32,7 +32,7 @@ public:
           fmt::format("Negative duration passed to durationToTimeval(): {}", d.count()));
     };
     // We need to worry about:
-    // - overflowing tv.tv_sec
+    // - overflowing tv
     // - overflowing when doing narrowing conversions, e.g. seconds -> nanoseconds
     // - practically, do we ever want to sleep for a super large amount of time?
     constexpr int64_t clip_to = INT32_MAX; // 136.102208 years

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -21,7 +21,8 @@ public:
    * duration conversions for its input arguments. This lets us have an opportunity to check bounds
    * before doing any conversions. When the passed in duration exceeds INT32_MAX max seconds, the
    * output will be clipped to yield INT32_MAX seconds and 0 microseconds for the
-   * output argument. Throws an EnvoyException on negative duration input.
+   * output argument. We clip to INT32_MAX to guard against overflowing the timeval structure.
+   * Throws an EnvoyException on negative duration input.
    * @tparam Duration std::chrono duration type, e.g. seconds, milliseconds, ...
    * @param d duration value
    * @param tv output parameter that will be updated

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -18,6 +18,7 @@ envoy_cc_test(
         "//source/common/stats:isolated_store_lib",
         "//test/mocks:common_lib",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -148,6 +148,8 @@ public:
   MOCK_METHOD0(disableTimer, void());
   MOCK_METHOD2(enableTimer,
                void(const std::chrono::milliseconds&, const ScopeTrackedObject* scope));
+  MOCK_METHOD2(enableHRTimer,
+               void(const std::chrono::microseconds&, const ScopeTrackedObject* scope));
   MOCK_METHOD0(enabled, bool());
 
   MockDispatcher* dispatcher_{};

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -61,7 +61,11 @@ public:
   // Timer
   void disableTimer() override;
   void enableTimer(const std::chrono::milliseconds& duration,
-                   const ScopeTrackedObject* scope) override;
+                   const ScopeTrackedObject* scope) override {
+    enableHRTimer(duration, scope);
+  };
+  void enableHRTimer(const std::chrono::microseconds& duration,
+                     const ScopeTrackedObject* scope) override;
   bool enabled() override {
     Thread::LockGuard lock(time_system_.mutex_);
     return armed_ || base_timer_->enabled();
@@ -177,8 +181,8 @@ void SimulatedTimeSystemHelper::Alarm::Alarm::disableTimerLockHeld() {
   }
 }
 
-void SimulatedTimeSystemHelper::Alarm::Alarm::enableTimer(const std::chrono::milliseconds& duration,
-                                                          const ScopeTrackedObject* scope) {
+void SimulatedTimeSystemHelper::Alarm::Alarm::enableHRTimer(
+    const std::chrono::microseconds& duration, const ScopeTrackedObject* scope) {
   Thread::LockGuard lock(time_system_.mutex_);
   disableTimerLockHeld();
   armed_ = true;
@@ -287,7 +291,7 @@ int64_t SimulatedTimeSystemHelper::nextIndex() {
 }
 
 void SimulatedTimeSystemHelper::addAlarmLockHeld(
-    Alarm* alarm, const std::chrono::milliseconds& duration) NO_THREAD_SAFETY_ANALYSIS {
+    Alarm* alarm, const std::chrono::microseconds& duration) NO_THREAD_SAFETY_ANALYSIS {
   ASSERT(&(alarm->timeSystem()) == this);
   alarm->setTimeLockHeld(monotonic_time_ + duration);
   alarms_.insert(alarm);

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -86,7 +86,7 @@ private:
   int64_t nextIndex();
 
   // Adds/removes an alarm.
-  void addAlarmLockHeld(Alarm*, const std::chrono::milliseconds& duration)
+  void addAlarmLockHeld(Alarm*, const std::chrono::microseconds& duration)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   void removeAlarmLockHeld(Alarm*) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -994,6 +994,7 @@ thru
 timespan
 timestamp
 timestamps
+timeval
 tm
 tmp
 tmpfile


### PR DESCRIPTION
- Updates TimerUtils::durationToTimeval to use templating to avoid
implicit conversions of durations when passing argument, thereby
generating an opportunity to bound the input before doing conversions
on it. Throws when passed a negative duration.
- Adds some more tests around this
- Slightly refactored version of  #9155

Risk Level: medium
Testing: unit tests
