### PR TITLE
jwt_authn: fix data race that leads to seg fault

### DIFF
--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -107,6 +107,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "filter_config_interface",
+    srcs = ["filter_config.cc"],
     hdrs = ["filter_config.h"],
     deps = [
         ":jwks_cache_lib",

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -1,0 +1,37 @@
+#include "extensions/filters/http/jwt_authn/filter_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace JwtAuthn {
+
+void FilterConfigImpl::init() {
+  ENVOY_LOG(debug, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
+
+  // Note: `this` and `context` have a a lifetime of the listener.
+  // That may be shorter of the tls callback if the listener is torn shortly after it is created.
+  // We use a shared pointer to make sure this object outlives the tls callbacks.
+  auto shared_this = shared_from_this();
+  tls_->set([shared_this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    return std::make_shared<ThreadLocalCache>(shared_this->proto_config_, shared_this->time_source_,
+                                              shared_this->api_);
+  });
+
+  for (const auto& rule : proto_config_.rules()) {
+    rule_pairs_.emplace_back(Matcher::create(rule),
+                             Verifier::create(rule.requires(), proto_config_.providers(), *this));
+  }
+
+  if (proto_config_.has_filter_state_rules()) {
+    filter_state_name_ = proto_config_.filter_state_rules().name();
+    for (const auto& it : proto_config_.filter_state_rules().requires()) {
+      filter_state_verifiers_.emplace(
+          it.first, Verifier::create(it.second, proto_config_.providers(), *this));
+    }
+  }
+}
+
+} // namespace JwtAuthn
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -36,8 +36,8 @@ public:
   JwksCache& getJwksCache() { return *jwks_cache_; }
 
 private:
-  // copy of the config, to ensure it exists throught out the lifetime of this object, as
-  // jwks_cache_ holds references to it.
+  // copy of the config, to ensure it exists through out the lifetime of this object, as jwks_cache_
+  // holds references to it.
   envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication config_;
   // The JwksCache object.
   JwksCachePtr jwks_cache_;

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -69,9 +69,10 @@ public:
         time_source_(context.dispatcher().timeSource()), api_(context.api()) {
     ENVOY_LOG(info, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
 
-    // note: this and context has a a lifetime that may be shorter of the tls callback
-    // rime source and api are from the server context who's lifetime is longer. 
-    // so use them explicitly.
+    // note: `this` and `context` has a a lifetime of the listener.
+    // that may be shorter of the tls callback if the listener is torn shortly after it is created.
+    // context.dispatcher().timeSource() and context.api() are from the server context who's
+    // lifetime is longer. so we use them explicitly.
     // we copy over the proto as we can't guarantee its lifetime otherwise
     auto& timeSource = context.dispatcher().timeSource();
     auto& api = context.api();

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -27,14 +27,18 @@ class ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
 public:
   // Load the config from envoy config.
   ThreadLocalCache(const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& config,
-                   TimeSource& time_source, Api::Api& api) {
-    jwks_cache_ = JwksCache::create(config, time_source, api);
+                   TimeSource& time_source, Api::Api& api)
+      : config_(config) {
+    jwks_cache_ = JwksCache::create(config_, time_source, api);
   }
 
   // Get the JwksCache object.
   JwksCache& getJwksCache() { return *jwks_cache_; }
 
 private:
+  // copy of the config, to ensure it exists throught out the lifetime of this object, as
+  // jwks_cache_ holds references to it.
+  envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication config_;
   // The JwksCache object.
   JwksCachePtr jwks_cache_;
 };

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -66,7 +66,7 @@ public:
   static std::shared_ptr<FilterConfig>
   create(envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
          const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-    auto ptr = std::shared_ptr<FilterConfig>(new FilterConfig(proto_config, stats_prefix, context));
+    std::shared_ptr<FilterConfig> ptr(new FilterConfig(proto_config, stats_prefix, context));
     ptr->init();
     return ptr;
   }

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -77,8 +77,8 @@ public:
     auto& timeSource = context.dispatcher().timeSource();
     auto& api = context.api();
     auto proto_config_copy = proto_config_;
-    tls_->set([proto_config_copy,
-               &timeSource, &api](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    tls_->set([proto_config_copy, &timeSource,
+               &api](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
       return std::make_shared<ThreadLocalCache>(proto_config_copy, timeSource, api);
     });
 

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -68,8 +68,10 @@ public:
         tls_(context.threadLocal().allocateSlot()), cm_(context.clusterManager()),
         time_source_(context.dispatcher().timeSource()), api_(context.api()) {
     ENVOY_LOG(info, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
-    tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<ThreadLocalCache>(proto_config_, time_source_, api_);
+    tls_->set([proto_config_copy = proto_config_,
+               &context](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return std::make_shared<ThreadLocalCache>(proto_config_copy,
+                                                context.dispatcher().timeSource(), context.api());
     });
 
     for (const auto& rule : proto_config_.rules()) {

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -45,7 +45,7 @@ FilterFactory::createFilterFactoryFromProtoTyped(const JwtAuthentication& proto_
                                                  const std::string& prefix,
                                                  Server::Configuration::FactoryContext& context) {
   validateJwtConfig(proto_config, context.api());
-  auto filter_config = FilterConfig::create(proto_config, prefix, context);
+  auto filter_config = FilterConfigImpl::create(proto_config, prefix, context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<Filter>(filter_config));
   };

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -45,7 +45,7 @@ FilterFactory::createFilterFactoryFromProtoTyped(const JwtAuthentication& proto_
                                                  const std::string& prefix,
                                                  Server::Configuration::FactoryContext& context) {
   validateJwtConfig(proto_config, context.api());
-  auto filter_config = std::make_shared<FilterConfig>(proto_config, prefix, context);
+  auto filter_config = FilterConfig::create(proto_config, prefix, context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<Filter>(filter_config));
   };

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -73,7 +73,7 @@ public:
   }
 
   void createVerifier() {
-    filter_config_ = ::std::make_shared<FilterConfig>(proto_config_, "", mock_factory_ctx_);
+    filter_config_ = FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_);
     verifier_ = Verifier::create(proto_config_.rules(0).requires(), proto_config_.providers(),
                                  *filter_config_);
   }
@@ -83,7 +83,7 @@ public:
   }
 
   JwtAuthentication proto_config_;
-  FilterConfigSharedPtr filter_config_;
+  std::shared_ptr<AuthFactory> filter_config_;
   VerifierConstPtr verifier_;
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -83,7 +83,7 @@ public:
   }
 
   JwtAuthentication proto_config_;
-  std::shared_ptr<AuthFactory> filter_config_;
+  std::shared_ptr<FilterConfigImpl> filter_config_;
   VerifierConstPtr verifier_;
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -42,7 +42,7 @@ public:
   void CreateAuthenticator(::google::jwt_verify::CheckAudience* check_audience = nullptr,
                            const absl::optional<std::string>& provider =
                                absl::make_optional<std::string>(ProviderName)) {
-    filter_config_ = ::std::make_shared<FilterConfig>(proto_config_, "", mock_factory_ctx_);
+    filter_config_ = FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_);
     raw_fetcher_ = new MockJwksFetcher;
     fetcher_.reset(raw_fetcher_);
     auth_ = Authenticator::create(
@@ -77,7 +77,7 @@ public:
 
   JwtAuthentication proto_config_;
   ExtractorConstPtr extractor_;
-  FilterConfigSharedPtr filter_config_;
+  std::shared_ptr<FilterConfigImpl> filter_config_;
   MockJwksFetcher* raw_fetcher_;
   JwksFetcherPtr fetcher_;
   AuthenticatorPtr auth_;

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -38,7 +38,7 @@ rules:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfig::create(proto_config, "", context);
+  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
 
   StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filter_conf->findVerifier(
@@ -85,7 +85,7 @@ rules:
 
     JwtAuthentication proto_config;
     TestUtility::loadFromYaml(config, proto_config);
-    auto filter_conf = FilterConfig::create(proto_config, "", context);
+    auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
   }
 
   // even though filter_conf is now de-allocated, using a reference to it might still work, as its
@@ -125,7 +125,7 @@ filter_state_rules:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfig::create(proto_config, "", context);
+  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
 
   // Empty filter_state
   StreamInfo::FilterStateImpl filter_state1(StreamInfo::FilterState::LifeSpan::FilterChain);

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -86,8 +86,6 @@ rules:
 
     JwtAuthentication proto_config;
     TestUtility::loadFromYaml(config, proto_config);
-    // when api and dispacher are requested provided them from server ctx
-    // capture the tls set
     std::unique_ptr<FilterConfig> filter_conf(new FilterConfig(proto_config, "", context));
     filter_conf_void = filter_conf.get();
   }

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -70,17 +70,16 @@ rules:
     provider_name: provider1
 )";
 
-
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
   // make sure that the thread callbacks are not invoked inline.
   server_context.thread_local_.defer_data = true;
   void* filter_conf_void;
   {
-    // scope in all the things that the filter depends on, so they are destroyed as we leave the 
+    // scope in all the things that the filter depends on, so they are destroyed as we leave the
     // scope.
     NiceMock<Server::Configuration::MockFactoryContext> context;
-    // the threadLocal, dispatcher and api that are used by the filter config, actually belong to the 
-    // server factory context that who's lifetime is longer. so we return them here.
+    // the threadLocal, dispatcher and api that are used by the filter config, actually belong to
+    // the server factory context that who's lifetime is longer. so we return them here.
     ON_CALL(context, dispatcher()).WillByDefault(ReturnRef(server_context.dispatcher()));
     ON_CALL(context, api()).WillByDefault(ReturnRef(server_context.api()));
     ON_CALL(context, threadLocal()).WillByDefault(ReturnRef(server_context.threadLocal()));
@@ -96,7 +95,7 @@ rules:
   // simulate the heap space being re-claimed. while this is bit hacky,
   // the test passes otherwise as a false positive.
   memset(filter_conf_void, 0, sizeof(FilterConfig));
-  
+
   // make sure the filter scheduled a callback
   EXPECT_EQ(1, server_context.thread_local_.deferred_data_.size());
 

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -54,7 +54,7 @@ public:
 class FilterTest : public testing::Test {
 public:
   void SetUp() override {
-    mock_config_ = ::std::make_shared<NiceMockz<MockFilterConfig>>();
+    mock_config_ = ::std::make_shared<NiceMock<MockFilterConfig>>();
 
     mock_verifier_ = std::make_unique<MockVerifier>();
     filter_ = std::make_unique<Filter>(mock_config_);

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -36,7 +36,7 @@ JwtAuthnFilterStats generateMockStats(Stats::Scope& scope) {
 class MockFilterConfig : public FilterConfig {
 public:
   MockFilterConfig() : stats_(generateMockStats(stats_store_)) {
-    ON_CALL(*this, bypassCorsPreflightRequest()).WillByDefault(Return(bypass_cors_preflight_));
+    ON_CALL(*this, bypassCorsPreflightRequest()).WillByDefault(Return(true));
     ON_CALL(*this, findVerifier(_, _)).WillByDefault(Return(nullptr));
     ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
   }
@@ -47,7 +47,6 @@ public:
   MOCK_METHOD(bool, bypassCorsPreflightRequest, (), (const));
   MOCK_METHOD(JwtAuthnFilterStats&, stats, ());
 
-  bool bypass_cors_preflight_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   JwtAuthnFilterStats stats_;
 };
@@ -55,7 +54,7 @@ public:
 class FilterTest : public testing::Test {
 public:
   void SetUp() override {
-    mock_config_ = ::std::make_shared<NiceMock<MockFilterConfig>>();
+    mock_config_ = ::std::make_shared<NiceMockz<MockFilterConfig>>();
     mock_config_->bypass_cors_preflight_ = true;
 
     mock_verifier_ = std::make_unique<MockVerifier>();

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -55,7 +55,6 @@ class FilterTest : public testing::Test {
 public:
   void SetUp() override {
     mock_config_ = ::std::make_shared<NiceMockz<MockFilterConfig>>();
-    mock_config_->bypass_cors_preflight_ = true;
 
     mock_verifier_ = std::make_unique<MockVerifier>();
     filter_ = std::make_unique<Filter>(mock_config_);

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -16,6 +16,7 @@ using ::google::jwt_verify::Status;
 using testing::_;
 using testing::Invoke;
 using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -28,22 +29,34 @@ public:
   MOCK_METHOD(bool, matches, (const Http::HeaderMap& headers), (const));
 };
 
+JwtAuthnFilterStats generateMockStats(Stats::Scope& scope) {
+  return {ALL_JWT_AUTHN_FILTER_STATS(POOL_COUNTER_PREFIX(scope, ""))};
+}
+
 class MockFilterConfig : public FilterConfig {
 public:
-  MockFilterConfig(
-      const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
-      : FilterConfig(proto_config, stats_prefix, context) {}
+  MockFilterConfig() : stats_(generateMockStats(stats_store_)) {
+    ON_CALL(*this, bypassCorsPreflightRequest()).WillByDefault(Return(bypass_cors_preflight_));
+    ON_CALL(*this, findVerifier(_, _)).WillByDefault(Return(nullptr));
+    ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
+  }
+
   MOCK_METHOD(const Verifier*, findVerifier,
               (const Http::HeaderMap& headers, const StreamInfo::FilterState& filter_state),
               (const));
+  MOCK_METHOD(bool, bypassCorsPreflightRequest, (), (const));
+  MOCK_METHOD(JwtAuthnFilterStats&, stats, ());
+
+  bool bypass_cors_preflight_;
+  NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  JwtAuthnFilterStats stats_;
 };
 
 class FilterTest : public testing::Test {
 public:
   void SetUp() override {
-    proto_config_.set_bypass_cors_preflight(true);
-    mock_config_ = ::std::make_shared<MockFilterConfig>(proto_config_, "", mock_context_);
+    mock_config_ = ::std::make_shared<NiceMock<MockFilterConfig>>();
+    mock_config_->bypass_cors_preflight_ = true;
 
     mock_verifier_ = std::make_unique<MockVerifier>();
     filter_ = std::make_unique<Filter>(mock_config_);
@@ -54,9 +67,7 @@ public:
     EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).WillOnce(Return(mock_verifier_.get()));
   }
 
-  JwtAuthentication proto_config_;
-  NiceMock<Server::Configuration::MockFactoryContext> mock_context_;
-  std::shared_ptr<MockFilterConfig> mock_config_;
+  std::shared_ptr<NiceMock<MockFilterConfig>> mock_config_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks_;
   std::unique_ptr<Filter> filter_;
   std::unique_ptr<MockVerifier> mock_verifier_;

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -34,13 +34,13 @@ ProtobufWkt::Struct getExpectedPayload(const std::string& name) {
 class ProviderVerifierTest : public testing::Test {
 public:
   void createVerifier() {
-    filter_config_ = ::std::make_shared<FilterConfig>(proto_config_, "", mock_factory_ctx_);
+    filter_config_ = FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_);
     verifier_ = Verifier::create(proto_config_.rules(0).requires(), proto_config_.providers(),
                                  *filter_config_);
   }
 
   JwtAuthentication proto_config_;
-  FilterConfigSharedPtr filter_config_;
+  std::shared_ptr<AuthFactory> filter_config_;
   VerifierConstPtr verifier_;
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;
@@ -175,8 +175,7 @@ TEST_F(ProviderVerifierTest, TestRequiresNonexistentProvider) {
   TestUtility::loadFromYaml(ExampleConfig, proto_config_);
   proto_config_.mutable_rules(0)->mutable_requires()->set_provider_name("nosuchprovider");
 
-  EXPECT_THROW(::std::make_shared<FilterConfig>(proto_config_, "", mock_factory_ctx_),
-               EnvoyException);
+  EXPECT_THROW(FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_), EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -40,7 +40,7 @@ public:
   }
 
   JwtAuthentication proto_config_;
-  std::shared_ptr<AuthFactory> filter_config_;
+  std::shared_ptr<FilterConfigImpl> filter_config_;
   VerifierConstPtr verifier_;
   NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx_;
   ContextSharedPtr context_;

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -72,7 +72,7 @@ public:
                               main_callback);
     }
 
-    void set(InitializeCb cb) override { 
+    void set(InitializeCb cb) override {
       if (parent_.defer_data) {
         parent_.deferred_data_[index_] = cb;
       } else {

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -46,6 +46,7 @@ public:
   struct SlotImpl : public Slot {
     SlotImpl(MockInstance& parent, uint32_t index) : parent_(parent), index_(index) {
       parent_.data_.resize(index_ + 1);
+      parent_.deferred_data_.resize(index_ + 1);
     }
 
     ~SlotImpl() override {
@@ -71,15 +72,30 @@ public:
                               main_callback);
     }
 
-    void set(InitializeCb cb) override { parent_.data_[index_] = cb(parent_.dispatcher_); }
+    void set(InitializeCb cb) override { 
+      if (parent_.defer_data) {
+        parent_.deferred_data_[index_] = cb;
+      } else {
+        parent_.data_[index_] = cb(parent_.dispatcher_);
+      }
+    }
 
     MockInstance& parent_;
     const uint32_t index_;
   };
 
+  void call() {
+    for (unsigned i = 0; i < deferred_data_.size(); i++) {
+      data_[i] = deferred_data_[i](dispatcher_);
+    }
+    deferred_data_.clear();
+  }
+
   uint32_t current_slot_{};
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   std::vector<ThreadLocalObjectSharedPtr> data_;
+  std::vector<Slot::InitializeCb> deferred_data_;
+  bool defer_data{};
   bool shutdown_{};
   bool registered_{true};
 };


### PR DESCRIPTION
If a listener is torn down shortly after it is created, a tls callback invoked by the filter config object access objects that are deleted. This PR fixes the issue.

Risk Level: Low-medium
Testing: Unit tests; also tested fix manually with patched envoy.
Docs Changes: N\A
Release Notes:  N\A