### PR TITLE
bazel: Add load statements for proto_library

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -1,8 +1,9 @@
-load("@com_google_protobuf//:protobuf.bzl", _py_proto_library = "py_proto_library")
 load("@com_envoyproxy_protoc_gen_validate//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_google_protobuf//:protobuf.bzl", _py_proto_library = "py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:external_proto_deps.bzl",
     "EXTERNAL_PROTO_CC_BAZEL_DEP_MAP",
@@ -108,7 +109,7 @@ def api_cc_py_proto_library(
         linkstatic = 0,
         has_services = 0):
     relative_name = ":" + name
-    native.proto_library(
+    proto_library(
         name = name,
         srcs = srcs,
         deps = deps + _COMMON_PROTO_DEPS,

--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 licenses(["notice"])  # Apache 2
 
 package_group(

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -25,6 +25,7 @@ licenses(["notice"])  # Apache 2
 # QUICHE platform APIs in //source/extensions/quic_listeners/quiche/platform/,
 # should remain largely the same.
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(":genrule_cmd.bzl", "genrule_cmd")
 load(
     "@envoy//bazel:envoy_build_system.bzl",

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -1,5 +1,6 @@
 licenses(["notice"])  # Apache 2
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",


### PR DESCRIPTION
This prepares Envoy for `--incompatible_load_proto_rules_from_bzl`.
See https://github.com/bazelbuild/bazel/issues/8922

Signed-off-by: Yannic Bonenberger <contact@yannic-bonenberger.com>
