### PR TITLE
config: flipping deprecated configs fatal by default

### DIFF
--- a/api/envoy/api/v2/cluster.proto
+++ b/api/envoy/api/v2/cluster.proto
@@ -19,6 +19,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -90,7 +91,7 @@ message Cluster {
     //
     //   **This load balancing policy is deprecated**. Use CLUSTER_PROVIDED instead.
     //
-    ORIGINAL_DST_LB = 4 [deprecated = true];
+    ORIGINAL_DST_LB = 4 [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
     // for an explanation.
@@ -590,7 +591,8 @@ message Cluster {
   //
   //   **This field is deprecated**. Use `transport_socket` with name `tls` instead. If both are
   //   set, `transport_socket` takes priority.
-  auth.UpstreamTlsContext tls_context = 11 [deprecated = true];
+  auth.UpstreamTlsContext tls_context = 11
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // HTTP protocol options that are applied only to upstream HTTP connections.
   // These options apply to all HTTP versions.
@@ -615,7 +617,8 @@ message Cluster {
   // for upstream connections. The key should match the extension filter name, such as
   // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
   // specific options.
-  map<string, google.protobuf.Struct> extension_protocol_options = 35 [deprecated = true];
+  map<string, google.protobuf.Struct> extension_protocol_options = 35
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // The extension_protocol_options field is used to provide extension-specific protocol options
   // for upstream connections. The key should match the extension filter name, such as

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -12,6 +12,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -107,7 +108,7 @@ message HealthCheck {
     // If set, health checks will be made using http/2.
     // Deprecated, use :ref:`codec_client_type
     // <envoy_api_field_core.HealthCheck.HttpHealthCheck.codec_client_type>` instead.
-    bool use_http2 = 7 [deprecated = true];
+    bool use_http2 = 7 [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
     // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open

--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -384,7 +384,11 @@ message RouteMatch {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
     //   untrusted input in all cases.
-    string regex = 3 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string regex = 3 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // If specified, the route is a regular expression rule meaning that the
     // regex must match the *:path* header once the query string is removed. The entire path
@@ -457,7 +461,8 @@ message CorsPolicy {
   //
   // .. attention::
   //  This field has been deprecated in favor of `allow_origin_string_match`.
-  repeated string allow_origin = 1 [deprecated = true];
+  repeated string allow_origin = 1
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // Specifies regex patterns that match allowed origins.
   //
@@ -1177,7 +1182,11 @@ message VirtualCluster {
   // .. attention::
   //   This field has been deprecated in favor of `headers` as it is not safe for use with
   //   untrusted input in all cases.
-  string pattern = 1 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+  string pattern = 1 [
+    deprecated = true,
+    (validate.rules).string = {max_bytes: 1024},
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Specifies a list of header matchers to use for matching requests. Each specified header must
   // match. The pseudo-headers `:path` and `:method` can be used to match the request path and
@@ -1194,7 +1203,8 @@ message VirtualCluster {
   //
   // .. attention::
   //   This field has been deprecated in favor of `headers`.
-  core.RequestMethod method = 3 [deprecated = true];
+  core.RequestMethod method = 3
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 }
 
 // Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`.
@@ -1382,7 +1392,11 @@ message HeaderMatcher {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex_match` as it is not safe for use
     //   with untrusted input in all cases.
-    string regex_match = 5 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string regex_match = 5 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // If specified, this regex string is a regular expression rule which implies the entire request
     // header value must match the regex. The rule will not match if only a subsequence of the
@@ -1446,7 +1460,7 @@ message QueryParameterMatcher {
   //
   // ..attention::
   //   This field is deprecated. Use an `exact` match inside the `string_match` field.
-  string value = 3 [deprecated = true];
+  string value = 3 [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // Specifies whether the query parameter value is a regular expression.
   // Defaults to false. The entire query parameter value (i.e., the part to
@@ -1455,7 +1469,8 @@ message QueryParameterMatcher {
   //
   // ..attention::
   //   This field is deprecated. Use a `safe_regex` match inside the `string_match` field.
-  google.protobuf.BoolValue regex = 4 [deprecated = true];
+  google.protobuf.BoolValue regex = 4
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   oneof query_parameter_match_specifier {
     // Specifies whether a query parameter value should match against a string.

--- a/api/envoy/config/cluster/v3alpha/BUILD
+++ b/api/envoy/config/cluster/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/cluster:pkg",
         "//envoy/config/core/v3alpha:pkg",

--- a/api/envoy/config/cluster/v3alpha/cluster.proto
+++ b/api/envoy/config/cluster/v3alpha/cluster.proto
@@ -20,6 +20,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.cluster.v3alpha";

--- a/api/envoy/config/core/v3alpha/health_check.proto
+++ b/api/envoy/config/core/v3alpha/health_check.proto
@@ -14,6 +14,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v3alpha";

--- a/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/core:pkg",
         "//envoy/config/filter/accesslog/v2:pkg",

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -15,6 +15,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -104,8 +105,11 @@ message HttpConnectionManager {
     //
     // .. attention::
     //  This field has been deprecated in favor of `traffic_direction`.
-    OperationName operation_name = 1
-        [deprecated = true, (validate.rules).enum = {defined_only: true}];
+    OperationName operation_name = 1 [
+      deprecated = true,
+      (validate.rules).enum = {defined_only: true},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // A list of header names used to create tags for the active span. The header name is used to
     // populate the tag name, and the header value is used to populate the tag value. The tag is
@@ -293,7 +297,8 @@ message HttpConnectionManager {
   // This field is deprecated. Use :ref:`idle_timeout
   // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
   // instead.
-  google.protobuf.Duration idle_timeout = 11 [deprecated = true];
+  google.protobuf.Duration idle_timeout = 11
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected

--- a/api/envoy/config/trace/v2/BUILD
+++ b/api/envoy/config/trace/v2/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2/core:pkg",
         "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto",
     ],

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -10,6 +10,7 @@ import "google/protobuf/wrappers.proto";
 
 import "opencensus/proto/trace/v1/trace_config.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
@@ -81,7 +82,7 @@ message ZipkinConfig {
     // Hence the motivation of adding HTTP_JSON_V1 as the default is to avoid a breaking change when
     // user upgrading Envoy with this change. Furthermore, we also immediately deprecate this field,
     // since in Zipkin realm this v1 version is considered to be not preferable anymore.]
-    HTTP_JSON_V1 = 0 [deprecated = true];
+    HTTP_JSON_V1 = 0 [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Zipkin API v2, JSON over HTTP.
     HTTP_JSON = 1;

--- a/api/envoy/config/trace/v3alpha/BUILD
+++ b/api/envoy/config/trace/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3alpha:pkg",
         "//envoy/config/trace/v2:pkg",
         "//envoy/config/trace/v2alpha:pkg",

--- a/api/envoy/config/trace/v3alpha/trace.proto
+++ b/api/envoy/config/trace/v3alpha/trace.proto
@@ -11,6 +11,7 @@ import "google/protobuf/wrappers.proto";
 import "opencensus/proto/trace/v1/trace_config.proto";
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3alpha";
@@ -94,7 +95,8 @@ message ZipkinConfig {
     // Hence the motivation of adding HTTP_JSON_V1 as the default is to avoid a breaking change when
     // user upgrading Envoy with this change. Furthermore, we also immediately deprecate this field,
     // since in Zipkin realm this v1 version is considered to be not preferable anymore.]
-    DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE = 0 [deprecated = true];
+    DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE = 0
+        [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Zipkin API v2, JSON over HTTP.
     HTTP_JSON = 1;

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3alpha/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v3alpha:pkg",
         "//envoy/config/core/v3alpha:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3alpha/http_connection_manager.proto
@@ -17,6 +17,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3alpha";

--- a/api/envoy/type/matcher/BUILD
+++ b/api/envoy/type/matcher/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["//envoy/type:pkg"],
+    deps = [
+        "//envoy/annotations:pkg",
+        "//envoy/type:pkg",
+    ],
 )

--- a/api/envoy/type/matcher/string.proto
+++ b/api/envoy/type/matcher/string.proto
@@ -4,6 +4,7 @@ package envoy.type.matcher;
 
 import "envoy/type/matcher/regex.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher";
@@ -54,7 +55,11 @@ message StringMatcher {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
     //   untrusted input in all cases.
-    string regex = 4 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string regex = 4 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];

--- a/api/envoy/type/matcher/v3alpha/BUILD
+++ b/api/envoy/type/matcher/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/type/matcher:pkg",
         "//envoy/type/v3alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/type/matcher/v3alpha/string.proto
+++ b/api/envoy/type/matcher/v3alpha/string.proto
@@ -6,6 +6,7 @@ import "envoy/type/matcher/v3alpha/regex.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher.v3alpha";

--- a/generated_api_shadow/envoy/api/v2/cluster.proto
+++ b/generated_api_shadow/envoy/api/v2/cluster.proto
@@ -19,6 +19,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -90,7 +91,7 @@ message Cluster {
     //
     //   **This load balancing policy is deprecated**. Use CLUSTER_PROVIDED instead.
     //
-    ORIGINAL_DST_LB = 4 [deprecated = true];
+    ORIGINAL_DST_LB = 4 [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
     // for an explanation.
@@ -590,7 +591,8 @@ message Cluster {
   //
   //   **This field is deprecated**. Use `transport_socket` with name `tls` instead. If both are
   //   set, `transport_socket` takes priority.
-  auth.UpstreamTlsContext tls_context = 11 [deprecated = true];
+  auth.UpstreamTlsContext tls_context = 11
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // HTTP protocol options that are applied only to upstream HTTP connections.
   // These options apply to all HTTP versions.
@@ -615,7 +617,8 @@ message Cluster {
   // for upstream connections. The key should match the extension filter name, such as
   // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
   // specific options.
-  map<string, google.protobuf.Struct> extension_protocol_options = 35 [deprecated = true];
+  map<string, google.protobuf.Struct> extension_protocol_options = 35
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // The extension_protocol_options field is used to provide extension-specific protocol options
   // for upstream connections. The key should match the extension filter name, such as

--- a/generated_api_shadow/envoy/api/v2/core/health_check.proto
+++ b/generated_api_shadow/envoy/api/v2/core/health_check.proto
@@ -12,6 +12,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -107,7 +108,7 @@ message HealthCheck {
     // If set, health checks will be made using http/2.
     // Deprecated, use :ref:`codec_client_type
     // <envoy_api_field_core.HealthCheck.HttpHealthCheck.codec_client_type>` instead.
-    bool use_http2 = 7 [deprecated = true];
+    bool use_http2 = 7 [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
     // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -384,7 +384,11 @@ message RouteMatch {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
     //   untrusted input in all cases.
-    string regex = 3 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string regex = 3 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // If specified, the route is a regular expression rule meaning that the
     // regex must match the *:path* header once the query string is removed. The entire path
@@ -457,7 +461,8 @@ message CorsPolicy {
   //
   // .. attention::
   //  This field has been deprecated in favor of `allow_origin_string_match`.
-  repeated string allow_origin = 1 [deprecated = true];
+  repeated string allow_origin = 1
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // Specifies regex patterns that match allowed origins.
   //
@@ -1177,7 +1182,11 @@ message VirtualCluster {
   // .. attention::
   //   This field has been deprecated in favor of `headers` as it is not safe for use with
   //   untrusted input in all cases.
-  string pattern = 1 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+  string pattern = 1 [
+    deprecated = true,
+    (validate.rules).string = {max_bytes: 1024},
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Specifies a list of header matchers to use for matching requests. Each specified header must
   // match. The pseudo-headers `:path` and `:method` can be used to match the request path and
@@ -1194,7 +1203,8 @@ message VirtualCluster {
   //
   // .. attention::
   //   This field has been deprecated in favor of `headers`.
-  core.RequestMethod method = 3 [deprecated = true];
+  core.RequestMethod method = 3
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 }
 
 // Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`.
@@ -1382,7 +1392,11 @@ message HeaderMatcher {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex_match` as it is not safe for use
     //   with untrusted input in all cases.
-    string regex_match = 5 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string regex_match = 5 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // If specified, this regex string is a regular expression rule which implies the entire request
     // header value must match the regex. The rule will not match if only a subsequence of the
@@ -1446,7 +1460,7 @@ message QueryParameterMatcher {
   //
   // ..attention::
   //   This field is deprecated. Use an `exact` match inside the `string_match` field.
-  string value = 3 [deprecated = true];
+  string value = 3 [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // Specifies whether the query parameter value is a regular expression.
   // Defaults to false. The entire query parameter value (i.e., the part to
@@ -1455,7 +1469,8 @@ message QueryParameterMatcher {
   //
   // ..attention::
   //   This field is deprecated. Use a `safe_regex` match inside the `string_match` field.
-  google.protobuf.BoolValue regex = 4 [deprecated = true];
+  google.protobuf.BoolValue regex = 4
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   oneof query_parameter_match_specifier {
     // Specifies whether a query parameter value should match against a string.

--- a/generated_api_shadow/envoy/config/cluster/v3alpha/BUILD
+++ b/generated_api_shadow/envoy/config/cluster/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/cluster:pkg",
         "//envoy/config/core/v3alpha:pkg",

--- a/generated_api_shadow/envoy/config/cluster/v3alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3alpha/cluster.proto
@@ -21,6 +21,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.cluster.v3alpha";
@@ -92,7 +93,8 @@ message Cluster {
     //
     //   **This load balancing policy is deprecated**. Use CLUSTER_PROVIDED instead.
     //
-    hidden_envoy_deprecated_ORIGINAL_DST_LB = 4 [deprecated = true];
+    hidden_envoy_deprecated_ORIGINAL_DST_LB = 4
+        [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
     // for an explanation.
@@ -639,7 +641,8 @@ message Cluster {
   //   **This field is deprecated**. Use `transport_socket` with name `tls` instead. If both are
   //   set, `transport_socket` takes priority.
   envoy.extensions.transport_sockets.tls.v3alpha.UpstreamTlsContext
-      hidden_envoy_deprecated_tls_context = 11 [deprecated = true];
+      hidden_envoy_deprecated_tls_context = 11
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // HTTP protocol options that are applied only to upstream HTTP connections.
   // These options apply to all HTTP versions.
@@ -665,7 +668,7 @@ message Cluster {
   // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
   // specific options.
   map<string, google.protobuf.Struct> hidden_envoy_deprecated_extension_protocol_options = 35
-      [deprecated = true];
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // The extension_protocol_options field is used to provide extension-specific protocol options
   // for upstream connections. The key should match the extension filter name, such as

--- a/generated_api_shadow/envoy/config/core/v3alpha/health_check.proto
+++ b/generated_api_shadow/envoy/config/core/v3alpha/health_check.proto
@@ -14,6 +14,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v3alpha";
@@ -115,7 +116,8 @@ message HealthCheck {
     // If set, health checks will be made using http/2.
     // Deprecated, use :ref:`codec_client_type
     // <envoy_api_field_config.core.v3alpha.HealthCheck.HttpHealthCheck.codec_client_type>` instead.
-    bool hidden_envoy_deprecated_use_http2 = 7 [deprecated = true];
+    bool hidden_envoy_deprecated_use_http2 = 7
+        [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
     // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open

--- a/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/core:pkg",
         "//envoy/config/filter/accesslog/v2:pkg",

--- a/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -15,6 +15,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "validate/validate.proto";
 
@@ -104,8 +105,11 @@ message HttpConnectionManager {
     //
     // .. attention::
     //  This field has been deprecated in favor of `traffic_direction`.
-    OperationName operation_name = 1
-        [deprecated = true, (validate.rules).enum = {defined_only: true}];
+    OperationName operation_name = 1 [
+      deprecated = true,
+      (validate.rules).enum = {defined_only: true},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // A list of header names used to create tags for the active span. The header name is used to
     // populate the tag name, and the header value is used to populate the tag value. The tag is
@@ -293,7 +297,8 @@ message HttpConnectionManager {
   // This field is deprecated. Use :ref:`idle_timeout
   // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
   // instead.
-  google.protobuf.Duration idle_timeout = 11 [deprecated = true];
+  google.protobuf.Duration idle_timeout = 11
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected

--- a/generated_api_shadow/envoy/config/route/v3alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3alpha/route_components.proto
@@ -407,8 +407,11 @@ message RouteMatch {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
     //   untrusted input in all cases.
-    string hidden_envoy_deprecated_regex = 3
-        [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string hidden_envoy_deprecated_regex = 3 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // If specified, the route is a regular expression rule meaning that the
     // regex must match the *:path* header once the query string is removed. The entire path
@@ -483,7 +486,8 @@ message CorsPolicy {
   //
   // .. attention::
   //  This field has been deprecated in favor of `allow_origin_string_match`.
-  repeated string hidden_envoy_deprecated_allow_origin = 1 [deprecated = true];
+  repeated string hidden_envoy_deprecated_allow_origin = 1
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // Specifies regex patterns that match allowed origins.
   //
@@ -1256,8 +1260,11 @@ message VirtualCluster {
   // .. attention::
   //   This field has been deprecated in favor of `headers` as it is not safe for use with
   //   untrusted input in all cases.
-  string hidden_envoy_deprecated_pattern = 1
-      [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+  string hidden_envoy_deprecated_pattern = 1 [
+    deprecated = true,
+    (validate.rules).string = {max_bytes: 1024},
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Specifies a list of header matchers to use for matching requests. Each specified header must
   // match. The pseudo-headers `:path` and `:method` can be used to match the request path and
@@ -1274,7 +1281,8 @@ message VirtualCluster {
   //
   // .. attention::
   //   This field has been deprecated in favor of `headers`.
-  core.v3alpha.RequestMethod hidden_envoy_deprecated_method = 3 [deprecated = true];
+  core.v3alpha.RequestMethod hidden_envoy_deprecated_method = 3
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 }
 
 // Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`.
@@ -1487,8 +1495,11 @@ message HeaderMatcher {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex_match` as it is not safe for use
     //   with untrusted input in all cases.
-    string hidden_envoy_deprecated_regex_match = 5
-        [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string hidden_envoy_deprecated_regex_match = 5 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // If specified, this regex string is a regular expression rule which implies the entire request
     // header value must match the regex. The rule will not match if only a subsequence of the
@@ -1555,7 +1566,8 @@ message QueryParameterMatcher {
   //
   // ..attention::
   //   This field is deprecated. Use an `exact` match inside the `string_match` field.
-  string hidden_envoy_deprecated_value = 3 [deprecated = true];
+  string hidden_envoy_deprecated_value = 3
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // Specifies whether the query parameter value is a regular expression.
   // Defaults to false. The entire query parameter value (i.e., the part to
@@ -1564,7 +1576,8 @@ message QueryParameterMatcher {
   //
   // ..attention::
   //   This field is deprecated. Use a `safe_regex` match inside the `string_match` field.
-  google.protobuf.BoolValue hidden_envoy_deprecated_regex = 4 [deprecated = true];
+  google.protobuf.BoolValue hidden_envoy_deprecated_regex = 4
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   oneof query_parameter_match_specifier {
     // Specifies whether a query parameter value should match against a string.

--- a/generated_api_shadow/envoy/config/trace/v2/BUILD
+++ b/generated_api_shadow/envoy/config/trace/v2/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2/core:pkg",
         "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto",
     ],

--- a/generated_api_shadow/envoy/config/trace/v2/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/trace.proto
@@ -10,6 +10,7 @@ import "google/protobuf/wrappers.proto";
 
 import "opencensus/proto/trace/v1/trace_config.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
@@ -81,7 +82,7 @@ message ZipkinConfig {
     // Hence the motivation of adding HTTP_JSON_V1 as the default is to avoid a breaking change when
     // user upgrading Envoy with this change. Furthermore, we also immediately deprecate this field,
     // since in Zipkin realm this v1 version is considered to be not preferable anymore.]
-    HTTP_JSON_V1 = 0 [deprecated = true];
+    HTTP_JSON_V1 = 0 [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Zipkin API v2, JSON over HTTP.
     HTTP_JSON = 1;

--- a/generated_api_shadow/envoy/config/trace/v3alpha/BUILD
+++ b/generated_api_shadow/envoy/config/trace/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3alpha:pkg",
         "//envoy/config/trace/v2:pkg",
         "//envoy/config/trace/v2alpha:pkg",

--- a/generated_api_shadow/envoy/config/trace/v3alpha/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v3alpha/trace.proto
@@ -11,6 +11,7 @@ import "google/protobuf/wrappers.proto";
 import "opencensus/proto/trace/v1/trace_config.proto";
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3alpha";
@@ -92,7 +93,8 @@ message ZipkinConfig {
     // Hence the motivation of adding HTTP_JSON_V1 as the default is to avoid a breaking change when
     // user upgrading Envoy with this change. Furthermore, we also immediately deprecate this field,
     // since in Zipkin realm this v1 version is considered to be not preferable anymore.]
-    hidden_envoy_deprecated_HTTP_JSON_V1 = 0 [deprecated = true];
+    hidden_envoy_deprecated_HTTP_JSON_V1 = 0
+        [deprecated = true, (envoy.annotations.disallowed_by_default_enum) = true];
 
     // Zipkin API v2, JSON over HTTP.
     HTTP_JSON = 1;

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v3alpha:pkg",
         "//envoy/config/core/v3alpha:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3alpha/http_connection_manager.proto
@@ -17,6 +17,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3alpha";
@@ -109,8 +110,11 @@ message HttpConnectionManager {
     //
     // .. attention::
     //  This field has been deprecated in favor of `traffic_direction`.
-    OperationName hidden_envoy_deprecated_operation_name = 1
-        [deprecated = true, (validate.rules).enum = {defined_only: true}];
+    OperationName hidden_envoy_deprecated_operation_name = 1 [
+      deprecated = true,
+      (validate.rules).enum = {defined_only: true},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // A list of header names used to create tags for the active span. The header name is used to
     // populate the tag name, and the header value is used to populate the tag value. The tag is
@@ -310,7 +314,8 @@ message HttpConnectionManager {
   // This field is deprecated. Use :ref:`idle_timeout
   // <envoy_api_field_extensions.filters.network.http_connection_manager.v3alpha.HttpConnectionManager.common_http_protocol_options>`
   // instead.
-  google.protobuf.Duration hidden_envoy_deprecated_idle_timeout = 11 [deprecated = true];
+  google.protobuf.Duration hidden_envoy_deprecated_idle_timeout = 11
+      [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected

--- a/generated_api_shadow/envoy/type/matcher/BUILD
+++ b/generated_api_shadow/envoy/type/matcher/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["//envoy/type:pkg"],
+    deps = [
+        "//envoy/annotations:pkg",
+        "//envoy/type:pkg",
+    ],
 )

--- a/generated_api_shadow/envoy/type/matcher/string.proto
+++ b/generated_api_shadow/envoy/type/matcher/string.proto
@@ -4,6 +4,7 @@ package envoy.type.matcher;
 
 import "envoy/type/matcher/regex.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher";
@@ -54,7 +55,11 @@ message StringMatcher {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
     //   untrusted input in all cases.
-    string regex = 4 [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string regex = 4 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];

--- a/generated_api_shadow/envoy/type/matcher/v3alpha/BUILD
+++ b/generated_api_shadow/envoy/type/matcher/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/type/matcher:pkg",
         "//envoy/type/v3alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/type/matcher/v3alpha/string.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3alpha/string.proto
@@ -6,6 +6,7 @@ import "envoy/type/matcher/v3alpha/regex.proto";
 
 import "udpa/annotations/versioning.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher.v3alpha";
@@ -58,8 +59,11 @@ message StringMatcher {
     // .. attention::
     //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
     //   untrusted input in all cases.
-    string hidden_envoy_deprecated_regex = 4
-        [deprecated = true, (validate.rules).string = {max_bytes: 1024}];
+    string hidden_envoy_deprecated_regex = 4 [
+      deprecated = true,
+      (validate.rules).string = {max_bytes: 1024},
+      (envoy.annotations.disallowed_by_default) = true
+    ];
 
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -340,11 +340,15 @@ void checkForDeprecatedNonRepeatedEnumValue(const Protobuf::Message& message,
 #ifdef ENVOY_DISABLE_DEPRECATED_FEATURES
   bool warn_only = false;
 #else
-  bool warn_only = !enum_value_descriptor->options().GetExtension(
-      envoy::annotations::disallowed_by_default_enum);
+  bool warn_only = true;
 #endif
 
   if (runtime) {
+    // This is set here, rather than above, so that in the absence of a
+    // registry (i.e. unit tests) the default for if a feature is allowed or not is
+    // based on ENVOY_DISABLE_DEPRECATED_FEATURES.
+    warn_only &= !enum_value_descriptor->options().GetExtension(
+        envoy::annotations::disallowed_by_default_enum);
     warn_only = runtime->snapshot().deprecatedFeatureEnabled(
         absl::StrCat("envoy.deprecated_features:", enum_value_descriptor->full_name()), warn_only);
   }
@@ -402,12 +406,16 @@ void checkForUnexpectedFields(const Protobuf::Message& message,
 #ifdef ENVOY_DISABLE_DEPRECATED_FEATURES
     bool warn_only = false;
 #else
-    bool warn_only = !field->options().GetExtension(envoy::annotations::disallowed_by_default);
+    bool warn_only = true;
 #endif
     // Allow runtime to be null both to not crash if this is called before server initialization,
     // and so proto validation works in context where runtime singleton is not set up (e.g.
     // standalone config validation utilities)
     if (runtime && field->options().deprecated()) {
+      // This is set here, rather than above, so that in the absence of a
+      // registry (i.e. test) the default for if a feature is allowed or not is
+      // based on ENVOY_DISABLE_DEPRECATED_FEATURES.
+      warn_only &= !field->options().GetExtension(envoy::annotations::disallowed_by_default);
       warn_only = runtime->snapshot().deprecatedFeatureEnabled(
           absl::StrCat("envoy.deprecated_features:", field->full_name()), warn_only);
     }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2787,11 +2787,6 @@ class RouteConfigurationV2 : public testing::Test, public ConfigImplTestBase {};
 
 // When removing runtime_key: this test can be removed.
 TEST_F(RouteConfigurationV2, DEPRECATED_FEATURE_TEST(RequestMirrorPolicy)) {
-  TestScopedRuntime scoped_runtime;
-  Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.deprecated_features:envoy.config.route.v3alpha.RouteAction.RequestMirrorPolicy."
-        "hidden_envoy_deprecated_runtime_key",
-        "true"}});
   const std::string yaml = R"EOF(
 name: foo
 virtual_hosts:

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -186,6 +186,9 @@ void IntegrationTestServer::onRuntimeCreated() {
   Runtime::LoaderSingleton::getExisting()->mergeValues(
       {{"envoy.deprecated_features:envoy.config.route.v3alpha.CorsPolicy."
         "hidden_envoy_deprecated_enabled",
+        "true"},
+       {"envoy.deprecated_features:envoy.config.route.v3alpha.CorsPolicy.hidden_envoy_deprecated_"
+        "allow_origin",
         "true"}});
 }
 


### PR DESCRIPTION
This PR makes the following fatal by default:
from cluster.proto: ORIGINAL_DST_LB, tls_context, extension_protocol_options
from health_check.proto: use_http2
from route_components.proto: allow_origin regex, pattern, method, regex_match, value
from http_connection_manager.proto: operation_name
from trace.proto: HTTP_JSON_V1
from string.proto: regex

Risk Level: Medium (who knows who is using them)
Testing: test framework updates
Docs Changes: n/a
Release Notes: n/a

Originally https://github.com/envoyproxy/envoy/pull/8847

