### PR TITLE
[test] fix protocol integration test flake

### DIFF
--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -958,6 +958,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersAccepted) {
 TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersRejected) {
   // Default header (and trailer) count limit is 100.
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
+  config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
   Http::TestHeaderMapImpl request_trailers;
   for (int i = 0; i < 150; i++) {
     request_trailers.addCopy("trailer", std::string(1, 'a'));


### PR DESCRIPTION
Fix flake in this test (1/1000) that when using HTTP Upstream, the too many trailers did not cause a close:
```
Value of: fake_upstream_connection_->close()
  Actual: false (The connection disconnected unexpectedly, and allow_unexpected_disconnects_ is false.
 See https://github.com/envoyproxy/envoy/blob/master/test/integration/README.md#unexpected-disconnects)
Expected: true
```
Risk level: Low
Testing: Run test 1000 times

Signed-off-by: Asra Ali <asraa@google.com>