### PR TITLE
[WIP] logger: Update fmt and spdlog

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -85,14 +85,14 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/mirror/tclap/archive/tclap-1-2-1-release-final.tar.gz"],
     ),
     com_github_fmtlib_fmt = dict(
-        sha256 = "4c0741e10183f75d7d6f730b8708a99b329b2f942dad5a9da3385ab92bb4a15c",
-        strip_prefix = "fmt-5.3.0",
-        urls = ["https://github.com/fmtlib/fmt/releases/download/5.3.0/fmt-5.3.0.zip"],
+        sha256 = "63650f3c39a96371f5810c4e41d6f9b0bb10305064e6faf201cbafe297ea30e8",
+        strip_prefix = "fmt-6.1.2",
+        urls = ["https://github.com/fmtlib/fmt/releases/download/6.1.2/fmt-6.1.2.zip"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "160845266e94db1d4922ef755637f6901266731c4cb3b30b45bf41efa0e6ab70",
-        strip_prefix = "spdlog-1.3.1",
-        urls = ["https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz"],
+        sha256 = "b38e0bbef7faac2b82fed550a0c19b0d4e7f6737d5321d4fd8f216b80f8aee8a",
+        strip_prefix = "spdlog-1.5.0",
+        urls = ["https://github.com/gabime/spdlog/archive/v1.5.0.tar.gz"],
     ),
     com_github_google_libprotobuf_mutator = dict(
         sha256 = "54597f640c0ab5e5d783d2f3d3cfe8ad6da999ef1a194d89c2c5ab89a1fd8e13",

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -62,7 +62,7 @@ void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
 
   // This memory buffer must exist in the scope of the entire function,
   // otherwise the string_view will refer to memory that is already free.
-  fmt::memory_buffer formatted;
+  spdlog::memory_buf_t formatted;
   if (formatter_) {
     formatter_->format(msg, formatted);
     msg_view = absl::string_view(formatted.data(), formatted.size());

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -106,9 +106,17 @@ parseUpstreamMetadataField(absl::string_view params_str) {
       return std::string();
     }
 
+    double number_value, integral;
     switch (value->kind_case()) {
     case ProtobufWkt::Value::kNumberValue:
-      return fmt::format("{}", value->number_value());
+      // Decompress the number value into integral and fractional. Check if the
+      // number value contains an integer value by checking the fractional part.
+      // If it contains an integer value, format it as an integer.
+      number_value = value->number_value();
+      if (std::modf(number_value, &integral) == 0.0) {
+        return fmt::format("{:d}", integral);
+      }
+      return fmt::format("{}", number_value);
 
     case ProtobufWkt::Value::kStringValue:
       return value->string_value();

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -391,8 +391,7 @@ TEST_P(AdminRequestTest, AdminRequestAfterRun) {
 TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
 
-  const std::string logger_name = "logger";
-  spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err, "error");
+  spdlog::details::log_msg log_msg("logger", spdlog::level::level_enum::err, "error");
   Logger::Registry::getSink()->log(log_msg);
 }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1410,10 +1410,10 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   // Ensure that the normal text format is used by default.
   Buffer::OwnedImpl response2;
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters", header_map, response2));
-  const std::string expected_text = R"EOF(fake_cluster::outlier::success_rate_average::0
-fake_cluster::outlier::success_rate_ejection_threshold::6
-fake_cluster::outlier::local_origin_success_rate_average::0
-fake_cluster::outlier::local_origin_success_rate_ejection_threshold::9
+  const std::string expected_text = R"EOF(fake_cluster::outlier::success_rate_average::0.0
+fake_cluster::outlier::success_rate_ejection_threshold::6.0
+fake_cluster::outlier::local_origin_success_rate_average::0.0
+fake_cluster::outlier::local_origin_success_rate_ejection_threshold::9.0
 fake_cluster::default_priority::max_connections::1
 fake_cluster::default_priority::max_pending_requests::1024
 fake_cluster::default_priority::max_requests::1024


### PR DESCRIPTION
**Description:**
Update fmt to version 6.1.2 and spdlog to version 1.5.0.
This requires using spdlog::memory_buf_t type instead of fmt::memory_buffer. The spdlog::memory_buf_t type is equal to fmt::basic_memory_buffer<char, 250>.
std::string cannot be used anymore as an argument to log_msg function, it expects the spdlog::string_view_t type
**Risk Level:** Low
**Testing:** Fixed unit test due to changes in spdlog
**Docs Changes:** N/A
**Release Notes:** Update fmt to 6.1.2 and spdlog to 1.5.0
