### PR TITLE
Router check tool: Set correct value for path redirect

### DIFF
--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -388,7 +388,7 @@ bool RouterCheckTool::compareRewriteHost(
 bool RouterCheckTool::compareRedirectPath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
   if (tool_config.route_->directResponseEntry() != nullptr) {
-    tool_config.route_->directResponseEntry()->rewritePathHeader(*tool_config.headers_, false);
+    tool_config.route_->directResponseEntry()->rewritePathHeader(*tool_config.headers_, true);
     actual = tool_config.route_->directResponseEntry()->newPath(*tool_config.headers_);
   }
 

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -388,6 +388,7 @@ bool RouterCheckTool::compareRewriteHost(
 bool RouterCheckTool::compareRedirectPath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
   if (tool_config.route_->directResponseEntry() != nullptr) {
+    tool_config.route_->directResponseEntry()->rewritePathHeader(*tool_config.headers_, false);
     actual = tool_config.route_->directResponseEntry()->newPath(*tool_config.headers_);
   }
 

--- a/test/tools/router_check/test/config/Redirect.golden.proto.json
+++ b/test/tools/router_check/test/config/Redirect.golden.proto.json
@@ -113,6 +113,22 @@
         "path_rewrite": "/second/test",
         "cluster_name": "www2"
       }
+    },
+    {
+      "test_name": "Test_11",
+      "input": {
+        "authority": "redirect.lyft.com",
+        "path": "/rewrite",
+        "method": "GET",
+        "ssl": true
+      },
+      "validate": {
+        "host_rewrite": "",
+        "virtual_host_name": "",
+        "path_rewrite": "",
+        "cluster_name": "",
+        "path_redirect": "https://redirect.lyft.com/blah"
+      }
     }
   ]
 }

--- a/test/tools/router_check/test/config/Redirect.yaml
+++ b/test/tools/router_check/test/config/Redirect.yaml
@@ -32,6 +32,10 @@ virtual_hosts:
   - redirect.lyft.com
   routes:
     - match:
+        prefix: /blah
+      route:
+        cluster: www2
+    - match:
         prefix: /foo
       redirect:
         host_redirect: new.lyft.com
@@ -44,3 +48,7 @@ virtual_hosts:
       redirect:
         host_redirect: new.lyft.com
         path_redirect: /new_baz
+    - match:
+        prefix: /rewrite
+      redirect:
+        prefix_rewrite: /blah


### PR DESCRIPTION
Signed-off-by: Lisa Lu <lisalu@lyft.com>

Description: This change fixes a bug in which the router check tool used an incorrect value for "path redirect" that did not actually contain the final redirect value. rewritePathHeader is called in order to actually perform prefix rewriting, [emulating how actual routing works](https://github.com/envoyproxy/envoy/blob/7c783720a84b568a899df76db448176e43c7f6f1/source/common/router/router.cc#L424).
Specifically, in Test_11, "path_redirect" would have been https://redirect.lyft.com/rewrite without my change and is https://redirect.lyft.com/blah with my change, which is a more accurate/useful test output.
Risk Level: Low
Testing: Added unit test case
Docs Changes: N/A
Release Notes: N/A
