### PR TITLE
check_format: Update error messages when `CLANG_FORMAT`, bazelbuild/buildtools are not found

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -218,7 +218,7 @@ def checkTools():
                             "users".format(CLANG_FORMAT_PATH))
   else:
     error_messages.append(
-        "Command {} not found. If you have clang-format in version 8.x.x "
+        "Command {} not found. If you have clang-format in version 9.x.x "
         "installed, but the binary name is different or it's not available in "
         "PATH, please use CLANG_FORMAT environment variable to specify the path. "
         "Examples:\n"
@@ -238,13 +238,13 @@ def checkTools():
                               "users".format(path))
     else:
 
-      error_messages.append(
-          "Command {} not found. If you have buildifier installed, but the binary "
-          "name is different or it's not available in $GOPATH/bin, please use "
-          "{} environment variable to specify the path. Example:\n"
-          "    export {}=/opt/bin/buildifier\n"
-          "If you don't have buildifier installed, you can install it by:\n"
-          "    go get -u github.com/bazelbuild/buildtools/{}".format(path, var, var, name))
+      error_messages.append("Command {} not found. If you have {} installed, but the binary "
+                            "name is different or it's not available in $GOPATH/bin, please use "
+                            "{} environment variable to specify the path. Example:\n"
+                            "    export {}=`which {}`\n"
+                            "If you don't have {} installed, you can install it by:\n"
+                            "    go get -u github.com/bazelbuild/buildtools/{}".format(
+                                path, name, var, var, name, name, name))
 
   checkBazelTool('buildifier', BUILDIFIER_PATH, 'BUILDIFIER_BIN')
   checkBazelTool('buildozer', BUILDOZER_PATH, 'BUILDOZER_BIN')


### PR DESCRIPTION
Description:

This updates error message for `CLANG_FORMAT` and `bazelbuild/buildtools` when these are not found.

Risk Level: Low
Testing: 

Manually run it, when `CLANG_FORMAT` and `bazelbuild/buildtools` are not found, the error messages are rendered as:

```
ERROR: Command clang-format-9 not found. If you have clang-format in version 9.x.x installed, but the binary name is different or it's not available in PATH, please use CLANG_FORMAT environment variable to specify the path. Examples:
    export CLANG_FORMAT=clang-format-9.0.0
    export CLANG_FORMAT=/opt/bin/clang-format-9
    export CLANG_FORMAT=/usr/local/opt/llvm@9/bin/clang-format
ERROR: Command /home/diorahman/go/bin/buildifier not found. If you have buildifier installed, but the binary name is different or it's not available in $GOPATH/bin, please use BUILDIFIER_BIN environment variable to specify the path. Example:
    export BUILDIFIER_BIN=`which buildifier`
If you don't have buildifier installed, you can install it by:
    go get -u github.com/bazelbuild/buildtools/buildifier
ERROR: Command /home/diorahman/go/bin/buildozer not found. If you have buildozer installed, but the binary name is different or it's not available in $GOPATH/bin, please use BUILDOZER_BIN environment variable to specify the path. Example:
    export BUILDOZER_BIN=`which buildozer`
If you don't have buildozer installed, you can install it by:
    go get -u github.com/bazelbuild/buildtools/buildozer

```

Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
