### PR TITLE
[fuzz] add PGV validation on enum

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -77,7 +77,7 @@ message VirtualHost {
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.
-  TlsRequirementType require_tls = 4;
+  TlsRequirementType require_tls = 4 [(validate.rules).enum = {defined_only: true}];
 
   // A list of virtual clusters defined for this virtual host. Virtual clusters
   // are used for additional statistics gathering.

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -81,7 +81,7 @@ message VirtualHost {
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.
-  TlsRequirementType require_tls = 4;
+  TlsRequirementType require_tls = 4 [(validate.rules).enum = {defined_only: true}];
 
   // A list of virtual clusters defined for this virtual host. Virtual clusters
   // are used for additional statistics gathering.

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -77,7 +77,7 @@ message VirtualHost {
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.
-  TlsRequirementType require_tls = 4;
+  TlsRequirementType require_tls = 4 [(validate.rules).enum = {defined_only: true}];
 
   // A list of virtual clusters defined for this virtual host. Virtual clusters
   // are used for additional statistics gathering.

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -79,7 +79,7 @@ message VirtualHost {
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.
-  TlsRequirementType require_tls = 4;
+  TlsRequirementType require_tls = 4 [(validate.rules).enum = {defined_only: true}];
 
   // A list of virtual clusters defined for this virtual host. Virtual clusters
   // are used for additional statistics gathering.

--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-6249350586171392
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-6249350586171392
@@ -1,0 +1,157 @@
+config {
+  virtual_hosts {
+    name: "7ard0" require_tls: 8  domains: ""
+    routes {
+      match {
+        case_sensitive {
+          value: true
+        }
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        }
+      }
+      redirect {
+        host_redirect: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn€nnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        strip_query: true
+      }
+      name: "\020"
+    }
+    routes {
+      match {
+        case_sensitive {
+          value: true
+        }
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn.nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        }
+      }
+      redirect {
+        path_redirect: "\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\1%7\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177"
+        strip_query: true
+      }
+    }
+    routes {
+      match {
+        path: ""
+      }
+      direct_response {
+        status: 246
+        body {
+          inline_bytes: "."
+        }
+      }
+    }
+    routes {
+      match {
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn?nnnnnnnnnnnnnnnnnnnnnnnnnnnnn^nnnnnnnnnnnnnnn"
+        }
+      }
+      redirect {
+        host_redirect: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        path_redirect: "\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\17€\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177"
+        strip_query: true
+      }
+    }
+    routes {
+      match {
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn?nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        }
+      }
+      redirect {
+        host_redirect: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn.nnnnnnnnnnnnnnnnnnnnnnnn"
+        path_redirect: "\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177K177\177\177\177\177\177\177\177"
+        strip_query: true
+      }
+    }
+    routes {
+      match {
+        case_sensitive {
+          value: true
+        }
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn?nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnn"
+        }
+      }
+      redirect {
+        strip_query: true
+      }
+    }
+    routes {
+      match {
+        case_sensitive {
+          value: true
+        }
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "."
+        }
+      }
+      redirect {
+        path_redirect: "\177\177\177\177\177\177\177\177\17%\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177"
+        strip_query: true
+      }
+    }
+    routes {
+      match {
+        case_sensitive {
+          value: true
+        }
+        safe_regex {
+          google_re2 {
+            max_program_size {
+              value: 1868323924
+            }
+          }
+          regex: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn‡nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        }
+      }
+      redirect {
+        host_redirect: "nnnnnnnnnnnnnnnnÑnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        strip_query: true
+      }
+      name: "\020"
+    }
+    routes {
+      match {
+        path: ""
+      }
+      direct_response {
+        status: 246
+        body {
+          inline_bytes: "."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Constrain `require_tls` enum to be defined.

Fixes oss-fuzz issue:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20168
Testing: 
Add corpus entry

Signed-off-by: Asra Ali <asraa@google.com>

