### PR TITLE
server: fix bogus startup log message

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -236,7 +236,9 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
     throw NoServingException();
   }
 
-  disabled_extensions_ = absl::StrSplit(disable_extensions.getValue(), ",");
+  if (!disable_extensions.getValue().empty()) {
+    disabled_extensions_ = absl::StrSplit(disable_extensions.getValue(), ",");
+  }
 }
 
 void OptionsImpl::parseComponentLogLevels(const std::string& component_log_levels) {


### PR DESCRIPTION
When Envoy splits the empty `--disable-extensions` flag at startup,
it ends up with a vector containing a single empty string. Since
the vector isn't empty, it tries to disable the extension with an
empty name. The fix is to not try to split the option string if it
is empty.

Risk Level: Low
Testing: Manually observed startup log
Docs Changes: N/A
Release Notes: N/A
Fixes: #9377 
