### PR TITLE
tracing: additional grpc request tags

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,6 +48,7 @@ Version history
 * tracing: added the ability to set custom tags on both the :ref:`HTTP connection manager<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` and the :ref:`HTTP route <envoy_api_field_route.Route.tracing>`.
 * tracing: added upstream_address tag.
 * tracing: added initial support for AWS X-Ray (local sampling rules only) :ref:`X-Ray Tracing <envoy_api_msg_config.trace.v2alpha.XRayConfig>`.
+* tracing: added tags for gRPC request path, authority, content-type and timeout.
 * udp: added initial support for :ref:`UDP proxy <config_udp_listener_filters_udp_proxy>`
 
 1.12.2 (December 10, 2019)

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -89,7 +89,7 @@ Decision HttpTracerUtility::isTracing(const StreamInfo::StreamInfo& stream_info,
 }
 
 static void addTagIfNotNull(Span& span, const std::string& tag, const Http::HeaderEntry* entry) {
-  if (entry) {
+  if (entry != nullptr) {
     span.setTag(tag, entry->value().getStringView());
   }
 }

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -88,17 +88,24 @@ Decision HttpTracerUtility::isTracing(const StreamInfo::StreamInfo& stream_info,
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
-static void addGrpcTags(Span& span, const Http::HeaderMap& headers) {
-  const Http::HeaderEntry* grpc_status_header = headers.GrpcStatus();
-  if (grpc_status_header) {
-    span.setTag(Tracing::Tags::get().GrpcStatusCode, grpc_status_header->value().getStringView());
+static void addTagIfNotNull(Span& span, const std::string& tag, const Http::HeaderEntry* entry) {
+  if (entry) {
+    span.setTag(tag, entry->value().getStringView());
   }
-  const Http::HeaderEntry* grpc_message_header = headers.GrpcMessage();
-  if (grpc_message_header) {
-    span.setTag(Tracing::Tags::get().GrpcMessage, grpc_message_header->value().getStringView());
-  }
-  absl::optional<Grpc::Status::GrpcStatus> grpc_status_code = Grpc::Common::getGrpcStatus(headers);
+}
+
+static void addGrpcRequestTags(Span& span, const Http::HeaderMap& headers) {
+  addTagIfNotNull(span, Tracing::Tags::get().GrpcPath, headers.Path());
+  addTagIfNotNull(span, Tracing::Tags::get().GrpcAuthority, headers.Host());
+  addTagIfNotNull(span, Tracing::Tags::get().GrpcContentType, headers.ContentType());
+  addTagIfNotNull(span, Tracing::Tags::get().GrpcTimeout, headers.GrpcTimeout());
+}
+
+static void addGrpcResponseTags(Span& span, const Http::HeaderMap& headers) {
+  addTagIfNotNull(span, Tracing::Tags::get().GrpcStatusCode, headers.GrpcStatus());
+  addTagIfNotNull(span, Tracing::Tags::get().GrpcMessage, headers.GrpcMessage());
   // Set error tag when status is not OK.
+  absl::optional<Grpc::Status::GrpcStatus> grpc_status_code = Grpc::Common::getGrpcStatus(headers);
   if (grpc_status_code && grpc_status_code.value() != Grpc::Status::WellKnownGrpcStatus::Ok) {
     span.setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
   }
@@ -168,6 +175,10 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span, const Http::HeaderMap
       span.setTag(Tracing::Tags::get().GuidXClientTraceId,
                   std::string(request_headers->ClientTraceId()->value().getStringView()));
     }
+
+    if (Grpc::Common::hasGrpcContentType(*request_headers)) {
+      addGrpcRequestTags(span, *request_headers);
+    }
   }
   CustomTagContext ctx{request_headers, stream_info};
 
@@ -220,9 +231,9 @@ void HttpTracerUtility::setCommonTags(Span& span, const Http::HeaderMap* respons
 
   // GRPC data.
   if (response_trailers && response_trailers->GrpcStatus() != nullptr) {
-    addGrpcTags(span, *response_trailers);
+    addGrpcResponseTags(span, *response_trailers);
   } else if (response_headers && response_headers->GrpcStatus() != nullptr) {
-    addGrpcTags(span, *response_headers);
+    addGrpcResponseTags(span, *response_headers);
   }
 
   if (tracing_config.verbose()) {

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -46,8 +46,12 @@ public:
   // Non-standard tag names.
   const std::string DownstreamCluster = "downstream_cluster";
   const std::string ErrorReason = "error.reason";
-  const std::string GrpcStatusCode = "grpc.status_code";
+  const std::string GrpcAuthority = "grpc.authority";
+  const std::string GrpcContentType = "grpc.content_type";
   const std::string GrpcMessage = "grpc.message";
+  const std::string GrpcPath = "grpc.path";
+  const std::string GrpcStatusCode = "grpc.status_code";
+  const std::string GrpcTimeout = "grpc.timeout";
   const std::string GuidXClientTraceId = "guid:x-client-trace-id";
   const std::string GuidXRequestId = "guid:x-request-id";
   const std::string HttpProtocol = "http.protocol";

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -522,6 +522,9 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("POST")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcPath), Eq("/pb.Foo/Bar")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcAuthority), Eq("example.com:80")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcContentType), Eq("application/grpc")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("")));
 
@@ -537,6 +540,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
                                           {":path", "/pb.Foo/Bar"},
                                           {":authority", "example.com:80"},
                                           {"content-type", "application/grpc"},
+                                          {"grpc-timeout", "10s"},
                                           {"te", "trailers"}};
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"},
@@ -556,6 +560,10 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("POST")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcPath), Eq("/pb.Foo/Bar")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcAuthority), Eq("example.com:80")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcContentType), Eq("application/grpc")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcTimeout), Eq("10s")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("7")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("permission denied")));
 
@@ -591,6 +599,9 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("POST")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcPath), Eq("/pb.Foo/Bar")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcAuthority), Eq("example.com:80")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcContentType), Eq("application/grpc")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("7")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("permission denied")));
 

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -505,6 +505,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
                                           {":path", "/pb.Foo/Bar"},
                                           {":authority", "example.com:80"},
                                           {"content-type", "application/grpc"},
+                                          {"x-forwarded-proto", "http"},
                                           {"te", "trailers"}};
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"},
@@ -518,7 +519,15 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
   EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
 
-  EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().DownstreamCluster), Eq("-")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().HttpUrl), Eq("http://example.com:80/pb.Foo/Bar")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UserAgent), Eq("-")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseSize), Eq("11")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("POST")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
@@ -541,6 +550,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
                                           {":authority", "example.com:80"},
                                           {"content-type", "application/grpc"},
                                           {"grpc-timeout", "10s"},
+                                          {"x-forwarded-proto", "http"},
                                           {"te", "trailers"}};
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"},
@@ -579,6 +589,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
                                           {":path", "/pb.Foo/Bar"},
                                           {":authority", "example.com:80"},
                                           {"content-type", "application/grpc"},
+                                          {"x-forwarded-proto", "http"},
                                           {"te", "trailers"}};
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"},


### PR DESCRIPTION
Description: adds tags for path, authority, content-type and timeouts to tracing spans when the traffic being monitored is grpc.
Risk Level: low
Testing: updated unit tests, executed locally and E2E using datadog tracing
Docs Changes: n/a
Release Notes: item added

Fixes #9002 