### PR TITLE
Update repokitteh sha to bring in improved ownerscheck

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -1,9 +1,11 @@
-use("github.com/repokitteh/modules/assign.star#22520d03464dd9503e036c7fa365c427723c4aaf")
-use("github.com/repokitteh/modules/review.star#22520d03464dd9503e036c7fa365c427723c4aaf")
-use("github.com/repokitteh/modules/wait.star#22520d03464dd9503e036c7fa365c427723c4aaf")
-use("github.com/repokitteh/modules/circleci.star#22520d03464dd9503e036c7fa365c427723c4aaf", secret_token=get_secret('circle_token'))
+pin("github.com/repokitteh/modules", "4ee2ed0c3622aad7fcddc04cb5dc866e44a541e6")
+
+use("github.com/repokitteh/modules/assign.star")
+use("github.com/repokitteh/modules/review.star")
+use("github.com/repokitteh/modules/wait.star")
+use("github.com/repokitteh/modules/circleci.star", secret_token=get_secret('circle_token'))
 use(
-  "github.com/repokitteh/modules/ownerscheck.star#22520d03464dd9503e036c7fa365c427723c4aaf",
+  "github.com/repokitteh/modules/ownerscheck.star",
   paths=[
     {
       "owner": "envoyproxy/api-shepherds!",

--- a/source/docs/repokitteh.md
+++ b/source/docs/repokitteh.md
@@ -85,3 +85,12 @@ Example:
 Restarts all failed CircleCI tests, as reported in the commit statuses.
 
 [Demo PR](https://github.com/envoyproxy/envoy/pull/5060#issuecomment-439285928)
+
+### [Granular Ownerscheck] (https://github.com/repokitteh/modules/blob/master/ownerscheck.star)
+
+Two types of approvals:
+1. Global approvals, done by approving the PR using Github's review approval feature.
+2. Partial approval, done by commenting "/lgtm [label]" where label is the label
+   associated with the path. This does not affect GitHub's PR approve status, only
+   this module's maintained commit status. This approval is automatically revoked
+   if any further changes are done to the relevant files in this spec.


### PR DESCRIPTION
Description:
Brings in https://github.com/repokitteh/modules/pull/22.
Also pins modules in a more easier to read way globally for the modules repository.

Risk Level:
None for production.

Testing:
In a separate PR (https://github.com/envoyproxy/envoy/pull/9294 -> https://github.com/repokitteh/modules/commit/4ee2ed0c3622aad7fcddc04cb5dc866e44a541e6).

Docs Changes:
TBD

Release Notes:
N/A
