### PR TITLE
Include <filesystem> when using stdc++17

### DIFF
--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -1,8 +1,10 @@
 #include "test/test_common/environment.h"
 
 // TODO(asraa): Remove <experimental/filesystem> and rely only on <filesystem> when Envoy requires
-// Clang >= 9.
+// stdc++17
 #if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#include <filesystem>
+#elif defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
 #include <filesystem>
 #elif defined __has_include
 #if __has_include(<experimental/filesystem>) && !defined(__APPLE__)

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -2,14 +2,16 @@
 
 // TODO(asraa): Remove <experimental/filesystem> and rely only on <filesystem> when Envoy requires
 // stdc++17
-#if defined(_LIBCPP_VERSION) && !defined(__APPLE__)
+#if defined __has_include
+#if __has_include(<filesystem>)
 #include <filesystem>
-#elif defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#include <filesystem>
-#elif defined __has_include
-#if __has_include(<experimental/filesystem>) && !defined(__APPLE__)
+#elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 #endif
+#else
+// __has_include was a key feature of stdc++17, so if it is absent,
+// we presume that only experimental/filesystem could be available.
+#include <experimental/filesystem>
 #endif
 #include <fstream>
 #include <iostream>

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -947,6 +947,7 @@ stacktrace
 startup
 stateful
 statsd
+stdc
 stderr
 stdev
 stdout


### PR DESCRIPTION
Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>
Co-authored-by: Sunjay Bhatia <sbhatia@pivotal.io>
Co-authored-by: William A Rowe Jr <wrowe@pivotal.io>

Description:
Correctly identify stdc++17 on windows to elect the use of <experimental/filesystem>
vs <filesystem>

Risk Level: low
Testing: local msvc on Windows, gcc on unix
Docs Changes: n/a
Release Notes: n/a
