### PR TITLE
Fix incorrect statement in degraded mode docs.

### DIFF
--- a/docs/root/intro/arch_overview/upstream/load_balancing/degraded.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/degraded.rst
@@ -6,14 +6,14 @@ Degraded endpoints
 Envoy supports marking certain endpoints as degraded, meaning that they are able to receive
 traffic, but should only receive traffic once there are not sufficient healthy hosts available.
 
-Routing to degraded hosts can be thought of as similar routing to hosts in a
+Routing to degraded hosts can be thought of as similar to routing to hosts in a
 lower :ref:`priority <arch_overview_load_balancing_priority_levels>`, although
-degraded hosts will count against their priority's health percentage when
-computing traffic spillover. As the amount of healthy hosts available is no
-longer sufficient to handle 100% of the load, traffic will spill over to
-degraded hosts using the same mechanism as priority spillover for healthy
-hosts. This ensures that traffic is gradually shifted to degraded hosts as it
-becomes necessary.
+degraded hosts will count against their original priority's health percentage
+for the purposes of computing traffic spillover. As the amount of healthy hosts
+available is no longer sufficient to handle 100% of the load, traffic will
+spill over to degraded hosts using the same mechanism as priority spillover for
+healthy hosts. This ensures that traffic is gradually shifted to degraded hosts
+as it becomes necessary.
 
 
 +--------------------------------+------------------------------+-------------------------------+

--- a/docs/root/intro/arch_overview/upstream/load_balancing/degraded.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/degraded.rst
@@ -6,12 +6,14 @@ Degraded endpoints
 Envoy supports marking certain endpoints as degraded, meaning that they are able to receive
 traffic, but should only receive traffic once there are not sufficient healthy hosts available.
 
-Routing to degraded hosts can be thought of as routing to hosts in a lower 
-:ref:`priority <arch_overview_load_balancing_priority_levels>`. As hosts in higher priorities go 
-unhealthy, traffic spills down to lower priorities. As the amount of healthy hosts
-available is no longer sufficient to handle 100% of the load, traffic will spill over to degraded 
-hosts using the same mechanism as priority spillover for healthy hosts. This ensures that 
-traffic is gradually shifted to degraded hosts as it becomes necessary.
+Routing to degraded hosts can be thought of as similar routing to hosts in a
+lower :ref:`priority <arch_overview_load_balancing_priority_levels>`, although
+degraded hosts will count against their priority's health percentage when
+computing traffic spillover. As the amount of healthy hosts available is no
+longer sufficient to handle 100% of the load, traffic will spill over to
+degraded hosts using the same mechanism as priority spillover for healthy
+hosts. This ensures that traffic is gradually shifted to degraded hosts as it
+becomes necessary.
 
 
 +--------------------------------+------------------------------+-------------------------------+


### PR DESCRIPTION
The docs claimed that degrading hosts is identical to putting them in a
different priority, however there is a slight difference in that
degraded hosts count toward the unhealthy % of their priority, whereas
they wouldn't if they were in a different priority.

This is apparent from looking at the 71%/29%/0% case in the table, where
spillover is happening but it wouldn't if the degraded nodes were in a
different priority (because p0 would still be considered 100% healthy).

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

Description: fix degraded mode docs
Risk Level: low
Testing: n/a
Docs Changes: fixes an incorrect statement
Release Notes: n/a

