### PR TITLE
misc: fix inappropriate uses of absl::StrCat

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -384,6 +384,7 @@ envoy_cc_library(
         ":thread_lib",
         ":utility_lib",
     ],
+    external_deps = ["abseil_str_format"],
 )
 
 envoy_cc_library(

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -378,13 +378,13 @@ envoy_cc_library(
     name = "perf_annotation_lib",
     srcs = ["perf_annotation.cc"],
     hdrs = ["perf_annotation.h"],
+    external_deps = ["abseil_str_format"],
     deps = [
         ":assert_lib",
         ":thread_annotations",
         ":thread_lib",
         ":utility_lib",
     ],
-    external_deps = ["abseil_str_format"],
 )
 
 envoy_cc_library(

--- a/source/common/common/perf_annotation.cc
+++ b/source/common/common/perf_annotation.cc
@@ -14,6 +14,7 @@
 #include "common/common/utility.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 
 namespace Envoy {
 
@@ -108,7 +109,7 @@ std::string PerfAnnotationContext::toString() {
             : std::to_string(
                   std::chrono::duration_cast<std::chrono::nanoseconds>(stats.total_).count() /
                   count));
-    columns[3].push_back(absl::StrCat("", stats.stddev_.computeStandardDeviation()));
+    columns[3].push_back(absl::StrFormat("%g", stats.stddev_.computeStandardDeviation()));
     columns[4].push_back(nanoseconds_string(stats.min_));
     columns[5].push_back(nanoseconds_string(stats.max_));
     const CategoryDescription& category_description = p->first;

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -182,7 +182,7 @@ bool ScopedRdsConfigSubscription::addOrUpdateScopes(
       ENVOY_LOG(debug, "srds: add/update scoped_route '{}', version: {}",
                 scoped_route_info->scopeName(), version_info);
     } catch (const EnvoyException& e) {
-      exception_msgs.emplace_back(absl::StrCat("", e.what()));
+      exception_msgs.emplace_back(e.what());
     }
   }
   return any_applied;

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -42,4 +42,5 @@ envoy_cc_library(
         "@envoy_api//envoy/type/metadata/v2:pkg_cc_proto",
         "@envoy_api//envoy/type/tracing/v2:pkg_cc_proto",
     ],
+    external_deps = ["abseil_str_format"],
 )

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     hdrs = [
         "http_tracer_impl.h",
     ],
+    external_deps = ["abseil_str_format"],
     deps = [
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",
@@ -42,5 +43,4 @@ envoy_cc_library(
         "@envoy_api//envoy/type/metadata/v2:pkg_cc_proto",
         "@envoy_api//envoy/type/tracing/v2:pkg_cc_proto",
     ],
-    external_deps = ["abseil_str_format"],
 )

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -21,6 +21,7 @@
 #include "common/stream_info/utility.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 
 namespace Envoy {
 namespace Tracing {
@@ -334,7 +335,7 @@ void MetadataCustomTag::apply(Span& span, const CustomTagContext& ctx) const {
     span.setTag(tag(), value.bool_value() ? "true" : "false");
     return;
   case ProtobufWkt::Value::kNumberValue:
-    span.setTag(tag(), absl::StrCat("", value.number_value()));
+    span.setTag(tag(), absl::StrFormat("%g", value.number_value()));
     return;
   case ProtobufWkt::Value::kStringValue:
     span.setTag(tag(), value.string_value());

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -779,7 +779,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::logHealthCheckStatus(
   if (grpc_status != Grpc::Status::WellKnownGrpcStatus::Ok && !grpc_message.empty()) {
     grpc_status_message = fmt::format("{} ({})", grpc_status, grpc_message);
   } else {
-    grpc_status_message = absl::StrCat("", grpc_status);
+    grpc_status_message = std::to_string(grpc_status);
   }
 
   ENVOY_CONN_LOG(debug, "hc grpc_status={} service_status={} health_flags={}", *client_,

--- a/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.cc
+++ b/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.cc
@@ -30,7 +30,7 @@ DynamicOpenTracingDriver::DynamicOpenTracingDriver(Stats::Store& stats, const st
 std::string DynamicOpenTracingDriver::formatErrorMessage(std::error_code error_code,
                                                          const std::string& error_message) {
   if (error_message.empty()) {
-    return absl::StrCat("", error_code.message());
+    return error_code.message();
   } else {
     return fmt::format("{}: {}", error_code.message(), error_message);
   }

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -115,7 +115,7 @@ private:
     case envoy::config::core::v3::SocketAddress::PortSpecifierCase::kPortValue:
     // default to port 0 if no port value is specified
     case envoy::config::core::v3::SocketAddress::PortSpecifierCase::PORT_SPECIFIER_NOT_SET:
-      return absl::StrCat("", socket_address.port_value());
+      return std::to_string(socket_address.port_value());
 
     default:
       throw EnvoyException(


### PR DESCRIPTION
Following up on @antoniovicente's comments on #9596 where `absl::StrCat` has an empty string as its first arg, basically just acting as a toString function. Replaced with either `std::to_string`, `absl::StrFormat`, or if the arg is just a string then removed `absl::StrCat` Per the Abseil source, passing a double to `absl::StrCat` effectively applies `%g` formatting to the double.
1) https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_cat.h#L237
2) https://github.com/abseil/abseil-cpp/blob/master/absl/strings/numbers.cc#L473

Signed-off-by: Derek Argueta <dereka@pinterest.com>