### PR TITLE
test: migrate mock methods batch 1/4

### DIFF
--- a/test/common/common/callback_impl_test.cc
+++ b/test/common/common/callback_impl_test.cc
@@ -10,7 +10,7 @@ namespace Common {
 
 class CallbackManagerTest : public testing::Test {
 public:
-  MOCK_METHOD1(called, void(int arg));
+  MOCK_METHOD(void, called, (int arg));
 };
 
 TEST_F(CallbackManagerTest, All) {

--- a/test/common/common/stack_array_test.cc
+++ b/test/common/common/stack_array_test.cc
@@ -12,7 +12,7 @@ public:
 
   int val_ = 0;
   TestEntry* self_;
-  MOCK_METHOD1(destructor_, void(int));
+  MOCK_METHOD(void, destructor_, (int));
 };
 
 TEST(StackArray, ConstructorsAndDestructorsCalled) {

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -24,7 +24,7 @@ protected:
 
 class WatchCallback {
 public:
-  MOCK_METHOD1(called, void(uint32_t));
+  MOCK_METHOD(void, called, (uint32_t));
 };
 
 TEST_F(WatcherImplTest, All) {

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -25,9 +25,9 @@ namespace {
 
 class MockGenericStub : public GoogleStub {
 public:
-  MOCK_METHOD3(PrepareCall_, grpc::GenericClientAsyncReaderWriter*(grpc::ClientContext* context,
-                                                                   const grpc::string& method,
-                                                                   grpc::CompletionQueue* cq));
+  MOCK_METHOD(grpc::GenericClientAsyncReaderWriter*, PrepareCall_,
+              (grpc::ClientContext * context, const grpc::string& method,
+               grpc::CompletionQueue* cq));
 
   std::unique_ptr<grpc::GenericClientAsyncReaderWriter>
   PrepareCall(grpc::ClientContext* context, const grpc::string& method,

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -35,7 +35,7 @@ namespace Http {
 
 class MockInternalAddressConfig : public Http::InternalAddressConfig {
 public:
-  MOCK_CONST_METHOD1(isInternalAddress, bool(const Network::Address::Instance&));
+  MOCK_METHOD(bool, isInternalAddress, (const Network::Address::Instance&), (const));
 };
 
 class MockConnectionManagerConfig : public ConnectionManagerConfig {
@@ -52,48 +52,48 @@ public:
     return ServerConnectionPtr{createCodec_(connection, instance, callbacks)};
   }
 
-  MOCK_METHOD0(accessLogs, const std::list<AccessLog::InstanceSharedPtr>&());
-  MOCK_METHOD3(createCodec_, ServerConnection*(Network::Connection&, const Buffer::Instance&,
-                                               ServerConnectionCallbacks&));
-  MOCK_METHOD0(dateProvider, DateProvider&());
-  MOCK_CONST_METHOD0(drainTimeout, std::chrono::milliseconds());
-  MOCK_METHOD0(filterFactory, FilterChainFactory&());
-  MOCK_CONST_METHOD0(generateRequestId, bool());
-  MOCK_CONST_METHOD0(preserveExternalRequestId, bool());
-  MOCK_CONST_METHOD0(maxRequestHeadersKb, uint32_t());
-  MOCK_CONST_METHOD0(maxRequestHeadersCount, uint32_t());
-  MOCK_CONST_METHOD0(idleTimeout, absl::optional<std::chrono::milliseconds>());
-  MOCK_CONST_METHOD0(isRoutable, bool());
-  MOCK_CONST_METHOD0(maxConnectionDuration, absl::optional<std::chrono::milliseconds>());
-  MOCK_CONST_METHOD0(streamIdleTimeout, std::chrono::milliseconds());
-  MOCK_CONST_METHOD0(requestTimeout, std::chrono::milliseconds());
-  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
-  MOCK_METHOD0(routeConfigProvider, Router::RouteConfigProvider*());
-  MOCK_METHOD0(scopedRouteConfigProvider, Config::ConfigProvider*());
-  MOCK_CONST_METHOD0(serverName, const std::string&());
-  MOCK_CONST_METHOD0(serverHeaderTransformation,
-                     HttpConnectionManagerProto::ServerHeaderTransformation());
-  MOCK_METHOD0(stats, ConnectionManagerStats&());
-  MOCK_METHOD0(tracingStats, ConnectionManagerTracingStats&());
-  MOCK_CONST_METHOD0(useRemoteAddress, bool());
+  MOCK_METHOD(const std::list<AccessLog::InstanceSharedPtr>&, accessLogs, ());
+  MOCK_METHOD(ServerConnection*, createCodec_,
+              (Network::Connection&, const Buffer::Instance&, ServerConnectionCallbacks&));
+  MOCK_METHOD(DateProvider&, dateProvider, ());
+  MOCK_METHOD(std::chrono::milliseconds, drainTimeout, (), (const));
+  MOCK_METHOD(FilterChainFactory&, filterFactory, ());
+  MOCK_METHOD(bool, generateRequestId, (), (const));
+  MOCK_METHOD(bool, preserveExternalRequestId, (), (const));
+  MOCK_METHOD(uint32_t, maxRequestHeadersKb, (), (const));
+  MOCK_METHOD(uint32_t, maxRequestHeadersCount, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(bool, isRoutable, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxConnectionDuration, (), (const));
+  MOCK_METHOD(std::chrono::milliseconds, streamIdleTimeout, (), (const));
+  MOCK_METHOD(std::chrono::milliseconds, requestTimeout, (), (const));
+  MOCK_METHOD(std::chrono::milliseconds, delayedCloseTimeout, (), (const));
+  MOCK_METHOD(Router::RouteConfigProvider*, routeConfigProvider, ());
+  MOCK_METHOD(Config::ConfigProvider*, scopedRouteConfigProvider, ());
+  MOCK_METHOD(const std::string&, serverName, (), (const));
+  MOCK_METHOD(HttpConnectionManagerProto::ServerHeaderTransformation, serverHeaderTransformation,
+              (), (const));
+  MOCK_METHOD(ConnectionManagerStats&, stats, ());
+  MOCK_METHOD(ConnectionManagerTracingStats&, tracingStats, ());
+  MOCK_METHOD(bool, useRemoteAddress, (), (const));
   const Http::InternalAddressConfig& internalAddressConfig() const override {
     return *internal_address_config_;
   }
-  MOCK_METHOD0(unixSocketInternal, bool());
-  MOCK_CONST_METHOD0(xffNumTrustedHops, uint32_t());
-  MOCK_CONST_METHOD0(skipXffAppend, bool());
-  MOCK_CONST_METHOD0(via, const std::string&());
-  MOCK_CONST_METHOD0(forwardClientCert, Http::ForwardClientCertType());
-  MOCK_CONST_METHOD0(setCurrentClientCertDetails,
-                     const std::vector<Http::ClientCertDetailsType>&());
-  MOCK_METHOD0(localAddress, const Network::Address::Instance&());
-  MOCK_METHOD0(userAgent, const absl::optional<std::string>&());
-  MOCK_METHOD0(tracingConfig, const Http::TracingConnectionManagerConfig*());
-  MOCK_METHOD0(listenerStats, ConnectionManagerListenerStats&());
-  MOCK_CONST_METHOD0(proxy100Continue, bool());
-  MOCK_CONST_METHOD0(http1Settings, const Http::Http1Settings&());
-  MOCK_CONST_METHOD0(shouldNormalizePath, bool());
-  MOCK_CONST_METHOD0(shouldMergeSlashes, bool());
+  MOCK_METHOD(bool, unixSocketInternal, ());
+  MOCK_METHOD(uint32_t, xffNumTrustedHops, (), (const));
+  MOCK_METHOD(bool, skipXffAppend, (), (const));
+  MOCK_METHOD(const std::string&, via, (), (const));
+  MOCK_METHOD(Http::ForwardClientCertType, forwardClientCert, (), (const));
+  MOCK_METHOD(const std::vector<Http::ClientCertDetailsType>&, setCurrentClientCertDetails, (),
+              (const));
+  MOCK_METHOD(const Network::Address::Instance&, localAddress, ());
+  MOCK_METHOD(const absl::optional<std::string>&, userAgent, ());
+  MOCK_METHOD(const Http::TracingConnectionManagerConfig*, tracingConfig, ());
+  MOCK_METHOD(ConnectionManagerListenerStats&, listenerStats, ());
+  MOCK_METHOD(bool, proxy100Continue, (), (const));
+  MOCK_METHOD(const Http::Http1Settings&, http1Settings, (), (const));
+  MOCK_METHOD(bool, shouldNormalizePath, (), (const));
+  MOCK_METHOD(bool, shouldMergeSlashes, (), (const));
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =
       std::make_unique<DefaultInternalAddressConfig>();

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -74,8 +74,8 @@ public:
     return CodecClientPtr{createCodecClient_()};
   }
 
-  MOCK_METHOD0(createCodecClient_, CodecClient*());
-  MOCK_METHOD0(onClientDestroy, void());
+  MOCK_METHOD(CodecClient*, createCodecClient_, ());
+  MOCK_METHOD(void, onClientDestroy, ());
 
   void expectClientCreate(Protocol protocol = Protocol::Http11) {
     test_clients_.emplace_back();

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -43,7 +43,7 @@ public:
     return CodecClientPtr{createCodecClient_(data)};
   }
 
-  MOCK_METHOD1(createCodecClient_, CodecClient*(Upstream::Host::CreateConnectionData& data));
+  MOCK_METHOD(CodecClient*, createCodecClient_, (Upstream::Host::CreateConnectionData & data));
 
   uint32_t maxTotalStreams() override { return max_streams_; }
 
@@ -126,7 +126,7 @@ public:
    */
   void completeRequestCloseUpstream(size_t index, ActiveTestRequest& r);
 
-  MOCK_METHOD0(onClientDestroy, void());
+  MOCK_METHOD(void, onClientDestroy, ());
 
   Stats::IsolatedStoreImpl stats_store_;
   Api::ApiPtr api_;

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -65,7 +65,7 @@ public:
                    bool bind_to_port)
       : ListenerImpl(dispatcher, std::move(socket), cb, bind_to_port) {}
 
-  MOCK_METHOD1(getLocalAddress, Address::InstanceConstSharedPtr(int fd));
+  MOCK_METHOD(Address::InstanceConstSharedPtr, getLocalAddress, (int fd));
 };
 
 using ListenerImplTest = ListenerImplTestBase;

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -110,12 +110,11 @@ public:
       : SdsApi(config_source, "abc.com", subscription_factory, time_source, validation_visitor_,
                server.stats(), init_manager, []() {}) {}
 
-  MOCK_METHOD2(onConfigUpdate,
-               void(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>&, const std::string&));
-  void
-  onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added,
-                 const Protobuf::RepeatedPtrField<std::string>& removed,
-                 const std::string& version) override {
+  MOCK_METHOD(void, onConfigUpdate,
+              (const Protobuf::RepeatedPtrField<ProtobufWkt::Any>&, const std::string&));
+  void onConfigUpdate(
+      const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added,
+      const Protobuf::RepeatedPtrField<std::string>& removed, const std::string& version) override {
     SdsApi::onConfigUpdate(added, removed, version);
   }
   void setSecret(const envoy::extensions::transport_sockets::tls::v3::Secret&) override {}
@@ -247,9 +246,9 @@ class MockCvcValidationCallback : public CvcValidationCallback {
 public:
   MockCvcValidationCallback() = default;
   ~MockCvcValidationCallback() override = default;
-  MOCK_METHOD1(
-      validateCvc,
-      void(const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&));
+  MOCK_METHOD(
+      void, validateCvc,
+      (const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&));
 };
 
 // Validate that CertificateValidationContextSdsApi updates secrets successfully if

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -112,9 +112,10 @@ public:
 
   MOCK_METHOD(void, onConfigUpdate,
               (const Protobuf::RepeatedPtrField<ProtobufWkt::Any>&, const std::string&));
-  void onConfigUpdate(
-      const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added,
-      const Protobuf::RepeatedPtrField<std::string>& removed, const std::string& version) override {
+  void
+  onConfigUpdate(const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>& added,
+                 const Protobuf::RepeatedPtrField<std::string>& removed,
+                 const std::string& version) override {
     SdsApi::onConfigUpdate(added, removed, version);
   }
   void setSecret(const envoy::extensions::transport_sockets::tls::v3::Secret&) override {}
@@ -246,9 +247,8 @@ class MockCvcValidationCallback : public CvcValidationCallback {
 public:
   MockCvcValidationCallback() = default;
   ~MockCvcValidationCallback() override = default;
-  MOCK_METHOD(
-      void, validateCvc,
-      (const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&));
+  MOCK_METHOD(void, validateCvc,
+              (const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&));
 };
 
 // Validate that CertificateValidationContextSdsApi updates secrets successfully if

--- a/test/common/singleton/manager_impl_test.cc
+++ b/test/common/singleton/manager_impl_test.cc
@@ -28,7 +28,7 @@ class TestSingleton : public Instance {
 public:
   ~TestSingleton() override { onDestroy(); }
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 };
 
 TEST(SingletonManagerImplTest, Basic) {

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -82,8 +82,8 @@ public:
     EXPECT_EQ(0U, pending_requests_.size());
   }
 
-  MOCK_METHOD0(onConnReleasedForTest, void());
-  MOCK_METHOD0(onConnDestroyedForTest, void());
+  MOCK_METHOD(void, onConnReleasedForTest, ());
+  MOCK_METHOD(void, onConnDestroyedForTest, ());
 
   struct TestConnection {
     Network::MockClientConnection* connection_;

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -19,7 +19,7 @@ class TestThreadLocalObject : public ThreadLocalObject {
 public:
   ~TestThreadLocalObject() override { onDestroy(); }
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 };
 
 class ThreadLocalInstanceImplTest : public testing::Test {
@@ -31,7 +31,7 @@ public:
     tls_.registerThread(thread_dispatcher_, false);
   }
 
-  MOCK_METHOD1(createThreadLocal, ThreadLocalObjectSharedPtr(Event::Dispatcher& dispatcher));
+  MOCK_METHOD(ThreadLocalObjectSharedPtr, createThreadLocal, (Event::Dispatcher & dispatcher));
 
   TestThreadLocalObject& setObject(Slot& slot) {
     std::shared_ptr<TestThreadLocalObject> object(new TestThreadLocalObject());

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2168,14 +2168,14 @@ class MockConnPoolWithDestroy : public Http::ConnectionPool::MockInstance {
 public:
   ~MockConnPoolWithDestroy() override { onDestroy(); }
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 };
 
 class MockTcpConnPoolWithDestroy : public Tcp::ConnectionPool::MockInstance {
 public:
   ~MockTcpConnPoolWithDestroy() override { onDestroy(); }
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 };
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/3518. Make sure we handle a
@@ -2782,7 +2782,7 @@ TEST_F(ClusterManagerImplTest, AddUpstreamFilters) {
 
 class ClusterManagerInitHelperTest : public testing::Test {
 public:
-  MOCK_METHOD1(onClusterInit, void(Cluster& cluster));
+  MOCK_METHOD(void, onClusterInit, (Cluster & cluster));
 
   NiceMock<MockClusterManager> cm_;
   ClusterManagerInitHelper init_helper_{cm_, [this](Cluster& cluster) { onClusterInit(cluster); }};

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -104,7 +104,7 @@ public:
   };
 
   // HttpHealthCheckerImpl
-  MOCK_METHOD1(createCodecClient_, Http::CodecClient*(Upstream::Host::CreateConnectionData&));
+  MOCK_METHOD(Http::CodecClient*, createCodecClient_, (Upstream::Host::CreateConnectionData&));
 
   Http::CodecClient::Type codecClientType() { return codec_client_type_; }
 };
@@ -695,7 +695,7 @@ public:
               cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
   }
 
-  MOCK_METHOD2(onHostStatus, void(HostSharedPtr host, HealthTransition changed_state));
+  MOCK_METHOD(void, onHostStatus, (HostSharedPtr host, HealthTransition changed_state));
 
   std::shared_ptr<MockClusterMockPrioritySet> cluster_;
   NiceMock<Event::MockDispatcher> dispatcher_;
@@ -3362,7 +3362,7 @@ public:
   };
 
   // GrpcHealthCheckerImpl
-  MOCK_METHOD1(createCodecClient_, Http::CodecClient*(Upstream::Host::CreateConnectionData&));
+  MOCK_METHOD(Http::CodecClient*, createCodecClient_, (Upstream::Host::CreateConnectionData&));
 };
 
 class GrpcHealthCheckerImplTestBase {
@@ -3709,7 +3709,7 @@ public:
     expectHostHealthy(true);
   }
 
-  MOCK_METHOD2(onHostStatus, void(HostSharedPtr host, HealthTransition changed_state));
+  MOCK_METHOD(void, onHostStatus, (HostSharedPtr host, HealthTransition changed_state));
 
   std::shared_ptr<MockClusterMockPrioritySet> cluster_;
   NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -57,7 +57,7 @@ TEST(OutlierDetectorImplFactoryTest, Detector) {
 
 class CallbackChecker {
 public:
-  MOCK_METHOD1(check, void(HostSharedPtr host));
+  MOCK_METHOD(void, check, (HostSharedPtr host));
 };
 
 class OutlierDetectorImplTest : public testing::Test {

--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -109,18 +109,16 @@ public:
 
   Secret::SecretManager& secretManager() override { return secret_manager_; }
 
-  MOCK_METHOD1(clusterManagerFromProto_,
-               ClusterManager*(const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
-  MOCK_METHOD3(allocateConnPool_,
-               Http::ConnectionPool::Instance*(HostConstSharedPtr host,
-                                               Network::ConnectionSocket::OptionsSharedPtr,
-                                               Network::TransportSocketOptionsSharedPtr));
-  MOCK_METHOD1(allocateTcpConnPool_, Tcp::ConnectionPool::Instance*(HostConstSharedPtr host));
-  MOCK_METHOD4(clusterFromProto_,
-               std::pair<ClusterSharedPtr, ThreadAwareLoadBalancer*>(
-                   const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cm,
-                   Outlier::EventLoggerSharedPtr outlier_event_logger, bool added_via_api));
-  MOCK_METHOD0(createCds_, CdsApi*());
+  MOCK_METHOD(ClusterManager*, clusterManagerFromProto_,
+              (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
+  MOCK_METHOD(Http::ConnectionPool::Instance*, allocateConnPool_,
+              (HostConstSharedPtr host, Network::ConnectionSocket::OptionsSharedPtr,
+               Network::TransportSocketOptionsSharedPtr));
+  MOCK_METHOD(Tcp::ConnectionPool::Instance*, allocateTcpConnPool_, (HostConstSharedPtr host));
+  MOCK_METHOD((std::pair<ClusterSharedPtr, ThreadAwareLoadBalancer*>), clusterFromProto_,
+              (const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cm,
+               Outlier::EventLoggerSharedPtr outlier_event_logger, bool added_via_api));
+  MOCK_METHOD(CdsApi*, createCds_, ());
 
   Stats::IsolatedStoreImpl stats_;
   NiceMock<ThreadLocal::MockInstance> tls_;
@@ -143,13 +141,13 @@ public:
 // Helper to intercept calls to postThreadLocalClusterUpdate.
 class MockLocalClusterUpdate {
 public:
-  MOCK_METHOD3(post, void(uint32_t priority, const HostVector& hosts_added,
-                          const HostVector& hosts_removed));
+  MOCK_METHOD(void, post,
+              (uint32_t priority, const HostVector& hosts_added, const HostVector& hosts_removed));
 };
 
 class MockLocalHostsRemoved {
 public:
-  MOCK_METHOD1(post, void(const HostVector&));
+  MOCK_METHOD(void, post, (const HostVector&));
 };
 
 // A test version of ClusterManagerImpl that provides a way to get a non-const handle to the

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -30,9 +30,9 @@ namespace {
 
 class FakeTransportSocketFactory : public Network::TransportSocketFactory {
 public:
-  MOCK_CONST_METHOD0(implementsSecureTransport, bool());
-  MOCK_CONST_METHOD1(createTransportSocket,
-                     Network::TransportSocketPtr(Network::TransportSocketOptionsSharedPtr));
+  MOCK_METHOD(bool, implementsSecureTransport, (), (const));
+  MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
+              (Network::TransportSocketOptionsSharedPtr), (const));
   FakeTransportSocketFactory(std::string id) : id_(std::move(id)) {}
   std::string id() const { return id_; }
 
@@ -45,9 +45,9 @@ class FooTransportSocketFactory
       public Server::Configuration::UpstreamTransportSocketConfigFactory,
       Logger::Loggable<Logger::Id::upstream> {
 public:
-  MOCK_CONST_METHOD0(implementsSecureTransport, bool());
-  MOCK_CONST_METHOD1(createTransportSocket,
-                     Network::TransportSocketPtr(Network::TransportSocketOptionsSharedPtr));
+  MOCK_METHOD(bool, implementsSecureTransport, (), (const));
+  MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
+              (Network::TransportSocketOptionsSharedPtr), (const));
 
   Network::TransportSocketFactoryPtr
   createTransportSocketFactory(const Protobuf::Message& proto,
@@ -134,14 +134,14 @@ transport_socket:
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(R"EOF(
 filter_metadata:
-  envoy.transport_socket_match: { sidecar: "true" } 
+  envoy.transport_socket_match: { sidecar: "true" }
 )EOF",
                             metadata);
 
   validate(metadata, "sidecar");
   TestUtility::loadFromYaml(R"EOF(
 filter_metadata:
-  envoy.transport_socket_match: { protocol: "http" } 
+  envoy.transport_socket_match: { protocol: "http" }
 )EOF",
                             metadata);
   validate(metadata, "http");

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -36,18 +36,17 @@ using envoy::data::accesslog::v3::HTTPAccessLogEntry;
 class MockGrpcAccessLogger : public GrpcCommon::GrpcAccessLogger {
 public:
   // GrpcAccessLogger
-  MOCK_METHOD1(log, void(HTTPAccessLogEntry&& entry));
-  MOCK_METHOD1(log, void(envoy::data::accesslog::v3::TCPAccessLogEntry&& entry));
+  MOCK_METHOD(void, log, (HTTPAccessLogEntry && entry));
+  MOCK_METHOD(void, log, (envoy::data::accesslog::v3::TCPAccessLogEntry && entry));
 };
 
 class MockGrpcAccessLoggerCache : public GrpcCommon::GrpcAccessLoggerCache {
 public:
   // GrpcAccessLoggerCache
-  MOCK_METHOD2(
-      getOrCreateLogger,
-      GrpcCommon::GrpcAccessLoggerSharedPtr(
-          const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-          GrpcCommon::GrpcAccessLoggerType logger_type));
+  MOCK_METHOD(
+      GrpcCommon::GrpcAccessLoggerSharedPtr, getOrCreateLogger,
+      (const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
+       GrpcCommon::GrpcAccessLoggerType logger_type));
 };
 
 class HttpGrpcAccessLogTest : public testing::Test {

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -43,10 +43,9 @@ public:
 class MockGrpcAccessLoggerCache : public GrpcCommon::GrpcAccessLoggerCache {
 public:
   // GrpcAccessLoggerCache
-  MOCK_METHOD(
-      GrpcCommon::GrpcAccessLoggerSharedPtr, getOrCreateLogger,
-      (const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-       GrpcCommon::GrpcAccessLoggerType logger_type));
+  MOCK_METHOD(GrpcCommon::GrpcAccessLoggerSharedPtr, getOrCreateLogger,
+              (const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
+               GrpcCommon::GrpcAccessLoggerType logger_type));
 };
 
 class HttpGrpcAccessLogTest : public testing::Test {

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -100,8 +100,8 @@ public:
     return &lb_context_;
   }
 
-  MOCK_METHOD2(onMemberUpdateCb, void(const Upstream::HostVector& hosts_added,
-                                      const Upstream::HostVector& hosts_removed));
+  MOCK_METHOD(void, onMemberUpdateCb,
+              (const Upstream::HostVector& hosts_added, const Upstream::HostVector& hosts_removed));
 
   Stats::IsolatedStoreImpl stats_store_;
   Ssl::MockContextManager ssl_context_manager_;

--- a/test/extensions/clusters/redis/mocks.h
+++ b/test/extensions/clusters/redis/mocks.h
@@ -21,8 +21,8 @@ public:
   MockClusterSlotUpdateCallBack();
   ~MockClusterSlotUpdateCallBack() override = default;
 
-  MOCK_METHOD2(onClusterSlotUpdate, bool(ClusterSlotsPtr&&, Upstream::HostMap));
-  MOCK_METHOD0(onHostHealthUpdate, void());
+  MOCK_METHOD(bool, onClusterSlotUpdate, (ClusterSlotsPtr&&, Upstream::HostMap));
+  MOCK_METHOD(void, onHostHealthUpdate, ());
 };
 
 } // namespace Redis

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -71,7 +71,7 @@ public:
         create_(host->address()->asString())};
   }
 
-  MOCK_METHOD1(create_, Extensions::NetworkFilters::Common::Redis::Client::Client*(std::string));
+  MOCK_METHOD(Extensions::NetworkFilters::Common::Redis::Client::Client*, create_, (std::string));
 
 protected:
   RedisClusterTest() : api_(Api::createApiForTest(stats_store_)) {}

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -52,9 +52,8 @@ public:
   MockDnsCacheManager();
   ~MockDnsCacheManager() override;
 
-  MOCK_METHOD(
-      DnsCacheSharedPtr, getCache,
-      (const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config));
+  MOCK_METHOD(DnsCacheSharedPtr, getCache,
+              (const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config));
 
   std::shared_ptr<MockDnsCache> dns_cache_{new MockDnsCache()};
 };

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -26,17 +26,17 @@ public:
     MockLoadDnsCacheEntryResult result = loadDnsCacheEntry_(host, default_port, callbacks);
     return {result.status_, LoadDnsCacheEntryHandlePtr{result.handle_}};
   }
-  MOCK_METHOD3(loadDnsCacheEntry_,
-               MockLoadDnsCacheEntryResult(absl::string_view host, uint16_t default_port,
-                                           LoadDnsCacheEntryCallbacks& callbacks));
+  MOCK_METHOD(MockLoadDnsCacheEntryResult, loadDnsCacheEntry_,
+              (absl::string_view host, uint16_t default_port,
+               LoadDnsCacheEntryCallbacks& callbacks));
 
   AddUpdateCallbacksHandlePtr addUpdateCallbacks(UpdateCallbacks& callbacks) override {
     return AddUpdateCallbacksHandlePtr{addUpdateCallbacks_(callbacks)};
   }
-  MOCK_METHOD1(addUpdateCallbacks_,
-               DnsCache::AddUpdateCallbacksHandle*(UpdateCallbacks& callbacks));
+  MOCK_METHOD(DnsCache::AddUpdateCallbacksHandle*, addUpdateCallbacks_,
+              (UpdateCallbacks & callbacks));
 
-  MOCK_METHOD0(hosts, absl::flat_hash_map<std::string, DnsHostInfoSharedPtr>());
+  MOCK_METHOD((absl::flat_hash_map<std::string, DnsHostInfoSharedPtr>), hosts, ());
 };
 
 class MockLoadDnsCacheEntryHandle : public DnsCache::LoadDnsCacheEntryHandle {
@@ -44,7 +44,7 @@ public:
   MockLoadDnsCacheEntryHandle();
   ~MockLoadDnsCacheEntryHandle() override;
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 };
 
 class MockDnsCacheManager : public DnsCacheManager {
@@ -52,10 +52,9 @@ public:
   MockDnsCacheManager();
   ~MockDnsCacheManager() override;
 
-  MOCK_METHOD1(
-      getCache,
-      DnsCacheSharedPtr(
-          const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config));
+  MOCK_METHOD(
+      DnsCacheSharedPtr, getCache,
+      (const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config));
 
   std::shared_ptr<MockDnsCache> dns_cache_{new MockDnsCache()};
 };
@@ -65,10 +64,10 @@ public:
   MockDnsHostInfo();
   ~MockDnsHostInfo() override;
 
-  MOCK_METHOD0(address, Network::Address::InstanceConstSharedPtr());
-  MOCK_CONST_METHOD0(resolvedHost, const std::string&());
-  MOCK_CONST_METHOD0(isIpAddress, bool());
-  MOCK_METHOD0(touch, void());
+  MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, ());
+  MOCK_METHOD(const std::string&, resolvedHost, (), (const));
+  MOCK_METHOD(bool, isIpAddress, (), (const));
+  MOCK_METHOD(void, touch, ());
 
   Network::Address::InstanceConstSharedPtr address_;
   std::string resolved_host_;
@@ -79,9 +78,9 @@ public:
   MockUpdateCallbacks();
   ~MockUpdateCallbacks() override;
 
-  MOCK_METHOD2(onDnsHostAddOrUpdate,
-               void(const std::string& host, const DnsHostInfoSharedPtr& address));
-  MOCK_METHOD1(onDnsHostRemove, void(const std::string& host));
+  MOCK_METHOD(void, onDnsHostAddOrUpdate,
+              (const std::string& host, const DnsHostInfoSharedPtr& address));
+  MOCK_METHOD(void, onDnsHostRemove, (const std::string& host));
 };
 
 class MockLoadDnsCacheEntryCallbacks : public DnsCache::LoadDnsCacheEntryCallbacks {
@@ -89,7 +88,7 @@ public:
   MockLoadDnsCacheEntryCallbacks();
   ~MockLoadDnsCacheEntryCallbacks() override;
 
-  MOCK_METHOD0(onLoadDnsCacheComplete, void());
+  MOCK_METHOD(void, onLoadDnsCacheComplete, ());
 };
 
 } // namespace DynamicForwardProxy

--- a/test/extensions/common/redis/mocks.h
+++ b/test/extensions/common/redis/mocks.h
@@ -14,14 +14,14 @@ public:
   MockClusterRefreshManager();
   ~MockClusterRefreshManager() override;
 
-  MOCK_METHOD1(onRedirection, bool(const std::string& cluster_name));
-  MOCK_METHOD1(onFailure, bool(const std::string& cluster_name));
-  MOCK_METHOD1(onHostDegraded, bool(const std::string& cluster_name));
-  MOCK_METHOD6(registerCluster,
-               HandlePtr(const std::string& cluster_name,
-                         std::chrono::milliseconds min_time_between_triggering,
-                         const uint32_t redirects_threshold, const uint32_t failure_threshold,
-                         const uint32_t host_degraded_threshold, const RefreshCB& cb));
+  MOCK_METHOD(bool, onRedirection, (const std::string& cluster_name));
+  MOCK_METHOD(bool, onFailure, (const std::string& cluster_name));
+  MOCK_METHOD(bool, onHostDegraded, (const std::string& cluster_name));
+  MOCK_METHOD(HandlePtr, registerCluster,
+              (const std::string& cluster_name,
+               std::chrono::milliseconds min_time_between_triggering,
+               const uint32_t redirects_threshold, const uint32_t failure_threshold,
+               const uint32_t host_degraded_threshold, const RefreshCB& cb));
 };
 
 } // namespace Redis

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -18,10 +18,10 @@ namespace {
 
 class MockExtensionConfig : public ExtensionConfig {
 public:
-  MOCK_METHOD0(adminId, const absl::string_view());
-  MOCK_METHOD0(clearTapConfig, void());
-  MOCK_METHOD2(newTapConfig,
-               void(envoy::config::tap::v3::TapConfig&& proto_config, Sink* admin_streamer));
+  MOCK_METHOD(const absl::string_view, adminId, ());
+  MOCK_METHOD(void, clearTapConfig, ());
+  MOCK_METHOD(void, newTapConfig,
+              (envoy::config::tap::v3::TapConfig && proto_config, Sink* admin_streamer));
 };
 
 class AdminHandlerTest : public testing::Test {

--- a/test/extensions/common/tap/common.h
+++ b/test/extensions/common/tap/common.h
@@ -43,7 +43,7 @@ public:
 
   void submitTrace(TraceWrapperPtr&& trace) override { submitTrace_(*trace); }
 
-  MOCK_METHOD1(submitTrace_, void(const envoy::data::tap::v3::TraceWrapper& trace));
+  MOCK_METHOD(void, submitTrace_, (const envoy::data::tap::v3::TraceWrapper& trace));
 };
 
 class MockMatcher : public Matcher {
@@ -51,15 +51,15 @@ public:
   using Matcher::Matcher;
   ~MockMatcher() override;
 
-  MOCK_CONST_METHOD1(onNewStream, void(MatchStatusVector& statuses));
-  MOCK_CONST_METHOD2(onHttpRequestHeaders,
-                     void(const Http::HeaderMap& request_headers, MatchStatusVector& statuses));
-  MOCK_CONST_METHOD2(onHttpRequestTrailers,
-                     void(const Http::HeaderMap& request_trailers, MatchStatusVector& statuses));
-  MOCK_CONST_METHOD2(onHttpResponseHeaders,
-                     void(const Http::HeaderMap& response_headers, MatchStatusVector& statuses));
-  MOCK_CONST_METHOD2(onHttpResponseTrailers,
-                     void(const Http::HeaderMap& response_trailers, MatchStatusVector& statuses));
+  MOCK_METHOD(void, onNewStream, (MatchStatusVector & statuses), (const));
+  MOCK_METHOD(void, onHttpRequestHeaders,
+              (const Http::HeaderMap& request_headers, MatchStatusVector& statuses), (const));
+  MOCK_METHOD(void, onHttpRequestTrailers,
+              (const Http::HeaderMap& request_trailers, MatchStatusVector& statuses), (const));
+  MOCK_METHOD(void, onHttpResponseHeaders,
+              (const Http::HeaderMap& response_headers, MatchStatusVector& statuses), (const));
+  MOCK_METHOD(void, onHttpResponseTrailers,
+              (const Http::HeaderMap& response_trailers, MatchStatusVector& statuses), (const));
 };
 
 } // namespace Tap

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -25,7 +25,7 @@ public:
   TestNullVmPlugin() = default;
   ~TestNullVmPlugin() override = default;
 
-  MOCK_METHOD0(start, void());
+  MOCK_METHOD(void, start, ());
 };
 
 class PluginFactory : public Null::NullVmPluginFactory {
@@ -106,8 +106,8 @@ TEST_F(BaseVmTest, NullVmMemory) {
 
 class MockHostFunctions {
 public:
-  MOCK_CONST_METHOD1(pong, void(uint32_t));
-  MOCK_CONST_METHOD0(random, uint32_t());
+  MOCK_METHOD(void, pong, (uint32_t), (const));
+  MOCK_METHOD(uint32_t, random, (), (const));
 };
 
 MockHostFunctions* g_host_functions;

--- a/test/extensions/filters/common/ext_authz/mocks.h
+++ b/test/extensions/filters/common/ext_authz/mocks.h
@@ -23,8 +23,7 @@ public:
   // ExtAuthz::Client
   MOCK_METHOD(void, cancel, ());
   MOCK_METHOD(void, check,
-              (RequestCallbacks & callbacks,
-               const envoy::service::auth::v3::CheckRequest& request,
+              (RequestCallbacks & callbacks, const envoy::service::auth::v3::CheckRequest& request,
                Tracing::Span& parent_span));
 };
 

--- a/test/extensions/filters/common/ext_authz/mocks.h
+++ b/test/extensions/filters/common/ext_authz/mocks.h
@@ -21,10 +21,11 @@ public:
   ~MockClient() override;
 
   // ExtAuthz::Client
-  MOCK_METHOD0(cancel, void());
-  MOCK_METHOD3(check, void(RequestCallbacks& callbacks,
-                           const envoy::service::auth::v3::CheckRequest& request,
-                           Tracing::Span& parent_span));
+  MOCK_METHOD(void, cancel, ());
+  MOCK_METHOD(void, check,
+              (RequestCallbacks & callbacks,
+               const envoy::service::auth::v3::CheckRequest& request,
+               Tracing::Span& parent_span));
 };
 
 class MockRequestCallbacks : public RequestCallbacks {
@@ -34,7 +35,7 @@ public:
 
   void onComplete(ResponsePtr&& response) override { onComplete_(response); }
 
-  MOCK_METHOD1(onComplete_, void(ResponsePtr& response));
+  MOCK_METHOD(void, onComplete_, (ResponsePtr & response));
 };
 
 } // namespace ExtAuthz

--- a/test/extensions/filters/common/lua/lua_test.cc
+++ b/test/extensions/filters/common/lua/lua_test.cc
@@ -27,8 +27,8 @@ public:
 
   static ExportedFunctions exportedFunctions() { return {{"testCall", static_luaTestCall}}; }
 
-  MOCK_METHOD1(doTestCall, int(lua_State* state));
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(int, doTestCall, (lua_State * state));
+  MOCK_METHOD(void, onDestroy, ());
 
 private:
   DECLARE_LUA_FUNCTION(TestObject, luaTestCall);

--- a/test/extensions/filters/common/lua/lua_wrappers.h
+++ b/test/extensions/filters/common/lua/lua_wrappers.h
@@ -38,7 +38,7 @@ public:
     return 0;
   }
 
-  MOCK_METHOD1(testPrint, void(const std::string&));
+  MOCK_METHOD(void, testPrint, (const std::string&));
 
   NiceMock<ThreadLocal::MockInstance> tls_;
   std::unique_ptr<ThreadLocalState> state_;

--- a/test/extensions/filters/common/ratelimit/mocks.h
+++ b/test/extensions/filters/common/ratelimit/mocks.h
@@ -21,10 +21,11 @@ public:
   ~MockClient() override;
 
   // RateLimit::Client
-  MOCK_METHOD0(cancel, void());
-  MOCK_METHOD4(limit, void(RequestCallbacks& callbacks, const std::string& domain,
-                           const std::vector<Envoy::RateLimit::Descriptor>& descriptors,
-                           Tracing::Span& parent_span));
+  MOCK_METHOD(void, cancel, ());
+  MOCK_METHOD(void, limit,
+              (RequestCallbacks & callbacks, const std::string& domain,
+               const std::vector<Envoy::RateLimit::Descriptor>& descriptors,
+               Tracing::Span& parent_span));
 };
 
 } // namespace RateLimit

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -40,8 +40,9 @@ public:
     complete_(status, response_headers_to_add.get(), request_headers_to_add.get());
   }
 
-  MOCK_METHOD3(complete_, void(LimitStatus status, const Http::HeaderMap* response_headers_to_add,
-                               const Http::HeaderMap* request_headers_to_add));
+  MOCK_METHOD(void, complete_,
+              (LimitStatus status, const Http::HeaderMap* response_headers_to_add,
+               const Http::HeaderMap* request_headers_to_add));
 };
 
 class RateLimitGrpcClientTest : public testing::Test {

--- a/test/extensions/filters/common/rbac/mocks.h
+++ b/test/extensions/filters/common/rbac/mocks.h
@@ -17,12 +17,15 @@ public:
   MockEngine(const envoy::config::rbac::v3::RBAC& rules)
       : RoleBasedAccessControlEngineImpl(rules){};
 
-  MOCK_CONST_METHOD4(allowed,
-                     bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
-                          const StreamInfo::StreamInfo&, std::string* effective_policy_id));
+  MOCK_METHOD(bool, allowed,
+              (const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
+               const StreamInfo::StreamInfo&, std::string* effective_policy_id),
+              (const));
 
-  MOCK_CONST_METHOD3(allowed, bool(const Envoy::Network::Connection&, const StreamInfo::StreamInfo&,
-                                   std::string* effective_policy_id));
+  MOCK_METHOD(bool, allowed,
+              (const Envoy::Network::Connection&, const StreamInfo::StreamInfo&,
+               std::string* effective_policy_id),
+              (const));
 };
 
 } // namespace RBAC

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -27,9 +27,9 @@ using ConcurrencyController::RequestForwardingAction;
 
 class MockConcurrencyController : public ConcurrencyController::ConcurrencyController {
 public:
-  MOCK_METHOD0(forwardingDecision, RequestForwardingAction());
-  MOCK_METHOD0(cancelLatencySample, void());
-  MOCK_METHOD1(recordLatencySample, void(std::chrono::nanoseconds));
+  MOCK_METHOD(RequestForwardingAction, forwardingDecision, ());
+  MOCK_METHOD(void, cancelLatencySample, ());
+  MOCK_METHOD(void, recordLatencySample, (std::chrono::nanoseconds));
 
   uint32_t concurrencyLimit() const override { return 0; }
 };

--- a/test/extensions/filters/http/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/filters/http/common/aws/credentials_provider_impl_test.cc
@@ -339,15 +339,14 @@ public:
 
   class MockCredentialsProviderChainFactories : public CredentialsProviderChainFactories {
   public:
-    MOCK_CONST_METHOD0(createEnvironmentCredentialsProvider, CredentialsProviderSharedPtr());
-    MOCK_CONST_METHOD4(createTaskRoleCredentialsProvider,
-                       CredentialsProviderSharedPtr(
-                           Api::Api&, const MetadataCredentialsProviderBase::MetadataFetcher&,
-                           absl::string_view, absl::string_view));
-    MOCK_CONST_METHOD2(createInstanceProfileCredentialsProvider,
-                       CredentialsProviderSharedPtr(
-                           Api::Api&,
-                           const MetadataCredentialsProviderBase::MetadataFetcher& fetcher));
+    MOCK_METHOD(CredentialsProviderSharedPtr, createEnvironmentCredentialsProvider, (), (const));
+    MOCK_METHOD(CredentialsProviderSharedPtr, createTaskRoleCredentialsProvider,
+                (Api::Api&, const MetadataCredentialsProviderBase::MetadataFetcher&,
+                 absl::string_view, absl::string_view),
+                (const));
+    MOCK_METHOD(CredentialsProviderSharedPtr, createInstanceProfileCredentialsProvider,
+                (Api::Api&, const MetadataCredentialsProviderBase::MetadataFetcher& fetcher),
+                (const));
   };
 
   Event::SimulatedTimeSystem time_system_;

--- a/test/extensions/filters/http/common/aws/mocks.h
+++ b/test/extensions/filters/http/common/aws/mocks.h
@@ -16,7 +16,7 @@ public:
   MockCredentialsProvider();
   ~MockCredentialsProvider() override;
 
-  MOCK_METHOD0(getCredentials, Credentials());
+  MOCK_METHOD(Credentials, getCredentials, ());
 };
 
 class MockSigner : public Signer {
@@ -24,15 +24,16 @@ public:
   MockSigner();
   ~MockSigner() override;
 
-  MOCK_METHOD2(sign, void(Http::Message&, bool));
+  MOCK_METHOD(void, sign, (Http::Message&, bool));
 };
 
 class MockMetadataFetcher {
 public:
   virtual ~MockMetadataFetcher() = default;
 
-  MOCK_CONST_METHOD3(fetch, absl::optional<std::string>(const std::string&, const std::string&,
-                                                        const absl::optional<std::string>&));
+  MOCK_METHOD(absl::optional<std::string>, fetch,
+              (const std::string&, const std::string&, const absl::optional<std::string>&),
+              (const));
 };
 
 class DummyMetadataFetcher {

--- a/test/extensions/filters/http/common/mock.h
+++ b/test/extensions/filters/http/common/mock.h
@@ -15,9 +15,10 @@ namespace Common {
 
 class MockJwksFetcher : public JwksFetcher {
 public:
-  MOCK_METHOD0(cancel, void());
-  MOCK_METHOD3(fetch, void(const envoy::config::core::v3::HttpUri& uri, Tracing::Span& parent_span,
-                           JwksReceiver& receiver));
+  MOCK_METHOD(void, cancel, ());
+  MOCK_METHOD(void, fetch,
+              (const envoy::config::core::v3::HttpUri& uri, Tracing::Span& parent_span,
+               JwksReceiver& receiver));
 };
 
 // A mock HTTP upstream.
@@ -53,8 +54,8 @@ public:
     ASSERT(jwks);
     onJwksSuccessImpl(*jwks.get());
   }
-  MOCK_METHOD1(onJwksSuccessImpl, void(const google::jwt_verify::Jwks& jwks));
-  MOCK_METHOD1(onJwksError, void(JwksFetcher::JwksReceiver::Failure reason));
+  MOCK_METHOD(void, onJwksSuccessImpl, (const google::jwt_verify::Jwks& jwks));
+  MOCK_METHOD(void, onJwksError, (JwksFetcher::JwksReceiver::Failure reason));
 };
 
 } // namespace Common

--- a/test/extensions/filters/http/fault/BUILD
+++ b/test/extensions/filters/http/fault/BUILD
@@ -62,5 +62,8 @@ envoy_extension_cc_test(
 envoy_cc_test_library(
     name = "utility_lib",
     hdrs = ["utility.h"],
-    deps = ["//test/test_common:utility_lib"],
+    deps = [
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/fault/v3:pkg_cc_proto",
+    ],
 )

--- a/test/extensions/filters/http/fault/BUILD
+++ b/test/extensions/filters/http/fault/BUILD
@@ -62,8 +62,5 @@ envoy_extension_cc_test(
 envoy_cc_test_library(
     name = "utility_lib",
     hdrs = ["utility.h"],
-    deps = [
-        "//test/test_common:utility_lib",
-        "@envoy_api//envoy/extensions/filters/http/fault/v3:pkg_cc_proto",
-    ],
+    deps = ["//test/test_common:utility_lib"],
 )

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -25,7 +25,7 @@ namespace {
 
 class MockMatcher : public Matcher {
 public:
-  MOCK_CONST_METHOD1(matches, bool(const Http::HeaderMap& headers));
+  MOCK_METHOD(bool, matches, (const Http::HeaderMap& headers), (const));
 };
 
 class MockFilterConfig : public FilterConfig {
@@ -34,8 +34,9 @@ public:
       const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
       : FilterConfig(proto_config, stats_prefix, context) {}
-  MOCK_CONST_METHOD2(findVerifier, const Verifier*(const Http::HeaderMap& headers,
-                                                   const StreamInfo::FilterState& filter_state));
+  MOCK_METHOD(const Verifier*, findVerifier,
+              (const Http::HeaderMap& headers, const StreamInfo::FilterState& filter_state),
+              (const));
 };
 
 class FilterTest : public testing::Test {

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -18,15 +18,18 @@ namespace JwtAuthn {
 
 class MockAuthFactory : public AuthFactory {
 public:
-  MOCK_CONST_METHOD4(create, AuthenticatorPtr(const ::google::jwt_verify::CheckAudience*,
-                                              const absl::optional<std::string>&, bool, bool));
+  MOCK_METHOD(AuthenticatorPtr, create,
+              (const ::google::jwt_verify::CheckAudience*, const absl::optional<std::string>&, bool,
+               bool),
+              (const));
 };
 
 class MockAuthenticator : public Authenticator {
 public:
-  MOCK_METHOD5(doVerify, void(Http::HeaderMap& headers, Tracing::Span& parent_span,
-                              std::vector<JwtLocationConstPtr>* tokens,
-                              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback));
+  MOCK_METHOD(void, doVerify,
+              (Http::HeaderMap & headers, Tracing::Span& parent_span,
+               std::vector<JwtLocationConstPtr>* tokens, SetPayloadCallback set_payload_cb,
+               AuthenticatorCallback callback));
 
   void verify(Http::HeaderMap& headers, Tracing::Span& parent_span,
               std::vector<JwtLocationConstPtr>&& tokens, SetPayloadCallback set_payload_cb,
@@ -34,24 +37,24 @@ public:
     doVerify(headers, parent_span, &tokens, std::move(set_payload_cb), std::move(callback));
   }
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 };
 
 class MockVerifierCallbacks : public Verifier::Callbacks {
 public:
-  MOCK_METHOD1(setPayload, void(const ProtobufWkt::Struct& payload));
-  MOCK_METHOD1(onComplete, void(const Status& status));
+  MOCK_METHOD(void, setPayload, (const ProtobufWkt::Struct& payload));
+  MOCK_METHOD(void, onComplete, (const Status& status));
 };
 
 class MockVerifier : public Verifier {
 public:
-  MOCK_CONST_METHOD1(verify, void(ContextSharedPtr context));
+  MOCK_METHOD(void, verify, (ContextSharedPtr context), (const));
 };
 
 class MockExtractor : public Extractor {
 public:
-  MOCK_CONST_METHOD1(extract, std::vector<JwtLocationConstPtr>(const Http::HeaderMap& headers));
-  MOCK_CONST_METHOD1(sanitizePayloadHeaders, void(Http::HeaderMap& headers));
+  MOCK_METHOD(std::vector<JwtLocationConstPtr>, extract, (const Http::HeaderMap& headers), (const));
+  MOCK_METHOD(void, sanitizePayloadHeaders, (Http::HeaderMap & headers), (const));
 };
 
 // A mock HTTP upstream with response body.

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -37,7 +37,7 @@ class TestFilter : public Filter {
 public:
   using Filter::Filter;
 
-  MOCK_METHOD2(scriptLog, void(spdlog::level::level_enum level, const char* message));
+  MOCK_METHOD(void, scriptLog, (spdlog::level::level_enum level, const char* message));
 };
 
 class LuaHttpFilterTest : public testing::Test {

--- a/test/extensions/filters/http/rbac/mocks.h
+++ b/test/extensions/filters/http/rbac/mocks.h
@@ -20,7 +20,7 @@ public:
       const envoy::extensions::filters::http::rbac::v3::RBACPerRoute& r)
       : RoleBasedAccessControlRouteSpecificFilterConfig(r){};
 
-  MOCK_CONST_METHOD0(engine, Filters::Common::RBAC::RoleBasedAccessControlEngineImpl&());
+  MOCK_METHOD(Filters::Common::RBAC::RoleBasedAccessControlEngineImpl&, engine, (), (const));
 };
 
 } // namespace

--- a/test/extensions/filters/http/tap/common.h
+++ b/test/extensions/filters/http/tap/common.h
@@ -19,15 +19,15 @@ public:
         createPerTapSinkHandleManager_(trace_id)};
   }
 
-  MOCK_METHOD1(createPerRequestTapper_, HttpPerRequestTapper*(uint64_t stream_id));
-  MOCK_METHOD1(createPerTapSinkHandleManager_,
-               Extensions::Common::Tap::PerTapSinkHandleManager*(uint64_t trace_id));
-  MOCK_CONST_METHOD0(maxBufferedRxBytes, uint32_t());
-  MOCK_CONST_METHOD0(maxBufferedTxBytes, uint32_t());
-  MOCK_CONST_METHOD0(createMatchStatusVector,
-                     Extensions::Common::Tap::Matcher::MatchStatusVector());
-  MOCK_CONST_METHOD0(rootMatcher, const Extensions::Common::Tap::Matcher&());
-  MOCK_CONST_METHOD0(streaming, bool());
+  MOCK_METHOD(HttpPerRequestTapper*, createPerRequestTapper_, (uint64_t stream_id));
+  MOCK_METHOD(Extensions::Common::Tap::PerTapSinkHandleManager*, createPerTapSinkHandleManager_,
+              (uint64_t trace_id));
+  MOCK_METHOD(uint32_t, maxBufferedRxBytes, (), (const));
+  MOCK_METHOD(uint32_t, maxBufferedTxBytes, (), (const));
+  MOCK_METHOD(Extensions::Common::Tap::Matcher::MatchStatusVector, createMatchStatusVector, (),
+              (const));
+  MOCK_METHOD(const Extensions::Common::Tap::Matcher&, rootMatcher, (), (const));
+  MOCK_METHOD(bool, streaming, (), (const));
 };
 
 } // namespace TapFilter

--- a/test/extensions/filters/http/tap/tap_filter_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 class MockFilterConfig : public FilterConfig {
 public:
-  MOCK_METHOD0(currentConfig, HttpTapConfigSharedPtr());
+  MOCK_METHOD(HttpTapConfigSharedPtr, currentConfig, ());
   FilterStats& stats() override { return stats_; }
 
   Stats::IsolatedStoreImpl stats_store_;
@@ -28,13 +28,13 @@ public:
 
 class MockHttpPerRequestTapper : public HttpPerRequestTapper {
 public:
-  MOCK_METHOD1(onRequestHeaders, void(const Http::HeaderMap& headers));
-  MOCK_METHOD1(onRequestBody, void(const Buffer::Instance& data));
-  MOCK_METHOD1(onRequestTrailers, void(const Http::HeaderMap& headers));
-  MOCK_METHOD1(onResponseHeaders, void(const Http::HeaderMap& headers));
-  MOCK_METHOD1(onResponseBody, void(const Buffer::Instance& data));
-  MOCK_METHOD1(onResponseTrailers, void(const Http::HeaderMap& headers));
-  MOCK_METHOD0(onDestroyLog, bool());
+  MOCK_METHOD(void, onRequestHeaders, (const Http::HeaderMap& headers));
+  MOCK_METHOD(void, onRequestBody, (const Buffer::Instance& data));
+  MOCK_METHOD(void, onRequestTrailers, (const Http::HeaderMap& headers));
+  MOCK_METHOD(void, onResponseHeaders, (const Http::HeaderMap& headers));
+  MOCK_METHOD(void, onResponseBody, (const Buffer::Instance& data));
+  MOCK_METHOD(void, onResponseTrailers, (const Http::HeaderMap& headers));
+  MOCK_METHOD(bool, onDestroyLog, ());
 };
 
 class TapFilterTest : public testing::Test {

--- a/test/extensions/filters/network/common/redis/mocks.h
+++ b/test/extensions/filters/network/common/redis/mocks.h
@@ -29,7 +29,7 @@ public:
   MockEncoder();
   ~MockEncoder() override;
 
-  MOCK_METHOD2(encode, void(const Common::Redis::RespValue& value, Buffer::Instance& out));
+  MOCK_METHOD(void, encode, (const Common::Redis::RespValue& value, Buffer::Instance& out));
 
 private:
   Common::Redis::EncoderImpl real_encoder_;
@@ -40,7 +40,7 @@ public:
   MockDecoder();
   ~MockDecoder() override;
 
-  MOCK_METHOD1(decode, void(Buffer::Instance& data));
+  MOCK_METHOD(void, decode, (Buffer::Instance & data));
 };
 
 namespace Client {
@@ -50,7 +50,7 @@ public:
   MockPoolRequest();
   ~MockPoolRequest() override;
 
-  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD(void, cancel, ());
 };
 
 class MockClient : public Client {
@@ -82,12 +82,12 @@ public:
     return makeRequest_(request, callbacks);
   }
 
-  MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
-  MOCK_METHOD0(active, bool());
-  MOCK_METHOD0(close, void());
-  MOCK_METHOD2(makeRequest_,
-               PoolRequest*(const Common::Redis::RespValue& request, ClientCallbacks& callbacks));
-  MOCK_METHOD1(initialize, void(const std::string& password));
+  MOCK_METHOD(void, addConnectionCallbacks, (Network::ConnectionCallbacks & callbacks));
+  MOCK_METHOD(bool, active, ());
+  MOCK_METHOD(void, close, ());
+  MOCK_METHOD(PoolRequest*, makeRequest_,
+              (const Common::Redis::RespValue& request, ClientCallbacks& callbacks));
+  MOCK_METHOD(void, initialize, (const std::string& password));
 
   std::list<Network::ConnectionCallbacks*> callbacks_;
   std::list<ClientCallbacks*> client_callbacks_;
@@ -104,10 +104,11 @@ public:
     return onRedirection_(value, host_address, ask_redirection);
   }
 
-  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
-  MOCK_METHOD0(onFailure, void());
-  MOCK_METHOD3(onRedirection_, bool(Common::Redis::RespValuePtr& value,
-                                    const std::string& host_address, bool ask_redirection));
+  MOCK_METHOD(void, onResponse_, (Common::Redis::RespValuePtr & value));
+  MOCK_METHOD(void, onFailure, ());
+  MOCK_METHOD(bool, onRedirection_,
+              (Common::Redis::RespValuePtr & value, const std::string& host_address,
+               bool ask_redirection));
 };
 
 } // namespace Client

--- a/test/extensions/filters/network/dubbo_proxy/BUILD
+++ b/test/extensions/filters/network/dubbo_proxy/BUILD
@@ -157,7 +157,6 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/dubbo_proxy/filters:well_known_names",
         "//source/extensions/filters/network/dubbo_proxy/router:config",
         "//test/mocks/server:server_mocks",
-        "@envoy_api//envoy/extensions/filters/network/dubbo_proxy/router/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/filters/network/dubbo_proxy/BUILD
+++ b/test/extensions/filters/network/dubbo_proxy/BUILD
@@ -157,6 +157,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/dubbo_proxy/filters:well_known_names",
         "//source/extensions/filters/network/dubbo_proxy/router:config",
         "//test/mocks/server:server_mocks",
+        "@envoy_api//envoy/extensions/filters/network/dubbo_proxy/router/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/filters/network/dubbo_proxy/mocks.h
+++ b/test/extensions/filters/network/dubbo_proxy/mocks.h
@@ -25,21 +25,21 @@ class MockStreamDecoder : public StreamDecoder {
 public:
   MockStreamDecoder();
 
-  MOCK_METHOD2(onMessageDecoded, FilterStatus(MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(FilterStatus, onMessageDecoded, (MessageMetadataSharedPtr, ContextSharedPtr));
 };
 
 class MockStreamEncoder : public StreamEncoder {
 public:
   MockStreamEncoder();
 
-  MOCK_METHOD2(onMessageEncoded, FilterStatus(MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(FilterStatus, onMessageEncoded, (MessageMetadataSharedPtr, ContextSharedPtr));
 };
 
 class MockStreamHandler : public StreamHandler {
 public:
   MockStreamHandler() = default;
 
-  MOCK_METHOD2(onStreamDecoded, void(MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, onStreamDecoded, (MessageMetadataSharedPtr, ContextSharedPtr));
 };
 
 class MockRequestDecoderCallbacks : public RequestDecoderCallbacks {
@@ -47,8 +47,8 @@ public:
   MockRequestDecoderCallbacks();
   ~MockRequestDecoderCallbacks() override = default;
 
-  MOCK_METHOD0(newStream, StreamHandler&());
-  MOCK_METHOD1(onHeartbeat, void(MessageMetadataSharedPtr));
+  MOCK_METHOD(StreamHandler&, newStream, ());
+  MOCK_METHOD(void, onHeartbeat, (MessageMetadataSharedPtr));
 
   MockStreamHandler handler_;
 };
@@ -57,8 +57,8 @@ public:
   MockResponseDecoderCallbacks();
   ~MockResponseDecoderCallbacks() override = default;
 
-  MOCK_METHOD0(newStream, StreamHandler&());
-  MOCK_METHOD1(onHeartbeat, void(MessageMetadataSharedPtr));
+  MOCK_METHOD(StreamHandler&, newStream, ());
+  MOCK_METHOD(void, onHeartbeat, (MessageMetadataSharedPtr));
 
   MockStreamHandler handler_;
 };
@@ -70,8 +70,8 @@ public:
       : ActiveStream(handler, metadata, context) {}
   ~MockActiveStream() = default;
 
-  MOCK_METHOD2(newStream, ActiveStream*(MessageMetadataSharedPtr, ContextSharedPtr));
-  MOCK_METHOD1(onHeartbeat, void(MessageMetadataSharedPtr));
+  MOCK_METHOD(ActiveStream*, newStream, (MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, onHeartbeat, (MessageMetadataSharedPtr));
 };
 
 class MockDecoderStateMachineDelegate : public DecoderStateMachine::Delegate {
@@ -79,8 +79,8 @@ public:
   MockDecoderStateMachineDelegate() = default;
   ~MockDecoderStateMachineDelegate() override = default;
 
-  MOCK_METHOD2(newStream, ActiveStream*(MessageMetadataSharedPtr, ContextSharedPtr));
-  MOCK_METHOD1(onHeartbeat, void(MessageMetadataSharedPtr));
+  MOCK_METHOD(ActiveStream*, newStream, (MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, onHeartbeat, (MessageMetadataSharedPtr));
 };
 
 class MockSerializer : public Serializer {
@@ -89,13 +89,13 @@ public:
   ~MockSerializer() override;
 
   // DubboProxy::Serializer
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(type, SerializationType());
-  MOCK_METHOD2(deserializeRpcInvocation,
-               std::pair<RpcInvocationSharedPtr, bool>(Buffer::Instance&, ContextSharedPtr));
-  MOCK_METHOD2(deserializeRpcResult,
-               std::pair<RpcResultSharedPtr, bool>(Buffer::Instance&, ContextSharedPtr));
-  MOCK_METHOD3(serializeRpcResult, size_t(Buffer::Instance&, const std::string&, RpcResponseType));
+  MOCK_METHOD(const std::string&, name, (), (const));
+  MOCK_METHOD(SerializationType, type, (), (const));
+  MOCK_METHOD((std::pair<RpcInvocationSharedPtr, bool>), deserializeRpcInvocation,
+              (Buffer::Instance&, ContextSharedPtr));
+  MOCK_METHOD((std::pair<RpcResultSharedPtr, bool>), deserializeRpcResult,
+              (Buffer::Instance&, ContextSharedPtr));
+  MOCK_METHOD(size_t, serializeRpcResult, (Buffer::Instance&, const std::string&, RpcResponseType));
 
   std::string name_{"mockDeserializer"};
   SerializationType type_{SerializationType::Hessian2};
@@ -106,14 +106,14 @@ public:
   MockProtocol();
   ~MockProtocol() override;
 
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(type, ProtocolType());
-  MOCK_CONST_METHOD0(serializer, Serializer*());
-  MOCK_METHOD2(decodeHeader,
-               std::pair<ContextSharedPtr, bool>(Buffer::Instance&, MessageMetadataSharedPtr));
-  MOCK_METHOD3(decodeData, bool(Buffer::Instance&, ContextSharedPtr, MessageMetadataSharedPtr));
-  MOCK_METHOD4(encode, bool(Buffer::Instance&, const MessageMetadata&, const std::string&,
-                            RpcResponseType));
+  MOCK_METHOD(const std::string&, name, (), (const));
+  MOCK_METHOD(ProtocolType, type, (), (const));
+  MOCK_METHOD(Serializer*, serializer, (), (const));
+  MOCK_METHOD((std::pair<ContextSharedPtr, bool>), decodeHeader,
+              (Buffer::Instance&, MessageMetadataSharedPtr));
+  MOCK_METHOD(bool, decodeData, (Buffer::Instance&, ContextSharedPtr, MessageMetadataSharedPtr));
+  MOCK_METHOD(bool, encode,
+              (Buffer::Instance&, const MessageMetadata&, const std::string&, RpcResponseType));
 
   std::string name_{"MockProtocol"};
   ProtocolType type_{ProtocolType::Dubbo};
@@ -157,7 +157,7 @@ public:
   MockFilterChainFactory();
   ~MockFilterChainFactory() override;
 
-  MOCK_METHOD1(createFilterChain, void(DubboFilters::FilterChainFactoryCallbacks& callbacks));
+  MOCK_METHOD(void, createFilterChain, (DubboFilters::FilterChainFactoryCallbacks & callbacks));
 };
 
 class MockFilterChainFactoryCallbacks : public FilterChainFactoryCallbacks {
@@ -165,9 +165,9 @@ public:
   MockFilterChainFactoryCallbacks();
   ~MockFilterChainFactoryCallbacks() override;
 
-  MOCK_METHOD1(addDecoderFilter, void(DecoderFilterSharedPtr));
-  MOCK_METHOD1(addEncoderFilter, void(EncoderFilterSharedPtr));
-  MOCK_METHOD1(addFilter, void(CodecFilterSharedPtr));
+  MOCK_METHOD(void, addDecoderFilter, (DecoderFilterSharedPtr));
+  MOCK_METHOD(void, addEncoderFilter, (EncoderFilterSharedPtr));
+  MOCK_METHOD(void, addFilter, (CodecFilterSharedPtr));
 };
 
 class MockDecoderFilter : public DecoderFilter {
@@ -176,9 +176,9 @@ public:
   ~MockDecoderFilter() override;
 
   // DubboProxy::DubboFilters::DecoderFilter
-  MOCK_METHOD0(onDestroy, void());
-  MOCK_METHOD1(setDecoderFilterCallbacks, void(DecoderFilterCallbacks& callbacks));
-  MOCK_METHOD2(onMessageDecoded, FilterStatus(MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, onDestroy, ());
+  MOCK_METHOD(void, setDecoderFilterCallbacks, (DecoderFilterCallbacks & callbacks));
+  MOCK_METHOD(FilterStatus, onMessageDecoded, (MessageMetadataSharedPtr, ContextSharedPtr));
 
   DecoderFilterCallbacks* callbacks_{};
 };
@@ -189,20 +189,20 @@ public:
   ~MockDecoderFilterCallbacks() override;
 
   // DubboProxy::DubboFilters::DecoderFilterCallbacks
-  MOCK_CONST_METHOD0(requestId, uint64_t());
-  MOCK_CONST_METHOD0(streamId, uint64_t());
-  MOCK_CONST_METHOD0(connection, const Network::Connection*());
-  MOCK_METHOD0(continueDecoding, void());
-  MOCK_METHOD0(route, Router::RouteConstSharedPtr());
-  MOCK_CONST_METHOD0(serializationType, SerializationType());
-  MOCK_CONST_METHOD0(protocolType, ProtocolType());
-  MOCK_METHOD2(sendLocalReply, void(const DirectResponse&, bool));
-  MOCK_METHOD0(startUpstreamResponse, void());
-  MOCK_METHOD1(upstreamData, UpstreamResponseStatus(Buffer::Instance&));
-  MOCK_METHOD0(resetDownstreamConnection, void());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
-  MOCK_METHOD0(resetStream, void());
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
+  MOCK_METHOD(uint64_t, requestId, (), (const));
+  MOCK_METHOD(uint64_t, streamId, (), (const));
+  MOCK_METHOD(const Network::Connection*, connection, (), (const));
+  MOCK_METHOD(void, continueDecoding, ());
+  MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
+  MOCK_METHOD(SerializationType, serializationType, (), (const));
+  MOCK_METHOD(ProtocolType, protocolType, (), (const));
+  MOCK_METHOD(void, sendLocalReply, (const DirectResponse&, bool));
+  MOCK_METHOD(void, startUpstreamResponse, ());
+  MOCK_METHOD(UpstreamResponseStatus, upstreamData, (Buffer::Instance&));
+  MOCK_METHOD(void, resetDownstreamConnection, ());
+  MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
+  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 
   uint64_t stream_id_{1};
   NiceMock<Network::MockConnection> connection_;
@@ -217,9 +217,9 @@ public:
   ~MockEncoderFilter() override;
 
   // DubboProxy::DubboFilters::EncoderFilter
-  MOCK_METHOD0(onDestroy, void());
-  MOCK_METHOD1(setEncoderFilterCallbacks, void(EncoderFilterCallbacks& callbacks));
-  MOCK_METHOD2(onMessageEncoded, FilterStatus(MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, onDestroy, ());
+  MOCK_METHOD(void, setEncoderFilterCallbacks, (EncoderFilterCallbacks & callbacks));
+  MOCK_METHOD(FilterStatus, onMessageEncoded, (MessageMetadataSharedPtr, ContextSharedPtr));
 
   EncoderFilterCallbacks* callbacks_{};
 };
@@ -230,17 +230,17 @@ public:
   ~MockEncoderFilterCallbacks() override;
 
   // DubboProxy::DubboFilters::MockEncoderFilterCallbacks
-  MOCK_CONST_METHOD0(requestId, uint64_t());
-  MOCK_CONST_METHOD0(streamId, uint64_t());
-  MOCK_CONST_METHOD0(connection, const Network::Connection*());
-  MOCK_METHOD0(route, Router::RouteConstSharedPtr());
-  MOCK_CONST_METHOD0(serializationType, SerializationType());
-  MOCK_CONST_METHOD0(protocolType, ProtocolType());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
-  MOCK_METHOD0(resetStream, void());
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
-  MOCK_METHOD0(continueEncoding, void());
-  MOCK_METHOD0(continueDecoding, void());
+  MOCK_METHOD(uint64_t, requestId, (), (const));
+  MOCK_METHOD(uint64_t, streamId, (), (const));
+  MOCK_METHOD(const Network::Connection*, connection, (), (const));
+  MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
+  MOCK_METHOD(SerializationType, serializationType, (), (const));
+  MOCK_METHOD(ProtocolType, protocolType, (), (const));
+  MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
+  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
+  MOCK_METHOD(void, continueEncoding, ());
+  MOCK_METHOD(void, continueDecoding, ());
 
   uint64_t stream_id_{1};
   NiceMock<Network::MockConnection> connection_;
@@ -254,11 +254,11 @@ public:
   MockCodecFilter();
   ~MockCodecFilter() override;
 
-  MOCK_METHOD0(onDestroy, void());
-  MOCK_METHOD1(setEncoderFilterCallbacks, void(EncoderFilterCallbacks& callbacks));
-  MOCK_METHOD2(onMessageEncoded, FilterStatus(MessageMetadataSharedPtr, ContextSharedPtr));
-  MOCK_METHOD1(setDecoderFilterCallbacks, void(DecoderFilterCallbacks& callbacks));
-  MOCK_METHOD2(onMessageDecoded, FilterStatus(MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, onDestroy, ());
+  MOCK_METHOD(void, setEncoderFilterCallbacks, (EncoderFilterCallbacks & callbacks));
+  MOCK_METHOD(FilterStatus, onMessageEncoded, (MessageMetadataSharedPtr, ContextSharedPtr));
+  MOCK_METHOD(void, setDecoderFilterCallbacks, (DecoderFilterCallbacks & callbacks));
+  MOCK_METHOD(FilterStatus, onMessageDecoded, (MessageMetadataSharedPtr, ContextSharedPtr));
 
   DecoderFilterCallbacks* decoder_callbacks_{};
   EncoderFilterCallbacks* encoder_callbacks_{};
@@ -269,8 +269,8 @@ public:
   MockDirectResponse() = default;
   ~MockDirectResponse() override = default;
 
-  MOCK_CONST_METHOD3(encode,
-                     DirectResponse::ResponseType(MessageMetadata&, Protocol&, Buffer::Instance&));
+  MOCK_METHOD(DirectResponse::ResponseType, encode,
+              (MessageMetadata&, Protocol&, Buffer::Instance&), (const));
 };
 
 template <class ConfigProto> class MockFactoryBase : public NamedDubboFilterConfigFactory {
@@ -326,8 +326,8 @@ public:
   ~MockRouteEntry() override;
 
   // DubboProxy::Router::RouteEntry
-  MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD0(metadataMatchCriteria, const Envoy::Router::MetadataMatchCriteria*());
+  MOCK_METHOD(const std::string&, clusterName, (), (const));
+  MOCK_METHOD(const Envoy::Router::MetadataMatchCriteria*, metadataMatchCriteria, (), (const));
 
   std::string cluster_name_{"fake_cluster"};
 };
@@ -338,7 +338,7 @@ public:
   ~MockRoute() override;
 
   // DubboProxy::Router::Route
-  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
+  MOCK_METHOD(const RouteEntry*, routeEntry, (), (const));
 
   NiceMock<MockRouteEntry> route_entry_;
 };

--- a/test/extensions/filters/network/kafka/broker/filter_unit_test.cc
+++ b/test/extensions/filters/network/kafka/broker/filter_unit_test.cc
@@ -21,12 +21,12 @@ namespace Broker {
 
 class MockKafkaMetricsFacade : public KafkaMetricsFacade {
 public:
-  MOCK_METHOD1(onMessage, void(AbstractRequestSharedPtr));
-  MOCK_METHOD1(onMessage, void(AbstractResponseSharedPtr));
-  MOCK_METHOD1(onFailedParse, void(RequestParseFailureSharedPtr));
-  MOCK_METHOD1(onFailedParse, void(ResponseMetadataSharedPtr));
-  MOCK_METHOD0(onRequestException, void());
-  MOCK_METHOD0(onResponseException, void());
+  MOCK_METHOD(void, onMessage, (AbstractRequestSharedPtr));
+  MOCK_METHOD(void, onMessage, (AbstractResponseSharedPtr));
+  MOCK_METHOD(void, onFailedParse, (RequestParseFailureSharedPtr));
+  MOCK_METHOD(void, onFailedParse, (ResponseMetadataSharedPtr));
+  MOCK_METHOD(void, onRequestException, ());
+  MOCK_METHOD(void, onResponseException, ());
 };
 
 using MockKafkaMetricsFacadeSharedPtr = std::shared_ptr<MockKafkaMetricsFacade>;
@@ -34,9 +34,9 @@ using MockKafkaMetricsFacadeSharedPtr = std::shared_ptr<MockKafkaMetricsFacade>;
 class MockResponseDecoder : public ResponseDecoder {
 public:
   MockResponseDecoder() : ResponseDecoder{{}} {};
-  MOCK_METHOD1(onData, void(Buffer::Instance&));
-  MOCK_METHOD3(expectResponse, void(const int32_t, const int16_t, const int16_t));
-  MOCK_METHOD0(reset, void());
+  MOCK_METHOD(void, onData, (Buffer::Instance&));
+  MOCK_METHOD(void, expectResponse, (const int32_t, const int16_t, const int16_t));
+  MOCK_METHOD(void, reset, ());
 };
 
 using MockResponseDecoderSharedPtr = std::shared_ptr<MockResponseDecoder>;
@@ -44,30 +44,30 @@ using MockResponseDecoderSharedPtr = std::shared_ptr<MockResponseDecoder>;
 class MockRequestDecoder : public RequestDecoder {
 public:
   MockRequestDecoder() : RequestDecoder{{}} {};
-  MOCK_METHOD1(onData, void(Buffer::Instance&));
-  MOCK_METHOD0(reset, void());
+  MOCK_METHOD(void, onData, (Buffer::Instance&));
+  MOCK_METHOD(void, reset, ());
 };
 
 using MockRequestDecoderSharedPtr = std::shared_ptr<MockRequestDecoder>;
 
 class MockTimeSource : public TimeSource {
 public:
-  MOCK_METHOD0(systemTime, SystemTime());
-  MOCK_METHOD0(monotonicTime, MonotonicTime());
+  MOCK_METHOD(SystemTime, systemTime, ());
+  MOCK_METHOD(MonotonicTime, monotonicTime, ());
 };
 
 class MockRichRequestMetrics : public RichRequestMetrics {
 public:
-  MOCK_METHOD1(onRequest, void(const int16_t));
-  MOCK_METHOD0(onUnknownRequest, void());
-  MOCK_METHOD0(onBrokenRequest, void());
+  MOCK_METHOD(void, onRequest, (const int16_t));
+  MOCK_METHOD(void, onUnknownRequest, ());
+  MOCK_METHOD(void, onBrokenRequest, ());
 };
 
 class MockRichResponseMetrics : public RichResponseMetrics {
 public:
-  MOCK_METHOD2(onResponse, void(const int16_t, const long long duration));
-  MOCK_METHOD0(onUnknownResponse, void());
-  MOCK_METHOD0(onBrokenResponse, void());
+  MOCK_METHOD(void, onResponse, (const int16_t, const long long duration));
+  MOCK_METHOD(void, onUnknownResponse, ());
+  MOCK_METHOD(void, onBrokenResponse, ());
 };
 
 class MockRequest : public AbstractRequest {

--- a/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
@@ -22,8 +22,8 @@ class KafkaRequestParserTest : public testing::Test, public BufferBasedTest {};
 class MockRequestParserResolver : public RequestParserResolver {
 public:
   MockRequestParserResolver() = default;
-  MOCK_CONST_METHOD3(createParser,
-                     RequestParserSharedPtr(int16_t, int16_t, RequestContextSharedPtr));
+  MOCK_METHOD(RequestParserSharedPtr, createParser, (int16_t, int16_t, RequestContextSharedPtr),
+              (const));
 };
 
 TEST_F(KafkaRequestParserTest, RequestStartParserTestShouldReturnRequestHeaderParser) {

--- a/test/extensions/filters/network/kafka/kafka_response_parser_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_response_parser_test.cc
@@ -22,7 +22,7 @@ class KafkaResponseParserTest : public testing::Test, public BufferBasedTest {};
 class MockResponseParserResolver : public ResponseParserResolver {
 public:
   MockResponseParserResolver() = default;
-  MOCK_CONST_METHOD1(createParser, ResponseParserSharedPtr(ResponseContextSharedPtr));
+  MOCK_METHOD(ResponseParserSharedPtr, createParser, (ResponseContextSharedPtr), (const));
 };
 
 class MockParser : public ResponseParser {

--- a/test/extensions/filters/network/kafka/protocol/requests_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/requests_test_cc.j2
@@ -25,8 +25,8 @@ protected:
 
 class MockMessageListener : public RequestCallback {
 public:
-  MOCK_METHOD1(onMessage, void(AbstractRequestSharedPtr));
-  MOCK_METHOD1(onFailedParse, void(RequestParseFailureSharedPtr));
+  MOCK_METHOD(void, onMessage, (AbstractRequestSharedPtr));
+  MOCK_METHOD(void, onFailedParse, (RequestParseFailureSharedPtr));
 };
 
 /**

--- a/test/extensions/filters/network/kafka/protocol/responses_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/responses_test_cc.j2
@@ -25,8 +25,8 @@ protected:
 
 class MockMessageListener : public ResponseCallback {
 public:
-  MOCK_METHOD1(onMessage, void(AbstractResponseSharedPtr));
-  MOCK_METHOD1(onFailedParse, void(ResponseMetadataSharedPtr));
+  MOCK_METHOD(void, onMessage, (AbstractResponseSharedPtr));
+  MOCK_METHOD(void, onFailedParse, (ResponseMetadataSharedPtr));
 };
 
 /**

--- a/test/extensions/filters/network/kafka/request_codec_unit_test.cc
+++ b/test/extensions/filters/network/kafka/request_codec_unit_test.cc
@@ -19,12 +19,12 @@ namespace RequestCodecUnitTest {
 
 class MockParserFactory : public InitialParserFactory {
 public:
-  MOCK_CONST_METHOD1(create, RequestParserSharedPtr(const RequestParserResolver&));
+  MOCK_METHOD(RequestParserSharedPtr, create, (const RequestParserResolver&), (const));
 };
 
 class MockParser : public RequestParser {
 public:
-  MOCK_METHOD1(parse, RequestParseResponse(absl::string_view&));
+  MOCK_METHOD(RequestParseResponse, parse, (absl::string_view&));
 };
 
 using MockParserSharedPtr = std::shared_ptr<MockParser>;
@@ -32,14 +32,14 @@ using MockParserSharedPtr = std::shared_ptr<MockParser>;
 class MockRequestParserResolver : public RequestParserResolver {
 public:
   MockRequestParserResolver() : RequestParserResolver({}){};
-  MOCK_CONST_METHOD3(createParser,
-                     RequestParserSharedPtr(int16_t, int16_t, RequestContextSharedPtr));
+  MOCK_METHOD(RequestParserSharedPtr, createParser, (int16_t, int16_t, RequestContextSharedPtr),
+              (const));
 };
 
 class MockRequestCallback : public RequestCallback {
 public:
-  MOCK_METHOD1(onMessage, void(AbstractRequestSharedPtr));
-  MOCK_METHOD1(onFailedParse, void(RequestParseFailureSharedPtr));
+  MOCK_METHOD(void, onMessage, (AbstractRequestSharedPtr));
+  MOCK_METHOD(void, onFailedParse, (RequestParseFailureSharedPtr));
 };
 
 using MockRequestCallbackSharedPtr = std::shared_ptr<MockRequestCallback>;

--- a/test/extensions/filters/network/kafka/response_codec_unit_test.cc
+++ b/test/extensions/filters/network/kafka/response_codec_unit_test.cc
@@ -19,13 +19,13 @@ namespace ResponseCodecUnitTest {
 
 class MockResponseInitialParserFactory : public ResponseInitialParserFactory {
 public:
-  MOCK_CONST_METHOD2(create, ResponseParserSharedPtr(ExpectedResponsesSharedPtr,
-                                                     const ResponseParserResolver&));
+  MOCK_METHOD(ResponseParserSharedPtr, create,
+              (ExpectedResponsesSharedPtr, const ResponseParserResolver&), (const));
 };
 
 class MockParser : public ResponseParser {
 public:
-  MOCK_METHOD1(parse, ResponseParseResponse(absl::string_view&));
+  MOCK_METHOD(ResponseParseResponse, parse, (absl::string_view&));
 };
 
 using MockParserSharedPtr = std::shared_ptr<MockParser>;
@@ -33,13 +33,13 @@ using MockParserSharedPtr = std::shared_ptr<MockParser>;
 class MockResponseParserResolver : public ResponseParserResolver {
 public:
   MockResponseParserResolver() : ResponseParserResolver({}){};
-  MOCK_CONST_METHOD1(createParser, ResponseParserSharedPtr(ResponseContextSharedPtr));
+  MOCK_METHOD(ResponseParserSharedPtr, createParser, (ResponseContextSharedPtr), (const));
 };
 
 class MockResponseCallback : public ResponseCallback {
 public:
-  MOCK_METHOD1(onMessage, void(AbstractResponseSharedPtr));
-  MOCK_METHOD1(onFailedParse, void(ResponseMetadataSharedPtr));
+  MOCK_METHOD(void, onMessage, (AbstractResponseSharedPtr));
+  MOCK_METHOD(void, onFailedParse, (ResponseMetadataSharedPtr));
 };
 
 using MockResponseCallbackSharedPtr = std::shared_ptr<MockResponseCallback>;

--- a/test/extensions/filters/network/mongo_proxy/codec_impl_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/codec_impl_test.cc
@@ -32,13 +32,13 @@ public:
     decodeCommandReply_(message);
   }
 
-  MOCK_METHOD1(decodeGetMore_, void(GetMoreMessagePtr& message));
-  MOCK_METHOD1(decodeInsert_, void(InsertMessagePtr& message));
-  MOCK_METHOD1(decodeKillCursors_, void(KillCursorsMessagePtr& message));
-  MOCK_METHOD1(decodeQuery_, void(QueryMessagePtr& message));
-  MOCK_METHOD1(decodeReply_, void(ReplyMessagePtr& message));
-  MOCK_METHOD1(decodeCommand_, void(CommandMessagePtr& message));
-  MOCK_METHOD1(decodeCommandReply_, void(CommandReplyMessagePtr& message));
+  MOCK_METHOD(void, decodeGetMore_, (GetMoreMessagePtr & message));
+  MOCK_METHOD(void, decodeInsert_, (InsertMessagePtr & message));
+  MOCK_METHOD(void, decodeKillCursors_, (KillCursorsMessagePtr & message));
+  MOCK_METHOD(void, decodeQuery_, (QueryMessagePtr & message));
+  MOCK_METHOD(void, decodeReply_, (ReplyMessagePtr & message));
+  MOCK_METHOD(void, decodeCommand_, (CommandMessagePtr & message));
+  MOCK_METHOD(void, decodeCommandReply_, (CommandReplyMessagePtr & message));
 };
 
 class MongoCodecImplTest : public testing::Test {

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -39,12 +39,12 @@ namespace MongoProxy {
 
 class MockDecoder : public Decoder {
 public:
-  MOCK_METHOD1(onData, void(Buffer::Instance& data));
+  MOCK_METHOD(void, onData, (Buffer::Instance & data));
 };
 
 class TestStatStore : public Stats::IsolatedStoreImpl {
 public:
-  MOCK_METHOD2(deliverHistogramToSinks, void(const Stats::Histogram& histogram, uint64_t value));
+  MOCK_METHOD(void, deliverHistogramToSinks, (const Stats::Histogram& histogram, uint64_t value));
 };
 
 class TestProxyFilter : public ProxyFilter {

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -264,7 +264,7 @@ public:
                                                                  host_address, false));
   }
 
-  MOCK_METHOD1(create_, Common::Redis::Client::Client*(Upstream::HostConstSharedPtr host));
+  MOCK_METHOD(Common::Redis::Client::Client*, create_, (Upstream::HostConstSharedPtr host));
 
   const std::string cluster_name_{"fake_cluster"};
   NiceMock<Upstream::MockClusterManager> cm_;

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -25,7 +25,7 @@ public:
   MockRouter(RouteSharedPtr route);
   ~MockRouter() override;
 
-  MOCK_METHOD1(upstreamPool, RouteSharedPtr(std::string& key));
+  MOCK_METHOD(RouteSharedPtr, upstreamPool, (std::string & key));
   RouteSharedPtr route_;
 };
 
@@ -34,8 +34,8 @@ public:
   MockRoute(ConnPool::InstanceSharedPtr);
   ~MockRoute() override;
 
-  MOCK_CONST_METHOD0(upstream, ConnPool::InstanceSharedPtr());
-  MOCK_CONST_METHOD0(mirrorPolicies, const MirrorPolicies&());
+  MOCK_METHOD(ConnPool::InstanceSharedPtr, upstream, (), (const));
+  MOCK_METHOD(const MirrorPolicies&, mirrorPolicies, (), (const));
   ConnPool::InstanceSharedPtr conn_pool_;
   MirrorPolicies policies_;
 };
@@ -45,8 +45,8 @@ public:
   MockMirrorPolicy(ConnPool::InstanceSharedPtr);
   ~MockMirrorPolicy() = default;
 
-  MOCK_CONST_METHOD0(upstream, ConnPool::InstanceSharedPtr());
-  MOCK_CONST_METHOD1(shouldMirror, bool(const std::string&));
+  MOCK_METHOD(ConnPool::InstanceSharedPtr, upstream, (), (const));
+  MOCK_METHOD(bool, shouldMirror, (const std::string&), (const));
 
   ConnPool::InstanceSharedPtr conn_pool_;
 };
@@ -61,8 +61,8 @@ public:
   void onResponse(Common::Redis::RespValuePtr&& value) override { onResponse_(value); }
   void onFailure() override { onFailure_(); }
 
-  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
-  MOCK_METHOD0(onFailure_, void());
+  MOCK_METHOD(void, onResponse_, (Common::Redis::RespValuePtr & value));
+  MOCK_METHOD(void, onFailure_, ());
 };
 
 class MockInstance : public Instance {
@@ -76,10 +76,9 @@ public:
     return makeRequest_(hash_key, request, callbacks);
   }
 
-  MOCK_METHOD3(makeRequest_,
-               Common::Redis::Client::PoolRequest*(const std::string& hash_key,
-                                                   RespVariant& request, PoolCallbacks& callbacks));
-  MOCK_METHOD0(onRedirection, bool());
+  MOCK_METHOD(Common::Redis::Client::PoolRequest*, makeRequest_,
+              (const std::string& hash_key, RespVariant& request, PoolCallbacks& callbacks));
+  MOCK_METHOD(bool, onRedirection, ());
 };
 } // namespace ConnPool
 
@@ -90,7 +89,7 @@ public:
   MockSplitRequest();
   ~MockSplitRequest() override;
 
-  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD(void, cancel, ());
 };
 
 class MockSplitCallbacks : public SplitCallbacks {
@@ -100,9 +99,9 @@ public:
 
   void onResponse(Common::Redis::RespValuePtr&& value) override { onResponse_(value); }
 
-  MOCK_METHOD0(connectionAllowed, bool());
-  MOCK_METHOD1(onAuth, void(const std::string& password));
-  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
+  MOCK_METHOD(bool, connectionAllowed, ());
+  MOCK_METHOD(void, onAuth, (const std::string& password));
+  MOCK_METHOD(void, onResponse_, (Common::Redis::RespValuePtr & value));
 };
 
 class MockInstance : public Instance {
@@ -115,8 +114,8 @@ public:
     return SplitRequestPtr{makeRequest_(*request, callbacks)};
   }
 
-  MOCK_METHOD2(makeRequest_,
-               SplitRequest*(const Common::Redis::RespValue& request, SplitCallbacks& callbacks));
+  MOCK_METHOD(SplitRequest*, makeRequest_,
+              (const Common::Redis::RespValue& request, SplitCallbacks& callbacks));
 };
 
 } // namespace CommandSplitter

--- a/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
@@ -26,7 +26,7 @@ public:
   MockBuffer() = default;
   ~MockBuffer() override = default;
 
-  MOCK_CONST_METHOD0(length, uint64_t());
+  MOCK_METHOD(uint64_t, length, (), (const));
 };
 
 MessageMetadataSharedPtr mkMessageMetadata(uint32_t num_headers) {

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -31,10 +31,10 @@ public:
   ~MockConfig() override;
 
   // ThriftProxy::Config
-  MOCK_METHOD0(filterFactory, ThriftFilters::FilterChainFactory&());
-  MOCK_METHOD0(stats, ThriftFilterStats&());
-  MOCK_METHOD1(createDecoder, DecoderPtr(DecoderCallbacks&));
-  MOCK_METHOD0(routerConfig, Router::Config&());
+  MOCK_METHOD(ThriftFilters::FilterChainFactory&, filterFactory, ());
+  MOCK_METHOD(ThriftFilterStats&, stats, ());
+  MOCK_METHOD(DecoderPtr, createDecoder, (DecoderCallbacks&));
+  MOCK_METHOD(Router::Config&, routerConfig, ());
 };
 
 class MockTransport : public Transport {
@@ -43,11 +43,11 @@ public:
   ~MockTransport() override;
 
   // ThriftProxy::Transport
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(type, TransportType());
-  MOCK_METHOD2(decodeFrameStart, bool(Buffer::Instance&, MessageMetadata&));
-  MOCK_METHOD1(decodeFrameEnd, bool(Buffer::Instance&));
-  MOCK_METHOD3(encodeFrame, void(Buffer::Instance&, const MessageMetadata&, Buffer::Instance&));
+  MOCK_METHOD(const std::string&, name, (), (const));
+  MOCK_METHOD(TransportType, type, (), (const));
+  MOCK_METHOD(bool, decodeFrameStart, (Buffer::Instance&, MessageMetadata&));
+  MOCK_METHOD(bool, decodeFrameEnd, (Buffer::Instance&));
+  MOCK_METHOD(void, encodeFrame, (Buffer::Instance&, const MessageMetadata&, Buffer::Instance&));
 
   std::string name_{"mock"};
   TransportType type_{TransportType::Auto};
@@ -59,60 +59,67 @@ public:
   ~MockProtocol() override;
 
   // ThriftProxy::Protocol
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(type, ProtocolType());
-  MOCK_METHOD1(setType, void(ProtocolType));
-  MOCK_METHOD2(readMessageBegin, bool(Buffer::Instance& buffer, MessageMetadata& metadata));
-  MOCK_METHOD1(readMessageEnd, bool(Buffer::Instance& buffer));
-  MOCK_METHOD2(readStructBegin, bool(Buffer::Instance& buffer, std::string& name));
-  MOCK_METHOD1(readStructEnd, bool(Buffer::Instance& buffer));
-  MOCK_METHOD4(readFieldBegin, bool(Buffer::Instance& buffer, std::string& name,
-                                    FieldType& field_type, int16_t& field_id));
-  MOCK_METHOD1(readFieldEnd, bool(Buffer::Instance& buffer));
-  MOCK_METHOD4(readMapBegin, bool(Buffer::Instance& buffer, FieldType& key_type,
-                                  FieldType& value_type, uint32_t& size));
-  MOCK_METHOD1(readMapEnd, bool(Buffer::Instance& buffer));
-  MOCK_METHOD3(readListBegin, bool(Buffer::Instance& buffer, FieldType& elem_type, uint32_t& size));
-  MOCK_METHOD1(readListEnd, bool(Buffer::Instance& buffer));
-  MOCK_METHOD3(readSetBegin, bool(Buffer::Instance& buffer, FieldType& elem_type, uint32_t& size));
-  MOCK_METHOD1(readSetEnd, bool(Buffer::Instance& buffer));
-  MOCK_METHOD2(readBool, bool(Buffer::Instance& buffer, bool& value));
-  MOCK_METHOD2(readByte, bool(Buffer::Instance& buffer, uint8_t& value));
-  MOCK_METHOD2(readInt16, bool(Buffer::Instance& buffer, int16_t& value));
-  MOCK_METHOD2(readInt32, bool(Buffer::Instance& buffer, int32_t& value));
-  MOCK_METHOD2(readInt64, bool(Buffer::Instance& buffer, int64_t& value));
-  MOCK_METHOD2(readDouble, bool(Buffer::Instance& buffer, double& value));
-  MOCK_METHOD2(readString, bool(Buffer::Instance& buffer, std::string& value));
-  MOCK_METHOD2(readBinary, bool(Buffer::Instance& buffer, std::string& value));
+  MOCK_METHOD(const std::string&, name, (), (const));
+  MOCK_METHOD(ProtocolType, type, (), (const));
+  MOCK_METHOD(void, setType, (ProtocolType));
+  MOCK_METHOD(bool, readMessageBegin, (Buffer::Instance & buffer, MessageMetadata& metadata));
+  MOCK_METHOD(bool, readMessageEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(bool, readStructBegin, (Buffer::Instance & buffer, std::string& name));
+  MOCK_METHOD(bool, readStructEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(bool, readFieldBegin,
+              (Buffer::Instance & buffer, std::string& name, FieldType& field_type,
+               int16_t& field_id));
+  MOCK_METHOD(bool, readFieldEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(bool, readMapBegin,
+              (Buffer::Instance & buffer, FieldType& key_type, FieldType& value_type,
+               uint32_t& size));
+  MOCK_METHOD(bool, readMapEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(bool, readListBegin,
+              (Buffer::Instance & buffer, FieldType& elem_type, uint32_t& size));
+  MOCK_METHOD(bool, readListEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(bool, readSetBegin,
+              (Buffer::Instance & buffer, FieldType& elem_type, uint32_t& size));
+  MOCK_METHOD(bool, readSetEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(bool, readBool, (Buffer::Instance & buffer, bool& value));
+  MOCK_METHOD(bool, readByte, (Buffer::Instance & buffer, uint8_t& value));
+  MOCK_METHOD(bool, readInt16, (Buffer::Instance & buffer, int16_t& value));
+  MOCK_METHOD(bool, readInt32, (Buffer::Instance & buffer, int32_t& value));
+  MOCK_METHOD(bool, readInt64, (Buffer::Instance & buffer, int64_t& value));
+  MOCK_METHOD(bool, readDouble, (Buffer::Instance & buffer, double& value));
+  MOCK_METHOD(bool, readString, (Buffer::Instance & buffer, std::string& value));
+  MOCK_METHOD(bool, readBinary, (Buffer::Instance & buffer, std::string& value));
 
-  MOCK_METHOD2(writeMessageBegin, void(Buffer::Instance& buffer, const MessageMetadata& metadata));
-  MOCK_METHOD1(writeMessageEnd, void(Buffer::Instance& buffer));
-  MOCK_METHOD2(writeStructBegin, void(Buffer::Instance& buffer, const std::string& name));
-  MOCK_METHOD1(writeStructEnd, void(Buffer::Instance& buffer));
-  MOCK_METHOD4(writeFieldBegin, void(Buffer::Instance& buffer, const std::string& name,
-                                     FieldType field_type, int16_t field_id));
-  MOCK_METHOD1(writeFieldEnd, void(Buffer::Instance& buffer));
-  MOCK_METHOD4(writeMapBegin, void(Buffer::Instance& buffer, FieldType key_type,
-                                   FieldType value_type, uint32_t size));
-  MOCK_METHOD1(writeMapEnd, void(Buffer::Instance& buffer));
-  MOCK_METHOD3(writeListBegin, void(Buffer::Instance& buffer, FieldType elem_type, uint32_t size));
-  MOCK_METHOD1(writeListEnd, void(Buffer::Instance& buffer));
-  MOCK_METHOD3(writeSetBegin, void(Buffer::Instance& buffer, FieldType elem_type, uint32_t size));
-  MOCK_METHOD1(writeSetEnd, void(Buffer::Instance& buffer));
-  MOCK_METHOD2(writeBool, void(Buffer::Instance& buffer, bool value));
-  MOCK_METHOD2(writeByte, void(Buffer::Instance& buffer, uint8_t value));
-  MOCK_METHOD2(writeInt16, void(Buffer::Instance& buffer, int16_t value));
-  MOCK_METHOD2(writeInt32, void(Buffer::Instance& buffer, int32_t value));
-  MOCK_METHOD2(writeInt64, void(Buffer::Instance& buffer, int64_t value));
-  MOCK_METHOD2(writeDouble, void(Buffer::Instance& buffer, double value));
-  MOCK_METHOD2(writeString, void(Buffer::Instance& buffer, const std::string& value));
-  MOCK_METHOD2(writeBinary, void(Buffer::Instance& buffer, const std::string& value));
-  MOCK_METHOD0(supportsUpgrade, bool());
-  MOCK_METHOD0(upgradeRequestDecoder, DecoderEventHandlerSharedPtr());
-  MOCK_METHOD1(upgradeResponse, DirectResponsePtr(const DecoderEventHandler&));
-  MOCK_METHOD3(attemptUpgrade,
-               ThriftObjectPtr(Transport&, ThriftConnectionState&, Buffer::Instance&));
-  MOCK_METHOD2(completeUpgrade, void(ThriftConnectionState&, ThriftObject&));
+  MOCK_METHOD(void, writeMessageBegin,
+              (Buffer::Instance & buffer, const MessageMetadata& metadata));
+  MOCK_METHOD(void, writeMessageEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(void, writeStructBegin, (Buffer::Instance & buffer, const std::string& name));
+  MOCK_METHOD(void, writeStructEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(void, writeFieldBegin,
+              (Buffer::Instance & buffer, const std::string& name, FieldType field_type,
+               int16_t field_id));
+  MOCK_METHOD(void, writeFieldEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(void, writeMapBegin,
+              (Buffer::Instance & buffer, FieldType key_type, FieldType value_type, uint32_t size));
+  MOCK_METHOD(void, writeMapEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(void, writeListBegin,
+              (Buffer::Instance & buffer, FieldType elem_type, uint32_t size));
+  MOCK_METHOD(void, writeListEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(void, writeSetBegin, (Buffer::Instance & buffer, FieldType elem_type, uint32_t size));
+  MOCK_METHOD(void, writeSetEnd, (Buffer::Instance & buffer));
+  MOCK_METHOD(void, writeBool, (Buffer::Instance & buffer, bool value));
+  MOCK_METHOD(void, writeByte, (Buffer::Instance & buffer, uint8_t value));
+  MOCK_METHOD(void, writeInt16, (Buffer::Instance & buffer, int16_t value));
+  MOCK_METHOD(void, writeInt32, (Buffer::Instance & buffer, int32_t value));
+  MOCK_METHOD(void, writeInt64, (Buffer::Instance & buffer, int64_t value));
+  MOCK_METHOD(void, writeDouble, (Buffer::Instance & buffer, double value));
+  MOCK_METHOD(void, writeString, (Buffer::Instance & buffer, const std::string& value));
+  MOCK_METHOD(void, writeBinary, (Buffer::Instance & buffer, const std::string& value));
+  MOCK_METHOD(bool, supportsUpgrade, ());
+  MOCK_METHOD(DecoderEventHandlerSharedPtr, upgradeRequestDecoder, ());
+  MOCK_METHOD(DirectResponsePtr, upgradeResponse, (const DecoderEventHandler&));
+  MOCK_METHOD(ThriftObjectPtr, attemptUpgrade,
+              (Transport&, ThriftConnectionState&, Buffer::Instance&));
+  MOCK_METHOD(void, completeUpgrade, (ThriftConnectionState&, ThriftObject&));
 
   std::string name_{"mock"};
   ProtocolType type_{ProtocolType::Auto};
@@ -124,7 +131,7 @@ public:
   ~MockDecoderCallbacks() override;
 
   // ThriftProxy::DecoderCallbacks
-  MOCK_METHOD0(newDecoderEventHandler, DecoderEventHandler&());
+  MOCK_METHOD(DecoderEventHandler&, newDecoderEventHandler, ());
 };
 
 class MockDecoderEventHandler : public DecoderEventHandler {
@@ -133,28 +140,29 @@ public:
   ~MockDecoderEventHandler() override;
 
   // ThriftProxy::DecoderEventHandler
-  MOCK_METHOD1(transportBegin, FilterStatus(MessageMetadataSharedPtr metadata));
-  MOCK_METHOD0(transportEnd, FilterStatus());
-  MOCK_METHOD1(messageBegin, FilterStatus(MessageMetadataSharedPtr metadata));
-  MOCK_METHOD0(messageEnd, FilterStatus());
-  MOCK_METHOD1(structBegin, FilterStatus(const absl::string_view name));
-  MOCK_METHOD0(structEnd, FilterStatus());
-  MOCK_METHOD3(fieldBegin,
-               FilterStatus(const absl::string_view name, FieldType& msg_type, int16_t& field_id));
-  MOCK_METHOD0(fieldEnd, FilterStatus());
-  MOCK_METHOD1(boolValue, FilterStatus(bool& value));
-  MOCK_METHOD1(byteValue, FilterStatus(uint8_t& value));
-  MOCK_METHOD1(int16Value, FilterStatus(int16_t& value));
-  MOCK_METHOD1(int32Value, FilterStatus(int32_t& value));
-  MOCK_METHOD1(int64Value, FilterStatus(int64_t& value));
-  MOCK_METHOD1(doubleValue, FilterStatus(double& value));
-  MOCK_METHOD1(stringValue, FilterStatus(absl::string_view value));
-  MOCK_METHOD3(mapBegin, FilterStatus(FieldType& key_type, FieldType& value_type, uint32_t& size));
-  MOCK_METHOD0(mapEnd, FilterStatus());
-  MOCK_METHOD2(listBegin, FilterStatus(FieldType& elem_type, uint32_t& size));
-  MOCK_METHOD0(listEnd, FilterStatus());
-  MOCK_METHOD2(setBegin, FilterStatus(FieldType& elem_type, uint32_t& size));
-  MOCK_METHOD0(setEnd, FilterStatus());
+  MOCK_METHOD(FilterStatus, transportBegin, (MessageMetadataSharedPtr metadata));
+  MOCK_METHOD(FilterStatus, transportEnd, ());
+  MOCK_METHOD(FilterStatus, messageBegin, (MessageMetadataSharedPtr metadata));
+  MOCK_METHOD(FilterStatus, messageEnd, ());
+  MOCK_METHOD(FilterStatus, structBegin, (const absl::string_view name));
+  MOCK_METHOD(FilterStatus, structEnd, ());
+  MOCK_METHOD(FilterStatus, fieldBegin,
+              (const absl::string_view name, FieldType& msg_type, int16_t& field_id));
+  MOCK_METHOD(FilterStatus, fieldEnd, ());
+  MOCK_METHOD(FilterStatus, boolValue, (bool& value));
+  MOCK_METHOD(FilterStatus, byteValue, (uint8_t & value));
+  MOCK_METHOD(FilterStatus, int16Value, (int16_t & value));
+  MOCK_METHOD(FilterStatus, int32Value, (int32_t & value));
+  MOCK_METHOD(FilterStatus, int64Value, (int64_t & value));
+  MOCK_METHOD(FilterStatus, doubleValue, (double& value));
+  MOCK_METHOD(FilterStatus, stringValue, (absl::string_view value));
+  MOCK_METHOD(FilterStatus, mapBegin,
+              (FieldType & key_type, FieldType& value_type, uint32_t& size));
+  MOCK_METHOD(FilterStatus, mapEnd, ());
+  MOCK_METHOD(FilterStatus, listBegin, (FieldType & elem_type, uint32_t& size));
+  MOCK_METHOD(FilterStatus, listEnd, ());
+  MOCK_METHOD(FilterStatus, setBegin, (FieldType & elem_type, uint32_t& size));
+  MOCK_METHOD(FilterStatus, setEnd, ());
 };
 
 class MockDirectResponse : public DirectResponse {
@@ -163,8 +171,8 @@ public:
   ~MockDirectResponse() override;
 
   // ThriftProxy::DirectResponse
-  MOCK_CONST_METHOD3(encode,
-                     DirectResponse::ResponseType(MessageMetadata&, Protocol&, Buffer::Instance&));
+  MOCK_METHOD(DirectResponse::ResponseType, encode,
+              (MessageMetadata&, Protocol&, Buffer::Instance&), (const));
 };
 
 class MockThriftObject : public ThriftObject {
@@ -172,8 +180,8 @@ public:
   MockThriftObject();
   ~MockThriftObject() override;
 
-  MOCK_CONST_METHOD0(fields, ThriftFieldPtrList&());
-  MOCK_METHOD1(onData, bool(Buffer::Instance&));
+  MOCK_METHOD(ThriftFieldPtrList&, fields, (), (const));
+  MOCK_METHOD(bool, onData, (Buffer::Instance&));
 };
 
 namespace Router {
@@ -187,7 +195,7 @@ public:
   MockFilterChainFactoryCallbacks();
   ~MockFilterChainFactoryCallbacks() override;
 
-  MOCK_METHOD1(addDecoderFilter, void(DecoderFilterSharedPtr));
+  MOCK_METHOD(void, addDecoderFilter, (DecoderFilterSharedPtr));
 };
 
 class MockDecoderFilter : public DecoderFilter {
@@ -196,33 +204,34 @@ public:
   ~MockDecoderFilter() override;
 
   // ThriftProxy::ThriftFilters::DecoderFilter
-  MOCK_METHOD0(onDestroy, void());
-  MOCK_METHOD1(setDecoderFilterCallbacks, void(DecoderFilterCallbacks& callbacks));
-  MOCK_METHOD0(resetUpstreamConnection, void());
+  MOCK_METHOD(void, onDestroy, ());
+  MOCK_METHOD(void, setDecoderFilterCallbacks, (DecoderFilterCallbacks & callbacks));
+  MOCK_METHOD(void, resetUpstreamConnection, ());
 
   // ThriftProxy::DecoderEventHandler
-  MOCK_METHOD1(transportBegin, FilterStatus(MessageMetadataSharedPtr metadata));
-  MOCK_METHOD0(transportEnd, FilterStatus());
-  MOCK_METHOD1(messageBegin, FilterStatus(MessageMetadataSharedPtr metadata));
-  MOCK_METHOD0(messageEnd, FilterStatus());
-  MOCK_METHOD1(structBegin, FilterStatus(absl::string_view name));
-  MOCK_METHOD0(structEnd, FilterStatus());
-  MOCK_METHOD3(fieldBegin,
-               FilterStatus(absl::string_view name, FieldType& msg_type, int16_t& field_id));
-  MOCK_METHOD0(fieldEnd, FilterStatus());
-  MOCK_METHOD1(boolValue, FilterStatus(bool& value));
-  MOCK_METHOD1(byteValue, FilterStatus(uint8_t& value));
-  MOCK_METHOD1(int16Value, FilterStatus(int16_t& value));
-  MOCK_METHOD1(int32Value, FilterStatus(int32_t& value));
-  MOCK_METHOD1(int64Value, FilterStatus(int64_t& value));
-  MOCK_METHOD1(doubleValue, FilterStatus(double& value));
-  MOCK_METHOD1(stringValue, FilterStatus(absl::string_view value));
-  MOCK_METHOD3(mapBegin, FilterStatus(FieldType& key_type, FieldType& value_type, uint32_t& size));
-  MOCK_METHOD0(mapEnd, FilterStatus());
-  MOCK_METHOD2(listBegin, FilterStatus(FieldType& elem_type, uint32_t& size));
-  MOCK_METHOD0(listEnd, FilterStatus());
-  MOCK_METHOD2(setBegin, FilterStatus(FieldType& elem_type, uint32_t& size));
-  MOCK_METHOD0(setEnd, FilterStatus());
+  MOCK_METHOD(FilterStatus, transportBegin, (MessageMetadataSharedPtr metadata));
+  MOCK_METHOD(FilterStatus, transportEnd, ());
+  MOCK_METHOD(FilterStatus, messageBegin, (MessageMetadataSharedPtr metadata));
+  MOCK_METHOD(FilterStatus, messageEnd, ());
+  MOCK_METHOD(FilterStatus, structBegin, (absl::string_view name));
+  MOCK_METHOD(FilterStatus, structEnd, ());
+  MOCK_METHOD(FilterStatus, fieldBegin,
+              (absl::string_view name, FieldType& msg_type, int16_t& field_id));
+  MOCK_METHOD(FilterStatus, fieldEnd, ());
+  MOCK_METHOD(FilterStatus, boolValue, (bool& value));
+  MOCK_METHOD(FilterStatus, byteValue, (uint8_t & value));
+  MOCK_METHOD(FilterStatus, int16Value, (int16_t & value));
+  MOCK_METHOD(FilterStatus, int32Value, (int32_t & value));
+  MOCK_METHOD(FilterStatus, int64Value, (int64_t & value));
+  MOCK_METHOD(FilterStatus, doubleValue, (double& value));
+  MOCK_METHOD(FilterStatus, stringValue, (absl::string_view value));
+  MOCK_METHOD(FilterStatus, mapBegin,
+              (FieldType & key_type, FieldType& value_type, uint32_t& size));
+  MOCK_METHOD(FilterStatus, mapEnd, ());
+  MOCK_METHOD(FilterStatus, listBegin, (FieldType & elem_type, uint32_t& size));
+  MOCK_METHOD(FilterStatus, listEnd, ());
+  MOCK_METHOD(FilterStatus, setBegin, (FieldType & elem_type, uint32_t& size));
+  MOCK_METHOD(FilterStatus, setEnd, ());
 };
 
 class MockDecoderFilterCallbacks : public DecoderFilterCallbacks {
@@ -231,17 +240,17 @@ public:
   ~MockDecoderFilterCallbacks() override;
 
   // ThriftProxy::ThriftFilters::DecoderFilterCallbacks
-  MOCK_CONST_METHOD0(streamId, uint64_t());
-  MOCK_CONST_METHOD0(connection, const Network::Connection*());
-  MOCK_METHOD0(continueDecoding, void());
-  MOCK_METHOD0(route, Router::RouteConstSharedPtr());
-  MOCK_CONST_METHOD0(downstreamTransportType, TransportType());
-  MOCK_CONST_METHOD0(downstreamProtocolType, ProtocolType());
-  MOCK_METHOD2(sendLocalReply, void(const DirectResponse&, bool));
-  MOCK_METHOD2(startUpstreamResponse, void(Transport&, Protocol&));
-  MOCK_METHOD1(upstreamData, ResponseStatus(Buffer::Instance&));
-  MOCK_METHOD0(resetDownstreamConnection, void());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
+  MOCK_METHOD(uint64_t, streamId, (), (const));
+  MOCK_METHOD(const Network::Connection*, connection, (), (const));
+  MOCK_METHOD(void, continueDecoding, ());
+  MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
+  MOCK_METHOD(TransportType, downstreamTransportType, (), (const));
+  MOCK_METHOD(ProtocolType, downstreamProtocolType, (), (const));
+  MOCK_METHOD(void, sendLocalReply, (const DirectResponse&, bool));
+  MOCK_METHOD(void, startUpstreamResponse, (Transport&, Protocol&));
+  MOCK_METHOD(ResponseStatus, upstreamData, (Buffer::Instance&));
+  MOCK_METHOD(void, resetDownstreamConnection, ());
+  MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
 
   uint64_t stream_id_{1};
   NiceMock<Network::MockConnection> connection_;
@@ -273,12 +282,12 @@ public:
   MockRateLimitPolicyEntry();
   ~MockRateLimitPolicyEntry() override;
 
-  MOCK_CONST_METHOD0(stage, uint32_t());
-  MOCK_CONST_METHOD0(disableKey, const std::string&());
-  MOCK_CONST_METHOD5(populateDescriptors,
-                     void(const RouteEntry&, std::vector<RateLimit::Descriptor>&,
-                          const std::string&, const MessageMetadata&,
-                          const Network::Address::Instance&));
+  MOCK_METHOD(uint32_t, stage, (), (const));
+  MOCK_METHOD(const std::string&, disableKey, (), (const));
+  MOCK_METHOD(void, populateDescriptors,
+              (const RouteEntry&, std::vector<RateLimit::Descriptor>&, const std::string&,
+               const MessageMetadata&, const Network::Address::Instance&),
+              (const));
 
   std::string disable_key_;
 };
@@ -288,10 +297,9 @@ public:
   MockRateLimitPolicy();
   ~MockRateLimitPolicy() override;
 
-  MOCK_CONST_METHOD0(empty, bool());
-  MOCK_CONST_METHOD1(
-      getApplicableRateLimit,
-      const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&(uint32_t));
+  MOCK_METHOD(bool, empty, (), (const));
+  MOCK_METHOD(const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&,
+              getApplicableRateLimit, (uint32_t), (const));
 
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limit_policy_entry_;
 };
@@ -302,12 +310,12 @@ public:
   ~MockRouteEntry() override;
 
   // ThriftProxy::Router::RouteEntry
-  MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD0(metadataMatchCriteria, const Envoy::Router::MetadataMatchCriteria*());
-  MOCK_CONST_METHOD0(tlsContextMatchCriteria, const Envoy::Router::TlsContextMatchCriteria*());
-  MOCK_CONST_METHOD0(rateLimitPolicy, RateLimitPolicy&());
-  MOCK_CONST_METHOD0(stripServiceName, bool());
-  MOCK_CONST_METHOD0(clusterHeader, const Http::LowerCaseString&());
+  MOCK_METHOD(const std::string&, clusterName, (), (const));
+  MOCK_METHOD(const Envoy::Router::MetadataMatchCriteria*, metadataMatchCriteria, (), (const));
+  MOCK_METHOD(const Envoy::Router::TlsContextMatchCriteria*, tlsContextMatchCriteria, (), (const));
+  MOCK_METHOD(RateLimitPolicy&, rateLimitPolicy, (), (const));
+  MOCK_METHOD(bool, stripServiceName, (), (const));
+  MOCK_METHOD(const Http::LowerCaseString&, clusterHeader, (), (const));
 
   std::string cluster_name_{"fake_cluster"};
   Http::LowerCaseString cluster_header_{""};
@@ -320,7 +328,7 @@ public:
   ~MockRoute() override;
 
   // ThriftProxy::Router::Route
-  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
+  MOCK_METHOD(const RouteEntry*, routeEntry, (), (const));
 
   NiceMock<MockRouteEntry> route_entry_;
 };

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -26,7 +26,7 @@ class TestUdpProxyFilter : public UdpProxyFilter {
 public:
   using UdpProxyFilter::UdpProxyFilter;
 
-  MOCK_METHOD1(createIoHandle, Network::IoHandlePtr(const Upstream::HostConstSharedPtr& host));
+  MOCK_METHOD(Network::IoHandlePtr, createIoHandle, (const Upstream::HostConstSharedPtr& host));
 };
 
 Api::IoCallUint64Result makeNoError(uint64_t rc) {

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -161,7 +161,7 @@ public:
     return Extensions::NetworkFilters::Common::Redis::Client::ClientPtr{create_()};
   }
 
-  MOCK_METHOD0(create_, Extensions::NetworkFilters::Common::Redis::Client::Client*());
+  MOCK_METHOD(Extensions::NetworkFilters::Common::Redis::Client::Client*, create_, ());
 
   void expectSessionCreate() {
     interval_timer_ = new Event::MockTimer(&dispatcher_);

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
@@ -52,8 +52,8 @@ public:
                  std::make_unique<quic::NullEncrypter>(quic::Perspective::IS_CLIENT));
   }
 
-  MOCK_METHOD2(SendConnectionClosePacket, void(quic::QuicErrorCode, const std::string&));
-  MOCK_METHOD1(SendControlFrame, bool(const quic::QuicFrame& frame));
+  MOCK_METHOD(void, SendConnectionClosePacket, (quic::QuicErrorCode, const std::string&));
+  MOCK_METHOD(bool, SendControlFrame, (const quic::QuicFrame& frame));
 
   using EnvoyQuicClientConnection::connectionStats;
 };

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
@@ -67,8 +67,8 @@ public:
     return EnvoyQuicConnection::connectionStats();
   }
 
-  MOCK_METHOD2(SendConnectionClosePacket, void(quic::QuicErrorCode, const std::string&));
-  MOCK_METHOD1(SendControlFrame, bool(const quic::QuicFrame& frame));
+  MOCK_METHOD(void, SendConnectionClosePacket, (quic::QuicErrorCode, const std::string&));
+  MOCK_METHOD(bool, SendControlFrame, (const quic::QuicFrame& frame));
 };
 
 // Derive to have simpler priority mechanism.

--- a/test/extensions/quic_listeners/quiche/platform/quic_mock_log_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/quic_mock_log_impl.h
@@ -27,7 +27,7 @@ public:
     }
   }
 
-  MOCK_METHOD2(Log, void(QuicLogLevel level, const std::string& message));
+  MOCK_METHOD(void, Log, (QuicLogLevel level, const std::string& message));
 
   void StartCapturingLogs() {
     ASSERT(!is_capturing_);

--- a/test/extensions/quic_listeners/quiche/test_utils.h
+++ b/test/extensions/quic_listeners/quiche/test_utils.h
@@ -29,17 +29,16 @@ public:
   }
 
   // From QuicSession.
-  MOCK_METHOD1(CreateIncomingStream, quic::QuicSpdyStream*(quic::QuicStreamId id));
-  MOCK_METHOD1(CreateIncomingStream, quic::QuicSpdyStream*(quic::PendingStream* pending));
-  MOCK_METHOD0(CreateOutgoingBidirectionalStream, quic::QuicSpdyStream*());
-  MOCK_METHOD0(CreateOutgoingUnidirectionalStream, quic::QuicSpdyStream*());
-  MOCK_METHOD1(ShouldCreateIncomingStream, bool(quic::QuicStreamId id));
-  MOCK_METHOD0(ShouldCreateOutgoingBidirectionalStream, bool());
-  MOCK_METHOD0(ShouldCreateOutgoingUnidirectionalStream, bool());
-  MOCK_METHOD5(WritevData,
-               quic::QuicConsumedData(quic::QuicStream* stream, quic::QuicStreamId id,
-                                      size_t write_length, quic::QuicStreamOffset offset,
-                                      quic::StreamSendingState state));
+  MOCK_METHOD(quic::QuicSpdyStream*, CreateIncomingStream, (quic::QuicStreamId id));
+  MOCK_METHOD(quic::QuicSpdyStream*, CreateIncomingStream, (quic::PendingStream * pending));
+  MOCK_METHOD(quic::QuicSpdyStream*, CreateOutgoingBidirectionalStream, ());
+  MOCK_METHOD(quic::QuicSpdyStream*, CreateOutgoingUnidirectionalStream, ());
+  MOCK_METHOD(bool, ShouldCreateIncomingStream, (quic::QuicStreamId id));
+  MOCK_METHOD(bool, ShouldCreateOutgoingBidirectionalStream, ());
+  MOCK_METHOD(bool, ShouldCreateOutgoingUnidirectionalStream, ());
+  MOCK_METHOD(quic::QuicConsumedData, WritevData,
+              (quic::QuicStream * stream, quic::QuicStreamId id, size_t write_length,
+               quic::QuicStreamOffset offset, quic::StreamSendingState state));
 
   absl::string_view requestedServerName() const override {
     return {GetCryptoStream()->crypto_negotiated_params().sni};
@@ -72,17 +71,16 @@ public:
         crypto_config_(quic::test::crypto_test_utils::ProofVerifierForTesting()) {}
 
   // From QuicSession.
-  MOCK_METHOD1(CreateIncomingStream, quic::QuicSpdyClientStream*(quic::QuicStreamId id));
-  MOCK_METHOD1(CreateIncomingStream, quic::QuicSpdyClientStream*(quic::PendingStream* pending));
-  MOCK_METHOD0(CreateOutgoingBidirectionalStream, quic::QuicSpdyClientStream*());
-  MOCK_METHOD0(CreateOutgoingUnidirectionalStream, quic::QuicSpdyClientStream*());
-  MOCK_METHOD1(ShouldCreateIncomingStream, bool(quic::QuicStreamId id));
-  MOCK_METHOD0(ShouldCreateOutgoingBidirectionalStream, bool());
-  MOCK_METHOD0(ShouldCreateOutgoingUnidirectionalStream, bool());
-  MOCK_METHOD5(WritevData,
-               quic::QuicConsumedData(quic::QuicStream* stream, quic::QuicStreamId id,
-                                      size_t write_length, quic::QuicStreamOffset offset,
-                                      quic::StreamSendingState state));
+  MOCK_METHOD(quic::QuicSpdyClientStream*, CreateIncomingStream, (quic::QuicStreamId id));
+  MOCK_METHOD(quic::QuicSpdyClientStream*, CreateIncomingStream, (quic::PendingStream * pending));
+  MOCK_METHOD(quic::QuicSpdyClientStream*, CreateOutgoingBidirectionalStream, ());
+  MOCK_METHOD(quic::QuicSpdyClientStream*, CreateOutgoingUnidirectionalStream, ());
+  MOCK_METHOD(bool, ShouldCreateIncomingStream, (quic::QuicStreamId id));
+  MOCK_METHOD(bool, ShouldCreateOutgoingBidirectionalStream, ());
+  MOCK_METHOD(bool, ShouldCreateOutgoingUnidirectionalStream, ());
+  MOCK_METHOD(quic::QuicConsumedData, WritevData,
+              (quic::QuicStream * stream, quic::QuicStreamId id, size_t write_length,
+               quic::QuicStreamOffset offset, quic::StreamSendingState state));
 
   absl::string_view requestedServerName() const override {
     return {GetCryptoStream()->crypto_negotiated_params().sni};

--- a/test/extensions/resource_monitors/fixed_heap/fixed_heap_monitor_test.cc
+++ b/test/extensions/resource_monitors/fixed_heap/fixed_heap_monitor_test.cc
@@ -16,8 +16,8 @@ class MockMemoryStatsReader : public MemoryStatsReader {
 public:
   MockMemoryStatsReader() = default;
 
-  MOCK_METHOD0(reservedHeapBytes, uint64_t());
-  MOCK_METHOD0(unmappedHeapBytes, uint64_t());
+  MOCK_METHOD(uint64_t, reservedHeapBytes, ());
+  MOCK_METHOD(uint64_t, unmappedHeapBytes, ());
 };
 
 class ResourcePressure : public Server::ResourceMonitor::Callbacks {

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -41,8 +41,8 @@ private:
 
 class MockedCallbacks : public Server::ResourceMonitor::Callbacks {
 public:
-  MOCK_METHOD1(onSuccess, void(const Server::ResourceUsage&));
-  MOCK_METHOD1(onFailure, void(const EnvoyException&));
+  MOCK_METHOD(void, onSuccess, (const Server::ResourceUsage&));
+  MOCK_METHOD(void, onFailure, (const EnvoyException&));
 };
 
 class InjectedResourceMonitorTest : public testing::Test {

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -26,7 +26,7 @@ namespace {
 
 class MockWriter : public Writer {
 public:
-  MOCK_METHOD1(write, void(const std::string& message));
+  MOCK_METHOD(void, write, (const std::string& message));
 };
 
 class UdpStatsdSinkTest : public testing::TestWithParam<Network::Address::IpVersion> {};

--- a/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
@@ -87,7 +87,7 @@ TEST_F(GrpcMetricsStreamerImplTest, StreamFailure) {
 class MockGrpcMetricsStreamer : public GrpcMetricsStreamer {
 public:
   // GrpcMetricsStreamer
-  MOCK_METHOD1(send, void(envoy::service::metrics::v3::StreamMetricsMessage& message));
+  MOCK_METHOD(void, send, (envoy::service::metrics::v3::StreamMetricsMessage & message));
 };
 
 class TestGrpcMetricsStreamer : public GrpcMetricsStreamer {

--- a/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
@@ -21,7 +21,7 @@ using testing::SaveArg;
 class MockTsiHandshakerCallbacks : public TsiHandshakerCallbacks {
 public:
   void onNextDone(NextResultPtr&& result) override { onNextDone_(result.get()); }
-  MOCK_METHOD1(onNextDone_, void(NextResult*));
+  MOCK_METHOD(void, onNextDone_, (NextResult*));
 
   void expectDone(tsi_result status, Buffer::Instance& to_send, CHandshakerResultPtr& result) {
     EXPECT_CALL(*this, onNextDone_(_))

--- a/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
+++ b/test/extensions/transport_sockets/tap/tap_config_impl_test.cc
@@ -32,16 +32,16 @@ public:
         createPerTapSinkHandleManager_(trace_id)};
   }
 
-  MOCK_METHOD1(createPerSocketTapper_, PerSocketTapper*(const Network::Connection& connection));
-  MOCK_METHOD1(createPerTapSinkHandleManager_,
-               Extensions::Common::Tap::PerTapSinkHandleManager*(uint64_t trace_id));
-  MOCK_CONST_METHOD0(maxBufferedRxBytes, uint32_t());
-  MOCK_CONST_METHOD0(maxBufferedTxBytes, uint32_t());
-  MOCK_CONST_METHOD0(createMatchStatusVector,
-                     Extensions::Common::Tap::Matcher::MatchStatusVector());
-  MOCK_CONST_METHOD0(rootMatcher, const Extensions::Common::Tap::Matcher&());
-  MOCK_CONST_METHOD0(streaming, bool());
-  MOCK_CONST_METHOD0(timeSource, TimeSource&());
+  MOCK_METHOD(PerSocketTapper*, createPerSocketTapper_, (const Network::Connection& connection));
+  MOCK_METHOD(Extensions::Common::Tap::PerTapSinkHandleManager*, createPerTapSinkHandleManager_,
+              (uint64_t trace_id));
+  MOCK_METHOD(uint32_t, maxBufferedRxBytes, (), (const));
+  MOCK_METHOD(uint32_t, maxBufferedTxBytes, (), (const));
+  MOCK_METHOD(Extensions::Common::Tap::Matcher::MatchStatusVector, createMatchStatusVector, (),
+              (const));
+  MOCK_METHOD(const Extensions::Common::Tap::Matcher&, rootMatcher, (), (const));
+  MOCK_METHOD(bool, streaming, (), (const));
+  MOCK_METHOD(TimeSource&, timeSource, (), (const));
 };
 
 class PerSocketTapperImplTest : public testing::Test {


### PR DESCRIPTION
Description: Breaking up #9629 into smaller pieces, just upgrading the `MOCK_` methods for `test/common/` and `test/extensions/.
Risk Level: low
Testing: existing
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Derek Argueta <dereka@pinterest.com>