### PR TITLE
WIP upstream: support per connection outlier detection

### DIFF
--- a/include/envoy/http/conn_pool.h
+++ b/include/envoy/http/conn_pool.h
@@ -62,6 +62,7 @@ public:
    */
   virtual void onPoolReady(Http::StreamEncoder& encoder,
                            Upstream::HostDescriptionConstSharedPtr host,
+                           const Network::Connection& connection,
                            const StreamInfo::StreamInfo& info) PURE;
 };
 

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -294,6 +294,16 @@ public:
    *         occurred an empty string is returned.
    */
   virtual absl::string_view transportFailureReason() const PURE;
+
+  /**
+   * Sets the outlier detection monitor to use for this connection.
+   */
+  virtual void setOutlierDetection(Upstream::Outlier::DetectorHostMonitorPtr&& monitor) PURE;
+
+  /**
+   * Retrieves the outlier detection monitor used for this connection.
+   */
+  virtual Upstream::Outlier::DetectorHostMonitor& outlierDetection() const PURE;
 };
 
 using ConnectionPtr = std::unique_ptr<Connection>;

--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -110,6 +110,8 @@ public:
    * and LocalOrigin type returns success rate for local origin errors.
    */
   virtual double successRate(SuccessRateMonitorType type) const PURE;
+
+  virtual bool ejected() const PURE;
 };
 
 using DetectorHostMonitorPtr = std::unique_ptr<DetectorHostMonitor>;
@@ -150,6 +152,11 @@ public:
    */
   virtual double
       successRateEjectionThreshold(DetectorHostMonitor::SuccessRateMonitorType) const PURE;
+
+  /**
+   * Adds a monitor for the provided connection.
+   */
+  virtual void addConnectionMonitor(Network::Connection& connection) PURE;
 };
 
 using DetectorSharedPtr = std::shared_ptr<Detector>;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -75,7 +75,7 @@ void ConnPoolImpl::attachRequestToClient(ActiveClient& client, StreamDecoder& re
   host_->cluster().stats().upstream_rq_total_.inc();
   host_->stats().rq_total_.inc();
   client.stream_wrapper_ = std::make_unique<StreamWrapper>(response_decoder, client);
-  callbacks.onPoolReady(*client.stream_wrapper_, client.real_host_description_,
+  callbacks.onPoolReady(*client.stream_wrapper_, client.real_host_description_, *client.connection_,
                         client.codec_client_->streamInfo());
 }
 
@@ -312,6 +312,7 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   Upstream::Host::CreateConnectionData data = parent_.host_->createConnection(
       parent_.dispatcher_, parent_.socket_options_, parent_.transport_socket_options_);
   real_host_description_ = data.host_description_;
+  connection_ = data.connection_.get();
   codec_client_ = parent_.createCodecClient(data);
   codec_client_->addConnectionCallbacks(*this);
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -101,6 +101,7 @@ protected:
     ConnPoolImpl& parent_;
     CodecClientPtr codec_client_;
     Upstream::HostDescriptionConstSharedPtr real_host_description_;
+    Network::Connection* connection_;
     StreamWrapperPtr stream_wrapper_;
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_connect_ms_;

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -27,7 +27,8 @@ public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority,
                const Network::ConnectionSocket::OptionsSharedPtr& options,
-               const Network::TransportSocketOptionsSharedPtr& transport_socket_options);
+               const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+               Upstream::Outlier::DetectorSharedPtr outlier_detector);
   ~ConnPoolImpl() override;
 
   // Http::ConnectionPool::Instance
@@ -73,6 +74,7 @@ protected:
     bool upstream_ready_{};
     Stats::TimespanPtr conn_length_;
     bool closed_with_active_rq_{};
+    Upstream::Outlier::EjectableMonitor* outlier_detector_;
   };
 
   using ActiveClientPtr = std::unique_ptr<ActiveClient>;
@@ -98,6 +100,7 @@ protected:
   std::list<DrainedCb> drained_callbacks_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
   const Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  const Upstream::Outlier::DetectorSharedPtr outlier_detector_;
 };
 
 /**

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -279,6 +279,7 @@ envoy_cc_library(
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/upstream:outlier_detection_interface",
         "//include/envoy/upstream:upstream_interface",
+        "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
         "//source/common/http:codes_lib",

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -305,6 +305,7 @@ private:
 
     struct ClusterEntry : public ThreadLocalCluster {
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
+                   Outlier::DetectorSharedPtr outlier_detector,
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry() override;
 
@@ -329,6 +330,7 @@ private:
       LoadBalancerPtr lb_;
       ClusterInfoConstSharedPtr cluster_info_;
       Http::AsyncClientImpl http_async_client_;
+      Outlier::DetectorSharedPtr outlier_detector_;
     };
 
     using ClusterEntryPtr = std::unique_ptr<ClusterEntry>;


### PR DESCRIPTION
A POC of how per connection outlier detection might work: whenever a
HTTP connection is created, a monitor is added to that connection. The
connection to the upstream is exposed to the router, allowing it to
record status/events on the connection.

The connection monitors are tracked in a TLS object to allow the outlier
detector to process the set of monitors to detect outliers without
having to having to coordinate with the main thread.

Ejections of connections happen in newStream in the HTTP connection pools: if
the connection has been marked for ejection, we drain the connections and avoid
scheduling new streams onto it (only implemented for HTTP/2 at the moment).

Currently only consecutive status codes detectors work, as the periodic
processing of connection monitors aren't done yet.

Opening now just to get some initial feedback on the approach

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Description:
Risk Level: 
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
