### PR TITLE
Correct trie test by comparing string contents

### DIFF
--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -802,34 +802,42 @@ TEST(DateFormatter, FromTimeSameWildcard) {
 
 TEST(TrieLookupTable, AddItems) {
   TrieLookupTable<const char*> trie;
-  EXPECT_TRUE(trie.add("foo", "a"));
-  EXPECT_TRUE(trie.add("bar", "b"));
-  EXPECT_EQ("a", trie.find("foo"));
-  EXPECT_EQ("b", trie.find("bar"));
+  const char* cstr_a = "a";
+  const char* cstr_b = "b";
+  const char* cstr_c = "c";
+
+  EXPECT_TRUE(trie.add("foo", cstr_a));
+  EXPECT_TRUE(trie.add("bar", cstr_b));
+  EXPECT_EQ(cstr_a, trie.find("foo"));
+  EXPECT_EQ(cstr_b, trie.find("bar"));
 
   // overwrite_existing = false
-  EXPECT_FALSE(trie.add("foo", "c", false));
-  EXPECT_EQ("a", trie.find("foo"));
+  EXPECT_FALSE(trie.add("foo", cstr_c, false));
+  EXPECT_EQ(cstr_a, trie.find("foo"));
 
   // overwrite_existing = true
-  EXPECT_TRUE(trie.add("foo", "c"));
-  EXPECT_EQ("c", trie.find("foo"));
+  EXPECT_TRUE(trie.add("foo", cstr_c));
+  EXPECT_EQ(cstr_c, trie.find("foo"));
 }
 
 TEST(TrieLookupTable, LongestPrefix) {
   TrieLookupTable<const char*> trie;
-  EXPECT_TRUE(trie.add("foo", "a"));
-  EXPECT_TRUE(trie.add("bar", "b"));
-  EXPECT_TRUE(trie.add("baro", "c"));
+  const char* cstr_a = "a";
+  const char* cstr_b = "b";
+  const char* cstr_c = "c";
 
-  EXPECT_EQ("a", trie.find("foo"));
-  EXPECT_EQ("a", trie.findLongestPrefix("foo"));
-  EXPECT_EQ("a", trie.findLongestPrefix("foosball"));
+  EXPECT_TRUE(trie.add("foo", cstr_a));
+  EXPECT_TRUE(trie.add("bar", cstr_b));
+  EXPECT_TRUE(trie.add("baro", cstr_c));
 
-  EXPECT_EQ("b", trie.find("bar"));
-  EXPECT_EQ("b", trie.findLongestPrefix("bar"));
-  EXPECT_EQ("b", trie.findLongestPrefix("baritone"));
-  EXPECT_EQ("c", trie.findLongestPrefix("barometer"));
+  EXPECT_EQ(cstr_a, trie.find("foo"));
+  EXPECT_EQ(cstr_a, trie.findLongestPrefix("foo"));
+  EXPECT_EQ(cstr_a, trie.findLongestPrefix("foosball"));
+
+  EXPECT_EQ(cstr_b, trie.find("bar"));
+  EXPECT_EQ(cstr_b, trie.findLongestPrefix("bar"));
+  EXPECT_EQ(cstr_b, trie.findLongestPrefix("baritone"));
+  EXPECT_EQ(cstr_c, trie.findLongestPrefix("barometer"));
 
   EXPECT_EQ(nullptr, trie.find("toto"));
   EXPECT_EQ(nullptr, trie.findLongestPrefix("toto"));


### PR DESCRIPTION
Description:
This test was only successful by the coincidence of the compiler
collapsing all duplicate const char* string globals, and fails
under debug builds. 

Always compare string values, not references, but if comparing
references, anchor them to the same const char*.

Signed-off-by: William A Rowe Jr <wrowe@pivotal.io>
Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>

Risk Level: Low
Testing: Local on Unix, Windows, optimized and non-optimized
Docs Changes: N/A
Release Notes: N/A
