### PR TITLE
ip tagging: remove TODO comment that won't be addressed

### DIFF
--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.cc
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.cc
@@ -81,7 +81,6 @@ Http::FilterHeadersStatus IpTaggingFilter::decodeHeaders(Http::HeaderMap& header
     headers.appendEnvoyIpTags(tags_join, ",");
 
     // We must clear the route cache or else we can't match on x-envoy-ip-tags.
-    // TODO(rgs): this should either be configurable, because it's expensive, or optimized.
     callbacks_->clearRouteCache();
 
     // For a large number(ex > 1000) of tags, stats cardinality will be an issue.


### PR DESCRIPTION
So clearing the route cache when there's an ip tags hit is something
that we've been doing for ~2 years. We used it in prod, it works and
it's not that expensive.

So, lets get rid of the comment that suggests it's either too
expensive or that it'll be refactored. I don't think the latter --
changing how the route cache works -- will happen in the near future
so lets just remove to the comment to avoid confusing newcomers
or casual readers.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
