### PR TITLE
Google Test simple_re doesn't support [0-9] patterns

### DIFF
--- a/test/common/common/regex_test.cc
+++ b/test/common/common/regex_test.cc
@@ -51,8 +51,13 @@ TEST(Utility, ParseRegex) {
     envoy::type::matcher::RegexMatcher matcher;
     matcher.mutable_google_re2()->mutable_max_program_size()->set_value(1);
     matcher.set_regex("/asdf/.*");
+#ifndef GTEST_USES_SIMPLE_RE
+    EXPECT_THROW_WITH_REGEX(Utility::parseRegex(matcher), EnvoyException,
+                            "RE2 program size of [0-9]+ > max program size of 1\\.");
+#else
     EXPECT_THROW_WITH_REGEX(Utility::parseRegex(matcher), EnvoyException,
                             "RE2 program size of \\d+ > max program size of 1\\.");
+#endif
   }
 }
 

--- a/test/common/common/regex_test.cc
+++ b/test/common/common/regex_test.cc
@@ -52,7 +52,7 @@ TEST(Utility, ParseRegex) {
     matcher.mutable_google_re2()->mutable_max_program_size()->set_value(1);
     matcher.set_regex("/asdf/.*");
     EXPECT_THROW_WITH_REGEX(Utility::parseRegex(matcher), EnvoyException,
-                            "RE2 program size of [0-9]+ > max program size of 1\\.");
+                            "RE2 program size of \\d+ > max program size of 1\\.");
   }
 }
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1572,6 +1572,7 @@ TEST_F(TcpProxyTest, DEPRECATED_FEATURE_TEST(AccessLogBytesRxTxDuration)) {
   EXPECT_THAT(access_log_data_,
               MatchesRegex("bytesreceived=1 bytessent=2 "
                            "datetime=\\d+-\\d+-\\d+T\\d+:\\d+:\\d+\\.\\d+Z nonzeronum=\\d+"));
+  EXPECT_THAT(access_log_data_, Not(MatchesRegex("nonzeronum=0")));
 #endif
 }
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1564,9 +1564,15 @@ TEST_F(TcpProxyTest, DEPRECATED_FEATURE_TEST(AccessLogBytesRxTxDuration)) {
   upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
   filter_.reset();
 
+#if !defined(WIN32)
   EXPECT_THAT(access_log_data_,
               MatchesRegex(
                   "bytesreceived=1 bytessent=2 datetime=[0-9-]+T[0-9:.]+Z nonzeronum=[1-9][0-9]*"));
+#else
+  EXPECT_THAT(access_log_data_,
+              MatchesRegex("bytesreceived=1 bytessent=2 "
+                           "datetime=\\d+-\\d+-\\d+T\\d+:\\d+:\\d+\\.\\d+Z nonzeronum=\\d+"));
+#endif
 }
 
 TEST_F(TcpProxyTest, DEPRECATED_FEATURE_TEST(AccessLogUpstreamSSLConnection)) {

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1564,7 +1564,7 @@ TEST_F(TcpProxyTest, DEPRECATED_FEATURE_TEST(AccessLogBytesRxTxDuration)) {
   upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
   filter_.reset();
 
-#if !defined(WIN32)
+#ifndef GTEST_USES_SIMPLE_RE
   EXPECT_THAT(access_log_data_,
               MatchesRegex(
                   "bytesreceived=1 bytessent=2 datetime=[0-9-]+T[0-9:.]+Z nonzeronum=[1-9][0-9]*"));

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -277,9 +277,15 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
   } while (log_result.empty());
 
   // Regex matching localhost:port
+#ifndef GTEST_USES_SIMPLE_RE
+  const std::string ip_port_regex = (GetParam() == Network::Address::IpVersion::v4)
+                                        ? R"EOF(127\.0\.0\.1:[0-9]+)EOF"
+                                        : R"EOF(\[::1\]:[0-9]+)EOF";
+#else
   const std::string ip_port_regex = (GetParam() == Network::Address::IpVersion::v4)
                                         ? R"EOF(127\.0\.0\.1:\d+)EOF"
                                         : R"EOF(\[::1\]:\d+)EOF";
+#endif
 
   const std::string ip_regex =
       (GetParam() == Network::Address::IpVersion::v4) ? R"EOF(127\.0\.0\.1)EOF" : R"EOF(::1)EOF";

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -278,8 +278,8 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
 
   // Regex matching localhost:port
   const std::string ip_port_regex = (GetParam() == Network::Address::IpVersion::v4)
-                                        ? R"EOF(127\.0\.0\.1:[0-9]+)EOF"
-                                        : R"EOF(\[::1\]:[0-9]+)EOF";
+                                        ? R"EOF(127\.0\.0\.1:\d+)EOF"
+                                        : R"EOF(\[::1\]:\d+)EOF";
 
   const std::string ip_regex =
       (GetParam() == Network::Address::IpVersion::v4) ? R"EOF(127\.0\.0\.1)EOF" : R"EOF(::1)EOF";
@@ -287,7 +287,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
   // Test that all three addresses were populated correctly. Only check the first line of
   // log output for simplicity.
   EXPECT_THAT(log_result,
-              MatchesRegex(fmt::format("upstreamlocal={0} upstreamhost={0} downstream={1}\n.*",
+              MatchesRegex(fmt::format("upstreamlocal={0} upstreamhost={0} downstream={1}\r?\n.*",
                                        ip_port_regex, ip_regex)));
 }
 


### PR DESCRIPTION
Replace [0-9] character group matches with \d supported by simple_re

This suggests we need Google Test to support Google re2
(and also should deprecate all std::regex in Envoy for re2)
but for the short term, solve these cases by simplifying the
pattern expressions. The one #ifdef presumes we wanted to
validate a non-'0' leading digit.

See: https://github.com/google/googletest/blob/587ceaeaee6c2ccb5e565858d7fe12aaf69795e6/googletest/include/gtest/gtest-death-test.h#L106

Signed-off-by: William A Rowe Jr <wrowe@pivotal.io>
Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>
Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>

Risk Level: Low
Testing: Local on MSVC, Linux gcc
Docs Changes: n/a
Release Notes: n/a
