### PR TITLE
Add robots.txt to index only the "latest" docs

### DIFF
--- a/docs/root/_static/robots.txt
+++ b/docs/root/_static/robots.txt
@@ -1,0 +1,1 @@
+User-agent: *

--- a/docs/root/_static/robots.txt
+++ b/docs/root/_static/robots.txt
@@ -1,1 +1,13 @@
 User-agent: *
+Disallow: /docs/envoy/v1.12.0/
+Disallow: /docs/envoy/v1.11.2/
+Disallow: /docs/envoy/v1.11.1/
+Disallow: /docs/envoy/v1.11.0/
+Disallow: /docs/envoy/v1.10.0/
+Disallow: /docs/envoy/v1.9.1/
+Disallow: /docs/envoy/v1.9.0/
+Disallow: /docs/envoy/v1.8.0/
+Disallow: /docs/envoy/v1.7.1/
+Disallow: /docs/envoy/v1.7.0/
+Disallow: /docs/envoy/v1.6.0/
+Disallow: /docs/envoy/v1.5.0/


### PR DESCRIPTION
This PR re-opens #9260, which was automatically closed as stale during winter break.

Description: Adds a robots.txt that instructs Google not to index docs versions that are not latest.
Risk Level: low
Fixes issue: #8838

I was hoping to find a more programmatic way to do this that doesn't require adding new entries for each docs version, but I haven't found one just yet.