### PR TITLE
Fix win32 breakage 18 dec

### DIFF
--- a/test/common/common/mem_block_builder_test.cc
+++ b/test/common/common/mem_block_builder_test.cc
@@ -68,27 +68,24 @@ TEST(MemBlockBuilderTest, AppendUint32) {
   EXPECT_EQ(0, mem_block.capacity());
 }
 
+#ifdef ENVOY_CONFIG_COVERAGE
+// For some reason, this test under coverage generates a list of testdata/*.
+static const char expected_death_regex[] = "";
+#else
+static const char expected_death_regex[] = ".*insufficient capacity.*";
+#endif
+
 TEST(MemBlockBuilderTest, AppendOneTooMuch) {
   MemBlockBuilder<uint8_t> mem_block(1);
   mem_block.appendOne(1);
-#ifdef ENVOY_CONFIG_COVERAGE
-  // For some reason, this test under coverage generates a list of testdata/*.
-  EXPECT_DEATH({ mem_block.appendOne(2); }, "");
-#else
-  EXPECT_DEATH({ mem_block.appendOne(2); }, ".*insufficient capacity.*");
-#endif
+  EXPECT_DEATH({ mem_block.appendOne(2); }, expected_death_regex);
 }
 
 TEST(MemBlockBuilderTest, AppendDataTooMuch) {
   MemBlockBuilder<uint8_t> mem_block(1);
   const uint8_t foo[] = {1, 2};
-#ifdef ENVOY_CONFIG_COVERAGE
-  // For some reason, this test under coverage generates a list of testdata/*.
-  EXPECT_DEATH({ mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo))); }, "");
-#else
   EXPECT_DEATH({ mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo))); },
-               ".*insufficient capacity.*");
-#endif
+               expected_death_regex);
 }
 
 } // namespace Envoy

--- a/test/common/common/mem_block_builder_test.cc
+++ b/test/common/common/mem_block_builder_test.cc
@@ -71,25 +71,24 @@ TEST(MemBlockBuilderTest, AppendUint32) {
 TEST(MemBlockBuilderTest, AppendOneTooMuch) {
   MemBlockBuilder<uint8_t> mem_block(1);
   mem_block.appendOne(1);
-  EXPECT_DEATH({ mem_block.appendOne(2); },
 #ifdef ENVOY_CONFIG_COVERAGE
-               "" // For some reason, this test under coverage generates a list of testdata/*.
+  // For some reason, this test under coverage generates a list of testdata/*.
+  EXPECT_DEATH({ mem_block.appendOne(2); }, "");
 #else
-               ".*insufficient capacity.*"
+  EXPECT_DEATH({ mem_block.appendOne(2); }, ".*insufficient capacity.*");
 #endif
-  );
 }
 
 TEST(MemBlockBuilderTest, AppendDataTooMuch) {
   MemBlockBuilder<uint8_t> mem_block(1);
   const uint8_t foo[] = {1, 2};
-  EXPECT_DEATH({ mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo))); },
 #ifdef ENVOY_CONFIG_COVERAGE
-               "" // For some reason, this test under coverage generates a list of testdata/*.
+  // For some reason, this test under coverage generates a list of testdata/*.
+  EXPECT_DEATH({ mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo))); }, "");
 #else
-               ".*insufficient capacity.*"
+  EXPECT_DEATH({ mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo))); },
+               ".*insufficient capacity.*");
 #endif
-  );
 }
 
 } // namespace Envoy

--- a/test/common/config/metadata_test.cc
+++ b/test/common/config/metadata_test.cc
@@ -60,7 +60,7 @@ public:
 
   struct Bar : public TypedMetadata::Object {};
 
-  class FooFactory : public TypedMetadataFactory::TypedMetadataFactory {
+  class FooFactory : public Envoy::Config::TypedMetadataFactory {
   public:
     const std::string name() const override { return "foo"; }
     // Throws EnvoyException (conversion failure) if d is empty.

--- a/test/common/config/metadata_test.cc
+++ b/test/common/config/metadata_test.cc
@@ -60,7 +60,7 @@ public:
 
   struct Bar : public TypedMetadata::Object {};
 
-  class FooFactory : public Envoy::Config::TypedMetadataFactory {
+  class FooFactory : public TypedMetadataFactory {
   public:
     const std::string name() const override { return "foo"; }
     // Throws EnvoyException (conversion failure) if d is empty.

--- a/tools/clang_tools/api_booster/main.cc
+++ b/tools/clang_tools/api_booster/main.cc
@@ -1,6 +1,6 @@
 // Upgrade a single Envoy C++ file to the latest API version.
 //
-// Currently this tool is a WiP and only does inference of .pb[.validate].h
+// Currently this tool is a WIP and only does inference of .pb[.validate].h
 // #include locations. This already exercises some of the muscles we need, such
 // as AST matching, rudimentary type inference and API type database lookup.
 //
@@ -112,7 +112,7 @@ public:
     return true;
   }
 
-  // Visitor callback for end of a compiation unit.
+  // Visitor callback for end of a compilation unit.
   void handleEndSource() override {
     // Dump known API header paths to stdout for api_boost.py to rewrite with
     // (no rewriting support in this tool yet).
@@ -161,7 +161,7 @@ private:
       // Die hard if we don't have a useful proto type for something that looks
       // like an API type(modulo a short whitelist).
       std::cerr << "Unknown API type: " << proto_type_name << std::endl;
-      // TODO(htuch): mabye there is a nicer way to terminate AST traversal?
+      // TODO(htuch): maybe there is a nicer way to terminate AST traversal?
       ::exit(1);
     }
 

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -428,7 +428,6 @@ codings
 combinatorial
 comparator
 compat
-compiation
 completable
 cond
 condvar
@@ -579,6 +578,7 @@ goog
 google
 goto
 gzip
+hackery
 hacky
 handshaker
 hardcoded
@@ -679,7 +679,6 @@ lowp
 ltrim
 lua
 lyft
-mabye
 maglev
 malloc
 matchable

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -13,6 +13,7 @@ API
 ASAN
 ASCII
 ASSERTs
+AST
 AWS
 BACKTRACE
 BSON
@@ -47,6 +48,7 @@ CTXs
 CVC
 CVE
 CX
+CYGWIN
 DER
 DESC
 DFATAL
@@ -56,7 +58,9 @@ DNS
 DRYs
 DS
 DST
+DW
 EADDRINUSE
+EADDRNOTAVAIL
 EAGAIN
 ECDH
 ECDHE
@@ -90,6 +94,7 @@ FCDS
 FFFF
 FIN
 FIPS
+FIRSTHDR
 FQDN
 FREEBIND
 FUZZER
@@ -149,6 +154,7 @@ LDS
 LEV
 LF
 LHS
+LLVM
 LRS
 MB
 MD
@@ -164,6 +170,7 @@ NACKs
 NBF
 NBSP
 NDEBUG
+NEXTHDR
 NGHTTP
 NOAUTH
 NODELAY
@@ -298,6 +305,7 @@ VLOG
 VM
 WASM
 WAVM
+WIP
 WKT
 WRR
 WS
@@ -525,6 +533,7 @@ evwatch
 exe
 execlp
 expectable
+extrahelp
 faceplant
 facto
 failover
@@ -644,6 +653,7 @@ lenenc
 lexically
 libc
 libevent
+libtool
 libstdc
 lifecycle
 lightstep

--- a/tools/type_whisperer/api_type_db.h
+++ b/tools/type_whisperer/api_type_db.h
@@ -9,7 +9,7 @@ namespace TypeWhisperer {
 
 // We don't expose the raw API type database to consumers, as this requires RTTI
 // and this may be linked in environments where this is not available (e.g.
-// libtooling binaries).
+// libtool binaries).
 class ApiTypeDb {
 public:
   static absl::optional<std::string> getProtoPathForType(const std::string& type_name);


### PR DESCRIPTION
Description:
This corrects the newest breakage on the Windows platform introduced in December.

Risk Level: Low
Testing: Local on Windows msvc and Linux gcc
Docs Changes: n/a
Release Notes: n/a
