### PR TITLE
WIP: Upgrade Kafka dependencies to 2.3.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -305,14 +305,14 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/protocolbuffers/upb/archive/8a3ae1ef3e3e3f26b45dec735c5776737fc7247f.tar.gz"],
     ),
     kafka_source = dict(
-        sha256 = "ae7a1696c0a0302b43c5b21e515c37e6ecd365941f68a510a7e442eebddf39a1",  # 2.2.0-rc2
-        strip_prefix = "kafka-2.2.0-rc2/clients/src/main/resources/common/message",
-        urls = ["https://github.com/apache/kafka/archive/2.2.0-rc2.zip"],
+        sha256 = "feaa32e5c42acf42bd587f8f0b1ccce679db227620da97eed013f4c44a44f64d",
+        strip_prefix = "kafka-2.3.1/clients/src/main/resources/common/message",
+        urls = ["https://github.com/apache/kafka/archive/2.3.1.zip"],
     ),
     kafka_server_binary = dict(
-        sha256 = "a009624fae678fa35968f945e18e45fbea9a30fa8080d5dcce7fdea726120027",
-        strip_prefix = "kafka_2.12-2.2.0",
-        urls = ["http://us.mirrors.quenda.co/apache/kafka/2.2.0/kafka_2.12-2.2.0.tgz"],
+        sha256 = "5a3ddd4148371284693370d56f6f66c7a86d86dd96c533447d2a94d176768d2e",
+        strip_prefix = "kafka_2.12-2.3.1",
+        urls = ["http://us.mirrors.quenda.co/apache/kafka/2.3.1/kafka_2.12-2.3.1.tgz"],
     ),
     kafka_python_client = dict(
         sha256 = "81f24a5d297531495e0ccb931fbd6c4d1ec96583cf5a730579a3726e63f59c47",

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -5,7 +5,7 @@ Kafka Broker filter
 
 The Apache Kafka broker filter decodes the client protocol for
 `Apache Kafka <https://kafka.apache.org/>`_, both the requests and responses in the payload.
-The message versions in `Kafka 2.0 <http://kafka.apache.org/20/protocol.html#protocol_api_keys>`_
+The message versions in `Kafka 2.3.1 <http://kafka.apache.org/231/protocol.html#protocol_api_keys>`_
 are supported.
 The filter attempts not to influence the communication between client and brokers, so the messages
 that could not be decoded (due to Kafka client or broker running a newer version than supported by
@@ -37,10 +37,12 @@ in the configuration snippet below:
     filter_chains:
     - filters:
       - name: envoy.filters.network.kafka_broker
-        config:
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.kafka_broker.v2alpha1.KafkaBroker
           stat_prefix: exampleprefix
       - name: envoy.tcp_proxy
-        config:
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           stat_prefix: tcp
           cluster: localkafka
   clusters:

--- a/source/extensions/filters/network/kafka/serialization/generator.py
+++ b/source/extensions/filters/network/kafka/serialization/generator.py
@@ -37,7 +37,7 @@ def get_field_counts():
   """
   Generate argument counts that should be processed by composite deserializers.
   """
-  return range(1, 10)
+  return range(1, 11)
 
 
 class RenderingHelper:


### PR DESCRIPTION
Description:
Upgrade Kafka client & server dependencies to 2.3.1.
In detail, we generate C++ code from metadata files in Kafka Java client source:
- 2.3 introduced default null value for some fields
- 2.3 introduced sub-structures that have the same name in different requests (e.g. `AlterConfigs` & `IncrementalAlterConfigs` have both `AlterConfig` sub-structures)
- 2.3 introduced a structure that has 10 fields (so need to generate one more composite deserializer)

This PR is the first one in upgrade series, I will need to follow up with upgrade to 2.4, it demands more work than I expected as it includes binary protocol changes described in https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
(tldr: new data types, changed structures, input json files also changed)

Risk Level: Low
Testing:
- unit tests
- integration tests using real Kafka server (2.3.1 as in dependencies) via `bazel test //test/extensions/filters/network/kafka/broker/integration_test:kafka_broker_integration_test --runs_per_test 100`
- manual testing with 2.3.1 Java Kafka client (on my machine)

Docs Changes: Kafka version mentions in docs
Release Notes: N/A