### PR TITLE
test flake: fix flake in ApiListener integration test

### DIFF
--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -5,7 +5,6 @@
 #include "test/test_common/utility.h"
 
 #include "absl/synchronization/notification.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -4,6 +4,8 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "absl/synchronization/notification.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -76,13 +78,15 @@ api_listener:
   NiceMock<Http::MockStreamEncoder> stream_encoder_;
 };
 
+ACTION_P(Notify, notification) { notification->Notify(); }
+
 INSTANTIATE_TEST_SUITE_P(IpVersions, ApiListenerIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
 TEST_P(ApiListenerIntegrationTest, Basic) {
-  ConditionalInitializer test_ran;
-  test_server_->server().dispatcher().post([this, &test_ran]() -> void {
+  absl::Notification done;
+  test_server_->server().dispatcher().post([this, &done]() -> void {
     ASSERT_TRUE(test_server_->server().listenerManager().apiListener().has_value());
     ASSERT_EQ("api_listener", test_server_->server().listenerManager().apiListener()->get().name());
     ASSERT_TRUE(test_server_->server().listenerManager().apiListener()->get().http().has_value());
@@ -97,17 +101,15 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
     Http::TestHeaderMapImpl expected_response_headers{{":status", "200"}};
     EXPECT_CALL(stream_encoder_, encodeHeaders(_, false));
     EXPECT_CALL(stream_encoder_, encodeData(_, false));
-    EXPECT_CALL(stream_encoder_, encodeData(BufferStringEqual(""), true));
+    EXPECT_CALL(stream_encoder_, encodeData(BufferStringEqual(""), true)).WillOnce(Notify(&done));
 
     // Send a headers-only request
     stream_decoder.decodeHeaders(
         Http::HeaderMapPtr(new Http::TestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         true);
-
-    test_ran.setReady();
   });
-  test_ran.waitReady();
+  done.WaitForNotification();
 }
 
 } // namespace

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -109,7 +109,7 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         true);
   });
-  done.WaitForNotification();
+  ASSERT_TRUE(done.WaitForNotificationWithTimeout(absl::Seconds(1)));
 }
 
 } // namespace


### PR DESCRIPTION
Description: previously the test was not waiting for the expectation on the server's thread to complete. Therefore, there was a use after free race condition with the ApiListener's TlsCachingDateProvider. This PR makes it so that the test waits for the expectation to be fulfilled  and thus prevents the race.
Risk Level: low
Testing: ran integration test a few thousand times locally on a linux machine.

Fixes https://github.com/envoyproxy/envoy/issues/9746