### PR TITLE
Add missing runtime_key_prefix to traffic_splitting.rst doc

### DIFF
--- a/docs/root/configuration/http/http_conn_man/traffic_splitting.rst
+++ b/docs/root/configuration/http/http_conn_man/traffic_splitting.rst
@@ -109,6 +109,7 @@ to each upstream cluster.
          - match: { prefix: / }
            route:
              weighted_clusters:
+               runtime_key_prefix: routing.traffic_split.helloworld
                clusters:
                  - name: helloworld_v1
                    weight: 33


### PR DESCRIPTION
I believe `runtime_key_prefix` property needs to be defined in the traffic_splitting.rst doc in order to make the sentence at the end of the doc work:

> The weights assigned to each cluster can be dynamically adjusted using the following runtime variables: `routing.traffic_split.helloworld.helloworld_v1`, `routing.traffic_split.helloworld.helloworld_v2` and `routing.traffic_split.helloworld.helloworld_v3`

Also totally possible that I completely misinterpreted the doc - feel free to ignore/close it if that's the case.