### PR TITLE
Adding trace headers in response.

### DIFF
--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -27,6 +27,13 @@ static_resources:
                   cluster: service1
                 decorator:
                   operation: checkAvailability
+              response_headers_to_add:
+              - header:
+                  key: "x-b3-traceid"
+                  value: "%REQ(x-b3-traceid)%"
+              - header:
+                  key: "x-request-id"
+                  value: "%REQ(x-request-id)%"
           http_filters:
           - name: envoy.router
             typed_config: {}


### PR DESCRIPTION
Description:  This PR adds two response headers to the `zipkin-tracing` example to help show how to return two key headers.  These response headers were requested to be added in the following two issues:

* https://github.com/envoyproxy/envoy/issues/8683
* https://github.com/envoyproxy/envoy/issues/9243

Risk Level:  Low
Testing: https://github.com/envoyproxy/envoy/issues/9243#issuecomment-562330414
Docs Changes: N/A
Release Notes:   This PR should be merged when 1.13.0 is released.
