### PR TITLE
docs: swap usage of "upstream" with "downstream"

### DIFF
--- a/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
+++ b/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
@@ -6,7 +6,7 @@ Proxy Protocol
 This listener filter adds support for
 `HAProxy Proxy Protocol <https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt>`_.
 
-In this mode, the upstream connection is assumed to come from a proxy
+In this mode, the downstream connection is assumed to come from a proxy
 which places the original coordinates (IP, PORT) into a connection-string.
 Envoy then extracts these and uses them as the remote address.
 


### PR DESCRIPTION
Signed-off-by: Weston Carlson <wez470@gmail.com>

Description: In Envoy, downstream is used to refer to the frontend/client, where as upstream refers to a backend/cluster. Listeners accept connections from the downstream. For the proxy protocol filter, it is assumed that the client/downstream is a proxy using the connection-string. The docs have been updated to convey this information.
Risk Level: Low
Testing: None
Docs Changes: refer to description
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
