### PR TITLE
examples: tracing config for zipkin and jaeger

### DIFF
--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -11,6 +11,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           generate_request_id: true
+          tracing: {}
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -10,6 +10,7 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing: {}
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -38,6 +39,7 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing: {}
           codec_type: auto
           stat_prefix: egress_http
           route_config:

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -10,6 +10,7 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing: {}
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -11,6 +11,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           generate_request_id: true
+          tracing: {}
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -10,6 +10,7 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing: {}
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -38,6 +39,7 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing: {}
           codec_type: auto
           stat_prefix: egress_http
           route_config:

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -10,6 +10,7 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing: {}
           codec_type: auto
           stat_prefix: ingress_http
           route_config:


### PR DESCRIPTION
Description:

This patch inserts tracing config entry into the HTTP Connection Manager config
of Zipkin and Jaeger examples.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Fixes #9880