### PR TITLE
git: ignore CMake files for Clion without Bazel plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ TAGS
 .vscode
 clang.bazelrc
 user.bazelrc
+CMakeLists.txt
+cmake-build-debug


### PR DESCRIPTION
Description:
The Bazel plugin is often not supported on the latest Clion builds, so it can be useful to use https://github.com/lizan/bazel-cmakelists to build a CMakeLists.txt to provide the dependency tree to Clion.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
