### PR TITLE
runtime: use string_view for snapshot lookup

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -114,7 +114,7 @@ public:
    * @param default_value supplies the default value that will be used if either the key
    *        does not exist or it is not a boolean.
    */
-  virtual bool deprecatedFeatureEnabled(const std::string& key, bool default_enabled) const PURE;
+  virtual bool deprecatedFeatureEnabled(absl::string_view key, bool default_enabled) const PURE;
 
   // Returns true if a runtime feature is enabled.
   //
@@ -135,7 +135,7 @@ public:
    *        does not exist or it is not an integer.
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key, uint64_t default_value) const PURE;
+  virtual bool featureEnabled(absl::string_view key, uint64_t default_value) const PURE;
 
   /**
    * Test if a feature is enabled using a supplied stable random value. This variant is used if
@@ -147,7 +147,7 @@ public:
    *        is enabled.
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key, uint64_t default_value,
+  virtual bool featureEnabled(absl::string_view key, uint64_t default_value,
                               uint64_t random_value) const PURE;
 
   /**
@@ -164,7 +164,7 @@ public:
    *        of [0, num_buckets).
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key, uint64_t default_value, uint64_t random_value,
+  virtual bool featureEnabled(absl::string_view key, uint64_t default_value, uint64_t random_value,
                               uint64_t num_buckets) const PURE;
 
   /**
@@ -184,7 +184,7 @@ public:
    *        does not exist or it is not a fractional percent.
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key,
+  virtual bool featureEnabled(absl::string_view key,
                               const envoy::type::v3::FractionalPercent& default_value) const PURE;
 
   /**
@@ -201,7 +201,7 @@ public:
    *        is enabled.
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key,
+  virtual bool featureEnabled(absl::string_view key,
                               const envoy::type::v3::FractionalPercent& default_value,
                               uint64_t random_value) const PURE;
 
@@ -210,14 +210,14 @@ public:
    * @param key supplies the key to fetch.
    * @return const std::string& the value or empty string if the key does not exist.
    */
-  virtual const std::string& get(const std::string& key) const PURE;
+  virtual const std::string& get(absl::string_view key) const PURE;
 
   /**
    * Returns whether the key has any value set.
    * @param key supplies the key to check.
    * @return bool if the key exists.
    */
-  virtual bool exists(const std::string& key) const PURE;
+  virtual bool exists(absl::string_view key) const PURE;
 
   /**
    * Fetch an integer runtime key. Runtime keys larger than ~2^53 may not be accurately converted
@@ -227,7 +227,7 @@ public:
    *        contain an integer.
    * @return uint64_t the runtime value or the default value.
    */
-  virtual uint64_t getInteger(const std::string& key, uint64_t default_value) const PURE;
+  virtual uint64_t getInteger(absl::string_view key, uint64_t default_value) const PURE;
 
   /**
    * Fetch a double runtime key.
@@ -236,7 +236,7 @@ public:
    *        contain a double.
    * @return double the runtime value or the default value.
    */
-  virtual double getDouble(const std::string& key, double default_value) const PURE;
+  virtual double getDouble(absl::string_view key, double default_value) const PURE;
 
   /**
    * Fetch a boolean runtime key.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -187,7 +187,7 @@ std::string RandomGeneratorImpl::uuid() {
   return std::string(uuid, UUID_LENGTH);
 }
 
-bool SnapshotImpl::deprecatedFeatureEnabled(const std::string& key, bool default_value) const {
+bool SnapshotImpl::deprecatedFeatureEnabled(absl::string_view key, bool default_value) const {
   // If the value is not explicitly set as a runtime boolean, trust the proto annotations passed as
   // default_value.
   if (!getBoolean(key, default_value)) {
@@ -211,12 +211,12 @@ bool SnapshotImpl::runtimeFeatureEnabled(absl::string_view key) const {
   return getBoolean(key, RuntimeFeaturesDefaults::get().enabledByDefault(key));
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key, uint64_t default_value,
+bool SnapshotImpl::featureEnabled(absl::string_view key, uint64_t default_value,
                                   uint64_t random_value, uint64_t num_buckets) const {
   return random_value % num_buckets < std::min(getInteger(key, default_value), num_buckets);
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key, uint64_t default_value) const {
+bool SnapshotImpl::featureEnabled(absl::string_view key, uint64_t default_value) const {
   // Avoid PRNG if we know we don't need it.
   uint64_t cutoff = std::min(getInteger(key, default_value), static_cast<uint64_t>(100));
   if (cutoff == 0) {
@@ -228,12 +228,12 @@ bool SnapshotImpl::featureEnabled(const std::string& key, uint64_t default_value
   }
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key, uint64_t default_value,
+bool SnapshotImpl::featureEnabled(absl::string_view key, uint64_t default_value,
                                   uint64_t random_value) const {
   return featureEnabled(key, default_value, random_value, 100);
 }
 
-const std::string& SnapshotImpl::get(const std::string& key) const {
+const std::string& SnapshotImpl::get(absl::string_view key) const {
   ASSERT(!isRuntimeFeature(key)); // Make sure runtime guarding is only used for getBoolean
   auto entry = values_.find(key);
   if (entry == values_.end()) {
@@ -243,12 +243,12 @@ const std::string& SnapshotImpl::get(const std::string& key) const {
   }
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key,
+bool SnapshotImpl::featureEnabled(absl::string_view key,
                                   const envoy::type::v3::FractionalPercent& default_value) const {
   return featureEnabled(key, default_value, generator_.random());
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key,
+bool SnapshotImpl::featureEnabled(absl::string_view key,
                                   const envoy::type::v3::FractionalPercent& default_value,
                                   uint64_t random_value) const {
   const auto& entry = values_.find(key);
@@ -275,7 +275,7 @@ bool SnapshotImpl::featureEnabled(const std::string& key,
   return ProtobufPercentHelper::evaluateFractionalPercent(percent, random_value);
 }
 
-uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value) const {
+uint64_t SnapshotImpl::getInteger(absl::string_view key, uint64_t default_value) const {
   ASSERT(!isRuntimeFeature(key));
   auto entry = values_.find(key);
   if (entry == values_.end() || !entry->second.uint_value_) {
@@ -285,7 +285,7 @@ uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value
   }
 }
 
-double SnapshotImpl::getDouble(const std::string& key, double default_value) const {
+double SnapshotImpl::getDouble(absl::string_view key, double default_value) const {
   ASSERT(!isRuntimeFeature(key)); // Make sure runtime guarding is only used for getBoolean
   auto entry = values_.find(key);
   if (entry == values_.end() || !entry->second.double_value_) {

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -81,24 +81,24 @@ public:
                std::vector<OverrideLayerConstPtr>&& layers);
 
   // Runtime::Snapshot
-  bool deprecatedFeatureEnabled(const std::string& key, bool default_value) const override;
+  bool deprecatedFeatureEnabled(absl::string_view key, bool default_value) const override;
   bool runtimeFeatureEnabled(absl::string_view key) const override;
-  bool featureEnabled(const std::string& key, uint64_t default_value, uint64_t random_value,
+  bool featureEnabled(absl::string_view key, uint64_t default_value, uint64_t random_value,
                       uint64_t num_buckets) const override;
-  bool featureEnabled(const std::string& key, uint64_t default_value) const override;
-  bool featureEnabled(const std::string& key, uint64_t default_value,
+  bool featureEnabled(absl::string_view key, uint64_t default_value) const override;
+  bool featureEnabled(absl::string_view key, uint64_t default_value,
                       uint64_t random_value) const override;
-  bool featureEnabled(const std::string& key,
+  bool featureEnabled(absl::string_view key,
                       const envoy::type::v3::FractionalPercent& default_value) const override;
-  bool featureEnabled(const std::string& key,
+  bool featureEnabled(absl::string_view key,
                       const envoy::type::v3::FractionalPercent& default_value,
                       uint64_t random_value) const override;
-  const std::string& get(const std::string& key) const override;
-  uint64_t getInteger(const std::string& key, uint64_t default_value) const override;
-  double getDouble(const std::string& key, double default_value) const override;
+  const std::string& get(absl::string_view key) const override;
+  uint64_t getInteger(absl::string_view key, uint64_t default_value) const override;
+  double getDouble(absl::string_view key, double default_value) const override;
   bool getBoolean(absl::string_view key, bool value) const override;
   const std::vector<OverrideLayerConstPtr>& getLayers() const override;
-  bool exists(const std::string& key) const override { return values_.contains(key); }
+  bool exists(absl::string_view key) const override { return values_.contains(key); }
 
   static Entry createEntry(const std::string& value);
   static Entry createEntry(const ProtobufWkt::Value& value);

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -75,8 +75,7 @@ public:
     // better for configuration tests.
     ScopedRuntimeInjector scoped_runtime(server_.runtime());
     ON_CALL(server_.runtime_loader_.snapshot_, deprecatedFeatureEnabled(_, _))
-        .WillByDefault(
-            Invoke([](const std::string&, bool default_value) { return default_value; }));
+        .WillByDefault(Invoke([](absl::string_view, bool default_value) { return default_value; }));
 
     envoy::config::bootstrap::v3::Bootstrap bootstrap;
     Server::InstanceUtil::loadBootstrapConfig(

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -41,27 +41,27 @@ public:
     }
   }
 
-  MOCK_METHOD(bool, deprecatedFeatureEnabled, (const std::string& key, bool default_enabled),
+  MOCK_METHOD(bool, deprecatedFeatureEnabled, (absl::string_view key, bool default_enabled),
               (const));
   MOCK_METHOD(bool, runtimeFeatureEnabled, (absl::string_view key), (const));
-  MOCK_METHOD(bool, featureEnabled, (const std::string& key, uint64_t default_value), (const));
+  MOCK_METHOD(bool, featureEnabled, (absl::string_view key, uint64_t default_value), (const));
   MOCK_METHOD(bool, featureEnabled,
-              (const std::string& key, uint64_t default_value, uint64_t random_value), (const));
+              (absl::string_view key, uint64_t default_value, uint64_t random_value), (const));
   MOCK_METHOD(bool, featureEnabled,
-              (const std::string& key, uint64_t default_value, uint64_t random_value,
+              (absl::string_view key, uint64_t default_value, uint64_t random_value,
                uint64_t num_buckets),
               (const));
   MOCK_METHOD(bool, featureEnabled,
-              (const std::string& key, const envoy::type::v3::FractionalPercent& default_value),
+              (absl::string_view key, const envoy::type::v3::FractionalPercent& default_value),
               (const));
   MOCK_METHOD(bool, featureEnabled,
-              (const std::string& key, const envoy::type::v3::FractionalPercent& default_value,
+              (absl::string_view key, const envoy::type::v3::FractionalPercent& default_value,
                uint64_t random_value),
               (const));
-  MOCK_METHOD(const std::string&, get, (const std::string& key), (const));
-  MOCK_METHOD(bool, exists, (const std::string& key), (const));
-  MOCK_METHOD(uint64_t, getInteger, (const std::string& key, uint64_t default_value), (const));
-  MOCK_METHOD(double, getDouble, (const std::string& key, double default_value), (const));
+  MOCK_METHOD(const std::string&, get, (absl::string_view key), (const));
+  MOCK_METHOD(bool, exists, (absl::string_view key), (const));
+  MOCK_METHOD(uint64_t, getInteger, (absl::string_view key, uint64_t default_value), (const));
+  MOCK_METHOD(double, getDouble, (absl::string_view key, double default_value), (const));
   MOCK_METHOD(bool, getBoolean, (absl::string_view key, bool default_value), (const));
   MOCK_METHOD(const std::vector<OverrideLayerConstPtr>&, getLayers, (), (const));
 };

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -30,7 +30,7 @@ public:
   ~MockSnapshot() override;
 
   // Provide a default implementation of mocked featureEnabled/2.
-  bool featureEnabledDefault(const std::string&, uint64_t default_value) {
+  bool featureEnabledDefault(absl::string_view, uint64_t default_value) {
     if (default_value == 0) {
       return false;
     } else if (default_value == 100) {

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -483,10 +483,10 @@ void RouterCheckTool::printResults() {
 
 // The Mock for runtime value checks.
 // This is a simple implementation to mimic the actual runtime checks in Snapshot.featureEnabled
-bool RouterCheckTool::runtimeMock(const std::string& key,
+bool RouterCheckTool::runtimeMock(absl::string_view key,
                                   const envoy::type::v3::FractionalPercent& default_value,
                                   uint64_t random_value) {
-  return !active_runtime_.empty() && active_runtime_.compare(key) == 0 &&
+  return !active_runtime_.empty() && key.compare(active_runtime_) == 0 &&
          ProtobufPercentHelper::evaluateFractionalPercent(default_value, random_value);
 }
 

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -155,7 +155,7 @@ private:
 
   void printResults();
 
-  bool runtimeMock(const std::string& key, const envoy::type::v3::FractionalPercent& default_value,
+  bool runtimeMock(absl::string_view key, const envoy::type::v3::FractionalPercent& default_value,
                    uint64_t random_value);
 
   bool headers_finalized_{false};


### PR DESCRIPTION
Description: `absl::flat_hash_map` supports heterogenous lookup between `std::string` and `absl::string_view`, so switch lookup methods to use `absl::string_view`. This is advantageous for clients calling something like `snapshot.get("foobar")`, as using string_view avoids constructing a temporary intermediate `std::string`, and also makes the interface unified as `getBoolean` is already using `absl::string_view`.
Risk Level: low
Testing: existing
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Derek Argueta <dereka@pinterest.com>