### PR TITLE
api: more accurately document required fields

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -103,7 +103,8 @@ message HealthCheck {
 
     // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open
-    // semantics of :ref:`Int64Range <envoy_api_msg_type.Int64Range>`.
+    // semantics of :ref:`Int64Range <envoy_api_msg_type.Int64Range>`. The start and end of each
+    // range are required. Only statuses in the range [100, 600) are allowed.
     repeated type.Int64Range expected_statuses = 9;
 
     // Use specified application protocol for health checks. This is to replace
@@ -198,12 +199,12 @@ message HealthCheck {
   // The number of unhealthy health checks required before a host is marked
   // unhealthy. Note that for *http* health checking if a host responds with 503
   // this threshold is ignored and the host is considered unhealthy immediately.
-  google.protobuf.UInt32Value unhealthy_threshold = 4;
+  google.protobuf.UInt32Value unhealthy_threshold = 4 [(validate.rules).message = {required: true}];
 
   // The number of healthy health checks required before a host is marked
   // healthy. Note that during startup, only a single successful health check is
   // required to mark a host healthy.
-  google.protobuf.UInt32Value healthy_threshold = 5;
+  google.protobuf.UInt32Value healthy_threshold = 5 [(validate.rules).message = {required: true}];
 
   // [#not-implemented-hide:] Non-serving port for health checking.
   google.protobuf.UInt32Value alt_port = 6;

--- a/api/envoy/api/v3alpha/core/health_check.proto
+++ b/api/envoy/api/v3alpha/core/health_check.proto
@@ -112,7 +112,8 @@ message HealthCheck {
 
     // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open
-    // semantics of :ref:`Int64Range <envoy_api_msg_type.v3alpha.Int64Range>`.
+    // semantics of :ref:`Int64Range <envoy_api_msg_type.v3alpha.Int64Range>`. The start and end of
+    // each range are required. Only statuses in the range [100, 600) are allowed.
     repeated type.v3alpha.Int64Range expected_statuses = 9;
 
     // Use specified application protocol for health checks. This is to replace
@@ -222,12 +223,12 @@ message HealthCheck {
   // The number of unhealthy health checks required before a host is marked
   // unhealthy. Note that for *http* health checking if a host responds with 503
   // this threshold is ignored and the host is considered unhealthy immediately.
-  google.protobuf.UInt32Value unhealthy_threshold = 4;
+  google.protobuf.UInt32Value unhealthy_threshold = 4 [(validate.rules).message = {required: true}];
 
   // The number of healthy health checks required before a host is marked
   // healthy. Note that during startup, only a single successful health check is
   // required to mark a host healthy.
-  google.protobuf.UInt32Value healthy_threshold = 5;
+  google.protobuf.UInt32Value healthy_threshold = 5 [(validate.rules).message = {required: true}];
 
   // [#not-implemented-hide:] Non-serving port for health checking.
   google.protobuf.UInt32Value alt_port = 6;

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -4146,6 +4146,8 @@ TEST(HealthCheckProto, Validation) {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
+    healthy_threshold: 1
+    unhealthy_threshold: 1
     no_traffic_interval: 0s
     http_health_check:
       service_name: locations
@@ -4158,6 +4160,8 @@ TEST(HealthCheckProto, Validation) {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
+    healthy_threshold: 1
+    unhealthy_threshold: 1
     unhealthy_interval: 0s
     http_health_check:
       service_name: locations
@@ -4170,6 +4174,8 @@ TEST(HealthCheckProto, Validation) {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
+    healthy_threshold: 1
+    unhealthy_threshold: 1
     unhealthy_edge_interval: 0s
     http_health_check:
       service_name: locations
@@ -4182,6 +4188,8 @@ TEST(HealthCheckProto, Validation) {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
+    healthy_threshold: 1
+    unhealthy_threshold: 1
     healthy_edge_interval: 0s
     http_health_check:
       service_name: locations
@@ -4189,6 +4197,30 @@ TEST(HealthCheckProto, Validation) {
     )EOF";
     EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
                             "Proto constraint validation failed.*value must be greater than.*");
+  }
+  {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    unhealthy_threshold: 1
+    http_health_check:
+      service_name: locations
+      path: /healthcheck
+    )EOF";
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
+                            "Proto constraint validation failed.*value is required.*");
+  }
+  {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    healthy_threshold: 1
+    http_health_check:
+      service_name: locations
+      path: /healthcheck
+    )EOF";
+    EXPECT_THROW_WITH_REGEX(TestUtility::validate(parseHealthCheckFromV2Yaml(yaml)), EnvoyException,
+                            "Proto constraint validation failed.*value is required.*");
   }
 }
 

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -404,6 +404,7 @@ def FormatFieldAsDefinitionListItem(outer_type_context, type_context, field):
   if field.options.HasExtension(validate_pb2.rules):
     rule = field.options.Extensions[validate_pb2.rules]
     if ((rule.HasField('message') and rule.message.required) or
+        (rule.HasField('duration') and rule.duration.required) or
         (rule.HasField('string') and rule.string.min_bytes > 0) or
         (rule.HasField('repeated') and rule.repeated.min_items > 0)):
       field_annotations = ['*REQUIRED*']


### PR DESCRIPTION
Modifies the protodoc tool to tag required duration fields as required.
Adds documentation around HttpHealthCheck.expected_statuses to clarify
what's expected of the Int64Range. Tags two Uint32Value fields as required
since they were implicitly treated as such (and generated missing field
exceptions when unset).

Risk Level: low
Testing: existing tests pass
Docs Changes: yes
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
