### PR TITLE
Remove duplicated words

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,7 +301,7 @@ should only be done to correct a DCO mistake.
 
 ## Triggering CI re-run without making changes
 
-To rerun failed tasks in CI, add a comment with the the line
+To rerun failed tasks in CI, add a comment with the line
 
 ```
 /retest

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -252,7 +252,7 @@ public:
         Endianness == ByteOrder::BigEndian ? displacement : Size - 1;
 
     // If Size == sizeof(T), we need to make sure we don't generate an invalid left shift
-    // (e.g. int32 << 32), even though we know that that branch of the conditional will.
+    // (e.g. int32 << 32), even though we know that branch of the conditional will.
     // not be taken. Size % sizeof(T) gives us the correct left shift when Size < sizeof(T),
     // and generates a left shift of 0 bits when Size == sizeof(T)
     const auto sign_extension_bits =

--- a/include/envoy/stats/symbol_table.h
+++ b/include/envoy/stats/symbol_table.h
@@ -46,7 +46,7 @@ public:
    * into the SymbolTable, which will not be optimal, but in practice appears
    * to be pretty good.
    *
-   * This is exposed in the interface for the benefit of join(), which which is
+   * This is exposed in the interface for the benefit of join(), which is
    * used in the hot-path to append two stat-names into a temp without taking
    * locks. This is used then in thread-local cache lookup, so that once warm,
    * no locks are taken when looking up stats.


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Signed-off-by: Nguyen Hai Truong <truongnh@fujitsu.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
