### PR TITLE
stats: disable real symbol tables till #9798 is resolved

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -164,7 +164,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   // is not safe to use real symbol tables.
   //   fake_symbol_table_enabled_ = use_fake_symbol_table.getValue();
   fake_symbol_table_enabled_ = false;
-  if (use_fake_symbol_table.getValue()) {
+  if (!use_fake_symbol_table.getValue()) {
     ENVOY_LOG(warn, "Real symbol tables are temporarily disabled due to #9768. "
                     "Using fake symbol tables");
   }

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -160,7 +160,15 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
 
   mutex_tracing_enabled_ = enable_mutex_tracing.getValue();
 
-  fake_symbol_table_enabled_ = use_fake_symbol_table.getValue();
+  // TODO(#9768); When This bug is fixed, we can remove this hack. Until then
+  // is not safe to use real symbol tables.
+  //   fake_symbol_table_enabled_ = use_fake_symbol_table.getValue();
+  fake_symbol_table_enabled_ = false;
+  if (use_fake_symbol_table.getValue()) {
+    ENVOY_LOG(warn, "Real symbol tables are temporarily disabled due to #9768. "
+                    "Using fake symbol tables");
+  }
+
   cpuset_threads_ = cpuset_threads.getValue();
 
   log_level_ = default_log_level;

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -95,7 +95,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_TRUE(options->cpusetThreadsEnabled());
   EXPECT_TRUE(options->allowUnknownStaticFields());
   EXPECT_TRUE(options->rejectUnknownDynamicFields());
-  EXPECT_TRUE(options->fakeSymbolTableEnabled());
+  EXPECT_FALSE(options->fakeSymbolTableEnabled()); // TODO(#9798): EXPECT_TRUE when fixed.
 
   options = createOptionsImpl("envoy --mode init_only");
   EXPECT_EQ(Server::Mode::InitOnly, options->mode());


### PR DESCRIPTION
Description: As a temporary workaround until #9768 is properly resolved, disable use of real symbol tables.
Risk Level: medium
Testing: test/server/...
Docs Changes: n/a
Release Notes: n/a

