### PR TITLE
ci: Fix windows ci

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -17,5 +17,7 @@ jobs:
       env:
         TOOLS_BIN_DIR: $(Pipeline.Workspace)\bin
 
-    - bash: ci/windows_ci_steps.sh
+    - bash: |
+        export PATH="/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64":$PATH
+        . ./ci/windows_ci_steps.sh
       displayName: "Run Windows CI"

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -17,7 +17,5 @@ jobs:
       env:
         TOOLS_BIN_DIR: $(Pipeline.Workspace)\bin
 
-    - bash: |
-        export PATH="/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64":$PATH
-        . ./ci/windows_ci_steps.sh
+    - bash: ci/windows_ci_steps.sh
       displayName: "Run Windows CI"

--- a/ci/windows_ci_setup.ps1
+++ b/ci/windows_ci_setup.ps1
@@ -6,3 +6,7 @@ mkdir "$env:TOOLS_BIN_DIR"
 
 $wc = New-Object System.Net.WebClient
 $wc.DownloadFile("https://github.com/bazelbuild/bazelisk/releases/download/v1.0/bazelisk-windows-amd64.exe", "$env:TOOLS_BIN_DIR\bazel.exe")
+
+# Install ninja.
+$choco = "$Env:ProgramData/chocolatey/choco.exe"
+iex "$choco install -y -f --acceptlicense --no-progress ninja"

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -13,6 +13,9 @@ df -h
 
 . "$(dirname "$0")"/setup_cache.sh
 
+# TODO(dio): Put in windows/.bazelrc.
+export PATH="/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64":$PATH
+
 BAZEL_STARTUP_OPTIONS="--bazelrc=windows/.bazelrc"
 BAZEL_BUILD_OPTIONS="--show_task_finish --verbose_failures \
   --test_output=all ${BAZEL_BUILD_EXTRA_OPTIONS} ${BAZEL_EXTRA_TEST_OPTIONS}"


### PR DESCRIPTION
This patch fixes windows CI by installing ninja from choco.

Risk Level: Low 
Testing: CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>