### PR TITLE
proto: force link missing v2 protos

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -248,6 +248,7 @@ envoy_cc_library(
     hdrs = ["protobuf_link_hacks.h"],
     deps = [
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
+        "@envoy_api//envoy/config/bootstrap/v2:pkg_cc_proto",
         "@envoy_api//envoy/service/cluster/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v2:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3alpha:pkg_cc_proto",

--- a/source/common/config/protobuf_link_hacks.h
+++ b/source/common/config/protobuf_link_hacks.h
@@ -57,6 +57,7 @@ const envoy::service::route::v3alpha::SrdsDummy _srds_dummy_v3;
 // is still included in cds_api_impl.cc. On the other side because the v2 hds header is not included
 // anywhere the v2 service type is getting dropped, and thus the descriptor is not present in the
 // descriptor pool.
+// https://github.com/envoyproxy/envoy/issues/9639
 const envoy::config::bootstrap::v2::Bootstrap _bootstrap_dummy_v2;
 const envoy::service::discovery::v2::Capability _hds_dummy_v2;
 

--- a/source/common/config/protobuf_link_hacks.h
+++ b/source/common/config/protobuf_link_hacks.h
@@ -7,6 +7,7 @@
 #include "envoy/api/v2/srds.pb.h"
 #include "envoy/service/cluster/v3alpha/cds.pb.h"
 #include "envoy/service/discovery/v2/ads.pb.h"
+#include "envoy/service/discovery/v2/hds.pb.h"
 #include "envoy/service/discovery/v2/rtds.pb.h"
 #include "envoy/service/discovery/v2/sds.pb.h"
 #include "envoy/service/discovery/v3alpha/ads.pb.h"
@@ -34,6 +35,7 @@ const envoy::api::v2::RdsDummy _rds_dummy_v2;
 const envoy::api::v2::CdsDummy _cds_dummy_v2;
 const envoy::api::v2::EdsDummy _eds_dummy_v2;
 const envoy::api::v2::SrdsDummy _srds_dummy_v2;
+const envoy::service::discovery::v2::Capability _hds_dummy_v2;
 
 const envoy::service::discovery::v3alpha::AdsDummy _ads_dummy_v3;
 const envoy::service::ratelimit::v3alpha::RateLimitRequest _rls_dummy_v3;
@@ -43,5 +45,8 @@ const envoy::service::listener::v3alpha::LdsDummy _lds_dummy_v3;
 const envoy::service::route::v3alpha::RdsDummy _rds_dummy_v3;
 const envoy::service::cluster::v3alpha::CdsDummy _cds_dummy_v3;
 const envoy::service::endpoint::v3alpha::EdsDummy _eds_dummy_v3;
-const envoy::service::route::v3alpha::SrdsDummy _srds_dummy_v4;
+const envoy::service::route::v3alpha::SrdsDummy _srds_dummy_v3;
+
+// note: hds force linking is not needed because it is still implicitly linked via
+// health_discovery_service.h
 } // namespace Envoy

--- a/source/common/config/protobuf_link_hacks.h
+++ b/source/common/config/protobuf_link_hacks.h
@@ -50,7 +50,7 @@ const envoy::service::route::v3alpha::SrdsDummy _srds_dummy_v3;
 // With the v2 -> v3 migration there is another, related linking issue.
 // Symbols for v2 protos which headers are not included in any file in the codebase are being
 // dropped by the linker in some circumstances. For example, in the Envoy Mobile iOS build system.
-// Even though all v2 pkgs are included as a dependency in their corresponding v3 package, and
+// Even though all v2 packages are included as a dependency in their corresponding v3 package, and
 // `always_link` is set for all proto bazel targets.
 // Further proof of this can be seen by way of counter example with the envoy.api.v2.Cluster type,
 // which is checked for by proto_descriptors.cc. This type **is** getting linked because its headers

--- a/source/common/config/protobuf_link_hacks.h
+++ b/source/common/config/protobuf_link_hacks.h
@@ -5,6 +5,7 @@
 #include "envoy/api/v2/lds.pb.h"
 #include "envoy/api/v2/rds.pb.h"
 #include "envoy/api/v2/srds.pb.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 #include "envoy/service/cluster/v3alpha/cds.pb.h"
 #include "envoy/service/discovery/v2/ads.pb.h"
 #include "envoy/service/discovery/v2/hds.pb.h"
@@ -35,7 +36,6 @@ const envoy::api::v2::RdsDummy _rds_dummy_v2;
 const envoy::api::v2::CdsDummy _cds_dummy_v2;
 const envoy::api::v2::EdsDummy _eds_dummy_v2;
 const envoy::api::v2::SrdsDummy _srds_dummy_v2;
-const envoy::service::discovery::v2::Capability _hds_dummy_v2;
 
 const envoy::service::discovery::v3alpha::AdsDummy _ads_dummy_v3;
 const envoy::service::ratelimit::v3alpha::RateLimitRequest _rls_dummy_v3;
@@ -47,6 +47,17 @@ const envoy::service::cluster::v3alpha::CdsDummy _cds_dummy_v3;
 const envoy::service::endpoint::v3alpha::EdsDummy _eds_dummy_v3;
 const envoy::service::route::v3alpha::SrdsDummy _srds_dummy_v3;
 
-// note: hds force linking is not needed because it is still implicitly linked via
-// health_discovery_service.h
+// With the v2 -> v3 migration there is another, related linking issue.
+// Symbols for v2 protos which headers are not included in any file in the codebase are being
+// dropped by the linker in some circumstances. For example, in the Envoy Mobile iOS build system.
+// Even though all v2 pkgs are included as a dependency in their corresponding v3 package, and
+// `always_link` is set for all proto bazel targets.
+// Further proof of this can be seen by way of counter example with the envoy.api.v2.Cluster type,
+// which is checked for by proto_descriptors.cc. This type **is** getting linked because its headers
+// is still included in cds_api_impl.cc. On the other side because the v2 hds header is not included
+// anywhere the v2 service type is getting dropped, and thus the descriptor is not present in the
+// descriptor pool.
+const envoy::config::bootstrap::v2::Bootstrap _bootstrap_dummy_v2;
+const envoy::service::discovery::v2::Capability _hds_dummy_v2;
+
 } // namespace Envoy

--- a/source/extensions/stat_sinks/metrics_service/BUILD
+++ b/source/extensions/stat_sinks/metrics_service/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/protobuf",
+        "@envoy_api//envoy/service/metrics/v3alpha:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/stat_sinks/metrics_service/BUILD
+++ b/source/extensions/stat_sinks/metrics_service/BUILD
@@ -33,7 +33,7 @@ envoy_cc_library(
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/protobuf",
-        "@envoy_api//envoy/service/metrics/v3alpha:pkg_cc_proto",
+        "@envoy_api//envoy/service/metrics/v2:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
@@ -12,6 +12,7 @@ namespace StatSinks {
 namespace MetricsService {
 
 void validateProtoDescriptors() {
+https: // github.com/envoyproxy/envoy/issues/9639
   const envoy::service::metrics::v2::StreamMetricsMessage _dummy_v2;
 
   const auto method = "envoy.service.metrics.v2.MetricsService.StreamMetrics";

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
@@ -1,5 +1,7 @@
 #include "extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.h"
 
+#include "envoy/service/metrics/v2/metrics_service.pb.h"
+
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 #include "common/protobuf/protobuf.h"
@@ -10,6 +12,8 @@ namespace StatSinks {
 namespace MetricsService {
 
 void validateProtoDescriptors() {
+  const envoy::service::metrics::v2::StreamMetricsMessage _dummy_v2;
+
   const auto method = "envoy.service.metrics.v2.MetricsService.StreamMetrics";
 
   RELEASE_ASSERT(Protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) != nullptr,

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
@@ -12,7 +12,7 @@ namespace StatSinks {
 namespace MetricsService {
 
 void validateProtoDescriptors() {
-https: // github.com/envoyproxy/envoy/issues/9639
+  // https://github.com/envoyproxy/envoy/issues/9639
   const envoy::service::metrics::v2::StreamMetricsMessage _dummy_v2;
 
   const auto method = "envoy.service.metrics.v2.MetricsService.StreamMetrics";


### PR DESCRIPTION
Description: https://github.com/envoyproxy/envoy/pull/9526 force linked most method descriptors. However, HDS was missing. This PR force links HDS v2.
Risk Level: low
Testing: compiled with Envoy Mobile's iOS dist target which, as discussed [here](https://github.com/envoyproxy/envoy/pull/9191), requires the hack currently in place.

Signed-off-by: Jose Nino <jnino@lyft.com>