### PR TITLE
context: add response.total_size

### DIFF
--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -83,7 +83,7 @@ The following attributes are exposed to the language runtime:
    response.headers, string map, All response headers
    response.trailers, string map, All response trailers
    response.size, int, Size of the response body
-   response.total_size, int, Total size of the response including the headers and the trailers
+   response.total_size, int, Total size of the response including the approximate uncompressed size of the headers and the trailers
    response.flags, int, Additional details about the response beyond the standard response code
    source.address, string, Downstream connection remote address
    source.port, int, Downstream connection remote port

--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -83,6 +83,7 @@ The following attributes are exposed to the language runtime:
    response.headers, string map, All response headers
    response.trailers, string map, All response trailers
    response.size, int, Size of the response body
+   response.total_size, int, Total size of the response including the headers and the trailers
    response.flags, int, Additional details about the response beyond the standard response code
    source.address, string, Downstream connection remote address
    source.port, int, Downstream connection remote port

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -147,6 +147,9 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
       return CelValue::CreateInt64(optional_status.value());
     }
     return {};
+  } else if (value == TotalSize) {
+    return CelValue::CreateInt64(info_.bytesSent() + headers_.value_->byteSize() +
+                                 trailers_.value_->byteSize());
   }
   return {};
 }

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -224,6 +224,13 @@ TEST(Context, ResponseAttributes) {
   }
 
   {
+    auto value = response[CelValue::CreateStringView(TotalSize)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    EXPECT_EQ(160, value.value().Int64OrDie());
+  }
+
+  {
     auto value = response[CelValue::CreateStringView(Code)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: define response.total_size. It is used via Wasm ABI in an istio telemetry extension, and we noticed it's missing.
Risk Level: low
Testing: unit
Docs Changes: list of properties updated
Release Notes: none