### PR TITLE
Change the X-Ray daemon namespace

### DIFF
--- a/source/extensions/tracers/xray/daemon.proto
+++ b/source/extensions/tracers/xray/daemon.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 // The structures in this file are merely for JSON serialization to communicate with the X-Ray
 // daemon. The X-Ray daemon does not speak protobuf.
-package envoy.tracers.xray.daemon;
+package source.extensions.tracers.xray.daemon;
 
 import "validate/validate.proto";
 

--- a/source/extensions/tracers/xray/daemon_broker.cc
+++ b/source/extensions/tracers/xray/daemon_broker.cc
@@ -17,7 +17,7 @@ namespace {
 // For example:
 // { "format": "json", "version": 1}
 std::string createHeader(const std::string& format, uint32_t version) {
-  envoy::tracers::xray::daemon::Header header;
+  source::extensions::tracers::xray::daemon::Header header;
   header.set_format(format);
   header.set_version(version);
 

--- a/source/extensions/tracers/xray/localized_sampling.cc
+++ b/source/extensions/tracers/xray/localized_sampling.cc
@@ -10,17 +10,17 @@ namespace Extensions {
 namespace Tracers {
 namespace XRay {
 
-constexpr static double DefaultRate = 0.5;
-constexpr static int DefaultFixedTarget = 1;
-constexpr static int SamplingFileVersion = 2;
-constexpr static char VersionJsonKey[] = "version";
-constexpr static char DefaultRuleJsonKey[] = "default";
-constexpr static char FixedTargetJsonKey[] = "fixed_target";
-constexpr static char RateJsonKey[] = "rate";
-constexpr static char CustomRulesJsonKey[] = "rules";
-constexpr static char HostJsonKey[] = "host";
-constexpr static char HttpMethodJsonKey[] = "http_method";
-constexpr static char UrlPathJsonKey[] = "url_path";
+constexpr double DefaultRate = 0.5;
+constexpr int DefaultFixedTarget = 1;
+constexpr int SamplingFileVersion = 2;
+constexpr auto VersionJsonKey = "version";
+constexpr auto DefaultRuleJsonKey = "default";
+constexpr auto FixedTargetJsonKey = "fixed_target";
+constexpr auto RateJsonKey = "rate";
+constexpr auto CustomRulesJsonKey = "rules";
+constexpr auto HostJsonKey = "host";
+constexpr auto HttpMethodJsonKey = "http_method";
+constexpr auto UrlPathJsonKey = "url_path";
 
 namespace {
 void fail(absl::string_view msg) {
@@ -30,9 +30,8 @@ void fail(absl::string_view msg) {
 
 bool is_valid_rate(double n) { return n >= 0 && n <= 1.0; }
 bool is_valid_fixed_target(double n) { return n >= 0 && static_cast<uint32_t>(n) == n; }
-} // namespace
 
-static bool validateRule(const ProtobufWkt::Struct& rule) {
+bool validateRule(const ProtobufWkt::Struct& rule) {
   using ProtobufWkt::Value;
 
   const auto host_it = rule.fields().find(HostJsonKey);
@@ -73,6 +72,7 @@ static bool validateRule(const ProtobufWkt::Struct& rule) {
   }
   return true;
 }
+} // namespace
 
 LocalizedSamplingRule LocalizedSamplingRule::createDefault() {
   return LocalizedSamplingRule(DefaultFixedTarget, DefaultRate);

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -61,7 +61,7 @@ void Span::setId(uint64_t id) { id_ = Hex::uint64ToHex(id); }
 
 void Span::finishSpan() {
   using std::chrono::time_point_cast;
-  using namespace envoy::tracers::xray;
+  using namespace source::extensions::tracers::xray;
   // X-Ray expects timestamps to be in epoch seconds with milli/micro-second precision as a fraction
   using SecondsWithFraction = std::chrono::duration<double>;
   if (!sampled()) {

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -1,9 +1,6 @@
 #include "extensions/tracers/xray/tracer.h"
 
-#include <sys/socket.h>
-
 #include <algorithm>
-#include <array>
 #include <chrono>
 #include <string>
 
@@ -107,7 +104,7 @@ void Span::injectContext(Http::HeaderMap& request_headers) {
   const std::string xray_header_value =
       fmt::format("root={};parent={};sampled={}", traceId(), Id(), sampled() ? "1" : "0");
 
-  // Set the XRay header in to envoy header map.
+  // Set the XRay header into envoy header map for visibility to upstream
   request_headers.addCopy(Http::LowerCaseString(XRayTraceHeader), xray_header_value);
 }
 

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -12,8 +12,9 @@ namespace Extensions {
 namespace Tracers {
 namespace XRay {
 
-constexpr static char DefaultDaemonEndpoint[] = "127.0.0.1:2000";
-static XRayHeader parseXRayHeader(const Http::LowerCaseString& header) {
+namespace {
+constexpr auto DefaultDaemonEndpoint = "127.0.0.1:2000";
+XRayHeader parseXRayHeader(const Http::LowerCaseString& header) {
   const auto& lowered_header = header.get();
   XRayHeader result;
   for (const auto& token : StringUtil::splitToken(lowered_header, ";")) {
@@ -34,6 +35,7 @@ static XRayHeader parseXRayHeader(const Http::LowerCaseString& header) {
   }
   return result;
 }
+} // namespace
 
 Driver::Driver(const XRayConfiguration& config, Server::Instance& server)
     : xray_config_(config), tls_slot_ptr_(server.threadLocal().allocateSlot()) {

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -25,7 +25,7 @@ namespace XRay {
 namespace {
 using ::testing::_;
 using ::testing::Invoke;
-using namespace envoy::tracers::xray;
+using namespace source::extensions::tracers::xray;
 
 struct MockDaemonBroker : DaemonBroker {
   MockDaemonBroker(const std::string& endpoint) { UNREFERENCED_PARAMETER(endpoint); }


### PR DESCRIPTION
Change the X-Ray daemon proto namespace.
This is not a breaking change. It's only used internally by the X-Ray tracer implementation.

I squeezed in couple minor cleanups that were going to make it in the next X-Ray PR anyways.

Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

