### PR TITLE
http2: removing legacy configuration options

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -346,57 +346,29 @@ void ConnectionImpl::StreamImpl::onMetadataDecoded(MetadataMapPtr&& metadata_map
   decoder_->decodeMetadata(std::move(metadata_map_ptr));
 }
 
-namespace {
-
-const char InvalidHttpMessagingOverrideKey[] =
-    "envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging";
-const char MaxOutboundFramesOverrideKey[] =
-    "envoy.reloadable_features.http2_protocol_options.max_outbound_frames";
-const char MaxOutboundControlFramesOverrideKey[] =
-    "envoy.reloadable_features.http2_protocol_options.max_outbound_control_frames";
-const char MaxConsecutiveInboundFramesWithEmptyPayloadOverrideKey[] =
-    "envoy.reloadable_features.http2_protocol_options."
-    "max_consecutive_inbound_frames_with_empty_payload";
-const char MaxInboundPriorityFramesPerStreamOverrideKey[] =
-    "envoy.reloadable_features.http2_protocol_options.max_inbound_priority_frames_per_stream";
-const char MaxInboundWindowUpdateFramesPerDataFrameSentOverrideKey[] =
-    "envoy.reloadable_features.http2_protocol_options."
-    "max_inbound_window_update_frames_per_data_frame_sent";
-
-bool checkRuntimeOverride(bool config_value, const char* override_key) {
-  return Runtime::runtimeFeatureEnabled(override_key) ? true : config_value;
-}
-
-} // namespace
-
 ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
                                const Http2Settings& http2_settings, const uint32_t max_headers_kb,
                                const uint32_t max_headers_count)
     : stats_{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http2."))}, connection_(connection),
       max_headers_kb_(max_headers_kb), max_headers_count_(max_headers_count),
       per_stream_buffer_limit_(http2_settings.initial_stream_window_size_),
-      stream_error_on_invalid_http_messaging_(checkRuntimeOverride(
-          http2_settings.stream_error_on_invalid_http_messaging_, InvalidHttpMessagingOverrideKey)),
+      stream_error_on_invalid_http_messaging_(
+          http2_settings.stream_error_on_invalid_http_messaging_),
       flood_detected_(false),
-      max_outbound_frames_(
-          Runtime::getInteger(MaxOutboundFramesOverrideKey, http2_settings.max_outbound_frames_)),
+      max_outbound_frames_(http2_settings.max_outbound_frames_),
       frame_buffer_releasor_([this](const Buffer::OwnedBufferFragmentImpl* fragment) {
         releaseOutboundFrame(fragment);
       }),
-      max_outbound_control_frames_(Runtime::getInteger(
-          MaxOutboundControlFramesOverrideKey, http2_settings.max_outbound_control_frames_)),
+      max_outbound_control_frames_(http2_settings.max_outbound_control_frames_),
       control_frame_buffer_releasor_([this](const Buffer::OwnedBufferFragmentImpl* fragment) {
         releaseOutboundControlFrame(fragment);
       }),
       max_consecutive_inbound_frames_with_empty_payload_(
-          Runtime::getInteger(MaxConsecutiveInboundFramesWithEmptyPayloadOverrideKey,
-                              http2_settings.max_consecutive_inbound_frames_with_empty_payload_)),
+                              http2_settings.max_consecutive_inbound_frames_with_empty_payload_),
       max_inbound_priority_frames_per_stream_(
-          Runtime::getInteger(MaxInboundPriorityFramesPerStreamOverrideKey,
-                              http2_settings.max_inbound_priority_frames_per_stream_)),
-      max_inbound_window_update_frames_per_data_frame_sent_(Runtime::getInteger(
-          MaxInboundWindowUpdateFramesPerDataFrameSentOverrideKey,
-          http2_settings.max_inbound_window_update_frames_per_data_frame_sent_)),
+                              http2_settings.max_inbound_priority_frames_per_stream_),
+      max_inbound_window_update_frames_per_data_frame_sent_(
+          http2_settings.max_inbound_window_update_frames_per_data_frame_sent_),
       dispatching_(false), raised_goaway_(false), pending_deferred_reset_(false) {}
 
 ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -354,8 +354,7 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
       per_stream_buffer_limit_(http2_settings.initial_stream_window_size_),
       stream_error_on_invalid_http_messaging_(
           http2_settings.stream_error_on_invalid_http_messaging_),
-      flood_detected_(false),
-      max_outbound_frames_(http2_settings.max_outbound_frames_),
+      flood_detected_(false), max_outbound_frames_(http2_settings.max_outbound_frames_),
       frame_buffer_releasor_([this](const Buffer::OwnedBufferFragmentImpl* fragment) {
         releaseOutboundFrame(fragment);
       }),
@@ -364,9 +363,9 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
         releaseOutboundControlFrame(fragment);
       }),
       max_consecutive_inbound_frames_with_empty_payload_(
-                              http2_settings.max_consecutive_inbound_frames_with_empty_payload_),
+          http2_settings.max_consecutive_inbound_frames_with_empty_payload_),
       max_inbound_priority_frames_per_stream_(
-                              http2_settings.max_inbound_priority_frames_per_stream_),
+          http2_settings.max_inbound_priority_frames_per_stream_),
       max_inbound_window_update_frames_per_data_frame_sent_(
           http2_settings.max_inbound_window_update_frames_per_data_frame_sent_),
       dispatching_(false), raised_goaway_(false), pending_deferred_reset_(false) {}

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -45,8 +45,6 @@ constexpr const char* runtime_features[] = {
 constexpr const char* disabled_runtime_features[] = {
     // Sentinel and test flag.
     "envoy.reloadable_features.test_feature_false",
-    // Should be removed as part of https://github.com/envoyproxy/envoy/issues/8993
-    "envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging",
 };
 
 RuntimeFeatures::RuntimeFeatures() {

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -34,18 +34,6 @@ namespace Envoy {
 namespace Runtime {
 namespace {
 
-// Before ASSERTS were added to ensure runtime features were restricted to
-// booleans, several integer features were added. isLegacyFeatures exempts
-// existing integer features from the checks until they can be cleaned up.
-// This includes
-// envoy.reloadable_features.max_[request|response]_headers_count from
-// include/envoy/http/codec.h as well as the http2_protocol_options overrides in
-// source/common/http/http2/codec_impl.cc
-bool isLegacyFeature(absl::string_view feature) {
-  return absl::StartsWith(feature, "envoy.reloadable_features.http2_protocol_options.") ||
-         absl::StartsWith(feature, "envoy.reloadable_features.max_re");
-}
-
 bool isRuntimeFeature(absl::string_view feature) {
   return RuntimeFeaturesDefaults::get().enabledByDefault(feature) ||
          RuntimeFeaturesDefaults::get().existsButDisabled(feature);
@@ -288,7 +276,7 @@ bool SnapshotImpl::featureEnabled(const std::string& key,
 }
 
 uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value) const {
-  ASSERT(isLegacyFeature(key) || !isRuntimeFeature(key));
+  ASSERT(!isRuntimeFeature(key));
   auto entry = values_.find(key);
   if (entry == values_.end() || !entry->second.uint_value_) {
     return default_value;


### PR DESCRIPTION
Removing some configuration knobs which were intended to be temporary runtime override knobs for high risk security fixes.  They've been running in prod so far so good.  Time to clean  up.

Risk Level: Medium (someone could have missed they were temporary)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #8993
