### PR TITLE
config: graceful handling of wire cast failures.

### DIFF
--- a/source/common/config/version_converter.cc
+++ b/source/common/config/version_converter.cc
@@ -1,5 +1,7 @@
 #include "common/config/version_converter.h"
 
+#include "envoy/common/exception.h"
+
 #include "common/common/assert.h"
 #include "common/config/api_type_oracle.h"
 #include "common/protobuf/well_known.h"
@@ -53,15 +55,15 @@ void traverseMutableMessage(ProtoVisitor& visitor, Protobuf::Message& message, c
   }
 }
 
-// Reinterpret a Protobuf message as another Protobuf message by converting to
-// wire format and back. This only works for messages that can be effectively
-// duck typed this way, e.g. with a subtype relationship modulo field name.
+// Reinterpret a Protobuf message as another Protobuf message by converting to wire format and back.
+// This only works for messages that can be effectively duck typed this way, e.g. with a subtype
+// relationship modulo field name.
 void wireCast(const Protobuf::Message& src, Protobuf::Message& dst) {
-  // This should always succeed, since we should be supplying compatible
-  // messages here, but provide a RELEASE_ASSERT as this is off critical path
-  // and we want to learn if it fails.
-  RELEASE_ASSERT(dst.ParseFromString(src.SerializeAsString()),
-                 "Unable to deserialize during wireCast()");
+  // This should should generally succeed, but if there are malformed UTF-8 strings in a message,
+  // this can fail.
+  if (!dst.ParseFromString(src.SerializeAsString())) {
+    throw EnvoyException("Unable to deserialize during wireCast()");
+  }
 }
 
 // Create a new dynamic message based on some message wire cast to the target

--- a/source/common/config/version_converter.h
+++ b/source/common/config/version_converter.h
@@ -38,6 +38,8 @@ public:
    *
    * @param prev_message previous version message input.
    * @param next_message next version message to generate.
+   *
+   * @throw EnvoyException if a Protobuf (de)serialization error occurs.
    */
   static void upgrade(const Protobuf::Message& prev_message, Protobuf::Message& next_message);
 
@@ -53,6 +55,8 @@ public:
    * @param message message input.
    * @return DynamicMessagePtr with the downgraded message (and associated
    *         factory state).
+   *
+   * @throw EnvoyException if a Protobuf (de)serialization error occurs.
    */
   static DynamicMessagePtr downgrade(const Protobuf::Message& message);
 
@@ -94,6 +98,8 @@ public:
    * @param upgraded_message upgraded message input.
    *
    * @return DynamicMessagePtr original message (as a dynamic message).
+   *
+   * @throw EnvoyException if a Protobuf (de)serialization error occurs.
    */
   static DynamicMessagePtr recoverOriginal(const Protobuf::Message& upgraded_message);
 

--- a/test/common/config/version_converter_test.cc
+++ b/test/common/config/version_converter_test.cc
@@ -62,6 +62,15 @@ TEST(VersionConverterTest, Upgrade) {
   EXPECT_THAT(original_sub_msg, ProtoEq(source.eds_cluster_config()));
 }
 
+// Bad UTF-8 can fail wire cast during upgrade.
+TEST(VersionConverterTest, UpgradeException) {
+  API_NO_BOOST(envoy::api::v2::Cluster) source;
+  source.mutable_eds_cluster_config()->set_service_name("UPST128\tAM_HO\001\202\247ST");
+  API_NO_BOOST(envoy::config::cluster::v3::Cluster) dst;
+  EXPECT_THROW_WITH_MESSAGE(VersionConverter::upgrade(source, dst), EnvoyException,
+                            "Unable to deserialize during wireCast()");
+}
+
 // Verify that VersionUtil::scrubHiddenEnvoyDeprecated recursively scrubs any
 // deprecated fields.
 TEST(VersionConverterTest, ScrubHiddenEnvoyDeprecated) {

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-6246954531291136
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-6246954531291136
@@ -1,0 +1,55 @@
+static_resources {
+  clusters {
+    name: "o"
+    connect_timeout {
+      nanos: 15118976
+    }
+    metadata {
+      filter_metadata {
+        key: ""
+      }
+      filter_metadata {
+        key: "\000\000"
+      }
+      filter_metadata {
+        key: "\000\000\001\002z3r90\000\000"
+      }
+      filter_metadata {
+        key: "\000\001\000"
+      }
+      filter_metadata {
+        key: "\000\\959798428\001\002z32902546264\23297677535337\000"
+      }
+      filter_metadata {
+        key: "\0147,83648\000\001\001"
+      }
+      filter_metadata {
+        key: "0"
+      }
+      filter_metadata {
+        key: "@"
+      }
+      filter_metadata {
+        key: "@@"
+      }
+      filter_metadata {
+        key: "UPST128\tAM_HO\001\202\247ST"
+        value {
+        }
+      }
+      filter_metadata {
+        key: "g"
+        value {
+        }
+      }
+      filter_metadata {
+        key: "m"
+        value {
+        }
+      }
+      filter_metadata {
+        key: "y"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This can happen when string fields with bad UTF-8 are upgraded etc.
Even if these are normally caught during config ingestion, a binary that
links Envoy and passes a bad proto in will trip over the RELEASE_ASSERT
that was previously there.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20192.

Risk level: Low
Testing: Additional unit test and corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>