### PR TITLE
Make only once abort or delay decision

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,6 +48,7 @@ Version history
 * tracing: added upstream_address tag.
 * tracing: added initial support for AWS X-Ray (local sampling rules only) :ref:`X-Ray Tracing <envoy_api_msg_config.trace.v2alpha.XRayConfig>`.
 * udp: added initial support for :ref:`UDP proxy <config_udp_listener_filters_udp_proxy>`
+* fault: fixed an issue where the http fault filter would repeatedly check the percentage of abort/delay when the `x-envoy-downstream-service-cluster` header was included in the request to ensure that the actual percentage of abort/delay matches the configuration of the filter.
 
 1.12.2 (December 10, 2019)
 ==========================

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -225,23 +225,21 @@ bool FaultFilter::isDelayEnabled() {
     return false;
   }
 
-  bool enabled = config_->runtime().snapshot().featureEnabled(
-      fault_settings_->delayPercentRuntime(), fault_settings_->requestDelay()->percentage());
   if (!downstream_cluster_delay_percent_key_.empty()) {
-    enabled |= config_->runtime().snapshot().featureEnabled(
+    return config_->runtime().snapshot().featureEnabled(
         downstream_cluster_delay_percent_key_, fault_settings_->requestDelay()->percentage());
   }
-  return enabled;
+  return config_->runtime().snapshot().featureEnabled(
+      fault_settings_->delayPercentRuntime(), fault_settings_->requestDelay()->percentage());
 }
 
 bool FaultFilter::isAbortEnabled() {
-  bool enabled = config_->runtime().snapshot().featureEnabled(
-      fault_settings_->abortPercentRuntime(), fault_settings_->abortPercentage());
   if (!downstream_cluster_abort_percent_key_.empty()) {
-    enabled |= config_->runtime().snapshot().featureEnabled(downstream_cluster_abort_percent_key_,
-                                                            fault_settings_->abortPercentage());
+    return config_->runtime().snapshot().featureEnabled(downstream_cluster_abort_percent_key_,
+                                                        fault_settings_->abortPercentage());
   }
-  return enabled;
+  return config_->runtime().snapshot().featureEnabled(fault_settings_->abortPercentRuntime(),
+                                                      fault_settings_->abortPercentage());
 }
 
 absl::optional<std::chrono::milliseconds>

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -383,10 +383,6 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
 
   // Delay related calls.
   EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.delay.fixed_delay_percent",
-                             Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(100))))
-      .WillOnce(Return(false));
-  EXPECT_CALL(runtime_.snapshot_,
               featureEnabled("fault.http.cluster.delay.fixed_delay_percent",
                              Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(100))))
       .WillOnce(Return(true));
@@ -403,10 +399,6 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
             filter_->decodeHeaders(request_headers_, false));
 
   // Abort related calls.
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.abort.abort_percent",
-                             Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(0))))
-      .WillOnce(Return(false));
   EXPECT_CALL(runtime_.snapshot_,
               featureEnabled("fault.http.cluster.abort.abort_percent",
                              Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(0))))
@@ -444,10 +436,6 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
 
   // Delay related calls.
   EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.delay.fixed_delay_percent",
-                             Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(100))))
-      .WillOnce(Return(false));
-  EXPECT_CALL(runtime_.snapshot_,
               featureEnabled("fault.http.cluster.delay.fixed_delay_percent",
                              Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(100))))
       .WillOnce(Return(true));
@@ -467,10 +455,6 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   EXPECT_EQ(1UL, config_->stats().active_faults_.value());
 
   // Abort related calls
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.abort.abort_percent",
-                             Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(100))))
-      .WillOnce(Return(false));
   EXPECT_CALL(runtime_.snapshot_,
               featureEnabled("fault.http.cluster.abort.abort_percent",
                              Matcher<const envoy::type::v3alpha::FractionalPercent&>(Percent(100))))


### PR DESCRIPTION
Signed-off-by: wbpcode <comems@msn.com>

Description:

In the original logic of fault filter, when the header contains the `x-envoy-downstream-service-cluster`, fault filter will execute the decision whether to abort or delay twice. As a result, the actual abort or delay ratio does not meet expectations. The expectations is `p` and the actual value will be `2p-p^2`.

For example, when the abort ratio is configured as 50%, if the header contains `x-envoy-downstream-service-cluster`, the actual abort ratio is 75%.

This problem can be reproduced by enabling `add_user_agent`. The current PR fixes this problem.

@alyssawilk 
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
