### PR TITLE
Move up life cycle callbacks before config_ to prevent use-after-free bug

### DIFF
--- a/source/server/server.h
+++ b/source/server/server.h
@@ -251,6 +251,9 @@ private:
   void notifyCallbacksForStage(
       Stage stage, Event::PostCb completion_cb = [] {});
 
+  using LifecycleNotifierCallbacks = std::list<StageCallback>;
+  using LifecycleNotifierCompletionCallbacks = std::list<StageCallbackWithCompletion>;
+
   // init_manager_ must come before any member that participates in initialization, and destructed
   // only after referencing members are gone, since initialization continuation can potentially
   // occur at any point during member lifetime. This init manager is populated with LdsApi targets.
@@ -285,6 +288,8 @@ private:
   ProdListenerComponentFactory listener_component_factory_;
   ProdWorkerFactory worker_factory_;
   std::unique_ptr<ListenerManager> listener_manager_;
+  absl::node_hash_map<Stage, LifecycleNotifierCallbacks> stage_callbacks_;
+  absl::node_hash_map<Stage, LifecycleNotifierCompletionCallbacks> stage_completable_callbacks_;
   Configuration::MainImpl config_;
   Network::DnsResolverSharedPtr dns_resolver_;
   Event::TimerPtr stat_flush_timer_;
@@ -314,18 +319,12 @@ private:
 
   ServerFactoryContextImpl server_context_;
 
-  using LifecycleNotifierCallbacks = std::list<StageCallback>;
-  using LifecycleNotifierCompletionCallbacks = std::list<StageCallbackWithCompletion>;
-
   template <class T>
   class LifecycleCallbackHandle : public ServerLifecycleNotifier::Handle, RaiiListElement<T> {
   public:
     LifecycleCallbackHandle(std::list<T>& callbacks, T& callback)
         : RaiiListElement<T>(callbacks, callback) {}
   };
-
-  absl::node_hash_map<Stage, LifecycleNotifierCallbacks> stage_callbacks_;
-  absl::node_hash_map<Stage, LifecycleNotifierCompletionCallbacks> stage_completable_callbacks_;
 };
 
 // Local implementation of Stats::MetricSnapshot used to flush metrics to sinks. We could

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -286,6 +286,7 @@ envoy_cc_test(
     name = "server_test",
     srcs = ["server_test.cc"],
     data = [
+        ":callbacks_stats_sink_bootstrap.yaml",
         ":cluster_dupe_bootstrap.yaml",
         ":cluster_health_check_bootstrap.yaml",
         ":empty_bootstrap.yaml",

--- a/test/server/callbacks_stats_sink_bootstrap.yaml
+++ b/test/server/callbacks_stats_sink_bootstrap.yaml
@@ -1,0 +1,16 @@
+node:
+  id: bootstrap_id
+  cluster: bootstrap_cluster
+  locality:
+    zone: bootstrap_zone
+    sub_zone: bootstrap_sub_zone
+  build_version: should_be_ignored
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0
+stats_sinks:
+- name: envoy.callbacks_stats_sink
+stats_flush_interval: 1s

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -957,6 +957,7 @@ TEST_P(StaticValidationTest, ClusterUnknownField) {
   EXPECT_TRUE(validate("cluster_unknown_field.yaml"));
 }
 
+// Custom StatsSink that registers both a Cluster update callback and Server lifecycle callback.
 class CallbacksStatsSink : public Stats::Sink, public Upstream::ClusterUpdateCallbacks {
 public:
   CallbacksStatsSink(Server::Instance& server)

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1001,7 +1001,6 @@ REGISTER_FACTORY(CallbacksStatsSinkFactory, Server::Configuration::StatsSinkFact
 // lifecycle callback is also used to ensure that the cluster update callback is freed during
 // Server::Instance's destruction. See issue #9292 for more details.
 TEST_P(ServerInstanceImplTest, CallbacksStatsSinkTest) {
-  ENVOY_LOG_MISC(warn, "starting server");
   initialize("test/server/callbacks_stats_sink_bootstrap.yaml");
   // Necessary to trigger server lifecycle callbacks, otherwise only terminate() is called.
   server_->shutdown();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -254,7 +254,7 @@ private:
   Stats::Counter& stats_flushed_;
 };
 
-// Custom StatsSinFactory that creates CustomStatsSink.
+// Custom StatsSinkFactory that creates CustomStatsSink.
 class CustomStatsSinkFactory : public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
@@ -955,6 +955,55 @@ TEST_P(StaticValidationTest, NetworkFilterUnknownField) {
 
 TEST_P(StaticValidationTest, ClusterUnknownField) {
   EXPECT_TRUE(validate("cluster_unknown_field.yaml"));
+}
+
+class CallbacksStatsSink : public Stats::Sink, public Upstream::ClusterUpdateCallbacks {
+public:
+  CallbacksStatsSink(Server::Instance& server)
+      : cluster_removal_cb_handle_(
+            server.clusterManager().addThreadLocalClusterUpdateCallbacks(*this)),
+        lifecycle_cb_handle_(server.lifecycleNotifier().registerCallback(
+            ServerLifecycleNotifier::Stage::ShutdownExit,
+            [this]() { cluster_removal_cb_handle_.reset(); })) {}
+
+  // Stats::Sink
+  void flush(Stats::MetricSnapshot&) override {}
+  void onHistogramComplete(const Stats::Histogram&, uint64_t) override {}
+
+  // Upstream::ClusterUpdateCallbacks
+  void onClusterAddOrUpdate(Upstream::ThreadLocalCluster&) override {}
+  void onClusterRemoval(const std::string&) override {}
+
+private:
+  Upstream::ClusterUpdateCallbacksHandlePtr cluster_removal_cb_handle_;
+  ServerLifecycleNotifier::HandlePtr lifecycle_cb_handle_;
+};
+
+class CallbacksStatsSinkFactory : public Server::Configuration::StatsSinkFactory {
+public:
+  // StatsSinkFactory
+  Stats::SinkPtr createStatsSink(const Protobuf::Message&, Server::Instance& server) override {
+    return std::make_unique<CallbacksStatsSink>(server);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
+  }
+
+  std::string name() override { return "envoy.callbacks_stats_sink"; }
+};
+
+REGISTER_FACTORY(CallbacksStatsSinkFactory, Server::Configuration::StatsSinkFactory);
+
+// This test ensures that a stats sink can use cluster update callbacks properly. Using only a
+// cluster update callback is insufficient to protect against double-free bugs, so a server
+// lifecycle callback is also used to ensure that the cluster update callback is freed during
+// Server::Instance's destruction. See issue #9292 for more details.
+TEST_P(ServerInstanceImplTest, CallbacksStatsSinkTest) {
+  ENVOY_LOG_MISC(warn, "starting server");
+  initialize("test/server/callbacks_stats_sink_bootstrap.yaml");
+  // Necessary to trigger server lifecycle callbacks, otherwise only terminate() is called.
+  server_->shutdown();
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Frank Fort <ffort@google.com>

Description: Cluster update callbacks (introduced in #2814) cannot be used correctly if the callback is owned by an object destroyed after the Envoy server's instance `thread_local_` object. Using a server lifecycle callback to free the cluster update callback handle also introduces another separate use-after-free bug related to the ordering of destruction of fields in `Envoy::Server::Instance`.

This PR mitigates the issue by moving the server lifecycle callbacks lists up above the `Configuration::MainImpl config_` object so that the Stats sinks can remove their handle before the server lifecycle callbacks lists destructor gets a chance to free the handle again.

See #9292 for more details.

Risk Level: Low
Testing: Ran `bazel test test/exe/... test/server/...` successfully.
Docs Changes: N/A
Release Notes: N/A
Fixes #9292 
