### PR TITLE
Use flag for decompression error

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,7 @@ Version history
 * buffer: remove old implementation
 * build: official released binary is now built against libc++.
 * cluster: added :ref: `aggregate cluster <arch_overview_aggregate_cluster>` that allows load balancing between clusters.
+* decompressor: Remove decompressor hard assert failure and replace with an error flag that can be checked.
 * ext_authz: added :ref:`configurable ability<envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate<envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the `ext_authz` service.
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by envoy.reloadable_features.connection_header_sanitization which defaults to true.
@@ -1073,3 +1074,4 @@ Version history
 ==========================
 
 Initial open source release.
+

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,7 +9,7 @@ Version history
 * buffer: remove old implementation
 * build: official released binary is now built against libc++.
 * cluster: added :ref: `aggregate cluster <arch_overview_aggregate_cluster>` that allows load balancing between clusters.
-* decompressor: Remove decompressor hard assert failure and replace with an error flag.
+* decompressor: remove decompressor hard assert failure and replace with an error flag.
 * ext_authz: added :ref:`configurable ability<envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate<envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the `ext_authz` service.
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by envoy.reloadable_features.connection_header_sanitization which defaults to true.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,7 +9,7 @@ Version history
 * buffer: remove old implementation
 * build: official released binary is now built against libc++.
 * cluster: added :ref: `aggregate cluster <arch_overview_aggregate_cluster>` that allows load balancing between clusters.
-* decompressor: Remove decompressor hard assert failure and replace with an error flag that can be checked.
+* decompressor: Remove decompressor hard assert failure and replace with an error flag.
 * ext_authz: added :ref:`configurable ability<envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate<envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the `ext_authz` service.
 * health check: gRPC health checker sets the gRPC deadline to the configured timeout duration.
 * http: added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by envoy.reloadable_features.connection_header_sanitization which defaults to true.
@@ -1074,4 +1074,3 @@ Version history
 ==========================
 
 Initial open source release.
-

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -29,6 +29,7 @@ namespace Logger {
   FUNCTION(config)                                                                                 \
   FUNCTION(connection)                                                                             \
   FUNCTION(conn_handler)                                                                           \
+  FUNCTION(decompression)                                                                          \
   FUNCTION(dubbo)                                                                                  \
   FUNCTION(file)                                                                                   \
   FUNCTION(filter)                                                                                 \

--- a/source/common/decompressor/BUILD
+++ b/source/common/decompressor/BUILD
@@ -17,5 +17,6 @@ envoy_cc_library(
         "//include/envoy/decompressor:decompressor_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:minimal_logger_lib",
     ],
 )

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -69,7 +69,7 @@ bool ZlibDecompressorImpl::inflateNext() {
   }
 
   if (result < 0) {
-    decompression_error_ = result; 
+    decompression_error_ = result;
     return false;
   }
 

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -68,7 +68,11 @@ bool ZlibDecompressorImpl::inflateNext() {
     return false; // This means that zlib needs more input, so stop here.
   }
 
-  RELEASE_ASSERT(result == Z_OK, "");
+  if (result < 0) {
+    decompression_error_ = result; 
+    return false;
+  }
+
   return true;
 }
 

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -3,9 +3,9 @@
 #include <memory>
 
 #include "envoy/common/exception.h"
-#include "common/common/logger.h"
 
 #include "common/common/assert.h"
+#include "common/common/logger.h"
 #include "common/common/stack_array.h"
 
 namespace Envoy {

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "envoy/common/exception.h"
+#include "common/common/logger.h"
 
 #include "common/common/assert.h"
 #include "common/common/stack_array.h"
@@ -70,6 +71,10 @@ bool ZlibDecompressorImpl::inflateNext() {
 
   if (result < 0) {
     decompression_error_ = result;
+    ENVOY_LOG(
+        trace,
+        "zlib decompression error: {}. Error codes are defined in https://www.zlib.net/manual.html",
+        result);
     return false;
   }
 

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -5,7 +5,6 @@
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
-#include "common/common/logger.h"
 #include "common/common/stack_array.h"
 
 namespace Envoy {

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -47,7 +47,6 @@ public:
   // When an error occurs, the result (a negative int) will be stored in this variable
   int decompression_error_{0};
 
-
 private:
   bool inflateNext();
   void updateOutput(Buffer::Instance& output_buffer);

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -12,7 +12,7 @@ namespace Decompressor {
 /**
  * Implementation of decompressor's interface.
  */
-class ZlibDecompressorImpl : public Decompressor
+class ZlibDecompressorImpl : public Decompressor,
                              public Logger::Loggable<Logger::Id::decompression> {
 public:
   ZlibDecompressorImpl();

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/common/logger.h"
 #include "envoy/decompressor/decompressor.h"
 
 #include "zlib.h"
@@ -10,7 +11,8 @@ namespace Decompressor {
 /**
  * Implementation of decompressor's interface.
  */
-class ZlibDecompressorImpl : public Decompressor {
+class ZlibDecompressorImpl : public Decompressor,
+                             public Loggable<Logger::Id::decompression> {
 public:
   ZlibDecompressorImpl();
 

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -43,6 +43,11 @@ public:
   // Decompressor
   void decompress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
 
+  // Int to track whether error occurred during decompression
+  // When an error occurs, the result (a negative int) will be stored in this variable
+  int decompression_error_{0};
+
+
 private:
   bool inflateNext();
   void updateOutput(Buffer::Instance& output_buffer);

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -43,8 +43,8 @@ public:
   // Decompressor
   void decompress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
 
-  // Int to track whether error occurred during decompression
-  // When an error occurs, the result (a negative int) will be stored in this variable
+  // Flag to track whether error occurred during decompression.
+  // When an error occurs, the error code (a negative int) will be stored in this variable.
   int decompression_error_{0};
 
 private:

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "common/common/logger.h"
 #include "envoy/decompressor/decompressor.h"
+
+#include "common/common/logger.h"
 
 #include "zlib.h"
 
@@ -11,8 +12,8 @@ namespace Decompressor {
 /**
  * Implementation of decompressor's interface.
  */
-class ZlibDecompressorImpl : public Decompressor,
-                             public Loggable<Logger::Id::decompression> {
+class ZlibDecompressorImpl : public Decompressor
+                             public Logger::Loggable<Logger::Id::decompression> {
 public:
   ZlibDecompressorImpl();
 

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -156,7 +156,7 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());
   EXPECT_EQ(original_text, decompressed_text);
-  ASSERT_EQ(0, decompressor.decompression_error_)
+  ASSERT_EQ(0, decompressor.decompression_error_);
 }
 
 // Tests decompression_error_ set to True when Decompression Fails

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -65,7 +65,7 @@ protected:
     decompressor.init(window_bits);
   }
 
-  static void unitializedDecompressorTestHelper() {
+  static void uninitializedDecompressorTestHelper() {
     Buffer::OwnedImpl input_buffer;
     Buffer::OwnedImpl output_buffer;
     ZlibDecompressorImpl decompressor;
@@ -79,7 +79,7 @@ protected:
 // init.
 TEST_F(ZlibDecompressorImplFailureTest, DecompressorFailureTest) {
   EXPECT_DEATH_LOG_TO_STDERR(decompressorBadInitTestHelper(100), "assert failure: result >= 0");
-  unitializedDecompressorTestHelper();
+  uninitializedDecompressorTestHelper();
 }
 
 // Exercises decompressor's checksum by calling it before init or decompress.

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -50,6 +50,7 @@ protected:
     ASSERT_EQ(compressor.checksum(), decompressor.checksum());
     ASSERT_EQ(original_text.length(), decompressed_text.length());
     EXPECT_EQ(original_text, decompressed_text);
+    ASSERT_EQ(0, decompressor.decompression_error_);
   }
 
   static const int64_t gzip_window_bits{31};
@@ -106,6 +107,7 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   drainBuffer(decompressor_output_buffer);
 
   EXPECT_EQ(compressor.checksum(), decompressor.checksum());
+  ASSERT_EQ(0, decompressor.decompression_error_);
 }
 
 // Exercises compression and decompression by compressing some data, decompressing it and then
@@ -154,6 +156,27 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());
   EXPECT_EQ(original_text, decompressed_text);
+  ASSERT_EQ(0, decompressor.decompression_error_)
+}
+
+// Tests decompression_error_ set to True when Decompression Fails
+TEST_F(ZlibDecompressorImplTest, FailedDecompression) {
+  Buffer::OwnedImpl buffer;
+  Buffer::OwnedImpl accumulation_buffer;
+
+  std::string original_text{};
+  for (uint64_t i = 0; i < 20; ++i) {
+    TestUtility::feedBufferWithRandomCharacters(buffer, default_input_size * i, i);
+    original_text.append(buffer.toString());
+    accumulation_buffer.add(buffer);
+    drainBuffer(buffer);
+  }
+  ZlibDecompressorImpl decompressor;
+  decompressor.init(gzip_window_bits);
+
+  decompressor.decompress(accumulation_buffer, buffer);
+
+  ASSERT_TRUE(decompressor.decompression_error_ < 0);
 }
 
 // Exercises decompression with a very small output buffer.
@@ -194,6 +217,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());
   EXPECT_EQ(original_text, decompressed_text);
+  ASSERT_EQ(0, decompressor.decompression_error_);
 }
 
 // Exercises decompression with other supported zlib initialization params.

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -58,7 +58,7 @@ protected:
   static const uint64_t default_input_size{796};
 };
 
-class ZlibDecompressorImplDeathTest : public ZlibDecompressorImplTest {
+class ZlibDecompressorImplFailureTest : public ZlibDecompressorImplTest {
 protected:
   static void decompressorBadInitTestHelper(int64_t window_bits) {
     ZlibDecompressorImpl decompressor;
@@ -71,13 +71,15 @@ protected:
     ZlibDecompressorImpl decompressor;
     TestUtility::feedBufferWithRandomCharacters(input_buffer, 100);
     decompressor.decompress(input_buffer, output_buffer);
+    ASSERT_TRUE(decompressor.decompression_error_ < 0);
   }
 };
 
-// Exercises death by passing bad initialization params or by calling decompress before init.
-TEST_F(ZlibDecompressorImplDeathTest, DecompressorDeathTest) {
+// Test different failures by passing bad initialization params or by calling decompress before
+// init.
+TEST_F(ZlibDecompressorImplFailureTest, DecompressorFailureTest) {
   EXPECT_DEATH_LOG_TO_STDERR(decompressorBadInitTestHelper(100), "assert failure: result >= 0");
-  EXPECT_DEATH_LOG_TO_STDERR(unitializedDecompressorTestHelper(), "assert failure: result == Z_OK");
+  unitializedDecompressorTestHelper();
 }
 
 // Exercises decompressor's checksum by calling it before init or decompress.


### PR DESCRIPTION
Description: Add flag for decompression failure rather than hard assert failure. This is a patch that Pinterest has been running for several months now.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: Added

Signed-off-by: Anika Mukherji <amukherji@pinterest.com>
