### PR TITLE
[fuzz] fix server test fuzz bugs

### DIFF
--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -93,7 +93,8 @@ message GrpcService {
       // [#next-free-field: 10]
       message StsService {
         // URI of the token exchange service that handles token exchange requests.
-        string token_exchange_service_uri = 1 [(validate.rules).string = {uri: true}];
+        // TODO(asraa): Add URI validation when implemented.
+        string token_exchange_service_uri = 1;
 
         // Location of the target service or resource where the client
         // intends to use the requested security token.

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -93,7 +93,8 @@ message GrpcService {
       // [#next-free-field: 10]
       message StsService {
         // URI of the token exchange service that handles token exchange requests.
-        // TODO(asraa): Add URI validation when implemented.
+        // [#comment:TODO(asraa): Add URI validation when implemented. Tracked by
+        // https://github.com/envoyproxy/protoc-gen-validate/issues/303]
         string token_exchange_service_uri = 1;
 
         // Location of the target service or resource where the client

--- a/api/envoy/api/v3alpha/core/grpc_service.proto
+++ b/api/envoy/api/v3alpha/core/grpc_service.proto
@@ -130,7 +130,8 @@ message GrpcService {
             "envoy.api.v2.core.GrpcService.GoogleGrpc.CallCredentials.StsService";
 
         // URI of the token exchange service that handles token exchange requests.
-        string token_exchange_service_uri = 1 [(validate.rules).string = {uri: true}];
+        // TODO(asraa): Add URI validation when implemented.
+        string token_exchange_service_uri = 1;
 
         // Location of the target service or resource where the client
         // intends to use the requested security token.

--- a/api/envoy/api/v3alpha/core/grpc_service.proto
+++ b/api/envoy/api/v3alpha/core/grpc_service.proto
@@ -130,7 +130,8 @@ message GrpcService {
             "envoy.api.v2.core.GrpcService.GoogleGrpc.CallCredentials.StsService";
 
         // URI of the token exchange service that handles token exchange requests.
-        // TODO(asraa): Add URI validation when implemented.
+        // [#comment:TODO(asraa): Add URI validation when implemented. Tracked by
+        // https://github.com/envoyproxy/protoc-gen-validate/issues/303]
         string token_exchange_service_uri = 1;
 
         // Location of the target service or resource where the client

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5633109961998336
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5633109961998336
@@ -1,0 +1,47 @@
+static_resources {
+  clusters {
+    name: "B"
+    connect_timeout {
+      nanos: 4
+    }
+    hosts {
+      pipe {
+        path: "l"
+      }
+    }
+    hosts {
+      pipe {
+        path: "\334\254"
+      }
+    }
+    health_checks {
+      timeout {
+        seconds: 512
+      }
+      interval {
+        nanos: 91
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+      }
+      http_health_check {
+        host: "#"
+        path: "="
+        codec_client_type: HTTP3
+      }
+      interval_jitter_percent: 1
+      always_log_health_check_failures: true
+    }
+  }
+}
+cluster_manager {
+  load_stats_config {
+    rate_limit_settings {
+      fill_rate {
+        value: 2.36453327863576e-312
+      }
+    }
+  }
+}
+flags_path: "\000\000\000\000\000\010NK"

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5665272556158976
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5665272556158976
@@ -1,0 +1,1 @@
+cluster_manager {   load_stats_config {     grpc_services {       google_grpc {         target_uri: " "         call_credentials {           sts_service {           }         }       }     }   } } 

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -52,6 +52,10 @@ makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
     }
   }
   for (auto& cluster : *output.mutable_static_resources()->mutable_clusters()) {
+    for (auto& health_check : *cluster.mutable_health_checks()) {
+      // QUIC is not enabled in production code yet, so remove references for HTTP3.
+      health_check.mutable_http_health_check()->clear_codec_client_type();
+    }
     for (auto& host : *cluster.mutable_hosts()) {
       makePortHermetic(test_env, host);
     }

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -53,7 +53,8 @@ makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
   }
   for (auto& cluster : *output.mutable_static_resources()->mutable_clusters()) {
     for (auto& health_check : *cluster.mutable_health_checks()) {
-      // QUIC is not enabled in production code yet, so remove references for HTTP3.
+      // TODO(asraa): QUIC is not enabled in production code yet, so remove references for HTTP3.
+      // Tracked at https://github.com/envoyproxy/envoy/issues/9513.
       health_check.mutable_http_health_check()->clear_codec_client_type();
     }
     for (auto& host : *cluster.mutable_hosts()) {


### PR DESCRIPTION
Fixes `server_fuzz_test` fuzz bugs:
* QUIC upstream not implemented in prod, so the fuzzer removes the  HTTP3 codec types for http health checks 
    - If this should be an permanent API level prod change, we should constrain the health check codec types, and I can make that fix.  @goaway 
* PGV validate throws a not yet implemented error on URIs. I removed this check for now and replaced with a TODO. If I catch the `std::exception` that is thrown and bypass it with a warning statement in the logs, we skip over other validations, which means that any fuzz test or user using this uri field will be in danger of failing because of other invalid fields @JimmyCYJ
   - PGV issue tracked: https://github.com/envoyproxy/protoc-gen-validate/issues/303

Fixes OSS-Fuzz Issues:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19614
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19689
 
 
Signed-off-by: Asra Ali <asraa@google.com>

