### PR TITLE
retry: validate retry previous priorities config

### DIFF
--- a/api/envoy/config/retry/previous_priorities/previous_priorities_config.proto
+++ b/api/envoy/config/retry/previous_priorities/previous_priorities_config.proto
@@ -6,6 +6,8 @@ option java_package = "io.envoyproxy.envoy.config.retry.previous_priorities";
 option java_outer_classname = "PreviousPrioritiesConfigProto";
 option java_multiple_files = true;
 
+import "validate/validate.proto";
+
 // A retry host selector that attempts to spread retries between priorities, even if certain
 // priorities would not normally be attempted due to higher priorities being available.
 //
@@ -41,5 +43,7 @@ message PreviousPrioritiesConfig {
   // load which excludes the priorities routed to with the first two attempts, and the fifth and
   // sixth attempt will use the priority load excluding the priorities used for the first four
   // attempts.
-  int32 update_frequency = 1;
+  //
+  // Must be greater than 0.
+  int32 update_frequency = 1 [(validate.rules).int32 = {gt: 0}];
 }

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -283,6 +283,18 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
   verifyPriorityLoads(expected_priority_load, expected_degraded_priority_load);
 }
 
+// Tests that an invalid frequency results into a config error.
+TEST_F(RetryPriorityTest, OverridenFrequencyInvalidValue) {
+  update_frequency_ = 0;
+
+  const Upstream::HealthyLoad original_priority_load({100, 0});
+  const Upstream::DegradedLoad original_degraded_priority_load({0, 0});
+
+  EXPECT_THROW_WITH_REGEX(initialize(original_priority_load, original_degraded_priority_load),
+                          EnvoyException,
+                          "Proto constraint validation failed.*value must be greater than.*");
+}
+
 } // namespace
 } // namespace Priority
 } // namespace Retry


### PR DESCRIPTION
Setting update_frequency to 0 causes a segfault. Prevent invalid values via validation.

Risk Level: low
Testing: added unit test
Doc Changes: updated
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
