### PR TITLE
protobuf: switching error message printing to upstream proto library

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -588,47 +588,8 @@ ProtobufWkt::Struct MessageUtil::keyValueStruct(const std::map<std::string, std:
   return struct_obj;
 }
 
-// TODO(alyssawilk) see if we can get proto's CodeEnumToString made accessible
-// to avoid copying it. Otherwise change this to absl::string_view.
 std::string MessageUtil::CodeEnumToString(ProtobufUtil::error::Code code) {
-  switch (code) {
-  case ProtobufUtil::error::OK:
-    return "OK";
-  case ProtobufUtil::error::CANCELLED:
-    return "CANCELLED";
-  case ProtobufUtil::error::UNKNOWN:
-    return "UNKNOWN";
-  case ProtobufUtil::error::INVALID_ARGUMENT:
-    return "INVALID_ARGUMENT";
-  case ProtobufUtil::error::DEADLINE_EXCEEDED:
-    return "DEADLINE_EXCEEDED";
-  case ProtobufUtil::error::NOT_FOUND:
-    return "NOT_FOUND";
-  case ProtobufUtil::error::ALREADY_EXISTS:
-    return "ALREADY_EXISTS";
-  case ProtobufUtil::error::PERMISSION_DENIED:
-    return "PERMISSION_DENIED";
-  case ProtobufUtil::error::UNAUTHENTICATED:
-    return "UNAUTHENTICATED";
-  case ProtobufUtil::error::RESOURCE_EXHAUSTED:
-    return "RESOURCE_EXHAUSTED";
-  case ProtobufUtil::error::FAILED_PRECONDITION:
-    return "FAILED_PRECONDITION";
-  case ProtobufUtil::error::ABORTED:
-    return "ABORTED";
-  case ProtobufUtil::error::OUT_OF_RANGE:
-    return "OUT_OF_RANGE";
-  case ProtobufUtil::error::UNIMPLEMENTED:
-    return "UNIMPLEMENTED";
-  case ProtobufUtil::error::INTERNAL:
-    return "INTERNAL";
-  case ProtobufUtil::error::UNAVAILABLE:
-    return "UNAVAILABLE";
-  case ProtobufUtil::error::DATA_LOSS:
-    return "DATA_LOSS";
-  default:
-    return "";
-  }
+  return ProtobufUtil::Status(code, "").ToString();
 }
 
 namespace {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1645,8 +1645,9 @@ TEST(StatusCode, Strings) {
   for (int i = 0; i < last_code; ++i) {
     EXPECT_NE(MessageUtil::CodeEnumToString(static_cast<ProtobufUtil::error::Code>(i)), "");
   }
-  ASSERT_EQ("",
+  ASSERT_EQ("UNKNOWN",
             MessageUtil::CodeEnumToString(static_cast<ProtobufUtil::error::Code>(last_code + 1)));
+  ASSERT_EQ("OK", MessageUtil::CodeEnumToString(ProtobufUtil::error::OK));
 }
 
 TEST(TypeUtilTest, TypeUrlToDescriptorFullName) {


### PR DESCRIPTION
Risk Level: Low (should only change printing of unknown values)
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a