### PR TITLE
test: fixing up QUIC test to not use deprecated fields

### DIFF
--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -36,9 +36,9 @@ filter_chains:
         validation_context:
           trusted_ca:
             filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
-          verify_subject_alt_name:
-          - localhost
-          - 127.0.0.1
+          match_subject_alt_names: 
+            exact: "localhost"
+            exact: "127.0.0.1"
 reuse_port: true
 udp_listener_config:
   udp_listener_name: "quiche_quic_listener"


### PR DESCRIPTION
When testing
bazel test //test/... --copt=-DENVOY_DISABLE_DEPRECATED_FEATURES over on https://github.com/envoyproxy/envoy/pull/9688
I noticed a failure in /test/server:listener_manager_impl_quic_only_test

We have a build building with disabling deprecated features, so that as folks deprecate features they update all example configs and all tests.
That happens to be the same build where we test all of our other compiler flags including the "make sure we build cleanly without QUIC" flags.  Which means QUIC is exempted from the "are our configs up to date test"

I don't think it's worth an extra full CI run to have one build for "do we build with QUIC disabled" and a second for "are our configs up to date" but I'm wondering if there's any other build we could just do a "no quic" compile check where it wouldn't be missed, so we don't have this annoying cruft gap.  Thoughts?

cc @danzh2010 @mattklein123 

Risk Level: n/a (test only)
Testing: yep
Docs Changes: no
Release Notes: no
