### PR TITLE
tools: fix a variable name in check_format.py

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -817,7 +817,7 @@ def checkFormatVisitor(arg, dir_name, names):
   # python lists are passed as references, this is used to collect the list of
   # async results (futures) from running checkFormat and passing them back to
   # the caller.
-  pool, result_list, owned_directories, error_messags = arg
+  pool, result_list, owned_directories, error_messages = arg
 
   # Sanity check CODEOWNERS.  This doesn't need to be done in a multi-threaded
   # manner as it is a small and limited list.


### PR DESCRIPTION
Description:

Python linter noticed that `error_messags` variable was unused in `check_format.py`. The code has (apparently accidently) so far used the global variable `error_messages`. Fix by renaming the variable to shadow the global. @alyssawilk can you verify that this is the intention in the code?

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
