### PR TITLE
Change accessor of filterstate to a const shared_ptr ref

### DIFF
--- a/include/envoy/stream_info/filter_state.h
+++ b/include/envoy/stream_info/filter_state.h
@@ -150,5 +150,7 @@ protected:
   virtual Object* getDataMutableGeneric(absl::string_view data_name) PURE;
 };
 
+using FilterStateSharedPtr = std::shared_ptr<FilterState>;
+
 } // namespace StreamInfo
 } // namespace Envoy

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -483,14 +483,6 @@ public:
   virtual const FilterState& filterState() const PURE;
 
   /**
-   * FilterState object to be shared between upstream and downstream filters.
-   * @param pointer to upstream connections filterstate.
-   * @return pointer to filterstate to be used by upstream connections.
-   */
-  virtual const FilterStateSharedPtr& upstreamFilterState() const PURE;
-  virtual void setUpstreamFilterState(const FilterStateSharedPtr& filter_state) PURE;
-
-  /**
    * @param SNI value requested.
    */
   virtual void setRequestedServerName(const absl::string_view requested_server_name) PURE;

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -479,18 +479,16 @@ public:
    * filters (append only). Both object types can be consumed by multiple filters.
    * @return the filter state associated with this request.
    */
-  virtual FilterState& filterState() PURE;
+  virtual const FilterStateSharedPtr& filterState() PURE;
   virtual const FilterState& filterState() const PURE;
-  virtual std::shared_ptr<FilterState> filterStatePtr() PURE;
 
   /**
    * FilterState object to be shared between upstream and downstream filters.
    * @param pointer to upstream connections filterstate.
    * @return pointer to filterstate to be used by upstream connections.
    */
-  virtual std::shared_ptr<FilterState> upstreamFilterState() PURE;
-  virtual const FilterState* upstreamFilterState() const PURE;
-  virtual void setUpstreamFilterState(std::shared_ptr<FilterState> filter_state) PURE;
+  virtual const FilterStateSharedPtr& upstreamFilterState() const PURE;
+  virtual void setUpstreamFilterState(const FilterStateSharedPtr& filter_state) PURE;
 
   /**
    * @param SNI value requested.

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -481,6 +481,16 @@ public:
    */
   virtual FilterState& filterState() PURE;
   virtual const FilterState& filterState() const PURE;
+  virtual std::shared_ptr<FilterState> filterStatePtr() PURE;
+
+  /**
+   * FilterState object to be shared between upstream and downstream filters.
+   * @param pointer to downstream connections filterstate.
+   * @return pointer to filterstate to be used by upstream connections.
+   */
+  virtual std::shared_ptr<FilterState> upstreamFilterState() PURE;
+  virtual const FilterState* upstreamFilterState() const PURE;
+  virtual void setUpstreamFilterState(std::shared_ptr<FilterState> filter_state) PURE;
 
   /**
    * @param SNI value requested.

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -485,7 +485,7 @@ public:
 
   /**
    * FilterState object to be shared between upstream and downstream filters.
-   * @param pointer to downstream connections filterstate.
+   * @param pointer to upstream connections filterstate.
    * @return pointer to filterstate to be used by upstream connections.
    */
   virtual std::shared_ptr<FilterState> upstreamFilterState() PURE;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -386,11 +386,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   // Extract debug configuration from filter state. This is used further along to determine whether
   // we should append cluster and host headers to the response, and whether to forward the request
   // upstream.
-  const StreamInfo::FilterState& filter_state = callbacks_->streamInfo().filterState();
+  const StreamInfo::FilterStateSharedPtr& filter_state = callbacks_->streamInfo().filterState();
   const DebugConfig* debug_config =
-      filter_state.hasData<DebugConfig>(DebugConfig::key())
-          ? &(filter_state.getDataReadOnly<DebugConfig>(DebugConfig::key()))
-          : nullptr;
+      filter_state ? filter_state->hasData<DebugConfig>(DebugConfig::key())
+                         ? &(filter_state->getDataReadOnly<DebugConfig>(DebugConfig::key()))
+                         : nullptr
+                   : nullptr;
 
   // TODO: Maybe add a filter API for this.
   grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
@@ -523,11 +524,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
       upstream_http_protocol_options.value().auto_sni()) {
     const auto parsed_authority =
         Http::Utility::parseAuthority(headers.Host()->value().getStringView());
-    if (!parsed_authority.is_ip_address_) {
+    const StreamInfo::FilterStateSharedPtr& filterState = callbacks_->streamInfo().filterState();
+    if (!parsed_authority.is_ip_address_ && filterState) {
       // TODO: Add SAN verification here and use it from dynamic_forward_proxy
       // Update filter state with the host/authority to use for setting SNI in the transport
       // socket options. This is referenced during the getConnPool() call below.
-      callbacks_->streamInfo().filterState().setData(
+      filterState->setData(
           Network::UpstreamServerName::key(),
           std::make_unique<Network::UpstreamServerName>(parsed_authority.host_),
           StreamInfo::FilterState::StateType::Mutable);
@@ -627,7 +629,7 @@ Http::ConnectionPool::Instance* Filter::getConnPool() {
   // Note: Cluster may downgrade HTTP2 to HTTP1 based on runtime configuration.
   Http::Protocol protocol = cluster_->upstreamHttpProtocol(callbacks_->streamInfo().protocol());
   transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
-      callbacks_->streamInfo().filterState());
+      *callbacks_->streamInfo().filterState());
 
   return config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), route_entry_->priority(),
                                             protocol, this);
@@ -1370,13 +1372,13 @@ bool Filter::setupRedirect(const Http::HeaderMap& headers, UpstreamRequest& upst
   attempting_internal_redirect_with_complete_stream_ =
       upstream_request.upstream_timing_.last_upstream_rx_byte_received_ && downstream_end_stream_;
 
-  StreamInfo::FilterState& filter_state = callbacks_->streamInfo().filterState();
+  const StreamInfo::FilterStateSharedPtr& filter_state = callbacks_->streamInfo().filterState();
 
   // As with setupRetry, redirects are not supported for streaming requests yet.
   if (downstream_end_stream_ &&
       !callbacks_->decodingBuffer() && // Redirects with body not yet supported.
-      location != nullptr &&
-      convertRequestHeadersForInternalRedirect(*downstream_headers_, filter_state,
+      location != nullptr && filter_state &&
+      convertRequestHeadersForInternalRedirect(*downstream_headers_, *filter_state,
                                                route_entry_->maxInternalRedirects(), *location,
                                                *callbacks_->connection()) &&
       callbacks_->recreateStream()) {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -388,10 +388,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   // upstream.
   const StreamInfo::FilterStateSharedPtr& filter_state = callbacks_->streamInfo().filterState();
   const DebugConfig* debug_config =
-      filter_state ? filter_state->hasData<DebugConfig>(DebugConfig::key())
-                         ? &(filter_state->getDataReadOnly<DebugConfig>(DebugConfig::key()))
-                         : nullptr
-                   : nullptr;
+      filter_state->hasData<DebugConfig>(DebugConfig::key())
+          ? &(filter_state->getDataReadOnly<DebugConfig>(DebugConfig::key()))
+          : nullptr;
 
   // TODO: Maybe add a filter API for this.
   grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
@@ -525,7 +524,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     const auto parsed_authority =
         Http::Utility::parseAuthority(headers.Host()->value().getStringView());
     const StreamInfo::FilterStateSharedPtr& filterState = callbacks_->streamInfo().filterState();
-    if (!parsed_authority.is_ip_address_ && filterState) {
+    if (!parsed_authority.is_ip_address_) {
       // TODO: Add SAN verification here and use it from dynamic_forward_proxy
       // Update filter state with the host/authority to use for setting SNI in the transport
       // socket options. This is referenced during the getConnPool() call below.
@@ -1371,15 +1370,13 @@ bool Filter::setupRedirect(const Http::HeaderMap& headers, UpstreamRequest& upst
   attempting_internal_redirect_with_complete_stream_ =
       upstream_request.upstream_timing_.last_upstream_rx_byte_received_ && downstream_end_stream_;
 
-  const StreamInfo::FilterStateSharedPtr& filter_state = callbacks_->streamInfo().filterState();
-
   // As with setupRetry, redirects are not supported for streaming requests yet.
   if (downstream_end_stream_ &&
       !callbacks_->decodingBuffer() && // Redirects with body not yet supported.
-      location != nullptr && filter_state &&
-      convertRequestHeadersForInternalRedirect(*downstream_headers_, *filter_state,
-                                               route_entry_->maxInternalRedirects(), *location,
-                                               *callbacks_->connection()) &&
+      location != nullptr &&
+      convertRequestHeadersForInternalRedirect(
+          *downstream_headers_, *callbacks_->streamInfo().filterState(),
+          route_entry_->maxInternalRedirects(), *location, *callbacks_->connection()) &&
       callbacks_->recreateStream()) {
     cluster_->stats().upstream_internal_redirect_succeeded_total_.inc();
     return true;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -529,10 +529,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
       // TODO: Add SAN verification here and use it from dynamic_forward_proxy
       // Update filter state with the host/authority to use for setting SNI in the transport
       // socket options. This is referenced during the getConnPool() call below.
-      filterState->setData(
-          Network::UpstreamServerName::key(),
-          std::make_unique<Network::UpstreamServerName>(parsed_authority.host_),
-          StreamInfo::FilterState::StateType::Mutable);
+      filterState->setData(Network::UpstreamServerName::key(),
+                           std::make_unique<Network::UpstreamServerName>(parsed_authority.host_),
+                           StreamInfo::FilterState::StateType::Mutable);
     }
   }
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -219,13 +219,6 @@ struct StreamInfoImpl : public StreamInfo {
   const FilterStateSharedPtr& filterState() override { return filter_state_; }
   const FilterState& filterState() const override { return *filter_state_; }
 
-  const FilterStateSharedPtr& upstreamFilterState() const override {
-    return upstream_filter_state_;
-  }
-  void setUpstreamFilterState(const FilterStateSharedPtr& filter_state) override {
-    upstream_filter_state_ = filter_state;
-  }
-
   void setRequestedServerName(absl::string_view requested_server_name) override {
     requested_server_name_ = std::string(requested_server_name);
   }
@@ -269,7 +262,6 @@ struct StreamInfoImpl : public StreamInfo {
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
   FilterStateSharedPtr filter_state_{};
-  FilterStateSharedPtr upstream_filter_state_{};
   std::string route_name_;
 
 private:

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -19,12 +19,14 @@ struct StreamInfoImpl : public StreamInfo {
   StreamInfoImpl(TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()),
-        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
+        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
+        upstream_filter_state_(nullptr) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
-        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
+        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
+        upstream_filter_state_(nullptr) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
                  std::shared_ptr<FilterState>& parent_filter_state)
@@ -33,7 +35,8 @@ struct StreamInfoImpl : public StreamInfo {
         filter_state_(std::make_shared<FilterStateImpl>(
             FilterStateImpl::LazyCreateAncestor(parent_filter_state,
                                                 FilterState::LifeSpan::DownstreamConnection),
-            FilterState::LifeSpan::FilterChain)) {}
+            FilterState::LifeSpan::FilterChain)),
+        upstream_filter_state_(nullptr) {}
 
   SystemTime startTime() const override { return start_time_; }
 
@@ -218,6 +221,13 @@ struct StreamInfoImpl : public StreamInfo {
 
   FilterState& filterState() override { return *filter_state_; }
   const FilterState& filterState() const override { return *filter_state_; }
+  std::shared_ptr<FilterState> filterStatePtr() override { return filter_state_; }
+
+  std::shared_ptr<FilterState> upstreamFilterState() override { return upstream_filter_state_; }
+  const FilterState* upstreamFilterState() const override { return upstream_filter_state_.get(); }
+  void setUpstreamFilterState(std::shared_ptr<FilterState> filter_state) override {
+    upstream_filter_state_ = filter_state;
+  }
 
   void setRequestedServerName(absl::string_view requested_server_name) override {
     requested_server_name_ = std::string(requested_server_name);
@@ -262,6 +272,7 @@ struct StreamInfoImpl : public StreamInfo {
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
   std::shared_ptr<FilterStateImpl> filter_state_;
+  std::shared_ptr<FilterState> upstream_filter_state_;
   std::string route_name_;
 
 private:

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -19,14 +19,12 @@ struct StreamInfoImpl : public StreamInfo {
   StreamInfoImpl(TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()),
-        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
-        upstream_filter_state_(nullptr) {}
+        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
-        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
-        upstream_filter_state_(nullptr) {}
+        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
                  std::shared_ptr<FilterState>& parent_filter_state)
@@ -35,8 +33,7 @@ struct StreamInfoImpl : public StreamInfo {
         filter_state_(std::make_shared<FilterStateImpl>(
             FilterStateImpl::LazyCreateAncestor(parent_filter_state,
                                                 FilterState::LifeSpan::DownstreamConnection),
-            FilterState::LifeSpan::FilterChain)),
-        upstream_filter_state_(nullptr) {}
+            FilterState::LifeSpan::FilterChain)) {}
 
   SystemTime startTime() const override { return start_time_; }
 
@@ -219,13 +216,13 @@ struct StreamInfoImpl : public StreamInfo {
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
-  FilterState& filterState() override { return *filter_state_; }
+  const FilterStateSharedPtr& filterState() override { return filter_state_; }
   const FilterState& filterState() const override { return *filter_state_; }
-  std::shared_ptr<FilterState> filterStatePtr() override { return filter_state_; }
 
-  std::shared_ptr<FilterState> upstreamFilterState() override { return upstream_filter_state_; }
-  const FilterState* upstreamFilterState() const override { return upstream_filter_state_.get(); }
-  void setUpstreamFilterState(std::shared_ptr<FilterState> filter_state) override {
+  const FilterStateSharedPtr& upstreamFilterState() const override {
+    return upstream_filter_state_;
+  }
+  void setUpstreamFilterState(const FilterStateSharedPtr& filter_state) override {
     upstream_filter_state_ = filter_state;
   }
 
@@ -271,8 +268,8 @@ struct StreamInfoImpl : public StreamInfo {
   bool health_check_request_{};
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
-  std::shared_ptr<FilterStateImpl> filter_state_;
-  std::shared_ptr<FilterState> upstream_filter_state_;
+  FilterStateSharedPtr filter_state_{};
+  FilterStateSharedPtr upstream_filter_state_{};
   std::string route_name_;
 
 private:

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -261,7 +261,7 @@ struct StreamInfoImpl : public StreamInfo {
   bool health_check_request_{};
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
-  FilterStateSharedPtr filter_state_{};
+  FilterStateSharedPtr filter_state_;
   std::string route_name_;
 
 private:

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -168,10 +168,11 @@ Config::Config(const envoy::extensions::filters::network::tcp_proxy::v3::TcpProx
 
 RouteConstSharedPtr Config::getRegularRouteFromEntries(Network::Connection& connection) {
   // First check if the per-connection state to see if we need to route to a pre-selected cluster
-  if (connection.streamInfo().filterState().hasData<PerConnectionCluster>(
+  if (connection.streamInfo().filterState() &&
+      connection.streamInfo().filterState()->hasData<PerConnectionCluster>(
           PerConnectionCluster::key())) {
     const PerConnectionCluster& per_connection_cluster =
-        connection.streamInfo().filterState().getDataReadOnly<PerConnectionCluster>(
+        connection.streamInfo().filterState()->getDataReadOnly<PerConnectionCluster>(
             PerConnectionCluster::key());
 
     envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy::DeprecatedV1::TCPRoute
@@ -469,7 +470,7 @@ void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
   getStreamInfo().setUpstreamSslConnection(connection.streamInfo().downstreamSslConnection());
 
   read_callbacks_->connection().streamInfo().setUpstreamFilterState(
-      connection.streamInfo().filterStatePtr());
+      connection.streamInfo().filterState());
 
   // Simulate the event that onPoolReady represents.
   upstream_callbacks_->onEvent(Network::ConnectionEvent::Connected);

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -168,8 +168,7 @@ Config::Config(const envoy::extensions::filters::network::tcp_proxy::v3::TcpProx
 
 RouteConstSharedPtr Config::getRegularRouteFromEntries(Network::Connection& connection) {
   // First check if the per-connection state to see if we need to route to a pre-selected cluster
-  if (connection.streamInfo().filterState() &&
-      connection.streamInfo().filterState()->hasData<PerConnectionCluster>(
+  if (connection.streamInfo().filterState()->hasData<PerConnectionCluster>(
           PerConnectionCluster::key())) {
     const PerConnectionCluster& per_connection_cluster =
         connection.streamInfo().filterState()->getDataReadOnly<PerConnectionCluster>(

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -469,9 +469,6 @@ void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
   getStreamInfo().setUpstreamLocalAddress(connection.localAddress());
   getStreamInfo().setUpstreamSslConnection(connection.streamInfo().downstreamSslConnection());
 
-  read_callbacks_->connection().streamInfo().setUpstreamFilterState(
-      connection.streamInfo().filterState());
-
   // Simulate the event that onPoolReady represents.
   upstream_callbacks_->onEvent(Network::ConnectionEvent::Connected);
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -468,6 +468,9 @@ void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
   getStreamInfo().setUpstreamLocalAddress(connection.localAddress());
   getStreamInfo().setUpstreamSslConnection(connection.streamInfo().downstreamSslConnection());
 
+  read_callbacks_->connection().streamInfo().setUpstreamFilterState(
+      connection.streamInfo().filterStatePtr());
+
   // Simulate the event that onPoolReady represents.
   upstream_callbacks_->onEvent(Network::ConnectionEvent::Connected);
 

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -81,10 +81,12 @@ public:
     if (filter_object_ == nullptr) {
       auto state = std::make_unique<GrpcStatsObject>();
       filter_object_ = state.get();
-      decoder_callbacks_->streamInfo().filterState().setData(
-          HttpFilterNames::get().GrpcStats, std::move(state),
-          StreamInfo::FilterState::StateType::Mutable,
-          StreamInfo::FilterState::LifeSpan::FilterChain);
+      if (decoder_callbacks_->streamInfo().filterState()) {
+        decoder_callbacks_->streamInfo().filterState()->setData(
+            HttpFilterNames::get().GrpcStats, std::move(state),
+            StreamInfo::FilterState::StateType::Mutable,
+            StreamInfo::FilterState::LifeSpan::FilterChain);
+      }
     }
     filter_object_->request_message_count = request_counter_.frameCount();
     filter_object_->response_message_count = response_counter_.frameCount();

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -81,12 +81,10 @@ public:
     if (filter_object_ == nullptr) {
       auto state = std::make_unique<GrpcStatsObject>();
       filter_object_ = state.get();
-      if (decoder_callbacks_->streamInfo().filterState()) {
-        decoder_callbacks_->streamInfo().filterState()->setData(
-            HttpFilterNames::get().GrpcStats, std::move(state),
-            StreamInfo::FilterState::StateType::Mutable,
-            StreamInfo::FilterState::LifeSpan::FilterChain);
-      }
+      decoder_callbacks_->streamInfo().filterState()->setData(
+          HttpFilterNames::get().GrpcStats, std::move(state),
+          StreamInfo::FilterState::StateType::Mutable,
+          StreamInfo::FilterState::LifeSpan::FilterChain);
     }
     filter_object_->request_message_count = request_counter_.frameCount();
     filter_object_->response_message_count = response_counter_.frameCount();

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -59,7 +59,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
 
   // Verify the JWT token, onComplete() will be called when completed.
   const auto* verifier =
-      config_->findVerifier(headers, decoder_callbacks_->streamInfo().filterState());
+      config_->findVerifier(headers, *decoder_callbacks_->streamInfo().filterState());
   if (!verifier) {
     onComplete(Status::Ok);
   } else {

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -316,8 +316,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::
-operator!=(const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
+    const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -316,8 +316,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::
-operator!=(const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
+  const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -316,8 +316,8 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
   return *this;
 }
 
-bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
-    const CompositeArrayConstIterator& rhs) const {
+bool RespValue::CompositeArray::CompositeArrayConstIterator::
+operator!=(const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -317,7 +317,7 @@ RespValue::CompositeArray::CompositeArrayConstIterator::operator++() {
 }
 
 bool RespValue::CompositeArray::CompositeArrayConstIterator::operator!=(
-  const CompositeArrayConstIterator& rhs) const {
+    const CompositeArrayConstIterator& rhs) const {
   return command_ != (rhs.command_) || &array_ != &(rhs.array_) || index_ != rhs.index_ ||
          first_ != rhs.first_;
 }

--- a/source/extensions/filters/network/sni_cluster/sni_cluster.cc
+++ b/source/extensions/filters/network/sni_cluster/sni_cluster.cc
@@ -15,10 +15,10 @@ Network::FilterStatus SniClusterFilter::onNewConnection() {
   ENVOY_CONN_LOG(trace, "sni_cluster: new connection with server name {}",
                  read_callbacks_->connection(), sni);
 
-  if (!sni.empty()) {
+  if (!sni.empty() && read_callbacks_->connection().streamInfo().filterState()) {
     // Set the tcp_proxy cluster to the same value as SNI. The data is mutable to allow
     // other filters to change it.
-    read_callbacks_->connection().streamInfo().filterState().setData(
+    read_callbacks_->connection().streamInfo().filterState()->setData(
         TcpProxy::PerConnectionCluster::key(),
         std::make_unique<TcpProxy::PerConnectionCluster>(sni),
         StreamInfo::FilterState::StateType::Mutable,

--- a/source/extensions/filters/network/sni_cluster/sni_cluster.cc
+++ b/source/extensions/filters/network/sni_cluster/sni_cluster.cc
@@ -15,7 +15,7 @@ Network::FilterStatus SniClusterFilter::onNewConnection() {
   ENVOY_CONN_LOG(trace, "sni_cluster: new connection with server name {}",
                  read_callbacks_->connection(), sni);
 
-  if (!sni.empty() && read_callbacks_->connection().streamInfo().filterState()) {
+  if (!sni.empty()) {
     // Set the tcp_proxy cluster to the same value as SNI. The data is mutable to allow
     // other filters to change it.
     read_callbacks_->connection().streamInfo().filterState()->setData(

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -1027,16 +1027,16 @@ TEST(AccessLogFormatterTest, DynamicMetadataFormatter) {
 TEST(AccessLogFormatterTest, FilterStateFormatter) {
   Http::TestHeaderMapImpl header;
   StreamInfo::MockStreamInfo stream_info;
-  stream_info.filter_state_.setData("key",
-                                    std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
-  stream_info.filter_state_.setData("key-struct",
-                                    std::make_unique<TestSerializedStructFilterState>(),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
-  stream_info.filter_state_.setData("key-no-serialization",
-                                    std::make_unique<StreamInfo::FilterState::Object>(),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
-  stream_info.filter_state_.setData(
+  stream_info.filter_state_->setData("key",
+                                     std::make_unique<Router::StringAccessorImpl>("test_value"),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("key-struct",
+                                     std::make_unique<TestSerializedStructFilterState>(),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("key-no-serialization",
+                                     std::make_unique<StreamInfo::FilterState::Object>(),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData(
       "key-serialization-error",
       std::make_unique<TestSerializedStructFilterState>(std::chrono::seconds(-281474976710656)),
       StreamInfo::FilterState::StateType::ReadOnly);
@@ -1299,11 +1299,12 @@ TEST(AccessLogFormatterTest, JsonFormatterTypedDynamicMetadataTest) {
 TEST(AccessLogFormatterTets, JsonFormatterFilterStateTest) {
   Http::TestHeaderMapImpl header;
   StreamInfo::MockStreamInfo stream_info;
-  stream_info.filter_state_.setData("test_key",
-                                    std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
-  stream_info.filter_state_.setData("test_obj", std::make_unique<TestSerializedStructFilterState>(),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("test_key",
+                                     std::make_unique<Router::StringAccessorImpl>("test_value"),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("test_obj",
+                                     std::make_unique<TestSerializedStructFilterState>(),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   std::unordered_map<std::string, std::string> expected_json_map = {
@@ -1320,11 +1321,12 @@ TEST(AccessLogFormatterTets, JsonFormatterFilterStateTest) {
 TEST(AccessLogFormatterTets, JsonFormatterTypedFilterStateTest) {
   Http::TestHeaderMapImpl header;
   StreamInfo::MockStreamInfo stream_info;
-  stream_info.filter_state_.setData("test_key",
-                                    std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
-  stream_info.filter_state_.setData("test_obj", std::make_unique<TestSerializedStructFilterState>(),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("test_key",
+                                     std::make_unique<Router::StringAccessorImpl>("test_value"),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("test_obj",
+                                     std::make_unique<TestSerializedStructFilterState>(),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   std::unordered_map<std::string, std::string> key_mapping = {
@@ -1414,9 +1416,9 @@ TEST(AccessLogFormatterTest, JsonFormatterTypedTest) {
   ProtobufWkt::Struct s;
   (*s.mutable_fields())["list"] = list;
 
-  stream_info.filter_state_.setData("test_obj",
-                                    std::make_unique<TestSerializedStructFilterState>(s),
-                                    StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("test_obj",
+                                     std::make_unique<TestSerializedStructFilterState>(s),
+                                     StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   std::unordered_map<std::string, std::string> key_mapping = {
@@ -1491,14 +1493,14 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
 
   {
     EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
-    stream_info.filter_state_.setData("testing",
-                                      std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                      StreamInfo::FilterState::StateType::ReadOnly,
-                                      StreamInfo::FilterState::LifeSpan::FilterChain);
-    stream_info.filter_state_.setData("serialized",
-                                      std::make_unique<TestSerializedUnknownFilterState>(),
-                                      StreamInfo::FilterState::StateType::ReadOnly,
-                                      StreamInfo::FilterState::LifeSpan::FilterChain);
+    stream_info.filter_state_->setData("testing",
+                                       std::make_unique<Router::StringAccessorImpl>("test_value"),
+                                       StreamInfo::FilterState::StateType::ReadOnly,
+                                       StreamInfo::FilterState::LifeSpan::FilterChain);
+    stream_info.filter_state_->setData("serialized",
+                                       std::make_unique<TestSerializedUnknownFilterState>(),
+                                       StreamInfo::FilterState::StateType::ReadOnly,
+                                       StreamInfo::FilterState::LifeSpan::FilterChain);
     const std::string format = "%FILTER_STATE(testing)%|%FILTER_STATE(serialized)%|"
                                "%FILTER_STATE(testing):8%|%FILTER_STATE(nonexisting)%";
     FormatterImpl formatter(format);

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -5117,15 +5117,15 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionFilterState) {
     InSequence s;
     EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
         .WillOnce(Invoke([this](HeaderMap&, bool) -> FilterHeadersStatus {
-          decoder_filters_[0]->callbacks_->streamInfo().filterState().setData(
+          decoder_filters_[0]->callbacks_->streamInfo().filterState()->setData(
               "per_filter_chain", std::make_unique<SimpleType>(1),
               StreamInfo::FilterState::StateType::ReadOnly,
               StreamInfo::FilterState::LifeSpan::FilterChain);
-          decoder_filters_[0]->callbacks_->streamInfo().filterState().setData(
+          decoder_filters_[0]->callbacks_->streamInfo().filterState()->setData(
               "per_downstream_request", std::make_unique<SimpleType>(2),
               StreamInfo::FilterState::StateType::ReadOnly,
               StreamInfo::FilterState::LifeSpan::DownstreamRequest);
-          decoder_filters_[0]->callbacks_->streamInfo().filterState().setData(
+          decoder_filters_[0]->callbacks_->streamInfo().filterState()->setData(
               "per_downstream_connection", std::make_unique<SimpleType>(3),
               StreamInfo::FilterState::StateType::ReadOnly,
               StreamInfo::FilterState::LifeSpan::DownstreamConnection);
@@ -5134,26 +5134,26 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionFilterState) {
     EXPECT_CALL(*decoder_filters_[1], decodeHeaders(_, true))
         .WillOnce(Invoke([this](HeaderMap&, bool) -> FilterHeadersStatus {
           EXPECT_FALSE(
-              decoder_filters_[1]->callbacks_->streamInfo().filterState().hasData<SimpleType>(
+              decoder_filters_[1]->callbacks_->streamInfo().filterState()->hasData<SimpleType>(
                   "per_filter_chain"));
           EXPECT_TRUE(
-              decoder_filters_[1]->callbacks_->streamInfo().filterState().hasData<SimpleType>(
+              decoder_filters_[1]->callbacks_->streamInfo().filterState()->hasData<SimpleType>(
                   "per_downstream_request"));
           EXPECT_TRUE(
-              decoder_filters_[1]->callbacks_->streamInfo().filterState().hasData<SimpleType>(
+              decoder_filters_[1]->callbacks_->streamInfo().filterState()->hasData<SimpleType>(
                   "per_downstream_connection"));
           return FilterHeadersStatus::StopIteration;
         }));
     EXPECT_CALL(*decoder_filters_[2], decodeHeaders(_, true))
         .WillOnce(Invoke([this](HeaderMap&, bool) -> FilterHeadersStatus {
           EXPECT_FALSE(
-              decoder_filters_[2]->callbacks_->streamInfo().filterState().hasData<SimpleType>(
+              decoder_filters_[2]->callbacks_->streamInfo().filterState()->hasData<SimpleType>(
                   "per_filter_chain"));
           EXPECT_FALSE(
-              decoder_filters_[2]->callbacks_->streamInfo().filterState().hasData<SimpleType>(
+              decoder_filters_[2]->callbacks_->streamInfo().filterState()->hasData<SimpleType>(
                   "per_downstream_request"));
           EXPECT_TRUE(
-              decoder_filters_[2]->callbacks_->streamInfo().filterState().hasData<SimpleType>(
+              decoder_filters_[2]->callbacks_->streamInfo().filterState()->hasData<SimpleType>(
                   "per_downstream_connection"));
           return FilterHeadersStatus::StopIteration;
         }));

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -570,33 +570,35 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithUpstreamMetadataVariableMiss
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithPerRequestStateVariable) {
-  Envoy::StreamInfo::FilterStateImpl filter_state(
-      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain);
-  filter_state.setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                       StreamInfo::FilterState::StateType::ReadOnly,
-                       StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_EQ("test_value", filter_state.getDataReadOnly<StringAccessor>("testing").asString());
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state(
+      std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
+          Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
+  filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
+                        StreamInfo::FilterState::StateType::ReadOnly,
+                        StreamInfo::FilterState::LifeSpan::FilterChain);
+  EXPECT_EQ("test_value", filter_state->getDataReadOnly<StringAccessor>("testing").asString());
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
-  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(filter_state));
+  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
 
   testFormatting(stream_info, "PER_REQUEST_STATE(testing)", "test_value");
   testFormatting(stream_info, "PER_REQUEST_STATE(testing2)", "");
-  EXPECT_EQ("test_value", filter_state.getDataReadOnly<StringAccessor>("testing").asString());
+  EXPECT_EQ("test_value", filter_state->getDataReadOnly<StringAccessor>("testing").asString());
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithNonStringPerRequestStateVariable) {
-  Envoy::StreamInfo::FilterStateImpl filter_state(
-      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain);
-  filter_state.setData("testing", std::make_unique<StreamInfo::TestIntAccessor>(1),
-                       StreamInfo::FilterState::StateType::ReadOnly,
-                       StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_EQ(1, filter_state.getDataReadOnly<StreamInfo::TestIntAccessor>("testing").access());
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state(
+      std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
+          Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
+  filter_state->setData("testing", std::make_unique<StreamInfo::TestIntAccessor>(1),
+                        StreamInfo::FilterState::StateType::ReadOnly,
+                        StreamInfo::FilterState::LifeSpan::FilterChain);
+  EXPECT_EQ(1, filter_state->getDataReadOnly<StreamInfo::TestIntAccessor>("testing").access());
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
-  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(filter_state));
+  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
 
   testFormatting(stream_info, "PER_REQUEST_STATE(testing)", "");
 }
@@ -843,13 +845,14 @@ TEST(HeaderParserTest, TestParseInternal) {
   const SystemTime start_time(std::chrono::milliseconds(1522796769123));
   ON_CALL(stream_info, startTime()).WillByDefault(Return(start_time));
 
-  Envoy::StreamInfo::FilterStateImpl filter_state(
-      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain);
-  filter_state.setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                       StreamInfo::FilterState::StateType::ReadOnly,
-                       StreamInfo::FilterState::LifeSpan::FilterChain);
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state(
+      std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
+          Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
+  filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
+                        StreamInfo::FilterState::StateType::ReadOnly,
+                        StreamInfo::FilterState::LifeSpan::FilterChain);
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
-  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(filter_state));
+  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
 
   for (const auto& test_case : test_cases) {
     Protobuf::RepeatedPtrField<envoy::config::core::v3::HeaderValueOption> to_add;
@@ -1013,13 +1016,14 @@ request_headers_to_remove: ["x-nope"]
       )EOF"));
   ON_CALL(*host, metadata()).WillByDefault(Return(metadata));
 
-  Envoy::StreamInfo::FilterStateImpl filter_state(
-      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain);
-  filter_state.setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                       StreamInfo::FilterState::StateType::ReadOnly,
-                       StreamInfo::FilterState::LifeSpan::FilterChain);
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state(
+      std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
+          Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
+  filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
+                        StreamInfo::FilterState::StateType::ReadOnly,
+                        StreamInfo::FilterState::LifeSpan::FilterChain);
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
-  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(filter_state));
+  ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
 
   req_header_parser->evaluateHeaders(header_map, stream_info);
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -233,7 +233,7 @@ public:
   }
 
   void setNumPreviousRedirect(uint32_t num_previous_redirects) {
-    callbacks_.streamInfo().filterState().setData(
+    callbacks_.streamInfo().filterState()->setData(
         "num_internal_redirects",
         std::make_shared<StreamInfo::UInt32AccessorImpl>(num_previous_redirects),
         StreamInfo::FilterState::StateType::Mutable,
@@ -305,9 +305,9 @@ TEST_F(RouterTest, UpdateFilterState) {
   ON_CALL(callbacks_.stream_info_, filterState())
       .WillByDefault(ReturnRef(stream_info.filterState()));
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _)).WillOnce(Return(&cancellable_));
-  stream_info.filterState().setData(Network::UpstreamServerName::key(),
-                                    std::make_unique<Network::UpstreamServerName>("dummy"),
-                                    StreamInfo::FilterState::StateType::Mutable);
+  stream_info.filterState()->setData(Network::UpstreamServerName::key(),
+                                     std::make_unique<Network::UpstreamServerName>("dummy"),
+                                     StreamInfo::FilterState::StateType::Mutable);
   expectResponseTimerCreate();
 
   Http::TestHeaderMapImpl headers;
@@ -316,7 +316,7 @@ TEST_F(RouterTest, UpdateFilterState) {
   router_.decodeHeaders(headers, true);
   EXPECT_EQ("host",
             stream_info.filterState()
-                .getDataReadOnly<Network::UpstreamServerName>(Network::UpstreamServerName::key())
+                ->getDataReadOnly<Network::UpstreamServerName>(Network::UpstreamServerName::key())
                 .value());
   EXPECT_CALL(cancellable_, cancel());
   router_.onDestroy();
@@ -840,9 +840,9 @@ void RouterTestBase::testAppendCluster(absl::optional<Http::LowerCaseString> clu
       /* host_address_header */ absl::nullopt,
       /* do_not_forward */ false,
       /* not_forwarded_header */ absl::nullopt);
-  callbacks_.streamInfo().filterState().setData(DebugConfig::key(), std::move(debug_config),
-                                                StreamInfo::FilterState::StateType::ReadOnly,
-                                                StreamInfo::FilterState::LifeSpan::FilterChain);
+  callbacks_.streamInfo().filterState()->setData(DebugConfig::key(), std::move(debug_config),
+                                                 StreamInfo::FilterState::StateType::ReadOnly,
+                                                 StreamInfo::FilterState::LifeSpan::FilterChain);
 
   NiceMock<Http::MockStreamEncoder> encoder;
   Http::StreamDecoder* response_decoder = nullptr;
@@ -892,9 +892,9 @@ void RouterTestBase::testAppendUpstreamHost(
       /* host_address_header */ host_address_header_name,
       /* do_not_forward */ false,
       /* not_forwarded_header */ absl::nullopt);
-  callbacks_.streamInfo().filterState().setData(DebugConfig::key(), std::move(debug_config),
-                                                StreamInfo::FilterState::StateType::ReadOnly,
-                                                StreamInfo::FilterState::LifeSpan::FilterChain);
+  callbacks_.streamInfo().filterState()->setData(DebugConfig::key(), std::move(debug_config),
+                                                 StreamInfo::FilterState::StateType::ReadOnly,
+                                                 StreamInfo::FilterState::LifeSpan::FilterChain);
   cm_.conn_pool_.host_->hostname_ = "scooby.doo";
 
   NiceMock<Http::MockStreamEncoder> encoder;
@@ -964,9 +964,9 @@ void RouterTestBase::testDoNotForward(
       /* host_address_header */ absl::nullopt,
       /* do_not_forward */ true,
       /* not_forwarded_header */ not_forwarded_header_name);
-  callbacks_.streamInfo().filterState().setData(DebugConfig::key(), std::move(debug_config),
-                                                StreamInfo::FilterState::StateType::ReadOnly,
-                                                StreamInfo::FilterState::LifeSpan::FilterChain);
+  callbacks_.streamInfo().filterState()->setData(DebugConfig::key(), std::move(debug_config),
+                                                 StreamInfo::FilterState::StateType::ReadOnly,
+                                                 StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Http::TestHeaderMapImpl response_headers{
       {":status", "204"},
@@ -997,9 +997,9 @@ TEST_F(RouterTest, AllDebugConfig) {
       /* host_address_header */ absl::nullopt,
       /* do_not_forward */ true,
       /* not_forwarded_header */ absl::nullopt);
-  callbacks_.streamInfo().filterState().setData(DebugConfig::key(), std::move(debug_config),
-                                                StreamInfo::FilterState::StateType::ReadOnly,
-                                                StreamInfo::FilterState::LifeSpan::FilterChain);
+  callbacks_.streamInfo().filterState()->setData(DebugConfig::key(), std::move(debug_config),
+                                                 StreamInfo::FilterState::StateType::ReadOnly,
+                                                 StreamInfo::FilterState::LifeSpan::FilterChain);
   cm_.conn_pool_.host_->hostname_ = "scooby.doo";
 
   Http::TestHeaderMapImpl response_headers{{":status", "204"},
@@ -3411,7 +3411,7 @@ TEST_F(RouterTest, HttpInternalRedirectSucceeded) {
   router_.onDestroy();
   EXPECT_EQ(3, callbacks_.streamInfo()
                    .filterState()
-                   .getDataMutable<StreamInfo::UInt32Accessor>("num_internal_redirects")
+                   ->getDataMutable<StreamInfo::UInt32Accessor>("num_internal_redirects")
                    .value());
 }
 
@@ -4528,7 +4528,7 @@ TEST_F(RouterTest, UpstreamSocketOptionsReturnedNonEmpty) {
 }
 
 TEST_F(RouterTest, ApplicationProtocols) {
-  callbacks_.streamInfo().filterState().setData(
+  callbacks_.streamInfo().filterState()->setData(
       Network::ApplicationProtocols::key(),
       std::make_unique<Network::ApplicationProtocols>(std::vector<std::string>{"foo", "bar"}),
       StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -162,10 +162,14 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     stream_info.route_entry_ = &route_entry;
     EXPECT_EQ(&route_entry, stream_info.routeEntry());
 
-    stream_info.filterState().setData("test", std::make_unique<TestIntAccessor>(1),
-                                      FilterState::StateType::ReadOnly,
-                                      FilterState::LifeSpan::FilterChain);
-    EXPECT_EQ(1, stream_info.filterState().getDataReadOnly<TestIntAccessor>("test").access());
+    stream_info.filterState()->setData("test", std::make_unique<TestIntAccessor>(1),
+                                       FilterState::StateType::ReadOnly,
+                                       FilterState::LifeSpan::FilterChain);
+    EXPECT_EQ(1, stream_info.filterState()->getDataReadOnly<TestIntAccessor>("test").access());
+
+    stream_info.setUpstreamFilterState(stream_info.filterState());
+    EXPECT_EQ(1,
+              stream_info.upstreamFilterState()->getDataReadOnly<TestIntAccessor>("test").access());
 
     EXPECT_EQ("", stream_info.requestedServerName());
     absl::string_view sni_name = "stubserver.org";

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -167,10 +167,6 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
                                        FilterState::LifeSpan::FilterChain);
     EXPECT_EQ(1, stream_info.filterState()->getDataReadOnly<TestIntAccessor>("test").access());
 
-    stream_info.setUpstreamFilterState(stream_info.filterState());
-    EXPECT_EQ(1,
-              stream_info.upstreamFilterState()->getDataReadOnly<TestIntAccessor>("test").access());
-
     EXPECT_EQ("", stream_info.requestedServerName());
     absl::string_view sni_name = "stubserver.org";
     stream_info.setRequestedServerName(sni_name);

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -177,14 +177,6 @@ public:
   const Envoy::StreamInfo::FilterStateSharedPtr& filterState() override { return filter_state_; }
   const Envoy::StreamInfo::FilterState& filterState() const override { return *filter_state_; }
 
-  const Envoy::StreamInfo::FilterStateSharedPtr& upstreamFilterState() const override {
-    return upstream_filter_state_;
-  }
-  void
-  setUpstreamFilterState(const Envoy::StreamInfo::FilterStateSharedPtr& filter_state) override {
-    upstream_filter_state_ = filter_state;
-  }
-
   void setRequestedServerName(const absl::string_view requested_server_name) override {
     requested_server_name_ = std::string(requested_server_name);
   }
@@ -232,9 +224,7 @@ public:
   Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
-  Envoy::StreamInfo::FilterStateSharedPtr filter_state_{new Envoy::StreamInfo::FilterStateImpl(
-      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain)};
-  Envoy::StreamInfo::FilterStateSharedPtr upstream_filter_state_{nullptr};
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state_{std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)};
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
   std::string requested_server_name_;
   std::string upstream_transport_failure_reason_;

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -224,7 +224,8 @@ public:
   Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
-  Envoy::StreamInfo::FilterStateSharedPtr filter_state_{std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)};
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state_{
+      std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)};
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
   std::string requested_server_name_;
   std::string upstream_transport_failure_reason_;

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -174,8 +174,16 @@ public:
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
-  const Envoy::StreamInfo::FilterState& filterState() const override { return filter_state_; }
-  Envoy::StreamInfo::FilterState& filterState() override { return filter_state_; }
+  const Envoy::StreamInfo::FilterStateSharedPtr& filterState() override { return filter_state_; }
+  const Envoy::StreamInfo::FilterState& filterState() const override { return *filter_state_; }
+
+  const Envoy::StreamInfo::FilterStateSharedPtr& upstreamFilterState() const override {
+    return upstream_filter_state_;
+  }
+  void
+  setUpstreamFilterState(const Envoy::StreamInfo::FilterStateSharedPtr& filter_state) override {
+    upstream_filter_state_ = filter_state;
+  }
 
   void setRequestedServerName(const absl::string_view requested_server_name) override {
     requested_server_name_ = std::string(requested_server_name);
@@ -224,7 +232,9 @@ public:
   Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
-  Envoy::StreamInfo::FilterStateImpl filter_state_;
+  Envoy::StreamInfo::FilterStateSharedPtr filter_state_{new Envoy::StreamInfo::FilterStateImpl(
+      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain)};
+  Envoy::StreamInfo::FilterStateSharedPtr upstream_filter_state_{nullptr};
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
   std::string requested_server_name_;
   std::string upstream_transport_failure_reason_;

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -12,7 +12,9 @@ namespace Envoy {
 
 class TestStreamInfo : public StreamInfo::StreamInfo {
 public:
-  TestStreamInfo() : filter_state_(Envoy::StreamInfo::FilterState::LifeSpan::FilterChain) {
+  TestStreamInfo()
+      : filter_state_(std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
+            Envoy::StreamInfo::FilterState::LifeSpan::FilterChain)) {
     // Use 1999-01-01 00:00:00 +0
     time_t fake_time = 915148800;
     start_time_ = std::chrono::system_clock::from_time_t(fake_time);
@@ -225,7 +227,8 @@ public:
   const Router::RouteEntry* route_entry_{};
   envoy::config::core::v3::Metadata metadata_{};
   Envoy::StreamInfo::FilterStateSharedPtr filter_state_{
-      std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)};
+      std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
+          Envoy::StreamInfo::FilterState::LifeSpan::FilterChain)};
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
   std::string requested_server_name_;
   std::string upstream_transport_failure_reason_;

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1776,7 +1776,6 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(UseClusterFromPerConnectionC
   initializeFilter();
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_NE(nullptr, stream_info.filterState());
   stream_info.filterState()->setData("envoy.tcp_proxy.cluster",
                                      std::make_unique<PerConnectionCluster>("filter_state_cluster"),
                                      StreamInfo::FilterState::StateType::Mutable,
@@ -1798,7 +1797,6 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(UpstreamServerName)) {
   initializeFilter();
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_NE(nullptr, stream_info.filterState());
   stream_info.filterState()->setData("envoy.network.upstream_server_name",
                                      std::make_unique<UpstreamServerName>("www.example.com"),
                                      StreamInfo::FilterState::StateType::ReadOnly,
@@ -1834,7 +1832,6 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(ApplicationProtocols)) {
   initializeFilter();
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_NE(nullptr, stream_info.filterState());
   stream_info.filterState()->setData(
       Network::ApplicationProtocols::key(),
       std::make_unique<Network::ApplicationProtocols>(std::vector<std::string>{"foo", "bar"}),

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -750,7 +750,8 @@ TEST(ConfigTest, PerConnectionClusterWithTopLevelMetadataMatchConfig) {
   HashedValue hv1(v1), hv2(v2);
 
   NiceMock<Network::MockConnection> connection;
-  connection.stream_info_.filterState().setData(
+  EXPECT_NE(nullptr, connection.stream_info_.filterState());
+  connection.stream_info_.filterState()->setData(
       "envoy.tcp_proxy.cluster", std::make_unique<PerConnectionCluster>("filter_state_cluster"),
       StreamInfo::FilterState::StateType::Mutable,
       StreamInfo::FilterState::LifeSpan::DownstreamConnection);
@@ -1775,10 +1776,11 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(UseClusterFromPerConnectionC
   initializeFilter();
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  stream_info.filterState().setData("envoy.tcp_proxy.cluster",
-                                    std::make_unique<PerConnectionCluster>("filter_state_cluster"),
-                                    StreamInfo::FilterState::StateType::Mutable,
-                                    StreamInfo::FilterState::LifeSpan::DownstreamConnection);
+  EXPECT_NE(nullptr, stream_info.filterState());
+  stream_info.filterState()->setData("envoy.tcp_proxy.cluster",
+                                     std::make_unique<PerConnectionCluster>("filter_state_cluster"),
+                                     StreamInfo::FilterState::StateType::Mutable,
+                                     StreamInfo::FilterState::LifeSpan::DownstreamConnection);
   ON_CALL(connection_, streamInfo()).WillByDefault(ReturnRef(stream_info));
   EXPECT_CALL(Const(connection_), streamInfo()).WillRepeatedly(ReturnRef(stream_info));
 
@@ -1796,10 +1798,11 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(UpstreamServerName)) {
   initializeFilter();
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  stream_info.filterState().setData("envoy.network.upstream_server_name",
-                                    std::make_unique<UpstreamServerName>("www.example.com"),
-                                    StreamInfo::FilterState::StateType::ReadOnly,
-                                    StreamInfo::FilterState::LifeSpan::DownstreamConnection);
+  EXPECT_NE(nullptr, stream_info.filterState());
+  stream_info.filterState()->setData("envoy.network.upstream_server_name",
+                                     std::make_unique<UpstreamServerName>("www.example.com"),
+                                     StreamInfo::FilterState::StateType::ReadOnly,
+                                     StreamInfo::FilterState::LifeSpan::DownstreamConnection);
 
   ON_CALL(connection_, streamInfo()).WillByDefault(ReturnRef(stream_info));
   EXPECT_CALL(Const(connection_), streamInfo()).WillRepeatedly(ReturnRef(stream_info));
@@ -1831,7 +1834,8 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(ApplicationProtocols)) {
   initializeFilter();
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  stream_info.filterState().setData(
+  EXPECT_NE(nullptr, stream_info.filterState());
+  stream_info.filterState()->setData(
       Network::ApplicationProtocols::key(),
       std::make_unique<Network::ApplicationProtocols>(std::vector<std::string>{"foo", "bar"}),
       StreamInfo::FilterState::StateType::ReadOnly,

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -750,7 +750,6 @@ TEST(ConfigTest, PerConnectionClusterWithTopLevelMetadataMatchConfig) {
   HashedValue hv1(v1), hv2(v2);
 
   NiceMock<Network::MockConnection> connection;
-  EXPECT_NE(nullptr, connection.stream_info_.filterState());
   connection.stream_info_.filterState()->setData(
       "envoy.tcp_proxy.cluster", std::make_unique<PerConnectionCluster>("filter_state_cluster"),
       StreamInfo::FilterState::StateType::Mutable,

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -145,11 +145,11 @@ TEST_F(HttpGrpcAccessLogTest, Marshalling) {
     stream_info.last_downstream_tx_byte_sent_ = 2ms;
     stream_info.setDownstreamLocalAddress(std::make_shared<Network::Address::PipeInstance>("/foo"));
     (*stream_info.metadata_.mutable_filter_metadata())["foo"] = ProtobufWkt::Struct();
-    stream_info.filter_state_.setData("string_accessor",
+    stream_info.filter_state_->setData("string_accessor",
                                       std::make_unique<Router::StringAccessorImpl>("test_value"),
                                       StreamInfo::FilterState::StateType::ReadOnly,
                                       StreamInfo::FilterState::LifeSpan::FilterChain);
-    stream_info.filter_state_.setData("serialized", std::make_unique<TestSerializedFilterState>(),
+    stream_info.filter_state_->setData("serialized", std::make_unique<TestSerializedFilterState>(),
                                       StreamInfo::FilterState::StateType::ReadOnly,
                                       StreamInfo::FilterState::LifeSpan::FilterChain);
     expectLog(R"EOF(

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -146,12 +146,12 @@ TEST_F(HttpGrpcAccessLogTest, Marshalling) {
     stream_info.setDownstreamLocalAddress(std::make_shared<Network::Address::PipeInstance>("/foo"));
     (*stream_info.metadata_.mutable_filter_metadata())["foo"] = ProtobufWkt::Struct();
     stream_info.filter_state_->setData("string_accessor",
-                                      std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                      StreamInfo::FilterState::StateType::ReadOnly,
-                                      StreamInfo::FilterState::LifeSpan::FilterChain);
+                                       std::make_unique<Router::StringAccessorImpl>("test_value"),
+                                       StreamInfo::FilterState::StateType::ReadOnly,
+                                       StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.filter_state_->setData("serialized", std::make_unique<TestSerializedFilterState>(),
-                                      StreamInfo::FilterState::StateType::ReadOnly,
-                                      StreamInfo::FilterState::LifeSpan::FilterChain);
+                                       StreamInfo::FilterState::StateType::ReadOnly,
+                                       StreamInfo::FilterState::LifeSpan::FilterChain);
     expectLog(R"EOF(
 common_properties:
   downstream_remote_address:

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -66,7 +66,8 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2HeaderOnlyResponse) {
                      ->statsScope()
                      .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
-  EXPECT_FALSE(stream_info_.filterState().hasDataWithName(HttpFilterNames::get().GrpcStats));
+  EXPECT_NE(nullptr, stream_info_.filterState());
+  EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
 TEST_F(GrpcStatsFilterConfigTest, StatsHttp2NormalResponse) {
@@ -90,7 +91,8 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2NormalResponse) {
                      ->statsScope()
                      .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
-  EXPECT_FALSE(stream_info_.filterState().hasDataWithName(HttpFilterNames::get().GrpcStats));
+  EXPECT_NE(nullptr, stream_info_.filterState());
+  EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
 TEST_F(GrpcStatsFilterConfigTest, StatsHttp2ContentTypeGrpcPlusProto) {
@@ -112,7 +114,8 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2ContentTypeGrpcPlusProto) {
                      ->statsScope()
                      .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
-  EXPECT_FALSE(stream_info_.filterState().hasDataWithName(HttpFilterNames::get().GrpcStats));
+  EXPECT_NE(nullptr, stream_info_.filterState());
+  EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
 TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
@@ -139,8 +142,9 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
                 ->statsScope()
                 .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.response_message_count")
                 .value());
-  const auto& data =
-      stream_info_.filterState().getDataReadOnly<GrpcStatsObject>(HttpFilterNames::get().GrpcStats);
+  EXPECT_NE(nullptr, stream_info_.filterState());
+  const auto& data = stream_info_.filterState()->getDataReadOnly<GrpcStatsObject>(
+      HttpFilterNames::get().GrpcStats);
   EXPECT_EQ(2U, data.request_message_count);
   EXPECT_EQ(0U, data.response_message_count);
 

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -66,7 +66,6 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2HeaderOnlyResponse) {
                      ->statsScope()
                      .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
-  EXPECT_NE(nullptr, stream_info_.filterState());
   EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
@@ -91,7 +90,6 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2NormalResponse) {
                      ->statsScope()
                      .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
-  EXPECT_NE(nullptr, stream_info_.filterState());
   EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
@@ -114,7 +112,6 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2ContentTypeGrpcPlusProto) {
                      ->statsScope()
                      .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
-  EXPECT_NE(nullptr, stream_info_.filterState());
   EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
@@ -142,7 +139,6 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
                 ->statsScope()
                 .counter("grpc.lyft.users.BadCompanions.GetBadCompanions.response_message_count")
                 .value());
-  EXPECT_NE(nullptr, stream_info_.filterState());
   const auto& data = stream_info_.filterState()->getDataReadOnly<GrpcStatsObject>(
       HttpFilterNames::get().GrpcStats);
   EXPECT_EQ(2U, data.request_message_count);

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -32,7 +32,7 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers, bool) override {
     const Http::HeaderEntry* entry = headers.get(header_);
     if (entry) {
-      decoder_callbacks_->streamInfo().filterState().setData(
+      decoder_callbacks_->streamInfo().filterState()->setData(
           state_, std::make_unique<Router::StringAccessorImpl>(entry->value().getStringView()),
           StreamInfo::FilterState::StateType::ReadOnly,
           StreamInfo::FilterState::LifeSpan::FilterChain);

--- a/test/extensions/filters/network/sni_cluster/sni_cluster_test.cc
+++ b/test/extensions/filters/network/sni_cluster/sni_cluster_test.cc
@@ -49,7 +49,7 @@ TEST(SniCluster, SetTcpProxyClusterOnlyIfSniIsPresent) {
         .WillByDefault(Return(EMPTY_STRING));
     filter.onNewConnection();
 
-    EXPECT_FALSE(stream_info.filterState().hasData<TcpProxy::PerConnectionCluster>(
+    EXPECT_FALSE(stream_info.filterState()->hasData<TcpProxy::PerConnectionCluster>(
         TcpProxy::PerConnectionCluster::key()));
   }
 
@@ -59,11 +59,11 @@ TEST(SniCluster, SetTcpProxyClusterOnlyIfSniIsPresent) {
         .WillByDefault(Return("filter_state_cluster"));
     filter.onNewConnection();
 
-    EXPECT_TRUE(stream_info.filterState().hasData<TcpProxy::PerConnectionCluster>(
+    EXPECT_TRUE(stream_info.filterState()->hasData<TcpProxy::PerConnectionCluster>(
         TcpProxy::PerConnectionCluster::key()));
 
     auto per_connection_cluster =
-        stream_info.filterState().getDataReadOnly<TcpProxy::PerConnectionCluster>(
+        stream_info.filterState()->getDataReadOnly<TcpProxy::PerConnectionCluster>(
             TcpProxy::PerConnectionCluster::key());
     EXPECT_EQ(per_connection_cluster.value(), "filter_state_cluster");
   }

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -15,7 +15,7 @@ namespace Envoy {
 namespace StreamInfo {
 
 MockStreamInfo::MockStreamInfo()
-    : filter_state_(FilterState::LifeSpan::FilterChain),
+    : filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
       downstream_local_address_(new Network::Address::Ipv4Instance("127.0.0.2")),
       downstream_direct_remote_address_(new Network::Address::Ipv4Instance("127.0.0.1")),
       downstream_remote_address_(new Network::Address::Ipv4Instance("127.0.0.1")) {
@@ -88,7 +88,12 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
-  ON_CALL(Const(*this), filterState()).WillByDefault(ReturnRef(filter_state_));
+  ON_CALL(Const(*this), filterState()).WillByDefault(ReturnRef(*filter_state_));
+  ON_CALL(*this, setUpstreamFilterState(_))
+      .WillByDefault(Invoke([this](const FilterStateSharedPtr& filter_state) {
+        upstream_filter_state_ = filter_state;
+      }));
+  ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(upstream_filter_state_));
   ON_CALL(*this, setRequestedServerName(_))
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
         requested_server_name_ = std::string(requested_server_name);

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -89,11 +89,6 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(Const(*this), filterState()).WillByDefault(ReturnRef(*filter_state_));
-  ON_CALL(*this, setUpstreamFilterState(_))
-      .WillByDefault(Invoke([this](const FilterStateSharedPtr& filter_state) {
-        upstream_filter_state_ = filter_state;
-      }));
-  ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(upstream_filter_state_));
   ON_CALL(*this, setRequestedServerName(_))
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
         requested_server_name_ = std::string(requested_server_name);

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -80,8 +80,6 @@ public:
               (const std::string&, const std::string&, const std::string&));
   MOCK_METHOD(const FilterStateSharedPtr&, filterState, ());
   MOCK_METHOD(const FilterState&, filterState, (), (const));
-  MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, (), (const));
-  MOCK_METHOD(void, setUpstreamFilterState, (const FilterStateSharedPtr&));
   MOCK_METHOD(void, setRequestedServerName, (const absl::string_view));
   MOCK_METHOD(const std::string&, requestedServerName, (), (const));
   MOCK_METHOD(void, setUpstreamTransportFailureReason, (absl::string_view));
@@ -105,9 +103,7 @@ public:
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   envoy::config::core::v3::Metadata metadata_;
-  std::shared_ptr<FilterState> filter_state_{
-      new FilterStateImpl(FilterState::LifeSpan::FilterChain)};
-  std::shared_ptr<FilterState> upstream_filter_state_{nullptr};
+  FilterStateSharePtr filter_state_;
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -103,7 +103,7 @@ public:
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   envoy::config::core::v3::Metadata metadata_;
-  FilterStateSharePtr filter_state_;
+  FilterStateSharedPtr filter_state_;
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -78,8 +78,10 @@ public:
   MOCK_METHOD(void, setDynamicMetadata, (const std::string&, const ProtobufWkt::Struct&));
   MOCK_METHOD(void, setDynamicMetadata,
               (const std::string&, const std::string&, const std::string&));
-  MOCK_METHOD(FilterState&, filterState, ());
+  MOCK_METHOD(const FilterStateSharedPtr&, filterState, ());
   MOCK_METHOD(const FilterState&, filterState, (), (const));
+  MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, ());
+  MOCK_METHOD(void, setUpstreamFilterState, (const FilterStateSharedPtr&));
   MOCK_METHOD(void, setRequestedServerName, (const absl::string_view));
   MOCK_METHOD(const std::string&, requestedServerName, (), (const));
   MOCK_METHOD(void, setUpstreamTransportFailureReason, (absl::string_view));
@@ -103,7 +105,9 @@ public:
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   envoy::config::core::v3::Metadata metadata_;
-  FilterStateImpl filter_state_;
+  std::shared_ptr<FilterState> filter_state_{
+      new FilterStateImpl(FilterState::LifeSpan::FilterChain)};
+  std::shared_ptr<FilterState> upstream_filter_state_{nullptr};
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -80,7 +80,7 @@ public:
               (const std::string&, const std::string&, const std::string&));
   MOCK_METHOD(const FilterStateSharedPtr&, filterState, ());
   MOCK_METHOD(const FilterState&, filterState, (), (const));
-  MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, ());
+  MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, (), (const));
   MOCK_METHOD(void, setUpstreamFilterState, (const FilterStateSharedPtr&));
   MOCK_METHOD(void, setRequestedServerName, (const absl::string_view));
   MOCK_METHOD(const std::string&, requestedServerName, (), (const));


### PR DESCRIPTION
Ref: https://github.com/envoyproxy/envoy-wasm/issues/291

Description: This is part one of the change to add an option to support looking up filterstate from upstream filters. This change just changes the non-const accessor of filterstate to a const shared_ptr ref of non-const filterstate object.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
