### PR TITLE
[buffer] Correctly handle the case of low_watermark of 0 with a non-zero high_watermark

### DIFF
--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -78,7 +78,7 @@ void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_waterm
 
 void WatermarkBuffer::checkLowWatermark() {
   if (!above_high_watermark_called_ ||
-      (high_watermark_ != 0 && OwnedImpl::length() >= low_watermark_)) {
+      (high_watermark_ != 0 && OwnedImpl::length() > low_watermark_)) {
     return;
   }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -880,7 +880,7 @@ TEST_P(ConnectionImplTest, WatermarkFuzzing) {
     // If after the bytes are flushed upstream the number of bytes remaining is
     // below the low watermark and the bytes were not previously below the low
     // watermark, expect the callback for going below.
-    if (new_bytes_buffered < 5 && is_above) {
+    if (new_bytes_buffered <= 5 && is_above) {
       ENVOY_LOG_MISC(trace, "Expect onBelowWriteBufferLowWatermark");
       EXPECT_CALL(client_callbacks_, onBelowWriteBufferLowWatermark());
       is_below = true;


### PR DESCRIPTION
Description: Trigger the low_watermark callback when the size of the buffer equals the low_watermark in order to fix handling of low_watermark of 0.  Before this change buffers with a low_watermark of 0 would not invoke the low_watermark callback when the buffer was fully drained.

This edge case can happen when Envoy is misconfigured by setting per_connection_buffer_limit_bytes to 1 byte for HTTP/1 or TCP proxy connections.  The low watermark is computed from the high watermark by dividing by 2 and rounding down, which results in a low watermark of 0.
Risk Level: Low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
