### PR TITLE
Restrict documentation line width

### DIFF
--- a/docs/root/_static/css/envoy.css
+++ b/docs/root/_static/css/envoy.css
@@ -1,10 +1,5 @@
 @import url("theme.css");
 
-/*Changing content max-width 100% ( 800px is default )*/
-.wy-nav-content {
-  max-width: 100% !important;
-}
-
 /* Splits a long line descriptions in tables in to multiple lines */
 .wy-table-responsive table td, .wy-table-responsive table th {
   white-space: normal !important;


### PR DESCRIPTION
Pull request #7993 made a CSS change that makes documentation content cover the entire page width. I take this to be a regression. Amongst technical writers, there's a broad consensus that long line lengths beyond about 3 alphabets produce undue strain on the eye (see [here](https://practicaltypography.com/line-length.html), [here](https://baymard.com/blog/line-length-readability), and [here](https://www.viget.com/articles/the-line-length-misconception), amongst others). This PR undoes those changes and re-introduces the 800px width.