### PR TITLE
string matcher: add ignore_case to StringMatcher

### DIFF
--- a/api/envoy/type/matcher/string.proto
+++ b/api/envoy/type/matcher/string.proto
@@ -14,7 +14,7 @@ option java_multiple_files = true;
 // [#protodoc-title: String matcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message StringMatcher {
   oneof match_pattern {
     option (validate.required) = true;
@@ -64,6 +64,11 @@ message StringMatcher {
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
   }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
 }
 
 // Specifies a list of ways to match a string.

--- a/api/envoy/type/matcher/v3/string.proto
+++ b/api/envoy/type/matcher/v3/string.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 // [#protodoc-title: String matcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message StringMatcher {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.matcher.StringMatcher";
 
@@ -53,6 +53,11 @@ message StringMatcher {
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
   }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
 }
 
 // Specifies a list of ways to match a string.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,6 +5,7 @@ Version history
 ================
 * config: use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 * retry: added a retry predicate that :ref:`rejects hosts based on metadata. <envoy_api_field_route.RetryPolicy.retry_host_predicate>`
+* string matcher: added :ref:`ignore_case <envoy_api_field_type.matcher.StringMatcher.ignore_case>` that allows case insensitive matching.
 * upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`. 
 
 1.13.0 (January 20, 2020)

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,7 +5,6 @@ Version history
 ================
 * config: use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 * retry: added a retry predicate that :ref:`rejects hosts based on metadata. <envoy_api_field_route.RetryPolicy.retry_host_predicate>`
-* string matcher: added :ref:`ignore_case <envoy_api_field_type.matcher.StringMatcher.ignore_case>` that allows case insensitive matching.
 * upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`. 
 
 1.13.0 (January 20, 2020)

--- a/generated_api_shadow/envoy/type/matcher/string.proto
+++ b/generated_api_shadow/envoy/type/matcher/string.proto
@@ -14,7 +14,7 @@ option java_multiple_files = true;
 // [#protodoc-title: String matcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message StringMatcher {
   oneof match_pattern {
     option (validate.required) = true;
@@ -64,6 +64,11 @@ message StringMatcher {
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
   }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
 }
 
 // Specifies a list of ways to match a string.

--- a/generated_api_shadow/envoy/type/matcher/v3/string.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/string.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 // [#protodoc-title: String matcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message StringMatcher {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.matcher.StringMatcher";
 
@@ -68,6 +68,11 @@ message StringMatcher {
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
   }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
 }
 
 // Specifies a list of ways to match a string.

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -65,10 +65,16 @@ StringMatcherImpl::StringMatcherImpl(const envoy::type::matcher::v3::StringMatch
     : matcher_(matcher) {
   if (matcher.match_pattern_case() ==
       envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kHiddenEnvoyDeprecatedRegex) {
+    if (matcher.ignore_case()) {
+      PANIC("ignore_case has no effect for regex.");
+    }
     regex_ =
         Regex::Utility::parseStdRegexAsCompiledMatcher(matcher_.hidden_envoy_deprecated_regex());
   } else if (matcher.match_pattern_case() ==
              envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kSafeRegex) {
+    if (matcher.ignore_case()) {
+      PANIC("ignore_case has no effect for safe_regex.");
+    }
     regex_ = Regex::Utility::parseRegex(matcher_.safe_regex());
   }
 }

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -84,11 +84,14 @@ bool StringMatcherImpl::match(const ProtobufWkt::Value& value) const {
 bool StringMatcherImpl::match(const absl::string_view value) const {
   switch (matcher_.match_pattern_case()) {
   case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact:
-    return matcher_.exact() == value;
+    return matcher_.ignore_case() ? absl::EqualsIgnoreCase(value, matcher_.exact())
+                                  : value == matcher_.exact();
   case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kPrefix:
-    return absl::StartsWith(value, matcher_.prefix());
+    return matcher_.ignore_case() ? absl::StartsWithIgnoreCase(value, matcher_.prefix())
+                                  : absl::StartsWith(value, matcher_.prefix());
   case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kSuffix:
-    return absl::EndsWith(value, matcher_.suffix());
+    return matcher_.ignore_case() ? absl::EndsWithIgnoreCase(value, matcher_.suffix())
+                                  : absl::EndsWith(value, matcher_.suffix());
   case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kHiddenEnvoyDeprecatedRegex:
   case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kSafeRegex:
     return regex_->match(value);

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -66,14 +66,14 @@ StringMatcherImpl::StringMatcherImpl(const envoy::type::matcher::v3::StringMatch
   if (matcher.match_pattern_case() ==
       envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kHiddenEnvoyDeprecatedRegex) {
     if (matcher.ignore_case()) {
-      PANIC("ignore_case has no effect for regex.");
+      throw EnvoyException("ignore_case has no effect for regex.");
     }
     regex_ =
         Regex::Utility::parseStdRegexAsCompiledMatcher(matcher_.hidden_envoy_deprecated_regex());
   } else if (matcher.match_pattern_case() ==
              envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kSafeRegex) {
     if (matcher.ignore_case()) {
-      PANIC("ignore_case has no effect for safe_regex.");
+      throw EnvoyException("ignore_case has no effect for safe_regex.");
     }
     regex_ = Regex::Utility::parseRegex(matcher_.safe_regex());
   }

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -137,6 +137,7 @@ envoy_cc_test(
         "//source/common/common:matchers_lib",
         "//source/common/config:metadata_lib",
         "//source/common/protobuf:utility_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",
     ],

--- a/test/common/common/matchers_test.cc
+++ b/test/common/common/matchers_test.cc
@@ -1,3 +1,4 @@
+#include "envoy/common/exception.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/type/matcher/v3/metadata.pb.h"
 #include "envoy/type/matcher/v3/string.pb.h"
@@ -6,6 +7,8 @@
 #include "common/common/matchers.h"
 #include "common/config/metadata.h"
 #include "common/protobuf/protobuf.h"
+
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -310,6 +313,15 @@ TEST(StringMatcher, SafeRegexValue) {
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("foo"));
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("foobar"));
   EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("bar"));
+}
+
+TEST(StringMatcher, SafeRegexValueIgnoreCase) {
+  envoy::type::matcher::v3::StringMatcher matcher;
+  matcher.set_ignore_case(true);
+  matcher.mutable_safe_regex()->mutable_google_re2();
+  matcher.mutable_safe_regex()->set_regex("foo");
+  EXPECT_THROW_WITH_MESSAGE(Matchers::StringMatcherImpl(matcher).match("foo"), EnvoyException,
+                            "ignore_case has no effect for safe_regex.");
 }
 
 TEST(LowerCaseStringMatcher, MatchExactValue) {

--- a/test/common/common/matchers_test.cc
+++ b/test/common/common/matchers_test.cc
@@ -258,6 +258,36 @@ TEST(MetadataTest, MatchDoubleListValue) {
   metadataValue.Clear();
 }
 
+TEST(StringMatcher, ExactMatchIgnoreCase) {
+  envoy::type::matcher::v3::StringMatcher matcher;
+  matcher.set_exact("exact");
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("exact"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("EXACT"));
+  matcher.set_ignore_case(true);
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("exact"));
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("EXACT"));
+}
+
+TEST(StringMatcher, PrefixMatchIgnoreCase) {
+  envoy::type::matcher::v3::StringMatcher matcher;
+  matcher.set_prefix("prefix");
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("prefix-abc"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("PREFIX-ABC"));
+  matcher.set_ignore_case(true);
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("prefix-abc"));
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("PREFIX-ABC"));
+}
+
+TEST(StringMatcher, SuffixMatchIgnoreCase) {
+  envoy::type::matcher::v3::StringMatcher matcher;
+  matcher.set_suffix("suffix");
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("abc-suffix"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("ABC-SUFFIX"));
+  matcher.set_ignore_case(true);
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("abc-suffix"));
+  EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("ABC-SUFFIX"));
+}
+
 TEST(StringMatcher, SafeRegexValue) {
   envoy::type::matcher::v3::StringMatcher matcher;
   matcher.mutable_safe_regex()->mutable_google_re2();

--- a/test/common/common/matchers_test.cc
+++ b/test/common/common/matchers_test.cc
@@ -263,9 +263,14 @@ TEST(StringMatcher, ExactMatchIgnoreCase) {
   matcher.set_exact("exact");
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("exact"));
   EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("EXACT"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("exacz"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("other"));
+
   matcher.set_ignore_case(true);
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("exact"));
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("EXACT"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("exacz"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("other"));
 }
 
 TEST(StringMatcher, PrefixMatchIgnoreCase) {
@@ -273,9 +278,14 @@ TEST(StringMatcher, PrefixMatchIgnoreCase) {
   matcher.set_prefix("prefix");
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("prefix-abc"));
   EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("PREFIX-ABC"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("prefiz-abc"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("other"));
+
   matcher.set_ignore_case(true);
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("prefix-abc"));
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("PREFIX-ABC"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("prefiz-abc"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("other"));
 }
 
 TEST(StringMatcher, SuffixMatchIgnoreCase) {
@@ -283,9 +293,14 @@ TEST(StringMatcher, SuffixMatchIgnoreCase) {
   matcher.set_suffix("suffix");
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("abc-suffix"));
   EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("ABC-SUFFIX"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("abc-suffiz"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("other"));
+
   matcher.set_ignore_case(true);
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("abc-suffix"));
   EXPECT_TRUE(Matchers::StringMatcherImpl(matcher).match("ABC-SUFFIX"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("abc-suffiz"));
+  EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("other"));
 }
 
 TEST(StringMatcher, SafeRegexValue) {

--- a/test/common/common/matchers_test.cc
+++ b/test/common/common/matchers_test.cc
@@ -315,6 +315,14 @@ TEST(StringMatcher, SafeRegexValue) {
   EXPECT_FALSE(Matchers::StringMatcherImpl(matcher).match("bar"));
 }
 
+TEST(StringMatcher, RegexValueIgnoreCase) {
+  envoy::type::matcher::v3::StringMatcher matcher;
+  matcher.set_ignore_case(true);
+  matcher.set_hidden_envoy_deprecated_regex("foo");
+  EXPECT_THROW_WITH_MESSAGE(Matchers::StringMatcherImpl(matcher).match("foo"), EnvoyException,
+                            "ignore_case has no effect for regex.");
+}
+
 TEST(StringMatcher, SafeRegexValueIgnoreCase) {
   envoy::type::matcher::v3::StringMatcher matcher;
   matcher.set_ignore_case(true);


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: add ignore_case to StringMatcher that allows case insensitive exact/prefix/suffix string matching
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
