### PR TITLE
filter: Add header fields and constants for HTTP Caching Filter #868

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -269,6 +269,7 @@ private:
   HEADER_FUNC(AccessControlAllowCredentials)                                                       \
   HEADER_FUNC(AccessControlExposeHeaders)                                                          \
   HEADER_FUNC(AccessControlMaxAge)                                                                 \
+  HEADER_FUNC(Age)                                                                                 \
   HEADER_FUNC(Authorization)                                                                       \
   HEADER_FUNC(CacheControl)                                                                        \
   HEADER_FUNC(ClientTraceId)                                                                       \
@@ -307,6 +308,7 @@ private:
   HEADER_FUNC(EnvoyUpstreamServiceTime)                                                            \
   HEADER_FUNC(Etag)                                                                                \
   HEADER_FUNC(Expect)                                                                              \
+  HEADER_FUNC(Expires)                                                                             \
   HEADER_FUNC(ForwardedClientCert)                                                                 \
   HEADER_FUNC(ForwardedFor)                                                                        \
   HEADER_FUNC(ForwardedProto)                                                                      \

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -59,6 +59,7 @@ public:
   const LowerCaseString AccessControlExposeHeaders{"access-control-expose-headers"};
   const LowerCaseString AccessControlMaxAge{"access-control-max-age"};
   const LowerCaseString AccessControlAllowCredentials{"access-control-allow-credentials"};
+  const LowerCaseString Age{"age"};
   const LowerCaseString Authorization{"authorization"};
   const LowerCaseString ProxyAuthenticate{"proxy-authenticate"};
   const LowerCaseString ProxyAuthorization{"proxy-authorization"};
@@ -117,6 +118,7 @@ public:
   const LowerCaseString EnvoyDecoratorOperation{absl::StrCat(prefix(), "-decorator-operation")};
   const LowerCaseString Etag{"etag"};
   const LowerCaseString Expect{"expect"};
+  const LowerCaseString Expires{"expires"};
   const LowerCaseString ForwardedClientCert{"x-forwarded-client-cert"};
   const LowerCaseString ForwardedFor{"x-forwarded-for"};
   const LowerCaseString ForwardedHost{"x-forwarded-host"};

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -173,6 +173,7 @@ public:
     const std::string NoCache{"no-cache"};
     const std::string NoCacheMaxAge0{"no-cache, max-age=0"};
     const std::string NoTransform{"no-transform"};
+    const std::string Private{"private"};
   } CacheControlValues;
 
   struct {


### PR DESCRIPTION
Description: Add "Age" and "Expires" direct access headers and HeaderValues constants, and "private" CacheControlValues constant. Broken out verbatim from #7198.
Risk Level: Low: No behavior change expected.
Testing: No new tests needed
Docs Changes: None
Release Notes: None
#868