### PR TITLE
Remove --experimental_remap_main_repo in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,7 +11,6 @@
 startup --host_jvm_args=-Xmx2g
 
 build --workspace_status_command=bazel/get_workspace_status
-build --experimental_remap_main_repo
 build --experimental_local_memory_estimate
 build --experimental_strict_action_env=true
 build --host_force_python=PY2


### PR DESCRIPTION
The `--experimental_remap_main_repo` flag has been deleted from Bazel.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
