### PR TITLE
cleanup: Remove createParentPath from TestEnvironment

### DIFF
--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -188,12 +188,6 @@ public:
   static void createPath(const std::string& path);
 
   /**
-   * Create a parent path on the filesystem (mkdir -p $(dirname ...) equivalent).
-   * @param path.
-   */
-  static void createParentPath(const std::string& path);
-
-  /**
    * Remove a path on the filesystem (rm -rf ... equivalent).
    * @param path.
    */


### PR DESCRIPTION
Description: Remove createParentPath from TestEnvironment. It is only used in TestEnvironment methods, nowhere else.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A