### PR TITLE
[tls][tickets]: add ability to specify lifetime hint

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -7,6 +7,7 @@ import "envoy/api/v2/core/config_source.proto";
 import "envoy/type/matcher/string.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -385,7 +386,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message DownstreamTlsContext {
   // Common TLS context settings.
   CommonTlsContext common_tls_context = 1;
@@ -405,13 +406,21 @@ message DownstreamTlsContext {
     // Config for fetching TLS session ticket keys via SDS API.
     SdsSecretConfig session_ticket_keys_sds_secret_config = 5;
   }
+
+  // If specified, session_timeout will change maximum lifetime (in seconds) of TLS session
+  // Currently this value is used as a hint to `TLS session ticket lifetime (for TLSv1.2)
+  // <https://tools.ietf.org/html/rfc5077#section-5.6>`
+  // only seconds could be specified (fractional seconds are going to be ignored).
+  google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {
+    lt {seconds: 4294967296}
+    gte {}
+  }];
 }
 
 message SdsSecretConfig {
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  // When both name and config are specified, then secret can be fetched and/or reloaded via SDS.
-  // When only name is specified, then secret will be loaded from static
-  // resources.
+  // When both name and config are specified, then secret can be fetched and/or reloaded via
+  // SDS. When only name is specified, then secret will be loaded from static resources.
   string name = 1;
 
   core.ConfigSource sds_config = 2;

--- a/api/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3alpha/config_source.proto";
 import "envoy/type/matcher/v3alpha/string.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -405,7 +406,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
@@ -428,15 +429,23 @@ message DownstreamTlsContext {
     // Config for fetching TLS session ticket keys via SDS API.
     SdsSecretConfig session_ticket_keys_sds_secret_config = 5;
   }
+
+  // If specified, session_timeout will change maximum lifetime (in seconds) of TLS session
+  // Currently this value is used as a hint to `TLS session ticket lifetime (for TLSv1.2)
+  // <https://tools.ietf.org/html/rfc5077#section-5.6>`
+  // only seconds could be specified (fractional seconds are going to be ignored).
+  google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {
+    lt {seconds: 4294967296}
+    gte {}
+  }];
 }
 
 message SdsSecretConfig {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.SdsSecretConfig";
 
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  // When both name and config are specified, then secret can be fetched and/or reloaded via SDS.
-  // When only name is specified, then secret will be loaded from static
-  // resources.
+  // When both name and config are specified, then secret can be fetched and/or reloaded via
+  // SDS. When only name is specified, then secret will be loaded from static resources.
   string name = 1;
 
   config.core.v3alpha.ConfigSource sds_config = 2;

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -7,6 +7,7 @@ import "envoy/api/v2/core/config_source.proto";
 import "envoy/type/matcher/string.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -385,7 +386,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message DownstreamTlsContext {
   // Common TLS context settings.
   CommonTlsContext common_tls_context = 1;
@@ -405,13 +406,21 @@ message DownstreamTlsContext {
     // Config for fetching TLS session ticket keys via SDS API.
     SdsSecretConfig session_ticket_keys_sds_secret_config = 5;
   }
+
+  // If specified, session_timeout will change maximum lifetime (in seconds) of TLS session
+  // Currently this value is used as a hint to `TLS session ticket lifetime (for TLSv1.2)
+  // <https://tools.ietf.org/html/rfc5077#section-5.6>`
+  // only seconds could be specified (fractional seconds are going to be ignored).
+  google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {
+    lt {seconds: 4294967296}
+    gte {}
+  }];
 }
 
 message SdsSecretConfig {
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  // When both name and config are specified, then secret can be fetched and/or reloaded via SDS.
-  // When only name is specified, then secret will be loaded from static
-  // resources.
+  // When both name and config are specified, then secret can be fetched and/or reloaded via
+  // SDS. When only name is specified, then secret will be loaded from static resources.
   string name = 1;
 
   core.ConfigSource sds_config = 2;

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3alpha/cert.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3alpha/config_source.proto";
 import "envoy/type/matcher/v3alpha/string.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -409,7 +410,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
@@ -432,15 +433,23 @@ message DownstreamTlsContext {
     // Config for fetching TLS session ticket keys via SDS API.
     SdsSecretConfig session_ticket_keys_sds_secret_config = 5;
   }
+
+  // If specified, session_timeout will change maximum lifetime (in seconds) of TLS session
+  // Currently this value is used as a hint to `TLS session ticket lifetime (for TLSv1.2)
+  // <https://tools.ietf.org/html/rfc5077#section-5.6>`
+  // only seconds could be specified (fractional seconds are going to be ignored).
+  google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {
+    lt {seconds: 4294967296}
+    gte {}
+  }];
 }
 
 message SdsSecretConfig {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.SdsSecretConfig";
 
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  // When both name and config are specified, then secret can be fetched and/or reloaded via SDS.
-  // When only name is specified, then secret will be loaded from static
-  // resources.
+  // When both name and config are specified, then secret can be fetched and/or reloaded via
+  // SDS. When only name is specified, then secret will be loaded from static resources.
   string name = 1;
 
   config.core.v3alpha.ConfigSource sds_config = 2;

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <functional>
 #include <string>
 #include <vector>
@@ -8,6 +9,8 @@
 #include "envoy/common/pure.h"
 #include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/tls_certificate_config.h"
+
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Ssl {
@@ -120,6 +123,12 @@ public:
    * are candidates for decrypting received tickets.
    */
   virtual const std::vector<SessionTicketKey>& sessionTicketKeys() const PURE;
+
+  /**
+   * @return timeout in seconds for the session.
+   * Session timeout is used to specify lifetime hint of tls tickets.
+   */
+  virtual absl::optional<std::chrono::seconds> sessionTimeout() const PURE;
 };
 
 using ServerContextConfigPtr = std::unique_ptr<ServerContextConfig>;

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -386,6 +386,11 @@ ServerContextConfigImpl::ServerContextConfigImpl(
              !config.common_tls_context().tls_certificate_sds_secret_configs().empty()) {
     throw EnvoyException("SDS and non-SDS TLS certificates may not be mixed in server contexts");
   }
+
+  if (config.has_session_timeout()) {
+    session_timeout_ =
+        std::chrono::seconds(DurationUtil::durationToSeconds(config.session_timeout()));
+  }
 }
 
 ServerContextConfigImpl::~ServerContextConfigImpl() {

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -134,6 +134,7 @@ public:
   const std::vector<SessionTicketKey>& sessionTicketKeys() const override {
     return session_ticket_keys_;
   }
+  absl::optional<std::chrono::seconds> sessionTimeout() const override { return session_timeout_; }
 
   bool isReady() const override {
     const bool parent_is_ready = ContextConfigImpl::isReady();
@@ -159,6 +160,8 @@ private:
   std::vector<ServerContextConfig::SessionTicketKey>
   getSessionTicketKeys(const envoy::api::v2::auth::TlsSessionTicketKeys& keys);
   ServerContextConfig::SessionTicketKey getSessionTicketKey(const std::string& key_data);
+
+  absl::optional<std::chrono::seconds> session_timeout_;
 };
 
 } // namespace Tls

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -957,6 +957,11 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
           });
     }
 
+    if (config.sessionTimeout()) {
+      auto timeout = config.sessionTimeout().value().count();
+      SSL_CTX_set_timeout(ctx.ssl_ctx_.get(), uint32_t(timeout));
+    }
+
     int rc = SSL_CTX_set_session_id_context(ctx.ssl_ctx_.get(), session_context_buf,
                                             session_context_len);
     RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -104,6 +104,7 @@ public:
   MOCK_CONST_METHOD0(minProtocolVersion, unsigned());
   MOCK_CONST_METHOD0(maxProtocolVersion, unsigned());
   MOCK_CONST_METHOD0(isReady, bool());
+  MOCK_CONST_METHOD0(sessionTimeout, absl::optional<std::chrono::seconds>());
   MOCK_METHOD1(setSecretUpdateCallback, void(std::function<void()> callback));
 
   MOCK_CONST_METHOD0(requireClientCertificate, bool());


### PR DESCRIPTION
This is rework of https://github.com/envoyproxy/envoy/pull/9149 (no changes to that one; mostly to workaround my bad merge in 9149)

Description:
allow to specify tls ticket's lifetime hint for pre TLSv1.3 clients. today, by default, this value is equal to 2 hours, which could be suboptimal in some scenarios (e.g. envoy being used as edge l7 proxy to server real user's traffic, where user could be inactive for more than 2h (e.g. sleeping etc)).

Risk Level: LOW
Testing:
new unittests + manual tests (w/ openssl s_client; see "ticket lifetime hint" field):

TLSv1.2 default (no session_timeout param in  config):

SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-CHACHA20-POLY1305
    Session-ID: B1A9C4D45CF77D90039A136AFD6C0D9DEB7C000D109E1A61681F064E4DE9465D
    Session-ID-ctx:
    Master-Key: E46750473598D278BDCA28DF3AC4174EAFFC6521AF57D1CB6532934B8EED354D302600966DE5C90E684DA9BE12252CDD
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 7200 (seconds)
    TLS session ticket:

TLSv1.2 w/ custom timeout of 2307 seconds

SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-CHACHA20-POLY1305
    Session-ID: 8413AAECF8FAEBF7D2148C81C716101BD6315F1A64C735802008DF3CB0C8D8E1
    Session-ID-ctx:
    Master-Key: C1B7B8238860132434ED61FDABF43093230F4A8A7F0ED0E9CEA78AC198B2F9A90E5FC19238E4D047F1C208D267E05E17
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 2307 (seconds)
    TLS session ticket:

TLSv1.3 w/ custom timeout of 2307 (which is ignored by TLSv1.3)

SSL-Session:
    Protocol  : TLSv1.3
    Cipher    : TLS_AES_256_GCM_SHA384
    Session-ID: 9B13E684C5F8210C1FA4F49F733CEAB85B38D87EF59D63A39B05E11F81BCF1CF
    Session-ID-ctx:
    Resumption PSK: 2BF43FB996DA64E68877E1FA10D79D62F5AAA0DE33D601E1D6C21CA74CBF5BCA2F1A026E83FB165D31612E3E1F52E7C9
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 172800 (seconds)
    TLS session ticket:

Docs Changes:
Release Notes:

Signed-off-by: Nikita V. Shirokov <tehnerd@tehnerd.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
