### PR TITLE
runtime: Bypass entry map lookup for empty keys

### DIFF
--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -235,7 +235,7 @@ bool SnapshotImpl::featureEnabled(absl::string_view key, uint64_t default_value,
 
 const std::string& SnapshotImpl::get(absl::string_view key) const {
   ASSERT(!isRuntimeFeature(key)); // Make sure runtime guarding is only used for getBoolean
-  auto entry = values_.find(key);
+  auto entry = key.empty() ? values_.end() : values_.find(key);
   if (entry == values_.end()) {
     return EMPTY_STRING;
   } else {
@@ -251,7 +251,7 @@ bool SnapshotImpl::featureEnabled(absl::string_view key,
 bool SnapshotImpl::featureEnabled(absl::string_view key,
                                   const envoy::type::v3::FractionalPercent& default_value,
                                   uint64_t random_value) const {
-  const auto& entry = values_.find(key);
+  const auto& entry = key.empty() ? values_.end() : values_.find(key);
   envoy::type::v3::FractionalPercent percent;
   if (entry != values_.end() && entry->second.fractional_percent_value_.has_value()) {
     percent = entry->second.fractional_percent_value_.value();
@@ -277,7 +277,7 @@ bool SnapshotImpl::featureEnabled(absl::string_view key,
 
 uint64_t SnapshotImpl::getInteger(absl::string_view key, uint64_t default_value) const {
   ASSERT(!isRuntimeFeature(key));
-  auto entry = values_.find(key);
+  const auto& entry = key.empty() ? values_.end() : values_.find(key);
   if (entry == values_.end() || !entry->second.uint_value_) {
     return default_value;
   } else {
@@ -287,7 +287,7 @@ uint64_t SnapshotImpl::getInteger(absl::string_view key, uint64_t default_value)
 
 double SnapshotImpl::getDouble(absl::string_view key, double default_value) const {
   ASSERT(!isRuntimeFeature(key)); // Make sure runtime guarding is only used for getBoolean
-  auto entry = values_.find(key);
+  const auto& entry = key.empty() ? values_.end() : values_.find(key);
   if (entry == values_.end() || !entry->second.double_value_) {
     return default_value;
   } else {
@@ -296,7 +296,7 @@ double SnapshotImpl::getDouble(absl::string_view key, double default_value) cons
 }
 
 bool SnapshotImpl::getBoolean(absl::string_view key, bool default_value) const {
-  auto entry = values_.find(key);
+  const auto& entry = key.empty() ? values_.end() : values_.find(key);
   if (entry == values_.end() || !entry->second.bool_value_.has_value()) {
     return default_value;
   } else {

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -161,6 +161,16 @@ public:
   ProtobufWkt::Struct base_;
 };
 
+TEST_F(DiskLoaderImplTest, EmptyKeyTest) {
+  EXPECT_EQ("", loader_->snapshot().get(""));
+  EXPECT_EQ(11, loader_->snapshot().getInteger("", 11));
+  EXPECT_EQ(1.1, loader_->snapshot().getDouble("", 1.1));
+  EXPECT_EQ(false, loader_->snapshot().featureEnabled("", 0));
+  EXPECT_EQ(true, loader_->snapshot().featureEnabled("", 100));
+  EXPECT_EQ(true, loader_->snapshot().getBoolean("", true));
+  EXPECT_EQ(false, loader_->snapshot().getBoolean("", false));
+}
+
 TEST_F(DiskLoaderImplTest, DoubleUintInteraction) {
   setup();
   run("test/common/runtime/test_data/current", "envoy_override");

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -162,6 +162,9 @@ public:
 };
 
 TEST_F(DiskLoaderImplTest, EmptyKeyTest) {
+  setup();
+  run("test/common/runtime/test_data/current", "envoy_override");
+
   EXPECT_EQ("", loader_->snapshot().get(""));
   EXPECT_EQ(11, loader_->snapshot().getInteger("", 11));
   EXPECT_EQ(1.1, loader_->snapshot().getDouble("", 1.1));


### PR DESCRIPTION
This patch is a minor optimization that short-circuits the lookup in the
EntryMap if the key is empty.

Risk Level: Low. No changes in behavior.
Testing: Existing unit tests.
Docs Changes: N/A
Release Notes: N/A