### PR TITLE
Delta CDS: add on-demand cds support

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cds.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cds.rst
@@ -18,3 +18,40 @@ Statistics
 ----------
 
 CDS has a :ref:`statistics <subscription_statistics>` tree rooted at *cluster_manager.cds.*
+
+On-demand CDS
+-----------------------------------
+
+Similar to VHDS on-demand feature in terms of hosts, the on-demand CDS API is an additional API
+that Envoy will call to dynamically fetch upstream clusters which Envoy interested in spontaneously.
+
+By default in CDS, all cluster configurations are sent to every Envoy instance in the mesh. The
+delta CDS provides the ability that the control panel can send incremental CDS to the Envoy instance,
+but Envoy instance can not feedback upstream clusters it interested in spontaneously, in other
+words, Envoy instance only can receive the CDS passively.
+
+In order to fix this issue, on-demand CDS uses the delta xDS protocol to allow a cluster configuration
+to be subscribed to and the necessary cluster configuration to be requested as needed. Instead
+of sending all cluster configuration or cluster configuration the Envoy instance aren't interested
+in, using on-demand CDS will allow an Envoy instance to subscribe and unsubscribe from a list of
+cluster configurations stored internally in the xDS management server. The xDS management server
+will monitor the list and use it to filter the configuration sent to an individual Envoy instance
+to only contain the subscribed cluster configurations.
+
+Subscribing to resources
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+On-demand CDS allows resources to be :ref:`subscribed <xds_protocol_delta_subscribe>` to using
+a :ref:`DeltaDiscoveryRequest <envoy_api_msg_DeltaDiscoveryRequest>`
+with the :ref:`type_url <envoy_api_field_DeltaDiscoveryRequest.type_url>` set to
+`type.googleapis.com/envoy.api.v2.Cluster` and
+:ref:`resource_names_subscribe <envoy_api_field_DeltaDiscoveryRequest.resource_names_subscribe>`
+set to a list of cluster resource names for which it would like configuration.
+
+Typical use case
+^^^^^^^^^^^^^^^^
+
+Sometimes, there will be a large amount of broker instances provided for
+`Apache RocketMQ <http://rocketmq.apache.org/>`_ to produce/consume messages. Perhaps the size of
+SToW CDS configurations will be more than 1GB, so it is not practical to deliver the SToW CDS from the
+control panel every time, which will cause huge overhead. In this case, on-demand CDS is essential.

--- a/docs/root/configuration/upstream/cluster_manager/cds.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cds.rst
@@ -26,9 +26,9 @@ Similar to VHDS on-demand feature in terms of hosts, the on-demand CDS API is an
 that Envoy will call to dynamically fetch upstream clusters which Envoy interested in spontaneously.
 
 By default in CDS, all cluster configurations are sent to every Envoy instance in the mesh. The
-delta CDS provides the ability that the control panel can send incremental CDS to the Envoy instance,
-but Envoy instance can not feedback upstream clusters it interested in spontaneously, in other
-words, Envoy instance only can receive the CDS passively.
+delta CDS provides the ability that the xDS management server can send incremental CDS to the Envoy
+instance, but Envoy instance can not feedback upstream clusters it interested in spontaneously, in
+other words, Envoy instance only can receive the CDS passively.
 
 In order to fix this issue, on-demand CDS uses the delta xDS protocol to allow a cluster configuration
 to be subscribed to and the necessary cluster configuration to be requested as needed. Instead
@@ -54,4 +54,4 @@ Typical use case
 Sometimes, there will be a large amount of broker instances provided for
 `Apache RocketMQ <http://rocketmq.apache.org/>`_ to produce/consume messages. Perhaps the size of
 SToW CDS configurations will be more than 1GB, so it is not practical to deliver the SToW CDS from the
-control panel every time, which will cause huge overhead. In this case, on-demand CDS is essential.
+management server every time, which will cause huge overhead. In this case, on-demand CDS is essential.

--- a/docs/root/configuration/upstream/cluster_manager/cds.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cds.rst
@@ -20,7 +20,7 @@ Statistics
 CDS has a :ref:`statistics <subscription_statistics>` tree rooted at *cluster_manager.cds.*
 
 On-demand CDS
------------------------------------
+-------------
 
 Similar to VHDS on-demand feature in terms of hosts, the on-demand CDS API is an additional API
 that Envoy will call to dynamically fetch upstream clusters which Envoy interested in spontaneously.

--- a/include/envoy/config/grpc_mux.h
+++ b/include/envoy/config/grpc_mux.h
@@ -127,8 +127,7 @@ public:
                                   std::chrono::milliseconds init_fetch_timeout) PURE;
 
   /**
-   * The only difference between addToWatch() and addOrUpdateWatch() is that the 'resources' here
-   * means the *extra* resources we interested in.
+   * Adds additional resources to the watch. Unlike addOrUpdateWatch, it never removes resources.
    */
   virtual Watch* addToWatch(const std::string& type_url, Watch* watch,
                             const std::set<std::string>& resources,

--- a/include/envoy/config/grpc_mux.h
+++ b/include/envoy/config/grpc_mux.h
@@ -125,6 +125,16 @@ public:
                                   const std::set<std::string>& resources,
                                   SubscriptionCallbacks& callbacks,
                                   std::chrono::milliseconds init_fetch_timeout) PURE;
+
+  /**
+   * The only difference between addToWatch() and addOrUpdateWatch() is that the 'resources' here
+   * means the *extra* resources we interested in.
+   */
+  virtual Watch* addToWatch(const std::string& type_url, Watch* watch,
+                            const std::set<std::string>& resources,
+                            SubscriptionCallbacks& callbacks,
+                            std::chrono::milliseconds init_fetch_timeout) PURE;
+
   virtual void removeWatch(const std::string& type_url, Watch* watch) PURE;
 
   /**

--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -90,6 +90,12 @@ public:
    * be passed to std::set_difference, which must be given sorted collections.
    */
   virtual void updateResourceInterest(const std::set<std::string>& update_to_these_names) PURE;
+
+  /**
+   * Add the resources to fetch.
+   * @param resources vector of resource names to fetch.
+   */
+  virtual void addToResourceInterest(const std::set<std::string>&){};
 };
 
 using SubscriptionPtr = std::unique_ptr<Subscription>;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -257,11 +257,6 @@ public:
   virtual const std::string versionInfo() const PURE;
 
   /**
-   * Update watch set of cluster resources interested.
-   */
-  virtual void updateClusterInterest(const std::set<std::string>& update_to_these_names) PURE;
-
-  /**
    * Add watch set of cluster resources interested.
    */
   virtual void addToClusterInterest(const std::set<std::string>& add_these_names) PURE;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -227,6 +227,10 @@ public:
    * @return Config::SubscriptionFactory& the subscription factory.
    */
   virtual Config::SubscriptionFactory& subscriptionFactory() PURE;
+
+  virtual void updateClusterInterest(const std::set<std::string>& update_to_these_names) PURE;
+
+  virtual void addToClusterInterest(const std::set<std::string>& add_these_names) PURE;
 };
 
 using ClusterManagerPtr = std::unique_ptr<ClusterManager>;
@@ -253,6 +257,16 @@ public:
    * @return std::string last accepted version from fetch.
    */
   virtual const std::string versionInfo() const PURE;
+
+  /**
+   * Update watch set of cluster resources interested.
+   */
+  virtual void updateClusterInterest(const std::set<std::string>& update_to_these_names) PURE;
+
+  /**
+   * Add watch set of cluster resources interested.
+   */
+  virtual void addToClusterInterest(const std::set<std::string>& add_these_names) PURE;
 };
 
 using CdsApiPtr = std::unique_ptr<CdsApi>;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -228,8 +228,6 @@ public:
    */
   virtual Config::SubscriptionFactory& subscriptionFactory() PURE;
 
-  virtual void updateClusterInterest(const std::set<std::string>& update_to_these_names) PURE;
-
   virtual void addToClusterInterest(const std::set<std::string>& add_these_names) PURE;
 };
 

--- a/source/common/config/delta_subscription_impl.cc
+++ b/source/common/config/delta_subscription_impl.cc
@@ -41,6 +41,11 @@ void DeltaSubscriptionImpl::updateResourceInterest(
   stats_.update_attempt_.inc();
 }
 
+void DeltaSubscriptionImpl::addToResourceInterest(const std::set<std::string>& add_these_names) {
+  watch_ = context_->addToWatch(type_url_, watch_, add_these_names, *this, init_fetch_timeout_);
+  stats_.update_attempt_.inc();
+}
+
 // Config::SubscriptionCallbacks
 void DeltaSubscriptionImpl::onConfigUpdate(
     const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,

--- a/source/common/config/delta_subscription_impl.h
+++ b/source/common/config/delta_subscription_impl.h
@@ -45,6 +45,7 @@ public:
   void start(const std::set<std::string>& resource_names) override;
 
   void updateResourceInterest(const std::set<std::string>& update_to_these_names) override;
+  void addToResourceInterest(const std::set<std::string>& add_these_names) override;
 
   // Config::SubscriptionCallbacks (all pass through to callbacks_!)
   void onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -50,6 +50,11 @@ public:
                           SubscriptionCallbacks&, std::chrono::milliseconds) override {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
+
+  Watch* addToWatch(const std::string&, Watch*, const std::set<std::string>&,
+                    SubscriptionCallbacks&, std::chrono::milliseconds) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   void removeWatch(const std::string&, Watch*) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
   void handleDiscoveryResponse(
@@ -154,6 +159,10 @@ public:
 
   Watch* addOrUpdateWatch(const std::string&, Watch*, const std::set<std::string>&,
                           SubscriptionCallbacks&, std::chrono::milliseconds) override {
+    throw EnvoyException("ADS must be configured to support an ADS config source");
+  }
+  Watch* addToWatch(const std::string&, Watch*, const std::set<std::string>&,
+                    SubscriptionCallbacks&, std::chrono::milliseconds) override {
     throw EnvoyException("ADS must be configured to support an ADS config source");
   }
   void removeWatch(const std::string&, Watch*) override {

--- a/source/common/config/new_grpc_mux_impl.cc
+++ b/source/common/config/new_grpc_mux_impl.cc
@@ -75,8 +75,9 @@ void NewGrpcMuxImpl::onDiscoveryResponse(
             message->system_version_info());
   auto sub = subscriptions_.find(message->type_url());
   if (sub == subscriptions_.end()) {
-    ENVOY_LOG(warn, "Dropping received DeltaDiscoveryResponse (with version {}) for non-existent "
-                    "subscription {}.",
+    ENVOY_LOG(warn,
+              "Dropping received DeltaDiscoveryResponse (with version {}) for non-existent "
+              "subscription {}.",
               message->system_version_info(), message->type_url());
     return;
   }

--- a/source/common/config/new_grpc_mux_impl.h
+++ b/source/common/config/new_grpc_mux_impl.h
@@ -37,6 +37,11 @@ public:
   Watch* addOrUpdateWatch(const std::string& type_url, Watch* watch,
                           const std::set<std::string>& resources, SubscriptionCallbacks& callbacks,
                           std::chrono::milliseconds init_fetch_timeout) override;
+
+  Watch* addToWatch(const std::string& type_url, Watch* watch,
+                    const std::set<std::string>& resources, SubscriptionCallbacks& callbacks,
+                    std::chrono::milliseconds init_fetch_timeout) override;
+
   void removeWatch(const std::string& type_url, Watch* watch) override;
 
   // TODO(fredlas) PR #8478 will remove this.
@@ -81,8 +86,11 @@ public:
   }
 
 private:
-  Watch* addWatch(const std::string& type_url, const std::set<std::string>& resources,
-                  SubscriptionCallbacks& callbacks, std::chrono::milliseconds init_fetch_timeout);
+  Watch* addWatch(const std::string& type_url, SubscriptionCallbacks& callbacks,
+                  std::chrono::milliseconds init_fetch_timeout);
+
+  void addToWatch(const std::string& type_url, Watch* watch,
+                  const std::set<std::string>& resources);
 
   // Updates the list of resource names watched by the given watch. If an added name is new across
   // the whole subscription, or if a removed name has no other watch interested in it, then the

--- a/source/common/config/watch_map.cc
+++ b/source/common/config/watch_map.cc
@@ -45,12 +45,10 @@ AddedRemoved WatchMap::updateWatchInterest(Watch* watch,
 AddedRemoved WatchMap::addToWatchInterest(Watch* watch,
                                           const std::set<std::string>& add_these_names) {
   std::vector<std::string> newly_added_to_watch(add_these_names.begin(), add_these_names.end());
-  std::vector<std::string> newly_removed_from_watch;
   watch->resource_names_.insert(add_these_names.begin(), add_these_names.end());
-  std::set<std::string> additions = add_these_names;
+  std::set<std::string> removals;
 
-  return AddedRemoved(findAdditions(newly_added_to_watch, watch),
-                      findRemovals(newly_removed_from_watch, watch));
+  return AddedRemoved(findAdditions(newly_added_to_watch, watch), std::move(removals));
 }
 
 absl::flat_hash_set<Watch*> WatchMap::watchesInterestedIn(const std::string& resource_name) {

--- a/source/common/config/watch_map.cc
+++ b/source/common/config/watch_map.cc
@@ -42,6 +42,17 @@ AddedRemoved WatchMap::updateWatchInterest(Watch* watch,
                       findRemovals(newly_removed_from_watch, watch));
 }
 
+AddedRemoved WatchMap::addToWatchInterest(Watch* watch,
+                                          const std::set<std::string>& add_these_names) {
+  std::vector<std::string> newly_added_to_watch(add_these_names.begin(), add_these_names.end());
+  std::vector<std::string> newly_removed_from_watch;
+  watch->resource_names_.insert(add_these_names.begin(), add_these_names.end());
+  std::set<std::string> additions = add_these_names;
+
+  return AddedRemoved(findAdditions(newly_added_to_watch, watch),
+                      findRemovals(newly_removed_from_watch, watch));
+}
+
 absl::flat_hash_set<Watch*> WatchMap::watchesInterestedIn(const std::string& resource_name) {
   absl::flat_hash_set<Watch*> ret = wildcard_watches_;
   const auto watches_interested = watch_interest_.find(resource_name);

--- a/source/common/config/watch_map.h
+++ b/source/common/config/watch_map.h
@@ -73,6 +73,9 @@ public:
   AddedRemoved updateWatchInterest(Watch* watch,
                                    const std::set<std::string>& update_to_these_names);
 
+  // Adds the extra set of resource names that the given watch should watch.
+  AddedRemoved addToWatchInterest(Watch* watch, const std::set<std::string>& add_these_names);
+
   // Expects that the watch to be removed has already had all of its resource names removed via
   // updateWatchInterest().
   void removeWatch(Watch* watch);

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -35,6 +35,14 @@ public:
   }
   const std::string versionInfo() const override { return system_version_info_; }
 
+  void updateClusterInterest(const std::set<std::string>& update_to_these_names) override {
+    subscription_->updateResourceInterest(update_to_these_names);
+  }
+
+  void addToClusterInterest(const std::set<std::string>& add_these_names) override {
+    subscription_->addToResourceInterest(add_these_names);
+  }
+
 private:
   // Config::SubscriptionCallbacks
   void onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources,

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -35,10 +35,6 @@ public:
   }
   const std::string versionInfo() const override { return system_version_info_; }
 
-  void updateClusterInterest(const std::set<std::string>& update_to_these_names) override {
-    subscription_->updateResourceInterest(update_to_these_names);
-  }
-
   void addToClusterInterest(const std::set<std::string>& add_these_names) override {
     subscription_->addToResourceInterest(add_these_names);
   }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -243,10 +243,6 @@ public:
 
   Config::SubscriptionFactory& subscriptionFactory() override { return subscription_factory_; }
 
-  void updateClusterInterest(const std::set<std::string>& update_to_these_names) override {
-    cds_api_->updateClusterInterest(update_to_these_names);
-  }
-
   void addToClusterInterest(const std::set<std::string>& add_these_names) override {
     cds_api_->addToClusterInterest(add_these_names);
   }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -243,6 +243,14 @@ public:
 
   Config::SubscriptionFactory& subscriptionFactory() override { return subscription_factory_; }
 
+  void updateClusterInterest(const std::set<std::string>& update_to_these_names) override {
+    cds_api_->updateClusterInterest(update_to_these_names);
+  }
+
+  void addToClusterInterest(const std::set<std::string>& add_these_names) override {
+    cds_api_->addToClusterInterest(add_these_names);
+  }
+
 protected:
   virtual void postThreadLocalDrainConnections(const Cluster& cluster,
                                                const HostVector& hosts_removed);

--- a/test/common/config/delta_subscription_impl_test.cc
+++ b/test/common/config/delta_subscription_impl_test.cc
@@ -56,6 +56,12 @@ TEST_F(DeltaSubscriptionImplTest, PauseHoldsRequest) {
   subscription_->resume();
 }
 
+TEST_F(DeltaSubscriptionImplTest, AddResourceCauseRequest) {
+  startSubscription({});
+  expectSendMessage({"name1", "name2"}, {}, Grpc::Status::WellKnownGrpcStatus::Ok, "", {});
+  subscription_->addToResourceInterest({"name1", "name2"});
+}
+
 TEST_F(DeltaSubscriptionImplTest, ResponseCausesAck) {
   startSubscription({"name1"});
   deliverConfigUpdate({"name1"}, "someversion", true);

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -99,6 +99,9 @@ public:
   MOCK_METHOD(Watch*, addOrUpdateWatch,
               (const std::string& type_url, Watch* watch, const std::set<std::string>& resources,
                SubscriptionCallbacks& callbacks, std::chrono::milliseconds init_fetch_timeout));
+  MOCK_METHOD(Watch*, addToWatch,
+              (const std::string& type_url, Watch* watch, const std::set<std::string>& resources,
+               SubscriptionCallbacks& callbacks, std::chrono::milliseconds init_fetch_timeout));
   MOCK_METHOD(void, removeWatch, (const std::string& type_url, Watch* watch));
 };
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -330,6 +330,7 @@ public:
   MOCK_METHOD(ClusterUpdateCallbacksHandle*, addThreadLocalClusterUpdateCallbacks_,
               (ClusterUpdateCallbacks & callbacks));
   MOCK_METHOD(Config::SubscriptionFactory&, subscriptionFactory, ());
+  MOCK_METHOD(void, addToClusterInterest, (const std::set<std::string>&));
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;
@@ -385,6 +386,7 @@ public:
   MOCK_METHOD(void, initialize, ());
   MOCK_METHOD(void, setInitializedCb, (std::function<void()> callback));
   MOCK_METHOD(const std::string, versionInfo, (), (const));
+  MOCK_METHOD(void, addToClusterInterest, (const std::set<std::string>&));
 
   std::function<void()> initialized_callback_;
 };


### PR DESCRIPTION
Signed-off-by: aaron-ai <yangkun.ayk@alibaba-inc.com>

Description: Apache RocketMQ needs the ability of on-demand CDS #9503 , so we split this part as an independent PR, this PR allows user can start a spontaneous DeltaDiscoveryRequests for CDS (AKA on-demand cds) by using addToClusterInterest in cluster_manager. 
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]: #9431 
