### PR TITLE
misc: fix spelling of "overridden"

### DIFF
--- a/docs/root/intro/arch_overview/upstream/load_balancing/subsets.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/subsets.rst
@@ -102,7 +102,7 @@ v: 1.2-pre, stage: dev  host4          Subset of hosts selected
 v: 1.0                  host1, host2   Fallback: No subset selector for "v" alone
 other: x                host1, host2   Fallback: No subset selector for "other"
 (none)                  host1, host2   Fallback: No subset requested
-stage: test             empty cluster  As fallback policy is overriden per selector with "NO_FALLBACK" value
+stage: test             empty cluster  As fallback policy is overridden per selector with "NO_FALLBACK" value
 ======================  =============  ======================================================================
 
 Metadata match criteria may also be specified on a route's weighted clusters. Metadata match

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -481,7 +481,7 @@ TEST_P(Http2CodecImplTest, InvalidHeadersFrameAllowed) {
   server_wrapper_.dispatch(Buffer::OwnedImpl(), *server_);
 }
 
-TEST_P(Http2CodecImplTest, InvalidHeadersFrameOverriden) {
+TEST_P(Http2CodecImplTest, InvalidHeadersFrameOverridden) {
   Runtime::LoaderSingleton::getExisting()->mergeValues(
       {{"envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging",
         "true"}});

--- a/test/extensions/retry/priority/previous_priorities/config_test.cc
+++ b/test/extensions/retry/priority/previous_priorities/config_test.cc
@@ -253,7 +253,7 @@ TEST_F(RetryPriorityTest, DefaultFrequencyUnhealthyPrioritiesDegradedLoadSpillov
 
 // Tests that we can override the frequency at which we update the priority load with the
 // update_frequency parameter.
-TEST_F(RetryPriorityTest, OverridenFrequency) {
+TEST_F(RetryPriorityTest, OverriddenFrequency) {
   update_frequency_ = 2;
 
   const Upstream::HealthyLoad original_priority_load({100, 0});
@@ -284,7 +284,7 @@ TEST_F(RetryPriorityTest, OverridenFrequency) {
 }
 
 // Tests that an invalid frequency results into a config error.
-TEST_F(RetryPriorityTest, OverridenFrequencyInvalidValue) {
+TEST_F(RetryPriorityTest, OverriddenFrequencyInvalidValue) {
   update_frequency_ = 0;
 
   const Upstream::HealthyLoad original_priority_load({100, 0});

--- a/tools/spelling_whitelist_words.txt
+++ b/tools/spelling_whitelist_words.txt
@@ -1,5 +1,2 @@
 # One word per line, these words are not spell checked.
 # you can add a comment to each word to explain why you don't need to do a spell check.
-
-# bazel keywords in bazel/cc_configure.bzl
-overriden


### PR DESCRIPTION
Description: `bazel/cc_configure.bzl` no longer exists, and thus no longer requires a whitelist override for the spelling of `overriden` which is masking the spelling mistake elsewhere.
Risk Level: low
Testing: n/a

Signed-off-by: Derek Argueta <dereka@pinterest.com>