### PR TITLE
Add HttpData to common fuzz test proto

### DIFF
--- a/test/fuzz/common.proto
+++ b/test/fuzz/common.proto
@@ -15,6 +15,13 @@ message Headers {
   repeated envoy.api.v2.core.HeaderValue headers = 1;
 }
 
+message HttpData {
+  Headers headers = 1;
+  string data = 2;
+  Headers trailers = 3;
+  Headers metadata = 4;
+}
+
 message StreamInfo {
   envoy.api.v2.core.Metadata dynamic_metadata = 1;
   uint64 start_time = 2;


### PR DESCRIPTION
Description: Filter-level fuzz tests often require fuzzing HTTP requests. Add a common `HttpData` proto that fuzz tests in envoy (and externally) can use.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Teju Nareddy <nareddyt@google.com>