### PR TITLE
tools: API boosting support for using decls and enum constants.

### DIFF
--- a/tools/api_boost/api_boost_test.py
+++ b/tools/api_boost/api_boost_test.py
@@ -5,6 +5,8 @@
 # tools/clang_tools/api_booster, as well as the type whisperer and API type
 # database.
 
+import argparse
+from collections import namedtuple
 import logging
 import os
 import pathlib
@@ -15,10 +17,14 @@ import tempfile
 
 import api_boost
 
+TestCase = namedtuple('TestCase', ['name', 'description'])
+
 # List of test in the form [(file_name, explanation)]
-TESTS = [
-    ('elaborated_type.cc', 'ElaboratedTypeLoc type upgrades'),
-]
+TESTS = list(map(lambda x: TestCase(*x), [
+    ('elaborated_type', 'ElaboratedTypeLoc type upgrades'),
+    ('using_decl', 'UsingDecl upgrades for named types'),
+    ('decl_ref_expr', 'DeclRefExpr upgrades for named constants'),
+]))
 
 TESTDATA_PATH = 'tools/api_boost/testdata'
 
@@ -31,29 +37,45 @@ def Diff(some_path, other_path):
 
 
 if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Golden C++ source tests for api_boost.py')
+  parser.add_argument('tests', nargs='*')
+  args = parser.parse_args()
+
   # Accumulated error messages.
   logging.basicConfig(format='%(message)s')
   messages = []
+
+  def ShouldRunTest(test_name):
+    return len(args.tests) == 0 or test_name in args.tests
 
   # Run API booster against test artifacts in a directory relative to workspace.
   # We use a temporary copy as the API booster does in-place rewriting.
   with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as path:
     # Setup temporary tree.
     shutil.copy(os.path.join(TESTDATA_PATH, 'BUILD'), path)
-    for filename, _ in TESTS:
-      shutil.copy(os.path.join(TESTDATA_PATH, filename), path)
+    for test in TESTS:
+      if ShouldRunTest(test.name):
+        shutil.copy(os.path.join(TESTDATA_PATH, test.name + '.cc'), path)
+      else:
+        # Place an empty file to make Bazel happy.
+        pathlib.Path(path, test.name + '.cc').write_text('')
 
     # Run API booster.
-    api_boost.ApiBoostTree([str(pathlib.Path(path).relative_to(pathlib.Path.cwd()))],
+    relpath_to_testdata = str(pathlib.Path(path).relative_to(pathlib.Path.cwd()))
+    api_boost.ApiBoostTree([relpath_to_testdata],
                            generate_compilation_database=True,
                            build_api_booster=True,
-                           debug_log=True)
+                           debug_log=True,
+                           sequential=True)
 
     # Validate output against golden files.
-    for filename, description in TESTS:
-      delta = Diff(os.path.join(TESTDATA_PATH, filename + '.gold'), os.path.join(path, filename))
-      if delta is not None:
-        messages.append('Non-empty diff for %s (%s):\n%s\n' % (filename, description, delta))
+    for test in TESTS:
+      if ShouldRunTest(test.name):
+        delta = Diff(os.path.join(TESTDATA_PATH, test.name + '.cc.gold'),
+                     os.path.join(path, test.name + '.cc'))
+        if delta is not None:
+          messages.append('Non-empty diff for %s (%s):\n%s\n' %
+                          (test.name, test.description, delta))
 
   if len(messages) > 0:
     logging.error('FAILED:\n{}'.format('\n'.join(messages)))

--- a/tools/api_boost/api_boost_test.py
+++ b/tools/api_boost/api_boost_test.py
@@ -20,11 +20,12 @@ import api_boost
 TestCase = namedtuple('TestCase', ['name', 'description'])
 
 # List of test in the form [(file_name, explanation)]
-TESTS = list(map(lambda x: TestCase(*x), [
-    ('elaborated_type', 'ElaboratedTypeLoc type upgrades'),
-    ('using_decl', 'UsingDecl upgrades for named types'),
-    ('decl_ref_expr', 'DeclRefExpr upgrades for named constants'),
-]))
+TESTS = list(
+    map(lambda x: TestCase(*x), [
+        ('elaborated_type', 'ElaboratedTypeLoc type upgrades'),
+        ('using_decl', 'UsingDecl upgrades for named types'),
+        ('decl_ref_expr', 'DeclRefExpr upgrades for named constants'),
+    ]))
 
 TESTDATA_PATH = 'tools/api_boost/testdata'
 

--- a/tools/api_boost/testdata/BUILD
+++ b/tools/api_boost/testdata/BUILD
@@ -9,7 +9,19 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "decl_ref_expr",
+    srcs = ["decl_ref_expr.cc"],
+    deps = ["@envoy_api//envoy/config/overload/v2alpha:pkg_cc_proto"],
+)
+
+envoy_cc_library(
     name = "elaborated_type",
     srcs = ["elaborated_type.cc"],
+    deps = ["@envoy_api//envoy/config/overload/v2alpha:pkg_cc_proto"],
+)
+
+envoy_cc_library(
+    name = "using_decl",
+    srcs = ["using_decl.cc"],
     deps = ["@envoy_api//envoy/config/overload/v2alpha:pkg_cc_proto"],
 )

--- a/tools/api_boost/testdata/decl_ref_expr.cc
+++ b/tools/api_boost/testdata/decl_ref_expr.cc
@@ -1,0 +1,21 @@
+#include "envoy/config/overload/v2alpha/overload.pb.h"
+
+using envoy::config::overload::v2alpha::Trigger;
+
+class ThresholdTriggerImpl {
+public:
+  ThresholdTriggerImpl(const envoy::config::overload::v2alpha::Trigger& config) {
+    switch (config.trigger_oneof_case()) {
+    case envoy::config::overload::v2alpha::Trigger::kThreshold:
+      break;
+    default:
+      break;
+    }
+    switch (config.trigger_oneof_case()) {
+    case Trigger::kThreshold:
+      break;
+    default:
+      break;
+    }
+  }
+};

--- a/tools/api_boost/testdata/decl_ref_expr.cc.gold
+++ b/tools/api_boost/testdata/decl_ref_expr.cc.gold
@@ -1,0 +1,21 @@
+#include "envoy/config/overload/v3alpha/overload.pb.h"
+
+using envoy::config::overload::v3alpha::Trigger;
+
+class ThresholdTriggerImpl {
+public:
+  ThresholdTriggerImpl(const envoy::config::overload::v3alpha::Trigger& config) {
+    switch (config.trigger_oneof_case()) {
+    case envoy::config::overload::v3alpha::Trigger::kThreshold:
+      break;
+    default:
+      break;
+    }
+    switch (config.trigger_oneof_case()) {
+    case Trigger::kThreshold:
+      break;
+    default:
+      break;
+    }
+  }
+};

--- a/tools/api_boost/testdata/using_decl.cc
+++ b/tools/api_boost/testdata/using_decl.cc
@@ -1,0 +1,10 @@
+#include "envoy/config/overload/v2alpha/overload.pb.h"
+
+using envoy::config::overload::v2alpha::ThresholdTrigger;
+using SomePtrAlias = std::unique_ptr<envoy::config::overload::v2alpha::ThresholdTrigger>;
+
+class ThresholdTriggerImpl {
+public:
+  ThresholdTriggerImpl(const ThresholdTrigger& /*config*/) {}
+  ThresholdTriggerImpl(SomePtrAlias /*config*/) {}
+};

--- a/tools/api_boost/testdata/using_decl.cc.gold
+++ b/tools/api_boost/testdata/using_decl.cc.gold
@@ -1,0 +1,10 @@
+#include "envoy/config/overload/v3alpha/overload.pb.h"
+
+using envoy::config::overload::v3alpha::ThresholdTrigger;
+using SomePtrAlias = std::unique_ptr<envoy::config::overload::v3alpha::ThresholdTrigger>;
+
+class ThresholdTriggerImpl {
+public:
+  ThresholdTriggerImpl(const ThresholdTrigger& /*config*/) {}
+  ThresholdTriggerImpl(SomePtrAlias /*config*/) {}
+};


### PR DESCRIPTION
Via AST node matchers on UsingDecl and DeclRefExpr. This commit also
refactors the clang::tooling::SourceFileCallbacks run() routine, by
moving to a per AST node dispatch model. This will support scaling to
additional AST node types in the future without having run() grow to
an unreadable length.

Risk level: Low
Testing: Additional golden tests.

Part of https://github.com/envoyproxy/envoy/issues/8082.

Signed-off-by: Harvey Tuch <htuch@google.com>