### PR TITLE
docs: fix TODOs in api docs

### DIFF
--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -141,6 +141,6 @@ message HostHealthStatus {
 
   // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported
   // here.
-  // TODO(mrice32): pipe through remaining EDS health status possibilities.
+  // [#comment:TODO(mrice32): pipe through remaining EDS health status possibilities.]
   api.v2.core.HealthStatus eds_health_status = 3;
 }

--- a/api/envoy/admin/v3alpha/clusters.proto
+++ b/api/envoy/admin/v3alpha/clusters.proto
@@ -152,6 +152,6 @@ message HostHealthStatus {
 
   // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported
   // here.
-  // TODO(mrice32): pipe through remaining EDS health status possibilities.
+  // [#comment:TODO(mrice32): pipe through remaining EDS health status possibilities.]
   api.v3alpha.core.HealthStatus eds_health_status = 3;
 }

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -517,7 +517,7 @@ message Cluster {
   // *TransportSocketMatch* in this field. Other client Envoys receive CDS without
   // *transport_socket_match* set, and still send plain text traffic to the same cluster.
   //
-  // TODO(incfly): add a detailed architecture doc on intended usage.
+  // [#comment:TODO(incfly): add a detailed architecture doc on intended usage.]
   repeated TransportSocketMatch transport_socket_matches = 43;
 
   // Supplies the name of the cluster which must be unique across all clusters.

--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -38,7 +38,8 @@ message ApiConfigSource {
     // with every update, the xDS server only sends what has changed since the last update.
     //
     // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
-    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    // Do not use for other xDSes.
+    // [#comment:TODO(fredlas) update/remove this warning when appropriate.]
     DELTA_GRPC = 3;
   }
 

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -552,7 +552,7 @@ message Cluster {
   // *TransportSocketMatch* in this field. Other client Envoys receive CDS without
   // *transport_socket_match* set, and still send plain text traffic to the same cluster.
   //
-  // TODO(incfly): add a detailed architecture doc on intended usage.
+  // [#comment:TODO(incfly): add a detailed architecture doc on intended usage.]
   repeated TransportSocketMatch transport_socket_matches = 43;
 
   // Supplies the name of the cluster which must be unique across all clusters.

--- a/api/envoy/api/v3alpha/core/config_source.proto
+++ b/api/envoy/api/v3alpha/core/config_source.proto
@@ -42,7 +42,8 @@ message ApiConfigSource {
     // with every update, the xDS server only sends what has changed since the last update.
     //
     // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
-    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    // Do not use for other xDSes.
+    // [#comment:TODO(fredlas) update/remove this warning when appropriate.]
     DELTA_GRPC = 3;
   }
 


### PR DESCRIPTION
Description: Some TODOs are currently visible on the documentation (for example https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/config_source.proto.html). Moved them into a `[#comment: ...]` block so that they are not rendered on the documentation page.
Risk Level: low

Signed-off-by: Derek Argueta <dereka@pinterest.com>