### PR TITLE
docs: show v2alpha network filters in documentation

### DIFF
--- a/docs/root/api-v2/config/filter/network/network.rst
+++ b/docs/root/api-v2/config/filter/network/network.rst
@@ -8,4 +8,5 @@ Network filters
   */empty/*
   */v1alpha1/*
   */v2/*
+  */v2alpha/*
   */v2alpha1/*


### PR DESCRIPTION
Description: The network filter documentation is not configured to search for `v2alpha`, which is the correct way to version alpha filters in v2. This brings it on par with http: https://github.com/envoyproxy/envoy/blob/master/docs/root/api-v2/config/filter/http/http.rst
Risk Level: low
Testing: N/A
Docs Changes: included
Release Notes: N/A
Relates to issue #8131

Signed-off-by: Derek Argueta <dereka@pinterest.com>