### PR TITLE
misc: cleanup - const-ness and more use of abseil string utilities

### DIFF
--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -22,7 +22,7 @@ public:
   /**
    * @return uint64_t the number of active connections owned by the handler.
    */
-  virtual uint64_t numConnections() PURE;
+  virtual uint64_t numConnections() const PURE;
 
   /**
    * Increment the return value of numConnections() by one.
@@ -77,7 +77,7 @@ public:
   /**
    * @return the stat prefix used for per-handler stats.
    */
-  virtual const std::string& statPrefix() PURE;
+  virtual const std::string& statPrefix() const PURE;
 
   /**
    * Used by ConnectionHandler to manage listeners.

--- a/include/envoy/router/route_config_update_receiver.h
+++ b/include/envoy/router/route_config_update_receiver.h
@@ -53,7 +53,7 @@ public:
   /**
    * @return std::string& the version of RouteConfiguration.
    */
-  virtual const std::string& configVersion() PURE;
+  virtual const std::string& configVersion() const PURE;
 
   /**
    * @return uint64_t the hash value of RouteConfiguration.

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -82,12 +82,12 @@ public:
   /**
    * @return const std::string& the admin access log path.
    */
-  virtual const std::string& accessLogPath() PURE;
+  virtual const std::string& accessLogPath() const PURE;
 
   /**
    * @return const std::string& profiler output path.
    */
-  virtual const std::string& profilePath() PURE;
+  virtual const std::string& profilePath() const PURE;
 
   /**
    * @return Network::Address::InstanceConstSharedPtr the server address.
@@ -115,7 +115,7 @@ public:
   /**
    * @return absl::optional<std::string> the path to look for flag files.
    */
-  virtual absl::optional<std::string> flagsPath() PURE;
+  virtual absl::optional<std::string> flagsPath() const PURE;
 
   /**
    * @return const envoy::config::bootstrap::v2::LayeredRuntime& runtime

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -169,7 +169,7 @@ public:
   /**
    * @return uint64_t the total number of connections owned by all listeners across all workers.
    */
-  virtual uint64_t numConnections() PURE;
+  virtual uint64_t numConnections() const PURE;
 
   /**
    * Remove a listener by name.

--- a/include/envoy/server/worker.h
+++ b/include/envoy/server/worker.h
@@ -35,7 +35,7 @@ public:
   /**
    * @return uint64_t the number of connections across all listeners that the worker owns.
    */
-  virtual uint64_t numConnections() PURE;
+  virtual uint64_t numConnections() const PURE;
 
   /**
    * Start the worker thread.

--- a/source/common/common/perf_annotation.cc
+++ b/source/common/common/perf_annotation.cc
@@ -108,7 +108,7 @@ std::string PerfAnnotationContext::toString() {
             : std::to_string(
                   std::chrono::duration_cast<std::chrono::nanoseconds>(stats.total_).count() /
                   count));
-    columns[3].push_back(fmt::format("{}", stats.stddev_.computeStandardDeviation()));
+    columns[3].push_back(absl::StrCat("", stats.stddev_.computeStandardDeviation()));
     columns[4].push_back(nanoseconds_string(stats.min_));
     columns[5].push_back(nanoseconds_string(stats.max_));
     const CategoryDescription& category_description = p->first;

--- a/source/common/config/config_provider_impl.h
+++ b/source/common/config/config_provider_impl.h
@@ -204,7 +204,7 @@ protected:
                                ConfigProviderManagerImplBase& config_provider_manager,
                                Server::Configuration::FactoryContext& factory_context)
       : name_(name), tls_(factory_context.threadLocal().allocateSlot()),
-        init_target_(fmt::format("ConfigSubscriptionCommonBase {}", name_), [this]() { start(); }),
+        init_target_(absl::StrCat("ConfigSubscriptionCommonBase ", name_), [this]() { start(); }),
         manager_identifier_(manager_identifier), config_provider_manager_(config_provider_manager),
         time_source_(factory_context.timeSource()),
         last_updated_(factory_context.timeSource().systemTime()) {

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -35,7 +35,7 @@ void WatcherImpl::addWatch(const std::string& path, uint32_t events, OnChangedCb
   // and then synthetically raise per file events.
   size_t last_slash = path.rfind('/');
   if (last_slash == std::string::npos) {
-    throw EnvoyException(fmt::format("invalid watch path {}", path));
+    throw EnvoyException(absl::StrCat("invalid watch path ", path));
   }
 
   std::string directory = last_slash != 0 ? path.substr(0, last_slash) : "/";

--- a/source/common/filesystem/kqueue/watcher_impl.cc
+++ b/source/common/filesystem/kqueue/watcher_impl.cc
@@ -34,7 +34,7 @@ WatcherImpl::~WatcherImpl() {
 void WatcherImpl::addWatch(const std::string& path, uint32_t events, Watcher::OnChangedCb cb) {
   FileWatchPtr watch = addWatch(path, events, cb, false);
   if (watch == nullptr) {
-    throw EnvoyException(fmt::format("invalid watch path {}", path));
+    throw EnvoyException(absl::StrCat("invalid watch path ", path));
   }
 }
 

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -17,6 +17,7 @@
 #include "common/filesystem/filesystem_impl.h"
 
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Filesystem {
@@ -91,14 +92,14 @@ ssize_t InstanceImplPosix::fileSize(const std::string& path) {
 
 std::string InstanceImplPosix::fileReadToEnd(const std::string& path) {
   if (illegalPath(path)) {
-    throw EnvoyException(fmt::format("Invalid path: {}", path));
+    throw EnvoyException(absl::StrCat("Invalid path: ", path));
   }
 
   std::ios::sync_with_stdio(false);
 
   std::ifstream file(path);
   if (file.fail()) {
-    throw EnvoyException(fmt::format("unable to read file: {}", path));
+    throw EnvoyException(absl::StrCat("unable to read file: ", path));
   }
 
   std::stringstream file_string;

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -84,7 +84,7 @@ ssize_t InstanceImplWin32::fileSize(const std::string& path) {
 
 std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {
   if (illegalPath(path)) {
-    throw EnvoyException(fmt::format("Invalid path: {}", path));
+    throw EnvoyException(absl::StrCat("Invalid path: ", path));
   }
 
   std::ios::sync_with_stdio(false);
@@ -93,7 +93,7 @@ std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {
   // 0x1a will be treated as EOF
   std::ifstream file(path, std::ios_base::binary);
   if (file.fail()) {
-    throw EnvoyException(fmt::format("unable to read file: {}", path));
+    throw EnvoyException(absl::StrCat("unable to read file: ", path));
   }
 
   std::stringstream file_string;

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -84,7 +84,7 @@ GoogleAsyncClientImpl::GoogleAsyncClientImpl(
   // Initialize client stats.
   stats_.streams_total_ = &scope_->counter("streams_total");
   for (uint32_t i = 0; i <= Status::WellKnownGrpcStatus::MaximumKnown; ++i) {
-    stats_.streams_closed_[i] = &scope_->counter(fmt::format("streams_closed_{}", i));
+    stats_.streams_closed_[i] = &scope_->counter(absl::StrCat("streams_closed_", i));
   }
 }
 

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -166,8 +166,8 @@ getGoogleGrpcChannelCredentials(const envoy::config::core::v3alpha::GrpcService&
         google_grpc_credentials_factory_name);
   }
   if (credentials_factory == nullptr) {
-    throw EnvoyException(fmt::format("Unknown google grpc credentials factory: {}",
-                                     google_grpc_credentials_factory_name));
+    throw EnvoyException(absl::StrCat("Unknown google grpc credentials factory: ",
+                                      google_grpc_credentials_factory_name));
   }
   return credentials_factory->getChannelCredentials(grpc_service, api);
 }

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -294,7 +294,8 @@ public:
   /**
    * @return ServerHeaderTransformation the transformation to apply to Server response headers.
    */
-  virtual HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const PURE;
+  virtual HttpConnectionManagerProto::ServerHeaderTransformation
+  serverHeaderTransformation() const PURE;
 
   /**
    * @return ConnectionManagerStats& the stats to write to.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -209,7 +209,7 @@ public:
    * @return the time in milliseconds the connection manager will wait between issuing a "shutdown
    *         notice" to the time it will issue a full GOAWAY and not accept any new streams.
    */
-  virtual std::chrono::milliseconds drainTimeout() PURE;
+  virtual std::chrono::milliseconds drainTimeout() const PURE;
 
   /**
    * @return FilterChainFactory& the HTTP level filter factory to build the connection's filter
@@ -221,7 +221,7 @@ public:
    * @return whether the connection manager will generate a fresh x-request-id if the request does
    *         not have one.
    */
-  virtual bool generateRequestId() PURE;
+  virtual bool generateRequestId() const PURE;
 
   /**
    * @return whether the x-request-id should not be reset on edge entry inside mesh
@@ -294,7 +294,7 @@ public:
   /**
    * @return ServerHeaderTransformation the transformation to apply to Server response headers.
    */
-  virtual HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() PURE;
+  virtual HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const PURE;
 
   /**
    * @return ConnectionManagerStats& the stats to write to.
@@ -310,7 +310,7 @@ public:
    * @return bool whether to use the remote address for populating XFF, determining internal request
    *         status, etc. or to assume that XFF will already be populated with the remote address.
    */
-  virtual bool useRemoteAddress() PURE;
+  virtual bool useRemoteAddress() const PURE;
 
   /**
    * @return InternalAddressConfig configuration for user defined internal addresses.
@@ -339,7 +339,7 @@ public:
   /**
    * @return ForwardClientCertType the configuration of how to forward the client cert information.
    */
-  virtual ForwardClientCertType forwardClientCert() PURE;
+  virtual ForwardClientCertType forwardClientCert() const PURE;
 
   /**
    * @return vector of ClientCertDetailsType the configuration of the current client cert's details

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -289,7 +289,7 @@ public:
   /**
    * @return const std::string& the server name to write into responses.
    */
-  virtual const std::string& serverName() PURE;
+  virtual const std::string& serverName() const PURE;
 
   /**
    * @return ServerHeaderTransformation the transformation to apply to Server response headers.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -42,6 +42,7 @@
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Http {
@@ -483,7 +484,7 @@ void ConnectionManagerImpl::chargeTracingStats(const Tracing::Reason& tracing_re
     break;
   default:
     throw std::invalid_argument(
-        fmt::format("invalid tracing reason, value: {}", static_cast<int32_t>(tracing_reason)));
+        absl::StrCat("invalid tracing reason, value: ", static_cast<int32_t>(tracing_reason)));
   }
 }
 

--- a/source/common/http/hash_policy.cc
+++ b/source/common/http/hash_policy.cc
@@ -4,6 +4,8 @@
 
 #include "common/http/utility.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Http {
 
@@ -144,7 +146,7 @@ HashPolicyImpl::HashPolicyImpl(
       break;
     default:
       throw EnvoyException(
-          fmt::format("Unsupported hash policy {}", hash_policy->policy_specifier_case()));
+          absl::StrCat("Unsupported hash policy ", hash_policy->policy_specifier_case()));
     }
   }
 }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -825,7 +825,7 @@ void ConnectionImpl::sendPendingFrames() {
     return;
   }
 
-  int rc = nghttp2_session_send(session_);
+  const int rc = nghttp2_session_send(session_);
   if (rc != 0) {
     ASSERT(rc == NGHTTP2_ERR_CALLBACK_FAILURE);
     // For errors caused by the pending outbound frame flood the FrameFloodException has
@@ -837,7 +837,7 @@ void ConnectionImpl::sendPendingFrames() {
       throw FrameFloodException("Too many frames in the outbound queue.");
     }
 
-    throw CodecProtocolException(fmt::format("{}", nghttp2_strerror(rc)));
+    throw CodecProtocolException(std::string(nghttp2_strerror(rc)));
   }
 
   // See ConnectionImpl::StreamImpl::resetStream() for why we do this. This is an uncommon event,

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -360,7 +360,7 @@ Utility::getLastAddressFromXFF(const Http::HeaderMap& request_headers, uint32_t 
   static const std::string separator(",");
   // Ignore the last num_to_skip addresses at the end of XFF.
   for (uint32_t i = 0; i < num_to_skip; i++) {
-    std::string::size_type last_comma = xff_string.rfind(separator);
+    const std::string::size_type last_comma = xff_string.rfind(separator);
     if (last_comma == std::string::npos) {
       return {nullptr, false};
     }
@@ -368,7 +368,7 @@ Utility::getLastAddressFromXFF(const Http::HeaderMap& request_headers, uint32_t 
   }
   // The text after the last remaining comma, or the entirety of the string if there
   // is no comma, is the requested IP address.
-  std::string::size_type last_comma = xff_string.rfind(separator);
+  const std::string::size_type last_comma = xff_string.rfind(separator);
   if (last_comma != std::string::npos && last_comma + separator.size() < xff_string.size()) {
     xff_string = xff_string.substr(last_comma + separator.size());
   }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -203,7 +203,7 @@ Ipv4Instance::Ipv4Instance(const std::string& address, uint32_t port) : Instance
     throw EnvoyException(fmt::format("invalid ipv4 address '{}'", address));
   }
 
-  friendly_name_ = fmt::format("{}:{}", address, port);
+  friendly_name_ = absl::StrCat(address, ":", port);
   validateIpv4Supported(friendly_name_);
   ip_.friendly_address_ = address;
 }
@@ -213,7 +213,7 @@ Ipv4Instance::Ipv4Instance(uint32_t port) : InstanceBase(Type::Ip) {
   ip_.ipv4_.address_.sin_family = AF_INET;
   ip_.ipv4_.address_.sin_port = htons(port);
   ip_.ipv4_.address_.sin_addr.s_addr = INADDR_ANY;
-  friendly_name_ = fmt::format("0.0.0.0:{}", port);
+  friendly_name_ = absl::StrCat("0.0.0.0:", port);
   validateIpv4Supported(friendly_name_);
   ip_.friendly_address_ = "0.0.0.0";
 }
@@ -409,7 +409,7 @@ Api::SysCallIntResult PipeInstance::bind(int fd) const {
   if (mode != 0 && !abstract_namespace_ && bind_result.rc_ == 0) {
     auto set_permissions = os_syscalls.chmod(address_.sun_path, mode);
     if (set_permissions.rc_ != 0) {
-      throw EnvoyException(fmt::format("Failed to create socket with mode {}", mode));
+      throw EnvoyException(absl::StrCat("Failed to create socket with mode ", mode));
     }
   }
   return bind_result;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -40,48 +40,48 @@ Address::InstanceConstSharedPtr Utility::resolveUrl(const std::string& url) {
     return Address::InstanceConstSharedPtr{
         new Address::PipeInstance(url.substr(UNIX_SCHEME.size()))};
   } else {
-    throw EnvoyException(fmt::format("unknown protocol scheme: {}", url));
+    throw EnvoyException(absl::StrCat("unknown protocol scheme: ", url));
   }
 }
 
-bool Utility::urlIsTcpScheme(const std::string& url) { return absl::StartsWith(url, TCP_SCHEME); }
+bool Utility::urlIsTcpScheme(absl::string_view url) { return absl::StartsWith(url, TCP_SCHEME); }
 
-bool Utility::urlIsUdpScheme(const std::string& url) { return absl::StartsWith(url, UDP_SCHEME); }
+bool Utility::urlIsUdpScheme(absl::string_view url) { return absl::StartsWith(url, UDP_SCHEME); }
 
-bool Utility::urlIsUnixScheme(const std::string& url) { return absl::StartsWith(url, UNIX_SCHEME); }
+bool Utility::urlIsUnixScheme(absl::string_view url) { return absl::StartsWith(url, UNIX_SCHEME); }
 
 namespace {
 
-std::string hostFromUrl(const std::string& url, const std::string& scheme,
-                        const std::string& scheme_name) {
+std::string hostFromUrl(const std::string& url, absl::string_view scheme,
+                        absl::string_view scheme_name) {
   if (!absl::StartsWith(url, scheme)) {
     throw EnvoyException(fmt::format("expected {} scheme, got: {}", scheme_name, url));
   }
 
-  size_t colon_index = url.find(':', scheme.size());
+  const size_t colon_index = url.find(':', scheme.size());
 
   if (colon_index == std::string::npos) {
-    throw EnvoyException(fmt::format("malformed url: {}", url));
+    throw EnvoyException(absl::StrCat("malformed url: ", url));
   }
 
   return url.substr(scheme.size(), colon_index - scheme.size());
 }
 
-uint32_t portFromUrl(const std::string& url, const std::string& scheme,
-                     const std::string& scheme_name) {
+uint32_t portFromUrl(const std::string& url, absl::string_view scheme,
+                     absl::string_view scheme_name) {
   if (!absl::StartsWith(url, scheme)) {
     throw EnvoyException(fmt::format("expected {} scheme, got: {}", scheme_name, url));
   }
 
-  size_t colon_index = url.find(':', scheme.size());
+  const size_t colon_index = url.find(':', scheme.size());
 
   if (colon_index == std::string::npos) {
-    throw EnvoyException(fmt::format("malformed url: {}", url));
+    throw EnvoyException(absl::StrCat("malformed url: ", url));
   }
 
-  size_t rcolon_index = url.rfind(':');
+  const size_t rcolon_index = url.rfind(':');
   if (colon_index != rcolon_index) {
-    throw EnvoyException(fmt::format("malformed url: {}", url));
+    throw EnvoyException(absl::StrCat("malformed url: ", url));
   }
 
   try {
@@ -183,8 +183,8 @@ Address::InstanceConstSharedPtr Utility::copyInternetAddressAndPort(const Addres
   return std::make_shared<Address::Ipv6Instance>(ip.addressAsString(), ip.port());
 }
 
-void Utility::throwWithMalformedIp(const std::string& ip_address) {
-  throw EnvoyException(fmt::format("malformed IP address: {}", ip_address));
+void Utility::throwWithMalformedIp(absl::string_view ip_address) {
+  throw EnvoyException(absl::StrCat("malformed IP address: ", ip_address));
 }
 
 // TODO(hennna): Currently getLocalAddress does not support choosing between
@@ -196,7 +196,7 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
   struct ifaddrs* ifa;
   Address::InstanceConstSharedPtr ret;
 
-  int rc = getifaddrs(&ifaddr);
+  const int rc = getifaddrs(&ifaddr);
   RELEASE_ASSERT(!rc, "");
 
   // man getifaddrs(3)

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -80,21 +80,21 @@ public:
    * @param url supplies the URL to match.
    * @return bool true if the URL matches the TCP scheme, false otherwise.
    */
-  static bool urlIsTcpScheme(const std::string& url);
+  static bool urlIsTcpScheme(absl::string_view url);
 
   /**
    * Match a URL to the UDP scheme
    * @param url supplies the URL to match.
    * @return bool true if the URL matches the UDP scheme, false otherwise.
    */
-  static bool urlIsUdpScheme(const std::string& url);
+  static bool urlIsUdpScheme(absl::string_view url);
 
   /**
    * Match a URL to the Unix scheme
    * @param url supplies the Unix to match.
    * @return bool true if the URL matches the Unix scheme, false otherwise.
    */
-  static bool urlIsUnixScheme(const std::string& url);
+  static bool urlIsUnixScheme(absl::string_view url);
 
   /**
    * Parses the host from a TCP URL
@@ -342,7 +342,7 @@ public:
                                                TimeSource& time_source, uint32_t& packets_dropped);
 
 private:
-  static void throwWithMalformedIp(const std::string& ip_address);
+  static void throwWithMalformedIp(absl::string_view ip_address);
 
   /**
    * Takes a number and flips the order in byte chunks. The last byte of the input will be the

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -370,7 +370,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                 Envoy::Http::LowerCaseString(upgrade_config.upgrade_type()).get(), enabled))
             .second;
     if (!success) {
-      throw EnvoyException(fmt::format("Duplicate upgrade {}", upgrade_config.upgrade_type()));
+      throw EnvoyException(absl::StrCat("Duplicate upgrade ", upgrade_config.upgrade_type()));
     }
   }
 }

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -132,7 +132,7 @@ ConfigUtility::parseDirectResponseBody(const envoy::config::route::v3alpha::Rout
     }
     const ssize_t size = api.fileSystem().fileSize(filename);
     if (size < 0) {
-      throw EnvoyException(fmt::format("cannot determine size of response body file {}", filename));
+      throw EnvoyException(absl::StrCat("cannot determine size of response body file ", filename));
     }
     if (size > MaxBodySize) {
       throw EnvoyException(fmt::format("response body file {} size is {} bytes; maximum is {}",

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -27,20 +27,20 @@ std::string formatUpstreamMetadataParseException(absl::string_view params,
                                                  const EnvoyException* cause = nullptr) {
   std::string reason;
   if (cause != nullptr) {
-    reason = fmt::format(", because {}", cause->what());
+    reason = absl::StrCat(", because ", cause->what());
   }
 
-  return fmt::format("Invalid header configuration. Expected format "
-                     "UPSTREAM_METADATA([\"namespace\", \"k\", ...]), actual format "
-                     "UPSTREAM_METADATA{}{}",
-                     params, reason);
+  return absl::StrCat("Invalid header configuration. Expected format "
+                      "UPSTREAM_METADATA([\"namespace\", \"k\", ...]), actual format "
+                      "UPSTREAM_METADATA",
+                      params, reason);
 }
 
 std::string formatPerRequestStateParseException(absl::string_view params) {
-  return fmt::format("Invalid header configuration. Expected format "
-                     "PER_REQUEST_STATE(<data_name>), actual format "
-                     "PER_REQUEST_STATE{}",
-                     params);
+  return absl::StrCat("Invalid header configuration. Expected format "
+                      "PER_REQUEST_STATE(<data_name>), actual format "
+                      "PER_REQUEST_STATE",
+                      params);
 }
 
 // Parses the parameters for UPSTREAM_METADATA and returns a function suitable for accessing the

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -43,7 +43,7 @@ public:
                     const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                     const std::string& version_info) override;
   const std::string& routeConfigName() const override { return route_config_proto_.name(); }
-  const std::string& configVersion() override { return last_config_version_; }
+  const std::string& configVersion() const override { return last_config_version_; }
   uint64_t configHash() const override { return last_config_hash_; }
   absl::optional<RouteConfigProvider::ConfigInfo> configInfo() const override {
     return config_info_;

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -182,7 +182,7 @@ bool ScopedRdsConfigSubscription::addOrUpdateScopes(
       ENVOY_LOG(debug, "srds: add/update scoped_route '{}', version: {}",
                 scoped_route_info->scopeName(), version_info);
     } catch (const EnvoyException& e) {
-      exception_msgs.emplace_back(fmt::format("{}", e.what()));
+      exception_msgs.emplace_back(absl::StrCat("", e.what()));
     }
   }
   return any_applied;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -413,11 +413,11 @@ void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix
 
   ENVOY_LOG(debug, "walking directory: {}", path);
   if (depth > MaxWalkDepth) {
-    throw EnvoyException(fmt::format("Walk recursion depth exceeded {}", MaxWalkDepth));
+    throw EnvoyException(absl::StrCat("Walk recursion depth exceeded ", MaxWalkDepth));
   }
   // Check if this is an obviously bad path.
   if (api.fileSystem().illegalPath(path)) {
-    throw EnvoyException(fmt::format("Invalid path: {}", path));
+    throw EnvoyException(absl::StrCat("Invalid path: ", path));
   }
 
   Filesystem::Directory directory(path);
@@ -475,7 +475,7 @@ void ProtoLayer::walkProtoValue(const ProtobufWkt::Value& v, const std::string& 
   case ProtobufWkt::Value::KIND_NOT_SET:
   case ProtobufWkt::Value::kListValue:
   case ProtobufWkt::Value::kNullValue:
-    throw EnvoyException(fmt::format("Invalid runtime entry value for {}", prefix));
+    throw EnvoyException(absl::StrCat("Invalid runtime entry value for ", prefix));
     break;
   case ProtobufWkt::Value::kStringValue:
     values_.emplace(prefix, SnapshotImpl::createEntry(v.string_value()));

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -28,7 +28,7 @@ void SecretManagerImpl::addStaticSecret(
     if (!static_tls_certificate_providers_.insert(std::make_pair(secret.name(), secret_provider))
              .second) {
       throw EnvoyException(
-          fmt::format("Duplicate static TlsCertificate secret name {}", secret.name()));
+          absl::StrCat("Duplicate static TlsCertificate secret name ", secret.name()));
     }
     break;
   }
@@ -38,8 +38,8 @@ void SecretManagerImpl::addStaticSecret(
     if (!static_certificate_validation_context_providers_
              .insert(std::make_pair(secret.name(), secret_provider))
              .second) {
-      throw EnvoyException(fmt::format(
-          "Duplicate static CertificateValidationContext secret name {}", secret.name()));
+      throw EnvoyException(absl::StrCat(
+          "Duplicate static CertificateValidationContext secret name ", secret.name()));
     }
     break;
   }
@@ -50,7 +50,7 @@ void SecretManagerImpl::addStaticSecret(
              .insert(std::make_pair(secret.name(), secret_provider))
              .second) {
       throw EnvoyException(
-          fmt::format("Duplicate static TlsSessionTicketKeys secret name {}", secret.name()));
+          absl::StrCat("Duplicate static TlsSessionTicketKeys secret name ", secret.name()));
     }
     break;
   }

--- a/source/common/ssl/certificate_validation_context_config_impl.cc
+++ b/source/common/ssl/certificate_validation_context_config_impl.cc
@@ -38,12 +38,11 @@ CertificateValidationContextConfigImpl::CertificateValidationContextConfigImpl(
                                        certificateRevocationListPath()));
     }
     if (!subject_alt_name_matchers_.empty() || !verify_subject_alt_name_list_.empty()) {
-      throw EnvoyException(fmt::format("SAN-based verification of peer certificates without "
-                                       "trusted CA is insecure and not allowed"));
+      throw EnvoyException("SAN-based verification of peer certificates without "
+                           "trusted CA is insecure and not allowed");
     }
     if (allow_expired_certificate_) {
-      throw EnvoyException(
-          fmt::format("Certificate validity period is always ignored without trusted CA"));
+      throw EnvoyException("Certificate validity period is always ignored without trusted CA");
     }
   }
 }

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -20,6 +20,8 @@
 #include "common/runtime/uuid_util.h"
 #include "common/stream_info/utility.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Tracing {
 
@@ -42,8 +44,8 @@ static std::string buildUrl(const Http::HeaderMap& request_headers,
     path = path.substr(0, max_path_length);
   }
 
-  return fmt::format("{}://{}{}", valueOrDefault(request_headers.ForwardedProto(), ""),
-                     valueOrDefault(request_headers.Host(), ""), path);
+  return absl::StrCat(valueOrDefault(request_headers.ForwardedProto(), ""), "://",
+                      valueOrDefault(request_headers.Host(), ""), path);
 }
 
 const std::string HttpTracerUtility::IngressOperation = "ingress";
@@ -321,7 +323,7 @@ void MetadataCustomTag::apply(Span& span, const CustomTagContext& ctx) const {
     span.setTag(tag(), value.bool_value() ? "true" : "false");
     return;
   case ProtobufWkt::Value::kNumberValue:
-    span.setTag(tag(), fmt::format("{}", value.number_value()));
+    span.setTag(tag(), absl::StrCat("", value.number_value()));
     return;
   case ProtobufWkt::Value::kStringValue:
     span.setTag(tag(), value.string_value());

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -23,6 +23,7 @@
 #include "extensions/health_checkers/well_known_names.h"
 
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Upstream {
@@ -768,7 +769,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::logHealthCheckStatus(
   if (grpc_status != Grpc::Status::WellKnownGrpcStatus::Ok && !grpc_message.empty()) {
     grpc_status_message = fmt::format("{} ({})", grpc_status, grpc_message);
   } else {
-    grpc_status_message = fmt::format("{}", grpc_status);
+    grpc_status_message = absl::StrCat("", grpc_status);
   }
 
   ENVOY_CONN_LOG(debug, "hc grpc_status={} service_status={} health_flags={}", *client_,

--- a/source/common/upstream/transport_socket_match_impl.cc
+++ b/source/common/upstream/transport_socket_match_impl.cc
@@ -24,7 +24,7 @@ TransportSocketMatcherImpl::TransportSocketMatcherImpl(
         socket_config, factory_context.messageValidationVisitor(), config_factory);
     FactoryMatch factory_match(
         socket_match.name(), config_factory.createTransportSocketFactory(*message, factory_context),
-        generateStats(socket_match.name() + "."));
+        generateStats(absl::StrCat(socket_match.name(), ".")));
     for (const auto& kv : socket_match.match().fields()) {
       factory_match.label_set.emplace_back(kv.first, kv.second);
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -46,6 +46,8 @@
 
 #include "extensions/transport_sockets/well_known_names.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Upstream {
 namespace {
@@ -653,7 +655,7 @@ ClusterInfoImpl::ClusterInfoImpl(
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       extension_protocol_options_(parseExtensionProtocolOptions(config, validation_visitor)),
       resource_managers_(config, runtime, name_, *stats_scope_),
-      maintenance_mode_runtime_key_(fmt::format("upstream.maintenance_mode.{}", name_)),
+      maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),
       source_address_(getSourceAddress(config, bind_config)),
       lb_least_request_config_(config.least_request_lb_config()),
       lb_ring_hash_config_(config.ring_hash_lb_config()),

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -27,12 +27,12 @@ public:
    * Returns the host that was actually resolved via DNS. If port was originally specified it will
    * be stripped from this return value.
    */
-  virtual const std::string& resolvedHost() PURE;
+  virtual const std::string& resolvedHost() const PURE;
 
   /**
    * Returns whether the original host is an IP address.
    */
-  virtual bool isIpAddress() PURE;
+  virtual bool isIpAddress() const PURE;
 
   /**
    * Indicates that the host has been used and should not be purged depending on any configured

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
@@ -81,8 +81,8 @@ private:
 
     // DnsHostInfo
     Network::Address::InstanceConstSharedPtr address() override { return address_; }
-    const std::string& resolvedHost() override { return resolved_host_; }
-    bool isIpAddress() override { return is_ip_address_; }
+    const std::string& resolvedHost() const override { return resolved_host_; }
+    bool isIpAddress() const override { return is_ip_address_; }
     void touch() override { last_used_time_ = time_source_.monotonicTime().time_since_epoch(); }
 
     TimeSource& time_source_;

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -62,8 +62,8 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, MessageMetadataSharedPtr
   SerializationType type = static_cast<SerializationType>(flag & SerializationTypeMask);
   if (!isValidSerializationType(type)) {
     throw EnvoyException(
-        fmt::format("invalid dubbo message serialization type {}",
-                    static_cast<std::underlying_type<SerializationType>::type>(type)));
+        absl::StrCat("invalid dubbo message serialization type ",
+                     static_cast<std::underlying_type<SerializationType>::type>(type)));
   }
 
   if (!is_two_way && metadata->message_type() != MessageType::HeartbeatRequest) {
@@ -78,8 +78,8 @@ void parseResponseInfoFromBuffer(Buffer::Instance& buffer, MessageMetadataShared
   ResponseStatus status = static_cast<ResponseStatus>(buffer.peekInt<uint8_t>(StatusOffset));
   if (!isValidResponseStatus(status)) {
     throw EnvoyException(
-        fmt::format("invalid dubbo message response status {}",
-                    static_cast<std::underlying_type<ResponseStatus>::type>(status)));
+        absl::StrCat("invalid dubbo message response status ",
+                     static_cast<std::underlying_type<ResponseStatus>::type>(status)));
   }
 
   metadata->setResponseStatus(status);
@@ -97,7 +97,7 @@ DubboProtocolImpl::decodeHeader(Buffer::Instance& buffer, MessageMetadataSharedP
 
   uint16_t magic_number = buffer.peekBEInt<uint16_t>();
   if (magic_number != MagicNumber) {
-    throw EnvoyException(fmt::format("invalid dubbo message magic number {}", magic_number));
+    throw EnvoyException(absl::StrCat("invalid dubbo message magic number ", magic_number));
   }
 
   uint8_t flag = buffer.peekInt<uint8_t>(FlagOffset);
@@ -109,7 +109,7 @@ DubboProtocolImpl::decodeHeader(Buffer::Instance& buffer, MessageMetadataSharedP
 
   // The body size of the heartbeat message is zero.
   if (body_size > MaxBodySize || body_size < 0) {
-    throw EnvoyException(fmt::format("invalid dubbo message size {}", body_size));
+    throw EnvoyException(absl::StrCat("invalid dubbo message size ", body_size));
   }
 
   metadata->setRequestId(request_id);

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -116,7 +116,7 @@ public:
   Config::ConfigProvider* scopedRouteConfigProvider() override {
     return scoped_routes_config_provider_.get();
   }
-  const std::string& serverName() override { return server_name_; }
+  const std::string& serverName() const override { return server_name_; }
   HttpConnectionManagerProto::ServerHeaderTransformation
   serverHeaderTransformation() const override {
     return server_transformation_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -97,9 +97,9 @@ public:
                                         const Buffer::Instance& data,
                                         Http::ServerConnectionCallbacks& callbacks) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
-  std::chrono::milliseconds drainTimeout() override { return drain_timeout_; }
+  std::chrono::milliseconds drainTimeout() const override { return drain_timeout_; }
   FilterChainFactory& filterFactory() override { return *this; }
-  bool generateRequestId() override { return generate_request_id_; }
+  bool generateRequestId() const override { return generate_request_id_; }
   bool preserveExternalRequestId() const override { return preserve_external_request_id_; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
@@ -117,19 +117,19 @@ public:
     return scoped_routes_config_provider_.get();
   }
   const std::string& serverName() override { return server_name_; }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() override {
+  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
     return server_transformation_;
   }
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
-  bool useRemoteAddress() override { return use_remote_address_; }
+  bool useRemoteAddress() const override { return use_remote_address_; }
   const Http::InternalAddressConfig& internalAddressConfig() const override {
     return *internal_address_config_;
   }
   uint32_t xffNumTrustedHops() const override { return xff_num_trusted_hops_; }
   bool skipXffAppend() const override { return skip_xff_append_; }
   const std::string& via() const override { return via_; }
-  Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
+  Http::ForwardClientCertType forwardClientCert() const override { return forward_client_cert_; }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -117,7 +117,8 @@ public:
     return scoped_routes_config_provider_.get();
   }
   const std::string& serverName() override { return server_name_; }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
+  HttpConnectionManagerProto::ServerHeaderTransformation
+  serverHeaderTransformation() const override {
     return server_transformation_;
   }
   Http::ConnectionManagerStats& stats() override { return stats_; }

--- a/source/extensions/filters/network/kafka/kafka_response_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/network/kafka/kafka_response_parser.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -43,7 +45,7 @@ ExpectedResponseSpec ResponseHeaderParser::getResponseSpec(const int32_t correla
   } else {
     // Response data should always be present in expected responses before response is to be parsed.
     throw EnvoyException(
-        fmt::format("no response metadata registered for correlation_id {}", correlation_id));
+        absl::StrCat("no response metadata registered for correlation_id ", correlation_id));
   }
 };
 

--- a/source/extensions/filters/network/kafka/serialization.cc
+++ b/source/extensions/filters/network/kafka/serialization.cc
@@ -51,12 +51,12 @@ uint32_t feedBytesIntoBuffers(absl::string_view& data, DeserializerType& length_
         ready = true;
       } else {
         // Invalid payload: null length for non-null object.
-        throw EnvoyException(fmt::format("invalid length: {}", required));
+        throw EnvoyException(absl::StrCat("invalid length: ", required));
       }
     }
 
     if (required < null_value_length) {
-      throw EnvoyException(fmt::format("invalid length: {}", required));
+      throw EnvoyException(absl::StrCat("invalid length: ", required));
     }
 
     length_consumed_marker = true;

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -14,6 +14,7 @@
 
 #include "extensions/filters/network/kafka/kafka_types.h"
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -322,7 +323,7 @@ public:
       if (required_ >= 0) {
         children_ = std::vector<DeserializerType>(required_);
       } else {
-        throw EnvoyException(fmt::format("invalid ARRAY length: {}", required_));
+        throw EnvoyException(absl::StrCat("invalid ARRAY length: ", required_));
       }
       length_consumed_ = true;
     }

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -90,7 +90,7 @@ bool BinaryProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& n
     }
     int16_t id = buffer.peekBEInt<int16_t>(1);
     if (id < 0) {
-      throw EnvoyException(fmt::format("invalid binary protocol field id {}", id));
+      throw EnvoyException(absl::StrCat("invalid binary protocol field id ", id));
     }
     field_id = id;
     buffer.drain(3);
@@ -121,7 +121,7 @@ bool BinaryProtocolImpl::readMapBegin(Buffer::Instance& buffer, FieldType& key_t
   FieldType vtype = static_cast<FieldType>(buffer.peekInt<int8_t>(1));
   int32_t s = buffer.peekBEInt<int32_t>(2);
   if (s < 0) {
-    throw EnvoyException(fmt::format("negative binary protocol map size {}", s));
+    throw EnvoyException(absl::StrCat("negative binary protocol map size ", s));
   }
 
   buffer.drain(6);
@@ -293,7 +293,7 @@ void BinaryProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) { UNREFERENCED_
 void BinaryProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                        FieldType value_type, uint32_t size) {
   if (size > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
-    throw EnvoyException(fmt::format("illegal binary protocol map size {}", size));
+    throw EnvoyException(absl::StrCat("illegal binary protocol map size ", size));
   }
 
   buffer.writeByte(static_cast<int8_t>(key_type));

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -53,7 +53,7 @@ bool CompactProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMeta
   }
 
   if (name_len < 0) {
-    throw EnvoyException(fmt::format("negative compact protocol message name length {}", name_len));
+    throw EnvoyException(absl::StrCat("negative compact protocol message name length ", name_len));
   }
 
   if (buffer.length() < static_cast<uint64_t>(id_size + name_len_size + name_len + 2)) {
@@ -138,7 +138,7 @@ bool CompactProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& 
     }
 
     if (id < 0 || id > std::numeric_limits<int16_t>::max()) {
-      throw EnvoyException(fmt::format("invalid compact protocol field id {}", id));
+      throw EnvoyException(absl::StrCat("invalid compact protocol field id ", id));
     }
 
     compact_field_type = static_cast<CompactFieldType>(delta_and_type);
@@ -179,7 +179,7 @@ bool CompactProtocolImpl::readMapBegin(Buffer::Instance& buffer, FieldType& key_
   }
 
   if (s < 0) {
-    throw EnvoyException(fmt::format("negative compact protocol map size {}", s));
+    throw EnvoyException(absl::StrCat("negative compact protocol map size ", s));
   }
 
   if (s == 0) {
@@ -468,7 +468,7 @@ void CompactProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) {
 void CompactProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                         FieldType value_type, uint32_t size) {
   if (size > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
-    throw EnvoyException(fmt::format("illegal compact protocol map size {}", size));
+    throw EnvoyException(absl::StrCat("illegal compact protocol map size ", size));
   }
 
   BufferHelper::writeVarIntI32(buffer, static_cast<int32_t>(size));

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
@@ -19,7 +19,7 @@ bool FramedTransportImpl::decodeFrameStart(Buffer::Instance& buffer, MessageMeta
   int32_t thrift_size = buffer.peekBEInt<int32_t>();
 
   if (thrift_size <= 0 || thrift_size > MaxFrameSize) {
-    throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", thrift_size));
+    throw EnvoyException(absl::StrCat("invalid thrift framed transport frame size ", thrift_size));
   }
 
   buffer.drain(4);
@@ -36,7 +36,7 @@ void FramedTransportImpl::encodeFrame(Buffer::Instance& buffer, const MessageMet
 
   uint64_t size = message.length();
   if (size == 0 || size > MaxFrameSize) {
-    throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", size));
+    throw EnvoyException(absl::StrCat("invalid thrift framed transport frame size ", size));
   }
 
   int32_t thrift_size = static_cast<int32_t>(size);

--- a/source/extensions/filters/network/thrift_proxy/router/router_ratelimit_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_ratelimit_impl.cc
@@ -112,7 +112,7 @@ RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(
       break;
     default:
       throw EnvoyException(
-          fmt::format("unsupported RateLimit Action {}", action.action_specifier_case()));
+          absl::StrCat("unsupported RateLimit Action ", action.action_specifier_case()));
     }
   }
 }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -73,7 +73,7 @@ public:
 private:
   static UdpProxyDownstreamStats generateStats(const std::string& stat_prefix,
                                                Stats::Scope& scope) {
-    const auto final_prefix = fmt::format("udp.{}", stat_prefix);
+    const auto final_prefix = absl::StrCat("udp.", stat_prefix);
     return {ALL_UDP_PROXY_DOWNSTREAM_STATS(POOL_COUNTER_PREFIX(scope, final_prefix),
                                            POOL_GAUGE_PREFIX(scope, final_prefix))};
   }

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -67,8 +67,8 @@ public:
   const std::string& getPrefix() { return prefix_; }
 
 private:
-  const std::string getName(const Stats::Metric& metric);
-  const std::string buildTagStr(const std::vector<Stats::Tag>& tags);
+  const std::string getName(const Stats::Metric& metric) const;
+  const std::string buildTagStr(const std::vector<Stats::Tag>& tags) const;
 
   ThreadLocal::SlotPtr tls_;
   Network::Address::InstanceConstSharedPtr server_address_;
@@ -108,7 +108,7 @@ private:
     void flushGauge(const std::string& name, uint64_t value);
     void endFlush(bool do_write);
     void onTimespanComplete(const std::string& name, std::chrono::milliseconds ms);
-    uint64_t usedBuffer();
+    uint64_t usedBuffer() const;
     void write(Buffer::Instance& buffer);
 
     // Network::ConnectionCallbacks

--- a/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.cc
+++ b/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.cc
@@ -30,7 +30,7 @@ DynamicOpenTracingDriver::DynamicOpenTracingDriver(Stats::Store& stats, const st
 std::string DynamicOpenTracingDriver::formatErrorMessage(std::error_code error_code,
                                                          const std::string& error_message) {
   if (error_message.empty()) {
-    return fmt::format("{}", error_code.message());
+    return absl::StrCat("", error_code.message());
   } else {
     return fmt::format("{}: {}", error_code.message(), error_message);
   }

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -96,19 +96,19 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
             fmt::format("Invalid traceid_high {} or tracid {}", high_tid.c_str(), low_tid.c_str()));
       }
     } else if (!StringUtil::atoull(tid.c_str(), trace_id, 16)) {
-      throw ExtractorException(fmt::format("Invalid trace_id {}", tid.c_str()));
+      throw ExtractorException(absl::StrCat("Invalid trace_id ", tid.c_str()));
     }
 
     const std::string spid(b3_span_id_entry->value().getStringView());
     if (!StringUtil::atoull(spid.c_str(), span_id, 16)) {
-      throw ExtractorException(fmt::format("Invalid span id {}", spid.c_str()));
+      throw ExtractorException(absl::StrCat("Invalid span id ", spid.c_str()));
     }
 
     auto b3_parent_id_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
     if (b3_parent_id_entry && !b3_parent_id_entry->value().empty()) {
       const std::string pspid(b3_parent_id_entry->value().getStringView());
       if (!StringUtil::atoull(pspid.c_str(), parent_id, 16)) {
-        throw ExtractorException(fmt::format("Invalid parent span id {}", pspid.c_str()));
+        throw ExtractorException(absl::StrCat("Invalid parent span id ", pspid.c_str()));
       }
     }
   } else {

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -140,7 +140,7 @@ public:
 
   // Server::Configuration::Initial
   Admin& admin() override { return admin_; }
-  absl::optional<std::string> flagsPath() override { return flags_path_; }
+  absl::optional<std::string> flagsPath() const override { return flags_path_; }
   const envoy::config::bootstrap::v3alpha::LayeredRuntime& runtime() override {
     return layered_runtime_;
   }
@@ -148,8 +148,8 @@ public:
 private:
   struct AdminImpl : public Admin {
     // Server::Configuration::Initial::Admin
-    const std::string& accessLogPath() override { return access_log_path_; }
-    const std::string& profilePath() override { return profile_path_; }
+    const std::string& accessLogPath() const override { return access_log_path_; }
+    const std::string& profilePath() const override { return profile_path_; }
     Network::Address::InstanceConstSharedPtr address() override { return address_; }
     Network::Socket::OptionsSharedPtr socketOptions() override { return socket_options_; }
 

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -63,7 +63,7 @@ public:
   ConnectionHandlerImpl(Event::Dispatcher& dispatcher, const std::string& per_handler_stat_prefix);
 
   // Network::ConnectionHandler
-  uint64_t numConnections() override { return num_handler_connections_; }
+  uint64_t numConnections() const override { return num_handler_connections_; }
   void incNumConnections() override;
   void decNumConnections() override;
   void addListener(Network::ListenerConfig& config) override;
@@ -72,7 +72,7 @@ public:
   void stopListeners() override;
   void disableListeners() override;
   void enableListeners() override;
-  const std::string& statPrefix() override { return per_handler_stat_prefix_; }
+  const std::string& statPrefix() const override { return per_handler_stat_prefix_; }
 
   /**
    * Wrapper for an active listener owned by this handler.

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -934,7 +934,7 @@ std::string PrometheusStatsFormatter::sanitizeName(const std::string& name) {
   // prometheus. Refer to https://prometheus.io/docs/concepts/data_model/.
   std::string stats_name = std::regex_replace(name, PromRegex, "_");
   if (stats_name[0] >= '0' && stats_name[0] <= '9') {
-    return fmt::format("_{}", stats_name);
+    return absl::StrCat("_", stats_name);
   } else {
     return stats_name;
   }

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -128,7 +128,8 @@ public:
     return &scoped_route_config_provider_;
   }
   const std::string& serverName() override { return Http::DefaultServerString::get(); }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
+  HttpConnectionManagerProto::ServerHeaderTransformation
+  serverHeaderTransformation() const override {
     return HttpConnectionManagerProto::OVERWRITE;
   }
   Http::ConnectionManagerStats& stats() override { return stats_; }

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -109,9 +109,9 @@ public:
                                         const Buffer::Instance& data,
                                         Http::ServerConnectionCallbacks& callbacks) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
-  std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
+  std::chrono::milliseconds drainTimeout() const override { return std::chrono::milliseconds(100); }
   Http::FilterChainFactory& filterFactory() override { return *this; }
-  bool generateRequestId() override { return false; }
+  bool generateRequestId() const override { return false; }
   bool preserveExternalRequestId() const override { return false; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   bool isRoutable() const override { return false; }
@@ -128,19 +128,19 @@ public:
     return &scoped_route_config_provider_;
   }
   const std::string& serverName() override { return Http::DefaultServerString::get(); }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() override {
+  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
     return HttpConnectionManagerProto::OVERWRITE;
   }
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
-  bool useRemoteAddress() override { return true; }
+  bool useRemoteAddress() const override { return true; }
   const Http::InternalAddressConfig& internalAddressConfig() const override {
     return internal_address_config_;
   }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
-  Http::ForwardClientCertType forwardClientCert() override {
+  Http::ForwardClientCertType forwardClientCert() const override {
     return Http::ForwardClientCertType::Sanitize;
   }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -127,7 +127,7 @@ public:
   Config::ConfigProvider* scopedRouteConfigProvider() override {
     return &scoped_route_config_provider_;
   }
-  const std::string& serverName() override { return Http::DefaultServerString::get(); }
+  const std::string& serverName() const override { return Http::DefaultServerString::get(); }
   HttpConnectionManagerProto::ServerHeaderTransformation
   serverHeaderTransformation() const override {
     return HttpConnectionManagerProto::OVERWRITE;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -232,7 +232,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
       enable_dispatcher_stats_(enable_dispatcher_stats) {
   for (uint32_t i = 0; i < server.options().concurrency(); i++) {
     workers_.emplace_back(
-        worker_factory.createWorker(server.overloadManager(), fmt::format("worker_{}", i)));
+        worker_factory.createWorker(server.overloadManager(), absl::StrCat("worker_", i)));
   }
 }
 
@@ -621,7 +621,7 @@ void ListenerManagerImpl::onListenerWarmed(ListenerImpl& listener) {
   updateWarmingActiveGauges();
 }
 
-uint64_t ListenerManagerImpl::numConnections() {
+uint64_t ListenerManagerImpl::numConnections() const {
   uint64_t num_connections = 0;
   for (const auto& worker : workers_) {
     num_connections += worker->numConnections();

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -138,7 +138,7 @@ public:
     lds_api_ = factory_.createLdsApi(lds_config);
   }
   std::vector<std::reference_wrapper<Network::ListenerConfig>> listeners() override;
-  uint64_t numConnections() override;
+  uint64_t numConnections() const override;
   bool removeListener(const std::string& listener_name) override;
   void startWorkers(GuardDog& guard_dog) override;
   void stopListeners(StopListenersType stop_listeners_type) override;

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -67,7 +67,7 @@ OverloadAction::OverloadAction(const envoy::config::overload::v3alpha::OverloadA
 
     if (!triggers_.insert(std::make_pair(trigger_config.name(), std::move(trigger))).second) {
       throw EnvoyException(
-          fmt::format("Duplicate trigger resource for overload action {}", config.name()));
+          absl::StrCat("Duplicate trigger resource for overload action ", config.name()));
     }
   }
 
@@ -117,7 +117,7 @@ OverloadManagerImpl::OverloadManagerImpl(
         resources_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
                            std::forward_as_tuple(name, std::move(monitor), *this, stats_scope));
     if (!result.second) {
-      throw EnvoyException(fmt::format("Duplicate resource monitor {}", name));
+      throw EnvoyException(absl::StrCat("Duplicate resource monitor ", name));
     }
   }
 
@@ -127,7 +127,7 @@ OverloadManagerImpl::OverloadManagerImpl(
     auto result = actions_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
                                    std::forward_as_tuple(action, stats_scope));
     if (!result.second) {
-      throw EnvoyException(fmt::format("Duplicate overload action {}", name));
+      throw EnvoyException(absl::StrCat("Duplicate overload action ", name));
     }
 
     for (const auto& trigger : action.triggers()) {

--- a/source/server/proto_descriptors.cc
+++ b/source/server/proto_descriptors.cc
@@ -5,6 +5,8 @@
 #include "common/config/protobuf_link_hacks.h"
 #include "common/protobuf/protobuf.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -33,7 +35,7 @@ void validateProtoDescriptors() {
 
   for (const auto& method : methods) {
     RELEASE_ASSERT(Protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) != nullptr,
-                   fmt::format("Unable to find method descriptor for {}", method));
+                   absl::StrCat("Unable to find method descriptor for ", method));
   }
 
   const auto types = {

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -50,7 +50,7 @@ void WorkerImpl::addListener(Network::ListenerConfig& listener, AddListenerCompl
   });
 }
 
-uint64_t WorkerImpl::numConnections() {
+uint64_t WorkerImpl::numConnections() const {
   uint64_t ret = 0;
   if (handler_) {
     ret = handler_->numConnections();

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -43,7 +43,7 @@ public:
 
   // Server::Worker
   void addListener(Network::ListenerConfig& listener, AddListenerCompletion completion) override;
-  uint64_t numConnections() override;
+  uint64_t numConnections() const override;
   void removeListener(Network::ListenerConfig& listener, std::function<void()> completion) override;
   void start(GuardDog& guard_dog) override;
   void initializeStats(Stats::Scope& scope, const std::string& prefix) override;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -108,7 +108,8 @@ public:
     return nullptr;
   }
   const std::string& serverName() override { return server_name_; }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
+  HttpConnectionManagerProto::ServerHeaderTransformation
+  serverHeaderTransformation() const override {
     return server_transformation_;
   }
   ConnectionManagerStats& stats() override { return stats_; }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -107,7 +107,7 @@ public:
     }
     return nullptr;
   }
-  const std::string& serverName() override { return server_name_; }
+  const std::string& serverName() const override { return server_name_; }
   HttpConnectionManagerProto::ServerHeaderTransformation
   serverHeaderTransformation() const override {
     return server_transformation_;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -81,9 +81,9 @@ public:
     return ServerConnectionPtr{codec_};
   }
   DateProvider& dateProvider() override { return date_provider_; }
-  std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
+  std::chrono::milliseconds drainTimeout() const override { return std::chrono::milliseconds(100); }
   FilterChainFactory& filterFactory() override { return filter_factory_; }
-  bool generateRequestId() override { return true; }
+  bool generateRequestId() const override { return true; }
   bool preserveExternalRequestId() const override { return false; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
@@ -108,19 +108,19 @@ public:
     return nullptr;
   }
   const std::string& serverName() override { return server_name_; }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() override {
+  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
     return server_transformation_;
   }
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
-  bool useRemoteAddress() override { return use_remote_address_; }
+  bool useRemoteAddress() const override { return use_remote_address_; }
   const Http::InternalAddressConfig& internalAddressConfig() const override {
     return internal_address_config_;
   }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
-  Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
+  Http::ForwardClientCertType forwardClientCert() const override { return forward_client_cert_; }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -305,7 +305,8 @@ public:
     return nullptr;
   }
   const std::string& serverName() override { return server_name_; }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
+  HttpConnectionManagerProto::ServerHeaderTransformation
+  serverHeaderTransformation() const override {
     return server_transformation_;
   }
   ConnectionManagerStats& stats() override { return stats_; }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -277,9 +277,9 @@ public:
     return ServerConnectionPtr{codec_};
   }
   DateProvider& dateProvider() override { return date_provider_; }
-  std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
+  std::chrono::milliseconds drainTimeout() const override { return std::chrono::milliseconds(100); }
   FilterChainFactory& filterFactory() override { return filter_factory_; }
-  bool generateRequestId() override { return true; }
+  bool generateRequestId() const override { return true; }
   bool preserveExternalRequestId() const override { return false; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
@@ -305,19 +305,19 @@ public:
     return nullptr;
   }
   const std::string& serverName() override { return server_name_; }
-  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() override {
+  HttpConnectionManagerProto::ServerHeaderTransformation serverHeaderTransformation() const override {
     return server_transformation_;
   }
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
-  bool useRemoteAddress() override { return use_remote_address_; }
+  bool useRemoteAddress() const override { return use_remote_address_; }
   const Http::InternalAddressConfig& internalAddressConfig() const override {
     return internal_address_config_;
   }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
-  Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
+  Http::ForwardClientCertType forwardClientCert() const override { return forward_client_cert_; }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
   }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -304,7 +304,7 @@ public:
     }
     return nullptr;
   }
-  const std::string& serverName() override { return server_name_; }
+  const std::string& serverName() const override { return server_name_; }
   HttpConnectionManagerProto::ServerHeaderTransformation
   serverHeaderTransformation() const override {
     return server_transformation_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -56,9 +56,9 @@ public:
   MOCK_METHOD3(createCodec_, ServerConnection*(Network::Connection&, const Buffer::Instance&,
                                                ServerConnectionCallbacks&));
   MOCK_METHOD0(dateProvider, DateProvider&());
-  MOCK_METHOD0(drainTimeout, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(drainTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(filterFactory, FilterChainFactory&());
-  MOCK_METHOD0(generateRequestId, bool());
+  MOCK_CONST_METHOD0(generateRequestId, bool());
   MOCK_CONST_METHOD0(preserveExternalRequestId, bool());
   MOCK_CONST_METHOD0(maxRequestHeadersKb, uint32_t());
   MOCK_CONST_METHOD0(maxRequestHeadersCount, uint32_t());
@@ -71,11 +71,11 @@ public:
   MOCK_METHOD0(routeConfigProvider, Router::RouteConfigProvider*());
   MOCK_METHOD0(scopedRouteConfigProvider, Config::ConfigProvider*());
   MOCK_METHOD0(serverName, const std::string&());
-  MOCK_METHOD0(serverHeaderTransformation,
-               HttpConnectionManagerProto::ServerHeaderTransformation());
+  MOCK_CONST_METHOD0(serverHeaderTransformation,
+                     HttpConnectionManagerProto::ServerHeaderTransformation());
   MOCK_METHOD0(stats, ConnectionManagerStats&());
   MOCK_METHOD0(tracingStats, ConnectionManagerTracingStats&());
-  MOCK_METHOD0(useRemoteAddress, bool());
+  MOCK_CONST_METHOD0(useRemoteAddress, bool());
   const Http::InternalAddressConfig& internalAddressConfig() const override {
     return *internal_address_config_;
   }
@@ -83,7 +83,7 @@ public:
   MOCK_CONST_METHOD0(xffNumTrustedHops, uint32_t());
   MOCK_CONST_METHOD0(skipXffAppend, bool());
   MOCK_CONST_METHOD0(via, const std::string&());
-  MOCK_METHOD0(forwardClientCert, Http::ForwardClientCertType());
+  MOCK_CONST_METHOD0(forwardClientCert, Http::ForwardClientCertType());
   MOCK_CONST_METHOD0(setCurrentClientCertDetails,
                      const std::vector<Http::ClientCertDetailsType>&());
   MOCK_METHOD0(localAddress, const Network::Address::Instance&());

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -70,7 +70,7 @@ public:
   MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(routeConfigProvider, Router::RouteConfigProvider*());
   MOCK_METHOD0(scopedRouteConfigProvider, Config::ConfigProvider*());
-  MOCK_METHOD0(serverName, const std::string&());
+  MOCK_CONST_METHOD0(serverName, const std::string&());
   MOCK_CONST_METHOD0(serverHeaderTransformation,
                      HttpConnectionManagerProto::ServerHeaderTransformation());
   MOCK_METHOD0(stats, ConnectionManagerStats&());

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1220,7 +1220,7 @@ TEST_P(Http2CodecImplTest, ManyLargeRequestHeadersUnderPerHeaderLimit) {
   HttpTestUtility::addDefaultHeaders(request_headers);
   std::string long_string = std::string(1024, 'q');
   for (int i = 0; i < 80; i++) {
-    request_headers.addCopy(fmt::format("{}", i), long_string);
+    request_headers.addCopy(std::to_string(i), long_string);
   }
 
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, _)).Times(1);
@@ -1238,7 +1238,7 @@ TEST_P(Http2CodecImplTest, LargeRequestHeadersAtMaxConfigurable) {
   HttpTestUtility::addDefaultHeaders(request_headers);
   std::string long_string = std::string(1024, 'q');
   for (int i = 0; i < 95; i++) {
-    request_headers.addCopy(fmt::format("{}", i), long_string);
+    request_headers.addCopy(std::to_string(i), long_string);
   }
 
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, _)).Times(1);

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -115,11 +115,11 @@ private:
     case envoy::config::core::v3alpha::SocketAddress::PortSpecifierCase::kPortValue:
     // default to port 0 if no port value is specified
     case envoy::config::core::v3alpha::SocketAddress::PortSpecifierCase::PORT_SPECIFIER_NOT_SET:
-      return fmt::format("{}", socket_address.port_value());
+      return absl::StrCat("", socket_address.port_value());
 
     default:
       throw EnvoyException(
-          fmt::format("Unknown port specifier type {}", socket_address.port_specifier_case()));
+          absl::StrCat("Unknown port specifier type ", socket_address.port_specifier_case()));
     }
   }
 

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -452,7 +452,7 @@ void ConfigHelper::finalize(const std::vector<uint32_t>& ports) {
                                  tls_config.value());
         cluster->clear_hidden_envoy_deprecated_tls_context();
       }
-      setTapTransportSocket(tap_path.value(), fmt::format("cluster_{}", i),
+      setTapTransportSocket(tap_path.value(), absl::StrCat("cluster_", i),
                             *cluster->mutable_transport_socket(), tls_config);
     }
   }

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -66,8 +66,8 @@ public:
   ~MockDnsHostInfo() override;
 
   MOCK_METHOD0(address, Network::Address::InstanceConstSharedPtr());
-  MOCK_METHOD0(resolvedHost, const std::string&());
-  MOCK_METHOD0(isIpAddress, bool());
+  MOCK_CONST_METHOD0(resolvedHost, const std::string&());
+  MOCK_CONST_METHOD0(isIpAddress, bool());
   MOCK_METHOD0(touch, void());
 
   Network::Address::InstanceConstSharedPtr address_;

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -92,7 +92,7 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
 
     EXPECT_THROW_WITH_MESSAGE(
         proto.readMessageBegin(buffer, metadata_), EnvoyException,
-        fmt::format("invalid compact protocol message type {}", invalid_msg_type));
+        absl::StrCat("invalid compact protocol message type ", invalid_msg_type));
     expectDefaultMetadata();
     EXPECT_EQ(buffer.length(), 4);
   }
@@ -1163,7 +1163,7 @@ TEST_F(CompactProtocolTest, WriteFieldBegin) {
 
     EXPECT_THROW_WITH_MESSAGE(proto.writeFieldBegin(buffer, "unused", field_type, 1),
                               EnvoyException,
-                              fmt::format("unknown protocol field type {}", invalid_field_type));
+                              absl::StrCat("unknown protocol field type ", invalid_field_type));
   }
 }
 

--- a/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
@@ -311,7 +311,7 @@ TEST(HeaderTransportTest, TransformErrors) {
     EXPECT_THAT(metadata, HasFrameSize(86U));
     EXPECT_THAT(metadata, HasProtocol(ProtocolType::Binary));
     EXPECT_THAT(metadata, HasAppException(AppExceptionType::MissingResult,
-                                          fmt::format("Unknown transform {}", xform_id)));
+                                          absl::StrCat("Unknown transform ", xform_id)));
   }
 
   // Only the first of multiple errors is reported

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -115,7 +115,7 @@ public:
       for (int i = 1; i < 4; i++) {
         auto* c = bootstrap.mutable_static_resources()->add_clusters();
         c->MergeFrom(bootstrap.static_resources().clusters()[0]);
-        c->set_name(fmt::format("cluster_{}", i));
+        c->set_name(absl::StrCat("cluster_", i));
       }
     });
 

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -1003,7 +1003,7 @@ TEST_F(ClientContextConfigImplTest, PasswordNotSuppliedTlsCertificates) {
   Stats::IsolatedStoreImpl store;
   EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config),
                           EnvoyException,
-                          fmt::format("Failed to load private key from {}", private_key_path));
+                          absl::StrCat("Failed to load private key from ", private_key_path));
 }
 
 // Validate that client context config with static certificate validation context is created

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -187,7 +187,7 @@ private:
       }
       for (int i = 1; i < num_clusters; ++i) {
         auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
-        cluster->set_name(fmt::format("cluster_{}", i));
+        cluster->set_name(absl::StrCat("cluster_", i));
       }
 
       for (int i = 0; i < num_clusters; ++i) {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -342,7 +342,7 @@ public:
   MockConnectionHandler();
   ~MockConnectionHandler() override;
 
-  MOCK_METHOD0(numConnections, uint64_t());
+  MOCK_CONST_METHOD0(numConnections, uint64_t());
   MOCK_METHOD0(incNumConnections, void());
   MOCK_METHOD0(decNumConnections, void());
   MOCK_METHOD1(addListener, void(ListenerConfig& config));
@@ -351,7 +351,7 @@ public:
   MOCK_METHOD0(stopListeners, void());
   MOCK_METHOD0(disableListeners, void());
   MOCK_METHOD0(enableListeners, void());
-  MOCK_METHOD0(statPrefix, const std::string&());
+  MOCK_CONST_METHOD0(statPrefix, const std::string&());
 };
 
 class MockIp : public Address::Ip {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -287,7 +287,7 @@ public:
                                          const std::string& version_info, bool modifiable));
   MOCK_METHOD1(createLdsApi, void(const envoy::config::core::v3alpha::ConfigSource& lds_config));
   MOCK_METHOD0(listeners, std::vector<std::reference_wrapper<Network::ListenerConfig>>());
-  MOCK_METHOD0(numConnections, uint64_t());
+  MOCK_CONST_METHOD0(numConnections, uint64_t());
   MOCK_METHOD1(removeListener, bool(const std::string& listener_name));
   MOCK_METHOD1(startWorkers, void(GuardDog& guard_dog));
   MOCK_METHOD1(stopListeners, void(StopListenersType listeners_type));
@@ -339,7 +339,7 @@ public:
   // Server::Worker
   MOCK_METHOD2(addListener,
                void(Network::ListenerConfig& listener, AddListenerCompletion completion));
-  MOCK_METHOD0(numConnections, uint64_t());
+  MOCK_CONST_METHOD0(numConnections, uint64_t());
   MOCK_METHOD2(removeListener,
                void(Network::ListenerConfig& listener, std::function<void()> completion));
   MOCK_METHOD1(start, void(GuardDog& guard_dog));

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -223,7 +223,7 @@ std::string TestUtility::xdsResourceName(const ProtobufWkt::Any& resource) {
     return TestUtility::anyConvert<envoy::service::runtime::v3alpha::Runtime>(resource).name();
   }
   throw EnvoyException(
-      fmt::format("xdsResourceName does not know about type URL {}", resource.type_url()));
+      absl::StrCat("xdsResourceName does not know about type URL ", resource.type_url()));
 }
 
 std::string TestUtility::addLeftAndRightPadding(absl::string_view to_pad, int desired_length) {


### PR DESCRIPTION
Description:
* mark variables `const` as appropriate
* mark methods as `const` as appropriate
* migrate `fmt::format("... {}", foo);` to `absl::StrCat("... ", foo);`
* migrate some `const std::string&` function parameter types to `absl::string_view` where appropriate

Risk Level: low
Testing: existing
Docs Changes: n/a
Release Notes: n/a
