### PR TITLE
admin: publish extension names in the config dump

### DIFF
--- a/api/envoy/admin/v2alpha/config_dump.proto
+++ b/api/envoy/admin/v2alpha/config_dump.proto
@@ -31,6 +31,7 @@ message ConfigDump {
   // * *clusters*: :ref:`ClustersConfigDump <envoy_api_msg_admin.v2alpha.ClustersConfigDump>`
   // * *listeners*: :ref:`ListenersConfigDump <envoy_api_msg_admin.v2alpha.ListenersConfigDump>`
   // * *routes*:  :ref:`RoutesConfigDump <envoy_api_msg_admin.v2alpha.RoutesConfigDump>`
+  // * *extensions*:  :ref:`ExtensionsConfigDump <envoy_api_msg_admin.v2alpha.ExtensionsConfigDump>`
   repeated google.protobuf.Any configs = 1;
 }
 
@@ -284,4 +285,15 @@ message SecretsConfigDump {
   // The dynamically loaded warming secrets. These are secrets that are currently undergoing
   // warming in preparation to service clusters or listeners.
   repeated DynamicSecret dynamic_warming_secrets = 3;
+}
+
+// This message lists the extensions that are available in the Envoy server.
+message ExtensionsConfigDump {
+  message ExtensionList {
+    repeated string extensions = 1;
+  }
+
+  // A map of extension category name to a list of the names of the
+  // extensions that are available in this category.
+  map<string, ExtensionList> categories = 1;
 }

--- a/api/envoy/admin/v3alpha/config_dump.proto
+++ b/api/envoy/admin/v3alpha/config_dump.proto
@@ -35,6 +35,7 @@ message ConfigDump {
   // * *clusters*: :ref:`ClustersConfigDump <envoy_api_msg_admin.v3alpha.ClustersConfigDump>`
   // * *listeners*: :ref:`ListenersConfigDump <envoy_api_msg_admin.v3alpha.ListenersConfigDump>`
   // * *routes*:  :ref:`RoutesConfigDump <envoy_api_msg_admin.v3alpha.RoutesConfigDump>`
+  // * *extensions*:  :ref:`ExtensionsConfigDump <envoy_api_msg_admin.v3alpha.ExtensionsConfigDump>`
   repeated google.protobuf.Any configs = 1;
 }
 
@@ -342,4 +343,21 @@ message SecretsConfigDump {
   // The dynamically loaded warming secrets. These are secrets that are currently undergoing
   // warming in preparation to service clusters or listeners.
   repeated DynamicSecret dynamic_warming_secrets = 3;
+}
+
+// This message lists the extensions that are available in the Envoy server.
+message ExtensionsConfigDump {
+  option (udpa.api.annotations.versioning).previous_message_type =
+      "envoy.admin.v2alpha.ExtensionsConfigDump";
+
+  message ExtensionList {
+    option (udpa.api.annotations.versioning).previous_message_type =
+        "envoy.admin.v2alpha.ExtensionsConfigDump.ExtensionList";
+
+    repeated string extensions = 1;
+  }
+
+  // A map of extension category name to a list of the names of the
+  // extensions that are available in this category.
+  map<string, ExtensionList> categories = 1;
 }

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.13.0 (pending)
 ================
 * access log: added FILTER_STATE :ref:`access log formatters <config_access_log_format>` and gRPC access logger.
+* admin: published extension names in the :http:get:`/config_dump` endpoint.
 * api: remove all support for v1
 * buffer: remove old implementation
 * build: official released binary is now built against libc++.

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -240,6 +240,7 @@ public:
 
 private:
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
+  ProtobufTypes::MessagePtr dumpExtensionsConfig();
   void flushStats();
   void flushStatsInternal();
   void updateServerStats();
@@ -296,7 +297,8 @@ private:
   bool terminated_;
   std::unique_ptr<Logger::FileSinkDelegate> file_logger_;
   envoy::config::bootstrap::v2::Bootstrap bootstrap_;
-  ConfigTracker::EntryOwnerPtr config_tracker_entry_;
+  ConfigTracker::EntryOwnerPtr bootstrap_config_entry_;
+  ConfigTracker::EntryOwnerPtr extensions_config_entry_;
   SystemTime bootstrap_config_update_time_;
   Grpc::AsyncClientManagerPtr async_client_manager_;
   Upstream::ProdClusterInfoFactory info_factory_;

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -8,6 +8,7 @@
 
 #include "common/common/fmt.h"
 #include "common/profiler/profiler.h"
+#include "common/protobuf/protobuf.h"
 #include "common/stats/stats_matcher_impl.h"
 
 #include "test/common/stats/stat_test_utility.h"
@@ -348,14 +349,14 @@ TEST_P(IntegrationAdminTest, Admin) {
       "type.googleapis.com/envoy.admin.v2alpha.RoutesConfigDump",
       "type.googleapis.com/envoy.admin.v2alpha.SecretsConfigDump"};
 
-  const std::array<MessagePtr> messages = {
-      MessagePtr(new envoy::admin::v2alpha::BootstrapConfigDump()),
-      MessagePtr(new envoy::admin::v2alpha::ClustersConfigDump()),
-      MessagePtr(new envoy::admin::v2alpha::ExtensionsConfigDump()),
-      MessagePtr(new envoy::admin::v2alpha::ListenersConfigDump()),
-      MessagePtr(new envoy::admin::v2alpha::ScopedRoutesConfigDump()),
-      MessagePtr(new envoy::admin::v2alpha::RoutesConfigDump()),
-      MessagePtr(new envoy::admin::v2alpha::SecretsConfigDump()),
+  const std::array<ProtobufTypes::MessagePtr, 7> messages = {
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::BootstrapConfigDump()),
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::ClustersConfigDump()),
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::ExtensionsConfigDump()),
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::ListenersConfigDump()),
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::ScopedRoutesConfigDump()),
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::RoutesConfigDump()),
+      ProtobufTypes::MessagePtr(new envoy::admin::v2alpha::SecretsConfigDump()),
   };
 
   static_assert(expected_types.size() == messages.size(), "inconsistent config dump message types");

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -1048,6 +1048,7 @@ unlink
 unlinked
 unmap
 unmapped
+unmarshalled
 unoptimized
 unordered
 unowned


### PR DESCRIPTION
*Description:* Publish extension names (grouped by category) in the `/config_dump` admin endpoint.
*Risk Level:* Low
*Testing:* Unit tests
*Docs Changes:* Generated API docs
*Release Notes:* Yes
*Fixes:* #9097 
