### PR TITLE
adaptive concurrency: Add an "enabled" stat and remove unused stats

### DIFF
--- a/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
+++ b/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
@@ -192,10 +192,21 @@ The adaptive concurrency filter outputs statistics in the
 comes from the owning HTTP connection manager. Statistics are specific to the concurrency
 controllers.
 
+Adaptive Concurrency Statistics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The adaptive concurrency filter uses the namespace
+*http.<stat_prefix>.adaptive_concurrency.*.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: auto
+
+  enabled, Gauge, Set to 1 if the filter is enabled and 0 otherwise.
+
 Gradient Controller Statistics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The gradient controller uses the namespace
-*http.<stat_prefix>.adaptive_concurrency.gradient_controller*.
+*http.<stat_prefix>.adaptive_concurrency.gradient_controller.*.
 
 .. csv-table::
   :header: Name, Type, Description
@@ -204,7 +215,5 @@ The gradient controller uses the namespace
   rq_blocked, Counter, Total requests that were blocked by the filter.
   min_rtt_calculation_active, Gauge, Set to 1 if the controller is in the process of a minRTT calculation. 0 otherwise.
   concurrency_limit, Gauge, The current concurrency limit.
-  gradient, Gauge, The current gradient value.
-  burst_queue_size, Gauge, The current headroom value in the concurrency limit calculation.
   min_rtt_msecs, Gauge, The current measured minRTT value.
   sample_rtt_msecs, Gauge, The current measured sampleRTT aggregate.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,6 +5,7 @@ Version history
 ================
 * access log: added FILTER_STATE :ref:`access log formatters <config_access_log_format>` and gRPC access logger.
 * access log: added a :ref:`typed JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format with non-string values
+* adaptive concurrency: removed gradient and burst queue stats and added enabled stat.
 * api: remove all support for v1
 * buffer: remove old implementation
 * build: official released binary is now built against libc++.

--- a/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h
+++ b/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h
@@ -23,6 +23,18 @@ namespace HttpFilters {
 namespace AdaptiveConcurrency {
 
 /**
+ * All stats for the adaptive concurrency filter.
+ */
+#define ALL_ADAPTIVE_CONCURRENCY_STATS(GAUGE) GAUGE(enabled, NeverImport)
+
+/**
+ * Wrapper struct for the adaptive concurrency stats. @see stats_macros.h
+ */
+struct AdaptiveConcurrencyStats {
+  ALL_ADAPTIVE_CONCURRENCY_STATS(GENERATE_GAUGE_STRUCT)
+};
+
+/**
  * Configuration for the adaptive concurrency limit filter.
  */
 class AdaptiveConcurrencyFilterConfig {
@@ -33,13 +45,23 @@ public:
       Runtime::Loader& runtime, std::string stats_prefix, Stats::Scope& scope,
       TimeSource& time_source);
 
-  bool filterEnabled() const { return adaptive_concurrency_feature_.enabled(); }
+  bool filterEnabled() const {
+    const bool enabled = adaptive_concurrency_feature_.enabled();
+    stats_.enabled_.set(enabled);
+    return enabled;
+  }
+
   TimeSource& timeSource() const { return time_source_; }
 
 private:
+  static AdaptiveConcurrencyStats generateStats(Stats::Scope& scope,
+                                                const std::string& stats_prefix);
+
   const std::string stats_prefix_;
   TimeSource& time_source_;
   Runtime::FeatureFlag adaptive_concurrency_feature_;
+  Stats::Scope& scope_;
+  AdaptiveConcurrencyStats stats_;
 };
 
 using AdaptiveConcurrencyFilterConfigSharedPtr =

--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.cc
@@ -155,11 +155,9 @@ uint32_t GradientController::calculateNewLimit() {
   const auto buffered_min_rtt = min_rtt_.count() + min_rtt_.count() * config_.minRTTBufferPercent();
   const double raw_gradient = static_cast<double>(buffered_min_rtt) / sample_rtt_.count();
   const double gradient = std::max<double>(0.5, std::min<double>(2.0, raw_gradient));
-  stats_.gradient_.set(gradient);
 
   const double limit = concurrencyLimit() * gradient;
   const double burst_headroom = sqrt(limit);
-  stats_.burst_queue_size_.set(burst_headroom);
 
   // The final concurrency value factors in the burst headroom and must be clamped to keep the value
   // in the range [1, configured_max].

--- a/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h
@@ -26,9 +26,7 @@ namespace ConcurrencyController {
  */
 #define ALL_GRADIENT_CONTROLLER_STATS(COUNTER, GAUGE)                                              \
   COUNTER(rq_blocked)                                                                              \
-  GAUGE(burst_queue_size, NeverImport)                                                             \
   GAUGE(concurrency_limit, NeverImport)                                                            \
-  GAUGE(gradient, NeverImport)                                                                     \
   GAUGE(min_rtt_calculation_active, Accumulate)                                                    \
   GAUGE(min_rtt_msecs, NeverImport)                                                                \
   GAUGE(sample_rtt_msecs, NeverImport)

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -113,6 +113,7 @@ enabled:
   Http::TestHeaderMapImpl response_headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   filter_->encodeComplete();
+  EXPECT_EQ(0, stats_.gauge("testprefix.enabled", Stats::Gauge::ImportMode::NeverImport).value());
 }
 
 TEST_F(AdaptiveConcurrencyFilterTest, TestEnableConfiguredInProto) {
@@ -199,6 +200,7 @@ TEST_F(AdaptiveConcurrencyFilterTest, RecordSampleOmission) {
   EXPECT_CALL(*controller_, forwardingDecision()).WillOnce(Return(RequestForwardingAction::Block));
   Http::TestHeaderMapImpl request_headers;
   filter_->decodeHeaders(request_headers, true);
+  EXPECT_EQ(1, stats_.gauge("testprefix.enabled", Stats::Gauge::ImportMode::NeverImport).value());
 
   filter_.reset();
 }


### PR DESCRIPTION
Removes the `gradient` and `burst_queue_size` stats. The gradient stat is not useful and one can simply derive it from the concurrency limit differential and the burst queue is the square-root of the concurrency limit.

This patch also adds a new gauge to indicate if the filter is enabled.

Risk Level: Low
Testing: Unit
Docs Changes: Done
Fixes: #9344 
