### PR TITLE
Allow setting LLVM_ROOT via an env var

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -80,7 +80,7 @@ function cleanup() {
 cleanup
 trap cleanup EXIT
 
-export LLVM_ROOT=/opt/llvm
+export LLVM_ROOT="${LLVM_ROOT:-/opt/llvm}"
 "$(dirname "$0")"/../bazel/setup_clang.sh "${LLVM_ROOT}"
 
 [[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=" --nocache_test_results --test_output=all"


### PR DESCRIPTION
This is a follow-up on #9535. With this change, I can
run `ci/do_ci.sh` without docker on OS X. E.g.:

```
NUM_CPUS=2 \
ENVOY_BUILD_TARGET="//pinterest:envoy" \
BUILD_DIR=$(pwd)/build \
ENVOY_SRCDIR=$(pwd)/envoy/ \
bash -x envoy/ci/do_ci.sh bazel.dev
```

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
