### PR TITLE
Fix incorrect cluster InitializePhase type

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -917,7 +917,9 @@ void ClusterImplBase::onPreInitComplete() {
   }
   initialization_started_ = true;
 
-  ENVOY_LOG(debug, "initializing secondary cluster {} completed", info()->name());
+  ENVOY_LOG(debug, "initializing {} cluster {} completed",
+            initializePhase() == InitializePhase::Primary ? "Primary" : "Secondary",
+            info()->name());
   init_manager_.initialize(init_watcher_);
 }
 


### PR DESCRIPTION
Description: Fix incorrect cluster InitializePhase type debug message. At the time of initialization of the cluster, all the InitializePhase type of cluster output were secondary
Risk Level: low
Testing: N/A
Docs Changes: N/A

Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>