### PR TITLE
Update dependencies - Go, bazel-skylib, bazel-compilation-database, b…

### DIFF
--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -1,5 +1,5 @@
-BAZEL_SKYLIB_RELEASE = "0.8.0"
-BAZEL_SKYLIB_SHA256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e"
+BAZEL_SKYLIB_RELEASE = "0.9.0"
+BAZEL_SKYLIB_SHA256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0"
 
 OPENCENSUS_PROTO_GIT_SHA = "5cec5ea58c3efa81fa808f2bd38ce182da9ee731"  # Jul 25, 2019
 OPENCENSUS_PROTO_SHA256 = "faeb93f293ff715b0cb530d273901c0e2e99277b9ed1c0a0326bca9ec5774ad2"
@@ -24,7 +24,7 @@ ZIPKINAPI_SHA256 = "688c4fe170821dd589f36ec45aaadc03a618a40283bc1f97da8fa11686fc
 REPOSITORY_LOCATIONS = dict(
     bazel_skylib = dict(
         sha256 = BAZEL_SKYLIB_SHA256,
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/" + BAZEL_SKYLIB_RELEASE + "/bazel-skylib." + BAZEL_SKYLIB_RELEASE + ".tar.gz"],
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/" + BAZEL_SKYLIB_RELEASE + "/bazel_skylib-" + BAZEL_SKYLIB_RELEASE + ".tar.gz"],
     ),
     com_envoyproxy_protoc_gen_validate = dict(
         sha256 = PGV_SHA256,

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -6,7 +6,7 @@ load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependenci
 load("@upb//bazel:repository_defs.bzl", upb_bazel_version_repository = "bazel_version_repository")
 
 # go version for rules_go
-GO_VERSION = "1.13.3"
+GO_VERSION = "1.13.5"
 
 def envoy_dependency_imports(go_version = GO_VERSION):
     rules_foreign_cc_dependencies()

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,29 +1,29 @@
 REPOSITORY_LOCATIONS = dict(
     bazel_compdb = dict(
-        sha256 = "801b35d996a097d223e028815fdba8667bf62bc5efb353486603d31fc2ba6ff9",
-        strip_prefix = "bazel-compilation-database-0.4.1",
-        urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.4.1.tar.gz"],
+        sha256 = "87e376a685eacfb27bcc0d0cdf5ded1d0b99d868390ac50f452ba6ed781caffe",
+        strip_prefix = "bazel-compilation-database-0.4.2",
+        urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.4.2.tar.gz"],
     ),
     bazel_gazelle = dict(
-        sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz"],
+        sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz"],
     ),
     bazel_toolchains = dict(
-        sha256 = "83352b6e68fa797184071f35e3b67c7c8815efadcea81bb9cdb6bbbf2e07d389",
-        strip_prefix = "bazel-toolchains-1.1.3",
+        sha256 = "ca8aa49ceb47e9bee04dd67f0bec0b010032b37ebbe67147b535237e801d9a87",
+        strip_prefix = "bazel-toolchains-1.2.2",
         urls = [
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.1.3/bazel-toolchains-1.1.3.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1.1.3.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.2.2/bazel-toolchains-1.2.2.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1.2.2.tar.gz",
         ],
     ),
     build_bazel_rules_apple = dict(
-        urls = ["https://github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz"],
-        strip_prefix = "rules_apple-b869b0d3868d78a1d4ffd866ccb304fb68aa12c3",
-        sha256 = "bdc8e66e70b8a75da23b79f1f8c6207356df07d041d96d2189add7ee0780cf4e",
+        sha256 = "7a7afdd4869bb201c9352eed2daf37294d42b093579b70423490c1b4d4f6ce42",
+        urls = ["https://github.com/bazelbuild/rules_apple/releases/download/0.19.0/rules_apple.0.19.0.tar.gz"],
     ),
     envoy_build_tools = dict(
         sha256 = "a81ff3a12adedfc4641a926c9b167c53bea62784a81ac9ced7893436c709b60b",
         strip_prefix = "envoy-build-tools-07314d549e27e9a4033af6236888d2a9ee0ad443",
+        # 2019-11-22
         urls = ["https://github.com/envoyproxy/envoy-build-tools/archive/07314d549e27e9a4033af6236888d2a9ee0ad443.tar.gz"],
     ),
     boringssl = dict(
@@ -234,8 +234,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/2feabd5d64436e670084091a937855972ee35161.tar.gz"],
     ),
     io_bazel_rules_go = dict(
-        sha256 = "842ec0e6b4fbfdd3de6150b61af92901eeb73681fd4d185746644c338f51d4c0",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.20.1/rules_go-v0.20.1.tar.gz"],
+        sha256 = "e88471aea3a3a4f19ec1310a55ba94772d087e9ce46e41ae38ecebe17935de7b",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz"],
     ),
     rules_foreign_cc = dict(
         sha256 = "3184c244b32e65637a74213fc448964b687390eeeca42a36286f874c046bba15",
@@ -267,9 +267,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/census-instrumentation/opencensus-cpp/archive/13b1a2f29f541b6b2c4cb8bc3f6fbf3589d44227.tar.gz"],
     ),
     com_github_curl = dict(
-        sha256 = "d0393da38ac74ffac67313072d7fe75b1fa1010eb5987f63f349b024a36b7ffb",
-        strip_prefix = "curl-7.66.0",
-        urls = ["https://github.com/curl/curl/releases/download/curl-7_66_0/curl-7.66.0.tar.gz"],
+        sha256 = "52af3361cf806330b88b4fe6f483b6844209d47ae196ac46da4de59bb361ab02",
+        strip_prefix = "curl-7.67.0",
+        urls = ["https://github.com/curl/curl/releases/download/curl-7_67_0/curl-7.67.0.tar.gz"],
     ),
     com_googlesource_chromium_v8 = dict(
         # This archive was created using https://storage.googleapis.com/envoyproxy-wee8/wee8-archive.sh
@@ -289,9 +289,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/cel-cpp/archive/4767e5de36c5701fa8ea46d7de3765161ef98353.tar.gz"],
     ),
     com_googlesource_code_re2 = dict(
-        sha256 = "b0382aa7369f373a0148218f2df5a6afd6bfa884ce4da2dfb576b979989e615e",
-        strip_prefix = "re2-2019-09-01",
-        urls = ["https://github.com/google/re2/archive/2019-09-01.tar.gz"],
+        sha256 = "7268e1b4254d9ffa5ccf010fee954150dbb788fd9705234442e7d9f0ee5a42d3",
+        strip_prefix = "re2-2019-12-01",
+        urls = ["https://github.com/google/re2/archive/2019-12-01.tar.gz"],
     ),
     # Included to access FuzzedDataProvider.h. This is compiler agnostic but
     # provided as part of the compiler-rt source distribution. We can't use the
@@ -307,8 +307,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.76/fuzzit_Linux_x86_64.zip"],
     ),
     upb = dict(
-        sha256 = "61d0417abd60e65ed589c9deee7c124fe76a4106831f6ad39464e1525cef1454",
-        strip_prefix = "upb-9effcbcb27f0a665f9f345030188c0b291e32482",
-        urls = ["https://github.com/protocolbuffers/upb/archive/9effcbcb27f0a665f9f345030188c0b291e32482.tar.gz"],
+        sha256 = "e9f281c56ab1eb1f97a80ca8a83bb7ef73d230eabb8591f83876f4e7b85d9b47",
+        strip_prefix = "upb-8a3ae1ef3e3e3f26b45dec735c5776737fc7247f",
+        # 2019-11-19
+        urls = ["https://github.com/protocolbuffers/upb/archive/8a3ae1ef3e3e3f26b45dec735c5776737fc7247f.tar.gz"],
     ),
 )

--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -23,8 +23,8 @@ cd ../
 
 # Test grpc bridge example
 # install go
-curl -O https://storage.googleapis.com/golang/go1.13.3.linux-amd64.tar.gz
-tar -xf go1.13.3.linux-amd64.tar.gz
+curl -O https://storage.googleapis.com/golang/go1.13.5.linux-amd64.tar.gz
+tar -xf go1.13.5.linux-amd64.tar.gz
 sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export GOPATH=$HOME/go


### PR DESCRIPTION
…azel-gazelle, bazel-toolchains, bazelbuild/rules_apple, rules_go, curl, re2, upd

Description: Update dependencies - Go, bazel-skylib, bazel-compilation-database, bazel-gazelle, bazel-toolchains, bazelbuild/rules_apple, rules_go, curl, re2, upd
- Go 1.13.5
- bazelbuild/bazel-skylib 0.9.0 ([release notes](https://github.com/bazelbuild/bazel-skylib/releases/tag/0.9.0)). This is required to move rules_apple to a release
- grailbio/bazel-compilation-database 0.4.2 ([release notes](https://github.com/grailbio/bazel-compilation-database/releases/tag/0.4.2))
- bazelbuild/bazel-gazelle 0.19.1 ([release notes](https://github.com/bazelbuild/bazel-gazelle/releases/tag/v0.19.1))
- bazelbuild/bazel-toolchains 1.2.2 ([changes](https://github.com/bazelbuild/bazel-toolchains/compare/1.1.3...1.2.2))
- bazelbuild/rules_apple 0.19.0 ([release notes](https://github.com/bazelbuild/rules_apple/releases/tag/0.19.0)). Switch to release from git sha
- bazelbuild/rules_go 0.20.3 ([release notes](https://github.com/bazelbuild/rules_go/releases/tag/v0.20.3))
- curl 7.67.0 ([changelog](https://curl.haxx.se/changes.html#7_67_0))
- re2 2019-12-01 ([changes](https://github.com/google/re2/compare/2019-09-01...2019-12-01))
- protocolbuffers/upb 2019-11-19 ([changes](https://github.com/protocolbuffers/upb/compare/9effcbcb27f0a665f9f345030188c0b291e32482...8a3ae1ef3e3e3f26b45dec735c5776737fc7247f))

Risk Level: Low
Testing: `bazel --nohome_rc test --config=libc++ //test/...`, `bazel --nohome_rc build --config=libc++ @envoy_api//envoy/...` and local testing 
Docs Changes: None required
Release Notes: None required

Signed-off-by: Michael P <michael@sooper.org>
