### PR TITLE
kafka: 2.4.0 support - add support for new data types added in 2.4

### DIFF
--- a/source/extensions/filters/network/kafka/BUILD
+++ b/source/extensions/filters/network/kafka/BUILD
@@ -205,6 +205,12 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "tagged_fields_lib",
+    hdrs = ["tagged_fields.h"],
+    deps = [":serialization_lib"],
+)
+
+envoy_cc_library(
     name = "serialization_lib",
     srcs = [
         "serialization.cc",

--- a/source/extensions/filters/network/kafka/serialization.cc
+++ b/source/extensions/filters/network/kafka/serialization.cc
@@ -6,12 +6,14 @@ namespace NetworkFilters {
 namespace Kafka {
 
 constexpr static int16_t NULL_STRING_LENGTH = -1;
+constexpr static uint32_t NULL_COMPACT_STRING_LENGTH = 0;
 constexpr static int32_t NULL_BYTES_LENGTH = -1;
+constexpr static uint32_t NULL_COMPACT_BYTES_LENGTH = 0;
 
 /**
  * Helper method for deserializers that get the length of data, and then copy the given bytes into a
- * local buffer. Templated as there are length and byte type differences. Impl note: This method
- * modifies (sets up) most of Deserializer's fields.
+ * local buffer. Templated as there are length and byte type differences.
+ * Impl note: This method modifies (sets up) most of Deserializer's fields.
  * @param data bytes to deserialize.
  * @param length_deserializer payload length deserializer.
  * @param length_consumed_marker marker telling whether length has been extracted from
@@ -102,6 +104,120 @@ uint32_t BytesDeserializer::feed(absl::string_view& data) {
 uint32_t NullableBytesDeserializer::feed(absl::string_view& data) {
   return feedBytesIntoBuffers<Int32Deserializer, int32_t, unsigned char>(
       data, length_buf_, length_consumed_, required_, data_buf_, ready_, NULL_BYTES_LENGTH, true);
+}
+
+/**
+ * Helper method for "compact" deserializers that get the length of data, and then copy the given
+ * bytes into a local buffer. Compared to `feedBytesIntoBuffers` we only use template for data type,
+ * as compact data types always use variable-length uint32 for data length.
+ * Impl note: This method modifies (sets up) most of Deserializer's fields.
+ * @param data bytes to deserialize.
+ * @param length_deserializer payload length deserializer.
+ * @param length_consumed_marker marker telling whether length has been extracted from
+ * length_deserializer, and underlying buffer has been initialized.
+ * @param required remaining bytes to consume.
+ * @param data_buffer buffer with capacity for 'required' bytes.
+ * @param ready marker telling whether this deserialized has finished processing.
+ * @param null_value_length value marking null values.
+ * @param allow_null_value whether null value if allowed.
+ * @return number of bytes consumed.
+ */
+template <typename ByteType>
+uint32_t
+feedCompactBytesIntoBuffers(absl::string_view& data, VarUInt32Deserializer& length_deserializer,
+                            bool& length_consumed_marker, uint32_t& required,
+                            std::vector<ByteType>& data_buffer, bool& ready,
+                            const uint32_t null_value_length, const bool allow_null_value) {
+
+  const uint32_t length_consumed = length_deserializer.feed(data);
+  if (!length_deserializer.ready()) {
+    // Break early: we still need to fill in length buffer.
+    return length_consumed;
+  }
+
+  if (!length_consumed_marker) {
+    // Length buffer is ready, but we have not yet processed the result.
+    // We need to extract the real data length and initialize buffer for it.
+    required = length_deserializer.get();
+
+    if (null_value_length == required) {
+      if (allow_null_value) {
+        // We have received 'null' value in deserializer that allows it (e.g. NullableCompactBytes),
+        // no more processing is necessary.
+        ready = true;
+      } else {
+        // Invalid payload: null length for non-null object.
+        throw EnvoyException(absl::StrCat("invalid length: ", required));
+      }
+    } else {
+      // Compact data types carry data length + 1 (0 is used to mark 'null' in nullable types).
+      required--;
+      data_buffer = std::vector<ByteType>(required);
+    }
+
+    length_consumed_marker = true;
+  }
+
+  if (ready) {
+    // Break early: we might not need to consume any bytes for nullable values OR in case of repeat
+    // invocation on already-ready buffer.
+    return length_consumed;
+  }
+
+  const uint32_t data_consumed = std::min<uint32_t>(required, data.size());
+  const uint32_t written = data_buffer.size() - required;
+  if (data_consumed > 0) {
+    memcpy(data_buffer.data() + written, data.data(), data_consumed);
+    required -= data_consumed;
+    data = {data.data() + data_consumed, data.size() - data_consumed};
+  }
+
+  // We have consumed all the bytes, mark the deserializer as ready.
+  if (required == 0) {
+    ready = true;
+  }
+
+  return length_consumed + data_consumed;
+}
+
+uint32_t CompactStringDeserializer::feed(absl::string_view& data) {
+  return feedCompactBytesIntoBuffers<char>(data, length_buf_, length_consumed_, required_,
+                                           data_buf_, ready_, NULL_COMPACT_STRING_LENGTH, false);
+}
+
+uint32_t NullableCompactStringDeserializer::feed(absl::string_view& data) {
+  return feedCompactBytesIntoBuffers<char>(data, length_buf_, length_consumed_, required_,
+                                           data_buf_, ready_, NULL_COMPACT_STRING_LENGTH, true);
+}
+
+NullableString NullableCompactStringDeserializer::get() const {
+  const uint32_t original_data_len = length_buf_.get();
+  if (NULL_COMPACT_STRING_LENGTH == original_data_len) {
+    return absl::nullopt;
+  } else {
+    return absl::make_optional(std::string(data_buf_.begin(), data_buf_.end()));
+  }
+}
+
+uint32_t CompactBytesDeserializer::feed(absl::string_view& data) {
+  return feedCompactBytesIntoBuffers<unsigned char>(data, length_buf_, length_consumed_, required_,
+                                                    data_buf_, ready_, NULL_COMPACT_BYTES_LENGTH,
+                                                    false);
+}
+
+uint32_t NullableCompactBytesDeserializer::feed(absl::string_view& data) {
+  return feedCompactBytesIntoBuffers<unsigned char>(data, length_buf_, length_consumed_, required_,
+                                                    data_buf_, ready_, NULL_COMPACT_BYTES_LENGTH,
+                                                    true);
+}
+
+NullableBytes NullableCompactBytesDeserializer::get() const {
+  const uint32_t original_data_len = length_buf_.get();
+  if (NULL_COMPACT_BYTES_LENGTH == original_data_len) {
+    return absl::nullopt;
+  } else {
+    return absl::make_optional(data_buf_);
+  }
 }
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/serialization.cc
+++ b/source/extensions/filters/network/kafka/serialization.cc
@@ -205,21 +205,6 @@ uint32_t CompactBytesDeserializer::feed(absl::string_view& data) {
                                                     false);
 }
 
-uint32_t NullableCompactBytesDeserializer::feed(absl::string_view& data) {
-  return feedCompactBytesIntoBuffers<unsigned char>(data, length_buf_, length_consumed_, required_,
-                                                    data_buf_, ready_, NULL_COMPACT_BYTES_LENGTH,
-                                                    true);
-}
-
-NullableBytes NullableCompactBytesDeserializer::get() const {
-  const uint32_t original_data_len = length_buf_.get();
-  if (NULL_COMPACT_BYTES_LENGTH == original_data_len) {
-    return absl::nullopt;
-  } else {
-    return absl::make_optional(data_buf_);
-  }
-}
-
 } // namespace Kafka
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -190,9 +190,9 @@ public:
       processed++;
 
       // Put the 7 bits where they should have been.
-      // Impl note: the cast is done to avoid undefined behaviour when offset_ >= 28 and the highest
-      // bit in el is set (what might occur when garbage data is being sent and then it would be
-      // treated as negative signed integer).
+      // Impl note: the cast is done to avoid undefined behaviour when offset_ >= 28 and some bits
+      // at positions 5-7 are set (we would have left shift of signed value that does not fit in
+      // data type).
       result_ |= ((static_cast<uint32_t>(el) & 0x7f) << offset_);
       if ((el & 0x80) == 0) {
         // If this was the last byte to process (what is marked by unset highest bit), we are done.

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -190,7 +190,10 @@ public:
       processed++;
 
       // Put the 7 bits where they should have been.
-      result_ |= ((el & 0x7f) << offset_);
+      // Impl note: the cast is done to avoid undefined behaviour when offset_ >= 28 and the highest
+      // bit in el is set (what might occur when garbage data is being sent and then it would be
+      // treated as negative signed integer).
+      result_ |= ((static_cast<uint32_t>(el) & 0x7f) << offset_);
       if ((el & 0x80) == 0) {
         // If this was the last byte to process (what is marked by unset highest bit), we are done.
         ready_ = true;

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -771,7 +771,6 @@ private:
  * structure-tree during encoding (currently api_version, as different request versions serialize
  * differently).
  */
-// TODO(adamkotwasinski) that class might be split into Request/ResponseEncodingContext in future
 class EncodingContext {
 public:
   EncodingContext(int16_t api_version) : api_version_{api_version} {};
@@ -795,6 +794,24 @@ public:
   template <typename T> uint32_t computeSize(const NullableArray<T>& arg) const;
 
   /**
+   * Compute size of given reference, if it were to be compactly encoded.
+   * @return serialized size of argument.
+   */
+  template <typename T> uint32_t computeCompactSize(const T& arg) const;
+
+  /**
+   * Compute size of given array, if it were to be compactly encoded.
+   * @return serialized size of argument.
+   */
+  template <typename T> uint32_t computeCompactSize(const std::vector<T>& arg) const;
+
+  /**
+   * Compute size of given nullable array, if it were to be encoded.
+   * @return serialized size of argument.
+   */
+  template <typename T> uint32_t computeCompactSize(const NullableArray<T>& arg) const;
+
+  /**
    * Encode given reference in a buffer.
    * @return bytes written
    */
@@ -811,6 +828,24 @@ public:
    * @return bytes written
    */
   template <typename T> uint32_t encode(const NullableArray<T>& arg, Buffer::Instance& dst);
+
+  /**
+   * Compactly encode given reference in a buffer.
+   * @return bytes written.
+   */
+  template <typename T> uint32_t encodeCompact(const T& arg, Buffer::Instance& dst);
+
+  /**
+   * Compactly encode given array in a buffer.
+   * @return bytes written.
+   */
+  template <typename T> uint32_t encodeCompact(const std::vector<T>& arg, Buffer::Instance& dst);
+
+  /**
+   * Compactly encode given nullable array in a buffer.
+   * @return bytes written.
+   */
+  template <typename T> uint32_t encodeCompact(const NullableArray<T>& arg, Buffer::Instance& dst);
 
   int16_t apiVersion() const { return api_version_; }
 
@@ -893,6 +928,89 @@ inline uint32_t EncodingContext::computeSize(const std::vector<T>& arg) const {
 template <typename T>
 inline uint32_t EncodingContext::computeSize(const NullableArray<T>& arg) const {
   return arg ? computeSize(*arg) : sizeof(int32_t);
+}
+
+/**
+ * For non-primitive types, call `computeCompactSize` on them, to delegate the work to the entity
+ * itself. The entity may use the information in context to decide which fields are included etc.
+ */
+template <typename T> inline uint32_t EncodingContext::computeCompactSize(const T& arg) const {
+  return arg.computeCompactSize(*this);
+}
+
+/**
+ * Template overload for int32_t.
+ * This data type is not compacted, so we just point to non-compact implementation.
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const int32_t& arg) const {
+  return computeSize(arg);
+}
+
+/**
+ * Template overload for uint32_t.
+ * For this data type, we notice that the result's length depends on whether there are any bits set
+ * in groups (1-7, 8-14, 15-21, 22-28, 29-32).
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const uint32_t& arg) const {
+  if (arg <= 0x7f) /* 2^7-1 */ {
+    return 1;
+  } else if (arg <= 0x3fff) /* 2^14-1 */ {
+    return 2;
+  } else if (arg <= 0x1fffff) /* 2^21-1 */ {
+    return 3;
+  } else if (arg <= 0xfffffff) /* 2^28-1 */ {
+    return 4;
+  } else {
+    return 5;
+  }
+}
+
+/**
+ * Template overload for compact string.
+ * Kafka CompactString's size is var-len encoding of N+1 + N bytes.
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const std::string& arg) const {
+  return computeCompactSize(static_cast<uint32_t>(arg.size()) + 1) + arg.size();
+}
+
+/**
+ * Template overload for compact nullable string.
+ * Kafka CompactString's size is var-len encoding of N+1 + N bytes, or 1 otherwise (because we
+ * var-length encode the length of 0).
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const NullableString& arg) const {
+  return arg ? computeCompactSize(*arg) : 1;
+}
+
+/**
+ * Template overload for compact byte array.
+ * Kafka CompactBytes' size is var-len encoding of N+1 + N bytes.
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const Bytes& arg) const {
+  return computeCompactSize(static_cast<uint32_t>(arg.size()) + 1) + arg.size();
+}
+
+/**
+ * Template overload for CompactArray of T.
+ * The size of array is compact size of header and all of its elements.
+ */
+template <typename T>
+uint32_t EncodingContext::computeCompactSize(const std::vector<T>& arg) const {
+  uint32_t result = computeCompactSize(static_cast<uint32_t>(arg.size()) + 1);
+  for (const T& el : arg) {
+    result += computeCompactSize(el);
+  }
+  return result;
+}
+
+/**
+ * Template overload for CompactNullableArray of T.
+ * The size of array is compact size of header and all of its elements; 1 otherwise (because we
+ * var-length encode the length of 0).
+ */
+template <typename T>
+uint32_t EncodingContext::computeCompactSize(const NullableArray<T>& arg) const {
+  return arg ? computeCompactSize(*arg) : 1;
 }
 
 /**
@@ -1017,6 +1135,118 @@ uint32_t EncodingContext::encode(const NullableArray<T>& arg, Buffer::Instance& 
   } else {
     const int32_t len = -1;
     return encode(len, dst);
+  }
+}
+
+/**
+ * For non-primitive types, call `encodeCompact` on them, to delegate the serialization to the
+ * entity itself.
+ */
+template <typename T>
+inline uint32_t EncodingContext::encodeCompact(const T& arg, Buffer::Instance& dst) {
+  return arg.encodeCompact(dst, *this);
+}
+
+/**
+ * int32_t is not encoded in compact fashion, so we just delegate to normal implementation.
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const int32_t& arg, Buffer::Instance& dst) {
+  return encode(arg, dst);
+}
+
+/**
+ * Template overload for variable-length uint32_t (VAR_UINT).
+ * Encode the value in 7-bit chunks + marker if field is the last one.
+ * Details:
+ * https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields#KIP-482:TheKafkaProtocolshouldSupportOptionalTaggedFields-UnsignedVarints
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const uint32_t& arg, Buffer::Instance& dst) {
+  uint32_t value = arg;
+
+  uint32_t elements_with_1 = 0;
+  // As long as there are bits set on indexes 8 or higher (counting from 1).
+  while ((value & ~(0x7f)) != 0) {
+    // Save next 7-bit batch with highest bit set.
+    const uint8_t el = (value & 0x7f) | 0x80;
+    dst.add(&el, sizeof(uint8_t));
+    value >>= 7;
+    elements_with_1++;
+  }
+
+  // After the loop has finished, we are certain that bit 8 = 0, so we can just add final element.
+  const uint8_t el = value;
+  dst.add(&el, sizeof(uint8_t));
+
+  return elements_with_1 + 1;
+}
+
+/**
+ * Template overload for std::string.
+ * Encode string as VAR_UINT + N bytes.
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const std::string& arg, Buffer::Instance& dst) {
+  const uint32_t string_length = arg.length();
+  const uint32_t header_length = encodeCompact(string_length + 1, dst);
+  dst.add(arg.c_str(), string_length);
+  return header_length + string_length;
+}
+
+/**
+ * Template overload for NullableString.
+ * Encode string as VAR_UINT + N bytes, or VAR_UINT 0 for null value.
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const NullableString& arg, Buffer::Instance& dst) {
+  if (arg.has_value()) {
+    return encodeCompact(*arg, dst);
+  } else {
+    const uint32_t len = 0;
+    return encodeCompact(len, dst);
+  }
+}
+
+/**
+ * Template overload for Bytes.
+ * Encode byte array as VAR_UINT + N bytes.
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const Bytes& arg, Buffer::Instance& dst) {
+  const uint32_t data_length = arg.size();
+  const uint32_t header_length = encodeCompact(data_length + 1, dst);
+  dst.add(arg.data(), data_length);
+  return header_length + data_length;
+}
+
+/**
+ * Encode object array of T as VAR_UINT + N elements.
+ * Each element of type T then serializes itself on its own.
+ */
+template <typename T>
+uint32_t EncodingContext::encodeCompact(const std::vector<T>& arg, Buffer::Instance& dst) {
+  const NullableArray<T> wrapped = {arg};
+  return encodeCompact(wrapped, dst);
+}
+
+/**
+ * Encode nullable object array of T as VAR_UINT + N elements, or VAR_UINT 0 for null value.
+ * Each element of type T then serializes itself on its own.
+ */
+template <typename T>
+uint32_t EncodingContext::encodeCompact(const NullableArray<T>& arg, Buffer::Instance& dst) {
+  if (arg.has_value()) {
+    const uint32_t len = arg->size() + 1;
+    const uint32_t header_length = encodeCompact(len, dst);
+    uint32_t written{0};
+    for (const T& el : *arg) {
+      written += encodeCompact(el, dst);
+    }
+    return header_length + written;
+  } else {
+    const uint32_t len = 0;
+    return encodeCompact(len, dst);
   }
 }
 

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -409,33 +409,6 @@ private:
 };
 
 /**
- * Deserializer of nullable compact bytes value.
- * First reads length (UNSIGNED_VARINT) and then allocates the buffer of given length.
- * If length was 0, buffer allocation is omitted and deserializer is immediately ready (returning
- * null value).
- *
- * From Kafka documentation:
- * First the length N+1 is given as an UNSIGNED_VARINT.
- * Then N bytes follow. A null object is represented with a length of 0.
- */
-class NullableCompactBytesDeserializer : public Deserializer<NullableBytes> {
-public:
-  uint32_t feed(absl::string_view& data) override;
-
-  bool ready() const override { return ready_; }
-
-  NullableBytes get() const override;
-
-private:
-  VarUInt32Deserializer length_buf_;
-  bool length_consumed_{false};
-  uint32_t required_;
-
-  std::vector<unsigned char> data_buf_;
-  bool ready_{false};
-};
-
-/**
  * Deserializer for array of objects of the same type.
  *
  * First reads the length of the array, then initializes N underlying deserializers of type

--- a/source/extensions/filters/network/kafka/tagged_fields.h
+++ b/source/extensions/filters/network/kafka/tagged_fields.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <vector>
+
+#include "extensions/filters/network/kafka/serialization.h"
+
+/**
+ * This header file provides serialization support for tagged fields structure added in 2.4.
+ * https://github.com/apache/kafka/blob/2.4.0/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+ *
+ * Impl note: contrary to other compact data structures, data in tagged field does not have +1 in
+ * data length.
+ */
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+/**
+ * Simple data-holding structure.
+ */
+struct TaggedField {
+
+  uint32_t tag_;
+  std::vector<unsigned char> data_;
+
+  uint32_t computeSize(const EncodingContext&) const {
+    // FIXME(adam.kotwasinski)
+    throw std::runtime_error("not implemented");
+  }
+
+  uint32_t encode(Buffer::Instance&, EncodingContext&) const {
+    // FIXME(adam.kotwasinski)
+    throw std::runtime_error("not implemented");
+  }
+
+  bool operator==(const TaggedField& rhs) const { return tag_ == rhs.tag_ && data_ == rhs.data_; }
+};
+
+/**
+ * Deserializer responsible for extracting a TaggedField from data provided.
+ */
+class TaggedFieldDeserializer : public Deserializer<TaggedField> {
+public:
+  TaggedFieldDeserializer() = default;
+
+  uint32_t feed(absl::string_view& data) override {
+    uint32_t consumed = 0;
+    consumed += tag_deserializer_.feed(data);
+    consumed += length_deserializer_.feed(data);
+
+    if (!length_deserializer_.ready()) {
+      return consumed;
+    }
+
+    if (!length_consumed_) {
+      required_ = length_deserializer_.get();
+      data_buffer_ = std::vector<unsigned char>(required_);
+      length_consumed_ = true;
+    }
+
+    const uint32_t data_consumed = std::min<uint32_t>(required_, data.size());
+    const uint32_t written = data_buffer_.size() - required_;
+    if (data_consumed > 0) {
+      memcpy(data_buffer_.data() + written, data.data(), data_consumed);
+      required_ -= data_consumed;
+      data = {data.data() + data_consumed, data.size() - data_consumed};
+    }
+
+    if (required_ == 0) {
+      ready_ = true;
+    }
+
+    return consumed;
+  };
+
+  bool ready() const override { return ready_; };
+
+  TaggedField get() const override { return {tag_deserializer_.get(), data_buffer_}; };
+
+private:
+  VarUInt32Deserializer tag_deserializer_;
+  VarUInt32Deserializer length_deserializer_;
+  bool length_consumed_{false};
+  uint32_t required_;
+  std::vector<unsigned char> data_buffer_;
+  bool ready_{false};
+};
+
+/**
+ * Aggregate of multiple TaggedField objects.
+ */
+struct TaggedFields {
+
+  const std::vector<TaggedField> fields_;
+
+  uint32_t computeSize(const EncodingContext&) const {
+    // FIXME(adam.kotwasinski)
+    throw std::runtime_error("not implemented");
+  }
+
+  uint32_t encode(Buffer::Instance&, EncodingContext&) const {
+    // FIXME(adam.kotwasinski)
+    throw std::runtime_error("not implemented");
+  }
+
+  bool operator==(const TaggedFields& rhs) const { return fields_ == rhs.fields_; }
+};
+
+/**
+ * Deserializer responsible for extracting tagged fields from data provided.
+ */
+class TaggedFieldsDeserializer : public Deserializer<TaggedFields> {
+public:
+  uint32_t feed(absl::string_view& data) override {
+
+    const uint32_t count_consumed = count_deserializer_.feed(data);
+    if (!count_deserializer_.ready()) {
+      return count_consumed;
+    }
+
+    if (!children_setup_) {
+      const uint32_t field_count = count_deserializer_.get();
+      children_ = std::vector<TaggedFieldDeserializer>(field_count);
+      children_setup_ = true;
+    }
+
+    if (ready_) {
+      return count_consumed;
+    }
+
+    uint32_t child_consumed{0};
+    for (TaggedFieldDeserializer& child : children_) {
+      child_consumed += child.feed(data);
+    }
+
+    bool children_ready_ = true;
+    for (TaggedFieldDeserializer& child : children_) {
+      children_ready_ &= child.ready();
+    }
+    ready_ = children_ready_;
+
+    return count_consumed + child_consumed;
+  };
+
+  bool ready() const override { return ready_; };
+
+  TaggedFields get() const override {
+    std::vector<TaggedField> fields{};
+    fields.reserve(children_.size());
+    for (const TaggedFieldDeserializer& child : children_) {
+      const TaggedField child_result = child.get();
+      fields.push_back(child_result);
+    }
+    return {fields};
+  };
+
+private:
+  VarUInt32Deserializer count_deserializer_;
+  std::vector<TaggedFieldDeserializer> children_;
+
+  bool children_setup_ = false;
+  bool ready_ = false;
+};
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -24,10 +24,14 @@ TEST_EmptyDeserializerShouldNotBeReady(Int32Deserializer);
 TEST_EmptyDeserializerShouldNotBeReady(UInt32Deserializer);
 TEST_EmptyDeserializerShouldNotBeReady(Int64Deserializer);
 TEST_EmptyDeserializerShouldNotBeReady(BooleanDeserializer);
+TEST_EmptyDeserializerShouldNotBeReady(VarUInt32Deserializer);
 
 TEST_EmptyDeserializerShouldNotBeReady(StringDeserializer);
+TEST_EmptyDeserializerShouldNotBeReady(CompactStringDeserializer);
 TEST_EmptyDeserializerShouldNotBeReady(NullableStringDeserializer);
+TEST_EmptyDeserializerShouldNotBeReady(NullableCompactStringDeserializer);
 TEST_EmptyDeserializerShouldNotBeReady(BytesDeserializer);
+TEST_EmptyDeserializerShouldNotBeReady(CompactBytesDeserializer);
 TEST_EmptyDeserializerShouldNotBeReady(NullableBytesDeserializer);
 
 TEST(ArrayDeserializer, EmptyBufferShouldNotBeReady) {
@@ -37,9 +41,23 @@ TEST(ArrayDeserializer, EmptyBufferShouldNotBeReady) {
   ASSERT_EQ(testee.ready(), false);
 }
 
+TEST(CompactArrayDeserializer, EmptyBufferShouldNotBeReady) {
+  // given
+  const CompactArrayDeserializer<int32_t, Int32Deserializer> testee{};
+  // when, then
+  ASSERT_EQ(testee.ready(), false);
+}
+
 TEST(NullableArrayDeserializer, EmptyBufferShouldNotBeReady) {
   // given
   const NullableArrayDeserializer<int8_t, Int8Deserializer> testee{};
+  // when, then
+  ASSERT_EQ(testee.ready(), false);
+}
+
+TEST(NullableCompactArrayDeserializer, EmptyBufferShouldNotBeReady) {
+  // given
+  const NullableCompactArrayDeserializer<int32_t, Int32Deserializer> testee{};
   // when, then
   ASSERT_EQ(testee.ready(), false);
 }
@@ -60,6 +78,60 @@ TEST_DeserializerShouldDeserialize(Int64Deserializer, int64_t, 42);
 TEST_DeserializerShouldDeserialize(BooleanDeserializer, bool, true);
 
 EncodingContext encoder{-1}; // Provided api_version does not matter for primitive types.
+
+// Variable-length uint32_t tests.
+
+TEST(VarUInt32Deserializer, ShouldDeserialize) {
+  const uint32_t value = 0;
+  serializeCompactThenDeserializeAndCheckEquality<VarUInt32Deserializer>(value);
+}
+
+TEST(VarUInt32Deserializer, ShouldDeserializeMaxUint32) {
+  const uint32_t value = std::numeric_limits<uint32_t>::max();
+  serializeCompactThenDeserializeAndCheckEquality<VarUInt32Deserializer>(value);
+}
+
+TEST(VarUInt32Deserializer, ShouldDeserializeEdgeValues) {
+  // Each of these values should fit in 1, 2, 3, 4 bytes.
+  std::vector<uint32_t> values = {0x7f, 0x3fff, 0x1fffff, 0xfffffff};
+  for (auto i = 0; i < static_cast<int>(values.size()); ++i) {
+    // given
+    Buffer::OwnedImpl buffer;
+
+    // when
+    const uint32_t written = encoder.encodeCompact(values[i], buffer);
+
+    // then
+    ASSERT_EQ(written, i + 1);
+    absl::string_view data = {getRawData(buffer), 1024};
+    // All bits in lower bytes need to be set.
+    for (auto j = 0; j + 1 < i; ++j) {
+      ASSERT_EQ(static_cast<uint8_t>(data[j]), 0xFF);
+    }
+    // Highest bit in last byte needs to be clear (end marker).
+    ASSERT_EQ(static_cast<uint8_t>(data[i]), 0x7F);
+  }
+}
+
+TEST(VarUInt32Deserializer, ShouldSerializeMaxUint32Properly) {
+  // given
+  Buffer::OwnedImpl buffer;
+
+  // when
+  const uint32_t value = std::numeric_limits<uint32_t>::max();
+  const uint32_t result = encoder.encodeCompact(value, buffer);
+
+  // then
+  ASSERT_EQ(result, 5);
+  absl::string_view data = {getRawData(buffer), 1024};
+  ASSERT_EQ(static_cast<uint8_t>(data[0]), 0xFF); // Bits 1-7 (starting at 1).
+  ASSERT_EQ(static_cast<uint8_t>(data[1]), 0xFF); // Bits 8-14.
+  ASSERT_EQ(static_cast<uint8_t>(data[2]), 0xFF); // Bits 15-21.
+  ASSERT_EQ(static_cast<uint8_t>(data[3]), 0xFF); // Bits 22-28.
+  ASSERT_EQ(static_cast<uint8_t>(data[4]), 0x0F); // Bits 29-32.
+}
+
+// String tests.
 
 TEST(StringDeserializer, ShouldDeserialize) {
   const std::string value = "sometext";
@@ -85,6 +157,35 @@ TEST(StringDeserializer, ShouldThrowOnInvalidLength) {
   // then
   EXPECT_THROW(testee.feed(data), EnvoyException);
 }
+
+// Compact string tests.
+
+TEST(CompactStringDeserializer, ShouldDeserialize) {
+  const std::string value = "sometext";
+  serializeCompactThenDeserializeAndCheckEquality<CompactStringDeserializer>(value);
+}
+
+TEST(CompactStringDeserializer, ShouldDeserializeEmptyString) {
+  const std::string value = "";
+  serializeCompactThenDeserializeAndCheckEquality<CompactStringDeserializer>(value);
+}
+
+TEST(CompactStringDeserializer, ShouldThrowOnInvalidLength) {
+  // given
+  CompactStringDeserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t len = 0; // COMPACT_STRING requires length >= 1.
+  encoder.encodeCompact(len, buffer);
+
+  absl::string_view data = {getRawData(buffer), 1024};
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data), EnvoyException);
+}
+
+// Nullable string tests.
 
 TEST(NullableStringDeserializer, ShouldDeserializeString) {
   // given
@@ -119,6 +220,28 @@ TEST(NullableStringDeserializer, ShouldThrowOnInvalidLength) {
   EXPECT_THROW(testee.feed(data), EnvoyException);
 }
 
+// Nullable compact string tests.
+
+TEST(NullableCompactStringDeserializer, ShouldDeserializeString) {
+  // given
+  const NullableString value{"sometext"};
+  serializeCompactThenDeserializeAndCheckEquality<NullableCompactStringDeserializer>(value);
+}
+
+TEST(NullableCompactStringDeserializer, ShouldDeserializeEmptyString) {
+  // given
+  const NullableString value{""};
+  serializeCompactThenDeserializeAndCheckEquality<NullableCompactStringDeserializer>(value);
+}
+
+TEST(NullableCompactStringDeserializer, ShouldDeserializeAbsentString) {
+  // given
+  const NullableString value = absl::nullopt;
+  serializeCompactThenDeserializeAndCheckEquality<NullableCompactStringDeserializer>(value);
+}
+
+// Byte array tests.
+
 TEST(BytesDeserializer, ShouldDeserialize) {
   const Bytes value{'a', 'b', 'c', 'd'};
   serializeThenDeserializeAndCheckEquality<BytesDeserializer>(value);
@@ -143,6 +266,35 @@ TEST(BytesDeserializer, ShouldThrowOnInvalidLength) {
   // then
   EXPECT_THROW(testee.feed(data), EnvoyException);
 }
+
+// Compact byte array tests.
+
+TEST(CompactBytesDeserializer, ShouldDeserialize) {
+  const Bytes value{'a', 'b', 'c', 'd'};
+  serializeCompactThenDeserializeAndCheckEquality<CompactBytesDeserializer>(value);
+}
+
+TEST(CompactBytesDeserializer, ShouldDeserializeEmptyBytes) {
+  const Bytes value{};
+  serializeCompactThenDeserializeAndCheckEquality<CompactBytesDeserializer>(value);
+}
+
+TEST(CompactBytesDeserializer, ShouldThrowOnInvalidLength) {
+  // given
+  CompactBytesDeserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t bytes_length = 0; // COMPACT_BYTES requires length >= 1.
+  encoder.encodeCompact(bytes_length, buffer);
+
+  absl::string_view data = {getRawData(buffer), 1024};
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data), EnvoyException);
+}
+
+// Nullable byte array tests.
 
 TEST(NullableBytesDeserializer, ShouldDeserialize) {
   const NullableBytes value{{'a', 'b', 'c', 'd'}};
@@ -174,6 +326,8 @@ TEST(NullableBytesDeserializer, ShouldThrowOnInvalidLength) {
   EXPECT_THROW(testee.feed(data), EnvoyException);
 }
 
+// Generic array tests.
+
 TEST(ArrayDeserializer, ShouldConsumeCorrectAmountOfData) {
   const std::vector<std::string> value{{"aaa", "bbbbb", "cc", "d", "e", "ffffffff"}};
   serializeThenDeserializeAndCheckEquality<ArrayDeserializer<std::string, StringDeserializer>>(
@@ -194,6 +348,31 @@ TEST(ArrayDeserializer, ShouldThrowOnInvalidLength) {
   // then
   EXPECT_THROW(testee.feed(data), EnvoyException);
 }
+
+// Compact generic array tests.
+
+TEST(CompactArrayDeserializer, ShouldConsumeCorrectAmountOfData) {
+  const std::vector<int32_t> value{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}};
+  serializeCompactThenDeserializeAndCheckEquality<
+      CompactArrayDeserializer<int32_t, Int32Deserializer>>(value);
+}
+
+TEST(CompactArrayDeserializer, ShouldThrowOnInvalidLength) {
+  // given
+  CompactArrayDeserializer<int8_t, Int8Deserializer> testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t len = 0; // COMPACT_ARRAY accepts length >= 1.
+  encoder.encodeCompact(len, buffer);
+
+  absl::string_view data = {getRawData(buffer), 1024};
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data), EnvoyException);
+}
+
+// Generic nullable array tests.
 
 TEST(NullableArrayDeserializer, ShouldConsumeCorrectAmountOfData) {
   const NullableArray<std::string> value{{"aaa", "bbbbb", "cc", "d", "e", "ffffffff"}};
@@ -220,6 +399,20 @@ TEST(NullableArrayDeserializer, ShouldThrowOnInvalidLength) {
   // when
   // then
   EXPECT_THROW(testee.feed(data), EnvoyException);
+}
+
+// Compact nullable generic array tests.
+
+TEST(NullableCompactArrayDeserializer, ShouldConsumeCorrectAmountOfData) {
+  const NullableArray<int32_t> value{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}};
+  serializeCompactThenDeserializeAndCheckEquality<
+      NullableCompactArrayDeserializer<int32_t, Int32Deserializer>>(value);
+}
+
+TEST(NullableCompactArrayDeserializer, ShouldConsumeNullArray) {
+  const NullableArray<int32_t> value = absl::nullopt;
+  serializeCompactThenDeserializeAndCheckEquality<
+      NullableCompactArrayDeserializer<int32_t, Int32Deserializer>>(value);
 }
 
 } // namespace SerializationTest

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -131,6 +131,25 @@ TEST(VarUInt32Deserializer, ShouldSerializeMaxUint32Properly) {
   ASSERT_EQ(static_cast<uint8_t>(data[4]), 0x0F); // Bits 29-32.
 }
 
+TEST(VarUInt32Deserializer, ShouldThrowIfNoEndWith5Bytes) {
+  // given
+  VarUInt32Deserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  // The buffer makes no sense, it's 5 times 0xFF, while varint encoding ensures that in the worst
+  // case 5th byte has the highest bit clear.
+  for (int i = 0; i < 5; ++i) {
+    const uint8_t all_bits_set = 0xFF;
+    buffer.add(&all_bits_set, sizeof(all_bits_set));
+  }
+
+  absl::string_view data = {getRawData(buffer), 1024};
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data), EnvoyException);
+}
+
 // String tests.
 
 TEST(StringDeserializer, ShouldDeserialize) {

--- a/test/extensions/filters/network/kafka/serialization_utilities.h
+++ b/test/extensions/filters/network/kafka/serialization_utilities.h
@@ -38,8 +38,6 @@ void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t written = encoder.encode(expected, buffer);
-  // Sanity check (expected serialized length should be equal to real serialized length.
-  ASSERT_EQ(written, encoder.computeSize(expected));
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
@@ -75,8 +73,6 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t written = encoder.encode(expected, buffer);
-  // Sanity check (expected serialized length should be equal to real serialized length.
-  ASSERT_EQ(written, encoder.computeSize(expected));
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
@@ -119,8 +115,6 @@ void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t written = encoder.encodeCompact(expected, buffer);
-  // Sanity check (expected serialized length should be equal to real serialized length.
-  ASSERT_EQ(written, encoder.computeCompactSize(expected));
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
@@ -154,8 +148,6 @@ void serializeCompactThenDeserializeAndCheckEqualityWithChunks(AT expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t written = encoder.encodeCompact(expected, buffer);
-  // Sanity check (expected serialized length should be equal to real serialized length.
-  ASSERT_EQ(written, encoder.computeCompactSize(expected));
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 

--- a/test/extensions/filters/network/kafka/serialization_utilities.h
+++ b/test/extensions/filters/network/kafka/serialization_utilities.h
@@ -38,6 +38,8 @@ void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t written = encoder.encode(expected, buffer);
+  // Sanity check (expected serialized length should be equal to real serialized length.
+  ASSERT_EQ(written, encoder.computeSize(expected));
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
@@ -73,6 +75,8 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t written = encoder.encode(expected, buffer);
+  // Sanity check (expected serialized length should be equal to real serialized length.
+  ASSERT_EQ(written, encoder.computeSize(expected));
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
 
@@ -106,10 +110,96 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
   ASSERT_EQ(more_data.size(), garbage_size);
 }
 
-// Wrapper to run both tests.
+// Same thing as 'serializeThenDeserializeAndCheckEqualityInOneGo', just uses compact encoding.
+template <typename BT, typename AT>
+void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
+  // given
+  BT testee{};
+
+  Buffer::OwnedImpl buffer;
+  EncodingContext encoder{-1};
+  const uint32_t written = encoder.encodeCompact(expected, buffer);
+  // Sanity check (expected serialized length should be equal to real serialized length.
+  ASSERT_EQ(written, encoder.computeCompactSize(expected));
+  // Insert garbage after serialized payload.
+  const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
+
+  // Tell parser that there is more data, it should never consume more than written.
+  const absl::string_view orig_data = {getRawData(buffer), written + garbage_size};
+  absl::string_view data = orig_data;
+
+  // when
+  const uint32_t consumed = testee.feed(data);
+
+  // then
+  ASSERT_EQ(consumed, written);
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), expected);
+  assertStringViewIncrement(data, orig_data, consumed);
+
+  // when - 2
+  const uint32_t consumed2 = testee.feed(data);
+
+  // then - 2 (nothing changes)
+  ASSERT_EQ(consumed2, 0);
+  assertStringViewIncrement(data, orig_data, consumed);
+}
+
+// Same thing as 'serializeThenDeserializeAndCheckEqualityWithChunks', just uses compact encoding.
+template <typename BT, typename AT>
+void serializeCompactThenDeserializeAndCheckEqualityWithChunks(AT expected) {
+  // given
+  BT testee{};
+
+  Buffer::OwnedImpl buffer;
+  EncodingContext encoder{-1};
+  const uint32_t written = encoder.encodeCompact(expected, buffer);
+  // Sanity check (expected serialized length should be equal to real serialized length.
+  ASSERT_EQ(written, encoder.computeCompactSize(expected));
+  // Insert garbage after serialized payload.
+  const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
+
+  const absl::string_view orig_data = {getRawData(buffer), written + garbage_size};
+
+  // when
+  absl::string_view data = orig_data;
+  uint32_t consumed = 0;
+  for (uint32_t i = 0; i < written; ++i) {
+    data = {data.data(), 1}; // Consume data byte-by-byte.
+    uint32_t step = testee.feed(data);
+    consumed += step;
+    ASSERT_EQ(step, 1);
+    ASSERT_EQ(data.size(), 0);
+  }
+
+  // then
+  ASSERT_EQ(consumed, written);
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), expected);
+
+  ASSERT_EQ(data.data(), orig_data.data() + consumed);
+
+  // when - 2
+  absl::string_view more_data = {data.data(), garbage_size};
+  const uint32_t consumed2 = testee.feed(more_data);
+
+  // then - 2 (nothing changes)
+  ASSERT_EQ(consumed2, 0);
+  ASSERT_EQ(more_data.data(), data.data());
+  ASSERT_EQ(more_data.size(), garbage_size);
+}
+
+// Wrapper to run both tests for normal serialization.
 template <typename BT, typename AT> void serializeThenDeserializeAndCheckEquality(AT expected) {
   serializeThenDeserializeAndCheckEqualityInOneGo<BT>(expected);
   serializeThenDeserializeAndCheckEqualityWithChunks<BT>(expected);
+}
+
+// Wrapper to run both tests for compact serialization.
+template <typename BT, typename AT>
+void serializeCompactThenDeserializeAndCheckEquality(AT expected) {
+  serializeCompactThenDeserializeAndCheckEqualityInOneGo<BT>(expected);
+  serializeCompactThenDeserializeAndCheckEqualityWithChunks<BT>(expected);
 }
 
 /**


### PR DESCRIPTION
Description:
Provide codec support for data types added in 2.4.0.

In detail, we Kafka 2.4 added some new things in protocol:
* variable-length uint32
* new _compact_ strings / byte-arrays / generic arrays that keep length using this varint, instead of fixed-len types
* predefined "tagged_fields" structure (that's very similar to generic array, but doesn't do the +1 length)

This PR should not have any impact on existing codebase, just the volume of changes (if everything was posted at once) is IMHO too large to comfortably review.
Relates to https://github.com/envoyproxy/envoy/issues/2852

These deserializers are working with 2.4 request types (they are not part of this PR as I'm still working on that and want to make another PR with them).
 
Risk Level: Low
Testing: Automated unit tests; embedded integration test (ensures compatibility with 2.3 client); manual tests with 2.3 client
Docs Changes: N/A
Release Notes: N/A