### PR TITLE
router: not to include port in SNI

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -521,15 +521,15 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   if (upstream_http_protocol_options.has_value() &&
       upstream_http_protocol_options.value().auto_sni()) {
-    const auto host_str = headers.Host()->value().getStringView();
-    const auto parsed_authority = Http::Utility::parseAuthority(host_str);
+    const auto parsed_authority =
+        Http::Utility::parseAuthority(headers.Host()->value().getStringView());
     if (!parsed_authority.is_ip_address_) {
       // TODO: Add SAN verification here and use it from dynamic_forward_proxy
       // Update filter state with the host/authority to use for setting SNI in the transport
       // socket options. This is referenced during the getConnPool() call below.
       callbacks_->streamInfo().filterState().setData(
           Network::UpstreamServerName::key(),
-          std::make_unique<Network::UpstreamServerName>(host_str),
+          std::make_unique<Network::UpstreamServerName>(parsed_authority.host_),
           StreamInfo::FilterState::StateType::Mutable);
     }
   }

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -100,5 +100,25 @@ TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
   EXPECT_STREQ(NULL, SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
 }
 
+TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
+  setup();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  const auto response_ =
+      sendRequestAndWaitForResponse(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                            {":path", "/"},
+                                                            {":scheme", "http"},
+                                                            {":authority", "example.com:8080"}},
+                                    0, default_response_headers_, 0);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response_->complete());
+
+  const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
+      dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
+          fake_upstream_connection_->connection().ssl().get());
+  EXPECT_STREQ("example.com",
+               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -100,7 +100,7 @@ TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
   EXPECT_STREQ(NULL, SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
 }
 
-TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
+TEST_P(AutoSniIntegrationTest, PassingHostWithoutPort) {
   setup();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   const auto response_ =


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
SNI shouldn't include port number per spec (RFC).

Risk Level: Low
Testing: integration test
Docs Changes: N/A
Release Notes: N/A
