### PR TITLE
Pull in v3 service libs for config_load_check_tool

### DIFF
--- a/test/tools/config_load_check/BUILD
+++ b/test/tools/config_load_check/BUILD
@@ -12,7 +12,10 @@ envoy_package()
 envoy_cc_test_library(
     name = "config_load_check_lib",
     srcs = ["config_load_check.cc"],
-    deps = ["//test/config_test:config_test_lib"],
+    deps = [
+        "//source/common/config:protobuf_link_hacks",
+        "//test/config_test:config_test_lib",
+    ],
 )
 
 envoy_cc_test_binary(

--- a/test/tools/config_load_check/BUILD
+++ b/test/tools/config_load_check/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test_binary(
         ":config_load_check_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:thread_lib",
+        "//source/common/config:protobuf_link_hacks",
         "//source/common/event:libevent_lib",
     ],
 )

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -6,6 +6,8 @@
 #include "common/common/fmt.h"
 #include "common/common/logger.h"
 #include "common/common/thread.h"
+#include "common/config/protobuf_link_hacks.h"
+
 #include "common/event/libevent.h"
 
 #include "test/config_test/config_test.h"

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -7,7 +7,6 @@
 #include "common/common/logger.h"
 #include "common/common/thread.h"
 #include "common/config/protobuf_link_hacks.h"
-
 #include "common/event/libevent.h"
 
 #include "test/config_test/config_test.h"


### PR DESCRIPTION
Usage of the config_load_check_tool triggers the following assertion, only for missing v3 service libs, in our CI infrastructure:
https://github.com/envoyproxy/envoy/blob/master/source/common/config/type_to_endpoint.cc#L51

It appears the v2 services are being linked via the following path:
```
>> bazel query "somepath(//test/tools/config_load_check:config_load_check_tool ,@envoy_api//envoy/api/v2:pkg_cc_proto)"
/home/tallen/src/envoy/tools/bazel.rc
//test/tools/config_load_check:config_load_check_tool
//test/tools/config_load_check:config_load_check_lib
//test/config_test:config_test_lib
//test/integration:integration_lib
@envoy_api//envoy/api/v2:pkg_cc_proto
```

It seems other places have in the v3 libs via protobuf_link_hacks, so this patch does the same for the config_load_check_tool.