### PR TITLE
Remove flag --experimental_remap_main_repo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,7 +11,6 @@
 startup --host_jvm_args=-Xmx2g
 
 build --workspace_status_command=bazel/get_workspace_status
-build --experimental_remap_main_repo
 build --experimental_local_memory_estimate
 build --experimental_strict_action_env=true
 build --host_force_python=PY2


### PR DESCRIPTION
It's on by default since Bazel 2.0, and the flag is now going away.

https://github.com/bazelbuild/bazel/issues/7130

Description: 
Risk Level: low
Testing: none
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]