### PR TITLE
test: statsd cleanup - change pointers to stack objects where applicable

### DIFF
--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <memory>
+#include <string>
 
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
@@ -68,17 +69,17 @@ TEST_F(TcpStatsdSinkTest, EmptyFlush) {
 
 TEST_F(TcpStatsdSinkTest, BasicFlow) {
   InSequence s;
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->latch_ = 1;
-  counter->used_ = true;
-  snapshot_.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.latch_ = 1;
+  counter.used_ = true;
+  snapshot_.counters_.push_back({1, counter});
 
-  auto gauge = std::make_shared<NiceMock<Stats::MockGauge>>();
-  gauge->name_ = "test_gauge";
-  gauge->value_ = 2;
-  gauge->used_ = true;
-  snapshot_.gauges_.push_back(*gauge);
+  NiceMock<Stats::MockGauge> gauge;
+  gauge.name_ = "test_gauge";
+  gauge.value_ = 2;
+  gauge.used_ = true;
+  snapshot_.gauges_.push_back(gauge);
 
   expectCreateConnection();
   EXPECT_CALL(*connection_,
@@ -142,11 +143,11 @@ TEST_F(TcpStatsdSinkTest, SiSuffix) {
 // infinitely buffer.
 TEST_F(TcpStatsdSinkTest, NoHost) {
   InSequence s;
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->latch_ = 1;
-  counter->used_ = true;
-  snapshot_.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.latch_ = 1;
+  counter.used_ = true;
+  snapshot_.counters_.push_back({1, counter});
 
   Upstream::MockHost::MockCreateConnectionData conn_info;
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _))
@@ -163,11 +164,11 @@ TEST_F(TcpStatsdSinkTest, WithCustomPrefix) {
       local_info_, "fake_cluster", tls_, cluster_manager_,
       cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_, "test_prefix");
 
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->latch_ = 1;
-  counter->used_ = true;
-  snapshot_.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.latch_ = 1;
+  counter.used_ = true;
+  snapshot_.counters_.push_back({1, counter});
 
   expectCreateConnection();
   EXPECT_CALL(*connection_, write(BufferStringEqual("test_prefix.test_counter:1|c\n"), _));
@@ -177,12 +178,12 @@ TEST_F(TcpStatsdSinkTest, WithCustomPrefix) {
 TEST_F(TcpStatsdSinkTest, BufferReallocate) {
   InSequence s;
 
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->latch_ = 1;
-  counter->used_ = true;
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.latch_ = 1;
+  counter.used_ = true;
 
-  snapshot_.counters_.resize(2000, {1, *counter});
+  snapshot_.counters_.resize(2000, {1, counter});
 
   expectCreateConnection();
   EXPECT_CALL(*connection_, write(_, _))
@@ -200,11 +201,11 @@ TEST_F(TcpStatsdSinkTest, BufferReallocate) {
 TEST_F(TcpStatsdSinkTest, Overflow) {
   InSequence s;
 
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->latch_ = 1;
-  counter->used_ = true;
-  snapshot_.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.latch_ = 1;
+  counter.used_ = true;
+  snapshot_.counters_.push_back({1, counter});
 
   // Synthetically set buffer above high watermark. Make sure we don't write anything.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -1,4 +1,7 @@
 #include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
@@ -45,17 +48,17 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   EXPECT_NE(fd, -1);
 
   // Check that fd has not changed.
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->used_ = true;
-  counter->latch_ = 1;
-  snapshot.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.used_ = true;
+  counter.latch_ = 1;
+  snapshot.counters_.push_back({1, counter});
 
-  auto gauge = std::make_shared<NiceMock<Stats::MockGauge>>();
-  gauge->name_ = "test_gauge";
-  gauge->value_ = 1;
-  gauge->used_ = true;
-  snapshot.gauges_.push_back(*gauge);
+  NiceMock<Stats::MockGauge> gauge;
+  gauge.name_ = "test_gauge";
+  gauge.value_ = 1;
+  gauge.used_ = true;
+  snapshot.gauges_.push_back(gauge);
 
   sink.flush(snapshot);
 
@@ -91,19 +94,19 @@ TEST_P(UdpStatsdSinkWithTagsTest, InitWithIpAddress) {
 
   // Check that fd has not changed.
   std::vector<Stats::Tag> tags = {Stats::Tag{"node", "test"}};
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->used_ = true;
-  counter->latch_ = 1;
-  counter->setTags(tags);
-  snapshot.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.used_ = true;
+  counter.latch_ = 1;
+  counter.setTags(tags);
+  snapshot.counters_.push_back({1, counter});
 
-  auto gauge = std::make_shared<NiceMock<Stats::MockGauge>>();
-  gauge->name_ = "test_gauge";
-  gauge->value_ = 1;
-  gauge->used_ = true;
-  gauge->setTags(tags);
-  snapshot.gauges_.push_back(*gauge);
+  NiceMock<Stats::MockGauge> gauge;
+  gauge.name_ = "test_gauge";
+  gauge.value_ = 1;
+  gauge.used_ = true;
+  gauge.setTags(tags);
+  snapshot.gauges_.push_back(gauge);
 
   sink.flush(snapshot);
 
@@ -128,22 +131,22 @@ TEST(UdpStatsdSinkTest, CheckActualStats) {
   NiceMock<ThreadLocal::MockInstance> tls_;
   UdpStatsdSink sink(tls_, writer_ptr, false);
 
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->used_ = true;
-  counter->latch_ = 1;
-  snapshot.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.used_ = true;
+  counter.latch_ = 1;
+  snapshot.counters_.push_back({1, counter});
 
   EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr),
               write("envoy.test_counter:1|c"));
   sink.flush(snapshot);
-  counter->used_ = false;
+  counter.used_ = false;
 
-  auto gauge = std::make_shared<NiceMock<Stats::MockGauge>>();
-  gauge->name_ = "test_gauge";
-  gauge->value_ = 1;
-  gauge->used_ = true;
-  snapshot.gauges_.push_back(*gauge);
+  NiceMock<Stats::MockGauge> gauge;
+  gauge.name_ = "test_gauge";
+  gauge.value_ = 1;
+  gauge.used_ = true;
+  snapshot.gauges_.push_back(gauge);
 
   EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr),
               write("envoy.test_gauge:1|g"));
@@ -164,16 +167,16 @@ TEST(UdpStatsdSinkTest, CheckActualStatsWithCustomPrefix) {
   NiceMock<ThreadLocal::MockInstance> tls_;
   UdpStatsdSink sink(tls_, writer_ptr, false, "test_prefix");
 
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->used_ = true;
-  counter->latch_ = 1;
-  snapshot.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.used_ = true;
+  counter.latch_ = 1;
+  snapshot.counters_.push_back({1, counter});
 
   EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr),
               write("test_prefix.test_counter:1|c"));
   sink.flush(snapshot);
-  counter->used_ = false;
+  counter.used_ = false;
 
   tls_.shutdownThread();
 }
@@ -226,24 +229,24 @@ TEST(UdpStatsdSinkWithTagsTest, CheckActualStats) {
   UdpStatsdSink sink(tls_, writer_ptr, true);
 
   std::vector<Stats::Tag> tags = {Stats::Tag{"key1", "value1"}, Stats::Tag{"key2", "value2"}};
-  auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
-  counter->name_ = "test_counter";
-  counter->used_ = true;
-  counter->latch_ = 1;
-  counter->setTags(tags);
-  snapshot.counters_.push_back({1, *counter});
+  NiceMock<Stats::MockCounter> counter;
+  counter.name_ = "test_counter";
+  counter.used_ = true;
+  counter.latch_ = 1;
+  counter.setTags(tags);
+  snapshot.counters_.push_back({1, counter});
 
   EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr),
               write("envoy.test_counter:1|c|#key1:value1,key2:value2"));
   sink.flush(snapshot);
-  counter->used_ = false;
+  counter.used_ = false;
 
-  auto gauge = std::make_shared<NiceMock<Stats::MockGauge>>();
-  gauge->name_ = "test_gauge";
-  gauge->value_ = 1;
-  gauge->used_ = true;
-  gauge->setTags(tags);
-  snapshot.gauges_.push_back(*gauge);
+  NiceMock<Stats::MockGauge> gauge;
+  gauge.name_ = "test_gauge";
+  gauge.value_ = 1;
+  gauge.used_ = true;
+  gauge.setTags(tags);
+  snapshot.gauges_.push_back(gauge);
 
   EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr),
               write("envoy.test_gauge:1|g|#key1:value1,key2:value2"));


### PR DESCRIPTION
Description: use of `std::make_shared` isn't necessary here, just use RAII.
Risk Level: low
Testing: existing
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Derek Argueta <dereka@pinterest.com>