### PR TITLE
build: some additional hardening options.

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -67,6 +67,7 @@ def _envoy_linkopts():
             "-pthread",
             "-lrt",
             "-ldl",
+            "-Wl,-z,relro,-z,now",
             "-Wl,--hash-style=gnu",
         ],
     }) + select({

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -11,6 +11,8 @@ def envoy_copts(repository, test = False):
         "-Wnon-virtual-dtor",
         "-Woverloaded-virtual",
         "-Wold-style-cast",
+        "-Wformat",
+        "-Wformat-security",
         "-Wvla",
         "-std=c++14",
     ]


### PR DESCRIPTION
* Enable format string warnings; I don't think this has any impact on Envoy since we don't tend to                                                                                                                                                                                                                              
  use printf etc., but belt-and-braces.                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                
* Enable RELRO for GOT protection, see                                                                                                                                                                                                                                                                                          
  https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro. I think                                                                                                                                                                                                                               
  this was already being enabled by Bazel, looking at the duplication                                                                                                                                                                                                                                                           
  in bazel-out/k8-fastbuild/bin/source/exe/envoy-static-2.params, but belt-and-braces.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                
Risk level: Low (only options that don't affect runtime performance enabled)                                                                                                                                                                                                                                                    
Testing: CI, manually verified bazel-out/k8-fastbuild/bin/source/exe/envoy-static-2.params.   

Related to #9087

Signed-off-by: Harvey Tuch <htuch@google.com>