### PR TITLE
statsd: remove undefined method

### DIFF
--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -102,7 +102,6 @@ private:
     ~TlsSink() override;
 
     void beginFlush(bool expect_empty_buffer);
-    void checkSize();
     void commonFlush(const std::string& name, uint64_t value, char stat_type);
     void flushCounter(const std::string& name, uint64_t delta);
     void flushGauge(const std::string& name, uint64_t value);


### PR DESCRIPTION
This method is declared in the header but has no implementation and is not called anywhere.

Signed-off-by: Derek Argueta <dereka@pinterest.com>