### PR TITLE
log: fix type name for DelegatingLogSinkSharedPtr

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -29,7 +29,7 @@ Logger::Logger(const std::string& name) {
   logger_->flush_on(spdlog::level::critical);
 }
 
-SinkDelegate::SinkDelegate(DelegatingLogSinkPtr log_sink)
+SinkDelegate::SinkDelegate(DelegatingLogSinkSharedPtr log_sink)
     : previous_delegate_(log_sink->delegate()), log_sink_(log_sink) {
   log_sink->setDelegate(this);
 }
@@ -39,7 +39,8 @@ SinkDelegate::~SinkDelegate() {
   log_sink_->setDelegate(previous_delegate_);
 }
 
-StderrSinkDelegate::StderrSinkDelegate(DelegatingLogSinkPtr log_sink) : SinkDelegate(log_sink) {}
+StderrSinkDelegate::StderrSinkDelegate(DelegatingLogSinkSharedPtr log_sink)
+    : SinkDelegate(log_sink) {}
 
 void StderrSinkDelegate::log(absl::string_view msg) {
   Thread::OptionalLockGuard guard(lock_);
@@ -87,8 +88,8 @@ std::string DelegatingLogSink::escapeLogLine(absl::string_view msg_view) {
   return absl::StrCat(absl::CEscape(msg_leading), msg_trailing_whitespace);
 }
 
-DelegatingLogSinkPtr DelegatingLogSink::init() {
-  DelegatingLogSinkPtr delegating_sink(new DelegatingLogSink);
+DelegatingLogSinkSharedPtr DelegatingLogSink::init() {
+  DelegatingLogSinkSharedPtr delegating_sink(new DelegatingLogSink);
   delegating_sink->stderr_sink_ = std::make_unique<StderrSinkDelegate>(delegating_sink);
   return delegating_sink;
 }

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -109,7 +109,7 @@ private:
 };
 
 class DelegatingLogSink;
-using DelegatingLogSinkPtr = std::shared_ptr<DelegatingLogSink>;
+using DelegatingLogSinkSharedPtr = std::shared_ptr<DelegatingLogSink>;
 
 /**
  * Captures a logging sink that can be delegated to for a bounded amount of time.
@@ -118,7 +118,7 @@ using DelegatingLogSinkPtr = std::shared_ptr<DelegatingLogSink>;
  */
 class SinkDelegate : NonCopyable {
 public:
-  explicit SinkDelegate(DelegatingLogSinkPtr log_sink);
+  explicit SinkDelegate(DelegatingLogSinkSharedPtr log_sink);
   virtual ~SinkDelegate();
 
   virtual void log(absl::string_view msg) PURE;
@@ -129,7 +129,7 @@ protected:
 
 private:
   SinkDelegate* previous_delegate_;
-  DelegatingLogSinkPtr log_sink_;
+  DelegatingLogSinkSharedPtr log_sink_;
 };
 
 /**
@@ -137,7 +137,7 @@ private:
  */
 class StderrSinkDelegate : public SinkDelegate {
 public:
-  explicit StderrSinkDelegate(DelegatingLogSinkPtr log_sink);
+  explicit StderrSinkDelegate(DelegatingLogSinkSharedPtr log_sink);
 
   // SinkDelegate
   void log(absl::string_view msg) override;
@@ -182,10 +182,10 @@ public:
    * A shared_ptr is required for sinks used
    * in spdlog::logger; it would not otherwise be required in Envoy. This method
    * must own the construction process because StderrSinkDelegate needs access to
-   * the DelegatingLogSinkPtr, not just the DelegatingLogSink*, and that is only
+   * the DelegatingLogSinkSharedPtr, not just the DelegatingLogSink*, and that is only
    * available after construction.
    */
-  static DelegatingLogSinkPtr init();
+  static DelegatingLogSinkSharedPtr init();
 
   /**
    * Give a log line with trailing whitespace, this will escape all c-style
@@ -254,8 +254,8 @@ public:
   /**
    * @return the singleton sink to use for all loggers.
    */
-  static DelegatingLogSinkPtr getSink() {
-    static DelegatingLogSinkPtr sink = DelegatingLogSink::init();
+  static DelegatingLogSinkSharedPtr getSink() {
+    static DelegatingLogSinkSharedPtr sink = DelegatingLogSink::init();
     return sink;
   }
 

--- a/source/common/common/logger_delegates.cc
+++ b/source/common/common/logger_delegates.cc
@@ -12,7 +12,7 @@ namespace Logger {
 
 FileSinkDelegate::FileSinkDelegate(const std::string& log_path,
                                    AccessLog::AccessLogManager& log_manager,
-                                   DelegatingLogSinkPtr log_sink)
+                                   DelegatingLogSinkSharedPtr log_sink)
     : SinkDelegate(log_sink), log_file_(log_manager.createAccessLog(log_path)) {}
 
 void FileSinkDelegate::log(absl::string_view msg) {

--- a/source/common/common/logger_delegates.h
+++ b/source/common/common/logger_delegates.h
@@ -15,7 +15,7 @@ namespace Envoy {
 namespace Logger {
 
 class DelegatingLogSink;
-using DelegatingLogSinkPtr = std::shared_ptr<DelegatingLogSink>;
+using DelegatingLogSinkSharedPtr = std::shared_ptr<DelegatingLogSink>;
 
 /**
  * SinkDelegate that writes log messages to a file.
@@ -23,7 +23,7 @@ using DelegatingLogSinkPtr = std::shared_ptr<DelegatingLogSink>;
 class FileSinkDelegate : public SinkDelegate {
 public:
   FileSinkDelegate(const std::string& log_path, AccessLog::AccessLogManager& log_manager,
-                   DelegatingLogSinkPtr log_sink);
+                   DelegatingLogSinkSharedPtr log_sink);
 
   // SinkDelegate
   void log(absl::string_view msg) override;

--- a/test/test_common/logging.cc
+++ b/test/test_common/logging.cc
@@ -21,7 +21,7 @@ LogLevelSetter::~LogLevelSetter() {
   ASSERT(prev_level == previous_levels_.end());
 }
 
-LogRecordingSink::LogRecordingSink(Logger::DelegatingLogSinkPtr log_sink)
+LogRecordingSink::LogRecordingSink(Logger::DelegatingLogSinkSharedPtr log_sink)
     : Logger::SinkDelegate(log_sink) {}
 LogRecordingSink::~LogRecordingSink() = default;
 

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -48,7 +48,7 @@ private:
  */
 class LogRecordingSink : public Logger::SinkDelegate {
 public:
-  explicit LogRecordingSink(Logger::DelegatingLogSinkPtr log_sink);
+  explicit LogRecordingSink(Logger::DelegatingLogSinkSharedPtr log_sink);
   ~LogRecordingSink() override;
 
   // Logger::SinkDelegate
@@ -91,7 +91,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
   do {                                                                                             \
     ASSERT_FALSE(expected_messages.empty()) << "Expected messages cannot be empty.";               \
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
-    Envoy::Logger::DelegatingLogSinkPtr sink_ptr = Envoy::Logger::Registry::getSink();             \
+    Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();             \
     sink_ptr->set_should_escape(escaped);                                                          \
     Envoy::LogRecordingSink log_recorder(sink_ptr);                                                \
     stmt;                                                                                          \

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -91,7 +91,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
   do {                                                                                             \
     ASSERT_FALSE(expected_messages.empty()) << "Expected messages cannot be empty.";               \
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
-    Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();             \
+    Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();       \
     sink_ptr->set_should_escape(escaped);                                                          \
     Envoy::LogRecordingSink log_recorder(sink_ptr);                                                \
     stmt;                                                                                          \


### PR DESCRIPTION
Description: I noticed while reading this file that the shared pointer alias was not following convention. This PR fixes that.
Risk Level: low
Testing: CI

Signed-off-by: Jose Nino <jnino@lyft.com>
