### PR TITLE
api: rename ConnectionSourceType::LOCAL to SAME_IP_OR_LOOPBACK.

### DIFF
--- a/api/envoy/api/v2/listener/BUILD
+++ b/api/envoy/api/v2/listener/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/api/v2/auth:pkg",
         "//envoy/api/v2/core:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -10,6 +10,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
@@ -72,7 +73,7 @@ message FilterChainMatch {
     ANY = 0;
 
     // Match a connection originating from the same host.
-    LOCAL = 1;
+    LOCAL = 1 [(udpa.annotations.enum_value_migrate).rename = "SAME_IP_OR_LOOPBACK"];
 
     // Match a connection originating from a different host.
     EXTERNAL = 2;

--- a/api/envoy/api/v3alpha/listener/listener.proto
+++ b/api/envoy/api/v3alpha/listener/listener.proto
@@ -76,7 +76,7 @@ message FilterChainMatch {
     ANY = 0;
 
     // Match a connection originating from the same host.
-    LOCAL = 1;
+    SAME_IP_OR_LOOPBACK = 1;
 
     // Match a connection originating from a different host.
     EXTERNAL = 2;

--- a/generated_api_shadow/envoy/admin/v2alpha/clusters.proto
+++ b/generated_api_shadow/envoy/admin/v2alpha/clusters.proto
@@ -141,6 +141,6 @@ message HostHealthStatus {
 
   // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported
   // here.
-  // TODO(mrice32): pipe through remaining EDS health status possibilities.
+  // [#comment:TODO(mrice32): pipe through remaining EDS health status possibilities.]
   api.v2.core.HealthStatus eds_health_status = 3;
 }

--- a/generated_api_shadow/envoy/admin/v3alpha/clusters.proto
+++ b/generated_api_shadow/envoy/admin/v3alpha/clusters.proto
@@ -152,6 +152,6 @@ message HostHealthStatus {
 
   // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported
   // here.
-  // TODO(mrice32): pipe through remaining EDS health status possibilities.
+  // [#comment:TODO(mrice32): pipe through remaining EDS health status possibilities.]
   api.v3alpha.core.HealthStatus eds_health_status = 3;
 }

--- a/generated_api_shadow/envoy/api/v2/cds.proto
+++ b/generated_api_shadow/envoy/api/v2/cds.proto
@@ -517,7 +517,7 @@ message Cluster {
   // *TransportSocketMatch* in this field. Other client Envoys receive CDS without
   // *transport_socket_match* set, and still send plain text traffic to the same cluster.
   //
-  // TODO(incfly): add a detailed architecture doc on intended usage.
+  // [#comment:TODO(incfly): add a detailed architecture doc on intended usage.]
   repeated TransportSocketMatch transport_socket_matches = 43;
 
   // Supplies the name of the cluster which must be unique across all clusters.

--- a/generated_api_shadow/envoy/api/v2/core/config_source.proto
+++ b/generated_api_shadow/envoy/api/v2/core/config_source.proto
@@ -38,7 +38,8 @@ message ApiConfigSource {
     // with every update, the xDS server only sends what has changed since the last update.
     //
     // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
-    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    // Do not use for other xDSes.
+    // [#comment:TODO(fredlas) update/remove this warning when appropriate.]
     DELTA_GRPC = 3;
   }
 

--- a/generated_api_shadow/envoy/api/v2/listener/BUILD
+++ b/generated_api_shadow/envoy/api/v2/listener/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/api/v2/auth:pkg",
         "//envoy/api/v2/core:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/api/v2/listener/listener.proto
+++ b/generated_api_shadow/envoy/api/v2/listener/listener.proto
@@ -10,6 +10,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.listener";
@@ -72,7 +73,7 @@ message FilterChainMatch {
     ANY = 0;
 
     // Match a connection originating from the same host.
-    LOCAL = 1;
+    LOCAL = 1 [(udpa.annotations.enum_value_migrate).rename = "SAME_IP_OR_LOOPBACK"];
 
     // Match a connection originating from a different host.
     EXTERNAL = 2;

--- a/generated_api_shadow/envoy/api/v3alpha/cds.proto
+++ b/generated_api_shadow/envoy/api/v3alpha/cds.proto
@@ -557,7 +557,7 @@ message Cluster {
   // *TransportSocketMatch* in this field. Other client Envoys receive CDS without
   // *transport_socket_match* set, and still send plain text traffic to the same cluster.
   //
-  // TODO(incfly): add a detailed architecture doc on intended usage.
+  // [#comment:TODO(incfly): add a detailed architecture doc on intended usage.]
   repeated TransportSocketMatch transport_socket_matches = 43;
 
   // Supplies the name of the cluster which must be unique across all clusters.

--- a/generated_api_shadow/envoy/api/v3alpha/core/config_source.proto
+++ b/generated_api_shadow/envoy/api/v3alpha/core/config_source.proto
@@ -42,7 +42,8 @@ message ApiConfigSource {
     // with every update, the xDS server only sends what has changed since the last update.
     //
     // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
-    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    // Do not use for other xDSes.
+    // [#comment:TODO(fredlas) update/remove this warning when appropriate.]
     DELTA_GRPC = 3;
   }
 

--- a/generated_api_shadow/envoy/api/v3alpha/listener/listener.proto
+++ b/generated_api_shadow/envoy/api/v3alpha/listener/listener.proto
@@ -77,7 +77,7 @@ message FilterChainMatch {
     ANY = 0;
 
     // Match a connection originating from the same host.
-    LOCAL = 1;
+    SAME_IP_OR_LOOPBACK = 1;
 
     // Match a connection originating from a different host.
     EXTERNAL = 2;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -232,7 +232,7 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
   return ret;
 }
 
-bool Utility::isLocalConnection(const ConnectionSocket& socket) {
+bool Utility::isSameIpOrLoopback(const ConnectionSocket& socket) {
   // These are local:
   // - Pipes
   // - Sockets to a loopback address

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -168,7 +168,7 @@ public:
    * Determine whether this is a local connection.
    * @return bool the address is a local connection.
    */
-  static bool isLocalConnection(const ConnectionSocket& socket);
+  static bool isSameIpOrLoopback(const ConnectionSocket& socket);
 
   /**
    * Determine whether this is an internal (RFC1918) address.

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -364,10 +364,10 @@ const Network::FilterChain* FilterChainManagerImpl::findFilterChainForSourceType
   const auto& filter_chain_external =
       source_types[envoy::api::v2::listener::FilterChainMatch::EXTERNAL];
 
-  // isLocalConnection can be expensive. Call it only if LOCAL or EXTERNAL have entries.
+  // isSameIpOrLoopback can be expensive. Call it only if LOCAL or EXTERNAL have entries.
   const bool is_local_connection =
       (!filter_chain_local.first.empty() || !filter_chain_external.first.empty())
-          ? Network::Utility::isLocalConnection(socket)
+          ? Network::Utility::isSameIpOrLoopback(socket)
           : false;
 
   if (is_local_connection) {

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -181,51 +181,51 @@ TEST(NetworkUtility, LocalConnection) {
 
   local_addr.reset(new Network::Address::Ipv4Instance("127.0.0.1"));
   remote_addr.reset(new Network::Address::PipeInstance("/pipe/path"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::PipeInstance("/pipe/path"));
   remote_addr.reset(new Network::Address::PipeInstance("/pipe/path"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv4Instance("127.0.0.1"));
   remote_addr.reset(new Network::Address::Ipv4Instance("127.0.0.1"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv4Instance("127.0.0.2"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4"));
   remote_addr.reset(new Network::Address::Ipv4Instance("8.8.8.8"));
-  EXPECT_FALSE(Utility::isLocalConnection(socket));
+  EXPECT_FALSE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4"));
   remote_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4", 1234));
   remote_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4", 4321));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv6Instance("::1"));
   remote_addr.reset(new Network::Address::Ipv6Instance("::1"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   local_addr.reset(new Network::Address::Ipv6Instance("::2"));
   remote_addr.reset(new Network::Address::Ipv6Instance("::1"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   remote_addr.reset(new Network::Address::Ipv6Instance("::3"));
-  EXPECT_FALSE(Utility::isLocalConnection(socket));
+  EXPECT_FALSE(Utility::isSameIpOrLoopback(socket));
 
   remote_addr.reset(new Network::Address::Ipv6Instance("::2"));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   remote_addr.reset(new Network::Address::Ipv6Instance("::2", 4321));
   local_addr.reset(new Network::Address::Ipv6Instance("::2", 1234));
-  EXPECT_TRUE(Utility::isLocalConnection(socket));
+  EXPECT_TRUE(Utility::isSameIpOrLoopback(socket));
 
   remote_addr.reset(new Network::Address::Ipv6Instance("fd00::"));
-  EXPECT_FALSE(Utility::isLocalConnection(socket));
+  EXPECT_FALSE(Utility::isSameIpOrLoopback(socket));
 }
 
 TEST(NetworkUtility, InternalAddress) {

--- a/tools/protoxform/migrate.py
+++ b/tools/protoxform/migrate.py
@@ -142,6 +142,8 @@ class UpgradeVisitor(visitor.Visitor):
         else:
           # Mark deprecated enum values as ready for deletion by protoxform.
           self._Deprecate(upgraded_proto, v)
+      elif v.options.HasExtension(migrate_pb2.enum_value_migrate):
+        self._Rename(v, v.options.Extensions[migrate_pb2.enum_value_migrate])
     return upgraded_proto
 
   def VisitFile(self, file_proto, type_context, services, msgs, enums):

--- a/tools/testdata/protoxform/envoy/v2/sample.proto
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto
@@ -8,6 +8,7 @@ enum SomeEnum {
   DEFAULT = 0 [deprecated = true];
   FOO = 1;
   BAR = 2 [deprecated = true];
+  BAZ = 3 [(udpa.annotations.enum_value_migrate).rename = "WOW"];
 }
 
 message Sample {

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.v2.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.v2.gold
@@ -12,6 +12,7 @@ enum SomeEnum {
   DEFAULT = 0 [deprecated = true];
   FOO = 1;
   BAR = 2 [deprecated = true];
+  BAZ = 3 [(udpa.annotations.enum_value_migrate).rename = "WOW"];
 }
 
 message Sample {

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.v3alpha.envoy_internal.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.v3alpha.envoy_internal.gold
@@ -12,6 +12,7 @@ enum SomeEnum {
   hidden_envoy_deprecated_DEFAULT = 0 [deprecated = true];
   FOO = 1;
   hidden_envoy_deprecated_BAR = 2 [deprecated = true];
+  WOW = 3;
 }
 
 message Sample {

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.v3alpha.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.v3alpha.gold
@@ -15,6 +15,7 @@ enum SomeEnum {
 
   DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE = 0 [deprecated = true];
   FOO = 1;
+  WOW = 3;
 }
 
 message Sample {


### PR DESCRIPTION
Also Utility::isLocalConnection() to Utility::isSameIpOrLoopback(). The
idea is to improve descriptive accuracy, see
https://github.com/envoyproxy/envoy/pull/7840#issuecomment-524002499.

Risk level: Low
Testing: additional protoxform golden test added for enum value renames.

Fixes #8081

Signed-off-by: Harvey Tuch <htuch@google.com>