### PR TITLE
rbac: match any uri san or dns san

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -17,6 +17,7 @@ Version history
 * lb_subset_config: new fallback policy for selectors: :ref:`KEYS_SUBSET<envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`
 * listeners: added :ref:`reuse_port<envoy_api_field_Listener.reuse_port>` option.
 * logger: added :ref:`--log-format-escaped <operations_cli>` command line option to escape newline characters in application logs.
+* rbac: added support for matching all subject alt names instead of first in :ref:`principal_name <envoy_api_field_config.rbac.v2.Principal.Authenticated.principal_name>`.
 * redis: performance improvement for larger split commands by avoiding string copies.
 * router: added support for REQ(header-name) :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 * router: skip the Location header when the response code is not a 201 or a 3xx.

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -140,22 +140,24 @@ bool AuthenticatedMatcher::matches(const Network::Connection& connection,
     return true;
   }
 
-  const auto uriSans = ssl->uriSanPeerCertificate();
-  std::string principal;
   // If set, The URI SAN  or DNS SAN in that order is used as Principal, otherwise the subject field
   // is used.
-  if (!uriSans.empty()) {
-    principal = uriSans[0];
-  } else {
-    const auto dnsSans = ssl->dnsSansPeerCertificate();
-    if (!dnsSans.empty()) {
-      principal = dnsSans[0];
-    } else {
-      principal = ssl->subjectPeerCertificate();
+  if (!ssl->uriSanPeerCertificate().empty()) {
+    for (const std::string& uri : ssl->uriSanPeerCertificate()) {
+      if (matcher_.value().match(uri)) {
+        return true;
+      }
     }
+  } else if (!ssl->dnsSansPeerCertificate().empty()) {
+    for (const std::string& dns : ssl->dnsSansPeerCertificate()) {
+      if (matcher_.value().match(dns)) {
+        return true;
+      }
+    }
+  } else {
+    return matcher_.value().match(ssl->subjectPeerCertificate());
   }
-
-  return matcher_.value().match(principal);
+  return false;
 }
 
 bool MetadataMatcher::matches(const Network::Connection&, const Envoy::Http::HeaderMap&,

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -197,9 +197,12 @@ TEST(AuthenticatedMatcher, uriSanPeerCertificate) {
   EXPECT_CALL(*ssl, uriSanPeerCertificate()).WillRepeatedly(Return(sans));
   EXPECT_CALL(Const(conn), ssl()).WillRepeatedly(Return(ssl));
 
-  // We should get the first URI SAN.
+  // We should check if any URI SAN matches.
   envoy::config::rbac::v2::Principal_Authenticated auth;
   auth.mutable_principal_name()->set_exact("foo");
+  checkMatcher(AuthenticatedMatcher(auth), true, conn);
+
+  auth.mutable_principal_name()->set_exact("baz");
   checkMatcher(AuthenticatedMatcher(auth), true, conn);
 
   auth.mutable_principal_name()->set_exact("bar");
@@ -219,9 +222,12 @@ TEST(AuthenticatedMatcher, dnsSanPeerCertificate) {
   EXPECT_CALL(*ssl, dnsSansPeerCertificate()).WillRepeatedly(Return(dns_sans));
   EXPECT_CALL(Const(conn), ssl()).WillRepeatedly(Return(ssl));
 
-  // We should get the first DNS SAN as URI SAN is not available.
+  // We should get check if any DNS SAN matches as URI SAN is not available.
   envoy::config::rbac::v2::Principal_Authenticated auth;
   auth.mutable_principal_name()->set_exact("foo");
+  checkMatcher(AuthenticatedMatcher(auth), true, conn);
+
+  auth.mutable_principal_name()->set_exact("baz");
   checkMatcher(AuthenticatedMatcher(auth), true, conn);
 
   auth.mutable_principal_name()->set_exact("bar");
@@ -303,7 +309,7 @@ TEST(PolicyMatcher, PolicyMatcher) {
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
 
   const std::vector<std::string> sans{"bar", "baz"};
-  EXPECT_CALL(*ssl, uriSanPeerCertificate()).Times(2).WillRepeatedly(Return(sans));
+  EXPECT_CALL(*ssl, uriSanPeerCertificate()).Times(4).WillRepeatedly(Return(sans));
   EXPECT_CALL(Const(conn), ssl()).Times(2).WillRepeatedly(Return(ssl));
   EXPECT_CALL(conn, localAddress()).Times(2).WillRepeatedly(ReturnRef(addr));
 


### PR DESCRIPTION
This PR implements matching that looks at any URI SAN or DNS SAN instead of the first one as is being today.
Risk Level: Low
Testing: Added
Docs Changes: N/A
Release Notes: N/A

