### PR TITLE
[cel] fix evaluator fuzz bug 

### DIFF
--- a/test/extensions/filters/common/expr/evaluator_corpus/clusterfuzz-testcase-minimized-evaluator_fuzz_test-5723735986536448
+++ b/test/extensions/filters/common/expr/evaluator_corpus/clusterfuzz-testcase-minimized-evaluator_fuzz_test-5723735986536448
@@ -1,0 +1,1 @@
+expression { } stream_info {   address {     pipe {       path: "            \0     "     }   } } 


### PR DESCRIPTION
Catches a malformed address now instead of crashing on it.

Testing: added corpus entry
Fixes OSS-Fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19559

Signed-off-by: Asra Ali <asraa@google.com>

