### PR TITLE
health checker: clear old TODO

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -149,8 +149,6 @@ envoy_cc_library(
         "//source/common/grpc:codec_lib",
         "//source/common/http:codec_client_lib",
         "//source/common/upstream:host_utility_lib",
-        # TODO(dio): Remove dependency to health checkers extension when redis_health_check is removed.
-        "//source/extensions/health_checkers:well_known_names",
     ],
 )
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -19,9 +19,6 @@
 #include "common/runtime/runtime_impl.h"
 #include "common/upstream/host_utility.h"
 
-// TODO(dio): Remove dependency to extension health checkers when redis_health_check is removed.
-#include "extensions/health_checkers/well_known_names.h"
-
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 


### PR DESCRIPTION
core health checking is no longer dependent on Redis, so this include can be removed. cc @dio 

Signed-off-by: Derek Argueta <dereka@pinterest.com>