### PR TITLE
assertions: add new class of known issue assertions

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -212,6 +212,11 @@ config_setting(
 )
 
 config_setting(
+    name = "debug_known_issues",
+    values = {"define": "known_issues=debug"},
+)
+
+config_setting(
     name = "enable_perf_annotation",
     values = {"define": "perf_annotation=enabled"},
 )

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -67,6 +67,9 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
                "//conditions:default": [],
            }) + select({
+               repository + "//bazel:debug_known_issues": ["-DENVOY_DEBUG_KNOWN_ISSUES=1"],
+               "//conditions:default": [],
+            }) + select({
                # APPLE_USE_RFC_3542 is needed to support IPV6_PKTINFO in MAC OS.
                repository + "//bazel:apple": ["-D__APPLE_USE_RFC_3542"],
                "//conditions:default": [],

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -74,6 +74,24 @@ void invokeDebugAssertionFailureRecordAction_ForAssertMacroUseOnly();
  */
 #define SECURITY_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort(), DETAILS)
 
+#if defined(ENVOY_DEBUG_KNOWN_ISSUES)
+/**
+ * Assert macro for an as-yet unidentified issue. Even with ASSERTS compiled in, it will be
+ * excluded, unless ENVOY_DEBUG_KNOWN_ISSUES is defined. It represents a condition that
+ * should always pass but that sometimes fails for an unknown reason. The macro allows it to
+ * be temporarily compiled out while the failure is triaged and investigated.
+ */
+#define KNOWN_ISSUE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort() DETAILS)
+#else
+// This non-implementation ensures that its argument is a valid expression that can be statically
+// casted to a bool, but the expression is never evaluated and will be compiled away.
+#define KNOWN_ISSUE_ASSERT(X, ...)                                                                 \
+  do {                                                                                             \
+    constexpr bool __assert_dummy_variable = false && static_cast<bool>(X);                        \
+    (void)__assert_dummy_variable;                                                                 \
+  } while (false)
+#endif // defined(ENVOY_DEBUG_KNOWN_ISSUES)
+
 #if !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
 
 #if !defined(NDEBUG) // If this is a debug build.


### PR DESCRIPTION
Description: Adds a new class of assertions, KNOWN_ISSUE_ASSERT, that may be compiled out even when other assertions are compiled in. The intent is to allow assertions to generally be compiled into releases, but to exclude instances that are known to fail for as-yet unknown or unresolved reasons. When the issue has been triaged and resolved, a KNOWN_ISSUE_ASSERT should generally become a regular ASSERT or RELEASE_ASSERT again.
Risk Level: Moderate
Testing: Not yet

Signed-off-by: Mike Schore <mike.schore@gmail.com>


