### PR TITLE
test: fixing example configs test to not allow deprecated configs

### DIFF
--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -57,7 +57,8 @@
             "@type": type.googleapis.com/envoy.config.filter.http.buffer.v2.Buffer
             max_request_bytes: 5242880
         - name: envoy.rate_limit
-          config:
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
             domain: envoy_front
             request_type: external
             rate_limit_service:

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -155,7 +155,8 @@ static_resources:
           use_remote_address: true
           http_filters:
           - name: envoy.rate_limit
-            config:
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
               domain: envoy_service_to_service
               rate_limit_service:
                  grpc_service:
@@ -215,7 +216,8 @@ static_resources:
           use_remote_address: true
           http_filters:
           - name: envoy.rate_limit
-            config:
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
               domain: envoy_service_to_service
               rate_limit_service:
                  grpc_service:
@@ -317,12 +319,14 @@ static_resources:
           stat_prefix: mongo_{{ key }}
           cluster: mongo_{{ key }}
       - name: envoy.mongo_proxy
-        config:
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.mongo_proxy.v2.MongoProxy
           stat_prefix: "{{ key }}"
           access_log: "/var/log/envoy/mongo_{{ key }}.log"
       {% if value.get('ratelimit', False) %}
       - name: envoy.ratelimit
-        config:
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.ratelimit.v3.RateLimit
           stat_prefix: "{{ key }}"
           domain: envoy_mongo_cps
           descriptors:
@@ -348,7 +352,8 @@ static_resources:
             trusted_ca:
               filename: certs/cacert.pem
             {% if host.get('verify_subject_alt_name', False) %}
-            verify_subject_alt_name: "{{host['verify_subject_alt_name'] }}"
+            match_subject_alt_names:
+              exact: "{{host['verify_subject_alt_name'] }}"
             {% endif %}
         {% if host.get('sni', False) %}
         sni: "{{ host['sni'] }}"
@@ -501,8 +506,8 @@ static_resources:
           validation_context:
             trusted_ca:
               filename: certs/cacert.pem
-            verify_subject_alt_name:
-            - collector-grpc.lightstep.com
+            match_subject_alt_names:
+              exact: "collector-grpc.lightstep.com"
   - name: cds_cluster
     connect_timeout: 0.25s
     type: STRICT_DNS

--- a/configs/routing_helper_v2.template.yaml
+++ b/configs/routing_helper_v2.template.yaml
@@ -31,7 +31,8 @@
   health_checks:
   - http_health_check:
       path: /healthcheck
-      service_name: accidents
+      service_name_matcher:
+        prefix: accidents
     timeout: 2s
     interval: 5s
     interval_jitter: 5s

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -5,7 +5,7 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-TEST(ExampleConfigsTest, DEPRECATED_FEATURE_TEST(All)) {
+TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
 


### PR DESCRIPTION
Lowering maintainer burden by making sure folks who deprecate fields update config examples.
Every week I forget to check this in, I end up with another field or two to trudge through :-/

Risk Level: low (improving config)
Testing: tests now pass 
Docs Changes: n/a
Release Notes: n/a
