### PR TITLE
Use Timer's enabled() method

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -480,7 +480,7 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   }
 
   // Ensure there's a timer set to deliver these updates.
-  if (!updates->timer_enabled_) {
+  if (!updates->timer_->enabled()) {
     updates->enableTimer(timeout);
   }
 
@@ -500,7 +500,6 @@ void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
   postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
 
   cm_stats_.cluster_updated_via_merge_.inc();
-  updates.timer_enabled_ = false;
   updates.last_updated_ = time_source_.monotonicTime();
 }
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -407,24 +407,22 @@ private:
   struct PendingUpdates {
     ~PendingUpdates() { disableTimer(); }
     void enableTimer(const uint64_t timeout) {
-      ASSERT(!timer_enabled_);
       if (timer_ != nullptr) {
+        ASSERT(!timer_->enabled());
         timer_->enableTimer(std::chrono::milliseconds(timeout));
-        timer_enabled_ = true;
       }
     }
     bool disableTimer() {
-      const bool was_enabled = timer_enabled_;
-      if (timer_ != nullptr) {
-        timer_->disableTimer();
-        timer_enabled_ = false;
+      if (timer_ == nullptr) {
+        return false;
       }
+
+      const bool was_enabled = timer_->enabled();
+      timer_->disableTimer();
       return was_enabled;
     }
 
     Event::TimerPtr timer_;
-    // TODO(rgs1): this should be part of Event::Timer's interface.
-    bool timer_enabled_{};
     // This is default constructed to the clock's epoch:
     // https://en.cppreference.com/w/cpp/chrono/time_point/time_point
     //


### PR DESCRIPTION
There's no need to manually track if a timer is enabled or not,
this is now provided by Timer's interface.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
