### PR TITLE
util: Add test for MemBlockBuilder::release(), which was not working (discovered in #8779).

### DIFF
--- a/source/common/common/mem_block_builder.h
+++ b/source/common/common/mem_block_builder.h
@@ -30,13 +30,15 @@ public:
   MemBlockBuilder() {}
 
   /**
-   * Populates (or repopulates) the MemBlockBuilder to make it the specified
-   * capacity. This does not have resize semantics; when populate() is called
-   * any previous contents are erased.
+   * Allocates (or reallocates) memory for the MemBlockBuilder to make it the
+   * specified capacity. This does not have resize semantics; when setCapacity()
+   * is called any previous contents are erased.
    *
    * @param capacity The number of memory elements to allocate.
    */
-  void populate(uint64_t capacity) { populateHelper(capacity, std::make_unique<T[]>(capacity)); }
+  void setCapacity(uint64_t capacity) {
+    setCapacityHelper(capacity, std::make_unique<T[]>(capacity));
+  }
 
   /**
    * @return the capacity.
@@ -88,7 +90,7 @@ public:
   /**
    * Empties the contents of this.
    */
-  void reset() { populateHelper(0, std::unique_ptr<T[]>(nullptr)); }
+  void reset() { setCapacityHelper(0, std::unique_ptr<T[]>(nullptr)); }
 
   /**
    * Returns the underlying storage as a unique pointer, clearing this.
@@ -111,7 +113,7 @@ public:
   uint64_t size() const { return write_span_.data() - data_.get(); }
 
 private:
-  void populateHelper(uint64_t capacity, std::unique_ptr<T[]> data) {
+  void setCapacityHelper(uint64_t capacity, std::unique_ptr<T[]> data) {
     data_ = std::move(data);
     write_span_ = absl::MakeSpan(data_.get(), capacity);
   }

--- a/source/common/common/mem_block_builder.h
+++ b/source/common/common/mem_block_builder.h
@@ -31,8 +31,8 @@ public:
 
   /**
    * Populates (or repopulates) the MemBlockBuilder to make it the specified
-   * capacity. This does not have resize semantics; when populate() is called any
-   * previous contents are erased.
+   * capacity. This does not have resize semantics; when populate() is called
+   * any previous contents are erased.
    *
    * @param capacity The number of memory elements to allocate.
    */
@@ -96,7 +96,7 @@ public:
    * @return the transferred storage.
    */
   std::unique_ptr<T[]> release() {
-    write_span_.reset();
+    write_span_ = absl::MakeSpan(static_cast<T*>(nullptr), 0);
     return std::move(data_);
   }
 

--- a/test/common/common/mem_block_builder_test.cc
+++ b/test/common/common/mem_block_builder_test.cc
@@ -56,8 +56,10 @@ TEST(MemBlockBuilderTest, AppendUint32) {
 
   append.appendBlock(mem_block);
   EXPECT_EQ(0, append.capacityRemaining());
+  uint64_t size = append.size();
+  std::unique_ptr<uint32_t[]> data = append.release();
   EXPECT_EQ((std::vector<uint32_t>{100008, 100009, 100005, 100006, 100007, 100008, 100009}),
-            append.span());
+            std::vector<uint32_t>(data.get(), data.get() + size));
 
   mem_block.reset();
   EXPECT_EQ(0, mem_block.capacity());

--- a/test/common/common/mem_block_builder_test.cc
+++ b/test/common/common/mem_block_builder_test.cc
@@ -17,7 +17,7 @@ TEST(MemBlockBuilderTest, AppendUint8) {
 
   MemBlockBuilder<uint8_t> append;
   EXPECT_EQ(0, append.capacity());
-  append.populate(7);
+  append.setCapacity(7);
   EXPECT_EQ(7, append.capacity());
   append.appendOne(8);
   append.appendOne(9);
@@ -48,7 +48,7 @@ TEST(MemBlockBuilderTest, AppendUint32) {
 
   MemBlockBuilder<uint32_t> append;
   EXPECT_EQ(0, append.capacity());
-  append.populate(7);
+  append.setCapacity(7);
   EXPECT_EQ(7, append.capacity());
   append.appendOne(100008);
   append.appendOne(100009);

--- a/test/common/common/mem_block_builder_test.cc
+++ b/test/common/common/mem_block_builder_test.cc
@@ -28,7 +28,10 @@ TEST(MemBlockBuilderTest, AppendUint8) {
 
   append.appendBlock(mem_block);
   EXPECT_EQ(0, append.capacityRemaining());
-  EXPECT_EQ((std::vector<uint8_t>{8, 9, 5, 6, 7, 8, 9}), append.span());
+  uint64_t size = append.size();
+  std::unique_ptr<uint8_t[]> data = append.release();
+  EXPECT_EQ((std::vector<uint8_t>{8, 9, 5, 6, 7, 8, 9}),
+            std::vector<uint8_t>(data.get(), data.get() + size));
 
   mem_block.reset();
   EXPECT_EQ(0, mem_block.capacity());


### PR DESCRIPTION
Description: Follow-up to #9306 which added a release() method, but after moving to an internal span representation it stopped working, and there was not a unit test for it. This adds the unit test and fixes the impl. I had promised follow-ups on 2 other issues raised by @mattklein123 in #9306 , but I'm leaning against one of them, and modified the other.
 * Reverting the write_span_ representation: I've grown enamored of it because it makes the implementation terser and easier to be confident in. We can re-visit if a perf bottleneck is measured.
 * Renaming populate() to resize() -- as explained in the comment for populate(), that method does not have resize semantics: old data is not preserved. However I renamed to setCapacity per discussion.


Risk Level: low
Testing: just the MemBlockBuilder test.
Docs Changes: n/a
Release Notes: n/a

