### PR TITLE
docs: Add a warning about undocumented behavioral changes when excluding stats

### DIFF
--- a/api/envoy/config/metrics/v2/stats.proto
+++ b/api/envoy/config/metrics/v2/stats.proto
@@ -67,6 +67,10 @@ message StatsConfig {
   // Inclusion/exclusion matcher for stat name creation. If not provided, all stats are instantiated
   // as normal. Preventing the instantiation of certain families of stats can improve memory
   // performance for Envoys running especially large configs.
+  //
+  // .. warning::
+  //   Excluding stats may affect Envoy's behavior in undocumented ways. See
+  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/api/envoy/config/metrics/v2/stats.proto
+++ b/api/envoy/config/metrics/v2/stats.proto
@@ -70,7 +70,8 @@ message StatsConfig {
   //
   // .. warning::
   //   Excluding stats may affect Envoy's behavior in undocumented ways. See
-  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
+  //   `issue #8771 <https://github.com/envoyproxy/envoy/issues/8771>`_ for more information.
+  //   If any unexpected behavior changes are observed, please open a new issue immediately.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/api/envoy/config/metrics/v3/stats.proto
+++ b/api/envoy/config/metrics/v3/stats.proto
@@ -76,6 +76,10 @@ message StatsConfig {
   // Inclusion/exclusion matcher for stat name creation. If not provided, all stats are instantiated
   // as normal. Preventing the instantiation of certain families of stats can improve memory
   // performance for Envoys running especially large configs.
+  //
+  // .. warning::
+  //   Excluding stats may affect Envoy's behavior in undocumented ways. See
+  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/api/envoy/config/metrics/v3/stats.proto
+++ b/api/envoy/config/metrics/v3/stats.proto
@@ -79,7 +79,8 @@ message StatsConfig {
   //
   // .. warning::
   //   Excluding stats may affect Envoy's behavior in undocumented ways. See
-  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
+  //   `issue #8771 <https://github.com/envoyproxy/envoy/issues/8771>`_ for more information.
+  //   If any unexpected behavior changes are observed, please open a new issue immediately.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/generated_api_shadow/envoy/config/metrics/v2/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v2/stats.proto
@@ -67,6 +67,10 @@ message StatsConfig {
   // Inclusion/exclusion matcher for stat name creation. If not provided, all stats are instantiated
   // as normal. Preventing the instantiation of certain families of stats can improve memory
   // performance for Envoys running especially large configs.
+  //
+  // .. warning::
+  //   Excluding stats may affect Envoy's behavior in undocumented ways. See
+  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/generated_api_shadow/envoy/config/metrics/v2/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v2/stats.proto
@@ -70,7 +70,8 @@ message StatsConfig {
   //
   // .. warning::
   //   Excluding stats may affect Envoy's behavior in undocumented ways. See
-  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
+  //   `issue #8771 <https://github.com/envoyproxy/envoy/issues/8771>`_ for more information.
+  //   If any unexpected behavior changes are observed, please open a new issue immediately.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/generated_api_shadow/envoy/config/metrics/v3/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v3/stats.proto
@@ -77,7 +77,8 @@ message StatsConfig {
   //
   // .. warning::
   //   Excluding stats may affect Envoy's behavior in undocumented ways. See
-  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
+  //   `issue #8771 <https://github.com/envoyproxy/envoy/issues/8771>`_ for more information.
+  //   If any unexpected behavior changes are observed, please open a new issue immediately.
   StatsMatcher stats_matcher = 3;
 }
 

--- a/generated_api_shadow/envoy/config/metrics/v3/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v3/stats.proto
@@ -74,6 +74,10 @@ message StatsConfig {
   // Inclusion/exclusion matcher for stat name creation. If not provided, all stats are instantiated
   // as normal. Preventing the instantiation of certain families of stats can improve memory
   // performance for Envoys running especially large configs.
+  //
+  // .. warning::
+  //   Excluding stats may affect Envoy's behavior in undocumented ways. See
+  //   [issue-9856](https://github.com/envoyproxy/envoy/issues/9856) for more information.
   StatsMatcher stats_matcher = 3;
 }
 


### PR DESCRIPTION
Description:
Add a warning to the effect that excluding stats may affect the behavior of Envoy in undocumented ways.
Per discussion in #9856 

Docs Changes:
Add a warning block to the v2 and v3 `api/envoy/config/metrics/vX/stats.proto` files. 