### PR TITLE
docs: fixed typo

### DIFF
--- a/docs/root/api/api_supported_versions.rst
+++ b/docs/root/api/api_supported_versions.rst
@@ -1,7 +1,7 @@
 .. _api_supported_versions:
 
-Suported API versions
-=====================
+Supported API versions
+======================
 
 Envoy's APIs follow a :repo:`versioning scheme <api/API_VERSIONING.md>` in which Envoy supports
 multiple major API versions at any point in time. The following versions are currently supported:


### PR DESCRIPTION
Description:
Fixed a typo in one of the titles in the api docs "Suported" -> "Supported".

Risk Level:
Low

Testing:
None

Docs Changes:
Changed "Suported" -> "Supported" in docs/root/api/api_supported_versions.rst

Release Notes:
N/A
