### PR TITLE
build: don't reference enum constants via mangled names.

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -88,6 +88,8 @@
   [Google C++ style guide](https://google.github.io/styleguide/cppguide.html#Unnamed_Namespaces_and_Static_Variables)
    allows either, but in Envoy we prefer anonymous namespaces.
 * Braces are required for all control statements include single line if, while, etc. statements.
+* Don't use [mangled Protobuf enum
+  names](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum).
 
 # Error handling
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -185,7 +185,7 @@ OriginalDstClusterFactory::createClusterImpl(
     throw EnvoyException(fmt::format(
         "cluster: LB policy {} is not valid for Cluster type {}. Only 'CLUSTER_PROVIDED' or "
         "'ORIGINAL_DST_LB' is allowed with cluster type 'ORIGINAL_DST'",
-        envoy::api::v2::Cluster_LbPolicy_Name(cluster.lb_policy()),
+        envoy::api::v2::Cluster::LbPolicy_Name(cluster.lb_policy()),
         envoy::api::v2::Cluster_DiscoveryType_Name(cluster.type())));
   }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -684,13 +684,13 @@ ClusterInfoImpl::ClusterInfoImpl(
       throw EnvoyException(
           fmt::format("cluster: LB policy {} is not valid for Cluster type {}. 'ORIGINAL_DST_LB' "
                       "is allowed only with cluster type 'ORIGINAL_DST'",
-                      envoy::api::v2::Cluster_LbPolicy_Name(config.lb_policy()),
+                      envoy::api::v2::Cluster::LbPolicy_Name(config.lb_policy()),
                       envoy::api::v2::Cluster_DiscoveryType_Name(config.type())));
     }
     if (config.has_lb_subset_config()) {
       throw EnvoyException(
           fmt::format("cluster: LB policy {} cannot be combined with lb_subset_config",
-                      envoy::api::v2::Cluster_LbPolicy_Name(config.lb_policy())));
+                      envoy::api::v2::Cluster::LbPolicy_Name(config.lb_policy())));
     }
 
     lb_type_ = LoadBalancerType::ClusterProvided;
@@ -702,7 +702,7 @@ ClusterInfoImpl::ClusterInfoImpl(
     if (config.has_lb_subset_config()) {
       throw EnvoyException(
           fmt::format("cluster: LB policy {} cannot be combined with lb_subset_config",
-                      envoy::api::v2::Cluster_LbPolicy_Name(config.lb_policy())));
+                      envoy::api::v2::Cluster::LbPolicy_Name(config.lb_policy())));
     }
 
     lb_type_ = LoadBalancerType::ClusterProvided;

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -29,8 +29,7 @@ Server::DrainManagerPtr ProdComponentFactory::createDrainManager(Server::Instanc
   // The global drain manager only triggers on listener modification, which effectively is
   // hot restart at the global level. The per-listener drain managers decide whether to
   // to include /healthcheck/fail status.
-  return std::make_unique<Server::DrainManagerImpl>(server,
-                                                    envoy::api::v2::Listener_DrainType_MODIFY_ONLY);
+  return std::make_unique<Server::DrainManagerImpl>(server, envoy::api::v2::Listener::MODIFY_ONLY);
 }
 
 Runtime::LoaderPtr ProdComponentFactory::createRuntime(Server::Instance& server,

--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
@@ -19,16 +19,16 @@ using namespace envoy::data::accesslog::v2;
 // TLS version to the corresponding enum value used in gRPC access logs.
 TLSProperties_TLSVersion tlsVersionStringToEnum(const std::string& tls_version) {
   if (tls_version == "TLSv1") {
-    return TLSProperties_TLSVersion_TLSv1;
+    return TLSProperties::TLSv1;
   } else if (tls_version == "TLSv1.1") {
-    return TLSProperties_TLSVersion_TLSv1_1;
+    return TLSProperties::TLSv1_1;
   } else if (tls_version == "TLSv1.2") {
-    return TLSProperties_TLSVersion_TLSv1_2;
+    return TLSProperties::TLSv1_2;
   } else if (tls_version == "TLSv1.3") {
-    return TLSProperties_TLSVersion_TLSv1_3;
+    return TLSProperties::TLSv1_3;
   }
 
-  return TLSProperties_TLSVersion_VERSION_UNSPECIFIED;
+  return TLSProperties::VERSION_UNSPECIFIED;
 }
 
 } // namespace
@@ -90,8 +90,7 @@ void Utility::responseFlagsToAccessLogResponseFlags(
 
   if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService)) {
     common_access_log.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
-        envoy::data::accesslog::v2::ResponseFlags_Unauthorized_Reason::
-            ResponseFlags_Unauthorized_Reason_EXTERNAL_SERVICE);
+        envoy::data::accesslog::v2::ResponseFlags::Unauthorized::EXTERNAL_SERVICE);
   }
 
   if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError)) {

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -66,9 +66,8 @@ void GrpcClientImpl::onSuccess(
     std::unique_ptr<envoy::service::ratelimit::v2::RateLimitResponse>&& response,
     Tracing::Span& span) {
   LimitStatus status = LimitStatus::OK;
-  ASSERT(response->overall_code() != envoy::service::ratelimit::v2::RateLimitResponse_Code_UNKNOWN);
-  if (response->overall_code() ==
-      envoy::service::ratelimit::v2::RateLimitResponse_Code_OVER_LIMIT) {
+  ASSERT(response->overall_code() != envoy::service::ratelimit::v2::RateLimitResponse::UNKNOWN);
+  if (response->overall_code() == envoy::service::ratelimit::v2::RateLimitResponse::OVER_LIMIT) {
     status = LimitStatus::OverLimit;
     span.setTag(Constants::get().TraceStatus, Constants::get().TraceOverLimit);
   } else {

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -12,8 +12,7 @@ namespace RBAC {
 
 RoleBasedAccessControlEngineImpl::RoleBasedAccessControlEngineImpl(
     const envoy::config::rbac::v2::RBAC& rules)
-    : allowed_if_matched_(rules.action() ==
-                          envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW) {
+    : allowed_if_matched_(rules.action() == envoy::config::rbac::v2::RBAC::ALLOW) {
   // guard expression builder by presence of a condition in policies
   for (const auto& policy : rules.policies()) {
     if (policy.second.has_condition()) {

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -56,11 +56,9 @@ GzipFilterConfig::GzipFilterConfig(const envoy::config::filter::http::gzip::v2::
 Compressor::ZlibCompressorImpl::CompressionLevel GzipFilterConfig::compressionLevelEnum(
     envoy::config::filter::http::gzip::v2::Gzip_CompressionLevel_Enum compression_level) {
   switch (compression_level) {
-  case envoy::config::filter::http::gzip::v2::Gzip_CompressionLevel_Enum::
-      Gzip_CompressionLevel_Enum_BEST:
+  case envoy::config::filter::http::gzip::v2::Gzip::CompressionLevel::BEST:
     return Compressor::ZlibCompressorImpl::CompressionLevel::Best;
-  case envoy::config::filter::http::gzip::v2::Gzip_CompressionLevel_Enum::
-      Gzip_CompressionLevel_Enum_SPEED:
+  case envoy::config::filter::http::gzip::v2::Gzip::CompressionLevel::SPEED:
     return Compressor::ZlibCompressorImpl::CompressionLevel::Speed;
   default:
     return Compressor::ZlibCompressorImpl::CompressionLevel::Standard;
@@ -70,14 +68,11 @@ Compressor::ZlibCompressorImpl::CompressionLevel GzipFilterConfig::compressionLe
 Compressor::ZlibCompressorImpl::CompressionStrategy GzipFilterConfig::compressionStrategyEnum(
     envoy::config::filter::http::gzip::v2::Gzip_CompressionStrategy compression_strategy) {
   switch (compression_strategy) {
-  case envoy::config::filter::http::gzip::v2::Gzip_CompressionStrategy::
-      Gzip_CompressionStrategy_RLE:
+  case envoy::config::filter::http::gzip::v2::Gzip::RLE:
     return Compressor::ZlibCompressorImpl::CompressionStrategy::Rle;
-  case envoy::config::filter::http::gzip::v2::Gzip_CompressionStrategy::
-      Gzip_CompressionStrategy_FILTERED:
+  case envoy::config::filter::http::gzip::v2::Gzip::FILTERED:
     return Compressor::ZlibCompressorImpl::CompressionStrategy::Filtered;
-  case envoy::config::filter::http::gzip::v2::Gzip_CompressionStrategy::
-      Gzip_CompressionStrategy_HUFFMAN:
+  case envoy::config::filter::http::gzip::v2::Gzip::HUFFMAN:
     return Compressor::ZlibCompressorImpl::CompressionStrategy::Huffman;
   default:
     return Compressor::ZlibCompressorImpl::CompressionStrategy::Standard;

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -97,7 +97,7 @@ bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta
   }
 
   std::string decodedValue = std::string(value);
-  if (encode == envoy::config::filter::http::header_to_metadata::v2::Config_ValueEncode_BASE64) {
+  if (encode == envoy::config::filter::http::header_to_metadata::v2::Config::BASE64) {
     decodedValue = Base64::decodeWithoutPadding(value);
     if (decodedValue.empty()) {
       ENVOY_LOG(debug, "Base64 decode failed");
@@ -107,10 +107,10 @@ bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta
 
   // Sane enough, add the key/value.
   switch (type) {
-  case envoy::config::filter::http::header_to_metadata::v2::Config_ValueType_STRING:
+  case envoy::config::filter::http::header_to_metadata::v2::Config::STRING:
     val.set_string_value(std::move(decodedValue));
     break;
-  case envoy::config::filter::http::header_to_metadata::v2::Config_ValueType_NUMBER: {
+  case envoy::config::filter::http::header_to_metadata::v2::Config::NUMBER: {
     double dval;
     if (absl::SimpleAtod(StringUtil::trim(decodedValue), &dval)) {
       val.set_number_value(dval);
@@ -120,7 +120,7 @@ bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta
     }
     break;
   }
-  case envoy::config::filter::http::header_to_metadata::v2::Config_ValueType_PROTOBUF_VALUE: {
+  case envoy::config::filter::http::header_to_metadata::v2::Config::PROTOBUF_VALUE: {
     if (!val.ParseFromString(decodedValue)) {
       ENVOY_LOG(debug, "parse from decoded string failed");
       return false;

--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
@@ -48,11 +48,11 @@ private:
   static FilterRequestType requestTypeEnum(
       envoy::config::filter::http::ip_tagging::v3alpha::IPTagging::RequestType request_type) {
     switch (request_type) {
-    case envoy::config::filter::http::ip_tagging::v3alpha::IPTagging_RequestType_BOTH:
+    case envoy::config::filter::http::ip_tagging::v3alpha::IPTagging::BOTH:
       return FilterRequestType::BOTH;
-    case envoy::config::filter::http::ip_tagging::v3alpha::IPTagging_RequestType_INTERNAL:
+    case envoy::config::filter::http::ip_tagging::v3alpha::IPTagging::INTERNAL:
       return FilterRequestType::INTERNAL;
-    case envoy::config::filter::http::ip_tagging::v3alpha::IPTagging_RequestType_EXTERNAL:
+    case envoy::config::filter::http::ip_tagging::v3alpha::IPTagging::EXTERNAL:
       return FilterRequestType::EXTERNAL;
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -29,23 +29,20 @@ ConfigImpl::ConfigImpl(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_upstream_unknown_connections, 100)),
       enable_command_stats_(config.enable_command_stats()) {
   switch (config.read_policy()) {
-  case envoy::config::filter::network::redis_proxy::v2::
-      RedisProxy_ConnPoolSettings_ReadPolicy_MASTER:
+  case envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::MASTER:
     read_policy_ = ReadPolicy::Master;
     break;
-  case envoy::config::filter::network::redis_proxy::v2::
-      RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_MASTER:
+  case envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::PREFER_MASTER:
     read_policy_ = ReadPolicy::PreferMaster;
     break;
-  case envoy::config::filter::network::redis_proxy::v2::
-      RedisProxy_ConnPoolSettings_ReadPolicy_REPLICA:
+  case envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::REPLICA:
     read_policy_ = ReadPolicy::Replica;
     break;
-  case envoy::config::filter::network::redis_proxy::v2::
-      RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_REPLICA:
+  case envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::
+      PREFER_REPLICA:
     read_policy_ = ReadPolicy::PreferReplica;
     break;
-  case envoy::config::filter::network::redis_proxy::v2::RedisProxy_ConnPoolSettings_ReadPolicy_ANY:
+  case envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::ANY:
     read_policy_ = ReadPolicy::Any;
     break;
   default:

--- a/source/extensions/tracers/xray/config.cc
+++ b/source/extensions/tracers/xray/config.cc
@@ -35,8 +35,7 @@ XRayTracerFactory::createHttpTracerTyped(const trace::XRayConfig& proto_config,
     ENVOY_LOG(error, "Failed to read sampling rules manifest because of {}.", e.what());
   }
 
-  if (proto_config.daemon_endpoint().protocol() !=
-      api::core::SocketAddress::Protocol::SocketAddress_Protocol_UDP) {
+  if (proto_config.daemon_endpoint().protocol() != api::core::SocketAddress::UDP) {
     throw EnvoyException("X-Ray daemon endpoint must be a UDP socket address");
   }
 

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -25,7 +25,7 @@ bool DrainManagerImpl::drainClose() const {
   // if even in the case of server health check failure we had some period of drain ramp up. This
   // would allow the other side to fail health check for the host which will require some thread
   // jumps versus immediately start GOAWAY/connection thrashing.
-  if (drain_type_ == envoy::api::v2::Listener_DrainType_DEFAULT && server_.healthCheckFailed()) {
+  if (drain_type_ == envoy::api::v2::Listener::DEFAULT && server_.healthCheckFailed()) {
     return true;
   }
 

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -359,13 +359,10 @@ const Network::FilterChain* FilterChainManagerImpl::findFilterChainForApplicatio
 const Network::FilterChain* FilterChainManagerImpl::findFilterChainForSourceTypes(
     const SourceTypesArray& source_types, const Network::ConnectionSocket& socket) const {
 
-  const auto& filter_chain_local =
-      source_types[envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType::
-                       FilterChainMatch_ConnectionSourceType_LOCAL];
+  const auto& filter_chain_local = source_types[envoy::api::v2::listener::FilterChainMatch::LOCAL];
 
   const auto& filter_chain_external =
-      source_types[envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType::
-                       FilterChainMatch_ConnectionSourceType_EXTERNAL];
+      source_types[envoy::api::v2::listener::FilterChainMatch::EXTERNAL];
 
   // isLocalConnection can be expensive. Call it only if LOCAL or EXTERNAL have entries.
   const bool is_local_connection =
@@ -383,9 +380,7 @@ const Network::FilterChain* FilterChainManagerImpl::findFilterChainForSourceType
     }
   }
 
-  const auto& filter_chain_any =
-      source_types[envoy::api::v2::listener::FilterChainMatch_ConnectionSourceType::
-                       FilterChainMatch_ConnectionSourceType_ANY];
+  const auto& filter_chain_any = source_types[envoy::api::v2::listener::FilterChainMatch::ANY];
 
   if (!filter_chain_any.first.empty()) {
     return findFilterChainForSourceIpAndPort(*filter_chain_any.second, socket);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -782,8 +782,8 @@ Http::Code AdminImpl::handlerReady(absl::string_view, Http::HeaderMap&, Buffer::
   const envoy::admin::v2alpha::ServerInfo::State state =
       Utility::serverState(server_.initManager().state(), server_.healthCheckFailed());
 
-  response.add(envoy::admin::v2alpha::ServerInfo_State_Name(state) + "\n");
-  Http::Code code = state == envoy::admin::v2alpha::ServerInfo_State_LIVE
+  response.add(envoy::admin::v2alpha::ServerInfo::State_Name(state) + "\n");
+  Http::Code code = state == envoy::admin::v2alpha::ServerInfo::LIVE
                         ? Http::Code::OK
                         : Http::Code::ServiceUnavailable;
   return code;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -393,15 +393,15 @@ public:
   ClusterManagerSubsetInitializationTest() = default;
 
   static std::vector<envoy::api::v2::Cluster_LbPolicy> lbPolicies() {
-    int first = static_cast<int>(envoy::api::v2::Cluster_LbPolicy_LbPolicy_MIN);
-    int last = static_cast<int>(envoy::api::v2::Cluster_LbPolicy_LbPolicy_MAX);
+    int first = static_cast<int>(envoy::api::v2::Cluster::LbPolicy_MIN);
+    int last = static_cast<int>(envoy::api::v2::Cluster::LbPolicy_MAX);
     ASSERT(first < last);
 
     std::vector<envoy::api::v2::Cluster_LbPolicy> policies;
     for (int i = first; i <= last; i++) {
-      if (envoy::api::v2::Cluster_LbPolicy_IsValid(i)) {
+      if (envoy::api::v2::Cluster::LbPolicy_IsValid(i)) {
         auto policy = static_cast<envoy::api::v2::Cluster_LbPolicy>(i);
-        if (policy != envoy::api::v2::Cluster_LbPolicy_LOAD_BALANCING_POLICY_CONFIG) {
+        if (policy != envoy::api::v2::Cluster::LOAD_BALANCING_POLICY_CONFIG) {
           policies.push_back(policy);
         }
       }
@@ -410,7 +410,7 @@ public:
   }
 
   static std::string paramName(const testing::TestParamInfo<ParamType>& info) {
-    const std::string& name = envoy::api::v2::Cluster_LbPolicy_Name(info.param);
+    const std::string& name = envoy::api::v2::Cluster::LbPolicy_Name(info.param);
     return absl::StrReplaceAll(name, {{"_", ""}});
   }
 };
@@ -443,23 +443,23 @@ TEST_P(ClusterManagerSubsetInitializationTest, SubsetLoadBalancerInitialization)
                   port_value: 8001
   )EOF";
 
-  const std::string& policy_name = envoy::api::v2::Cluster_LbPolicy_Name(GetParam());
+  const std::string& policy_name = envoy::api::v2::Cluster::LbPolicy_Name(GetParam());
 
   std::string cluster_type = "type: STATIC";
-  if (GetParam() == envoy::api::v2::Cluster_LbPolicy_ORIGINAL_DST_LB) {
+  if (GetParam() == envoy::api::v2::Cluster::ORIGINAL_DST_LB) {
     cluster_type = "type: ORIGINAL_DST";
-  } else if (GetParam() == envoy::api::v2::Cluster_LbPolicy_CLUSTER_PROVIDED) {
+  } else if (GetParam() == envoy::api::v2::Cluster::CLUSTER_PROVIDED) {
     // This custom cluster type is registered by linking test/integration/custom/static_cluster.cc.
     cluster_type = "cluster_type: { name: envoy.clusters.custom_static_with_lb }";
   }
   const std::string yaml = fmt::format(yamlPattern, cluster_type, policy_name);
 
-  if (GetParam() == envoy::api::v2::Cluster_LbPolicy_ORIGINAL_DST_LB ||
-      GetParam() == envoy::api::v2::Cluster_LbPolicy_CLUSTER_PROVIDED) {
+  if (GetParam() == envoy::api::v2::Cluster::ORIGINAL_DST_LB ||
+      GetParam() == envoy::api::v2::Cluster::CLUSTER_PROVIDED) {
     EXPECT_THROW_WITH_MESSAGE(
         create(parseBootstrapFromV2Yaml(yaml)), EnvoyException,
         fmt::format("cluster: LB policy {} cannot be combined with lb_subset_config",
-                    envoy::api::v2::Cluster_LbPolicy_Name(GetParam())));
+                    envoy::api::v2::Cluster::LbPolicy_Name(GetParam())));
 
   } else {
     create(parseBootstrapFromV2Yaml(yaml));

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -208,8 +208,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMurmur2) {
   hostSet().runCallbacks({}, {});
 
   config_ = envoy::api::v2::Cluster::RingHashLbConfig();
-  config_.value().set_hash_function(envoy::api::v2::Cluster_RingHashLbConfig_HashFunction::
-                                        Cluster_RingHashLbConfig_HashFunction_MURMUR_HASH_2);
+  config_.value().set_hash_function(envoy::api::v2::Cluster::RingHashLbConfig::MURMUR_HASH_2);
   config_.value().mutable_minimum_ring_size()->set_value(12);
   init();
   EXPECT_EQ(12, lb_->stats().size_.value());

--- a/test/extensions/access_loggers/grpc/grpc_access_log_utils_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_utils_test.cc
@@ -33,8 +33,7 @@ TEST(UtilityResponseFlagsToAccessLogResponseFlagsTest, All) {
   common_access_log_expected.mutable_response_flags()->set_fault_injected(true);
   common_access_log_expected.mutable_response_flags()->set_rate_limited(true);
   common_access_log_expected.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
-      envoy::data::accesslog::v2::ResponseFlags_Unauthorized_Reason::
-          ResponseFlags_Unauthorized_Reason_EXTERNAL_SERVICE);
+      envoy::data::accesslog::v2::ResponseFlags::Unauthorized::EXTERNAL_SERVICE);
   common_access_log_expected.mutable_response_flags()->set_rate_limit_service_error(true);
   common_access_log_expected.mutable_response_flags()->set_downstream_connection_termination(true);
   common_access_log_expected.mutable_response_flags()->set_upstream_retry_limit_exceeded(true);

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -82,7 +82,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     EXPECT_EQ(nullptr, headers.RequestId());
 
     response = std::make_unique<envoy::service::ratelimit::v2::RateLimitResponse>();
-    response->set_overall_code(envoy::service::ratelimit::v2::RateLimitResponse_Code_OVER_LIMIT);
+    response->set_overall_code(envoy::service::ratelimit::v2::RateLimitResponse::OVER_LIMIT);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("over_limit")));
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OverLimit, _, _));
     client_.onSuccess(std::move(response), span_);
@@ -101,7 +101,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     client_.onCreateInitialMetadata(headers);
 
     response = std::make_unique<envoy::service::ratelimit::v2::RateLimitResponse>();
-    response->set_overall_code(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK);
+    response->set_overall_code(envoy::service::ratelimit::v2::RateLimitResponse::OK);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("ok")));
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _, _));
     client_.onSuccess(std::move(response), span_);

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -36,10 +36,10 @@ void checkEngine(const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expe
 
 TEST(RoleBasedAccessControlEngineImpl, Disabled) {
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   checkEngine(RBAC::RoleBasedAccessControlEngineImpl(rbac), false);
 
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_DENY);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::DENY);
   checkEngine(RBAC::RoleBasedAccessControlEngineImpl(rbac), true);
 }
 
@@ -48,7 +48,7 @@ TEST(RoleBasedAccessControlEngineImpl, Disabled) {
 TEST(RoleBasedAccessControlEngineImpl, InvalidConfig) {
   {
     envoy::config::rbac::v2::RBAC rbac;
-    rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+    rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
     envoy::config::rbac::v2::Policy policy;
     (*rbac.mutable_policies())["foo"] = policy;
 
@@ -59,7 +59,7 @@ TEST(RoleBasedAccessControlEngineImpl, InvalidConfig) {
 
   {
     envoy::config::rbac::v2::RBAC rbac;
-    rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+    rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
     envoy::config::rbac::v2::Policy policy;
     policy.add_permissions();
     (*rbac.mutable_policies())["foo"] = policy;
@@ -71,7 +71,7 @@ TEST(RoleBasedAccessControlEngineImpl, InvalidConfig) {
 
   {
     envoy::config::rbac::v2::RBAC rbac;
-    rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+    rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
     envoy::config::rbac::v2::Policy policy;
     auto* permission = policy.add_permissions();
     auto* and_rules = permission->mutable_and_rules();
@@ -86,7 +86,7 @@ TEST(RoleBasedAccessControlEngineImpl, InvalidConfig) {
 
   {
     envoy::config::rbac::v2::RBAC rbac;
-    rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+    rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
     envoy::config::rbac::v2::Policy policy;
     auto* permission = policy.add_permissions();
     permission->set_any(true);
@@ -99,7 +99,7 @@ TEST(RoleBasedAccessControlEngineImpl, InvalidConfig) {
 
   {
     envoy::config::rbac::v2::RBAC rbac;
-    rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+    rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
     envoy::config::rbac::v2::Policy policy;
     auto* permission = policy.add_permissions();
     permission->set_any(true);
@@ -113,7 +113,7 @@ TEST(RoleBasedAccessControlEngineImpl, InvalidConfig) {
 
   {
     envoy::config::rbac::v2::RBAC rbac;
-    rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+    rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
     envoy::config::rbac::v2::Policy policy;
     auto* permission = policy.add_permissions();
     permission->set_any(true);
@@ -135,7 +135,7 @@ TEST(RoleBasedAccessControlEngineImpl, AllowedWhitelist) {
   policy.add_principals()->set_any(true);
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
@@ -156,7 +156,7 @@ TEST(RoleBasedAccessControlEngineImpl, DeniedBlacklist) {
   policy.add_principals()->set_any(true);
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_DENY);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::DENY);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
@@ -182,7 +182,7 @@ TEST(RoleBasedAccessControlEngineImpl, BasicCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
   checkEngine(engine, false);
@@ -202,7 +202,7 @@ TEST(RoleBasedAccessControlEngineImpl, MalformedCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
 
   EXPECT_THROW_WITH_REGEX(RBAC::RoleBasedAccessControlEngineImpl engine(rbac), EnvoyException,
@@ -220,7 +220,7 @@ TEST(RoleBasedAccessControlEngineImpl, MistypedCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
   checkEngine(engine, false);
@@ -245,7 +245,7 @@ TEST(RoleBasedAccessControlEngineImpl, ErrorCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
   checkEngine(engine, false, Envoy::Network::MockConnection());
@@ -275,7 +275,7 @@ TEST(RoleBasedAccessControlEngineImpl, HeaderCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
@@ -316,7 +316,7 @@ TEST(RoleBasedAccessControlEngineImpl, MetadataCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
@@ -341,7 +341,7 @@ TEST(RoleBasedAccessControlEngineImpl, ConjunctiveCondition) {
   )EOF"));
 
   envoy::config::rbac::v2::RBAC rbac;
-  rbac.set_action(envoy::config::rbac::v2::RBAC_Action::RBAC_Action_ALLOW);
+  rbac.set_action(envoy::config::rbac::v2::RBAC::ALLOW);
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -142,8 +142,7 @@ TEST_F(RoleBasedAccessControlFilterTest, RouteLocalOverride) {
   setDestinationPort(456);
 
   envoy::config::filter::http::rbac::v2::RBACPerRoute route_config;
-  route_config.mutable_rbac()->mutable_rules()->set_action(
-      envoy::config::rbac::v2::RBAC_Action::RBAC_Action_DENY);
+  route_config.mutable_rbac()->mutable_rules()->set_action(envoy::config::rbac::v2::RBAC::DENY);
   NiceMock<Filters::Common::RBAC::MockEngine> engine{route_config.rbac().rules()};
   NiceMock<MockRoleBasedAccessControlRouteSpecificFilterConfig> per_route_config_{route_config};
 

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -355,23 +355,23 @@ TEST_F(RedisClientImplTest, InitializedWithAuthPassword) {
 }
 
 TEST_F(RedisClientImplTest, InitializedWithPreferMasterReadPolicy) {
-  testInitializeReadPolicy(envoy::config::filter::network::redis_proxy::v2::
-                               RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_MASTER);
+  testInitializeReadPolicy(
+      envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::PREFER_MASTER);
 }
 
 TEST_F(RedisClientImplTest, InitializedWithReplicaReadPolicy) {
-  testInitializeReadPolicy(envoy::config::filter::network::redis_proxy::v2::
-                               RedisProxy_ConnPoolSettings_ReadPolicy_REPLICA);
+  testInitializeReadPolicy(
+      envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::REPLICA);
 }
 
 TEST_F(RedisClientImplTest, InitializedWithPreferReplicaReadPolicy) {
-  testInitializeReadPolicy(envoy::config::filter::network::redis_proxy::v2::
-                               RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_REPLICA);
+  testInitializeReadPolicy(envoy::config::filter::network::redis_proxy::v2::RedisProxy::
+                               ConnPoolSettings::PREFER_REPLICA);
 }
 
 TEST_F(RedisClientImplTest, InitializedWithAnyReadPolicy) {
   testInitializeReadPolicy(
-      envoy::config::filter::network::redis_proxy::v2::RedisProxy_ConnPoolSettings_ReadPolicy_ANY);
+      envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::ANY);
 }
 
 TEST_F(RedisClientImplTest, Cancel) {

--- a/test/extensions/filters/network/common/redis/test_utils.h
+++ b/test/extensions/filters/network/common/redis/test_utils.h
@@ -20,8 +20,8 @@ createConnPoolSettings(
     int64_t millis = 20, bool hashtagging = true, bool redirection_support = true,
     uint32_t max_unknown_conns = 100,
     envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::ReadPolicy
-        read_policy = envoy::config::filter::network::redis_proxy::v2::
-            RedisProxy_ConnPoolSettings_ReadPolicy_MASTER) {
+        read_policy =
+            envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::MASTER) {
   envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings setting{};
   setting.mutable_op_timeout()->CopyFrom(Protobuf::util::TimeUtil::MillisecondsToDuration(millis));
   setting.set_enable_hashtagging(hashtagging);

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -275,8 +275,8 @@ public:
   std::string auth_password_;
   NiceMock<Api::MockApi> api_;
   envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::ReadPolicy
-      read_policy_ = envoy::config::filter::network::redis_proxy::v2::
-          RedisProxy_ConnPoolSettings_ReadPolicy_MASTER;
+      read_policy_ =
+          envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::MASTER;
   NiceMock<Stats::MockCounter> upstream_cx_drained_;
   NiceMock<Stats::MockCounter> max_upstream_unknown_connections_reached_;
   std::shared_ptr<NiceMock<Extensions::Common::Redis::MockClusterRefreshManager>>
@@ -375,18 +375,17 @@ TEST_F(RedisConnPoolImplTest, ClientRequestFailed) {
 };
 
 TEST_F(RedisConnPoolImplTest, BasicWithReadPolicy) {
-  testReadPolicy(envoy::config::filter::network::redis_proxy::v2::
-                     RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_MASTER,
-                 NetworkFilters::Common::Redis::Client::ReadPolicy::PreferMaster);
-  testReadPolicy(envoy::config::filter::network::redis_proxy::v2::
-                     RedisProxy_ConnPoolSettings_ReadPolicy_REPLICA,
-                 NetworkFilters::Common::Redis::Client::ReadPolicy::Replica);
-  testReadPolicy(envoy::config::filter::network::redis_proxy::v2::
-                     RedisProxy_ConnPoolSettings_ReadPolicy_PREFER_REPLICA,
-                 NetworkFilters::Common::Redis::Client::ReadPolicy::PreferReplica);
   testReadPolicy(
-      envoy::config::filter::network::redis_proxy::v2::RedisProxy_ConnPoolSettings_ReadPolicy_ANY,
-      NetworkFilters::Common::Redis::Client::ReadPolicy::Any);
+      envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::PREFER_MASTER,
+      NetworkFilters::Common::Redis::Client::ReadPolicy::PreferMaster);
+  testReadPolicy(
+      envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::REPLICA,
+      NetworkFilters::Common::Redis::Client::ReadPolicy::Replica);
+  testReadPolicy(
+      envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::PREFER_REPLICA,
+      NetworkFilters::Common::Redis::Client::ReadPolicy::PreferReplica);
+  testReadPolicy(envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings::ANY,
+                 NetworkFilters::Common::Redis::Client::ReadPolicy::Any);
 };
 
 TEST_F(RedisConnPoolImplTest, Hashtagging) {

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1201,7 +1201,7 @@ Http2RingHashIntegrationTest::Http2RingHashIntegrationTest() {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
     auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
     cluster->clear_hosts();
-    cluster->set_lb_policy(envoy::api::v2::Cluster_LbPolicy_RING_HASH);
+    cluster->set_lb_policy(envoy::api::v2::Cluster::RING_HASH);
     for (int i = 0; i < num_upstreams_; i++) {
       auto* socket = cluster->add_hosts()->mutable_socket_address();
       socket->set_address(Network::Test::getLoopbackAddressString(version_));

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -15,21 +15,21 @@ class HttpSubsetLbIntegrationTest : public testing::TestWithParam<envoy::api::v2
 public:
   // Returns all load balancer types except ORIGINAL_DST_LB and CLUSTER_PROVIDED.
   static std::vector<envoy::api::v2::Cluster_LbPolicy> getSubsetLbTestParams() {
-    int first = static_cast<int>(envoy::api::v2::Cluster_LbPolicy_LbPolicy_MIN);
-    int last = static_cast<int>(envoy::api::v2::Cluster_LbPolicy_LbPolicy_MAX);
+    int first = static_cast<int>(envoy::api::v2::Cluster::LbPolicy_MIN);
+    int last = static_cast<int>(envoy::api::v2::Cluster::LbPolicy_MAX);
     ASSERT(first < last);
 
     std::vector<envoy::api::v2::Cluster_LbPolicy> ret;
     for (int i = first; i <= last; i++) {
-      if (!envoy::api::v2::Cluster_LbPolicy_IsValid(i)) {
+      if (!envoy::api::v2::Cluster::LbPolicy_IsValid(i)) {
         continue;
       }
 
       auto policy = static_cast<envoy::api::v2::Cluster_LbPolicy>(i);
 
-      if (policy == envoy::api::v2::Cluster_LbPolicy_ORIGINAL_DST_LB ||
-          policy == envoy::api::v2::Cluster_LbPolicy_CLUSTER_PROVIDED ||
-          policy == envoy::api::v2::Cluster_LbPolicy_LOAD_BALANCING_POLICY_CONFIG) {
+      if (policy == envoy::api::v2::Cluster::ORIGINAL_DST_LB ||
+          policy == envoy::api::v2::Cluster::CLUSTER_PROVIDED ||
+          policy == envoy::api::v2::Cluster::LOAD_BALANCING_POLICY_CONFIG) {
         continue;
       }
 
@@ -42,7 +42,7 @@ public:
   // Converts an LbPolicy to strings suitable for test names.
   static std::string
   subsetLbTestParamsToString(const testing::TestParamInfo<envoy::api::v2::Cluster_LbPolicy>& p) {
-    const std::string& policy_name = envoy::api::v2::Cluster_LbPolicy_Name(p.param);
+    const std::string& policy_name = envoy::api::v2::Cluster::LbPolicy_Name(p.param);
     return absl::StrReplaceAll(policy_name, {{"_", ""}});
   }
 
@@ -50,8 +50,8 @@ public:
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1,
                             TestEnvironment::getIpVersionsForTest().front(),
                             ConfigHelper::HTTP_PROXY_CONFIG),
-        num_hosts_{4}, is_hash_lb_(GetParam() == envoy::api::v2::Cluster_LbPolicy_RING_HASH ||
-                                   GetParam() == envoy::api::v2::Cluster_LbPolicy_MAGLEV) {
+        num_hosts_{4}, is_hash_lb_(GetParam() == envoy::api::v2::Cluster::RING_HASH ||
+                                   GetParam() == envoy::api::v2::Cluster::MAGLEV) {
     autonomous_upstream_ = true;
     setUpstreamCount(num_hosts_);
 
@@ -177,10 +177,10 @@ public:
 
     if (is_hash_lb_) {
       EXPECT_EQ(hosts.size(), 1) << "Expected a single unique host to be selected for "
-                                 << envoy::api::v2::Cluster_LbPolicy_Name(GetParam());
+                                 << envoy::api::v2::Cluster::LbPolicy_Name(GetParam());
     } else {
       EXPECT_GT(hosts.size(), 1) << "Expected multiple hosts to be selected for "
-                                 << envoy::api::v2::Cluster_LbPolicy_Name(GetParam());
+                                 << envoy::api::v2::Cluster::LbPolicy_Name(GetParam());
     }
   }
 

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -174,7 +174,7 @@ public:
   void basicFlow() {
     initiateClientConnection();
     waitForRatelimitRequest();
-    sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK,
+    sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse::OK,
                           Http::HeaderMapImpl{}, Http::HeaderMapImpl{});
     waitForSuccessfulUpstreamResponse();
     cleanup();
@@ -218,7 +218,7 @@ TEST_P(RatelimitIntegrationTest, OkWithHeaders) {
                                                      {"x-ratelimit-remaining", "500"}};
   Http::TestHeaderMapImpl request_headers_to_add{{"x-ratelimit-done", "true"}};
 
-  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OK,
+  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse::OK,
                         ratelimit_response_headers, request_headers_to_add);
   waitForSuccessfulUpstreamResponse();
 
@@ -250,7 +250,7 @@ TEST_P(RatelimitIntegrationTest, OkWithHeaders) {
 TEST_P(RatelimitIntegrationTest, OverLimit) {
   initiateClientConnection();
   waitForRatelimitRequest();
-  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OVER_LIMIT,
+  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse::OVER_LIMIT,
                         Http::HeaderMapImpl{}, Http::HeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
   cleanup();
@@ -265,7 +265,7 @@ TEST_P(RatelimitIntegrationTest, OverLimitWithHeaders) {
   waitForRatelimitRequest();
   Http::TestHeaderMapImpl ratelimit_response_headers{
       {"x-ratelimit-limit", "1000"}, {"x-ratelimit-remaining", "0"}, {"retry-after", "33"}};
-  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse_Code_OVER_LIMIT,
+  sendRateLimitResponse(envoy::service::ratelimit::v2::RateLimitResponse::OVER_LIMIT,
                         ratelimit_response_headers, Http::HeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
 

--- a/test/server/drain_manager_impl_test.cc
+++ b/test/server/drain_manager_impl_test.cc
@@ -28,7 +28,7 @@ public:
 
 TEST_F(DrainManagerImplTest, Default) {
   InSequence s;
-  DrainManagerImpl drain_manager(server_, envoy::api::v2::Listener_DrainType_DEFAULT);
+  DrainManagerImpl drain_manager(server_, envoy::api::v2::Listener::DEFAULT);
 
   // Test parent shutdown.
   Event::MockTimer* shutdown_timer = new Event::MockTimer(&server_.dispatcher_);
@@ -66,7 +66,7 @@ TEST_F(DrainManagerImplTest, Default) {
 
 TEST_F(DrainManagerImplTest, ModifyOnly) {
   InSequence s;
-  DrainManagerImpl drain_manager(server_, envoy::api::v2::Listener_DrainType_MODIFY_ONLY);
+  DrainManagerImpl drain_manager(server_, envoy::api::v2::Listener::MODIFY_ONLY);
 
   EXPECT_CALL(server_, healthCheckFailed()).Times(0);
   EXPECT_FALSE(drain_manager.drainClose());

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -440,7 +440,7 @@ TEST_F(ListenerManagerImplTest, ModifyOnlyDrainType) {
   )EOF";
 
   ListenerHandle* listener_foo =
-      expectListenerCreate(false, true, envoy::api::v2::Listener_DrainType_MODIFY_ONLY);
+      expectListenerCreate(false, true, envoy::api::v2::Listener::MODIFY_ONLY);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, {true}));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), "", true));
   checkStats(1, 0, 0, 0, 1, 0);
@@ -482,7 +482,7 @@ drain_type: modify_only
   )EOF";
 
   ListenerHandle* listener_foo_different_address =
-      expectListenerCreate(false, true, envoy::api::v2::Listener_DrainType_MODIFY_ONLY);
+      expectListenerCreate(false, true, envoy::api::v2::Listener::MODIFY_ONLY);
   EXPECT_CALL(*listener_foo_different_address, onDestroy());
   EXPECT_THROW_WITH_MESSAGE(
       manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_different_address_yaml),

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -89,7 +89,7 @@ protected:
    */
   ListenerHandle* expectListenerCreate(
       bool need_init, bool added_via_api,
-      envoy::api::v2::Listener::DrainType drain_type = envoy::api::v2::Listener_DrainType_DEFAULT) {
+      envoy::api::v2::Listener::DrainType drain_type = envoy::api::v2::Listener::DEFAULT) {
     if (added_via_api) {
       EXPECT_CALL(server_.validation_context_, staticValidationVisitor()).Times(0);
       EXPECT_CALL(server_.validation_context_, dynamicValidationVisitor());

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -565,6 +565,9 @@ def checkSourceLine(line, file_path, reportError):
      ('.counter(' in line or '.gauge(' in line or '.histogram(' in line):
     reportError("Don't lookup stats by name at runtime; use StatName saved during construction")
 
+  if re.search("envoy::[a-z0-9_:]+::[A-Z]\w*_\w*_[A-Z]{2}", line):
+    reportError("Don't use mangled Protobuf names for enum constants")
+
   hist_m = re.search("(?<=HISTOGRAM\()[a-zA-Z0-9_]+_(b|kb|mb|ns|us|ms|s)(?=,)", line)
   if hist_m and not whitelistedForHistogramSiSuffix(hist_m.group(0)):
     reportError(

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -206,10 +206,11 @@ def runChecks():
       "grpc_shutdown.cc",
       "Don't call grpc_init() or grpc_shutdown() directly, instantiate Grpc::GoogleGrpcContext. " +
       "See #8282")
-
   errors += fixFileExpectingFailure(
       "api/missing_package.proto",
       "Unable to find package name for proto file: ./api/missing_package.proto")
+  errors += checkUnfixableError("proto_enum_mangling.cc",
+                                "Don't use mangled Protobuf names for enum constants")
 
   # The following files have errors that can be automatically fixed.
   errors += checkAndFixError("over_enthusiastic_spaces.cc",

--- a/tools/testdata/check_format/proto_enum_mangling.cc
+++ b/tools/testdata/check_format/proto_enum_mangling.cc
@@ -1,0 +1,7 @@
+#include "foo.h"
+
+namespace Envoy {
+
+void foo() { auto bar = ::envoy::foo::bar::v2::RedisProxy_ConnPoolSettings_ReadPolicy_ANY; }
+
+} // namespace Envoy


### PR DESCRIPTION
Mangled names exist only to help with forward declarations, proto style
explicitly discourages this, see
https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum.

By avoiding the mangled names, we simplify API boosting tooling.

Risk level: Low
Testing: New check_format test.

Signed-off-by: Harvey Tuch <htuch@google.com>