### PR TITLE
tracing: Add decorator propagate field to enable passing the operatio…

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -1124,6 +1124,9 @@ message Decorator {
   //   by the :ref:`x-envoy-decorator-operation
   //   <config_http_filters_router_x-envoy-decorator-operation>` header.
   string operation = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // Whether the decorated details should be propagated to the other party. The default is true.
+  google.protobuf.BoolValue propagate = 2;
 }
 
 message Tracing {

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1113,6 +1113,9 @@ message Decorator {
   //   by the :ref:`x-envoy-decorator-operation
   //   <config_http_filters_router_x-envoy-decorator-operation>` header.
   string operation = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // Whether the decorated details should be propagated to the other party. The default is true.
+  google.protobuf.BoolValue propagate = 2;
 }
 
 message Tracing {

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -1124,6 +1124,9 @@ message Decorator {
   //   by the :ref:`x-envoy-decorator-operation
   //   <config_http_filters_router_x-envoy-decorator-operation>` header.
   string operation = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // Whether the decorated details should be propagated to the other party. The default is true.
+  google.protobuf.BoolValue propagate = 2;
 }
 
 message Tracing {

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1190,6 +1190,9 @@ message Decorator {
   //   by the :ref:`x-envoy-decorator-operation
   //   <config_http_filters_router_x-envoy-decorator-operation>` header.
   string operation = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // Whether the decorated details should be propagated to the other party. The default is true.
+  google.protobuf.BoolValue propagate = 2;
 }
 
 message Tracing {

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -822,7 +822,7 @@ public:
    * should be propagated to other services.
    * @return whether to propagate
    */
-  virtual bool getPropagate() const PURE;
+  virtual bool propagate() const PURE;
 };
 
 using DecoratorConstPtr = std::unique_ptr<const Decorator>;

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -816,6 +816,13 @@ public:
    * @return the operation name
    */
   virtual const std::string& getOperation() const PURE;
+
+  /**
+   * This method returns whether the decorator information
+   * should be propagated to other services.
+   * @return whether to propagate
+   */
+  virtual bool getPropagate() const PURE;
 };
 
 using DecoratorConstPtr = std::unique_ptr<const Decorator>;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1530,8 +1530,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     }
   }
 
-  const bool modified_end_stream =
-      state_.encoding_headers_only_ || (end_stream && continue_data_entry == encoder_filters_.end());
+  const bool modified_end_stream = state_.encoding_headers_only_ ||
+                                   (end_stream && continue_data_entry == encoder_filters_.end());
   encodeHeadersInternal(headers, modified_end_stream);
 
   if (continue_data_entry != encoder_filters_.end() && !modified_end_stream) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -935,7 +935,7 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
 
     decorator->apply(*active_span_);
 
-    decorated_propagate_ = decorator->getPropagate();
+    decorated_propagate_ = decorator->propagate();
 
     // Cache decorated operation.
     if (!decorator->getOperation().empty()) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -931,13 +931,15 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
 
   // If a decorator has been defined, apply it to the active span.
   if (hasCachedRoute() && cached_route_.value()->decorator()) {
-    cached_route_.value()->decorator()->apply(*active_span_);
+    const Router::Decorator* decorator = cached_route_.value()->decorator();
 
-    decorated_propagate_ = cached_route_.value()->decorator()->getPropagate();
+    decorator->apply(*active_span_);
+
+    decorated_propagate_ = decorator->getPropagate();
 
     // Cache decorated operation.
-    if (!cached_route_.value()->decorator()->getOperation().empty()) {
-      decorated_operation_ = &cached_route_.value()->decorator()->getOperation();
+    if (!decorator->getOperation().empty()) {
+      decorated_operation_ = &decorator->getOperation();
     }
   }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -743,8 +743,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     state_.created_filter_chain_ = true;
     connection_manager_.stats_.named_.downstream_rq_overload_close_.inc();
     sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_),
-                   Http::Code::ServiceUnavailable, "envoy overloaded", nullptr, state_.is_head_request_,
-                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().Overload);
+                   Http::Code::ServiceUnavailable, "envoy overloaded", nullptr,
+                   state_.is_head_request_, absl::nullopt,
+                   StreamInfo::ResponseCodeDetails::get().Overload);
     return;
   }
 
@@ -772,8 +773,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     stream_info_.protocol(protocol);
     if (!connection_manager_.config_.http1Settings().accept_http_10_) {
       // Send "Upgrade Required" if HTTP/1.0 support is not explicitly configured on.
-      sendLocalReply(false, Code::UpgradeRequired, "", nullptr, state_.is_head_request_, absl::nullopt,
-                     StreamInfo::ResponseCodeDetails::get().LowVersion);
+      sendLocalReply(false, Code::UpgradeRequired, "", nullptr, state_.is_head_request_,
+                     absl::nullopt, StreamInfo::ResponseCodeDetails::get().LowVersion);
       return;
     } else {
       // HTTP/1.0 defaults to single-use connections. Make sure the connection
@@ -980,8 +981,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilte
   for (; entry != decoder_filters_.end(); entry++) {
     ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeHeaders));
     state_.filter_call_state_ |= FilterCallState::DecodeHeaders;
-    (*entry)->end_stream_ =
-        state_.decoding_headers_only_ || (end_stream && continue_data_entry == decoder_filters_.end());
+    (*entry)->end_stream_ = state_.decoding_headers_only_ ||
+                            (end_stream && continue_data_entry == decoder_filters_.end());
     FilterHeadersStatus status = (*entry)->decodeHeaders(headers, (*entry)->end_stream_);
 
     ASSERT(!(status == FilterHeadersStatus::ContinueAndEndStream && (*entry)->end_stream_));
@@ -1498,8 +1499,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
   for (; entry != encoder_filters_.end(); entry++) {
     ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeHeaders));
     state_.filter_call_state_ |= FilterCallState::EncodeHeaders;
-    (*entry)->end_stream_ =
-        state_.encoding_headers_only_ || (end_stream && continue_data_entry == encoder_filters_.end());
+    (*entry)->end_stream_ = state_.encoding_headers_only_ ||
+                            (end_stream && continue_data_entry == encoder_filters_.end());
     FilterHeadersStatus status = (*entry)->handle_->encodeHeaders(headers, (*entry)->end_stream_);
     if ((*entry)->end_stream_) {
       (*entry)->handle_->encodeComplete();
@@ -1653,8 +1654,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(HeaderMap& heade
   // Now actually encode via the codec.
   stream_info_.onFirstDownstreamTxByteSent();
   response_encoder_->encodeHeaders(
-      headers,
-      state_.encoding_headers_only_ || (end_stream && continue_data_entry == encoder_filters_.end()));
+      headers, state_.encoding_headers_only_ ||
+                   (end_stream && continue_data_entry == encoder_filters_.end()));
   if (continue_data_entry != encoder_filters_.end()) {
     // We use the continueEncoding() code since it will correctly handle not calling
     // encodeHeaders() again. Fake setting StopSingleIteration since the continueEncoding() code

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -282,8 +282,8 @@ private:
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                         absl::string_view details) override {
       parent_.stream_info_.setResponseCodeDetails(details);
-      parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, parent_.state_.is_head_request_,
-                             grpc_status, details);
+      parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers,
+                             parent_.state_.is_head_request_, grpc_status, details);
     }
     void encode100ContinueHeaders(HeaderMapPtr&& headers) override;
     void encodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
@@ -549,7 +549,8 @@ private:
       const char* spaces = spacesForLevel(indent_level);
       os << spaces << "ActiveStream " << this << DUMP_MEMBER(stream_id_)
          << DUMP_MEMBER(state_.has_continue_headers_) << DUMP_MEMBER(state_.is_head_request_)
-         << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_) << "\n";
+         << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_)
+         << "\n";
 
       DUMP_DETAILS(request_headers_);
       DUMP_DETAILS(request_trailers_);
@@ -637,7 +638,8 @@ private:
       // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
       bool has_continue_headers_ : 1;
       bool is_head_request_ : 1;
-      // Whether a filter has indicated that the request should be treated as a headers only request.
+      // Whether a filter has indicated that the request should be treated as a headers only
+      // request.
       bool decoding_headers_only_;
       // Whether a filter has indicated that the response should be treated as a headers only
       // response.

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -282,7 +282,7 @@ private:
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                         absl::string_view details) override {
       parent_.stream_info_.setResponseCodeDetails(details);
-      parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, parent_.is_head_request_,
+      parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, parent_.state_.is_head_request_,
                              grpc_status, details);
     }
     void encode100ContinueHeaders(HeaderMapPtr&& headers) override;
@@ -548,8 +548,8 @@ private:
     void dumpState(std::ostream& os, int indent_level = 0) const override {
       const char* spaces = spacesForLevel(indent_level);
       os << spaces << "ActiveStream " << this << DUMP_MEMBER(stream_id_)
-         << DUMP_MEMBER(has_continue_headers_) << DUMP_MEMBER(is_head_request_)
-         << DUMP_MEMBER(decoding_headers_only_) << DUMP_MEMBER(encoding_headers_only_) << "\n";
+         << DUMP_MEMBER(state_.has_continue_headers_) << DUMP_MEMBER(state_.is_head_request_)
+         << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_) << "\n";
 
       DUMP_DETAILS(request_headers_);
       DUMP_DETAILS(request_trailers_);
@@ -604,7 +604,8 @@ private:
       State()
           : remote_complete_(false), local_complete_(false), codec_saw_local_complete_(false),
             saw_connection_close_(false), successful_upgrade_(false), created_filter_chain_(false),
-            is_internally_created_(false) {}
+            is_internally_created_(false), decorated_propagate_(true), has_continue_headers_(false),
+            is_head_request_(false), decoding_headers_only_(false), encoding_headers_only_(false) {}
 
       uint32_t filter_call_state_{0};
       // The following 3 members are booleans rather than part of the space-saving bitfield as they
@@ -630,6 +631,17 @@ private:
       // Used to track which filter is the latest filter that has received data.
       ActiveStreamEncoderFilter* latest_data_encoding_filter_{};
       ActiveStreamDecoderFilter* latest_data_decoding_filter_{};
+
+      bool decorated_propagate_ : 1;
+      // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
+      // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
+      bool has_continue_headers_ : 1;
+      bool is_head_request_ : 1;
+      // Whether a filter has indicated that the request should be treated as a headers only request.
+      bool decoding_headers_only_;
+      // Whether a filter has indicated that the response should be treated as a headers only
+      // response.
+      bool encoding_headers_only_;
     };
 
     // Possibly increases buffer_limit_ to the value of limit.
@@ -698,16 +710,6 @@ private:
     uint32_t buffer_limit_{0};
     uint32_t high_watermark_count_{0};
     const std::string* decorated_operation_{nullptr};
-    bool decorated_propagate_ = true;
-    // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
-    // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
-    bool has_continue_headers_{};
-    bool is_head_request_{};
-    // Whether a filter has indicated that the request should be treated as a headers only request.
-    bool decoding_headers_only_{};
-    // Whether a filter has indicated that the response should be treated as a headers only
-    // response.
-    bool encoding_headers_only_{};
     Network::Socket::OptionsSharedPtr upstream_options_;
     std::unique_ptr<RouteConfigUpdateRequester> route_config_update_requester_;
     std::unique_ptr<Tracing::CustomTagMap> tracing_custom_tags_{nullptr};

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -629,10 +629,6 @@ private:
       // internal redirects or other streams created via recreateStream().
       bool is_internally_created_ : 1;
 
-      // Used to track which filter is the latest filter that has received data.
-      ActiveStreamEncoderFilter* latest_data_encoding_filter_{};
-      ActiveStreamDecoderFilter* latest_data_decoding_filter_{};
-
       bool decorated_propagate_ : 1;
       // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
       // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
@@ -644,6 +640,10 @@ private:
       // Whether a filter has indicated that the response should be treated as a headers only
       // response.
       bool encoding_headers_only_;
+
+      // Used to track which filter is the latest filter that has received data.
+      ActiveStreamEncoderFilter* latest_data_encoding_filter_{};
+      ActiveStreamDecoderFilter* latest_data_decoding_filter_{};
     };
 
     // Possibly increases buffer_limit_ to the value of limit.

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -698,6 +698,7 @@ private:
     uint32_t buffer_limit_{0};
     uint32_t high_watermark_count_{0};
     const std::string* decorated_operation_{nullptr};
+    bool decorated_propagate_ = true;
     // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
     // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
     bool has_continue_headers_{};

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -188,7 +188,8 @@ ShadowPolicyImpl::ShadowPolicyImpl(const RequestMirrorPolicy& config) {
 }
 
 DecoratorImpl::DecoratorImpl(const envoy::config::route::v3::Decorator& decorator)
-    : operation_(decorator.operation()) {}
+    : operation_(decorator.operation()),
+      propagate_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(decorator, propagate, true)) {}
 
 void DecoratorImpl::apply(Tracing::Span& span) const {
   if (!operation_.empty()) {
@@ -197,6 +198,8 @@ void DecoratorImpl::apply(Tracing::Span& span) const {
 }
 
 const std::string& DecoratorImpl::getOperation() const { return operation_; }
+
+bool DecoratorImpl::getPropagate() const { return propagate_; }
 
 RouteTracingImpl::RouteTracingImpl(const envoy::config::route::v3::Tracing& tracing) {
   if (!tracing.has_client_sampling()) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -199,7 +199,7 @@ void DecoratorImpl::apply(Tracing::Span& span) const {
 
 const std::string& DecoratorImpl::getOperation() const { return operation_; }
 
-bool DecoratorImpl::getPropagate() const { return propagate_; }
+bool DecoratorImpl::propagate() const { return propagate_; }
 
 RouteTracingImpl::RouteTracingImpl(const envoy::config::route::v3::Tracing& tracing) {
   if (!tracing.has_client_sampling()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -336,8 +336,12 @@ public:
   // Decorator::getOperation
   const std::string& getOperation() const override;
 
+  // Decorator::getOperation
+  bool getPropagate() const override;
+
 private:
   const std::string operation_;
+  const bool propagate_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -337,7 +337,7 @@ public:
   const std::string& getOperation() const override;
 
   // Decorator::getOperation
-  bool getPropagate() const override;
+  bool propagate() const override;
 
 private:
   const std::string operation_;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -982,7 +982,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
-  EXPECT_EQ(true, route_config_provider_.route_config_->route_->decorator_.getPropagate());
+  EXPECT_EQ(true, route_config_provider_.route_config_->route_->decorator_.propagate());
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(
@@ -1043,7 +1043,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
-  ON_CALL(route_config_provider_.route_config_->route_->decorator_, getPropagate())
+  ON_CALL(route_config_provider_.route_config_->route_->decorator_, propagate())
       .WillByDefault(Return(false));
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
@@ -1193,7 +1193,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
-  EXPECT_EQ(true, route_config_provider_.route_config_->route_->decorator_.getPropagate());
+  EXPECT_EQ(true, route_config_provider_.route_config_->route_->decorator_.propagate());
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(
@@ -1270,7 +1270,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
-  ON_CALL(route_config_provider_.route_config_->route_->decorator_, getPropagate())
+  ON_CALL(route_config_provider_.route_config_->route_->decorator_, propagate())
       .WillByDefault(Return(false));
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1068,8 +1068,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   use_remote_address_ = false;
   EXPECT_CALL(random_, uuid()).Times(0);
 
-  StreamDecoder* decoder = nullptr;
-  NiceMock<MockStreamEncoder> encoder;
+  RequestDecoder* decoder = nullptr;
+  NiceMock<MockResponseEncoder> encoder;
   EXPECT_CALL(*codec_, dispatch(_)).WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
     decoder = &conn_manager_->newStream(encoder);
 
@@ -1295,8 +1295,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   use_remote_address_ = false;
   EXPECT_CALL(random_, uuid()).Times(0);
 
-  StreamDecoder* decoder = nullptr;
-  NiceMock<MockStreamEncoder> encoder;
+  RequestDecoder* decoder = nullptr;
+  NiceMock<MockResponseEncoder> encoder;
   EXPECT_CALL(*codec_, dispatch(_)).WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
     decoder = &conn_manager_->newStream(encoder);
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -978,10 +978,11 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+  EXPECT_EQ(true, route_config_provider_.route_config_->route_->decorator_.getPropagate());
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(
@@ -1029,6 +1030,72 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   conn_manager_->onData(fake_input, false);
 }
 
+TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecoratorPropagateFalse) {
+  setup(false, "");
+
+  auto* span = new NiceMock<Tracing::MockSpan>();
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+                     const Tracing::Decision) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+
+            return span;
+          }));
+  route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
+  ON_CALL(route_config_provider_.route_config_->route_->decorator_, getPropagate())
+      .WillByDefault(Return(false));
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
+      .WillOnce(Invoke(
+          [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+  EXPECT_CALL(*span, finishSpan());
+  EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*span, setOperation(_)).Times(0);
+
+  std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamDecoderFilter(filter);
+      }));
+
+  // Treat request as internal, otherwise x-request-id header will be overwritten.
+  use_remote_address_ = false;
+  EXPECT_CALL(random_, uuid()).Times(0);
+
+  StreamDecoder* decoder = nullptr;
+  NiceMock<MockStreamEncoder> encoder;
+  EXPECT_CALL(*codec_, dispatch(_)).WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
+    decoder = &conn_manager_->newStream(encoder);
+
+    HeaderMapPtr headers{
+        new TestHeaderMapImpl{{":method", "GET"},
+                              {":authority", "host"},
+                              {":path", "/"},
+                              {"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}}};
+    decoder->decodeHeaders(std::move(headers), true);
+
+    HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
+    filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+    filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
+    data.drain(4);
+  }));
+
+  // Verify decorator operation response header has NOT been defined (i.e. not propagated).
+  EXPECT_CALL(encoder, encodeHeaders(_, true))
+      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+        EXPECT_EQ(nullptr, headers.EnvoyDecoratorOperation());
+      }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+}
+
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecoratorOverrideOp) {
   setup(false, "");
 
@@ -1042,7 +1109,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
@@ -1122,10 +1189,11 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+  EXPECT_EQ(true, route_config_provider_.route_config_->route_->decorator_.getPropagate());
   EXPECT_CALL(*span, finishSpan());
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(
@@ -1176,6 +1244,87 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   conn_manager_->onData(fake_input, false);
 }
 
+TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecoratorPropagateFalse) {
+  setup(false, "");
+  envoy::type::v3::FractionalPercent percent1;
+  percent1.set_numerator(100);
+  envoy::type::v3::FractionalPercent percent2;
+  percent2.set_numerator(10000);
+  percent2.set_denominator(envoy::type::v3::FractionalPercent::TEN_THOUSAND);
+  tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(
+      TracingConnectionManagerConfig{Tracing::OperationName::Egress,
+                                     {{":method", requestHeaderCustomTag(":method")}},
+                                     percent1,
+                                     percent2,
+                                     percent1,
+                                     false,
+                                     256});
+
+  auto* span = new NiceMock<Tracing::MockSpan>();
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+                     const Tracing::Decision) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
+
+            return span;
+          }));
+  route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
+  ON_CALL(route_config_provider_.route_config_->route_->decorator_, getPropagate())
+      .WillByDefault(Return(false));
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
+      .WillOnce(Invoke(
+          [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
+  EXPECT_CALL(*span, finishSpan());
+  EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*span, setOperation(_)).Times(0);
+
+  std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamDecoderFilter(filter);
+      }));
+
+  // Treat request as internal, otherwise x-request-id header will be overwritten.
+  use_remote_address_ = false;
+  EXPECT_CALL(random_, uuid()).Times(0);
+
+  StreamDecoder* decoder = nullptr;
+  NiceMock<MockStreamEncoder> encoder;
+  EXPECT_CALL(*codec_, dispatch(_)).WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
+    decoder = &conn_manager_->newStream(encoder);
+
+    HeaderMapPtr headers{
+        new TestHeaderMapImpl{{":method", "GET"},
+                              {":authority", "host"},
+                              {":path", "/"},
+                              {"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}}};
+    decoder->decodeHeaders(std::move(headers), true);
+
+    HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
+    filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+    filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
+
+    data.drain(4);
+  }));
+
+  // Verify that decorator operation has NOT been set as request header (propagate is false)
+  EXPECT_CALL(*filter, decodeHeaders(_, true))
+      .WillOnce(Invoke([](HeaderMap& headers, bool) -> FilterHeadersStatus {
+        EXPECT_EQ(nullptr, headers.EnvoyDecoratorOperation());
+        return FilterHeadersStatus::StopIteration;
+      }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+}
+
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecoratorOverrideOp) {
   setup(false, "");
   envoy::type::v3::FractionalPercent percent1;
@@ -1202,7 +1351,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -978,7 +978,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
@@ -1045,7 +1045,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
   ON_CALL(route_config_provider_.route_config_->route_->decorator_, getPropagate())
       .WillByDefault(Return(false));
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
@@ -1109,7 +1109,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
@@ -1189,7 +1189,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
@@ -1272,7 +1272,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
   ON_CALL(route_config_provider_.route_config_->route_->decorator_, getPropagate())
       .WillByDefault(Return(false));
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));
@@ -1351,7 +1351,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
             return span;
           }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
-  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(5);
+  EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(2);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
       .WillOnce(Invoke(
           [&](const Tracing::Span& apply_to_span) -> void { EXPECT_EQ(span, &apply_to_span); }));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4990,6 +4990,7 @@ virtual_hosts:
       cluster: foo
     decorator:
       operation: myFoo
+      propagate: false
   - match:
       prefix: "/bar"
     route:
@@ -5004,6 +5005,7 @@ virtual_hosts:
     Tracing::MockSpan span;
     EXPECT_CALL(span, setOperation(Eq("myFoo")));
     route->decorator()->apply(span);
+    EXPECT_EQ(false, route->decorator()->getPropagate());
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "GET");

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -5005,7 +5005,7 @@ virtual_hosts:
     Tracing::MockSpan span;
     EXPECT_CALL(span, setOperation(Eq("myFoo")));
     route->decorator()->apply(span);
-    EXPECT_EQ(false, route->decorator()->getPropagate());
+    EXPECT_EQ(false, route->decorator()->propagate());
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "GET");

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -112,7 +112,7 @@ MockConfig::~MockConfig() = default;
 
 MockDecorator::MockDecorator() {
   ON_CALL(*this, getOperation()).WillByDefault(ReturnRef(operation_));
-  ON_CALL(*this, getPropagate()).WillByDefault(Return(true));
+  ON_CALL(*this, propagate()).WillByDefault(Return(true));
 }
 MockDecorator::~MockDecorator() = default;
 

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -112,6 +112,7 @@ MockConfig::~MockConfig() = default;
 
 MockDecorator::MockDecorator() {
   ON_CALL(*this, getOperation()).WillByDefault(ReturnRef(operation_));
+  ON_CALL(*this, getPropagate()).WillByDefault(Return(true));
 }
 MockDecorator::~MockDecorator() = default;
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -371,6 +371,7 @@ public:
 
   // Router::Decorator
   MOCK_METHOD(const std::string&, getOperation, (), (const));
+  MOCK_METHOD(bool, getPropagate, (), (const));
   MOCK_METHOD(void, apply, (Tracing::Span & span), (const));
 
   std::string operation_{"fake_operation"};

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -371,7 +371,7 @@ public:
 
   // Router::Decorator
   MOCK_METHOD(const std::string&, getOperation, (), (const));
-  MOCK_METHOD(bool, getPropagate, (), (const));
+  MOCK_METHOD(bool, propagate, (), (const));
   MOCK_METHOD(void, apply, (Tracing::Span & span), (const));
 
   std::string operation_{"fake_operation"};


### PR DESCRIPTION
…n via headers to be disabled

Signed-off-by: Gary Brown <gary@brownuk.com>

Fixes #9778 

Description: Add a field to enable the decorator operation propagation (via http headers) to be disabled.
Risk Level: low
Testing: Added test to check whether the header is included in requests and responses. Existing behaviour is preserved.
Docs Changes: Additional `propagate` field to be documented.
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
