### PR TITLE
config: add clarifying comment to watch_map.cc

### DIFF
--- a/source/common/config/watch_map.cc
+++ b/source/common/config/watch_map.cc
@@ -150,6 +150,7 @@ std::set<std::string> WatchMap::findAdditions(const std::vector<std::string>& ne
       newly_added_to_subscription.insert(name);
       watch_interest_[name] = {watch};
     } else {
+      // Add this watch to the already-existing set at watch_interest_[name]
       entry->second.insert(watch);
     }
   }


### PR DESCRIPTION
I thought I noticed a bug in watch_map.cc: that a set in watch_interest_ could
never have more than one item. It took me a while to realize otherwise. If the
author gets confused, it probably needs a comment.

Risk Level: none
Testing: comment change only