### PR TITLE
source/test: misc. fixups for API boosting.

### DIFF
--- a/source/common/config/type_to_endpoint.cc
+++ b/source/common/config/type_to_endpoint.cc
@@ -16,26 +16,31 @@ namespace Config {
 
 const char UnknownMethod[] = "could_not_lookup_method_due_to_unknown_type_url";
 
-#define API_TYPE_URL_IS(x) (type_url == Grpc::Common::typeUrl(x().GetDescriptor()->full_name()))
-#define DISCOVERY_TYPE_URL_IS(x)                                                                   \
-  (type_url == Grpc::Common::typeUrl(x().GetDescriptor()->full_name()))
+namespace {
+
+bool typeUrlIs(absl::string_view type_url, const Protobuf::Message& msg) {
+  return Grpc::Common::typeUrl(msg.GetDescriptor()->full_name()) == type_url;
+}
+
+} // namespace
+
 const Protobuf::MethodDescriptor& deltaGrpcMethod(absl::string_view type_url) {
   std::string method_name = UnknownMethod;
-  if (API_TYPE_URL_IS(envoy::api::v2::RouteConfiguration)) {
+  if (typeUrlIs(type_url, envoy::api::v2::RouteConfiguration())) {
     method_name = "envoy.api.v2.RouteDiscoveryService.DeltaRoutes";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::ScopedRouteConfiguration)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::ScopedRouteConfiguration())) {
     method_name = "envoy.api.v2.ScopedRoutesDiscoveryService.DeltaScopedRoutes";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::route::VirtualHost)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::route::VirtualHost())) {
     method_name = "envoy.api.v2.VirtualHostDiscoveryService.DeltaVirtualHosts";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::auth::Secret)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::auth::Secret())) {
     method_name = "envoy.service.discovery.v2.SecretDiscoveryService.DeltaSecrets";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::Cluster)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::Cluster())) {
     method_name = "envoy.api.v2.ClusterDiscoveryService.DeltaClusters";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::ClusterLoadAssignment)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::ClusterLoadAssignment())) {
     method_name = "envoy.api.v2.EndpointDiscoveryService.DeltaEndpoints";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::Listener)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::Listener())) {
     method_name = "envoy.api.v2.ListenerDiscoveryService.DeltaListeners";
-  } else if (DISCOVERY_TYPE_URL_IS(envoy::service::discovery::v2::Runtime)) {
+  } else if (typeUrlIs(type_url, envoy::service::discovery::v2::Runtime())) {
     method_name = "envoy.service.discovery.v2.RuntimeDiscoveryService.DeltaRuntime";
   }
   ASSERT(method_name != UnknownMethod);
@@ -44,19 +49,19 @@ const Protobuf::MethodDescriptor& deltaGrpcMethod(absl::string_view type_url) {
 
 const Protobuf::MethodDescriptor& sotwGrpcMethod(absl::string_view type_url) {
   std::string method_name = UnknownMethod;
-  if (API_TYPE_URL_IS(envoy::api::v2::RouteConfiguration)) {
+  if (typeUrlIs(type_url, envoy::api::v2::RouteConfiguration())) {
     method_name = "envoy.api.v2.RouteDiscoveryService.StreamRoutes";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::ScopedRouteConfiguration)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::ScopedRouteConfiguration())) {
     method_name = "envoy.api.v2.ScopedRoutesDiscoveryService.StreamScopedRoutes";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::auth::Secret)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::auth::Secret())) {
     method_name = "envoy.service.discovery.v2.SecretDiscoveryService.StreamSecrets";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::Cluster)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::Cluster())) {
     method_name = "envoy.api.v2.ClusterDiscoveryService.StreamClusters";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::ClusterLoadAssignment)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::ClusterLoadAssignment())) {
     method_name = "envoy.api.v2.EndpointDiscoveryService.StreamEndpoints";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::Listener)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::Listener())) {
     method_name = "envoy.api.v2.ListenerDiscoveryService.StreamListeners";
-  } else if (DISCOVERY_TYPE_URL_IS(envoy::service::discovery::v2::Runtime)) {
+  } else if (typeUrlIs(type_url, envoy::service::discovery::v2::Runtime())) {
     method_name = "envoy.service.discovery.v2.RuntimeDiscoveryService.StreamRuntime";
   }
   ASSERT(method_name != UnknownMethod);
@@ -65,25 +70,24 @@ const Protobuf::MethodDescriptor& sotwGrpcMethod(absl::string_view type_url) {
 
 const Protobuf::MethodDescriptor& restMethod(absl::string_view type_url) {
   std::string method_name = UnknownMethod;
-  if (API_TYPE_URL_IS(envoy::api::v2::RouteConfiguration)) {
+  if (typeUrlIs(type_url, envoy::api::v2::RouteConfiguration())) {
     method_name = "envoy.api.v2.RouteDiscoveryService.FetchRoutes";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::ScopedRouteConfiguration)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::ScopedRouteConfiguration())) {
     method_name = "envoy.api.v2.ScopedRoutesDiscoveryService.FetchScopedRoutes";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::auth::Secret)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::auth::Secret())) {
     method_name = "envoy.service.discovery.v2.SecretDiscoveryService.FetchSecrets";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::Cluster)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::Cluster())) {
     method_name = "envoy.api.v2.ClusterDiscoveryService.FetchClusters";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::ClusterLoadAssignment)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::ClusterLoadAssignment())) {
     method_name = "envoy.api.v2.EndpointDiscoveryService.FetchEndpoints";
-  } else if (API_TYPE_URL_IS(envoy::api::v2::Listener)) {
+  } else if (typeUrlIs(type_url, envoy::api::v2::Listener())) {
     method_name = "envoy.api.v2.ListenerDiscoveryService.FetchListeners";
-  } else if (DISCOVERY_TYPE_URL_IS(envoy::service::discovery::v2::Runtime)) {
+  } else if (typeUrlIs(type_url, envoy::service::discovery::v2::Runtime())) {
     method_name = "envoy.service.discovery.v2.RuntimeDiscoveryService.FetchRuntime";
   }
   ASSERT(method_name != UnknownMethod);
   return *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(method_name);
 }
-#undef API_TYPE_URL_IS
 
 } // namespace Config
 } // namespace Envoy

--- a/source/common/config/type_to_endpoint.cc
+++ b/source/common/config/type_to_endpoint.cc
@@ -16,28 +16,26 @@ namespace Config {
 
 const char UnknownMethod[] = "could_not_lookup_method_due_to_unknown_type_url";
 
-#define API_TYPE_URL_IS(x)                                                                         \
-  (type_url == Grpc::Common::typeUrl(envoy::api::v2::x().GetDescriptor()->full_name()))
+#define API_TYPE_URL_IS(x) (type_url == Grpc::Common::typeUrl(x().GetDescriptor()->full_name()))
 #define DISCOVERY_TYPE_URL_IS(x)                                                                   \
-  (type_url ==                                                                                     \
-   Grpc::Common::typeUrl(envoy::service::discovery::v2::x().GetDescriptor()->full_name()))
+  (type_url == Grpc::Common::typeUrl(x().GetDescriptor()->full_name()))
 const Protobuf::MethodDescriptor& deltaGrpcMethod(absl::string_view type_url) {
   std::string method_name = UnknownMethod;
-  if (API_TYPE_URL_IS(RouteConfiguration)) {
+  if (API_TYPE_URL_IS(envoy::api::v2::RouteConfiguration)) {
     method_name = "envoy.api.v2.RouteDiscoveryService.DeltaRoutes";
-  } else if (API_TYPE_URL_IS(ScopedRouteConfiguration)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::ScopedRouteConfiguration)) {
     method_name = "envoy.api.v2.ScopedRoutesDiscoveryService.DeltaScopedRoutes";
-  } else if (API_TYPE_URL_IS(route::VirtualHost)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::route::VirtualHost)) {
     method_name = "envoy.api.v2.VirtualHostDiscoveryService.DeltaVirtualHosts";
-  } else if (API_TYPE_URL_IS(auth::Secret)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::auth::Secret)) {
     method_name = "envoy.service.discovery.v2.SecretDiscoveryService.DeltaSecrets";
-  } else if (API_TYPE_URL_IS(Cluster)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::Cluster)) {
     method_name = "envoy.api.v2.ClusterDiscoveryService.DeltaClusters";
-  } else if (API_TYPE_URL_IS(ClusterLoadAssignment)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::ClusterLoadAssignment)) {
     method_name = "envoy.api.v2.EndpointDiscoveryService.DeltaEndpoints";
-  } else if (API_TYPE_URL_IS(Listener)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::Listener)) {
     method_name = "envoy.api.v2.ListenerDiscoveryService.DeltaListeners";
-  } else if (DISCOVERY_TYPE_URL_IS(Runtime)) {
+  } else if (DISCOVERY_TYPE_URL_IS(envoy::service::discovery::v2::Runtime)) {
     method_name = "envoy.service.discovery.v2.RuntimeDiscoveryService.DeltaRuntime";
   }
   ASSERT(method_name != UnknownMethod);
@@ -46,19 +44,19 @@ const Protobuf::MethodDescriptor& deltaGrpcMethod(absl::string_view type_url) {
 
 const Protobuf::MethodDescriptor& sotwGrpcMethod(absl::string_view type_url) {
   std::string method_name = UnknownMethod;
-  if (API_TYPE_URL_IS(RouteConfiguration)) {
+  if (API_TYPE_URL_IS(envoy::api::v2::RouteConfiguration)) {
     method_name = "envoy.api.v2.RouteDiscoveryService.StreamRoutes";
-  } else if (API_TYPE_URL_IS(ScopedRouteConfiguration)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::ScopedRouteConfiguration)) {
     method_name = "envoy.api.v2.ScopedRoutesDiscoveryService.StreamScopedRoutes";
-  } else if (API_TYPE_URL_IS(auth::Secret)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::auth::Secret)) {
     method_name = "envoy.service.discovery.v2.SecretDiscoveryService.StreamSecrets";
-  } else if (API_TYPE_URL_IS(Cluster)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::Cluster)) {
     method_name = "envoy.api.v2.ClusterDiscoveryService.StreamClusters";
-  } else if (API_TYPE_URL_IS(ClusterLoadAssignment)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::ClusterLoadAssignment)) {
     method_name = "envoy.api.v2.EndpointDiscoveryService.StreamEndpoints";
-  } else if (API_TYPE_URL_IS(Listener)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::Listener)) {
     method_name = "envoy.api.v2.ListenerDiscoveryService.StreamListeners";
-  } else if (DISCOVERY_TYPE_URL_IS(Runtime)) {
+  } else if (DISCOVERY_TYPE_URL_IS(envoy::service::discovery::v2::Runtime)) {
     method_name = "envoy.service.discovery.v2.RuntimeDiscoveryService.StreamRuntime";
   }
   ASSERT(method_name != UnknownMethod);
@@ -67,19 +65,19 @@ const Protobuf::MethodDescriptor& sotwGrpcMethod(absl::string_view type_url) {
 
 const Protobuf::MethodDescriptor& restMethod(absl::string_view type_url) {
   std::string method_name = UnknownMethod;
-  if (API_TYPE_URL_IS(RouteConfiguration)) {
+  if (API_TYPE_URL_IS(envoy::api::v2::RouteConfiguration)) {
     method_name = "envoy.api.v2.RouteDiscoveryService.FetchRoutes";
-  } else if (API_TYPE_URL_IS(ScopedRouteConfiguration)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::ScopedRouteConfiguration)) {
     method_name = "envoy.api.v2.ScopedRoutesDiscoveryService.FetchScopedRoutes";
-  } else if (API_TYPE_URL_IS(auth::Secret)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::auth::Secret)) {
     method_name = "envoy.service.discovery.v2.SecretDiscoveryService.FetchSecrets";
-  } else if (API_TYPE_URL_IS(Cluster)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::Cluster)) {
     method_name = "envoy.api.v2.ClusterDiscoveryService.FetchClusters";
-  } else if (API_TYPE_URL_IS(ClusterLoadAssignment)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::ClusterLoadAssignment)) {
     method_name = "envoy.api.v2.EndpointDiscoveryService.FetchEndpoints";
-  } else if (API_TYPE_URL_IS(Listener)) {
+  } else if (API_TYPE_URL_IS(envoy::api::v2::Listener)) {
     method_name = "envoy.api.v2.ListenerDiscoveryService.FetchListeners";
-  } else if (DISCOVERY_TYPE_URL_IS(Runtime)) {
+  } else if (DISCOVERY_TYPE_URL_IS(envoy::service::discovery::v2::Runtime)) {
     method_name = "envoy.service.discovery.v2.RuntimeDiscoveryService.FetchRuntime";
   }
   ASSERT(method_name != UnknownMethod);

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -158,7 +158,7 @@ CorsPolicyImpl::CorsPolicyImpl(const envoy::api::v2::route::CorsPolicy& config,
     : config_(config), loader_(loader), allow_methods_(config.allow_methods()),
       allow_headers_(config.allow_headers()), expose_headers_(config.expose_headers()),
       max_age_(config.max_age()),
-      legacy_enabled_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, enabled, true)) {
+      legacy_enabled_(config.has_enabled() ? config.enabled().value() : true) {
   for (const auto& origin : config.allow_origin()) {
     envoy::type::matcher::StringMatcher matcher_config;
     matcher_config.set_exact(origin);

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -30,7 +30,7 @@ maybeCreateStringMatcher(const envoy::api::v2::route::QueryParameterMatcher& con
     }
 
     envoy::type::matcher::StringMatcher matcher_config;
-    if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {
+    if (config.has_regex() ? config.regex().value() : false) {
       matcher_config.set_regex(config.value());
     } else {
       matcher_config.set_exact(config.value());

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -45,10 +45,11 @@ public:
   bool onDestroyLog() override;
 
 private:
-  using MutableBodyChunk =
-      envoy::data::tap::v2alpha::Body* (envoy::data::tap::v2alpha::HttpStreamedTraceSegment::*)();
-  using MutableMessage = envoy::data::tap::v2alpha::HttpBufferedTrace::Message* (
-      envoy::data::tap::v2alpha::HttpBufferedTrace::*)();
+  using HttpStreamedTraceSegment = envoy::data::tap::v2alpha::HttpStreamedTraceSegment;
+  using MutableBodyChunk = envoy::data::tap::v2alpha::Body* (HttpStreamedTraceSegment::*)();
+  using HttpBufferedTrace = envoy::data::tap::v2alpha::HttpBufferedTrace;
+  using MutableMessage =
+      envoy::data::tap::v2alpha::HttpBufferedTrace::Message* (HttpBufferedTrace::*)();
 
   void onBody(const Buffer::Instance& data,
               Extensions::Common::Tap::TraceWrapperPtr& buffered_streamed_body,

--- a/source/extensions/tracers/xray/config.cc
+++ b/source/extensions/tracers/xray/config.cc
@@ -19,14 +19,10 @@ namespace Extensions {
 namespace Tracers {
 namespace XRay {
 
-namespace api = ::envoy::api::v2;
-namespace trace = envoy::config::trace::v2alpha;
-
 XRayTracerFactory::XRayTracerFactory() : FactoryBase(TracerNames::get().XRay) {}
 
-Tracing::HttpTracerPtr
-XRayTracerFactory::createHttpTracerTyped(const trace::XRayConfig& proto_config,
-                                         Server::Instance& server) {
+Tracing::HttpTracerPtr XRayTracerFactory::createHttpTracerTyped(
+    const envoy::config::trace::v2alpha::XRayConfig& proto_config, Server::Instance& server) {
   std::string sampling_rules_json;
   try {
     sampling_rules_json =
@@ -36,12 +32,12 @@ XRayTracerFactory::createHttpTracerTyped(const trace::XRayConfig& proto_config,
   }
 
   if (proto_config.daemon_endpoint().protocol() !=
-      api::core::SocketAddress::Protocol::SocketAddress_Protocol_UDP) {
+      envoy::api::v2::core::SocketAddress::Protocol::SocketAddress_Protocol_UDP) {
     throw EnvoyException("X-Ray daemon endpoint must be a UDP socket address");
   }
 
   if (proto_config.daemon_endpoint().port_specifier_case() !=
-      api::core::SocketAddress::PortSpecifierCase::kPortValue) {
+      envoy::api::v2::core::SocketAddress::PortSpecifierCase::kPortValue) {
     throw EnvoyException("X-Ray daemon port must be specified as number. Not a named port.");
   }
 

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_package",
     "envoy_proto_library",
 )
@@ -78,9 +78,8 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_binary(
+envoy_cc_test_binary(
     name = "access_log_formatter_speed_test",
-    testonly = 1,
     srcs = ["access_log_formatter_speed_test.cc"],
     external_deps = [
         "benchmark",

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1050,7 +1050,7 @@ typed_config:
   path: /dev/null
 )EOF";
 
-  const auto desc = envoy::config::filter::accesslog::v2::GrpcStatusFilter_Status_descriptor();
+  const auto desc = envoy::config::filter::accesslog::v2::GrpcStatusFilter::Status_descriptor();
   const int grpcStatuses = static_cast<int>(Grpc::Status::WellKnownGrpcStatus::MaximumKnown) + 1;
   if (desc->value_count() != grpcStatuses) {
     FAIL() << "Mismatch in number of gRPC statuses, GrpcStatus has " << grpcStatuses

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -221,7 +221,7 @@ envoy_cc_test(
     deps = ["//source/common/common:callback_impl_lib"],
 )
 
-envoy_cc_binary(
+envoy_cc_test_binary(
     name = "utility_speed_test",
     srcs = ["utility_speed_test.cc"],
     external_deps = [

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -2,7 +2,6 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_binary",
     "envoy_cc_test",
     "envoy_cc_test_binary",
     "envoy_cc_test_library",
@@ -285,9 +284,8 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_binary(
+envoy_cc_test_binary(
     name = "lc_trie_speed_test",
-    testonly = 1,
     srcs = ["lc_trie_speed_test.cc"],
     external_deps = [
         "benchmark",

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -2,8 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_binary",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -326,9 +326,8 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_binary(
+envoy_cc_test_binary(
     name = "load_balancer_benchmark",
-    testonly = 1,
     srcs = ["load_balancer_benchmark.cc"],
     external_deps = [
         "benchmark",

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_binary",
     "envoy_cc_library",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -23,9 +23,8 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_binary(
+envoy_cc_test_binary(
     name = "tls_inspector_benchmark",
-    testonly = 1,
     srcs = ["tls_inspector_benchmark.cc"],
     external_deps = [
         "benchmark",


### PR DESCRIPTION
* Avoid using macros for API types, so that Clang can see them.

* Avoid namespace gymnastics.

* Some renames to avoid mangled names. See #9450 for enum demangling,
  this is some misc. other cases. They don't seem super common.

* Use envoy_cc_test_binary for test binaries.

Risk level: Low
Testing: bazel test //test/...

Signed-off-by: Harvey Tuch <htuch@google.com>