### PR TITLE
Delete outdated comment

### DIFF
--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -86,9 +86,6 @@ public:
   // endpoints churning during a deploy of a large cluster). A possible improvement
   // would be to use TLS and post metadata updates from the main thread. This model would
   // possibly benefit other related and expensive computations too (e.g.: updating subsets).
-  //
-  // TODO(rgs1): we should move to absl locks, once there's support for R/W locks. We should
-  // also add lock annotations, once they work correctly with R/W locks.
   const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
     absl::ReaderMutexLock lock(&metadata_mutex_);
     return metadata_;


### PR DESCRIPTION
`metadata_` is now guarded by absl locks and lock annotations were
also added by @akonradi.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
