### PR TITLE
docs: fix invalid transport_socket value

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -487,12 +487,12 @@ message Cluster {
   //    match:
   //      acceptMTLS: true
   //    transport_socket:
-  //      name: tls
+  //      name: envoy.transport_sockets.tls
   //      config: { ... } # tls socket configuration
   //  - name: "defaultToPlaintext"
   //    match: {}
   //    transport_socket:
-  //      name: "rawbuffer"
+  //      name: envoy.transport_sockets.raw_buffer
   //
   // Connections to the endpoints whose metadata value under *envoy.transport_socket*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -522,12 +522,12 @@ message Cluster {
   //    match:
   //      acceptMTLS: true
   //    transport_socket:
-  //      name: tls
+  //      name: envoy.transport_sockets.tls
   //      config: { ... } # tls socket configuration
   //  - name: "defaultToPlaintext"
   //    match: {}
   //    transport_socket:
-  //      name: "rawbuffer"
+  //      name: envoy.transport_sockets.raw_buffer
   //
   // Connections to the endpoints whose metadata value under *envoy.transport_socket*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.

--- a/test/integration/transport_socket_match_integration_test.cc
+++ b/test/integration/transport_socket_match_integration_test.cc
@@ -38,7 +38,7 @@ name: "tls_socket"
 match:
   mtlsReady: "true"
 transport_socket:
-  name: "tls"
+  name: envoy.transport_sockets.tls
   typed_config:
     "@type": type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
     common_tls_context:


### PR DESCRIPTION
`rawbuffer` is invalid:
```
[2019-12-18 16:14:39.489][1760241][critical][main] [source/server/server.cc:94] error initializing configuration 'envoy.yaml': Didn't find a registered implementation for name: 'rawbuffer'
[2019-12-18 16:14:39.489][1760241][info][main] [source/server/server.cc:577] exiting
Didn't find a registered implementation for name: 'rawbuffer'
```
while here, updated them to the fully-qualified name, since `tls`, `raw_buffer`, etc. are deprecated:
```
[2019-12-18 16:15:37.997][1762851][warning][config] [bazel-out/darwin-fastbuild/bin/include/envoy/registry/_virtual_includes/registry/envoy/registry/registry.h:230] tls is deprecated, use envoy.transport_sockets.tls instead.
```

Signed-off-by: Derek Argueta <dereka@pinterest.com>