### PR TITLE
Refactor primitive stats and add null primitive stats

### DIFF
--- a/include/envoy/stats/primitive_stats_macros.h
+++ b/include/envoy/stats/primitive_stats_macros.h
@@ -47,8 +47,8 @@ namespace Envoy {
 #define GENERATE_NULL_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::NullPrimitiveGaugeImpl NAME##_;
 
 // Name and counter/gauge reference pair used to construct map of counters/gauges.
-#define PRIMITIVE_COUNTER_NAME_AND_REFERENCE(X) {absl::string_view(#X), std::ref(X##_)},
-#define PRIMITIVE_GAUGE_NAME_AND_REFERENCE(X) {absl::string_view(#X), std::ref(X##_)},
+#define PRIMITIVE_COUNTER_NAME_AND_REFERENCE(X) {absl::string_view(#X), X##_},
+#define PRIMITIVE_GAUGE_NAME_AND_REFERENCE(X) {absl::string_view(#X), X##_},
 
 // Ignore a counter or gauge.
 #define IGNORE_PRIMITIVE_COUNTER(X)

--- a/include/envoy/stats/primitive_stats_macros.h
+++ b/include/envoy/stats/primitive_stats_macros.h
@@ -40,8 +40,11 @@ namespace Envoy {
  */
 
 // Fully-qualified for use in external callsites.
-#define GENERATE_PRIMITIVE_COUNTER_STRUCT(NAME) Envoy::Stats::PrimitiveCounter NAME##_;
-#define GENERATE_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::PrimitiveGauge NAME##_;
+#define GENERATE_PRIMITIVE_COUNTER_STRUCT(NAME) Envoy::Stats::PrimitiveCounterImpl NAME##_;
+#define GENERATE_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::PrimitiveGaugeImpl NAME##_;
+
+#define GENERATE_NULL_PRIMITIVE_COUNTER_STRUCT(NAME) Envoy::Stats::NullPrimitiveCounterImpl NAME##_;
+#define GENERATE_NULL_PRIMITIVE_GAUGE_STRUCT(NAME) Envoy::Stats::NullPrimitiveGaugeImpl NAME##_;
 
 // Name and counter/gauge reference pair used to construct map of counters/gauges.
 #define PRIMITIVE_COUNTER_NAME_AND_REFERENCE(X) {absl::string_view(#X), std::ref(X##_)},

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -351,6 +351,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // 2019/11/01  8859     1299         1315   build: switch to libc++ by default
   // 2019/11/12  8998     1299         1350   test: adjust memory limit for macOS
   // 2019/11/15  9040     1283         1350   build: update protobuf to 3.10.1
+  // 2020/01/06  9565     1347         1350   Refactor primitive stats and add null primitive stats
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -360,7 +361,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // If you encounter a failure here, please see
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
-  EXPECT_MEMORY_EQ(m_per_host, 1283);
+  EXPECT_MEMORY_EQ(m_per_host, 1347);
   EXPECT_MEMORY_LE(m_per_host, 1350);
 }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1278,20 +1278,20 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   ON_CALL(*host, hostname()).WillByDefault(ReturnRef(hostname));
 
   // Add stats in random order and validate that they come in order.
-  Stats::PrimitiveCounter test_counter;
+  Stats::PrimitiveCounterImpl test_counter;
   test_counter.add(10);
-  Stats::PrimitiveCounter rest_counter;
+  Stats::PrimitiveCounterImpl rest_counter;
   rest_counter.add(10);
-  Stats::PrimitiveCounter arest_counter;
+  Stats::PrimitiveCounterImpl arest_counter;
   arest_counter.add(5);
   std::vector<std::pair<absl::string_view, Stats::PrimitiveCounterReference>> counters = {
       {"arest_counter", arest_counter},
       {"rest_counter", rest_counter},
       {"test_counter", test_counter},
   };
-  Stats::PrimitiveGauge test_gauge;
+  Stats::PrimitiveGaugeImpl test_gauge;
   test_gauge.set(11);
-  Stats::PrimitiveGauge atest_gauge;
+  Stats::PrimitiveGaugeImpl atest_gauge;
   atest_gauge.set(10);
   std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>> gauges = {
       {"atest_gauge", atest_gauge},


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

Description: Refactor primitive stats and add null primitive stats, the main purpose is to provide an implementation of null host stats to make it easy to disable host stats when necessary
Risk Level: low
Testing:  existing tests
Docs Changes: N/A
Release Notes: N/A
