### PR TITLE
docs: Update docs and e-mail templates to use envoy-security-announce

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ to find out more about the origin story and design philosophy of Envoy
 
 * [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce): Low frequency mailing
   list where we will email announcements only.
+* [envoy-security-announce](https://groups.google.com/forum/#!forum/envoy-security-announce): Low frequency mailing
+  list where we will email security related announcements only.
 * [envoy-users](https://groups.google.com/forum/#!forum/envoy-users): General user discussion.
 * [envoy-dev](https://groups.google.com/forum/#!forum/envoy-dev): Envoy developer discussion (APIs,
   feature design, etc.).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,8 +74,9 @@ If a vulnerability does not affect any point release but only master, additional
 
 * If the issue is detected and a fix is available within 5 days of the introduction of the
   vulnerability, the fix will be publicly reviewed and landed on master. A courtesy e-mail will be
-  sent to envoy-users@googlegroups.com, envoy-dev@googlegroups.com and
-  cncf-envoy-distributors-announce@lists.cncf.io if the severity is medium or greater.
+  sent to envoy-users@googlegroups.com, envoy-dev@googlegroups.com,
+  envoy-security-announce@googlegroups.com and cncf-envoy-distributors-announce@lists.cncf.io if 
+  the severity is medium or greater.
 * If the vulnerability has been in existence for more than 5 days, we will activate the security
   release process for any medium or higher vulnerabilities. Low severity vulnerabilities will still
   be merged onto master as soon as a fix is available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,7 +131,7 @@ or mitigation so that a realistic timeline can be communicated to users.
 
 **Disclosure of Forthcoming Fix to Users** (Completed within 1-7 days of Disclosure)
 
-- The Fix Lead will email [envoy-announce@googlegroups.com](https://groups.google.com/forum/#!forum/envoy-announce)
+- The Fix Lead will email [envoy-security-announce@googlegroups.com](https://groups.google.com/forum/#!forum/envoy-security-announce)
   informing users that a security vulnerability has been disclosed and that a fix will be made
   available at YYYY-MM-DD HH:MM UTC in the future via this list. This time is the Release Date.
 - The Fix Lead will include any mitigating steps users can take until a fix is available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -132,6 +132,7 @@ or mitigation so that a realistic timeline can be communicated to users.
 **Disclosure of Forthcoming Fix to Users** (Completed within 1-7 days of Disclosure)
 
 - The Fix Lead will email [envoy-security-announce@googlegroups.com](https://groups.google.com/forum/#!forum/envoy-security-announce)
+  (CC [envoy-announce@googlegroups.com](https://groups.google.com/forum/#!forum/envoy-announce))
   informing users that a security vulnerability has been disclosed and that a fix will be made
   available at YYYY-MM-DD HH:MM UTC in the future via this list. This time is the Release Date.
 - The Fix Lead will include any mitigating steps users can take until a fix is available.

--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -2,12 +2,12 @@
 
 This is a collection of email templates to handle various situations the security team encounters.
 
-## Upcoming security release to envoy-announce@googlegroups.com
+## Upcoming security release to envoy-security-announce@googlegroups.com
 
 ```
 Subject: Upcoming security release of Envoy $VERSION
-To: envoy-announce@googlegroups.com
-Cc: envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
+To: envoy-security-announce@googlegroups.com
+Cc: envoy-announce@googlegroups.com, envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
 
 Hello Envoy Community,
 
@@ -105,8 +105,8 @@ $PERSON (on behalf of the Envoy security team and maintainers)
 
 ```
 Subject: Security release of Envoy $VERSION is now available
-To: envoy-announce@googlegroups.com
-Cc: envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
+To: envoy-security-announce@googlegroups.com
+Cc: envoy-announce@googlegroups.com, envoy-security@googlegroups.com, envoy-maintainers@googlegroups.com
 
 Hello Envoy Community,
 

--- a/security/gh-cve-template.md
+++ b/security/gh-cve-template.md
@@ -1,7 +1,7 @@
 >This template is for public disclosure of CVE details on Envoy's GitHub. It should be filed
 with the public release of a security patch version, and will be linked to in the announcement sent
-to envoy-announce@googlegroups.com. The title of this issue should be the CVE identifier and it
-should have the `security` label applied.
+to envoy-security-announce@googlegroups.com. The title of this issue should be the CVE identifier
+and it should have the `security` label applied.
 
 # CVE-YEAR-ABCDEF
 


### PR DESCRIPTION
Update docs and e-mail templates to use envoy-security-announce@googlegroups.com mailing list

Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: No
Fixes #9304

Signed-off-by: Yan Avlasov <yavlasov@google.com>
