### PR TITLE
config: remove NullGrpcMuxImpl

### DIFF
--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -138,34 +138,5 @@ private:
   const envoy::config::core::v3::ApiVersion transport_api_version_;
 };
 
-class NullGrpcMuxImpl : public GrpcMux,
-                        GrpcStreamCallbacks<envoy::service::discovery::v3::DiscoveryResponse> {
-public:
-  void start() override {}
-  GrpcMuxWatchPtr subscribe(const std::string&, const std::set<std::string>&,
-                            GrpcMuxCallbacks&) override {
-    throw EnvoyException("ADS must be configured to support an ADS config source");
-  }
-  // TODO(fredlas) PR #8478 will remove this.
-  bool isDelta() const override { return false; }
-  void pause(const std::string&) override {}
-  void resume(const std::string&) override {}
-  bool paused(const std::string&) const override { return false; }
-
-  Watch* addOrUpdateWatch(const std::string&, Watch*, const std::set<std::string>&,
-                          SubscriptionCallbacks&, std::chrono::milliseconds) override {
-    throw EnvoyException("ADS must be configured to support an ADS config source");
-  }
-  void removeWatch(const std::string&, Watch*) override {
-    throw EnvoyException("ADS must be configured to support an ADS config source");
-  }
-
-  void onWriteable() override {}
-  void onStreamEstablished() override {}
-  void onEstablishmentFailure() override {}
-  void onDiscoveryResponse(
-      std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse>&&) override {}
-};
-
 } // namespace Config
 } // namespace Envoy

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -109,14 +109,6 @@ public:
   Event::SimulatedTimeSystem time_system_;
 };
 
-// TODO(fredlas) #8478 will delete this.
-TEST_F(GrpcMuxImplTest, JustForCoverageTodoDelete) {
-  setup();
-  NullGrpcMuxImpl fake;
-  EXPECT_FALSE(grpc_mux_->isDelta());
-  EXPECT_FALSE(fake.isDelta());
-}
-
 // Validate behavior when multiple type URL watches are maintained, watches are created/destroyed
 // (via RAII).
 TEST_F(GrpcMuxImplTest, MultipleTypeUrlStreams) {


### PR DESCRIPTION
Signed-off-by: Bill Gallagher <bgallagher@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: removes a class that serves no purpose
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
