### PR TITLE
stats: flip polarity of override

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -163,7 +163,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   // TODO(#9768); When This bug is fixed, we can remove this hack. Until then
   // is not safe to use real symbol tables.
   //   fake_symbol_table_enabled_ = use_fake_symbol_table.getValue();
-  fake_symbol_table_enabled_ = false;
+  fake_symbol_table_enabled_ = true;
   if (!use_fake_symbol_table.getValue()) {
     ENVOY_LOG(warn, "Real symbol tables are temporarily disabled due to #9768. "
                     "Using fake symbol tables");

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -74,7 +74,7 @@ TEST_F(OptionsImplTest, All) {
       "--file-flush-interval-msec 9000 "
       "--drain-time-s 60 --log-format [%v] --parent-shutdown-time-s 90 --log-path /foo/bar "
       "--disable-hot-restart --cpuset-threads --allow-unknown-static-fields "
-      "--reject-unknown-dynamic-fields");
+      "--reject-unknown-dynamic-fields --use-fake-symbol-table 0");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());
@@ -95,7 +95,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_TRUE(options->cpusetThreadsEnabled());
   EXPECT_TRUE(options->allowUnknownStaticFields());
   EXPECT_TRUE(options->rejectUnknownDynamicFields());
-  EXPECT_FALSE(options->fakeSymbolTableEnabled()); // TODO(#9798): EXPECT_TRUE when fixed.
+  EXPECT_TRUE(options->fakeSymbolTableEnabled());
 
   options = createOptionsImpl("envoy --mode init_only");
   EXPECT_EQ(Server::Mode::InitOnly, options->mode());


### PR DESCRIPTION
Description: reversed the bit of the override in #9770 , forcing real symbol tables. Not my intent. Reversing it back.
Risk Level: low
Testing: hot_restart_test options_impl_test, manually running server and checking which symbol table via assert
Docs Changes: n/a
Release Notes: n/a

