### PR TITLE
Enable v8 build on Arm64 server

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -2,9 +2,9 @@
 
 set -e
 
-# This works only on Linux-x86_64 and macOS-x86_64.
-if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || `uname -m` != "x86_64" ]]; then
-  echo "ERROR: wee8 is currently supported only on Linux-x86_64 and macOS-x86_64."
+# This works only on Linux-x86_64, Linux-aarch64 and macOS-x86_64.
+if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || ( `uname -m` != "x86_64" && `uname -m` != "aarch64" ) ]]; then
+  echo "ERROR: wee8 is currently supported only on Linux-x86_64, Linux-aarch64 and macOS-x86_64."
   exit 1
 fi
 
@@ -70,14 +70,23 @@ WEE8_BUILD_ARGS+=" v8_use_external_startup_data=false"
 # Disable read-only heap, since it's leaky and HEAPCHECK complains about it.
 # TODO(PiotrSikora): remove when fixed upstream.
 WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
+# Support Arm64
+if [[ `uname -m` == "aarch64" ]]; then
+  WEE8_BUILD_ARGS+=" target_cpu=\"arm64\""
+fi
 
 # Build wee8.
-if [[ `uname` == "Darwin" ]]; then
-  buildtools/mac/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+if [[ `uname -m` == "aarch64" ]]; then
+  gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  ninja -C out/wee8 wee8
 else
-  buildtools/linux64/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  if [[ `uname` == "Darwin" ]]; then
+    buildtools/mac/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  else
+    buildtools/linux64/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  fi
+  third_party/depot_tools/ninja -C out/wee8 wee8
 fi
-third_party/depot_tools/ninja -C out/wee8 wee8
 
 # Move compiled library to the expected destinations.
 popd


### PR DESCRIPTION
This patch enable the v8 build on Arm64 native build environments for
envoy. There are some modifications about wee8 build scripts and wee8
patch as following:
1. Modify the wee8.patch for supporting ninja on Arm64 platform
2. Modify the corresponding varible in building scripts.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
