### PR TITLE
docs: add note about missing primary cluster

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -549,7 +549,9 @@ message RouteAction {
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
   //
-  // Note that shadowing will not be triggered if the primary cluster does not exist.
+  // .. note::
+  //
+  //   Shadowing will not be triggered if the primary cluster does not exist.
   message RequestMirrorPolicy {
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.

--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -548,6 +548,8 @@ message RouteAction {
   //
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
+  //
+  // Note that shadowing will not be triggered if the primary cluster does not exist.
   message RequestMirrorPolicy {
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -513,7 +513,9 @@ message RouteAction {
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
   //
-  // Note that shadowing will not be triggered if the primary cluster does not exist.
+  // .. note::
+  //
+  //   Shadowing will not be triggered if the primary cluster does not exist.
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -512,6 +512,8 @@ message RouteAction {
   //
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
+  //
+  // Note that shadowing will not be triggered if the primary cluster does not exist.
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -548,6 +548,10 @@ message RouteAction {
   //
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
+  //
+  // .. note::
+  //
+  //   Shadowing will not be triggered if the primary cluster does not exist.
   message RequestMirrorPolicy {
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -575,6 +575,10 @@ message RouteAction {
   //
   // During shadowing, the host/authority header is altered such that *-shadow* is appended. This is
   // useful for logging. For example, *cluster1* becomes *cluster1-shadow*.
+  //
+  // .. note::
+  //
+  //   Shadowing will not be triggered if the primary cluster does not exist.
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";


### PR DESCRIPTION
This is expected behavior, but just lets add a note to
RequestMirrorPolicy as a reminder.

Fixes #9698

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
