### PR TITLE
docs: fix docs for RBE configs

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -51,7 +51,7 @@ pip3 install -r "${SCRIPT_DIR}"/requirements.txt
 rm -rf bazel-bin/external/envoy_api
 
 # This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
-BAZEL_BUILD_OPTIONS+=" --remote_download_outputs=all"
+BAZEL_BUILD_OPTIONS+=" --remote_download_outputs=all --strategy=protodoc=sandboxed,local"
 
 export EXTENSION_DB_PATH="$(realpath "${BUILD_DIR}/extension_db.json")"
 


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
This is broken in #8906 because extension db is loaded outside Bazel. cc @htuch.

Risk Level: Low
Testing: local
Docs Changes: N/A
Release Notes: N/A
