### PR TITLE
test: migrate remaining MOCK_METHOD[0-9] calls 4/4

### DIFF
--- a/source/extensions/common/wasm/null/null_vm_plugin.h
+++ b/source/extensions/common/wasm/null/null_vm_plugin.h
@@ -17,7 +17,7 @@ public:
   virtual ~NullVmPlugin() = default;
 
   // NB: These are defined rather than declared PURE because gmock uses __LINE__ internally for
-  // uniqueness, making it impossible to use FOR_ALL_WASM_VM_EXPORTS with MOCK_METHOD2.
+  // uniqueness, making it impossible to use FOR_ALL_WASM_VM_EXPORTS with MOCK_METHOD.
 #define _DEFINE_GET_FUNCTION(_T)                                                                   \
   virtual void getFunction(absl::string_view, _T* f) { *f = nullptr; }
   FOR_ALL_WASM_VM_EXPORTS(_DEFINE_GET_FUNCTION)

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -16,9 +16,9 @@ public:
   ~MockAccessLogFile() override;
 
   // AccessLog::AccessLogFile
-  MOCK_METHOD1(write, void(absl::string_view data));
-  MOCK_METHOD0(reopen, void());
-  MOCK_METHOD0(flush, void());
+  MOCK_METHOD(void, write, (absl::string_view data));
+  MOCK_METHOD(void, reopen, ());
+  MOCK_METHOD(void, flush, ());
 };
 
 class MockFilter : public Filter {
@@ -27,10 +27,9 @@ public:
   ~MockFilter() override;
 
   // AccessLog::Filter
-  MOCK_METHOD4(evaluate,
-               bool(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                    const Http::HeaderMap& response_headers,
-                    const Http::HeaderMap& response_trailers));
+  MOCK_METHOD(bool, evaluate,
+              (const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
+               const Http::HeaderMap& response_headers, const Http::HeaderMap& response_trailers));
 };
 
 class MockAccessLogManager : public AccessLogManager {
@@ -39,8 +38,8 @@ public:
   ~MockAccessLogManager() override;
 
   // AccessLog::AccessLogManager
-  MOCK_METHOD0(reopen, void());
-  MOCK_METHOD1(createAccessLog, AccessLogFileSharedPtr(const std::string& file_name));
+  MOCK_METHOD(void, reopen, ());
+  MOCK_METHOD(AccessLogFileSharedPtr, createAccessLog, (const std::string& file_name));
 
   std::shared_ptr<MockAccessLogFile> file_{new testing::NiceMock<MockAccessLogFile>()};
 };
@@ -51,10 +50,10 @@ public:
   ~MockInstance() override;
 
   // AccessLog::Instance
-  MOCK_METHOD4(log,
-               void(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                    const Http::HeaderMap* response_trailers,
-                    const StreamInfo::StreamInfo& stream_info));
+  MOCK_METHOD(void, log,
+              (const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
+               const Http::HeaderMap* response_trailers,
+               const StreamInfo::StreamInfo& stream_info));
 };
 
 } // namespace AccessLog

--- a/test/mocks/api/hot_restart.h
+++ b/test/mocks/api/hot_restart.h
@@ -12,8 +12,8 @@ namespace Api {
 class MockHotRestartOsSysCalls : public HotRestartOsSysCallsImpl {
 public:
   // Api::HotRestartOsSysCalls
-  MOCK_METHOD3(shmOpen, SysCallIntResult(const char*, int, mode_t));
-  MOCK_METHOD1(shmUnlink, SysCallIntResult(const char*));
+  MOCK_METHOD(SysCallIntResult, shmOpen, (const char*, int, mode_t));
+  MOCK_METHOD(SysCallIntResult, shmUnlink, (const char*));
 };
 
 } // namespace Api

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -33,14 +33,13 @@ public:
   Event::DispatcherPtr allocateDispatcher(Buffer::WatermarkFactoryPtr&& watermark_factory) override;
   TimeSource& timeSource() override { return time_system_; }
 
-  MOCK_METHOD1(allocateDispatcher_, Event::Dispatcher*(Event::TimeSystem&));
-  MOCK_METHOD2(allocateDispatcher_,
-               Event::Dispatcher*(Buffer::WatermarkFactoryPtr&& watermark_factory,
-                                  Event::TimeSystem&));
-  MOCK_METHOD0(fileSystem, Filesystem::Instance&());
-  MOCK_METHOD0(threadFactory, Thread::ThreadFactory&());
-  MOCK_METHOD0(rootScope, const Stats::Scope&());
-  MOCK_METHOD0(processContext, OptProcessContextRef());
+  MOCK_METHOD(Event::Dispatcher*, allocateDispatcher_, (Event::TimeSystem&));
+  MOCK_METHOD(Event::Dispatcher*, allocateDispatcher_,
+              (Buffer::WatermarkFactoryPtr && watermark_factory, Event::TimeSystem&));
+  MOCK_METHOD(Filesystem::Instance&, fileSystem, ());
+  MOCK_METHOD(Thread::ThreadFactory&, threadFactory, ());
+  MOCK_METHOD(const Stats::Scope&, rootScope, ());
+  MOCK_METHOD(OptProcessContextRef, processContext, ());
 
   testing::NiceMock<Filesystem::MockInstance> file_system_;
   Event::GlobalTimeSystem time_system_;
@@ -58,25 +57,25 @@ public:
   SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
                               socklen_t* optlen) override;
 
-  MOCK_METHOD3(bind, SysCallIntResult(int sockfd, const sockaddr* addr, socklen_t addrlen));
-  MOCK_METHOD3(ioctl, SysCallIntResult(int sockfd, unsigned long int request, void* argp));
-  MOCK_METHOD1(close, SysCallIntResult(int));
-  MOCK_METHOD3(writev, SysCallSizeResult(int, const iovec*, int));
-  MOCK_METHOD3(sendmsg, SysCallSizeResult(int fd, const msghdr* message, int flags));
-  MOCK_METHOD3(readv, SysCallSizeResult(int, const iovec*, int));
-  MOCK_METHOD4(recv, SysCallSizeResult(int socket, void* buffer, size_t length, int flags));
-  MOCK_METHOD3(recvmsg, SysCallSizeResult(int socket, struct msghdr* msg, int flags));
-  MOCK_METHOD2(ftruncate, SysCallIntResult(int fd, off_t length));
-  MOCK_METHOD6(mmap, SysCallPtrResult(void* addr, size_t length, int prot, int flags, int fd,
-                                      off_t offset));
-  MOCK_METHOD2(stat, SysCallIntResult(const char* name, struct stat* stat));
-  MOCK_METHOD2(chmod, SysCallIntResult(const std::string& name, mode_t mode));
-  MOCK_METHOD5(setsockopt_,
-               int(int sockfd, int level, int optname, const void* optval, socklen_t optlen));
-  MOCK_METHOD5(getsockopt_,
-               int(int sockfd, int level, int optname, void* optval, socklen_t* optlen));
-  MOCK_METHOD3(socket, SysCallIntResult(int domain, int type, int protocol));
-  MOCK_METHOD2(gethostname, SysCallIntResult(char* name, size_t length));
+  MOCK_METHOD(SysCallIntResult, bind, (int sockfd, const sockaddr* addr, socklen_t addrlen));
+  MOCK_METHOD(SysCallIntResult, ioctl, (int sockfd, unsigned long int request, void* argp));
+  MOCK_METHOD(SysCallIntResult, close, (int));
+  MOCK_METHOD(SysCallSizeResult, writev, (int, const iovec*, int));
+  MOCK_METHOD(SysCallSizeResult, sendmsg, (int fd, const msghdr* message, int flags));
+  MOCK_METHOD(SysCallSizeResult, readv, (int, const iovec*, int));
+  MOCK_METHOD(SysCallSizeResult, recv, (int socket, void* buffer, size_t length, int flags));
+  MOCK_METHOD(SysCallSizeResult, recvmsg, (int socket, struct msghdr* msg, int flags));
+  MOCK_METHOD(SysCallIntResult, ftruncate, (int fd, off_t length));
+  MOCK_METHOD(SysCallPtrResult, mmap,
+              (void* addr, size_t length, int prot, int flags, int fd, off_t offset));
+  MOCK_METHOD(SysCallIntResult, stat, (const char* name, struct stat* stat));
+  MOCK_METHOD(SysCallIntResult, chmod, (const std::string& name, mode_t mode));
+  MOCK_METHOD(int, setsockopt_,
+              (int sockfd, int level, int optname, const void* optval, socklen_t optlen));
+  MOCK_METHOD(int, getsockopt_,
+              (int sockfd, int level, int optname, void* optval, socklen_t* optlen));
+  MOCK_METHOD(SysCallIntResult, socket, (int domain, int type, int protocol));
+  MOCK_METHOD(SysCallIntResult, gethostname, (char* name, size_t length));
 
   // Map from (sockfd,level,optname) to boolean socket option.
   using SockOptKey = std::tuple<int, int, int>;
@@ -87,7 +86,7 @@ public:
 class MockLinuxOsSysCalls : public LinuxOsSysCallsImpl {
 public:
   // Api::LinuxOsSysCalls
-  MOCK_METHOD3(sched_getaffinity, SysCallIntResult(pid_t pid, size_t cpusetsize, cpu_set_t* mask));
+  MOCK_METHOD(SysCallIntResult, sched_getaffinity, (pid_t pid, size_t cpusetsize, cpu_set_t* mask));
 };
 #endif
 

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -19,10 +19,10 @@ public:
   MockBufferBase();
   MockBufferBase(std::function<void()> below_low, std::function<void()> above_high);
 
-  MOCK_METHOD1(write, Api::IoCallUint64Result(Network::IoHandle& io_handle));
-  MOCK_METHOD1(move, void(Buffer::Instance& rhs));
-  MOCK_METHOD2(move, void(Buffer::Instance& rhs, uint64_t length));
-  MOCK_METHOD1(drain, void(uint64_t size));
+  MOCK_METHOD(Api::IoCallUint64Result, write, (Network::IoHandle & io_handle));
+  MOCK_METHOD(void, move, (Buffer::Instance & rhs));
+  MOCK_METHOD(void, move, (Buffer::Instance & rhs, uint64_t length));
+  MOCK_METHOD(void, drain, (uint64_t size));
 
   void baseMove(Buffer::Instance& rhs) { BaseClass::move(rhs); }
   void baseDrain(uint64_t size) { BaseClass::drain(size); }
@@ -97,8 +97,8 @@ public:
     return Buffer::InstancePtr{create_(below_low, above_high)};
   }
 
-  MOCK_METHOD2(create_, Buffer::Instance*(std::function<void()> below_low,
-                                          std::function<void()> above_high));
+  MOCK_METHOD(Buffer::Instance*, create_,
+              (std::function<void()> below_low, std::function<void()> above_high));
 };
 
 MATCHER_P(BufferEqual, rhs, testing::PrintToString(*rhs)) {

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -37,7 +37,7 @@ public:
   ReadyWatcher();
   ~ReadyWatcher();
 
-  MOCK_METHOD0(ready, void());
+  MOCK_METHOD(void, ready, ());
 };
 
 // TODO(jmarantz): get rid of this and use SimulatedTimeSystem in its place.
@@ -59,8 +59,8 @@ public:
           const Duration& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) override {
     return real_time_.waitFor(mutex, condvar, duration); // NO_CHECK_FORMAT(real_time)
   }
-  MOCK_METHOD0(systemTime, SystemTime());
-  MOCK_METHOD0(monotonicTime, MonotonicTime());
+  MOCK_METHOD(SystemTime, systemTime, ());
+  MOCK_METHOD(MonotonicTime, monotonicTime, ());
 
   Event::TestRealTimeSystem real_time_; // NO_CHECK_FORMAT(real_time)
 };
@@ -89,7 +89,7 @@ inline bool operator==(const StringViewSaver& saver, const char* str) {
 
 class MockScopedTrackedObject : public ScopeTrackedObject {
 public:
-  MOCK_CONST_METHOD2(dumpState, void(std::ostream&, int));
+  MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));
 };
 
 } // namespace Envoy

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -87,39 +87,37 @@ public:
   }
 
   // Event::Dispatcher
-  MOCK_METHOD2(initializeStats, void(Stats::Scope&, const std::string&));
-  MOCK_METHOD0(clearDeferredDeleteList, void());
-  MOCK_METHOD0(createServerConnection_, Network::Connection*());
-  MOCK_METHOD4(
-      createClientConnection_,
-      Network::ClientConnection*(Network::Address::InstanceConstSharedPtr address,
-                                 Network::Address::InstanceConstSharedPtr source_address,
-                                 Network::TransportSocketPtr& transport_socket,
-                                 const Network::ConnectionSocket::OptionsSharedPtr& options));
-  MOCK_METHOD2(createDnsResolver,
-               Network::DnsResolverSharedPtr(
-                   const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers,
-                   const bool use_tcp_for_dns_lookups));
-  MOCK_METHOD4(createFileEvent_,
-               FileEvent*(int fd, FileReadyCb cb, FileTriggerType trigger, uint32_t events));
-  MOCK_METHOD0(createFilesystemWatcher_, Filesystem::Watcher*());
-  MOCK_METHOD3(createListener_,
-               Network::Listener*(Network::SocketSharedPtr&& socket, Network::ListenerCallbacks& cb,
-                                  bool bind_to_port));
-  MOCK_METHOD2(createUdpListener_, Network::UdpListener*(Network::SocketSharedPtr&& socket,
-                                                         Network::UdpListenerCallbacks& cb));
-  MOCK_METHOD1(createTimer_, Timer*(Event::TimerCb cb));
-  MOCK_METHOD1(deferredDelete_, void(DeferredDeletable* to_delete));
-  MOCK_METHOD0(exit, void());
-  MOCK_METHOD2(listenForSignal_, SignalEvent*(int signal_num, SignalCb cb));
-  MOCK_METHOD1(post, void(std::function<void()> callback));
-  MOCK_METHOD1(run, void(RunType type));
-  MOCK_METHOD1(setTrackedObject, const ScopeTrackedObject*(const ScopeTrackedObject* object));
-  MOCK_CONST_METHOD0(isThreadSafe, bool());
+  MOCK_METHOD(void, initializeStats, (Stats::Scope&, const std::string&));
+  MOCK_METHOD(void, clearDeferredDeleteList, ());
+  MOCK_METHOD(Network::Connection*, createServerConnection_, ());
+  MOCK_METHOD(Network::ClientConnection*, createClientConnection_,
+              (Network::Address::InstanceConstSharedPtr address,
+               Network::Address::InstanceConstSharedPtr source_address,
+               Network::TransportSocketPtr& transport_socket,
+               const Network::ConnectionSocket::OptionsSharedPtr& options));
+  MOCK_METHOD(Network::DnsResolverSharedPtr, createDnsResolver,
+              (const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers,
+               const bool use_tcp_for_dns_lookups));
+  MOCK_METHOD(FileEvent*, createFileEvent_,
+              (int fd, FileReadyCb cb, FileTriggerType trigger, uint32_t events));
+  MOCK_METHOD(Filesystem::Watcher*, createFilesystemWatcher_, ());
+  MOCK_METHOD(Network::Listener*, createListener_,
+              (Network::SocketSharedPtr && socket, Network::ListenerCallbacks& cb,
+               bool bind_to_port));
+  MOCK_METHOD(Network::UdpListener*, createUdpListener_,
+              (Network::SocketSharedPtr && socket, Network::UdpListenerCallbacks& cb));
+  MOCK_METHOD(Timer*, createTimer_, (Event::TimerCb cb));
+  MOCK_METHOD(void, deferredDelete_, (DeferredDeletable * to_delete));
+  MOCK_METHOD(void, exit, ());
+  MOCK_METHOD(SignalEvent*, listenForSignal_, (int signal_num, SignalCb cb));
+  MOCK_METHOD(void, post, (std::function<void()> callback));
+  MOCK_METHOD(void, run, (RunType type));
+  MOCK_METHOD(const ScopeTrackedObject*, setTrackedObject, (const ScopeTrackedObject* object));
+  MOCK_METHOD(bool, isThreadSafe, (), (const));
   Buffer::WatermarkFactory& getWatermarkFactory() override { return buffer_factory_; }
-  MOCK_METHOD0(getCurrentThreadId, Thread::ThreadId());
-  MOCK_CONST_METHOD0(approximateMonotonicTime, MonotonicTime());
-  MOCK_METHOD0(updateApproximateMonotonicTime, void());
+  MOCK_METHOD(Thread::ThreadId, getCurrentThreadId, ());
+  MOCK_METHOD(MonotonicTime, approximateMonotonicTime, (), (const));
+  MOCK_METHOD(void, updateApproximateMonotonicTime, ());
 
   GlobalTimeSystem time_system_;
   std::list<DeferredDeletablePtr> to_delete_;
@@ -145,12 +143,12 @@ public:
   }
 
   // Timer
-  MOCK_METHOD0(disableTimer, void());
-  MOCK_METHOD2(enableTimer,
-               void(const std::chrono::milliseconds&, const ScopeTrackedObject* scope));
-  MOCK_METHOD2(enableHRTimer,
-               void(const std::chrono::microseconds&, const ScopeTrackedObject* scope));
-  MOCK_METHOD0(enabled, bool());
+  MOCK_METHOD(void, disableTimer, ());
+  MOCK_METHOD(void, enableTimer,
+              (const std::chrono::milliseconds&, const ScopeTrackedObject* scope));
+  MOCK_METHOD(void, enableHRTimer,
+              (const std::chrono::microseconds&, const ScopeTrackedObject* scope));
+  MOCK_METHOD(bool, enabled, ());
 
   MockDispatcher* dispatcher_{};
   const ScopeTrackedObject* scope_{};
@@ -173,8 +171,8 @@ public:
   MockFileEvent();
   ~MockFileEvent() override;
 
-  MOCK_METHOD1(activate, void(uint32_t events));
-  MOCK_METHOD1(setEnabled, void(uint32_t events));
+  MOCK_METHOD(void, activate, (uint32_t events));
+  MOCK_METHOD(void, setEnabled, (uint32_t events));
 };
 
 } // namespace Event

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -22,7 +22,7 @@ public:
   MockAsyncRequest();
   ~MockAsyncRequest() override;
 
-  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD(void, cancel, ());
 };
 
 class MockAsyncStream : public RawAsyncStream {
@@ -33,9 +33,9 @@ public:
   void sendMessageRaw(Buffer::InstancePtr&& request, bool end_stream) override {
     sendMessageRaw_(request, end_stream);
   }
-  MOCK_METHOD2_T(sendMessageRaw_, void(Buffer::InstancePtr& request, bool end_stream));
-  MOCK_METHOD0_T(closeStream, void());
-  MOCK_METHOD0_T(resetStream, void());
+  MOCK_METHOD(void, sendMessageRaw_, (Buffer::InstancePtr & request, bool end_stream));
+  MOCK_METHOD(void, closeStream, ());
+  MOCK_METHOD(void, resetStream, ());
 };
 
 template <class ResponseType>
@@ -45,10 +45,10 @@ public:
     onSuccess_(*response, span);
   }
 
-  MOCK_METHOD1_T(onCreateInitialMetadata, void(Http::HeaderMap& metadata));
-  MOCK_METHOD2_T(onSuccess_, void(const ResponseType& response, Tracing::Span& span));
-  MOCK_METHOD3_T(onFailure,
-                 void(Status::GrpcStatus status, const std::string& message, Tracing::Span& span));
+  MOCK_METHOD(void, onCreateInitialMetadata, (Http::HeaderMap & metadata));
+  MOCK_METHOD(void, onSuccess_, (const ResponseType& response, Tracing::Span& span));
+  MOCK_METHOD(void, onFailure,
+              (Status::GrpcStatus status, const std::string& message, Tracing::Span& span));
 };
 
 template <class ResponseType>
@@ -64,24 +64,23 @@ public:
     onReceiveTrailingMetadata_(*metadata);
   }
 
-  MOCK_METHOD1_T(onCreateInitialMetadata, void(Http::HeaderMap& metadata));
-  MOCK_METHOD1_T(onReceiveInitialMetadata_, void(const Http::HeaderMap& metadata));
-  MOCK_METHOD1_T(onReceiveMessage_, void(const ResponseType& message));
-  MOCK_METHOD1_T(onReceiveTrailingMetadata_, void(const Http::HeaderMap& metadata));
-  MOCK_METHOD2_T(onRemoteClose, void(Status::GrpcStatus status, const std::string& message));
+  MOCK_METHOD(void, onCreateInitialMetadata, (Http::HeaderMap & metadata));
+  MOCK_METHOD(void, onReceiveInitialMetadata_, (const Http::HeaderMap& metadata));
+  MOCK_METHOD(void, onReceiveMessage_, (const ResponseType& message));
+  MOCK_METHOD(void, onReceiveTrailingMetadata_, (const Http::HeaderMap& metadata));
+  MOCK_METHOD(void, onRemoteClose, (Status::GrpcStatus status, const std::string& message));
 };
 
 class MockAsyncClient : public RawAsyncClient {
 public:
-  MOCK_METHOD6_T(sendRaw,
-                 AsyncRequest*(absl::string_view service_full_name, absl::string_view method_name,
-                               Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
-                               Tracing::Span& parent_span,
-                               const Http::AsyncClient::RequestOptions& options));
-  MOCK_METHOD4_T(startRaw,
-                 RawAsyncStream*(absl::string_view service_full_name, absl::string_view method_name,
-                                 RawAsyncStreamCallbacks& callbacks,
-                                 const Http::AsyncClient::StreamOptions& options));
+  MOCK_METHOD(AsyncRequest*, sendRaw,
+              (absl::string_view service_full_name, absl::string_view method_name,
+               Buffer::InstancePtr&& request, RawAsyncRequestCallbacks& callbacks,
+               Tracing::Span& parent_span, const Http::AsyncClient::RequestOptions& options));
+  MOCK_METHOD(RawAsyncStream*, startRaw,
+              (absl::string_view service_full_name, absl::string_view method_name,
+               RawAsyncStreamCallbacks& callbacks,
+               const Http::AsyncClient::StreamOptions& options));
 };
 
 class MockAsyncClientFactory : public AsyncClientFactory {
@@ -89,7 +88,7 @@ public:
   MockAsyncClientFactory();
   ~MockAsyncClientFactory() override;
 
-  MOCK_METHOD0(create, RawAsyncClientPtr());
+  MOCK_METHOD(RawAsyncClientPtr, create, ());
 };
 
 class MockAsyncClientManager : public AsyncClientManager {
@@ -97,9 +96,9 @@ public:
   MockAsyncClientManager();
   ~MockAsyncClientManager() override;
 
-  MOCK_METHOD3(factoryForGrpcService,
-               AsyncClientFactoryPtr(const envoy::config::core::v3::GrpcService& grpc_service,
-                                     Stats::Scope& scope, bool skip_cluster_check));
+  MOCK_METHOD(AsyncClientFactoryPtr, factoryForGrpcService,
+              (const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope,
+               bool skip_cluster_check));
 };
 
 MATCHER_P(ProtoBufferEq, expected, "") {

--- a/test/mocks/http/api_listener.h
+++ b/test/mocks/http/api_listener.h
@@ -12,8 +12,8 @@ public:
   ~MockApiListener() override;
 
   // Http::ApiListener
-  MOCK_METHOD2(newStream,
-               StreamDecoder&(StreamEncoder& response_encoder, bool is_internally_created));
+  MOCK_METHOD(StreamDecoder&, newStream,
+              (StreamEncoder & response_encoder, bool is_internally_created));
 };
 
 } // namespace Http

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -17,7 +17,7 @@ public:
   ~MockCancellable() override;
 
   // Http::ConnectionPool::Cancellable
-  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD(void, cancel, ());
 };
 
 class MockInstance : public Instance {
@@ -26,13 +26,13 @@ public:
   ~MockInstance() override;
 
   // Http::ConnectionPool::Instance
-  MOCK_CONST_METHOD0(protocol, Http::Protocol());
-  MOCK_METHOD1(addDrainedCallback, void(DrainedCb cb));
-  MOCK_METHOD0(drainConnections, void());
-  MOCK_CONST_METHOD0(hasActiveConnections, bool());
-  MOCK_METHOD2(newStream, Cancellable*(Http::StreamDecoder& response_decoder,
-                                       Http::ConnectionPool::Callbacks& callbacks));
-  MOCK_CONST_METHOD0(host, Upstream::HostDescriptionConstSharedPtr());
+  MOCK_METHOD(Http::Protocol, protocol, (), (const));
+  MOCK_METHOD(void, addDrainedCallback, (DrainedCb cb));
+  MOCK_METHOD(void, drainConnections, ());
+  MOCK_METHOD(bool, hasActiveConnections, (), (const));
+  MOCK_METHOD(Cancellable*, newStream,
+              (Http::StreamDecoder & response_decoder, Http::ConnectionPool::Callbacks& callbacks));
+  MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_;
 };

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -44,7 +44,7 @@ public:
   ~MockConnectionCallbacks() override;
 
   // Http::ConnectionCallbacks
-  MOCK_METHOD0(onGoAway, void());
+  MOCK_METHOD(void, onGoAway, ());
 };
 
 class MockServerConnectionCallbacks : public ServerConnectionCallbacks,
@@ -54,8 +54,8 @@ public:
   ~MockServerConnectionCallbacks() override;
 
   // Http::ServerConnectionCallbacks
-  MOCK_METHOD2(newStream,
-               StreamDecoder&(StreamEncoder& response_encoder, bool is_internally_created));
+  MOCK_METHOD(StreamDecoder&, newStream,
+              (StreamEncoder & response_encoder, bool is_internally_created));
 };
 
 class MockStreamCallbacks : public StreamCallbacks {
@@ -64,9 +64,9 @@ public:
   ~MockStreamCallbacks() override;
 
   // Http::StreamCallbacks
-  MOCK_METHOD2(onResetStream, void(StreamResetReason reason, absl::string_view));
-  MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
+  MOCK_METHOD(void, onResetStream, (StreamResetReason reason, absl::string_view));
+  MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
+  MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
 };
 
 class MockServerConnection : public ServerConnection {
@@ -75,13 +75,13 @@ public:
   ~MockServerConnection() override;
 
   // Http::Connection
-  MOCK_METHOD1(dispatch, void(Buffer::Instance& data));
-  MOCK_METHOD0(goAway, void());
-  MOCK_METHOD0(protocol, Protocol());
-  MOCK_METHOD0(shutdownNotice, void());
-  MOCK_METHOD0(wantsToWrite, bool());
-  MOCK_METHOD0(onUnderlyingConnectionAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onUnderlyingConnectionBelowWriteBufferLowWatermark, void());
+  MOCK_METHOD(void, dispatch, (Buffer::Instance & data));
+  MOCK_METHOD(void, goAway, ());
+  MOCK_METHOD(Protocol, protocol, ());
+  MOCK_METHOD(void, shutdownNotice, ());
+  MOCK_METHOD(bool, wantsToWrite, ());
+  MOCK_METHOD(void, onUnderlyingConnectionAboveWriteBufferHighWatermark, ());
+  MOCK_METHOD(void, onUnderlyingConnectionBelowWriteBufferLowWatermark, ());
 
   Protocol protocol_{Protocol::Http11};
 };
@@ -92,16 +92,16 @@ public:
   ~MockClientConnection() override;
 
   // Http::Connection
-  MOCK_METHOD1(dispatch, void(Buffer::Instance& data));
-  MOCK_METHOD0(goAway, void());
-  MOCK_METHOD0(protocol, Protocol());
-  MOCK_METHOD0(shutdownNotice, void());
-  MOCK_METHOD0(wantsToWrite, bool());
-  MOCK_METHOD0(onUnderlyingConnectionAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onUnderlyingConnectionBelowWriteBufferLowWatermark, void());
+  MOCK_METHOD(void, dispatch, (Buffer::Instance & data));
+  MOCK_METHOD(void, goAway, ());
+  MOCK_METHOD(Protocol, protocol, ());
+  MOCK_METHOD(void, shutdownNotice, ());
+  MOCK_METHOD(bool, wantsToWrite, ());
+  MOCK_METHOD(void, onUnderlyingConnectionAboveWriteBufferHighWatermark, ());
+  MOCK_METHOD(void, onUnderlyingConnectionBelowWriteBufferLowWatermark, ());
 
   // Http::ClientConnection
-  MOCK_METHOD1(newStream, StreamEncoder&(StreamDecoder& response_decoder));
+  MOCK_METHOD(StreamEncoder&, newStream, (StreamDecoder & response_decoder));
 };
 
 class MockFilterChainFactory : public FilterChainFactory {
@@ -110,10 +110,10 @@ public:
   ~MockFilterChainFactory() override;
 
   // Http::FilterChainFactory
-  MOCK_METHOD1(createFilterChain, void(FilterChainFactoryCallbacks& callbacks));
-  MOCK_METHOD3(createUpgradeFilterChain, bool(absl::string_view upgrade_type,
-                                              const FilterChainFactory::UpgradeMap* upgrade_map,
-                                              FilterChainFactoryCallbacks& callbacks));
+  MOCK_METHOD(void, createFilterChain, (FilterChainFactoryCallbacks & callbacks));
+  MOCK_METHOD(bool, createUpgradeFilterChain,
+              (absl::string_view upgrade_type, const FilterChainFactory::UpgradeMap* upgrade_map,
+               FilterChainFactoryCallbacks& callbacks));
 };
 
 class MockStreamFilterCallbacksBase {
@@ -131,28 +131,28 @@ public:
   ~MockStreamDecoderFilterCallbacks() override;
 
   // Http::StreamFilterCallbacks
-  MOCK_METHOD0(connection, const Network::Connection*());
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
-  MOCK_METHOD0(resetStream, void());
-  MOCK_METHOD0(clusterInfo, Upstream::ClusterInfoConstSharedPtr());
-  MOCK_METHOD0(route, Router::RouteConstSharedPtr());
-  MOCK_METHOD1(requestRouteConfigUpdate, void(Http::RouteConfigUpdatedCallbackSharedPtr));
-  MOCK_METHOD0(routeConfig, absl::optional<Router::ConfigConstSharedPtr>());
-  MOCK_METHOD0(clearRouteCache, void());
-  MOCK_CONST_METHOD0(streamId, uint64_t());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
-  MOCK_METHOD0(activeSpan, Tracing::Span&());
-  MOCK_METHOD0(tracingConfig, Tracing::Config&());
-  MOCK_METHOD0(scope, const ScopeTrackedObject&());
-  MOCK_METHOD0(onDecoderFilterAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onDecoderFilterBelowWriteBufferLowWatermark, void());
-  MOCK_METHOD1(addDownstreamWatermarkCallbacks, void(DownstreamWatermarkCallbacks&));
-  MOCK_METHOD1(removeDownstreamWatermarkCallbacks, void(DownstreamWatermarkCallbacks&));
-  MOCK_METHOD1(setDecoderBufferLimit, void(uint32_t));
-  MOCK_METHOD0(decoderBufferLimit, uint32_t());
-  MOCK_METHOD0(recreateStream, bool());
-  MOCK_METHOD1(addUpstreamSocketOptions, void(const Network::Socket::OptionsSharedPtr& options));
-  MOCK_CONST_METHOD0(getUpstreamSocketOptions, Network::Socket::OptionsSharedPtr());
+  MOCK_METHOD(const Network::Connection*, connection, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
+  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, clusterInfo, ());
+  MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
+  MOCK_METHOD(void, requestRouteConfigUpdate, (Http::RouteConfigUpdatedCallbackSharedPtr));
+  MOCK_METHOD(absl::optional<Router::ConfigConstSharedPtr>, routeConfig, ());
+  MOCK_METHOD(void, clearRouteCache, ());
+  MOCK_METHOD(uint64_t, streamId, (), (const));
+  MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
+  MOCK_METHOD(Tracing::Span&, activeSpan, ());
+  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(const ScopeTrackedObject&, scope, ());
+  MOCK_METHOD(void, onDecoderFilterAboveWriteBufferHighWatermark, ());
+  MOCK_METHOD(void, onDecoderFilterBelowWriteBufferLowWatermark, ());
+  MOCK_METHOD(void, addDownstreamWatermarkCallbacks, (DownstreamWatermarkCallbacks&));
+  MOCK_METHOD(void, removeDownstreamWatermarkCallbacks, (DownstreamWatermarkCallbacks&));
+  MOCK_METHOD(void, setDecoderBufferLimit, (uint32_t));
+  MOCK_METHOD(uint32_t, decoderBufferLimit, ());
+  MOCK_METHOD(bool, recreateStream, ());
+  MOCK_METHOD(void, addUpstreamSocketOptions, (const Network::Socket::OptionsSharedPtr& options));
+  MOCK_METHOD(Network::Socket::OptionsSharedPtr, getUpstreamSocketOptions, (), (const));
 
   // Http::StreamDecoderFilterCallbacks
   void sendLocalReply_(Code code, absl::string_view body,
@@ -171,22 +171,23 @@ public:
     encodeMetadata_(std::move(metadata_map));
   }
 
-  MOCK_METHOD0(continueDecoding, void());
-  MOCK_METHOD2(addDecodedData, void(Buffer::Instance& data, bool streaming));
-  MOCK_METHOD2(injectDecodedDataToFilterChain, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD0(addDecodedTrailers, HeaderMap&());
-  MOCK_METHOD0(addDecodedMetadata, MetadataMapVector&());
-  MOCK_METHOD0(decodingBuffer, const Buffer::Instance*());
-  MOCK_METHOD1(modifyDecodingBuffer, void(std::function<void(Buffer::Instance&)>));
-  MOCK_METHOD1(encode100ContinueHeaders_, void(HeaderMap& headers));
-  MOCK_METHOD2(encodeHeaders_, void(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(encodeData, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(encodeTrailers_, void(HeaderMap& trailers));
-  MOCK_METHOD1(encodeMetadata_, void(MetadataMapPtr metadata_map));
-  MOCK_METHOD5(sendLocalReply, void(Code code, absl::string_view body,
-                                    std::function<void(HeaderMap& headers)> modify_headers,
-                                    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
-                                    absl::string_view details));
+  MOCK_METHOD(void, continueDecoding, ());
+  MOCK_METHOD(void, addDecodedData, (Buffer::Instance & data, bool streaming));
+  MOCK_METHOD(void, injectDecodedDataToFilterChain, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(HeaderMap&, addDecodedTrailers, ());
+  MOCK_METHOD(MetadataMapVector&, addDecodedMetadata, ());
+  MOCK_METHOD(const Buffer::Instance*, decodingBuffer, ());
+  MOCK_METHOD(void, modifyDecodingBuffer, (std::function<void(Buffer::Instance&)>));
+  MOCK_METHOD(void, encode100ContinueHeaders_, (HeaderMap & headers));
+  MOCK_METHOD(void, encodeHeaders_, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(void, encodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(void, encodeTrailers_, (HeaderMap & trailers));
+  MOCK_METHOD(void, encodeMetadata_, (MetadataMapPtr metadata_map));
+  MOCK_METHOD(void, sendLocalReply,
+              (Code code, absl::string_view body,
+               std::function<void(HeaderMap& headers)> modify_headers,
+               const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+               absl::string_view details));
 
   Buffer::InstancePtr buffer_;
   std::list<DownstreamWatermarkCallbacks*> callbacks_{};
@@ -206,32 +207,32 @@ public:
   ~MockStreamEncoderFilterCallbacks() override;
 
   // Http::StreamFilterCallbacks
-  MOCK_METHOD0(connection, const Network::Connection*());
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
-  MOCK_METHOD0(resetStream, void());
-  MOCK_METHOD0(clusterInfo, Upstream::ClusterInfoConstSharedPtr());
-  MOCK_METHOD0(route, Router::RouteConstSharedPtr());
-  MOCK_METHOD1(requestRouteConfigUpdate, void(std::function<void()>));
-  MOCK_METHOD0(canRequestRouteConfigUpdate, bool());
-  MOCK_METHOD0(clearRouteCache, void());
-  MOCK_CONST_METHOD0(streamId, uint64_t());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
-  MOCK_METHOD0(activeSpan, Tracing::Span&());
-  MOCK_METHOD0(tracingConfig, Tracing::Config&());
-  MOCK_METHOD0(scope, const ScopeTrackedObject&());
-  MOCK_METHOD0(onEncoderFilterAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onEncoderFilterBelowWriteBufferLowWatermark, void());
-  MOCK_METHOD1(setEncoderBufferLimit, void(uint32_t));
-  MOCK_METHOD0(encoderBufferLimit, uint32_t());
+  MOCK_METHOD(const Network::Connection*, connection, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
+  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, clusterInfo, ());
+  MOCK_METHOD(void, requestRouteConfigUpdate, (std::function<void()>));
+  MOCK_METHOD(bool, canRequestRouteConfigUpdate, ());
+  MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
+  MOCK_METHOD(void, clearRouteCache, ());
+  MOCK_METHOD(uint64_t, streamId, (), (const));
+  MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
+  MOCK_METHOD(Tracing::Span&, activeSpan, ());
+  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(const ScopeTrackedObject&, scope, ());
+  MOCK_METHOD(void, onEncoderFilterAboveWriteBufferHighWatermark, ());
+  MOCK_METHOD(void, onEncoderFilterBelowWriteBufferLowWatermark, ());
+  MOCK_METHOD(void, setEncoderBufferLimit, (uint32_t));
+  MOCK_METHOD(uint32_t, encoderBufferLimit, ());
 
   // Http::StreamEncoderFilterCallbacks
-  MOCK_METHOD2(addEncodedData, void(Buffer::Instance& data, bool streaming));
-  MOCK_METHOD2(injectEncodedDataToFilterChain, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD0(addEncodedTrailers, HeaderMap&());
-  MOCK_METHOD1(addEncodedMetadata, void(Http::MetadataMapPtr&&));
-  MOCK_METHOD0(continueEncoding, void());
-  MOCK_METHOD0(encodingBuffer, const Buffer::Instance*());
-  MOCK_METHOD1(modifyEncodingBuffer, void(std::function<void(Buffer::Instance&)>));
+  MOCK_METHOD(void, addEncodedData, (Buffer::Instance & data, bool streaming));
+  MOCK_METHOD(void, injectEncodedDataToFilterChain, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(HeaderMap&, addEncodedTrailers, ());
+  MOCK_METHOD(void, addEncodedMetadata, (Http::MetadataMapPtr &&));
+  MOCK_METHOD(void, continueEncoding, ());
+  MOCK_METHOD(const Buffer::Instance*, encodingBuffer, ());
+  MOCK_METHOD(void, modifyEncodingBuffer, (std::function<void(Buffer::Instance&)>));
 
   Buffer::InstancePtr buffer_;
   testing::NiceMock<Tracing::MockSpan> active_span_;
@@ -245,15 +246,15 @@ public:
   ~MockStreamDecoderFilter() override;
 
   // Http::StreamFilterBase
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 
   // Http::StreamDecoderFilter
-  MOCK_METHOD2(decodeHeaders, FilterHeadersStatus(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(decodeData, FilterDataStatus(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(decodeTrailers, FilterTrailersStatus(HeaderMap& trailers));
-  MOCK_METHOD1(decodeMetadata, FilterMetadataStatus(Http::MetadataMap& metadata_map));
-  MOCK_METHOD1(setDecoderFilterCallbacks, void(StreamDecoderFilterCallbacks& callbacks));
-  MOCK_METHOD0(decodeComplete, void());
+  MOCK_METHOD(FilterHeadersStatus, decodeHeaders, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(FilterDataStatus, decodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(FilterTrailersStatus, decodeTrailers, (HeaderMap & trailers));
+  MOCK_METHOD(FilterMetadataStatus, decodeMetadata, (Http::MetadataMap & metadata_map));
+  MOCK_METHOD(void, setDecoderFilterCallbacks, (StreamDecoderFilterCallbacks & callbacks));
+  MOCK_METHOD(void, decodeComplete, ());
 
   Http::StreamDecoderFilterCallbacks* callbacks_{};
 };
@@ -264,16 +265,16 @@ public:
   ~MockStreamEncoderFilter() override;
 
   // Http::StreamFilterBase
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 
   // Http::MockStreamEncoderFilter
-  MOCK_METHOD1(encode100ContinueHeaders, FilterHeadersStatus(HeaderMap& headers));
-  MOCK_METHOD2(encodeHeaders, FilterHeadersStatus(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(encodeData, FilterDataStatus(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(encodeTrailers, FilterTrailersStatus(HeaderMap& trailers));
-  MOCK_METHOD1(encodeMetadata, FilterMetadataStatus(MetadataMap& metadata_map));
-  MOCK_METHOD1(setEncoderFilterCallbacks, void(StreamEncoderFilterCallbacks& callbacks));
-  MOCK_METHOD0(encodeComplete, void());
+  MOCK_METHOD(FilterHeadersStatus, encode100ContinueHeaders, (HeaderMap & headers));
+  MOCK_METHOD(FilterHeadersStatus, encodeHeaders, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(FilterDataStatus, encodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(FilterTrailersStatus, encodeTrailers, (HeaderMap & trailers));
+  MOCK_METHOD(FilterMetadataStatus, encodeMetadata, (MetadataMap & metadata_map));
+  MOCK_METHOD(void, setEncoderFilterCallbacks, (StreamEncoderFilterCallbacks & callbacks));
+  MOCK_METHOD(void, encodeComplete, ());
 
   Http::StreamEncoderFilterCallbacks* callbacks_{};
 };
@@ -284,22 +285,22 @@ public:
   ~MockStreamFilter() override;
 
   // Http::StreamFilterBase
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 
   // Http::StreamDecoderFilter
-  MOCK_METHOD2(decodeHeaders, FilterHeadersStatus(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(decodeData, FilterDataStatus(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(decodeTrailers, FilterTrailersStatus(HeaderMap& trailers));
-  MOCK_METHOD1(decodeMetadata, FilterMetadataStatus(Http::MetadataMap& metadata_map));
-  MOCK_METHOD1(setDecoderFilterCallbacks, void(StreamDecoderFilterCallbacks& callbacks));
+  MOCK_METHOD(FilterHeadersStatus, decodeHeaders, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(FilterDataStatus, decodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(FilterTrailersStatus, decodeTrailers, (HeaderMap & trailers));
+  MOCK_METHOD(FilterMetadataStatus, decodeMetadata, (Http::MetadataMap & metadata_map));
+  MOCK_METHOD(void, setDecoderFilterCallbacks, (StreamDecoderFilterCallbacks & callbacks));
 
   // Http::MockStreamEncoderFilter
-  MOCK_METHOD1(encode100ContinueHeaders, FilterHeadersStatus(HeaderMap& headers));
-  MOCK_METHOD2(encodeHeaders, FilterHeadersStatus(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(encodeData, FilterDataStatus(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(encodeTrailers, FilterTrailersStatus(HeaderMap& trailers));
-  MOCK_METHOD1(encodeMetadata, FilterMetadataStatus(MetadataMap& metadata_map));
-  MOCK_METHOD1(setEncoderFilterCallbacks, void(StreamEncoderFilterCallbacks& callbacks));
+  MOCK_METHOD(FilterHeadersStatus, encode100ContinueHeaders, (HeaderMap & headers));
+  MOCK_METHOD(FilterHeadersStatus, encodeHeaders, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(FilterDataStatus, encodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(FilterTrailersStatus, encodeTrailers, (HeaderMap & trailers));
+  MOCK_METHOD(FilterMetadataStatus, encodeMetadata, (MetadataMap & metadata_map));
+  MOCK_METHOD(void, setEncoderFilterCallbacks, (StreamEncoderFilterCallbacks & callbacks));
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
@@ -310,19 +311,19 @@ public:
   MockAsyncClient();
   ~MockAsyncClient() override;
 
-  MOCK_METHOD0(onRequestDestroy, void());
+  MOCK_METHOD(void, onRequestDestroy, ());
 
   // Http::AsyncClient
   Request* send(MessagePtr&& request, Callbacks& callbacks, const RequestOptions& args) override {
     return send_(request, callbacks, args);
   }
 
-  MOCK_METHOD3(send_,
-               Request*(MessagePtr& request, Callbacks& callbacks, const RequestOptions& args));
+  MOCK_METHOD(Request*, send_,
+              (MessagePtr & request, Callbacks& callbacks, const RequestOptions& args));
 
-  MOCK_METHOD2(start, Stream*(StreamCallbacks& callbacks, const StreamOptions& args));
+  MOCK_METHOD(Stream*, start, (StreamCallbacks & callbacks, const StreamOptions& args));
 
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 
   NiceMock<Event::MockDispatcher> dispatcher_;
 };
@@ -335,8 +336,8 @@ public:
   void onSuccess(MessagePtr&& response) override { onSuccess_(response.get()); }
 
   // Http::AsyncClient::Callbacks
-  MOCK_METHOD1(onSuccess_, void(Message* response));
-  MOCK_METHOD1(onFailure, void(Http::AsyncClient::FailureReason reason));
+  MOCK_METHOD(void, onSuccess_, (Message * response));
+  MOCK_METHOD(void, onFailure, (Http::AsyncClient::FailureReason reason));
 };
 
 class MockAsyncClientStreamCallbacks : public AsyncClient::StreamCallbacks {
@@ -349,11 +350,11 @@ public:
   }
   void onTrailers(HeaderMapPtr&& trailers) override { onTrailers_(*trailers); }
 
-  MOCK_METHOD2(onHeaders_, void(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(onData, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(onTrailers_, void(HeaderMap& headers));
-  MOCK_METHOD0(onComplete, void());
-  MOCK_METHOD0(onReset, void());
+  MOCK_METHOD(void, onHeaders_, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(void, onData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(void, onTrailers_, (HeaderMap & headers));
+  MOCK_METHOD(void, onComplete, ());
+  MOCK_METHOD(void, onReset, ());
 };
 
 class MockAsyncClientRequest : public AsyncClient::Request {
@@ -361,7 +362,7 @@ public:
   MockAsyncClientRequest(MockAsyncClient* client);
   ~MockAsyncClientRequest() override;
 
-  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD(void, cancel, ());
 
   MockAsyncClient* client_;
 };
@@ -371,10 +372,10 @@ public:
   MockAsyncClientStream();
   ~MockAsyncClientStream() override;
 
-  MOCK_METHOD2(sendHeaders, void(HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(sendData, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(sendTrailers, void(HeaderMap& trailers));
-  MOCK_METHOD0(reset, void());
+  MOCK_METHOD(void, sendHeaders, (HeaderMap & headers, bool end_stream));
+  MOCK_METHOD(void, sendData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(void, sendTrailers, (HeaderMap & trailers));
+  MOCK_METHOD(void, reset, ());
 };
 
 class MockFilterChainFactoryCallbacks : public Http::FilterChainFactoryCallbacks {
@@ -382,16 +383,16 @@ public:
   MockFilterChainFactoryCallbacks();
   ~MockFilterChainFactoryCallbacks() override;
 
-  MOCK_METHOD1(addStreamDecoderFilter, void(Http::StreamDecoderFilterSharedPtr filter));
-  MOCK_METHOD1(addStreamEncoderFilter, void(Http::StreamEncoderFilterSharedPtr filter));
-  MOCK_METHOD1(addStreamFilter, void(Http::StreamFilterSharedPtr filter));
-  MOCK_METHOD1(addAccessLogHandler, void(AccessLog::InstanceSharedPtr handler));
+  MOCK_METHOD(void, addStreamDecoderFilter, (Http::StreamDecoderFilterSharedPtr filter));
+  MOCK_METHOD(void, addStreamEncoderFilter, (Http::StreamEncoderFilterSharedPtr filter));
+  MOCK_METHOD(void, addStreamFilter, (Http::StreamFilterSharedPtr filter));
+  MOCK_METHOD(void, addAccessLogHandler, (AccessLog::InstanceSharedPtr handler));
 };
 
 class MockDownstreamWatermarkCallbacks : public DownstreamWatermarkCallbacks {
 public:
-  MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
+  MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
+  MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
 };
 
 } // namespace Http

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -13,13 +13,13 @@ public:
   ~MockStream() override;
 
   // Http::Stream
-  MOCK_METHOD1(addCallbacks, void(StreamCallbacks& callbacks));
-  MOCK_METHOD1(removeCallbacks, void(StreamCallbacks& callbacks));
-  MOCK_METHOD1(resetStream, void(StreamResetReason reason));
-  MOCK_METHOD1(readDisable, void(bool disable));
-  MOCK_METHOD2(setWriteBufferWatermarks, void(uint32_t, uint32_t));
-  MOCK_METHOD0(bufferLimit, uint32_t());
-  MOCK_METHOD0(connectionLocalAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_METHOD(void, addCallbacks, (StreamCallbacks & callbacks));
+  MOCK_METHOD(void, removeCallbacks, (StreamCallbacks & callbacks));
+  MOCK_METHOD(void, resetStream, (StreamResetReason reason));
+  MOCK_METHOD(void, readDisable, (bool disable));
+  MOCK_METHOD(void, setWriteBufferWatermarks, (uint32_t, uint32_t));
+  MOCK_METHOD(uint32_t, bufferLimit, ());
+  MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, connectionLocalAddress, ());
 
   std::list<StreamCallbacks*> callbacks_{};
   Network::Address::InstanceConstSharedPtr connection_local_address_;

--- a/test/mocks/init/mocks.h
+++ b/test/mocks/init/mocks.h
@@ -18,7 +18,7 @@ namespace Init {
 class ExpectableWatcherImpl : public WatcherImpl {
 public:
   ExpectableWatcherImpl(absl::string_view name = "test");
-  MOCK_CONST_METHOD0(ready, void());
+  MOCK_METHOD(void, ready, (), (const));
 
   /**
    * Convenience method to provide a shorthand for EXPECT_CALL(watcher, ready()). Can be chained,
@@ -35,7 +35,7 @@ public:
 class ExpectableTargetImpl : public TargetImpl {
 public:
   ExpectableTargetImpl(absl::string_view name = "test");
-  MOCK_METHOD0(initialize, void());
+  MOCK_METHOD(void, initialize, ());
 
   /**
    * Convenience method to provide a shorthand for EXPECT_CALL(target, initialize()). Can be
@@ -57,7 +57,7 @@ class ExpectableSharedTargetImpl : public SharedTargetImpl {
 public:
   ExpectableSharedTargetImpl(absl::string_view name = "test");
   ExpectableSharedTargetImpl(absl::string_view name, InitializeFn fn);
-  MOCK_METHOD0(initialize, void());
+  MOCK_METHOD(void, initialize, ());
 
   ::testing::internal::TypedExpectation<void()>& expectInitialize();
 };
@@ -69,9 +69,9 @@ public:
  * invoking the saved target with the watcher argument.
  */
 struct MockManager : Manager {
-  MOCK_CONST_METHOD0(state, Manager::State());
-  MOCK_METHOD1(add, void(const Target&));
-  MOCK_METHOD1(initialize, void(const Watcher&));
+  MOCK_METHOD(Manager::State, state, (), (const));
+  MOCK_METHOD(void, add, (const Target&));
+  MOCK_METHOD(void, initialize, (const Watcher&));
 };
 
 } // namespace Init

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -15,11 +15,11 @@ public:
   MockLocalInfo();
   ~MockLocalInfo() override;
 
-  MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
-  MOCK_CONST_METHOD0(zoneName, const std::string&());
-  MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD0(nodeName, const std::string&());
-  MOCK_CONST_METHOD0(node, envoy::config::core::v3::Node&());
+  MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
+  MOCK_METHOD(const std::string&, zoneName, (), (const));
+  MOCK_METHOD(const std::string&, clusterName, (), (const));
+  MOCK_METHOD(const std::string&, nodeName, (), (const));
+  MOCK_METHOD(envoy::config::core::v3::Node&, node, (), (const));
 
   Network::Address::InstanceConstSharedPtr address_;
   // TODO(htuch): Make this behave closer to the real implementation, with the various property

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -12,17 +12,19 @@ public:
   MockIoHandle();
   ~MockIoHandle();
 
-  MOCK_CONST_METHOD0(fd, int());
-  MOCK_METHOD0(close, Api::IoCallUint64Result());
-  MOCK_CONST_METHOD0(isOpen, bool());
-  MOCK_METHOD3(readv, Api::IoCallUint64Result(uint64_t max_length, Buffer::RawSlice* slices,
-                                              uint64_t num_slice));
-  MOCK_METHOD2(writev, Api::IoCallUint64Result(const Buffer::RawSlice* slices, uint64_t num_slice));
-  MOCK_METHOD5(sendmsg, Api::IoCallUint64Result(const Buffer::RawSlice* slices, uint64_t num_slice,
-                                                int flags, const Address::Ip* self_ip,
-                                                const Address::Instance& peer_address));
-  MOCK_METHOD4(recvmsg, Api::IoCallUint64Result(Buffer::RawSlice* slices, const uint64_t num_slice,
-                                                uint32_t self_port, RecvMsgOutput& output));
+  MOCK_METHOD(int, fd, (), (const));
+  MOCK_METHOD(Api::IoCallUint64Result, close, ());
+  MOCK_METHOD(bool, isOpen, (), (const));
+  MOCK_METHOD(Api::IoCallUint64Result, readv,
+              (uint64_t max_length, Buffer::RawSlice* slices, uint64_t num_slice));
+  MOCK_METHOD(Api::IoCallUint64Result, writev,
+              (const Buffer::RawSlice* slices, uint64_t num_slice));
+  MOCK_METHOD(Api::IoCallUint64Result, sendmsg,
+              (const Buffer::RawSlice* slices, uint64_t num_slice, int flags,
+               const Address::Ip* self_ip, const Address::Instance& peer_address));
+  MOCK_METHOD(Api::IoCallUint64Result, recvmsg,
+              (Buffer::RawSlice * slices, const uint64_t num_slice, uint32_t self_port,
+               RecvMsgOutput& output));
 };
 
 } // namespace Network

--- a/test/mocks/protobuf/mocks.h
+++ b/test/mocks/protobuf/mocks.h
@@ -12,7 +12,7 @@ public:
   MockValidationVisitor();
   ~MockValidationVisitor() override;
 
-  MOCK_METHOD1(onUnknownField, void(absl::string_view));
+  MOCK_METHOD(void, onUnknownField, (absl::string_view));
 };
 
 class MockValidationContext : public ValidationContext {
@@ -20,8 +20,8 @@ public:
   MockValidationContext();
   ~MockValidationContext() override;
 
-  MOCK_METHOD0(staticValidationVisitor, ValidationVisitor&());
-  MOCK_METHOD0(dynamicValidationVisitor, ValidationVisitor&());
+  MOCK_METHOD(ValidationVisitor&, staticValidationVisitor, ());
+  MOCK_METHOD(ValidationVisitor&, dynamicValidationVisitor, ());
 
   MockValidationVisitor static_validation_visitor_;
   MockValidationVisitor dynamic_validation_visitor_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -45,14 +45,14 @@ public:
   ~MockDirectResponseEntry() override;
 
   // DirectResponseEntry
-  MOCK_CONST_METHOD2(finalizeResponseHeaders,
-                     void(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info));
-  MOCK_CONST_METHOD1(newPath, std::string(const Http::HeaderMap& headers));
-  MOCK_CONST_METHOD2(rewritePathHeader,
-                     void(Http::HeaderMap& headers, bool insert_envoy_original_path));
-  MOCK_CONST_METHOD0(responseCode, Http::Code());
-  MOCK_CONST_METHOD0(responseBody, const std::string&());
-  MOCK_CONST_METHOD0(routeName, const std::string&());
+  MOCK_METHOD(void, finalizeResponseHeaders,
+              (Http::HeaderMap & headers, const StreamInfo::StreamInfo& stream_info), (const));
+  MOCK_METHOD(std::string, newPath, (const Http::HeaderMap& headers), (const));
+  MOCK_METHOD(void, rewritePathHeader, (Http::HeaderMap & headers, bool insert_envoy_original_path),
+              (const));
+  MOCK_METHOD(Http::Code, responseCode, (), (const));
+  MOCK_METHOD(const std::string&, responseBody, (), (const));
+  MOCK_METHOD(const std::string&, routeName, (), (const));
 };
 
 class TestCorsPolicy : public CorsPolicy {
@@ -102,8 +102,8 @@ public:
   std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
   uint32_t numRetries() const override { return num_retries_; }
   uint32_t retryOn() const override { return retry_on_; }
-  MOCK_CONST_METHOD0(retryHostPredicates, std::vector<Upstream::RetryHostPredicateSharedPtr>());
-  MOCK_CONST_METHOD0(retryPriority, Upstream::RetryPrioritySharedPtr());
+  MOCK_METHOD(std::vector<Upstream::RetryHostPredicateSharedPtr>, retryHostPredicates, (), (const));
+  MOCK_METHOD(Upstream::RetryPrioritySharedPtr, retryPriority, (), (const));
   uint32_t hostSelectionMaxAttempts() const override { return host_selection_max_attempts_; }
   const std::vector<uint32_t>& retriableStatusCodes() const override {
     return retriable_status_codes_;
@@ -138,19 +138,18 @@ public:
   void expectHedgedPerTryTimeoutRetry();
   void expectResetRetry();
 
-  MOCK_METHOD0(enabled, bool());
-  MOCK_METHOD2(shouldRetryHeaders,
-               RetryStatus(const Http::HeaderMap& response_headers, DoRetryCallback callback));
-  MOCK_METHOD1(wouldRetryFromHeaders, bool(const Http::HeaderMap& response_headers));
-  MOCK_METHOD2(shouldRetryReset,
-               RetryStatus(const Http::StreamResetReason reset_reason, DoRetryCallback callback));
-  MOCK_METHOD1(shouldHedgeRetryPerTryTimeout, RetryStatus(DoRetryCallback callback));
-  MOCK_METHOD1(onHostAttempted, void(Upstream::HostDescriptionConstSharedPtr));
-  MOCK_METHOD1(shouldSelectAnotherHost, bool(const Upstream::Host& host));
-  MOCK_METHOD2(priorityLoadForRetry,
-               const Upstream::HealthyAndDegradedLoad&(const Upstream::PrioritySet&,
-                                                       const Upstream::HealthyAndDegradedLoad&));
-  MOCK_CONST_METHOD0(hostSelectionMaxAttempts, uint32_t());
+  MOCK_METHOD(bool, enabled, ());
+  MOCK_METHOD(RetryStatus, shouldRetryHeaders,
+              (const Http::HeaderMap& response_headers, DoRetryCallback callback));
+  MOCK_METHOD(bool, wouldRetryFromHeaders, (const Http::HeaderMap& response_headers));
+  MOCK_METHOD(RetryStatus, shouldRetryReset,
+              (const Http::StreamResetReason reset_reason, DoRetryCallback callback));
+  MOCK_METHOD(RetryStatus, shouldHedgeRetryPerTryTimeout, (DoRetryCallback callback));
+  MOCK_METHOD(void, onHostAttempted, (Upstream::HostDescriptionConstSharedPtr));
+  MOCK_METHOD(bool, shouldSelectAnotherHost, (const Upstream::Host& host));
+  MOCK_METHOD(const Upstream::HealthyAndDegradedLoad&, priorityLoadForRetry,
+              (const Upstream::PrioritySet&, const Upstream::HealthyAndDegradedLoad&));
+  MOCK_METHOD(uint32_t, hostSelectionMaxAttempts, (), (const));
 
   DoRetryCallback callback_;
 };
@@ -161,13 +160,13 @@ public:
   ~MockRateLimitPolicyEntry() override;
 
   // Router::RateLimitPolicyEntry
-  MOCK_CONST_METHOD0(stage, uint64_t());
-  MOCK_CONST_METHOD0(disableKey, const std::string&());
-  MOCK_CONST_METHOD5(populateDescriptors,
-                     void(const RouteEntry& route,
-                          std::vector<Envoy::RateLimit::Descriptor>& descriptors,
-                          const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address));
+  MOCK_METHOD(uint64_t, stage, (), (const));
+  MOCK_METHOD(const std::string&, disableKey, (), (const));
+  MOCK_METHOD(void, populateDescriptors,
+              (const RouteEntry& route, std::vector<Envoy::RateLimit::Descriptor>& descriptors,
+               const std::string& local_service_cluster, const Http::HeaderMap& headers,
+               const Network::Address::Instance& remote_address),
+              (const));
 
   uint64_t stage_{};
   std::string disable_key_;
@@ -179,10 +178,9 @@ public:
   ~MockRateLimitPolicy() override;
 
   // Router::RateLimitPolicy
-  MOCK_CONST_METHOD1(
-      getApplicableRateLimit,
-      std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&(uint64_t stage));
-  MOCK_CONST_METHOD0(empty, bool());
+  MOCK_METHOD(std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&,
+              getApplicableRateLimit, (uint64_t stage), (const));
+  MOCK_METHOD(bool, empty, (), (const));
 
   std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>> rate_limit_policy_entry_;
 };
@@ -213,8 +211,9 @@ public:
     shadow_(cluster, request, timeout);
   }
 
-  MOCK_METHOD3(shadow_, void(const std::string& cluster, Http::MessagePtr& request,
-                             std::chrono::milliseconds timeout));
+  MOCK_METHOD(void, shadow_,
+              (const std::string& cluster, Http::MessagePtr& request,
+               std::chrono::milliseconds timeout));
 };
 
 class TestVirtualCluster : public VirtualCluster {
@@ -232,15 +231,15 @@ public:
   ~MockVirtualHost() override;
 
   // Router::VirtualHost
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
-  MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
-  MOCK_CONST_METHOD0(routeConfig, const Config&());
-  MOCK_CONST_METHOD1(perFilterConfig, const RouteSpecificFilterConfig*(const std::string&));
-  MOCK_CONST_METHOD0(includeAttemptCount, bool());
-  MOCK_METHOD0(retryPriority, Upstream::RetryPrioritySharedPtr());
-  MOCK_METHOD0(retryHostPredicate, Upstream::RetryHostPredicateSharedPtr());
-  MOCK_CONST_METHOD0(retryShadowBufferLimit, uint32_t());
+  MOCK_METHOD(const std::string&, name, (), (const));
+  MOCK_METHOD(const RateLimitPolicy&, rateLimitPolicy, (), (const));
+  MOCK_METHOD(const CorsPolicy*, corsPolicy, (), (const));
+  MOCK_METHOD(const Config&, routeConfig, (), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
+  MOCK_METHOD(bool, includeAttemptCount, (), (const));
+  MOCK_METHOD(Upstream::RetryPrioritySharedPtr, retryPriority, ());
+  MOCK_METHOD(Upstream::RetryHostPredicateSharedPtr, retryHostPredicate, ());
+  MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
 
   Stats::StatName statName() const override {
     stat_name_ = std::make_unique<Stats::StatNameManagedStorage>(name(), *symbol_table_);
@@ -260,10 +259,10 @@ public:
   ~MockHashPolicy() override;
 
   // Http::HashPolicy
-  MOCK_CONST_METHOD3(generateHash,
-                     absl::optional<uint64_t>(const Network::Address::Instance* downstream_address,
-                                              const Http::HeaderMap& headers,
-                                              const AddCookieCallback add_cookie));
+  MOCK_METHOD(absl::optional<uint64_t>, generateHash,
+              (const Network::Address::Instance* downstream_address, const Http::HeaderMap& headers,
+               const AddCookieCallback add_cookie),
+              (const));
 };
 
 class MockMetadataMatchCriteria : public MetadataMatchCriteria {
@@ -272,11 +271,12 @@ public:
   ~MockMetadataMatchCriteria() override;
 
   // Router::MetadataMatchCriteria
-  MOCK_CONST_METHOD0(metadataMatchCriteria,
-                     const std::vector<MetadataMatchCriterionConstSharedPtr>&());
-  MOCK_CONST_METHOD1(mergeMatchCriteria, MetadataMatchCriteriaConstPtr(const ProtobufWkt::Struct&));
-  MOCK_CONST_METHOD1(filterMatchCriteria,
-                     MetadataMatchCriteriaConstPtr(const std::set<std::string>&));
+  MOCK_METHOD(const std::vector<MetadataMatchCriterionConstSharedPtr>&, metadataMatchCriteria, (),
+              (const));
+  MOCK_METHOD(MetadataMatchCriteriaConstPtr, mergeMatchCriteria, (const ProtobufWkt::Struct&),
+              (const));
+  MOCK_METHOD(MetadataMatchCriteriaConstPtr, filterMatchCriteria, (const std::set<std::string>&),
+              (const));
 };
 
 class MockTlsContextMatchCriteria : public TlsContextMatchCriteria {
@@ -285,7 +285,7 @@ public:
   ~MockTlsContextMatchCriteria() override;
 
   // Router::MockTlsContextMatchCriteria
-  MOCK_CONST_METHOD0(presented, const absl::optional<bool>&());
+  MOCK_METHOD(const absl::optional<bool>&, presented, (), (const));
 };
 
 class MockPathMatchCriterion : public PathMatchCriterion {
@@ -294,8 +294,8 @@ public:
   ~MockPathMatchCriterion() override;
 
   // Router::PathMatchCriterion
-  MOCK_CONST_METHOD0(matchType, PathMatchType());
-  MOCK_CONST_METHOD0(matcher, const std::string&());
+  MOCK_METHOD(PathMatchType, matchType, (), (const));
+  MOCK_METHOD(const std::string&, matcher, (), (const));
 
   PathMatchType type_;
   std::string matcher_;
@@ -307,42 +307,43 @@ public:
   ~MockRouteEntry() override;
 
   // Router::Config
-  MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD0(clusterNotFoundResponseCode, Http::Code());
-  MOCK_CONST_METHOD3(finalizeRequestHeaders,
-                     void(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
-                          bool insert_envoy_original_path));
-  MOCK_CONST_METHOD2(finalizeResponseHeaders,
-                     void(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info));
-  MOCK_CONST_METHOD0(hashPolicy, const Http::HashPolicy*());
-  MOCK_CONST_METHOD0(hedgePolicy, const HedgePolicy&());
-  MOCK_CONST_METHOD0(metadataMatchCriteria, const Router::MetadataMatchCriteria*());
-  MOCK_CONST_METHOD0(tlsContextMatchCriteria, const Router::TlsContextMatchCriteria*());
-  MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
-  MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
-  MOCK_CONST_METHOD0(retryPolicy, const RetryPolicy&());
-  MOCK_CONST_METHOD0(retryShadowBufferLimit, uint32_t());
-  MOCK_CONST_METHOD0(shadowPolicies, const std::vector<ShadowPolicyPtr>&());
-  MOCK_CONST_METHOD0(timeout, std::chrono::milliseconds());
-  MOCK_CONST_METHOD0(idleTimeout, absl::optional<std::chrono::milliseconds>());
-  MOCK_CONST_METHOD0(maxGrpcTimeout, absl::optional<std::chrono::milliseconds>());
-  MOCK_CONST_METHOD0(grpcTimeoutOffset, absl::optional<std::chrono::milliseconds>());
-  MOCK_CONST_METHOD1(virtualCluster, const VirtualCluster*(const Http::HeaderMap& headers));
-  MOCK_CONST_METHOD0(virtualHostName, const std::string&());
-  MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
-  MOCK_CONST_METHOD0(autoHostRewrite, bool());
-  MOCK_CONST_METHOD0(opaqueConfig, const std::multimap<std::string, std::string>&());
-  MOCK_CONST_METHOD0(includeVirtualHostRateLimits, bool());
-  MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
-  MOCK_CONST_METHOD0(metadata, const envoy::config::core::v3::Metadata&());
-  MOCK_CONST_METHOD0(typedMetadata, const Envoy::Config::TypedMetadata&());
-  MOCK_CONST_METHOD0(pathMatchCriterion, const PathMatchCriterion&());
-  MOCK_CONST_METHOD1(perFilterConfig, const RouteSpecificFilterConfig*(const std::string&));
-  MOCK_CONST_METHOD0(includeAttemptCount, bool());
-  MOCK_CONST_METHOD0(upgradeMap, const UpgradeMap&());
-  MOCK_CONST_METHOD0(internalRedirectAction, InternalRedirectAction());
-  MOCK_CONST_METHOD0(maxInternalRedirects, uint32_t());
-  MOCK_CONST_METHOD0(routeName, const std::string&());
+  MOCK_METHOD(const std::string&, clusterName, (), (const));
+  MOCK_METHOD(Http::Code, clusterNotFoundResponseCode, (), (const));
+  MOCK_METHOD(void, finalizeRequestHeaders,
+              (Http::HeaderMap & headers, const StreamInfo::StreamInfo& stream_info,
+               bool insert_envoy_original_path),
+              (const));
+  MOCK_METHOD(void, finalizeResponseHeaders,
+              (Http::HeaderMap & headers, const StreamInfo::StreamInfo& stream_info), (const));
+  MOCK_METHOD(const Http::HashPolicy*, hashPolicy, (), (const));
+  MOCK_METHOD(const HedgePolicy&, hedgePolicy, (), (const));
+  MOCK_METHOD(const Router::MetadataMatchCriteria*, metadataMatchCriteria, (), (const));
+  MOCK_METHOD(const Router::TlsContextMatchCriteria*, tlsContextMatchCriteria, (), (const));
+  MOCK_METHOD(Upstream::ResourcePriority, priority, (), (const));
+  MOCK_METHOD(const RateLimitPolicy&, rateLimitPolicy, (), (const));
+  MOCK_METHOD(const RetryPolicy&, retryPolicy, (), (const));
+  MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
+  MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
+  MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxGrpcTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutOffset, (), (const));
+  MOCK_METHOD(const VirtualCluster*, virtualCluster, (const Http::HeaderMap& headers), (const));
+  MOCK_METHOD(const std::string&, virtualHostName, (), (const));
+  MOCK_METHOD(const VirtualHost&, virtualHost, (), (const));
+  MOCK_METHOD(bool, autoHostRewrite, (), (const));
+  MOCK_METHOD((const std::multimap<std::string, std::string>&), opaqueConfig, (), (const));
+  MOCK_METHOD(bool, includeVirtualHostRateLimits, (), (const));
+  MOCK_METHOD(const CorsPolicy*, corsPolicy, (), (const));
+  MOCK_METHOD(const envoy::config::core::v3::Metadata&, metadata, (), (const));
+  MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
+  MOCK_METHOD(const PathMatchCriterion&, pathMatchCriterion, (), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
+  MOCK_METHOD(bool, includeAttemptCount, (), (const));
+  MOCK_METHOD(const UpgradeMap&, upgradeMap, (), (const));
+  MOCK_METHOD(InternalRedirectAction, internalRedirectAction, (), (const));
+  MOCK_METHOD(uint32_t, maxInternalRedirects, (), (const));
+  MOCK_METHOD(const std::string&, routeName, (), (const));
 
   std::string cluster_name_{"fake_cluster"};
   std::string route_name_{"fake_route_name"};
@@ -368,8 +369,8 @@ public:
   ~MockDecorator() override;
 
   // Router::Decorator
-  MOCK_CONST_METHOD0(getOperation, const std::string&());
-  MOCK_CONST_METHOD1(apply, void(Tracing::Span& span));
+  MOCK_METHOD(const std::string&, getOperation, (), (const));
+  MOCK_METHOD(void, apply, (Tracing::Span & span), (const));
 
   std::string operation_{"fake_operation"};
 };
@@ -380,10 +381,10 @@ public:
   ~MockRouteTracing() override;
 
   // Router::RouteTracing
-  MOCK_CONST_METHOD0(getClientSampling, const envoy::type::v3::FractionalPercent&());
-  MOCK_CONST_METHOD0(getRandomSampling, const envoy::type::v3::FractionalPercent&());
-  MOCK_CONST_METHOD0(getOverallSampling, const envoy::type::v3::FractionalPercent&());
-  MOCK_CONST_METHOD0(getCustomTags, const Tracing::CustomTagMap&());
+  MOCK_METHOD(const envoy::type::v3::FractionalPercent&, getClientSampling, (), (const));
+  MOCK_METHOD(const envoy::type::v3::FractionalPercent&, getRandomSampling, (), (const));
+  MOCK_METHOD(const envoy::type::v3::FractionalPercent&, getOverallSampling, (), (const));
+  MOCK_METHOD(const Tracing::CustomTagMap&, getCustomTags, (), (const));
 };
 
 class MockRoute : public Route {
@@ -392,11 +393,11 @@ public:
   ~MockRoute() override;
 
   // Router::Route
-  MOCK_CONST_METHOD0(directResponseEntry, const DirectResponseEntry*());
-  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
-  MOCK_CONST_METHOD0(decorator, const Decorator*());
-  MOCK_CONST_METHOD0(tracingConfig, const RouteTracing*());
-  MOCK_CONST_METHOD1(perFilterConfig, const RouteSpecificFilterConfig*(const std::string&));
+  MOCK_METHOD(const DirectResponseEntry*, directResponseEntry, (), (const));
+  MOCK_METHOD(const RouteEntry*, routeEntry, (), (const));
+  MOCK_METHOD(const Decorator*, decorator, (), (const));
+  MOCK_METHOD(const RouteTracing*, tracingConfig, (), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
 
   testing::NiceMock<MockRouteEntry> route_entry_;
   testing::NiceMock<MockDecorator> decorator_;
@@ -409,13 +410,13 @@ public:
   ~MockConfig() override;
 
   // Router::Config
-  MOCK_CONST_METHOD3(route, RouteConstSharedPtr(const Http::HeaderMap&,
-                                                const Envoy::StreamInfo::StreamInfo&,
-                                                uint64_t random_value));
-  MOCK_CONST_METHOD0(internalOnlyHeaders, const std::list<Http::LowerCaseString>&());
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(usesVhds, bool());
-  MOCK_CONST_METHOD0(mostSpecificHeaderMutationsWins, bool());
+  MOCK_METHOD(RouteConstSharedPtr, route,
+              (const Http::HeaderMap&, const Envoy::StreamInfo::StreamInfo&, uint64_t random_value),
+              (const));
+  MOCK_METHOD(const std::list<Http::LowerCaseString>&, internalOnlyHeaders, (), (const));
+  MOCK_METHOD(const std::string&, name, (), (const));
+  MOCK_METHOD(bool, usesVhds, (), (const));
+  MOCK_METHOD(bool, mostSpecificHeaderMutationsWins, (), (const));
 
   std::shared_ptr<MockRoute> route_;
   std::list<Http::LowerCaseString> internal_only_headers_;
@@ -427,14 +428,14 @@ public:
   MockRouteConfigProvider();
   ~MockRouteConfigProvider() override;
 
-  MOCK_METHOD0(config, ConfigConstSharedPtr());
-  MOCK_CONST_METHOD0(configInfo, absl::optional<ConfigInfo>());
-  MOCK_CONST_METHOD0(lastUpdated, SystemTime());
-  MOCK_METHOD0(onConfigUpdate, void());
-  MOCK_CONST_METHOD1(validateConfig, void(const envoy::config::route::v3::RouteConfiguration&));
-  MOCK_METHOD3(requestVirtualHostsUpdate,
-               void(const std::string&, Event::Dispatcher&,
-                    std::weak_ptr<Http::RouteConfigUpdatedCallback> route_config_updated_cb));
+  MOCK_METHOD(ConfigConstSharedPtr, config, ());
+  MOCK_METHOD(absl::optional<ConfigInfo>, configInfo, (), (const));
+  MOCK_METHOD(SystemTime, lastUpdated, (), (const));
+  MOCK_METHOD(void, onConfigUpdate, ());
+  MOCK_METHOD(void, validateConfig, (const envoy::config::route::v3::RouteConfiguration&), (const));
+  MOCK_METHOD(void, requestVirtualHostsUpdate,
+              (const std::string&, Event::Dispatcher&,
+               std::weak_ptr<Http::RouteConfigUpdatedCallback> route_config_updated_cb));
 
   std::shared_ptr<NiceMock<MockConfig>> route_config_{new NiceMock<MockConfig>()};
 };
@@ -444,15 +445,13 @@ public:
   MockRouteConfigProviderManager();
   ~MockRouteConfigProviderManager() override;
 
-  MOCK_METHOD4(createRdsRouteConfigProvider,
-               RouteConfigProviderSharedPtr(
-                   const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
-                   Server::Configuration::FactoryContext& factory_context,
-                   const std::string& stat_prefix, Init::Manager& init_manager));
-  MOCK_METHOD2(
-      createStaticRouteConfigProvider,
-      RouteConfigProviderPtr(const envoy::config::route::v3::RouteConfiguration& route_config,
-                             Server::Configuration::FactoryContext& factory_context));
+  MOCK_METHOD(RouteConfigProviderSharedPtr, createRdsRouteConfigProvider,
+              (const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
+               Server::Configuration::FactoryContext& factory_context,
+               const std::string& stat_prefix, Init::Manager& init_manager));
+  MOCK_METHOD(RouteConfigProviderPtr, createStaticRouteConfigProvider,
+              (const envoy::config::route::v3::RouteConfiguration& route_config,
+               Server::Configuration::FactoryContext& factory_context));
 };
 
 class MockScopedConfig : public ScopedConfig {
@@ -460,7 +459,7 @@ public:
   MockScopedConfig();
   ~MockScopedConfig() override;
 
-  MOCK_CONST_METHOD1(getRouteConfig, ConfigConstSharedPtr(const Http::HeaderMap& headers));
+  MOCK_METHOD(ConfigConstSharedPtr, getRouteConfig, (const Http::HeaderMap& headers), (const));
 
   std::shared_ptr<MockConfig> route_config_{new NiceMock<MockConfig>()};
 };
@@ -471,11 +470,11 @@ public:
   ~MockScopedRouteConfigProvider() override;
 
   // Config::ConfigProvider
-  MOCK_CONST_METHOD0(lastUpdated, SystemTime());
-  MOCK_CONST_METHOD0(getConfigProto, Protobuf::Message*());
-  MOCK_CONST_METHOD0(getConfigProtos, Envoy::Config::ConfigProvider::ConfigProtoVector());
-  MOCK_CONST_METHOD0(getConfig, ConfigConstSharedPtr());
-  MOCK_CONST_METHOD0(apiType, ApiType());
+  MOCK_METHOD(SystemTime, lastUpdated, (), (const));
+  MOCK_METHOD(Protobuf::Message*, getConfigProto, (), (const));
+  MOCK_METHOD(Envoy::Config::ConfigProvider::ConfigProtoVector, getConfigProtos, (), (const));
+  MOCK_METHOD(ConfigConstSharedPtr, getConfig, (), (const));
+  MOCK_METHOD(ApiType, apiType, (), (const));
 
   std::shared_ptr<MockScopedConfig> config_;
 };

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -88,7 +88,7 @@ public:
 
 class MockLdsApi : public LdsApi {
 public:
-  MOCK_CONST_METHOD0(versionInfo, std::string());
+  MOCK_METHOD(std::string, versionInfo, (), (const));
 };
 
 TEST_F(ListenerManagerImplWithRealFiltersTest, EmptyFilter) {

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -31,7 +31,7 @@ public:
   ListenerHandle() { EXPECT_CALL(*drain_manager_, startParentShutdownSequence()).Times(0); }
   ~ListenerHandle() { onDestroy(); }
 
-  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD(void, onDestroy, ());
 
   Init::ExpectableTargetImpl target_;
   MockDrainManager* drain_manager_ = new MockDrainManager();


### PR DESCRIPTION
update remaining uses of deprecated MOCK_METHOD[0-9] in favor of the new style.
