### PR TITLE
http: extract common connect timeout handling to base class

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -116,7 +116,9 @@ envoy_cc_library(
     hdrs = ["conn_pool_base.h"],
     deps = [
         "//include/envoy/http:conn_pool_interface",
+        "//include/envoy/stats:timespan_interface",
         "//source/common/common:linked_object",
+        "//source/common/stats:timespan_lib",
     ],
 )
 

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -17,6 +17,8 @@ protected:
       : host_(host), priority_(priority) {}
   virtual ~ConnPoolImplBase() = default;
 
+  // ActiveClient provides a base class for connection pool clients that handles connection timings
+  // as well as managing the connection timeout.
   class ActiveClient {
   public:
     ActiveClient(Event::Dispatcher& dispatcher, const Upstream::ClusterInfo& cluster);
@@ -71,6 +73,6 @@ protected:
   // When calling purgePendingRequests, this list will be used to hold the requests we are about
   // to purge. We need this if one cancelled requests cancels a different pending request
   std::list<PendingRequestPtr> pending_requests_to_purge_;
-}; // namespace Http
+};
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -147,9 +147,8 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
       // already have "reset" the stream to fire the reset callback. All we do here is just
       // destroy the client.
       removed = client.removeFromList(busy_clients_);
-    } else if (!client.connect_timer_) {
-      // The connect timer is destroyed on connect. The lack of a connect timer means that this
-      // client is idle and in the ready pool.
+    } else if (client.connectionState() ==
+               ConnPoolImplBase::ActiveClient::ConnectionState::Connected) {
       removed = client.removeFromList(ready_clients_);
       check_for_drained = false;
     } else {
@@ -181,18 +180,14 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, Network::ConnectionEv
     }
   }
 
-  if (client.connect_timer_) {
-    client.connect_timer_->disableTimer();
-    client.connect_timer_.reset();
-  }
+  client.disarmConnectTimeout();
 
   // Note that the order in this function is important. Concretely, we must destroy the connect
   // timer before we process a connected idle client, because if this results in an immediate
   // drain/destruction event, we key off of the existence of the connect timer above to determine
   // whether the client is in the ready list (connected) or the busy list (failed to connect).
   if (event == Network::ConnectionEvent::Connected) {
-    client.conn_connect_ms_->complete();
-    client.conn_connect_ms_.reset();
+    client.recordConnectionSetup();
     processIdleClient(client, false);
   }
 }
@@ -303,12 +298,9 @@ void ConnPoolImpl::StreamWrapper::onDecodeComplete() {
 }
 
 ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
-    : parent_(parent),
-      connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })),
+    : ConnPoolImplBase::ActiveClient(parent.dispatcher_, parent.host_->cluster()), parent_(parent),
       remaining_requests_(parent_.host_->cluster().maxRequestsPerConnection()) {
 
-  conn_connect_ms_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
-      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSource());
   Upstream::Host::CreateConnectionData data = parent_.host_->createConnection(
       parent_.dispatcher_, parent_.socket_options_, parent_.transport_socket_options_);
   real_host_description_ = data.host_description_;
@@ -320,9 +312,6 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_http1_total_.inc();
   parent_.host_->stats().cx_total_.inc();
   parent_.host_->stats().cx_active_.inc();
-  conn_length_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
-      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSource());
-  connect_timer_->enableTimer(parent_.host_->cluster().connectTimeout());
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().inc();
 
   codec_client_->setConnectionStats(
@@ -336,7 +325,6 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
 ConnPoolImpl::ActiveClient::~ActiveClient() {
   parent_.host_->cluster().stats().upstream_cx_active_.dec();
   parent_.host_->stats().cx_active_.dec();
-  conn_length_->complete();
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().dec();
 }
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -83,13 +83,14 @@ protected:
 
   using StreamWrapperPtr = std::unique_ptr<StreamWrapper>;
 
-  struct ActiveClient : LinkedObject<ActiveClient>,
+  struct ActiveClient : ConnPoolImplBase::ActiveClient,
+                        LinkedObject<ActiveClient>,
                         public Network::ConnectionCallbacks,
                         public Event::DeferredDeletable {
     ActiveClient(ConnPoolImpl& parent);
     ~ActiveClient() override;
 
-    void onConnectTimeout();
+    void onConnectTimeout() override;
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override {
@@ -102,9 +103,6 @@ protected:
     CodecClientPtr codec_client_;
     Upstream::HostDescriptionConstSharedPtr real_host_description_;
     StreamWrapperPtr stream_wrapper_;
-    Event::TimerPtr connect_timer_;
-    Stats::TimespanPtr conn_connect_ms_;
-    Stats::TimespanPtr conn_length_;
     uint64_t remaining_requests_;
   };
 

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -98,10 +98,10 @@ public:
           }
         },
         Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), *test_client.client_dispatcher_);
+    EXPECT_CALL(*test_client.connect_timer_, enableTimer(_, _));
     EXPECT_CALL(mock_dispatcher_, createClientConnection_(_, _, _, _))
         .WillOnce(Return(test_client.connection_));
     EXPECT_CALL(*this, createCodecClient_()).WillOnce(Return(test_client.codec_client_));
-    EXPECT_CALL(*test_client.connect_timer_, enableTimer(_, _));
     ON_CALL(*test_client.codec_, protocol()).WillByDefault(Return(protocol));
   }
 
@@ -432,10 +432,10 @@ TEST_F(Http1ConnPoolImplTest, MeasureConnectTime) {
 
   // Cleanup, cause the connections to go away.
   for (auto& test_client : conn_pool_.test_clients_) {
+    EXPECT_CALL(conn_pool_, onClientDestroy());
     EXPECT_CALL(
         cluster_->stats_store_,
         deliverHistogramToSinks(Property(&Stats::Metric::name, "upstream_cx_length_ms"), _));
-    EXPECT_CALL(conn_pool_, onClientDestroy());
     test_client.connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   }
   dispatcher_.clearDeferredDeleteList();


### PR DESCRIPTION
This makes both ActiveClient implementations share a common base class
which manages connection timeout + timespans.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
