### PR TITLE
api: xDS API version specifier

### DIFF
--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -102,8 +102,19 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message ConfigSource {
+  enum XdsApiVersion {
+    // set api version automatically, default version is set as v2.
+    AUTO = 0;
+
+    // use xDS v2 API
+    V2 = 1;
+
+    // use xDS v3alpha API
+    V3ALPHA = 2;
+  }
+
   oneof config_source_specifier {
     option (validate.required) = true;
 
@@ -149,4 +160,7 @@ message ConfigSource {
   // means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
   // timeout applies). The default is 15s.
   google.protobuf.Duration initial_fetch_timeout = 4;
+
+  // API version for xDS endpoint
+  XdsApiVersion version = 6;
 }

--- a/api/envoy/api/v3alpha/core/config_source.proto
+++ b/api/envoy/api/v3alpha/core/config_source.proto
@@ -112,9 +112,20 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.ConfigSource";
+
+  enum XdsApiVersion {
+    // set api version automatically, default version is set as v2.
+    AUTO = 0;
+
+    // use xDS v2 API
+    V2 = 1;
+
+    // use xDS v3alpha API
+    V3ALPHA = 2;
+  }
 
   oneof config_source_specifier {
     option (validate.required) = true;
@@ -161,4 +172,7 @@ message ConfigSource {
   // means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
   // timeout applies). The default is 15s.
   google.protobuf.Duration initial_fetch_timeout = 4;
+
+  // API version for xDS endpoint
+  XdsApiVersion version = 6;
 }

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -138,6 +138,7 @@ envoy_cc_library(
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
         "@envoy_api//envoy/api/v2/route:pkg_cc_proto",
+        "@envoy_api//envoy/api/v3alpha/route:pkg_cc_proto",
     ],
 )
 
@@ -170,6 +171,8 @@ envoy_cc_library(
         "//source/common/router:vhds_lib",
         "@envoy_api//envoy/admin/v2alpha:pkg_cc_proto",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
+        "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/api/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:pkg_cc_proto",
     ],
 )
@@ -211,6 +214,7 @@ envoy_cc_library(
         "@envoy_api//envoy/admin/v2alpha:pkg_cc_proto",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/api/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:pkg_cc_proto",
     ],
 )

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -7,6 +7,7 @@
 #include <unordered_set>
 
 #include "envoy/admin/v2alpha/config_dump.pb.h"
+#include "envoy/api/v2/core/config_source.pb.h"
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/rds.pb.h"
 #include "envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.h"
@@ -139,10 +140,12 @@ private:
       const uint64_t manager_identifier,
       Server::Configuration::ServerFactoryContext& factory_context,
       ProtobufMessage::ValidationVisitor& validator, Init::Manager& init_manager,
-      const std::string& stat_prefix,
-      RouteConfigProviderManagerImpl& route_config_provider_manager);
+      const std::string& stat_prefix, RouteConfigProviderManagerImpl& route_config_provider_manager,
+      const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version =
+          envoy::api::v2::core::ConfigSource::AUTO);
 
   bool validateUpdateSize(int num_resources);
+  std::string loadTypeUrl();
 
   Init::Manager& getRdsConfigInitManager() { return init_manager_; }
 
@@ -162,6 +165,7 @@ private:
   VhdsSubscriptionPtr vhds_subscription_;
   RouteConfigUpdatePtr config_update_info_;
   Common::CallbackManager<> update_callback_manager_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 
   friend class RouteConfigProviderManagerImpl;
   // Access to addUpdateCallback

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -7,6 +7,7 @@
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/srds.pb.h"
 #include "envoy/api/v2/srds.pb.validate.h"
+#include "envoy/api/v3alpha/srds.pb.h"
 #include "envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.h"
 
 #include "common/common/assert.h"
@@ -98,13 +99,11 @@ ScopedRdsConfigSubscription::ScopedRdsConfigSubscription(
       stats_({ALL_SCOPED_RDS_STATS(POOL_COUNTER(*scope_))}),
       rds_config_source_(std::move(rds_config_source)),
       validation_visitor_(factory_context.messageValidationVisitor()), stat_prefix_(stat_prefix),
-      route_config_provider_manager_(route_config_provider_manager) {
+      route_config_provider_manager_(route_config_provider_manager),
+      xds_api_version_(rds_config_source.version()) {
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
-          scoped_rds.scoped_rds_config_source(),
-          Grpc::Common::typeUrl(
-              envoy::api::v2::ScopedRouteConfiguration().GetDescriptor()->full_name()),
-          *scope_, *this);
+          scoped_rds.scoped_rds_config_source(), loadTypeUrl(), *scope_, *this);
 
   initialize([scope_key_builder]() -> Envoy::Config::ConfigProvider::ConfigConstSharedPtr {
     return std::make_shared<ScopedConfigImpl>(
@@ -341,6 +340,21 @@ void ScopedRdsConfigSubscription::onConfigUpdate(
     *to_remove_repeated.Add() = scoped_route.first;
   }
   onConfigUpdate(to_add_repeated, to_remove_repeated, version_info);
+}
+
+std::string ScopedRdsConfigSubscription::loadTypeUrl() {
+  switch (xds_api_version_) {
+  // automatically set api version as V2
+  case envoy::api::v2::core::ConfigSource::AUTO:
+  case envoy::api::v2::core::ConfigSource::V2:
+    return Grpc::Common::typeUrl(
+        envoy::api::v2::ScopedRouteConfiguration().GetDescriptor()->full_name());
+  case envoy::api::v2::core::ConfigSource::V3ALPHA:
+    return Grpc::Common::typeUrl(
+        envoy::api::v3alpha::ScopedRouteConfiguration().GetDescriptor()->full_name());
+  default:
+    throw EnvoyException(fmt::format("type {} is not supported", xds_api_version_));
+  }
 }
 
 ScopedRdsConfigProvider::ScopedRdsConfigProvider(

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -160,6 +160,7 @@ private:
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::ScopedRouteConfiguration>(resource).name();
   }
+  std::string loadTypeUrl();
   // Propagate RDS updates to ScopeConfigImpl in workers.
   void onRdsConfigUpdate(const std::string& scope_name,
                          RdsRouteConfigSubscription& rds_subscription);
@@ -183,6 +184,7 @@ private:
   ProtobufMessage::ValidationVisitor& validation_visitor_;
   const std::string stat_prefix_;
   RouteConfigProviderManager& route_config_provider_manager_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 };
 
 using ScopedRdsConfigSubscriptionSharedPtr = std::shared_ptr<ScopedRdsConfigSubscription>;

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -8,6 +8,7 @@
 #include "envoy/api/v2/core/config_source.pb.h"
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/route/route.pb.h"
+#include "envoy/api/v3alpha/route/route.pb.h"
 
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
@@ -19,17 +20,18 @@ namespace Envoy {
 namespace Router {
 
 // Implements callbacks to handle DeltaDiscovery protocol for VirtualHostDiscoveryService
-VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
-                                   Server::Configuration::ServerFactoryContext& factory_context,
-                                   const std::string& stat_prefix,
-                                   std::unordered_set<RouteConfigProvider*>& route_config_providers)
+VhdsSubscription::VhdsSubscription(
+    RouteConfigUpdatePtr& config_update_info,
+    Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
+    std::unordered_set<RouteConfigProvider*>& route_config_providers,
+    const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version)
     : config_update_info_(config_update_info),
       scope_(factory_context.scope().createScope(stat_prefix + "vhds." +
                                                  config_update_info_->routeConfigName() + ".")),
       stats_({ALL_VHDS_STATS(POOL_COUNTER(*scope_))}),
       init_target_(fmt::format("VhdsConfigSubscription {}", config_update_info_->routeConfigName()),
                    [this]() { subscription_->start({}); }),
-      route_config_providers_(route_config_providers) {
+      route_config_providers_(route_config_providers), xds_api_version_(xds_api_version) {
   const auto& config_source = config_update_info_->routeConfiguration()
                                   .vhds()
                                   .config_source()
@@ -41,9 +43,8 @@ VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
 
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
-          config_update_info_->routeConfiguration().vhds().config_source(),
-          Grpc::Common::typeUrl(envoy::api::v2::route::VirtualHost().GetDescriptor()->full_name()),
-          *scope_, *this);
+          config_update_info_->routeConfiguration().vhds().config_source(), loadTypeUrl(), *scope_,
+          *this);
 }
 
 void VhdsSubscription::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
@@ -70,5 +71,17 @@ void VhdsSubscription::onConfigUpdate(
   init_target_.ready();
 }
 
+std::string VhdsSubscription::loadTypeUrl() {
+  switch (xds_api_version_) {
+  // automatically set api version as V2
+  case envoy::api::v2::core::ConfigSource::AUTO:
+  case envoy::api::v2::core::ConfigSource::V2:
+    return Grpc::Common::typeUrl(envoy::api::v2::route::VirtualHost().GetDescriptor()->full_name());
+  case envoy::api::v2::core::ConfigSource::V3ALPHA:
+    return Grpc::Common::typeUrl(envoy::api::v2::route::VirtualHost().GetDescriptor()->full_name());
+  default:
+    throw EnvoyException(fmt::format("type {} is not supported", xds_api_version_));
+  }
+}
 } // namespace Router
 } // namespace Envoy

--- a/source/common/router/vhds.h
+++ b/source/common/router/vhds.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "envoy/api/v2/core/config_source.pb.h"
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/route/route.pb.h"
 #include "envoy/config/subscription.h"
@@ -39,7 +40,9 @@ public:
   VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
                    Server::Configuration::ServerFactoryContext& factory_context,
                    const std::string& stat_prefix,
-                   std::unordered_set<RouteConfigProvider*>& route_config_providers);
+                   std::unordered_set<RouteConfigProvider*>& route_config_providers,
+                   const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version =
+                       envoy::api::v2::core::ConfigSource::AUTO);
   ~VhdsSubscription() override { init_target_.ready(); }
 
   void registerInitTargetWithInitManager(Init::Manager& m) { m.add(init_target_); }
@@ -57,6 +60,7 @@ private:
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::route::VirtualHost>(resource).name();
   }
+  std::string loadTypeUrl();
 
   RouteConfigUpdatePtr& config_update_info_;
   Stats::ScopePtr scope_;
@@ -64,6 +68,7 @@ private:
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
   Init::TargetImpl init_target_;
   std::unordered_set<RouteConfigProvider*>& route_config_providers_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 };
 
 using VhdsSubscriptionPtr = std::unique_ptr<VhdsSubscription>;

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v2:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v2:pkg_cc_proto",
+        "@envoy_api//envoy/service/discovery/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/type:pkg_cc_proto",
     ],
 )

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -10,6 +10,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/service/discovery/v2/rtds.pb.h"
 #include "envoy/service/discovery/v2/rtds.pb.validate.h"
+#include "envoy/service/discovery/v3alpha/rtds.pb.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/type/percent.pb.h"
 #include "envoy/type/percent.pb.validate.h"
@@ -546,11 +547,12 @@ void LoaderImpl::initialize(Upstream::ClusterManager& cm) { cm_ = &cm; }
 
 RtdsSubscription::RtdsSubscription(
     LoaderImpl& parent, const envoy::config::bootstrap::v2::RuntimeLayer::RtdsLayer& rtds_layer,
-    Stats::Store& store, ProtobufMessage::ValidationVisitor& validation_visitor)
+    Stats::Store& store, ProtobufMessage::ValidationVisitor& validation_visitor,
+    const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version)
     : parent_(parent), config_source_(rtds_layer.rtds_config()), store_(store),
       resource_name_(rtds_layer.name()),
       init_target_("RTDS " + resource_name_, [this]() { start(); }),
-      validation_visitor_(validation_visitor) {}
+      validation_visitor_(validation_visitor), xds_api_version_(xds_api_version) {}
 
 void RtdsSubscription::onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,
                                       const std::string&) {
@@ -589,9 +591,7 @@ void RtdsSubscription::start() {
   // cluster manager resources are not available in the constructor when
   // instantiated in the server instance.
   subscription_ = parent_.cm_->subscriptionFactory().subscriptionFromConfigSource(
-      config_source_,
-      Grpc::Common::typeUrl(envoy::service::discovery::v2::Runtime().GetDescriptor()->full_name()),
-      store_, *this);
+      config_source_, loadTypeUrl(), store_, *this);
   subscription_->start({resource_name_});
 }
 
@@ -600,6 +600,21 @@ void RtdsSubscription::validateUpdateSize(uint32_t num_resources) {
     init_target_.ready();
     throw EnvoyException(fmt::format("Unexpected RTDS resource length: {}", num_resources));
     // (would be a return false here)
+  }
+}
+
+std::string RtdsSubscription::loadTypeUrl() {
+  switch (xds_api_version_) {
+  // automatically set api version as V2
+  case envoy::api::v2::core::ConfigSource::AUTO:
+  case envoy::api::v2::core::ConfigSource::V2:
+    return Grpc::Common::typeUrl(
+        envoy::service::discovery::v2::Runtime().GetDescriptor()->full_name());
+  case envoy::api::v2::core::ConfigSource::V3ALPHA:
+    return Grpc::Common::typeUrl(
+        envoy::service::discovery::v3alpha::Runtime().GetDescriptor()->full_name());
+  default:
+    throw EnvoyException(fmt::format("type {} is not supported", xds_api_version_));
   }
 }
 

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -202,7 +202,9 @@ class LoaderImpl;
 struct RtdsSubscription : Config::SubscriptionCallbacks, Logger::Loggable<Logger::Id::runtime> {
   RtdsSubscription(LoaderImpl& parent,
                    const envoy::config::bootstrap::v2::RuntimeLayer::RtdsLayer& rtds_layer,
-                   Stats::Store& store, ProtobufMessage::ValidationVisitor& validation_visitor);
+                   Stats::Store& store, ProtobufMessage::ValidationVisitor& validation_visitor,
+                   const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version =
+                       envoy::api::v2::core::ConfigSource::AUTO);
 
   // Config::SubscriptionCallbacks
   void onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,
@@ -219,6 +221,7 @@ struct RtdsSubscription : Config::SubscriptionCallbacks, Logger::Loggable<Logger
 
   void start();
   void validateUpdateSize(uint32_t num_resources);
+  std::string loadTypeUrl();
 
   LoaderImpl& parent_;
   const envoy::api::v2::core::ConfigSource config_source_;
@@ -228,6 +231,7 @@ struct RtdsSubscription : Config::SubscriptionCallbacks, Logger::Loggable<Logger
   Init::TargetImpl init_target_;
   ProtobufWkt::Struct proto_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 };
 
 using RtdsSubscriptionPtr = std::unique_ptr<RtdsSubscription>;

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -42,7 +42,9 @@ public:
   SdsApi(envoy::api::v2::core::ConfigSource sds_config, absl::string_view sds_config_name,
          Config::SubscriptionFactory& subscription_factory, TimeSource& time_source,
          ProtobufMessage::ValidationVisitor& validation_visitor, Stats::Store& stats,
-         Init::Manager& init_manager, std::function<void()> destructor_cb);
+         Init::Manager& init_manager, std::function<void()> destructor_cb,
+         const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version =
+             envoy::api::v2::core::ConfigSource::AUTO);
 
   SecretData secretData();
 
@@ -62,6 +64,7 @@ protected:
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::auth::Secret>(resource).name();
   }
+  std::string loadTypeUrl();
 
 private:
   void validateUpdateSize(int num_resources);
@@ -79,6 +82,7 @@ private:
   Config::SubscriptionFactory& subscription_factory_;
   TimeSource& time_source_;
   SecretData secret_data_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 };
 
 class TlsCertificateSdsApi;

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/api/v3alpha:pkg_cc_proto",
     ],
 )
 
@@ -357,6 +358,7 @@ envoy_cc_library(
         "//source/extensions/clusters:well_known_names",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/api/v3alpha:pkg_cc_proto",
     ],
 )
 

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -26,7 +26,9 @@ class CdsApiImpl : public CdsApi,
 public:
   static CdsApiPtr create(const envoy::api::v2::core::ConfigSource& cds_config, ClusterManager& cm,
                           Stats::Scope& scope,
-                          ProtobufMessage::ValidationVisitor& validation_visitor);
+                          ProtobufMessage::ValidationVisitor& validation_visitor,
+                          const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version =
+                              envoy::api::v2::core::ConfigSource::AUTO);
 
   // Upstream::CdsApi
   void initialize() override { subscription_->start({}); }
@@ -47,9 +49,10 @@ private:
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource).name();
   }
-
+  std::string loadTypeUrl();
   CdsApiImpl(const envoy::api::v2::core::ConfigSource& cds_config, ClusterManager& cm,
-             Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor);
+             Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor,
+             const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version);
   void runInitializeCallbackIfAny();
 
   ClusterManager& cm_;
@@ -58,6 +61,7 @@ private:
   std::function<void()> initialize_callback_;
   Stats::ScopePtr scope_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -5,6 +5,8 @@
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/eds.pb.h"
 #include "envoy/api/v2/eds.pb.validate.h"
+#include "envoy/api/v3alpha/cds.pb.h"
+#include "envoy/common/exception.h"
 
 #include "common/common/utility.h"
 
@@ -14,14 +16,16 @@ namespace Upstream {
 EdsClusterImpl::EdsClusterImpl(
     const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
-    Stats::ScopePtr&& stats_scope, bool added_via_api)
+    Stats::ScopePtr&& stats_scope, bool added_via_api,
+    const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version)
     : BaseDynamicClusterImpl(cluster, runtime, factory_context, std::move(stats_scope),
                              added_via_api),
       local_info_(factory_context.localInfo()),
       cluster_name_(cluster.eds_cluster_config().service_name().empty()
                         ? cluster.name()
                         : cluster.eds_cluster_config().service_name()),
-      validation_visitor_(factory_context.messageValidationVisitor()) {
+      validation_visitor_(factory_context.messageValidationVisitor()),
+      xds_api_version_(xds_api_version) {
   Event::Dispatcher& dispatcher = factory_context.dispatcher();
   assignment_timeout_ = dispatcher.createTimer([this]() -> void { onAssignmentTimeout(); });
   const auto& eds_config = cluster.eds_cluster_config().eds_config();
@@ -33,10 +37,7 @@ EdsClusterImpl::EdsClusterImpl(
   }
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
-          eds_config,
-          Grpc::Common::typeUrl(
-              envoy::api::v2::ClusterLoadAssignment().GetDescriptor()->full_name()),
-          info_->statsScope(), *this);
+          eds_config, loadTypeUrl(), info_->statsScope(), *this);
 }
 
 void EdsClusterImpl::startPreInit() { subscription_->start({cluster_name_}); }
@@ -213,6 +214,21 @@ void EdsClusterImpl::reloadHealthyHostsHelper(const HostSharedPtr& host) {
   if (host_to_exclude != nullptr) {
     ASSERT(all_hosts_.find(host_to_exclude->address()->asString()) != all_hosts_.end());
     all_hosts_.erase(host_to_exclude->address()->asString());
+  }
+}
+
+std::string EdsClusterImpl::loadTypeUrl() {
+  switch (xds_api_version_) {
+  // automatically set api version as V2
+  case envoy::api::v2::core::ConfigSource::AUTO:
+  case envoy::api::v2::core::ConfigSource::V2:
+    return Grpc::Common::typeUrl(
+        envoy::api::v2::ClusterLoadAssignment().GetDescriptor()->full_name());
+  case envoy::api::v2::core::ConfigSource::V3ALPHA:
+    return Grpc::Common::typeUrl(
+        envoy::api::v3alpha::ClusterLoadAssignment().GetDescriptor()->full_name());
+  default:
+    throw EnvoyException(fmt::format("type {} is not supported", xds_api_version_));
   }
 }
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -260,6 +260,7 @@ envoy_cc_library(
         "@envoy_api//envoy/admin/v2alpha:pkg_cc_proto",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/api/v3alpha:pkg_cc_proto",
     ],
 )
 

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -7,6 +7,7 @@
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/lds.pb.h"
 #include "envoy/api/v2/lds.pb.validate.h"
+#include "envoy/api/v3alpha/lds.pb.h"
 #include "envoy/stats/scope.h"
 
 #include "common/common/cleanup.h"
@@ -22,13 +23,13 @@ namespace Server {
 LdsApiImpl::LdsApiImpl(const envoy::api::v2::core::ConfigSource& lds_config,
                        Upstream::ClusterManager& cm, Init::Manager& init_manager,
                        Stats::Scope& scope, ListenerManager& lm,
-                       ProtobufMessage::ValidationVisitor& validation_visitor)
+                       ProtobufMessage::ValidationVisitor& validation_visitor,
+                       const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version)
     : listener_manager_(lm), scope_(scope.createScope("listener_manager.lds.")), cm_(cm),
       init_target_("LDS", [this]() { subscription_->start({}); }),
-      validation_visitor_(validation_visitor) {
-  subscription_ = cm.subscriptionFactory().subscriptionFromConfigSource(
-      lds_config, Grpc::Common::typeUrl(envoy::api::v2::Listener().GetDescriptor()->full_name()),
-      *scope_, *this);
+      validation_visitor_(validation_visitor), xds_api_version_(xds_api_version) {
+  subscription_ = cm.subscriptionFactory().subscriptionFromConfigSource(lds_config, loadTypeUrl(),
+                                                                        *scope_, *this);
   init_manager.add(init_target_);
 }
 
@@ -130,5 +131,17 @@ void LdsApiImpl::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason r
   init_target_.ready();
 }
 
+std::string LdsApiImpl::loadTypeUrl() {
+  switch (xds_api_version_) {
+  // automatically set api version as V2
+  case envoy::api::v2::core::ConfigSource::AUTO:
+  case envoy::api::v2::core::ConfigSource::V2:
+    return Grpc::Common::typeUrl(envoy::api::v2::Listener().GetDescriptor()->full_name());
+  case envoy::api::v2::core::ConfigSource::V3ALPHA:
+    return Grpc::Common::typeUrl(envoy::api::v3alpha::Listener().GetDescriptor()->full_name());
+  default:
+    throw EnvoyException(fmt::format("type {} is not supported", xds_api_version_));
+  }
+}
 } // namespace Server
 } // namespace Envoy

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -5,6 +5,7 @@
 #include "envoy/api/v2/core/config_source.pb.h"
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/lds.pb.h"
+#include "envoy/api/v3alpha/lds.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/config/subscription_factory.h"
 #include "envoy/init/manager.h"
@@ -26,7 +27,9 @@ class LdsApiImpl : public LdsApi,
 public:
   LdsApiImpl(const envoy::api::v2::core::ConfigSource& lds_config, Upstream::ClusterManager& cm,
              Init::Manager& init_manager, Stats::Scope& scope, ListenerManager& lm,
-             ProtobufMessage::ValidationVisitor& validation_visitor);
+             ProtobufMessage::ValidationVisitor& validation_visitor,
+             const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version =
+                 envoy::api::v2::core::ConfigSource::AUTO);
 
   // Server::LdsApi
   std::string versionInfo() const override { return system_version_info_; }
@@ -43,6 +46,7 @@ private:
   std::string resourceName(const ProtobufWkt::Any& resource) override {
     return MessageUtil::anyConvert<envoy::api::v2::Listener>(resource).name();
   }
+  std::string loadTypeUrl();
 
   std::unique_ptr<Config::Subscription> subscription_;
   std::string system_version_info_;
@@ -51,6 +55,7 @@ private:
   Upstream::ClusterManager& cm_;
   Init::TargetImpl init_target_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
+  const envoy::api::v2::core::ConfigSource::XdsApiVersion xds_api_version_;
 };
 
 } // namespace Server


### PR DESCRIPTION
Signed-off-by: shikugawa <rei@tetrate.io>

Description: It enables to specify API versioning for xDS for #8421, allow to write like this config
```
eds_cluster_config:
    eds_config:
       version: V2 
       api_config_source:
          api_type: GRPC
	  grpc_services:
            envoy_grpc:
               cluster_name: eds_cluster
```

Risk Level: Low
Testing: unit test(maybe it is needed to add integration test)
Docs Changes: needed
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
