### PR TITLE
listener: use typed config for transport socket conversion.

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -756,7 +756,7 @@ std::unique_ptr<Network::FilterChain> ListenerFilterChainFactoryBuilder::buildFi
   if (!filter_chain.has_transport_socket()) {
     if (filter_chain.has_tls_context()) {
       transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
-      MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config());
+      transport_socket.mutable_typed_config()->PackFrom(filter_chain.tls_context());
     } else {
       transport_socket.set_name(
           Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);


### PR DESCRIPTION
Previously we were converting to deprecated Struct config, which is (1)
deprecated and (2) breaks API boosting, since we end up placing v3
config in Structs.

Risk level: Low
Testing: All tests pass before/after API boosting. This is an internal
  implementation change, existing transport sockets cover behaviors.

Signed-off-by: Harvey Tuch <htuch@google.com>