### PR TITLE
docs: remove redundant "the" from SDS readme

### DIFF
--- a/docs/root/configuration/security/secret.rst
+++ b/docs/root/configuration/security/secret.rst
@@ -7,7 +7,7 @@ TLS certificates, the secrets, can be specified in the bootstrap.static_resource
 :ref:`secrets <envoy_api_field_config.bootstrap.v2.Bootstrap.StaticResources.secrets>`.
 But they can also be fetched remotely by secret discovery service (SDS).
 
-The most important benefit of SDS is to simplify the certificate management. Without this feature, in k8s deployment, certificates must be created as secrets and mounted into the proxy containers. If certificates are expired, the secrets need to be updated and the proxy containers need to be re-deployed. With SDS, a central SDS server will push certificates to all Envoy instances. If certificates are expired, the server just pushes new certificates to Envoy instances, Envoy will use the new ones right away without re-deployment.
+The most important benefit of SDS is to simplify certificate management. Without this feature, in k8s deployment, certificates must be created as secrets and mounted into the proxy containers. If certificates are expired, the secrets need to be updated and the proxy containers need to be re-deployed. With SDS, a central SDS server will push certificates to all Envoy instances. If certificates are expired, the server just pushes new certificates to Envoy instances, Envoy will use the new ones right away without re-deployment.
 
 If a listener server certificate needs to be fetched by SDS remotely, it will NOT be marked as active, its port will not be opened before the certificates are fetched. If Envoy fails to fetch the certificates due to connection failures, or bad response data, the listener will be marked as active, and the port will be open, but the connection to the port will be reset.
 


### PR DESCRIPTION
Description: a minor tweak to the SDS readme which removes a redundant word
Risk Level: low (docs)
Testing: none
Docs Changes: N/A
Release Notes: not user or extension developer impacting