### PR TITLE
[test] install a sighandler on test/fuzz:main so stack trace is logged if test crashes

### DIFF
--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -18,6 +18,9 @@ envoy_proto_library(
 envoy_cc_test_library(
     name = "main",
     srcs = ["main.cc"],
+    external_deps = [
+        "abseil_symbolize",
+    ],
     deps = [
         ":fuzz_runner_lib",
         "//source/common/common:assert_lib",

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -25,7 +25,10 @@ envoy_cc_test_library(
         "//source/common/stats:isolated_store_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
-    ],
+    ] + select({
+        "//bazel:disable_signal_trace": [],
+        "//conditions:default": ["//source/common/signal:sigaction_lib"],
+    }),
 )
 
 envoy_cc_test_library(

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -19,6 +19,10 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#ifdef ENVOY_HANDLE_SIGNALS
+#include "common/signal/signal_action.h"
+#endif
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -47,6 +51,13 @@ INSTANTIATE_TEST_SUITE_P(CorpusExamples, FuzzerCorpusTest, testing::ValuesIn(tes
 } // namespace Envoy
 
 int main(int argc, char** argv) {
+#ifndef __APPLE__
+  absl::InitializeSymbolizer(argv[0]);
+#endif
+#ifdef ENVOY_HANDLE_SIGNALS
+  // Enabled by default. Control with "bazel --define=signal_trace=disabled"
+  Envoy::SignalAction handle_sigs;
+#endif
   // Expected usage: <test path> <corpus paths..> [other gtest flags]
   RELEASE_ASSERT(argc >= 2, "");
   // Consider any file after the test path which doesn't have a - prefix to be a corpus entry.

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -19,6 +19,8 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "absl/debugging/symbolize.h"
+
 #ifdef ENVOY_HANDLE_SIGNALS
 #include "common/signal/signal_action.h"
 #endif


### PR DESCRIPTION
Description: Install the signal handler in the main method used by fuzz tests so that nice stack traces are printed when those tests abort.
Risk Level: n/a
Testing: n/a (test infrastructure)
Docs Changes: n/a
Release Notes: n/a
