### PR TITLE
network: Use zero initialiser instead of memset

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -25,8 +25,7 @@ DnsResolverImpl::DnsResolverImpl(
     const bool use_tcp_for_dns_lookups)
     : dispatcher_(dispatcher),
       timer_(dispatcher.createTimer([this] { onEventCallback(ARES_SOCKET_BAD, 0); })) {
-  ares_options options;
-  memset(&options, 0, sizeof(options));
+  ares_options options{};
   int optmask = 0;
 
   if (use_tcp_for_dns_lookups) {

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -880,7 +880,7 @@ TEST_P(DnsImplAresFlagsForTcpTest, TcpLookupsEnabled) {
   server_->addCName("root.cnam.domain", "result.cname.domain");
   server_->addHosts("result.cname.domain", {"201.134.56.7"}, RecordType::A);
   std::list<Address::InstanceConstSharedPtr> address_list;
-  struct ares_options opts {};
+  ares_options opts{};
   int optmask = 0;
   EXPECT_EQ(ARES_SUCCESS, ares_save_options(peer_->channel(), &opts, &optmask));
   EXPECT_TRUE((opts.flags & ARES_FLAG_USEVC) == ARES_FLAG_USEVC);
@@ -908,7 +908,7 @@ TEST_P(DnsImplAresFlagsForUdpTest, UdpLookupsEnabled) {
   server_->addCName("root.cnam.domain", "result.cname.domain");
   server_->addHosts("result.cname.domain", {"201.134.56.7"}, RecordType::A);
   std::list<Address::InstanceConstSharedPtr> address_list;
-  struct ares_options opts {};
+  ares_options opts{};
   int optmask = 0;
   EXPECT_EQ(ARES_SUCCESS, ares_save_options(peer_->channel(), &opts, &optmask));
   EXPECT_FALSE((opts.flags & ARES_FLAG_USEVC) == ARES_FLAG_USEVC);

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -880,8 +880,7 @@ TEST_P(DnsImplAresFlagsForTcpTest, TcpLookupsEnabled) {
   server_->addCName("root.cnam.domain", "result.cname.domain");
   server_->addHosts("result.cname.domain", {"201.134.56.7"}, RecordType::A);
   std::list<Address::InstanceConstSharedPtr> address_list;
-  struct ares_options opts;
-  memset(&opts, 0, sizeof(opts));
+  struct ares_options opts {};
   int optmask = 0;
   EXPECT_EQ(ARES_SUCCESS, ares_save_options(peer_->channel(), &opts, &optmask));
   EXPECT_TRUE((opts.flags & ARES_FLAG_USEVC) == ARES_FLAG_USEVC);
@@ -909,8 +908,7 @@ TEST_P(DnsImplAresFlagsForUdpTest, UdpLookupsEnabled) {
   server_->addCName("root.cnam.domain", "result.cname.domain");
   server_->addHosts("result.cname.domain", {"201.134.56.7"}, RecordType::A);
   std::list<Address::InstanceConstSharedPtr> address_list;
-  struct ares_options opts;
-  memset(&opts, 0, sizeof(opts));
+  struct ares_options opts {};
   int optmask = 0;
   EXPECT_EQ(ARES_SUCCESS, ares_save_options(peer_->channel(), &opts, &optmask));
   EXPECT_FALSE((opts.flags & ARES_FLAG_USEVC) == ARES_FLAG_USEVC);


### PR DESCRIPTION
Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>

Description: This change is to use zero initialiser instead of memset function. Using zero initialiser will init all plain (POD) fields to zeros. Using memset function instead may lead to errors, as it sets all bytes (value+alignment bytes) for all fields (non primitive ones as well) inside `cares_optioins` structure to zeros.
More info: https://stackoverflow.com/questions/1998752/memset-or-value-initialization-to-zero-out-a-struct.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
