### PR TITLE
tls: request client certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ clang.bazelrc
 user.bazelrc
 CMakeLists.txt
 cmake-build-debug
+.DS_Store
+.idea

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -389,7 +389,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DownstreamTlsContext {
   // Common TLS context settings.
   CommonTlsContext common_tls_context = 1;
@@ -397,6 +397,9 @@ message DownstreamTlsContext {
   // If specified, Envoy will reject connections without a valid client
   // certificate.
   google.protobuf.BoolValue require_client_certificate = 2;
+
+  // If specified, Envoy will request a client certificate.
+  google.protobuf.BoolValue request_client_certificate = 7;
 
   // If specified, Envoy will reject connections without a valid and matching SNI.
   // [#not-implemented-hide:]

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -404,7 +404,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
@@ -415,6 +415,9 @@ message DownstreamTlsContext {
   // If specified, Envoy will reject connections without a valid client
   // certificate.
   google.protobuf.BoolValue require_client_certificate = 2;
+
+  // If specified, Envoy will request a client certificate.
+  google.protobuf.BoolValue request_client_certificate = 7;
 
   // If specified, Envoy will reject connections without a valid and matching SNI.
   // [#not-implemented-hide:]

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -389,7 +389,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DownstreamTlsContext {
   // Common TLS context settings.
   CommonTlsContext common_tls_context = 1;
@@ -397,6 +397,9 @@ message DownstreamTlsContext {
   // If specified, Envoy will reject connections without a valid client
   // certificate.
   google.protobuf.BoolValue require_client_certificate = 2;
+
+  // If specified, Envoy will request a client certificate.
+  google.protobuf.BoolValue request_client_certificate = 7;
 
   // If specified, Envoy will reject connections without a valid and matching SNI.
   // [#not-implemented-hide:]

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -409,7 +409,7 @@ message UpstreamTlsContext {
   google.protobuf.UInt32Value max_session_keys = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DownstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.DownstreamTlsContext";
@@ -420,6 +420,9 @@ message DownstreamTlsContext {
   // If specified, Envoy will reject connections without a valid client
   // certificate.
   google.protobuf.BoolValue require_client_certificate = 2;
+
+  // If specified, Envoy will request a client certificate.
+  google.protobuf.BoolValue request_client_certificate = 7;
 
   // If specified, Envoy will reject connections without a valid and matching SNI.
   // [#not-implemented-hide:]

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -118,6 +118,11 @@ public:
   virtual bool requireClientCertificate() const PURE;
 
   /**
+   * @return True if client certificate should be requested requested, false otherwise.
+   */
+  virtual bool requestClientCertificate() const PURE;
+
+  /**
    * @return The keys to use for encrypting and decrypting session tickets.
    * The first element is used for encrypting new tickets, and all elements
    * are candidates for decrypting received tickets.

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -373,6 +373,8 @@ ServerContextConfigImpl::ServerContextConfigImpl(
                         DEFAULT_CIPHER_SUITES, DEFAULT_CURVES, factory_context),
       require_client_certificate_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, false)),
+      request_client_certificate_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, request_client_certificate, false)),
       session_ticket_keys_provider_(
           getTlsSessionTicketKeysConfigProvider(factory_context, config)) {
   if (session_ticket_keys_provider_ != nullptr) {

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -134,6 +134,7 @@ public:
 
   // Ssl::ServerContextConfig
   bool requireClientCertificate() const override { return require_client_certificate_; }
+  bool requestClientCertificate() const override { return request_client_certificate_; }
   const std::vector<SessionTicketKey>& sessionTicketKeys() const override {
     return session_ticket_keys_;
   }
@@ -155,6 +156,7 @@ private:
   static const std::string DEFAULT_CURVES;
 
   const bool require_client_certificate_;
+  const bool request_client_certificate_;
   std::vector<SessionTicketKey> session_ticket_keys_;
   const Secret::TlsSessionTicketKeysConfigProviderSharedPtr session_ticket_keys_provider_;
   Common::CallbackHandle* stk_update_callback_handle_{};

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -929,6 +929,10 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
       });
 
   for (auto& ctx : tls_contexts_) {
+    if (config.requestClientCertificate()) {
+      SSL_CTX_set_verify(ctx.ssl_ctx_.get(), SSL_VERIFY_PEER, nullptr);
+    }
+
     if (config.certificateValidationContext() != nullptr &&
         !config.certificateValidationContext()->caCert().empty()) {
       ctx.addClientValidationContext(*config.certificateValidationContext(),

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -1141,6 +1141,103 @@ TEST_P(SslSocketTest, GetPeerCert) {
                .setExpectedPeerCert(expected_peer_cert));
 }
 
+
+TEST_P(SslSocketTest, RequestPeerCertNoCert) {
+  const std::string client_ctx_yaml = R"EOF(
+    common_tls_context:
+  )EOF";
+
+  const std::string server_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_tmpdir }}/unittestcert.pem"
+      private_key:
+        filename: "{{ test_tmpdir }}/unittestkey.pem"
+  request_client_certificate: true
+)EOF";
+
+  TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
+  testUtil(test_options.setExpectedServerStats("ssl.no_certificate")
+               .setExpectNoCert()
+               .setExpectNoCertChain());
+}
+
+TEST_P(SslSocketTest, RequestPeerCert) {
+  const std::string client_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+)EOF";
+
+  const std::string server_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
+  request_client_certificate: true
+)EOF";
+
+  TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
+  std::string expected_peer_cert =
+      TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+          "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"));
+  testUtil(test_options.setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL)
+               .setExpectedPeerIssuer(
+                   "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US")
+               .setExpectedPeerSubject(
+                   "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US")
+               .setExpectedLocalSubject(
+                   "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US")
+               .setExpectedPeerCert(expected_peer_cert));
+}
+
+TEST_P(SslSocketTest, RequirePeerCertTakesPrecedenceOverRequest) {
+  const std::string client_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+)EOF";
+
+  const std::string server_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
+  require_client_certificate: true
+  request_client_certificate: true
+)EOF";
+
+  TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
+  std::string expected_peer_cert =
+      TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+          "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"));
+  testUtil(test_options.setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL)
+               .setExpectedPeerIssuer(
+                   "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US")
+               .setExpectedPeerSubject(
+                   "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US")
+               .setExpectedLocalSubject(
+                   "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US")
+               .setExpectedPeerCert(expected_peer_cert));
+}
+
 TEST_P(SslSocketTest, GetPeerCertChain) {
   const std::string client_ctx_yaml = R"EOF(
   common_tls_context:

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -108,6 +108,7 @@ public:
   MOCK_METHOD(void, setSecretUpdateCallback, (std::function<void()> callback));
 
   MOCK_METHOD(bool, requireClientCertificate, (), (const));
+  MOCK_METHOD(bool, requestClientCertificate, (), (const));
   MOCK_METHOD(const std::vector<SessionTicketKey>&, sessionTicketKeys, (), (const));
 };
 


### PR DESCRIPTION
Description: 

Allows Envoy to request a client certificate in cases where more than one type of client authentication is required. For example, some API gateways allow both mutual TLS (where a client certificate is needed) and OAuth2 (which uses a JWT). While this can be done with different listeners or a filter match on the SNI, this use case requires multiple types of authentication on the same SNI. This pull request adds the capability for Envoy to _request_, but not _require_ a client certificate. If the client provides a certificate, it will be validated against the configured downstream validation context.

Risk Level: Low

Testing: 

Added unit tests to verify that `require_client_certificate` takes precedence over`request_client_certificate` and that the certificate is validated against the configured validation context.

Docs Changes: 

Only the new option needs to be documented.

Release Notes: