### PR TITLE
tls: Use the length value of the ASN1_STRING when copying it to std::string

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -550,12 +550,12 @@ std::string ContextImpl::generalNameAsString(const GENERAL_NAME* general_name) {
   switch (general_name->type) {
   case GEN_DNS: {
     ASN1_STRING* str = general_name->d.dNSName;
-    san = reinterpret_cast<const char*>(ASN1_STRING_data(str));
+    san.assign(reinterpret_cast<const char*>(ASN1_STRING_data(str)), ASN1_STRING_length(str));
     break;
   }
   case GEN_URI: {
     ASN1_STRING* str = general_name->d.uniformResourceIdentifier;
-    san = reinterpret_cast<const char*>(ASN1_STRING_data(str));
+    san.assign(reinterpret_cast<const char*>(ASN1_STRING_data(str)), ASN1_STRING_length(str));
     break;
   }
   case GEN_IPADD: {


### PR DESCRIPTION
OpenSLL docs state that data returned by the ASN1_STRING_data is not guaranteed to be 0 terminated. In practice however it is as OpenSLL defensively places 0 at the end of the ASN1_STRING structure (also making it hard to construct unit tests). This PR is mostly for pedantic reasons to comply with the doc's writ rather that any actual problem.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
