### PR TITLE
build: Fix name conflict in files generated from semantic_version.proto

### DIFF
--- a/api/envoy/type/semantic_version.proto
+++ b/api/envoy/type/semantic_version.proto
@@ -12,9 +12,9 @@ option java_multiple_files = true;
 // expected behaviors and APIs, the patch version field is used only
 // for security fixes and can be generally ignored.
 message SemanticVersion {
-  uint32 major = 1;
+  uint32 major_number = 1;
 
-  uint32 minor = 2;
+  uint32 minor_number = 2;
 
   uint32 patch = 3;
 }

--- a/api/envoy/type/v3alpha/semantic_version.proto
+++ b/api/envoy/type/v3alpha/semantic_version.proto
@@ -16,9 +16,9 @@ option java_multiple_files = true;
 message SemanticVersion {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.SemanticVersion";
 
-  uint32 major = 1;
+  uint32 major_number = 1;
 
-  uint32 minor = 2;
+  uint32 minor_number = 2;
 
   uint32 patch = 3;
 }

--- a/generated_api_shadow/envoy/type/semantic_version.proto
+++ b/generated_api_shadow/envoy/type/semantic_version.proto
@@ -12,9 +12,9 @@ option java_multiple_files = true;
 // expected behaviors and APIs, the patch version field is used only
 // for security fixes and can be generally ignored.
 message SemanticVersion {
-  uint32 major = 1;
+  uint32 major_number = 1;
 
-  uint32 minor = 2;
+  uint32 minor_number = 2;
 
   uint32 patch = 3;
 }

--- a/generated_api_shadow/envoy/type/v3alpha/semantic_version.proto
+++ b/generated_api_shadow/envoy/type/v3alpha/semantic_version.proto
@@ -16,9 +16,9 @@ option java_multiple_files = true;
 message SemanticVersion {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.SemanticVersion";
 
-  uint32 major = 1;
+  uint32 major_number = 1;
 
-  uint32 minor = 2;
+  uint32 minor_number = 2;
 
   uint32 patch = 3;
 }

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -426,8 +426,8 @@ private:
   makeBuildVersion(uint32_t major, uint32_t minor, uint32_t patch,
                    const std::map<std::string, std::string>& metadata) {
     envoy::config::core::v3alpha::BuildVersion version;
-    version.mutable_version()->set_major(major);
-    version.mutable_version()->set_minor(minor);
+    version.mutable_version()->set_major_number(major);
+    version.mutable_version()->set_minor_number(minor);
     version.mutable_version()->set_patch(patch);
     *version.mutable_metadata() = MessageUtil::keyValueStruct(metadata);
     return version;

--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -68,10 +68,10 @@ envoy::config::core::v3alpha::BuildVersion VersionInfo::makeBuildVersion(const c
   if (std::regex_match(version, match, ver_regex)) {
     int value = 0;
     if (absl::SimpleAtoi(match.str(major), &value)) {
-      result.mutable_version()->set_major(value);
+      result.mutable_version()->set_major_number(value);
     }
     if (absl::SimpleAtoi(match.str(minor), &value)) {
-      result.mutable_version()->set_minor(value);
+      result.mutable_version()->set_minor_number(value);
     }
     if (absl::SimpleAtoi(match.str(patch), &value)) {
       result.mutable_version()->set_patch(value);

--- a/test/common/common/version_test.cc
+++ b/test/common/common/version_test.cc
@@ -19,8 +19,8 @@ public:
 TEST(VersionTest, BuildVersion) {
   auto build_version = VersionInfo::buildVersion();
   std::string version_string =
-      absl::StrCat(build_version.version().major(), ".", build_version.version().minor(), ".",
-                   build_version.version().patch());
+      absl::StrCat(build_version.version().major_number(), ".",
+                   build_version.version().minor_number(), ".", build_version.version().patch());
 
   const auto& fields = build_version.metadata().fields();
   if (fields.find(BuildVersionMetadataKeys::get().BuildLabel) != fields.end()) {
@@ -40,8 +40,8 @@ TEST(VersionTest, BuildVersion) {
 
 TEST(VersionTest, MakeBuildVersionWithLabel) {
   auto build_version = VersionInfoTestPeer::makeBuildVersion("1.2.3-foo-bar");
-  EXPECT_EQ(1, build_version.version().major());
-  EXPECT_EQ(2, build_version.version().minor());
+  EXPECT_EQ(1, build_version.version().major_number());
+  EXPECT_EQ(2, build_version.version().minor_number());
   EXPECT_EQ(3, build_version.version().patch());
   const auto& fields = build_version.metadata().fields();
   EXPECT_GE(fields.size(), 1);
@@ -50,8 +50,8 @@ TEST(VersionTest, MakeBuildVersionWithLabel) {
 
 TEST(VersionTest, MakeBuildVersionWithoutLabel) {
   auto build_version = VersionInfoTestPeer::makeBuildVersion("1.2.3");
-  EXPECT_EQ(1, build_version.version().major());
-  EXPECT_EQ(2, build_version.version().minor());
+  EXPECT_EQ(1, build_version.version().major_number());
+  EXPECT_EQ(2, build_version.version().minor_number());
   EXPECT_EQ(3, build_version.version().patch());
   const auto& fields = build_version.metadata().fields();
   EXPECT_EQ(fields.find(BuildVersionMetadataKeys::get().BuildLabel), fields.end());
@@ -61,8 +61,8 @@ TEST(VersionTest, MakeBuildVersionWithoutLabel) {
 
 TEST(VersionTest, MakeBadBuildVersion) {
   auto build_version = VersionInfoTestPeer::makeBuildVersion("1.foo.3-bar");
-  EXPECT_EQ(0, build_version.version().major());
-  EXPECT_EQ(0, build_version.version().minor());
+  EXPECT_EQ(0, build_version.version().major_number());
+  EXPECT_EQ(0, build_version.version().minor_number());
   EXPECT_EQ(0, build_version.version().patch());
   const auto& fields = build_version.metadata().fields();
   EXPECT_EQ(fields.find(BuildVersionMetadataKeys::get().BuildLabel), fields.end());

--- a/test/common/config/registry_test.cc
+++ b/test/common/config/registry_test.cc
@@ -129,8 +129,8 @@ TEST(RegistryTest, VersionedFactory) {
   auto version =
       factories.find("testing.published")->second->getFactoryVersion("testing.published.versioned");
   EXPECT_TRUE(version.has_value());
-  EXPECT_EQ(2, version.value().version().major());
-  EXPECT_EQ(5, version.value().version().minor());
+  EXPECT_EQ(2, version.value().version().major_number());
+  EXPECT_EQ(5, version.value().version().minor_number());
   EXPECT_EQ(39, version.value().version().patch());
   EXPECT_EQ(1, version.value().metadata().fields().size());
   EXPECT_EQ("alpha", version.value().metadata().fields().at("build.label").string_value());
@@ -162,8 +162,8 @@ TEST(RegistryTest, VersionedWithDeprecatednamesFactory) {
   auto version = factories.find("testing.published")
                      ->second->getFactoryVersion("testing.published.versioned.instead_name");
   EXPECT_TRUE(version.has_value());
-  EXPECT_EQ(0, version.value().version().major());
-  EXPECT_EQ(0, version.value().version().minor());
+  EXPECT_EQ(0, version.value().version().major_number());
+  EXPECT_EQ(0, version.value().version().minor_number());
   EXPECT_EQ(1, version.value().version().patch());
   EXPECT_EQ(1, version.value().metadata().fields().size());
   EXPECT_EQ("private", version.value().metadata().fields().at("build.kind").string_value());

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -219,8 +219,8 @@ protected:
 
   void expectCorrectBuildVersion(const envoy::config::core::v3alpha::BuildVersion& build_version) {
     std::string version_string =
-        absl::StrCat(build_version.version().major(), ".", build_version.version().minor(), ".",
-                     build_version.version().patch());
+        absl::StrCat(build_version.version().major_number(), ".",
+                     build_version.version().minor_number(), ".", build_version.version().patch());
     const auto& fields = build_version.metadata().fields();
     if (fields.find(BuildVersionMetadataKeys::get().BuildLabel) != fields.end()) {
       absl::StrAppend(&version_string, "-",


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

Description: Fix name conflict in files generated from semantic_version.proto
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] #9630 
