### PR TITLE
tests: fix failing stats integration test on macOS

### DIFF
--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -316,7 +316,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // 2019/11/15  9040     35029       35500   build: update protobuf to 3.10.1
   // 2019/11/15  9040     35061       35500   upstream: track whether cluster is local
   // 2019/12/20  8779     35053       35000   use var-length coding for name lengths
-  // 2020/01/07  9069     35548       35700   upstream: Implement retry concurrency budgets
+  // 2020/01/07  9069     35548       36000   upstream: Implement retry concurrency budgets
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -331,7 +331,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 35548); // 104 bytes higher than a debug build.
-  EXPECT_MEMORY_LE(m_per_cluster, 35700);
+  EXPECT_MEMORY_LE(m_per_cluster, 36000);
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {


### PR DESCRIPTION
Since #9069, macOS builds have been failing because they use slightly
more memory for stats than the new limit. Bump limit to next even
multiple of 1000.

Risk Level: low, test change only
Docs Changes: n/a
Release Notes: n/a
Fixes: #9605 

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
