### PR TITLE
rbac context: add request protocol

### DIFF
--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -77,7 +77,7 @@ The following attributes are exposed to the language runtime:
    request.id, string, Request ID
    request.size, int, Size of the request body
    request.total_size, int, Total size of the request including the headers
-   request.protocol, string, Request protocol, e.g. "HTTP/2"
+   request.protocol, string, Request protocol e.g. "HTTP/2"
    response.code, int, Response HTTP status code
    response.headers, string map, All response headers
    response.trailers, string map, All response trailers

--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -77,6 +77,7 @@ The following attributes are exposed to the language runtime:
    request.id, string, Request ID
    request.size, int, Size of the request body
    request.total_size, int, Total size of the request including the headers
+   request.protocol, string, Request protocol, e.g. "HTTP/2"
    response.code, int, Response HTTP status code
    response.headers, string map, All response headers
    response.trailers, string map, All response trailers

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/common/expr/context.h"
 
+#include "common/http/utility.h"
+
 #include "absl/strings/numbers.h"
 #include "absl/time/time.h"
 
@@ -81,6 +83,12 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
     auto duration = info_.requestComplete();
     if (duration.has_value()) {
       return CelValue::CreateDuration(absl::FromChrono(duration.value()));
+    }
+  } else if (value == Protocol) {
+    if (info_.protocol().has_value()) {
+      return CelValue::CreateString(&Http::Utility::getProtocolString(info_.protocol().value()));
+    } else {
+      return {};
     }
   }
 

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -30,6 +30,7 @@ constexpr absl::string_view UserAgent = "useragent";
 constexpr absl::string_view Size = "size";
 constexpr absl::string_view TotalSize = "total_size";
 constexpr absl::string_view Duration = "duration";
+constexpr absl::string_view Protocol = "protocol";
 
 // Symbols for traversing the response properties
 constexpr absl::string_view Response = "response";

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -45,6 +45,7 @@ TEST(Context, RequestAttributes) {
   EXPECT_CALL(info, startTime()).WillRepeatedly(Return(start_time));
   absl::optional<std::chrono::nanoseconds> dur = std::chrono::nanoseconds(15000000);
   EXPECT_CALL(info, requestComplete()).WillRepeatedly(Return(dur));
+  EXPECT_CALL(info, protocol()).WillRepeatedly(Return(Http::Protocol::Http2));
 
   // stub methods
   EXPECT_EQ(0, request.size());
@@ -156,6 +157,13 @@ TEST(Context, RequestAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsDuration());
     EXPECT_EQ("15ms", absl::FormatDuration(value.value().DurationOrDie()));
+  }
+
+  {
+    auto value = request[CelValue::CreateStringView(Protocol)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("HTTP/2", value.value().StringOrDie().value());
   }
 }
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: populate `request.protocol` from stream info (left over from a previous iteration).
Risk Level: low 
Testing: unit
Docs Changes: added a line to RBAC doc
Release Notes: none