### PR TITLE
Make `do_ci.sh check_format` run outside of CI

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -65,7 +65,7 @@ export USER=bazel
 export TEST_TMPDIR=${BUILD_DIR}/tmp
 export BAZEL="bazel"
 export PATH=/opt/llvm/bin:$PATH
-export CLANG_FORMAT=clang-format
+export CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
 
 if [[ -f "/etc/redhat-release" ]]; then
   export BAZEL_BUILD_EXTRA_OPTIONS+="--copt=-DENVOY_IGNORE_GLIBCXX_USE_CXX11_ABI_ERROR=1"
@@ -114,8 +114,8 @@ mkdir -p "${ENVOY_FAILED_TEST_LOGS}"
 export ENVOY_BUILD_PROFILE="${ENVOY_BUILD_DIR}"/generated/build-profile
 mkdir -p "${ENVOY_BUILD_PROFILE}"
 
-export BUILDIFIER_BIN="/usr/local/bin/buildifier"
-export BUILDOZER_BIN="/usr/local/bin/buildozer"
+export BUILDIFIER_BIN="${BUILDIFIER_BIN:-/usr/local/bin/buildifier}"
+export BUILDOZER_BIN="${BUILDOZER_BIN:-/usr/local/bin/buildozer}"
 
 # We set up an Envoy consuming project for test builds only if '-nofetch'
 # is not set AND this is an Envoy build. For derivative builds where Envoy

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -12,7 +12,6 @@ import argparse
 import logging
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 
@@ -123,6 +122,10 @@ def checkToolNotFoundError():
   oldPath = os.environ["PATH"]
   os.environ["PATH"] = "/sbin:/usr/sbin"
   clang_format = os.getenv("CLANG_FORMAT", "clang-format-9")
+  # If CLANG_FORMAT points directly to the binary, skip this test.
+  if os.path.isfile(clang_format) and os.access(clang_format, os.X_OK):
+    os.environ["PATH"] = oldPath
+    return 0
   errors = checkFileExpectingError("no_namespace_envoy.cc", "Command %s not found." % clang_format)
   os.environ["PATH"] = oldPath
   return errors


### PR DESCRIPTION
With this change, this now works:

```
CLANG_FORMAT=/usr/local/Cellar/llvm/9.0.0_1/bin/clang-format \
BUILDIFIER_BIN=~/go/bin/buildifier \
BUILDOZER_BIN=~/go/bin/buildozer \
LLVM_ROOT=/usr/local/opt/llvm/ \
NUM_CPUS=2 \
BUILD_DIR=/tmp \
ENVOY_SRCDIR=$(pwd) \
bash -x ci/do_ci.sh check_format
```

which is very handy for validating PRs locally without using
docker.

Note: this will only work if nothing in your $PATH contains
spaces, which breaks `./tools/proto_format.sh check`. I'll
fix that in a follow-up.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
