### PR TITLE
Upgrade grpc_json_transcoder security_posture

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -45,7 +45,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
-    security_posture = "unknown",
+    security_posture = "robust_to_untrusted_downstream_and_upstream",
     deps = [
         "//include/envoy/registry",
         "//source/extensions/filters/http:well_known_names",


### PR DESCRIPTION
Like to use this PR to start the discussion of how to upgrade security_posture of this filter.  

It heavily uses the code from this [repo](https://github.com/grpc-ecosystem/grpc-httpjson-transcoding)

Proposed plan to add fuzz tests for that repo.


Risk Level:  None
Testing: None
Docs Changes: 
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
