### PR TITLE
[WIP] Surface defects in broken check_format.py on master

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -24,7 +24,7 @@ SUFFIXES = ("BUILD", "WORKSPACE", ".bzl", ".cc", ".h", ".java", ".m", ".md", ".m
 DOCS_SUFFIX = (".md", ".rst")
 PROTO_SUFFIX = (".proto")
 
-# Files in these paths can make reference to protobuf stuff directly
+# Files in these paths can directly reference protobuf stuff
 GOOGLE_PROTOBUF_WHITELIST = ("ci/prebuilt", "source/common/protobuf", "api/test")
 REPOSITORIES_BZL = "bazel/repositories.bzl"
 


### PR DESCRIPTION
DO NOT MERGE

Test comment modification of check_format.py to trigger check_format_test.py
and demonstrate that check_format.py on master is presently broken in combination
with clang-format-9 and current test framework/rulesets.