### PR TITLE
fuzz: fix incorrect evaluator test

### DIFF
--- a/test/extensions/filters/common/expr/evaluator_corpus/emptystruct
+++ b/test/extensions/filters/common/expr/evaluator_corpus/emptystruct
@@ -1,0 +1,4 @@
+expression {
+  struct_expr {
+  }
+}

--- a/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
@@ -42,11 +42,12 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::common::expr::EvaluatorTest
 
     // Evaluate the CEL expression.
     Protobuf::Arena arena;
-    Expr::evaluate(*expr, nullptr, stream_info, &request_headers, &response_headers,
+    Expr::evaluate(*expr, &arena, stream_info, &request_headers, &response_headers,
                    &response_trailers);
   } catch (const CelException& e) {
     ENVOY_LOG_MISC(debug, "CelException: {}", e.what());
   }
+
 }
 
 } // namespace

--- a/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
@@ -47,7 +47,6 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::common::expr::EvaluatorTest
   } catch (const CelException& e) {
     ENVOY_LOG_MISC(debug, "CelException: {}", e.what());
   }
-
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: pass an arena to evaluate call. Arena is used to allocate temporary objects (e.g. an empty map).
/assign @asraa 
/assign @htuch 
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
