### PR TITLE
thread synchronizer: fix assertion

### DIFF
--- a/source/common/common/thread_synchronizer.cc
+++ b/source/common/common/thread_synchronizer.cc
@@ -63,7 +63,6 @@ void ThreadSynchronizer::syncPointWorker(absl::string_view event_name) {
 void ThreadSynchronizer::barrierOnWorker(absl::string_view event_name) {
   SynchronizerEntry& entry = getOrCreateEntry(event_name);
   absl::MutexLock lock(&entry.mutex_);
-  ASSERT(!entry.at_barrier_ && entry.wait_on_);
   ENVOY_LOG(debug, "thread synchronizer: barrier on {}", event_name);
   entry.mutex_.Await(absl::Condition(&entry.at_barrier_));
   ENVOY_LOG(debug, "thread synchronizer: barrier complete {}", event_name);


### PR DESCRIPTION
The other thread can already have entered the wait.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
