### PR TITLE
buffer filter: correct implied constraint

### DIFF
--- a/api/envoy/config/filter/http/buffer/v2/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v2/buffer.proto
@@ -19,7 +19,8 @@ message Buffer {
 
   // The maximum request size that the filter will buffer before the connection
   // manager will stop buffering and return a 413 response.
-  google.protobuf.UInt32Value max_request_bytes = 1 [(validate.rules).uint32 = {gt: 0}];
+  google.protobuf.UInt32Value max_request_bytes = 1
+      [(validate.rules).uint32 = {gt: 0}, (validate.rules).message = {required: true}];
 }
 
 message BufferPerRoute {

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -59,6 +59,17 @@ TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
   cb(filter_callback);
 }
 
+TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
+  BufferFilterFactory factory;
+  envoy::config::filter::http::buffer::v2::Buffer config =
+      *dynamic_cast<envoy::config::filter::http::buffer::v2::Buffer*>(
+          factory.createEmptyConfigProto().get());
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, "stats", context),
+                          EnvoyException, "Proto constraint validation failed");
+}
+
 TEST(BufferFilterFactoryTest, BufferFilterEmptyRouteProto) {
   BufferFilterFactory factory;
   EXPECT_NO_THROW({


### PR DESCRIPTION
The max_request_bytes field is assumed to have a value set that is
greater than zero. The code ASSERTs this and does unpleasent things
if not set. This corrects that built-in assumption. Note that this
field could be a primitive integer with a constraint, but it doesn't
seem worth that churn to fix.

Fixes https://github.com/envoyproxy/envoy/issues/7650

Risk Level: Low
Testing: New UT
Docs Changes: N/A
Release Notes: N/A
