### PR TITLE
config: Change quic_http_integration_test to use typed_config

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -144,7 +144,8 @@ const std::string ConfigHelper::QUIC_HTTP_PROXY_CONFIG = BASE_UDP_LISTENER_CONFI
             name: envoy.file_access_log
             filter:
               not_health_check_filter:  {}
-            config:
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
               path: /dev/null
           route_config:
             virtual_hosts:

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -101,7 +101,7 @@ public:
       auto* filter_chain =
           bootstrap.mutable_static_resources()->mutable_listeners(0)->mutable_filter_chains(0);
       auto* transport_socket = filter_chain->mutable_transport_socket();
-      TestUtility::jsonConvert(tls_context, *transport_socket->mutable_config());
+      transport_socket->mutable_typed_config()->PackFrom(tls_context);
     });
     config_helper_.addConfigModifier(
         [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A 
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
