### PR TITLE
xds: fix upstream filter typed struct conversion

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -772,9 +772,8 @@ ClusterInfoImpl::ClusterInfoImpl(
     auto& factory = Config::Utility::getAndCheckFactory<
         Server::Configuration::NamedUpstreamNetworkFilterConfigFactory>(proto_config);
     auto message = factory.createEmptyConfigProto();
-    if (!proto_config.typed_config().value().empty()) {
-      MessageUtil::unpackTo(proto_config.typed_config(), *message);
-    }
+    Config::Utility::translateOpaqueConfig(proto_config.typed_config(), ProtobufWkt::Struct(),
+                                           factory_context.messageValidationVisitor(), *message);
     Network::FilterFactoryCb callback =
         factory.createFilterFactoryFromProto(*message, *factory_context_);
     filter_factories_.push_back(callback);


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: add support for typed struct in cluster filter
Risk Level: low
Testing: code refactory, double checked that there's no other unpackTo directly from typed config
Docs Changes: none
Release Notes: none
Fixes: https://github.com/envoyproxy/envoy/issues/9640