### PR TITLE
[http] Simplify H1 codec by removing the reserve/commit pattern

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -74,15 +74,13 @@ StreamEncoderImpl::StreamEncoderImpl(ConnectionImpl& connection,
 void StreamEncoderImpl::encodeHeader(const char* key, uint32_t key_size, const char* value,
                                      uint32_t value_size) {
 
-  connection_.reserveBuffer(key_size + value_size + 4);
   ASSERT(key_size > 0);
 
   connection_.copyToBuffer(key, key_size);
   connection_.addCharToBuffer(':');
   connection_.addCharToBuffer(' ');
   connection_.copyToBuffer(value, value_size);
-  connection_.addCharToBuffer('\r');
-  connection_.addCharToBuffer('\n');
+  connection_.addToBuffer(CRLF);
 }
 void StreamEncoderImpl::encodeHeader(absl::string_view key, absl::string_view value) {
   this->encodeHeader(key.data(), key.size(), value.data(), value.size());
@@ -175,9 +173,7 @@ void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream)
     }
   }
 
-  connection_.reserveBuffer(2);
-  connection_.addCharToBuffer('\r');
-  connection_.addCharToBuffer('\n');
+  connection_.addToBuffer(CRLF);
 
   if (end_stream) {
     endEncode();
@@ -249,49 +245,22 @@ void StreamEncoderImpl::endEncode() {
 }
 
 void ConnectionImpl::flushOutput() {
-  if (reserved_current_) {
-    reserved_iovec_.len_ = reserved_current_ - static_cast<char*>(reserved_iovec_.mem_);
-    output_buffer_.commit(&reserved_iovec_, 1);
-    reserved_current_ = nullptr;
-  }
-
   connection().write(output_buffer_, false);
   ASSERT(0UL == output_buffer_.length());
 }
 
+void ConnectionImpl::addToBuffer(absl::string_view data) { output_buffer_.add(data); }
+
 void ConnectionImpl::addCharToBuffer(char c) {
-  ASSERT(bufferRemainingSize() >= 1);
-  *reserved_current_++ = c;
+  output_buffer_.add(&c, 1);
 }
 
 void ConnectionImpl::addIntToBuffer(uint64_t i) {
-  reserved_current_ += StringUtil::itoa(reserved_current_, bufferRemainingSize(), i);
-}
-
-uint64_t ConnectionImpl::bufferRemainingSize() {
-  return reserved_iovec_.len_ - (reserved_current_ - static_cast<char*>(reserved_iovec_.mem_));
+  output_buffer_.add(absl::StrCat(i));
 }
 
 void ConnectionImpl::copyToBuffer(const char* data, uint64_t length) {
-  ASSERT(bufferRemainingSize() >= length);
-  memcpy(reserved_current_, data, length);
-  reserved_current_ += length;
-}
-
-void ConnectionImpl::reserveBuffer(uint64_t size) {
-  if (reserved_current_ && bufferRemainingSize() >= size) {
-    return;
-  }
-
-  if (reserved_current_) {
-    reserved_iovec_.len_ = reserved_current_ - static_cast<char*>(reserved_iovec_.mem_);
-    output_buffer_.commit(&reserved_iovec_, 1);
-  }
-
-  // TODO PERF: It would be better to allow a split reservation. That will make fill code more
-  //            complicated.
-  output_buffer_.reserve(std::max<uint64_t>(4096, size), &reserved_iovec_, 1);
-  reserved_current_ = static_cast<char*>(reserved_iovec_.mem_);
+  output_buffer_.add(data, length);
 }
 
 void StreamEncoderImpl::resetStream(StreamResetReason reason) {
@@ -313,7 +282,6 @@ void ResponseStreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end
   started_response_ = true;
   uint64_t numeric_status = Utility::getResponseStatus(headers);
 
-  connection_.reserveBuffer(4096);
   if (connection_.protocol() == Protocol::Http10 && connection_.supports_http_10()) {
     connection_.copyToBuffer(HTTP_10_RESPONSE_PREFIX, sizeof(HTTP_10_RESPONSE_PREFIX) - 1);
   } else {
@@ -353,7 +321,6 @@ void RequestStreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_
     head_request_ = true;
   }
   connection_.onEncodeHeaders(headers);
-  connection_.reserveBuffer(path->value().size() + method->value().size() + 4096);
   connection_.copyToBuffer(method->value().getStringView().data(), method->value().size());
   connection_.addCharToBuffer(' ');
   connection_.copyToBuffer(path->value().getStringView().data(), path->value().size());

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -251,13 +251,9 @@ void ConnectionImpl::flushOutput() {
 
 void ConnectionImpl::addToBuffer(absl::string_view data) { output_buffer_.add(data); }
 
-void ConnectionImpl::addCharToBuffer(char c) {
-  output_buffer_.add(&c, 1);
-}
+void ConnectionImpl::addCharToBuffer(char c) { output_buffer_.add(&c, 1); }
 
-void ConnectionImpl::addIntToBuffer(uint64_t i) {
-  output_buffer_.add(absl::StrCat(i));
-}
+void ConnectionImpl::addIntToBuffer(uint64_t i) { output_buffer_.add(absl::StrCat(i)); }
 
 void ConnectionImpl::copyToBuffer(const char* data, uint64_t length) {
   output_buffer_.add(data, length);

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -174,6 +174,7 @@ public:
    */
   void flushOutput();
 
+  void addToBuffer(absl::string_view data);
   void addCharToBuffer(char c);
   void addIntToBuffer(uint64_t i);
   Buffer::WatermarkBuffer& buffer() { return output_buffer_; }
@@ -315,8 +316,6 @@ private:
   HeaderString current_header_field_;
   HeaderString current_header_value_;
   Buffer::WatermarkBuffer output_buffer_;
-  Buffer::RawSlice reserved_iovec_;
-  char* reserved_current_{};
   Protocol protocol_{Protocol::Http11};
   const uint32_t max_headers_kb_;
   const uint32_t max_headers_count_;


### PR DESCRIPTION
This simplifies the H/1 codec by removing the pre-buffer reserved_iovec_ in the HTTP1 codec.

This change reduces effective memory usage by removing the need to round up when reserving memory blocks in OwnedImpl::reserve. The `output_buffer_` in the codec is a watermark buffer that on adds will `checkHighWatermark`. Performance may suffer slightly due to an increase in number of calls to `checkHighWatermark` while serializing headers.

(Before the change, watermarks were checked at most twice in ConnectionImpl::reserveBuffer (commit if needed and reserve), and not in the following calls to add/copy to the buffer. Now, add/copyToBuffer directly call the watermark buffer, so check watermarks are increased.)

Risk level: medium/high
Testing: existing tests pass (suggestions welcome for more if I can peak at the connection's buffer)

Signed-off-by: Asra Ali <asraa@google.com>

