### PR TITLE
router: preserve retry flags when retriable req headers are used 

### DIFF
--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -92,14 +92,17 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
 
   if (!retriable_request_headers_.empty()) {
     // If this route limits retries by request headers, make sure there is a match.
-    uint32_t request_header_match = 0;
+    bool request_header_match = false;
     for (const auto& retriable_header : retriable_request_headers_) {
       if (retriable_header->matchesHeaders(request_headers)) {
-        request_header_match = 1;
+        request_header_match = true;
         break;
       }
     }
-    retry_on_ &= request_header_match;
+
+    if (!request_header_match) {
+      retry_on_ = 0;
+    }
   }
   if (retry_on_ != 0 && request_headers.EnvoyMaxRetries()) {
     uint64_t temp;

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -61,8 +61,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
       priority_(priority), retry_host_predicates_(route_policy.retryHostPredicates()),
       retry_priority_(route_policy.retryPriority()),
       retriable_status_codes_(route_policy.retriableStatusCodes()),
-      retriable_headers_(route_policy.retriableHeaders()),
-      retriable_request_headers_(route_policy.retriableRequestHeaders()) {
+      retriable_headers_(route_policy.retriableHeaders()) {
 
   std::chrono::milliseconds base_interval(
       runtime_.snapshot().getInteger("upstream.base_retry_backoff_ms", 25));
@@ -90,10 +89,11 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
         parseRetryGrpcOn(request_headers.EnvoyRetryGrpcOn()->value().getStringView()).first;
   }
 
-  if (!retriable_request_headers_.empty()) {
+  const auto& retriable_request_headers = route_policy.retriableRequestHeaders();
+  if (!retriable_request_headers.empty()) {
     // If this route limits retries by request headers, make sure there is a match.
     bool request_header_match = false;
-    for (const auto& retriable_header : retriable_request_headers_) {
+    for (const auto& retriable_header : retriable_request_headers) {
       if (retriable_header->matchesHeaders(request_headers)) {
         request_header_match = true;
         break;

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -110,7 +110,6 @@ private:
   uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;
   std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
-  std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
 };
 
 } // namespace Router

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -705,15 +705,30 @@ TEST_F(RouterRetryStateImplTest, PolicyLimitedByRequestHeaders) {
   }
 
   {
+    Http::TestHeaderMapImpl request_headers{{":method", "GET"}, {"x-envoy-retry-on", "retriable-4xx"}};
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+    Http::TestHeaderMapImpl response_headers{{":status", "409"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
+  {
     Http::TestHeaderMapImpl request_headers{{":method", "GET"}, {"x-envoy-retry-on", "5xx"}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
+    Http::TestHeaderMapImpl response_headers{{":status", "500"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
 
   {
     Http::TestHeaderMapImpl request_headers{{":method", "HEAD"}, {"x-envoy-retry-on", "5xx"}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
+    Http::TestHeaderMapImpl response_headers{{":status", "500"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
 
   {

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -705,7 +705,8 @@ TEST_F(RouterRetryStateImplTest, PolicyLimitedByRequestHeaders) {
   }
 
   {
-    Http::TestHeaderMapImpl request_headers{{":method", "GET"}, {"x-envoy-retry-on", "retriable-4xx"}};
+    Http::TestHeaderMapImpl request_headers{{":method", "GET"},
+                                            {"x-envoy-retry-on", "retriable-4xx"}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
     Http::TestHeaderMapImpl response_headers{{":status", "409"}};

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -732,6 +732,16 @@ TEST_F(RouterRetryStateImplTest, PolicyLimitedByRequestHeaders) {
     EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
   }
 
+  // Sanity check that we're only enabling retries for the configured retry-on.
+  {
+    Http::TestHeaderMapImpl request_headers{{":method", "HEAD"}, {"x-envoy-retry-on", "retriable-4xx"}};
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+    Http::TestHeaderMapImpl response_headers{{":status", "500"}};
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
+  }
+
   {
     Http::TestHeaderMapImpl request_headers{{":method", "POST"}, {"x-envoy-retry-on", "5xx"}};
     setup(request_headers);

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -734,7 +734,8 @@ TEST_F(RouterRetryStateImplTest, PolicyLimitedByRequestHeaders) {
 
   // Sanity check that we're only enabling retries for the configured retry-on.
   {
-    Http::TestHeaderMapImpl request_headers{{":method", "HEAD"}, {"x-envoy-retry-on", "retriable-4xx"}};
+    Http::TestHeaderMapImpl request_headers{{":method", "HEAD"},
+                                            {"x-envoy-retry-on", "retriable-4xx"}};
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
     Http::TestHeaderMapImpl response_headers{{":status", "500"}};

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -739,7 +739,6 @@ TEST_F(RouterRetryStateImplTest, PolicyLimitedByRequestHeaders) {
     setup(request_headers);
     EXPECT_TRUE(state_->enabled());
     Http::TestHeaderMapImpl response_headers{{":status", "500"}};
-    expectTimerCreateAndEnable();
     EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(response_headers, callback_));
   }
 


### PR DESCRIPTION
Previously, when a retriable request header was found the retry bitset
would be AND'd with 1, which meant that only the 0x1 flag (5xx) would be
retained. This PR updates it to instead clear out the bitset when no
flags are missing - this should ensure that all retry flags are
preserved when using retriable request headers.

Also removes retriable_request_headers from the RetryPolicyImpl type -
they were only being read in the ctor.

Signed-off-by: Snow Pettersen <aickck@gmail.com>

Risk Level: Low
Testing: UT
Docs Changes: n/a
Release Notes: n/a