### PR TITLE
thrift: introduce PassThroughDecoderFilter

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/filters/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/filters/BUILD
@@ -50,3 +50,11 @@ envoy_cc_library(
         "//source/common/singleton:const_singleton",
     ],
 )
+
+envoy_cc_library(
+    name = "pass_through_filter_lib",
+    hdrs = ["pass_through_filter.h"],
+    deps = [
+        ":filter_interface"
+    ]
+)

--- a/source/extensions/filters/network/thrift_proxy/filters/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/filters/BUILD
@@ -55,6 +55,6 @@ envoy_cc_library(
     name = "pass_through_filter_lib",
     hdrs = ["pass_through_filter.h"],
     deps = [
-        ":filter_interface"
-    ]
+        ":filter_interface",
+    ],
 )

--- a/source/extensions/filters/network/thrift_proxy/filters/pass_through_filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/pass_through_filter.h
@@ -11,7 +11,8 @@ namespace ThriftProxy {
 namespace ThriftFilters {
 
 /**
- * Pass through Thrift decoder filter. Continue at each decoding state within the series of transitions.
+ * Pass through Thrift decoder filter. Continue at each decoding state within the series of
+ * transitions.
  */
 class PassThroughDecoderFilter : public DecoderFilter {
 public:

--- a/source/extensions/filters/network/thrift_proxy/filters/pass_through_filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/pass_through_filter.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "extensions/filters/network/thrift_proxy/filters/filter.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+namespace ThriftFilters {
+
+/**
+ * Pass through Thrift decoder filter. Continue at each decoding state within the series of transitions.
+ */
+class PassThroughDecoderFilter : public DecoderFilter {
+public:
+  // ThriftDecoderFilter
+  void onDestroy() override {}
+
+  void setDecoderFilterCallbacks(DecoderFilterCallbacks& callbacks) override {
+    decoder_callbacks_ = &callbacks;
+  };
+
+  // Thrift Decoder State Machine
+  ThriftProxy::FilterStatus transportBegin(ThriftProxy::MessageMetadataSharedPtr) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus transportEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+  ThriftProxy::FilterStatus messageBegin(ThriftProxy::MessageMetadataSharedPtr) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus messageEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+  ThriftProxy::FilterStatus structBegin(absl::string_view) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus structEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+  ThriftProxy::FilterStatus fieldBegin(absl::string_view, ThriftProxy::FieldType&,
+                                       int16_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus fieldEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+  ThriftProxy::FilterStatus boolValue(bool&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus byteValue(uint8_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus int16Value(int16_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus int32Value(int32_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus int64Value(int64_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus doubleValue(double&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus stringValue(absl::string_view) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus mapBegin(ThriftProxy::FieldType&, ThriftProxy::FieldType&,
+                                     uint32_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus mapEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+  ThriftProxy::FilterStatus listBegin(ThriftProxy::FieldType&, uint32_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus listEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+  ThriftProxy::FilterStatus setBegin(ThriftProxy::FieldType&, uint32_t&) override {
+    return ThriftProxy::FilterStatus::Continue;
+  }
+
+  ThriftProxy::FilterStatus setEnd() override { return ThriftProxy::FilterStatus::Continue; }
+
+protected:
+  DecoderFilterCallbacks* decoder_callbacks_{};
+};
+
+} // namespace ThriftFilters
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/BUILD
@@ -21,7 +21,7 @@ envoy_cc_library(
         "//source/extensions/filters/common/ratelimit:ratelimit_lib",
         "//source/extensions/filters/common/ratelimit:stat_names_lib",
         "//source/extensions/filters/network/thrift_proxy:app_exception_lib",
-        "//source/extensions/filters/network/thrift_proxy/filters:filter_interface",
+        "//source/extensions/filters/network/thrift_proxy/filters:pass_through_filter_lib",
         "//source/extensions/filters/network/thrift_proxy/router:router_ratelimit_interface",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/filters/ratelimit/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -80,7 +80,8 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
       decoder_callbacks_->sendLocalReply(
           ThriftProxy::AppException(ThriftProxy::AppExceptionType::InternalError, "limiter error"),
           false);
-      decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError);
+      decoder_callbacks_->streamInfo().setResponseFlag(
+          StreamInfo::ResponseFlag::RateLimitServiceError);
       return;
     }
     cluster_->statsScope().counterFromStatName(stat_names.failure_mode_allowed_).inc();
@@ -117,7 +118,8 @@ void Filter::populateRateLimitDescriptors(
       continue;
     }
     rate_limit.populateDescriptors(*route_entry, descriptors, config_->localInfo().clusterName(),
-                                   metadata, *decoder_callbacks_->streamInfo().downstreamRemoteAddress());
+                                   metadata,
+                                   *decoder_callbacks_->streamInfo().downstreamRemoteAddress());
   }
 }
 

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -25,7 +25,7 @@ ThriftProxy::FilterStatus Filter::messageBegin(ThriftProxy::MessageMetadataShare
 }
 
 void Filter::initiateCall(const ThriftProxy::MessageMetadata& metadata) {
-  ThriftProxy::Router::RouteConstSharedPtr route = callbacks_->route();
+  ThriftProxy::Router::RouteConstSharedPtr route = decoder_callbacks_->route();
   if (!route || !route->routeEntry()) {
     return;
   }
@@ -77,10 +77,10 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
     cluster_->statsScope().counterFromStatName(stat_names.error_).inc();
     if (!config_->failureModeAllow()) {
       state_ = State::Responded;
-      callbacks_->sendLocalReply(
+      decoder_callbacks_->sendLocalReply(
           ThriftProxy::AppException(ThriftProxy::AppExceptionType::InternalError, "limiter error"),
           false);
-      callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError);
+      decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError);
       return;
     }
     cluster_->statsScope().counterFromStatName(stat_names.failure_mode_allowed_).inc();
@@ -89,17 +89,17 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
     cluster_->statsScope().counterFromStatName(stat_names.over_limit_).inc();
     if (config_->runtime().snapshot().featureEnabled("ratelimit.thrift_filter_enforcing", 100)) {
       state_ = State::Responded;
-      callbacks_->sendLocalReply(
+      decoder_callbacks_->sendLocalReply(
           ThriftProxy::AppException(ThriftProxy::AppExceptionType::InternalError, "over limit"),
           false);
-      callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
+      decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
       return;
     }
     break;
   }
 
   if (!initiating_call_) {
-    callbacks_->continueDecoding();
+    decoder_callbacks_->continueDecoding();
   }
 }
 
@@ -117,7 +117,7 @@ void Filter::populateRateLimitDescriptors(
       continue;
     }
     rate_limit.populateDescriptors(*route_entry, descriptors, config_->localInfo().clusterName(),
-                                   metadata, *callbacks_->streamInfo().downstreamRemoteAddress());
+                                   metadata, *decoder_callbacks_->streamInfo().downstreamRemoteAddress());
   }
 }
 

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -13,7 +13,7 @@
 
 #include "extensions/filters/common/ratelimit/ratelimit.h"
 #include "extensions/filters/common/ratelimit/stat_names.h"
-#include "extensions/filters/network/thrift_proxy/filters/filter.h"
+#include "extensions/filters/network/thrift_proxy/filters/pass_through_filter.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -65,69 +65,16 @@ using ConfigSharedPtr = std::shared_ptr<Config>;
  * error is returned and the failure_mode_deny option is enabled, an application exception is
  * returned. By default, errors allow the request to continue.
  */
-class Filter : public ThriftProxy::ThriftFilters::DecoderFilter,
+class Filter : public ThriftProxy::ThriftFilters::PassThroughDecoderFilter,
                public Filters::Common::RateLimit::RequestCallbacks {
 public:
   Filter(ConfigSharedPtr config, Filters::Common::RateLimit::ClientPtr&& client)
       : config_(std::move(config)), client_(std::move(client)) {}
   ~Filter() override = default;
 
-  // ThriftFilters::ThriftDecoderFilter
+  // ThriftFilters::PassThroughDecoderFilter
   void onDestroy() override;
-  void setDecoderFilterCallbacks(
-      ThriftProxy::ThriftFilters::DecoderFilterCallbacks& callbacks) override {
-    callbacks_ = &callbacks;
-  };
-  ThriftProxy::FilterStatus
-  transportBegin(NetworkFilters::ThriftProxy::MessageMetadataSharedPtr) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus transportEnd() override { return ThriftProxy::FilterStatus::Continue; }
   ThriftProxy::FilterStatus messageBegin(ThriftProxy::MessageMetadataSharedPtr) override;
-  ThriftProxy::FilterStatus messageEnd() override { return ThriftProxy::FilterStatus::Continue; }
-  ThriftProxy::FilterStatus structBegin(absl::string_view) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus structEnd() override { return ThriftProxy::FilterStatus::Continue; }
-  ThriftProxy::FilterStatus fieldBegin(absl::string_view, ThriftProxy::FieldType&,
-                                       int16_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus fieldEnd() override { return ThriftProxy::FilterStatus::Continue; }
-  ThriftProxy::FilterStatus boolValue(bool&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus byteValue(uint8_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus int16Value(int16_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus int32Value(int32_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus int64Value(int64_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus doubleValue(double&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus stringValue(absl::string_view) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus mapBegin(ThriftProxy::FieldType&, ThriftProxy::FieldType&,
-                                     uint32_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus mapEnd() override { return ThriftProxy::FilterStatus::Continue; }
-  ThriftProxy::FilterStatus listBegin(ThriftProxy::FieldType&, uint32_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus listEnd() override { return ThriftProxy::FilterStatus::Continue; }
-  ThriftProxy::FilterStatus setBegin(ThriftProxy::FieldType&, uint32_t&) override {
-    return ThriftProxy::FilterStatus::Continue;
-  }
-  ThriftProxy::FilterStatus setEnd() override { return ThriftProxy::FilterStatus::Continue; }
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
@@ -145,7 +92,6 @@ private:
 
   ConfigSharedPtr config_;
   Filters::Common::RateLimit::ClientPtr client_;
-  ThriftProxy::ThriftFilters::DecoderFilterCallbacks* callbacks_{};
   State state_{State::NotStarted};
   Upstream::ClusterInfoConstSharedPtr cluster_;
   bool initiating_call_{false};

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -73,7 +73,6 @@ public:
   ~Filter() override = default;
 
   // ThriftFilters::PassThroughDecoderFilter
-  void onDestroy() override;
   ThriftProxy::FilterStatus messageBegin(ThriftProxy::MessageMetadataSharedPtr) override;
 
   // RateLimit::RequestCallbacks

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -73,6 +73,7 @@ public:
   ~Filter() override = default;
 
   // ThriftFilters::PassThroughDecoderFilter
+  void onDestroy() override;
   ThriftProxy::FilterStatus messageBegin(ThriftProxy::MessageMetadataSharedPtr) override;
 
   // RateLimit::RequestCallbacks


### PR DESCRIPTION
Description: The Thrift decoder state machine has a lot of FilterStatus methods, making simple Thrift filters a bit cumbersome. This introduces a base class that returns `FilterStatus::Continue` for all methods so that subclasses can override the methods that matter to them, as shown with the thrift rate limit filter.
Risk Level: low
Testing: existing
Docs Changes: n/a
Release Notes: n/a
