### PR TITLE
common: Move platform specific includes to platform.h

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sys/stat.h>
-
 #include <memory>
 #include <string>
 

--- a/include/envoy/api/os_sys_calls_hot_restart.h
+++ b/include/envoy/api/os_sys_calls_hot_restart.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#ifndef WIN32
-#include <sys/mman.h> // for mode_t
-
-#endif
-
 #include "envoy/api/os_sys_calls_common.h"
 #include "envoy/common/pure.h"
 

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -43,13 +43,20 @@ typedef unsigned int sa_family_t;
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/fcntl.h>
+#include <sys/inotify.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h> // for mode_t
+#include <sys/prctl.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif
+#include <sys/types.h>
 #include <sys/uio.h> // for iovec
 #include <sys/un.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #if defined(__linux__)

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sys/types.h>
-
 #include <array>
 #include <cstdint>
 #include <memory>

--- a/include/envoy/network/resolver.h
+++ b/include/envoy/network/resolver.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <sys/types.h>
-
 #include <cstdint>
 #include <string>
 
 #include "envoy/api/v2/core/address.pb.h"
+#include "envoy/common/platform.h"
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -1,7 +1,6 @@
 #include "common/api/os_sys_calls_impl.h"
 
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include <cerrno>

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "envoy/api/os_sys_calls.h"
+#include "envoy/common/platform.h"
 
 #include "common/singleton/threadsafe_singleton.h"
 

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -1,10 +1,6 @@
 #include "common/common/assert.h"
 #include "common/common/thread_impl.h"
 
-#if defined(__linux__)
-#include <sys/syscall.h>
-#endif
-
 namespace Envoy {
 namespace Thread {
 

--- a/source/common/common/posix/thread_impl.h
+++ b/source/common/common/posix/thread_impl.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 
+#include "envoy/common/platform.h"
 #include "envoy/thread/thread.h"
 
 namespace Envoy {

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -1,5 +1,3 @@
-#include <sys/inotify.h>
-
 #include <cstdint>
 #include <string>
 

--- a/source/common/filesystem/inotify/watcher_impl.h
+++ b/source/common/filesystem/inotify/watcher_impl.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "envoy/common/platform.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/watcher.h"
 

--- a/source/common/filesystem/kqueue/watcher_impl.cc
+++ b/source/common/filesystem/kqueue/watcher_impl.cc
@@ -1,7 +1,3 @@
-#include <sys/event.h>
-#include <sys/fcntl.h>
-#include <sys/types.h>
-
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -1,6 +1,5 @@
 #include <dirent.h>
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include <cstdlib>

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -1,6 +1,5 @@
 #include <fcntl.h>
 #include <io.h>
-#include <sys/stat.h>
 
 #include <fstream>
 #include <iostream>

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sys/types.h>
-
 #include <array>
 #include <cstdint>
 #include <string>

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -1,7 +1,5 @@
 #include "common/network/listen_socket_impl.h"
 
-#include <sys/types.h>
-
 #include <string>
 
 #include "envoy/api/v2/core/base.pb.h"

--- a/source/common/signal/signal_action.cc
+++ b/source/common/signal/signal_action.cc
@@ -1,7 +1,5 @@
 #include "common/signal/signal_action.h"
 
-#include <sys/mman.h>
-
 #include <csignal>
 
 #include "common/common/assert.h"

--- a/source/extensions/quic_listeners/quiche/envoy_quic_utils.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_utils.cc
@@ -1,7 +1,5 @@
 #include "extensions/quic_listeners/quiche/envoy_quic_utils.h"
 
-#include <sys/socket.h>
-
 #include "envoy/api/v2/core/base.pb.h"
 
 #include "common/network/socket_option_factory.h"

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -1,9 +1,5 @@
 #include "server/hot_restart_impl.h"
 
-#include <sys/prctl.h>
-#include <sys/types.h>
-#include <sys/un.h>
-
 #include <csignal>
 #include <cstdint>
 #include <memory>

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <fcntl.h>
-#include <sys/un.h>
 
 #include <array>
 #include <atomic>

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <fcntl.h>
-#include <sys/un.h>
 
 #include <array>
 #include <atomic>

--- a/test/common/signal/signals_test.cc
+++ b/test/common/signal/signals_test.cc
@@ -1,6 +1,6 @@
-#include <sys/mman.h>
-
 #include <csignal>
+
+#include "envoy/common/platform.h"
 
 #include "common/signal/signal_action.h"
 

--- a/test/extensions/quic_listeners/quiche/envoy_quic_writer_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_writer_test.cc
@@ -1,7 +1,7 @@
-#include <sys/types.h>
-
 #include <memory>
 #include <string>
+
+#include "envoy/common/platform.h"
 
 #include "common/network/address_impl.h"
 #include "common/network/io_socket_error_impl.h"

--- a/test/extensions/quic_listeners/quiche/platform/epoll_address_test_utils_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/epoll_address_test_utils_impl.h
@@ -6,10 +6,9 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
-#include <sys/socket.h>
-
 #include <algorithm>
 
+#include "envoy/common/platform.h"
 #include "envoy/network/address.h"
 
 #include "test/test_common/environment.h"

--- a/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
+++ b/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
@@ -1,6 +1,6 @@
-#include <sys/socket.h>
-
 #include <memory>
+
+#include "envoy/common/platform.h"
 
 #include "common/network/address_impl.h"
 

--- a/test/integration/tcp_dump.cc
+++ b/test/integration/tcp_dump.cc
@@ -1,11 +1,11 @@
 #include "test/integration/tcp_dump.h"
 
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include <csignal>
 #include <fstream>
+
+#include "envoy/common/platform.h"
 
 #include "common/common/assert.h"
 #include "common/common/fmt.h"


### PR DESCRIPTION
This change moves all platform specific includes (sys/*) to platform.h
header.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Fixes: #9161

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>