### PR TITLE
test: remove some API version asserts.

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -741,8 +741,6 @@ bool ConfigHelper::loadHttpConnectionManager(
   auto* hcm_filter = getFilterFromListener("envoy.http_connection_manager");
   if (hcm_filter) {
     auto* config = hcm_filter->mutable_typed_config();
-    ASSERT(config->Is<
-           envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager>());
     hcm = MessageUtil::anyConvert<
         envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager>(
         *config);

--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -56,12 +56,9 @@ public:
       auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
       auto* filter_chain = listener->mutable_filter_chains(0);
       auto* config_blob = filter_chain->mutable_filters(0)->mutable_typed_config();
-
-      ASSERT_TRUE(config_blob->Is<envoy::config::filter::network::tcp_proxy::v2::TcpProxy>());
       auto tcp_proxy_config =
           MessageUtil::anyConvert<envoy::config::filter::network::tcp_proxy::v2::TcpProxy>(
               *config_blob);
-
       auto* access_log = tcp_proxy_config.add_access_log();
       access_log->set_name("envoy.tcp_grpc_access_log");
       envoy::config::accesslog::v2::TcpGrpcAccessLogConfig access_log_config;


### PR DESCRIPTION
These are no longer true once we upgrade, since we could have v2 or
v3alpha of these messages around.

Risk level: Low
Testing: Part of the set of post-upgrade patches needed to make all
  tests pass.

Signed-off-by: Harvey Tuch <htuch@google.com>