### PR TITLE
Fix various win32 compile issues

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -132,11 +132,11 @@ envoy_cmake_external(
         "//bazel:windows_x86_64": [
             "event.lib",
             "event_core.lib",
-            "event_extra.lib",
         ],
         "//conditions:default": [
             "libevent.a",
             "libevent_pthreads.a",
+            "libevent_core.a",
         ],
     }),
 )

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -281,8 +281,8 @@ void LoadBalancerBase::recalculateLoadInTotalPanic() {
   // First calculate total number of hosts across all priorities regardless
   // whether they are healthy or not.
   const uint32_t total_hosts_count = std::accumulate(
-      priority_set_.hostSetsPerPriority().begin(), priority_set_.hostSetsPerPriority().end(), 0,
-      [](size_t acc, const std::unique_ptr<Envoy::Upstream::HostSet>& host_set) {
+      priority_set_.hostSetsPerPriority().begin(), priority_set_.hostSetsPerPriority().end(),
+      (size_t)0, [](size_t acc, const std::unique_ptr<Envoy::Upstream::HostSet>& host_set) {
         return acc + host_set->hosts().size();
       });
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -280,11 +280,12 @@ void LoadBalancerBase::recalculatePerPriorityPanic() {
 void LoadBalancerBase::recalculateLoadInTotalPanic() {
   // First calculate total number of hosts across all priorities regardless
   // whether they are healthy or not.
-  const uint32_t total_hosts_count = std::accumulate(
-      priority_set_.hostSetsPerPriority().begin(), priority_set_.hostSetsPerPriority().end(),
-      (size_t)0, [](size_t acc, const std::unique_ptr<Envoy::Upstream::HostSet>& host_set) {
-        return acc + host_set->hosts().size();
-      });
+  const uint32_t total_hosts_count =
+      std::accumulate(priority_set_.hostSetsPerPriority().begin(),
+                      priority_set_.hostSetsPerPriority().end(), static_cast<size_t>(0),
+                      [](size_t acc, const std::unique_ptr<Envoy::Upstream::HostSet>& host_set) {
+                        return acc + host_set->hosts().size();
+                      });
 
   if (0 == total_hosts_count) {
     // Backend is empty, but load must be distributed somewhere.

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -965,7 +965,7 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
     }
 
     int rc =
-        SSL_CTX_set_session_id_context(ctx.ssl_ctx_.get(), session_id.begin(), session_id.size());
+        SSL_CTX_set_session_id_context(ctx.ssl_ctx_.get(), session_id.data(), session_id.size());
     RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));
   }
 }
@@ -1096,7 +1096,7 @@ ServerContextImpl::generateHashForSessionContextId(const std::vector<std::string
   static_assert(session_id.size() == SHA256_DIGEST_LENGTH, "hash size mismatch");
   static_assert(session_id.size() == SSL_MAX_SSL_SESSION_ID_LENGTH, "TLS session ID size mismatch");
 
-  rc = EVP_DigestFinal(md.get(), session_id.begin(), &hash_length);
+  rc = EVP_DigestFinal(md.get(), session_id.data(), &hash_length);
   RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));
   RELEASE_ASSERT(hash_length == session_id.size(),
                  "SHA256 hash length must match TLS Session ID size");

--- a/test/common/filesystem/directory_test.cc
+++ b/test/common/filesystem/directory_test.cc
@@ -190,7 +190,13 @@ TEST_F(DirectoryTest, DirectoryWithBrokenSymlink) {
   const EntrySet expected = {
       {".", FileType::Directory},
       {"..", FileType::Directory},
+#ifndef WIN32
+// On Linux, a broken directory link is simply a symlink to be rm'ed
       {"link_dir", FileType::Regular},
+#else
+// On Windows, a broken directory link remains a directory link to be rmdir'ed
+      {"link_dir", FileType::Directory},
+#endif
   };
   EXPECT_EQ(expected, getDirectoryContents(dir_path_, false));
 }

--- a/test/common/filesystem/directory_test.cc
+++ b/test/common/filesystem/directory_test.cc
@@ -191,10 +191,10 @@ TEST_F(DirectoryTest, DirectoryWithBrokenSymlink) {
       {".", FileType::Directory},
       {"..", FileType::Directory},
 #ifndef WIN32
-// On Linux, a broken directory link is simply a symlink to be rm'ed
+      // On Linux, a broken directory link is simply a symlink to be rm'ed
       {"link_dir", FileType::Regular},
 #else
-// On Windows, a broken directory link remains a directory link to be rmdir'ed
+      // On Windows, a broken directory link remains a directory link to be rmdir'ed
       {"link_dir", FileType::Directory},
 #endif
   };

--- a/tools/spelling_dictionary.txt
+++ b/tools/spelling_dictionary.txt
@@ -922,6 +922,7 @@ resync
 ret
 retriable
 retriggers
+rmdir
 rollout
 roundtrip
 rpcs


### PR DESCRIPTION
Description:

Address recent breakage and a few easily reviewed long-standing open win32 issues.

Note specifically that the first commit to foreign_cc BoringSSL build addresses the fact that its own bazel build doesn't respect our choice to build a static library. The patch deserve additions and further adjustment, but resolves https://github.com/envoyproxy/envoy/pull/8754 which could not be reopened due to my force push.

Risk Level: low
Testing: local on windows msvc, linux gcc
Docs Changes: n/a
Release Notes: n/a
