### PR TITLE
metrics service: force link v2 config

### DIFF
--- a/source/extensions/stat_sinks/metrics_service/BUILD
+++ b/source/extensions/stat_sinks/metrics_service/BUILD
@@ -32,6 +32,7 @@ envoy_cc_library(
     hdrs = ["grpc_metrics_proto_descriptors.h"],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/config:api_version_lib",
         "//source/common/protobuf",
         "@envoy_api//envoy/config/metrics/v2:pkg_cc_proto",
         "@envoy_api//envoy/service/metrics/v2:pkg_cc_proto",

--- a/source/extensions/stat_sinks/metrics_service/BUILD
+++ b/source/extensions/stat_sinks/metrics_service/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/protobuf",
+        "@envoy_api//envoy/config/metrics/v2:pkg_cc_proto",
         "@envoy_api//envoy/service/metrics/v2:pkg_cc_proto",
     ],
 )

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
@@ -5,6 +5,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
+#include "common/config/api_version.h"
 #include "common/protobuf/protobuf.h"
 
 namespace Envoy {
@@ -14,11 +15,11 @@ namespace MetricsService {
 
 void validateProtoDescriptors() {
   // https://github.com/envoyproxy/envoy/issues/9639
-  const envoy::service::metrics::v2::StreamMetricsMessage _dummy_service_v2;
+  const API_NO_BOOST(envoy::service::metrics::v2::StreamMetricsMessage) _dummy_service_v2;
   // https://github.com/envoyproxy/envoy/pull/9618 made it necessary to register the previous
   // version's config descriptor by calling ApiTypeOracle::getEarlierVersionDescriptor which has an
   // assertion for nullptr types.
-  const envoy::config::metrics::v2::MetricsServiceConfig _dummy_config_v2;
+  const API_NO_BOOST(envoy::config::metrics::v2::MetricsServiceConfig) _dummy_config_v2;
 
   const auto method = "envoy.service.metrics.v2.MetricsService.StreamMetrics";
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
@@ -1,6 +1,7 @@
 #include "extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.h"
 
 #include "envoy/service/metrics/v2/metrics_service.pb.h"
+#include "envoy/config/metrics/v2/metrics_service.pb.h"
 
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
@@ -13,12 +14,22 @@ namespace MetricsService {
 
 void validateProtoDescriptors() {
   // https://github.com/envoyproxy/envoy/issues/9639
-  const envoy::service::metrics::v2::StreamMetricsMessage _dummy_v2;
+  const envoy::service::metrics::v2::StreamMetricsMessage _dummy_service_v2;
+  // https://github.com/envoyproxy/envoy/pull/9618 made it necessary to register the previous
+  // version's config descriptor by calling ApiTypeOracle::getEarlierVersionDescriptor which has an
+  // assertion for nullptr types.
+  const envoy::config::metrics::v2::MetricsServiceConfig _dummy_config_v2;
 
   const auto method = "envoy.service.metrics.v2.MetricsService.StreamMetrics";
 
   RELEASE_ASSERT(Protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) != nullptr,
                  "");
+
+  const auto config = "envoy.config.metrics.v2.MetricsServiceConfig";
+
+  // Keeping this as an ASSERT because ApiTypeOracle::getEarlierVersionDescriptor also has an
+  // ASSERT.
+  ASSERT(Protobuf::DescriptorPool::generated_pool()->FindMessageTypeByName(config) != nullptr, "");
 };
 } // namespace MetricsService
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.cc
@@ -1,7 +1,7 @@
 #include "extensions/stat_sinks/metrics_service/grpc_metrics_proto_descriptors.h"
 
-#include "envoy/service/metrics/v2/metrics_service.pb.h"
 #include "envoy/config/metrics/v2/metrics_service.pb.h"
+#include "envoy/service/metrics/v2/metrics_service.pb.h"
 
 #include "common/common/assert.h"
 #include "common/common/fmt.h"


### PR DESCRIPTION
Description: force link the v2 proto for metrics service config. Needed in some linking scenarios. Related to #9639.
Risk Level: low
Testing: on an iOS build of Envoy Mobile.

Signed-off-by: Jose Nino <jnino@lyft.com>