### PR TITLE
thrift_proxy: remove alpha status

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -36,7 +36,6 @@ envoy_cc_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     security_posture = "requires_trusted_downstream_and_upstream",
-    status = "alpha",
     deps = [
         ":app_exception_lib",
         ":auto_protocol_lib",

--- a/source/extensions/filters/network/thrift_proxy/router/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/router/BUILD
@@ -14,7 +14,6 @@ envoy_cc_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     security_posture = "requires_trusted_downstream_and_upstream",
-    status = "alpha",
     deps = [
         ":router_lib",
         "//include/envoy/registry",


### PR DESCRIPTION
We've been using this in prod for a couple of months and for
a few different services.

A few critical bugs have been fixed (#9089 and #6549) and some
necessary stats/features have been added (#9203 and #8994), so
it's probably a good time to graduate at least the proxy
and the router filter.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
