### PR TITLE
api: mark drain_connections_on_host_removal for renaming

### DIFF
--- a/api/envoy/api/v2/BUILD
+++ b/api/envoy/api/v2/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/api/v2/route:pkg",
         "//envoy/config/listener/v2:pkg",
         "//envoy/type:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -26,6 +26,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
 // [#protodoc-title: Clusters]
@@ -769,13 +770,11 @@ message Cluster {
   //   time exclusively closing these connections, and not processing any other traffic.
   bool close_connections_on_host_health_failure = 31;
 
-  // If this cluster uses EDS or STRICT_DNS to configure its hosts, immediately drain
-  // connections from any hosts that are removed from service discovery.
-  //
-  // This only affects behavior for hosts that are being actively health checked.
-  // If this flag is not set to true, Envoy will wait until the hosts fail active health
-  // checking before removing it from the cluster.
-  bool drain_connections_on_host_removal = 32;
+  // If set to true, Envoy will ignore the health value of a host when processing its removal
+  // from service discovery. This means that if active health checking is used, Envoy will *not*
+  // wait for the endpoint to go unhealthy before removing it.
+  bool drain_connections_on_host_removal = 32
+      [(udpa.annotations.field_migrate).rename = "ignore_health_on_host_removal"];
 
   // An (optional) network filter chain, listed in the order the filters should be applied.
   // The chain will be applied to all outgoing connections that Envoy makes to the upstream

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -791,13 +791,10 @@ message Cluster {
   //   time exclusively closing these connections, and not processing any other traffic.
   bool close_connections_on_host_health_failure = 31;
 
-  // If this cluster uses EDS or STRICT_DNS to configure its hosts, immediately drain
-  // connections from any hosts that are removed from service discovery.
-  //
-  // This only affects behavior for hosts that are being actively health checked.
-  // If this flag is not set to true, Envoy will wait until the hosts fail active health
-  // checking before removing it from the cluster.
-  bool drain_connections_on_host_removal = 32;
+  // If set to true, Envoy will ignore the health value of a host when processing its removal
+  // from service discovery. This means that if active health checking is used, Envoy will *not*
+  // wait for the endpoint to go unhealthy before removing it.
+  bool ignore_health_on_host_removal = 32;
 
   // An (optional) network filter chain, listed in the order the filters should be applied.
   // The chain will be applied to all outgoing connections that Envoy makes to the upstream


### PR DESCRIPTION
Updates the documentation to be less specific about the behavior of
removing an endpoint, as there are cases that does not result in
draining connections (e.g. when an endpoint is removed from one priority
but added to another).

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Low
Testing: n/a
Docs Changes: Updated proto docs
Release Notes: n/a
Fixes #8056

