### PR TITLE
Make cluster host stats configurable

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -46,7 +46,7 @@ service ClusterDiscoveryService {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 46]
+// [#next-free-field: 47]
 message Cluster {
   // Refer to :ref:`service discovery type <arch_overview_service_discovery_types>`
   // for an explanation on each type.
@@ -801,6 +801,9 @@ message Cluster {
   // maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
   // from the LRS stream here.]
   core.ConfigSource lrs_server = 42;
+
+  // If set to true, the Envoy will disables host stats to reduce the memory consumption.
+  bool disable_host_stats = 46;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/api/envoy/api/v3alpha/cds.proto
+++ b/api/envoy/api/v3alpha/cds.proto
@@ -46,7 +46,7 @@ service ClusterDiscoveryService {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 46]
+// [#next-free-field: 47]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -821,6 +821,9 @@ message Cluster {
   // maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
   // from the LRS stream here.]
   core.ConfigSource lrs_server = 42;
+
+  // If set to true, the Envoy will disables host stats to reduce the memory consumption.
+  bool disable_host_stats = 46;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/generated_api_shadow/envoy/api/v2/cds.proto
+++ b/generated_api_shadow/envoy/api/v2/cds.proto
@@ -46,7 +46,7 @@ service ClusterDiscoveryService {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 46]
+// [#next-free-field: 47]
 message Cluster {
   // Refer to :ref:`service discovery type <arch_overview_service_discovery_types>`
   // for an explanation on each type.
@@ -801,6 +801,9 @@ message Cluster {
   // maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
   // from the LRS stream here.]
   core.ConfigSource lrs_server = 42;
+
+  // If set to true, the Envoy will disables host stats to reduce the memory consumption.
+  bool disable_host_stats = 46;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/generated_api_shadow/envoy/api/v3alpha/cds.proto
+++ b/generated_api_shadow/envoy/api/v3alpha/cds.proto
@@ -47,7 +47,7 @@ service ClusterDiscoveryService {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 46]
+// [#next-free-field: 47]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -841,6 +841,9 @@ message Cluster {
   // maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
   // from the LRS stream here.]
   core.ConfigSource lrs_server = 42;
+
+  // If set to true, the Envoy will disables host stats to reduce the memory consumption.
+  bool disable_host_stats = 46;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/include/envoy/stats/primitive_stats_macros.h
+++ b/include/envoy/stats/primitive_stats_macros.h
@@ -40,12 +40,20 @@ namespace Envoy {
  */
 
 // Fully-qualified for use in external callsites.
-#define GENERATE_PRIMITIVE_COUNTER_STRUCT(NAME) Envoy::Stats::PrimitiveCounter NAME##_;
-#define GENERATE_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::PrimitiveGauge NAME##_;
+#define DATA_PRIMITIVE_STATS_DECL(NAME) host_stats_data.NAME##_,
+
+#define GENERATE_PRIMITIVE_COUNTER_STRUCT(NAME) Envoy::Stats::PrimitiveCounterImpl NAME##_;
+#define GENERATE_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::PrimitiveGaugeImpl NAME##_;
+
+#define GENERATE_NULL_PRIMITIVE_COUNTER_STRUCT(NAME) Envoy::Stats::NullPrimitiveCounterImpl NAME##_;
+#define GENERATE_NULL_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::NullPrimitiveGaugeImpl NAME##_;
+
+#define GENERATE_PRIMITIVE_COUNTER_STRUCT_REFERENCE(NAME) Envoy::Stats::PrimitiveCounter& NAME##_;
+#define GENERATE_PRIMITIVE_GAUGE_STRUCT_REFERENCE(NAME) Envoy::Stats::PrimitiveGauge& NAME##_;
 
 // Name and counter/gauge reference pair used to construct map of counters/gauges.
-#define PRIMITIVE_COUNTER_NAME_AND_REFERENCE(X) {absl::string_view(#X), std::ref(X##_)},
-#define PRIMITIVE_GAUGE_NAME_AND_REFERENCE(X) {absl::string_view(#X), std::ref(X##_)},
+#define PRIMITIVE_COUNTER_NAME_AND_REFERENCE(X) {absl::string_view(#X), X##_},
+#define PRIMITIVE_GAUGE_NAME_AND_REFERENCE(X) {absl::string_view(#X), X##_},
 
 // Ignore a counter or gauge.
 #define IGNORE_PRIMITIVE_COUNTER(X)

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -870,6 +870,11 @@ public:
   virtual Http::Protocol
   upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_protocol) const PURE;
 
+  /**
+   * @return Whether to disable host stats to reduce memory consumption
+   */
+  virtual bool disableHostStats() const PURE;
+
 protected:
   /**
    * Invoked by extensionProtocolOptionsTyped.

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -74,7 +74,7 @@ public:
       const envoy::api::v2::core::Locality& locality,
       const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config,
       uint32_t priority);
-
+  static HostStats generateStats(bool disable_host_stats);
   Network::TransportSocketFactory& transportSocketFactory() const override {
     return socket_factory_;
   }
@@ -578,6 +578,7 @@ public:
   void createNetworkFilterChain(Network::Connection&) const override;
   Http::Protocol
   upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_protocol) const override;
+  bool disableHostStats() const override { return disable_host_stats_; }
 
 private:
   struct ResourceManagers {
@@ -628,6 +629,7 @@ private:
   const absl::optional<envoy::api::v2::Cluster::CustomClusterType> cluster_type_;
   const std::unique_ptr<Server::Configuration::CommonFactoryContext> factory_context_;
   std::vector<Network::FilterFactoryCb> filter_factories_;
+  const bool disable_host_stats_;
 };
 
 /**

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -116,6 +116,8 @@ envoy_cc_test(
     srcs = ["host_stats_test.cc"],
     deps = [
         "//include/envoy/upstream:host_description_interface",
+        "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
     ],
 )
 

--- a/test/common/upstream/host_stats_test.cc
+++ b/test/common/upstream/host_stats_test.cc
@@ -1,5 +1,7 @@
 #include "envoy/upstream/host_description.h"
 
+#include "common/upstream/upstream_impl.h"
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -8,7 +10,7 @@ namespace {
 
 // Verify that counters are sorted by name.
 TEST(HostStatsTest, CountersSortedByName) {
-  HostStats host_stats;
+  HostStats host_stats(HostDescriptionImpl::generateStats(false));
   std::vector<std::pair<absl::string_view, Stats::PrimitiveCounterReference>> counters =
       host_stats.counters();
   EXPECT_FALSE(counters.empty());
@@ -20,7 +22,7 @@ TEST(HostStatsTest, CountersSortedByName) {
 
 // Verify that gauges are sorted by name.
 TEST(HostStatsTest, GaugesSortedByName) {
-  HostStats host_stats;
+  HostStats host_stats(HostDescriptionImpl::generateStats(false));
   std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>> gauges =
       host_stats.gauges();
   EXPECT_FALSE(gauges.empty());

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -112,6 +112,7 @@ public:
   MOCK_CONST_METHOD0(eds_service_name, absl::optional<std::string>());
   MOCK_CONST_METHOD1(createNetworkFilterChain, void(Network::Connection&));
   MOCK_CONST_METHOD1(upstreamHttpProtocol, Http::Protocol(absl::optional<Http::Protocol>));
+  MOCK_CONST_METHOD0(disableHostStats, bool());
 
   std::string name_{"fake_cluster"};
   absl::optional<std::string> eds_service_name_;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -10,6 +10,7 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/stats/fake_symbol_table_impl.h"
+#include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/network/transport_socket.h"
 #include "test/mocks/upstream/cluster_info.h"
@@ -110,7 +111,7 @@ public:
   testing::NiceMock<MockHealthCheckHostMonitor> health_checker_;
   Network::TransportSocketFactoryPtr socket_factory_;
   testing::NiceMock<MockClusterInfo> cluster_;
-  HostStats stats_;
+  HostStats stats_{HostDescriptionImpl::generateStats(false)};
   mutable Stats::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;
 };
@@ -191,7 +192,7 @@ public:
   testing::NiceMock<MockClusterInfo> cluster_;
   Network::TransportSocketFactoryPtr socket_factory_;
   testing::NiceMock<Outlier::MockDetectorHostMonitor> outlier_detector_;
-  HostStats stats_;
+  HostStats stats_{HostDescriptionImpl::generateStats(false)};
   mutable Stats::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;
 };

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1278,20 +1278,20 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   ON_CALL(*host, hostname()).WillByDefault(ReturnRef(hostname));
 
   // Add stats in random order and validate that they come in order.
-  Stats::PrimitiveCounter test_counter;
+  Stats::PrimitiveCounterImpl test_counter;
   test_counter.add(10);
-  Stats::PrimitiveCounter rest_counter;
+  Stats::PrimitiveCounterImpl rest_counter;
   rest_counter.add(10);
-  Stats::PrimitiveCounter arest_counter;
+  Stats::PrimitiveCounterImpl arest_counter;
   arest_counter.add(5);
   std::vector<std::pair<absl::string_view, Stats::PrimitiveCounterReference>> counters = {
       {"arest_counter", arest_counter},
       {"rest_counter", rest_counter},
       {"test_counter", test_counter},
   };
-  Stats::PrimitiveGauge test_gauge;
+  Stats::PrimitiveGaugeImpl test_gauge;
   test_gauge.set(11);
-  Stats::PrimitiveGauge atest_gauge;
+  Stats::PrimitiveGaugeImpl atest_gauge;
   atest_gauge.set(10);
   std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>> gauges = {
       {"atest_gauge", atest_gauge},


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

Description: Make cluster host stats configurable
Risk Level: low
Testing: N/A
Docs Changes:  N/A
Release Notes: N/A
[Optional Fixes #Issue] #7525
[Optional Deprecated:]
