### PR TITLE
repokitteh: add backport labeling

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -16,3 +16,8 @@ use(
 )
 
 alias('retest', 'retry-circle')
+
+def _backport():
+  github.issue_label('backport/review')
+
+command(name='backport', func=_backport)

--- a/repokitteh.star
+++ b/repokitteh.star
@@ -20,4 +20,4 @@ alias('retest', 'retry-circle')
 def _backport():
   github.issue_label('backport/review')
 
-command(name='backport', func=_backport)
+handlers.command(name='backport', func=_backport)

--- a/source/docs/repokitteh.md
+++ b/source/docs/repokitteh.md
@@ -86,7 +86,7 @@ Restarts all failed CircleCI tests, as reported in the commit statuses.
 
 [Demo PR](https://github.com/envoyproxy/envoy/pull/5060#issuecomment-439285928)
 
-### [Granular Ownerscheck] (https://github.com/repokitteh/modules/blob/master/ownerscheck.star)
+### [Granular Ownerscheck](https://github.com/repokitteh/modules/blob/master/ownerscheck.star)
 
 Two types of approvals:
 1. Global approvals, done by approving the PR using Github's review approval feature.
@@ -94,3 +94,11 @@ Two types of approvals:
    associated with the path. This does not affect GitHub's PR approve status, only
    this module's maintained commit status. This approval is automatically revoked
    if any further changes are done to the relevant files in this spec.
+
+#### Backport labeling
+
+```
+/backport
+```
+
+will labels the PR commented on with `backport/review`.


### PR DESCRIPTION
Description: Add a /backport command. Labels PR as 'backport/review'.
Risk Level: None.
Testing: In this PR.
Docs Changes: In this PR.
Release Notes: None
