### PR TITLE
access_loggers: use new-style names

### DIFF
--- a/api/envoy/config/accesslog/v2/als.proto
+++ b/api/envoy/config/accesslog/v2/als.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.acces
 
 // [#protodoc-title: gRPC Access Log Service (ALS)]
 
-// Configuration for the built-in *envoy.http_grpc_access_log*
+// Configuration for the built-in *envoy.access_loggers.http_grpc*
 // :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`. This configuration will
 // populate :ref:`StreamAccessLogsMessage.http_logs
 // <envoy_api_field_service.accesslog.v2.StreamAccessLogsMessage.http_logs>`.
@@ -38,7 +38,7 @@ message HttpGrpcAccessLogConfig {
   repeated string additional_response_trailers_to_log = 4;
 }
 
-// Configuration for the built-in *envoy.tcp_grpc_access_log* type. This configuration will
+// Configuration for the built-in *envoy.access_loggers.tcp_grpc* type. This configuration will
 // populate *StreamAccessLogsMessage.tcp_logs*.
 // [#extension: envoy.access_loggers.tcp_grpc]
 message TcpGrpcAccessLogConfig {

--- a/api/envoy/config/accesslog/v2/file.proto
+++ b/api/envoy/config/accesslog/v2/file.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.acces
 // [#extension: envoy.access_loggers.file]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`
-// that writes log entries directly to a file. Configures the built-in *envoy.file_access_log*
+// that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
 // AccessLog.
 message FileAccessLog {
   // A path to a local file to which to write the access log entries.

--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -30,9 +30,9 @@ message AccessLog {
   // The name of the access log implementation to instantiate. The name must
   // match a statically registered access log. Current built-in loggers include:
   //
-  // #. "envoy.file_access_log"
-  // #. "envoy.http_grpc_access_log"
-  // #. "envoy.tcp_grpc_access_log"
+  // #. "envoy.access_loggers.file"
+  // #. "envoy.access_loggers.http_grpc"
+  // #. "envoy.access_loggers.tcp_grpc"
   string name = 1;
 
   // Filter which is used to determine if the access log needs to be written.
@@ -41,11 +41,11 @@ message AccessLog {
   // Custom configuration that depends on the access log being instantiated. Built-in
   // configurations include:
   //
-  // #. "envoy.file_access_log": :ref:`FileAccessLog
+  // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_extensions.access_loggers.file.v3.FileAccessLog>`
-  // #. "envoy.http_grpc_access_log": :ref:`HttpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.http_grpc": :ref:`HttpGrpcAccessLogConfig
   //    <envoy_api_msg_extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig>`
-  // #. "envoy.tcp_grpc_access_log": :ref:`TcpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.tcp_grpc": :ref:`TcpGrpcAccessLogConfig
   //    <envoy_api_msg_extensions.access_loggers.grpc.v3.TcpGrpcAccessLogConfig>`
   oneof config_type {
     google.protobuf.Any typed_config = 4;

--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -23,9 +23,9 @@ message AccessLog {
   // The name of the access log implementation to instantiate. The name must
   // match a statically registered access log. Current built-in loggers include:
   //
-  // #. "envoy.file_access_log"
-  // #. "envoy.http_grpc_access_log"
-  // #. "envoy.tcp_grpc_access_log"
+  // #. "envoy.access_loggers.file"
+  // #. "envoy.access_loggers.http_grpc"
+  // #. "envoy.access_loggers.tcp_grpc"
   string name = 1;
 
   // Filter which is used to determine if the access log needs to be written.
@@ -34,11 +34,11 @@ message AccessLog {
   // Custom configuration that depends on the access log being instantiated. Built-in
   // configurations include:
   //
-  // #. "envoy.file_access_log": :ref:`FileAccessLog
+  // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_config.accesslog.v2.FileAccessLog>`
-  // #. "envoy.http_grpc_access_log": :ref:`HttpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.http_grpc": :ref:`HttpGrpcAccessLogConfig
   //    <envoy_api_msg_config.accesslog.v2.HttpGrpcAccessLogConfig>`
-  // #. "envoy.tcp_grpc_access_log": :ref:`TcpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.tcp_grpc": :ref:`TcpGrpcAccessLogConfig
   //    <envoy_api_msg_config.accesslog.v2.TcpGrpcAccessLogConfig>`
   oneof config_type {
     google.protobuf.Struct config = 3 [deprecated = true];

--- a/api/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/api/envoy/extensions/access_loggers/file/v3/file.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 // [#extension: envoy.access_loggers.file]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`
-// that writes log entries directly to a file. Configures the built-in *envoy.file_access_log*
+// that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
 // AccessLog.
 message FileAccessLog {
   option (udpa.annotations.versioning).previous_message_type =

--- a/api/envoy/extensions/access_loggers/grpc/v3/als.proto
+++ b/api/envoy/extensions/access_loggers/grpc/v3/als.proto
@@ -17,7 +17,7 @@ option java_multiple_files = true;
 
 // [#protodoc-title: gRPC Access Log Service (ALS)]
 
-// Configuration for the built-in *envoy.http_grpc_access_log*
+// Configuration for the built-in *envoy.access_loggers.http_grpc*
 // :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`. This configuration will
 // populate :ref:`StreamAccessLogsMessage.http_logs
 // <envoy_api_field_service.accesslog.v3.StreamAccessLogsMessage.http_logs>`.
@@ -41,7 +41,7 @@ message HttpGrpcAccessLogConfig {
   repeated string additional_response_trailers_to_log = 4;
 }
 
-// Configuration for the built-in *envoy.tcp_grpc_access_log* type. This configuration will
+// Configuration for the built-in *envoy.access_loggers.tcp_grpc* type. This configuration will
 // populate *StreamAccessLogsMessage.tcp_logs*.
 // [#extension: envoy.access_loggers.tcp_grpc]
 message TcpGrpcAccessLogConfig {

--- a/configs/envoy_double_proxy_v2.template.yaml
+++ b/configs/envoy_double_proxy_v2.template.yaml
@@ -63,7 +63,7 @@
         common_http_protocol_options:
           idle_timeout: 840s
         access_log:
-        - name: envoy.file_access_log
+        - name: envoy.access_loggers.file
           filter:
             or_filter:
               filters:

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -73,7 +73,7 @@
         common_http_protocol_options:
           idle_timeout: 840s
         access_log:
-        - name: envoy.file_access_log
+        - name: envoy.access_loggers.file
           filter:
             or_filter:
               filters:

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -48,14 +48,14 @@
         - name: envoy.router
           typed_config: {}
         access_log:
-        - name: envoy.file_access_log
+        - name: envoy.access_loggers.file
           filter:
             not_health_check_filter:  {}
           typed_config:
             "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
             path: "/var/log/envoy/ingress_http.log"
             {{ access_log_helper.ingress_full()|indent(10)}}
-        - name: envoy.file_access_log
+        - name: envoy.access_loggers.file
           filter:
             and_filter:
               filters:
@@ -84,7 +84,7 @@
             "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
             path: "/var/log/envoy/ingress_http_error.log"
             {{ access_log_helper.ingress_sampled_log()|indent(10)}}
-        - name: envoy.file_access_log
+        - name: envoy.access_loggers.file
           filter:
             and_filter:
               filters:
@@ -131,7 +131,7 @@ static_resources:
           common_http_protocol_options:
             idle_timeout: 840s
           access_log:
-          - name: envoy.file_access_log
+          - name: envoy.access_loggers.file
             filter:
               or_filter:
                 filters:
@@ -192,7 +192,7 @@ static_resources:
           common_http_protocol_options:
             idle_timeout: 840s
           access_log:
-          - name: envoy.file_access_log
+          - name: envoy.access_loggers.file
             filter:
               or_filter:
                 filters:
@@ -270,7 +270,7 @@ static_resources:
           - name: envoy.router
             typed_config: {}
           access_log:
-          - name: envoy.file_access_log
+          - name: envoy.access_loggers.file
             filter:
               or_filter:
                 filters:

--- a/docs/root/configuration/http/http_filters/grpc_http1_reverse_bridge_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_http1_reverse_bridge_filter.rst
@@ -63,7 +63,7 @@ How to disable HTTP/1.1 reverse bridge filter per route
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             access_log:
-            - name: envoy.file_access_log
+            - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                 path: /dev/stdout

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -15,6 +15,16 @@ Deprecated items below are listed in chronological order.
 * The previous behavior for upstream connection pool circuit breaking described
   `here <https://www.envoyproxy.io/docs/envoy/v1.13.0/intro/arch_overview/upstream/circuit_breaking>`_ has
   been deprecated in favor of the new behavior described :ref:`here <arch_overview_circuit_break>`.
+* Access Logger names have been deprecated in favor of the extension name from the envoy build
+  system.
+
+  .. csv-table::
+    :header: Canonical Names, Deprecated Names
+    :widths: 1, 1
+
+    envoy.access_loggers.file, envoy.file_access_log
+    envoy.access_loggers.http_grpc, envoy.http_grpc_access_log
+    envoy.access_loggers.tcp_grpc, envoy.tcp_grpc_access_log
 
 1.13.0 (January 20, 2020)
 =========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,6 +3,8 @@ Version history
 
 1.14.0 (Pending)
 ================
+* access loggers: access logger extensions use the "envoy.access_loggers" name space. A mapping
+  of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * config: use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 * http: fixing a bug in HTTP/1.0 responses where Connection: keep-alive was not appended for connections which were kept alive.
 * retry: added a retry predicate that :ref:`rejects hosts based on metadata. <envoy_api_field_route.RetryPolicy.retry_host_predicate>`
@@ -16,7 +18,7 @@ Version history
   "envoy.reloadable_features.new_http2_connection_pool_behavior" and then re-configure your clusters or
   restart Envoy. The behavior will not switch until the connection pools are recreated. The new
   circuit breaker behavior is described :ref:`here <arch_overview_circuit_break>`.
-* upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`. 
+* upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`.
 
 1.13.0 (January 20, 2020)
 =========================

--- a/examples/cors/backend/front-envoy.yaml
+++ b/examples/cors/backend/front-envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
-            - name: envoy.file_access_log
+            - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                 path: "/var/log/access.log"

--- a/examples/cors/frontend/front-envoy.yaml
+++ b/examples/cors/frontend/front-envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
-            - name: envoy.file_access_log
+            - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                 path: "/var/log/access.log"

--- a/examples/csrf/crosssite/front-envoy.yaml
+++ b/examples/csrf/crosssite/front-envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
-            - name: envoy.file_access_log
+            - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                 path: "/var/log/access.log"

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
-            - name: envoy.file_access_log
+            - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                 path: "/var/log/access.log"

--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
-            name: envoy.file_access_log
+            name: envoy.access_loggers.file
             typed_config:
               "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
               path: /dev/stdout

--- a/examples/grpc-bridge/client/envoy-proxy.yaml
+++ b/examples/grpc-bridge/client/envoy-proxy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           add_user_agent: true
           access_log:
-          - name: envoy.file_access_log
+          - name: envoy.access_loggers.file
             typed_config:
               "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
               path: "/dev/stdout"

--- a/examples/grpc-bridge/server/envoy-proxy.yaml
+++ b/examples/grpc-bridge/server/envoy-proxy.yaml
@@ -12,7 +12,7 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
-          - name: envoy.file_access_log
+          - name: envoy.access_loggers.file
             typed_config:
               "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
               path: "/dev/stdout"

--- a/generated_api_shadow/envoy/config/accesslog/v2/als.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v2/als.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.acces
 
 // [#protodoc-title: gRPC Access Log Service (ALS)]
 
-// Configuration for the built-in *envoy.http_grpc_access_log*
+// Configuration for the built-in *envoy.access_loggers.http_grpc*
 // :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`. This configuration will
 // populate :ref:`StreamAccessLogsMessage.http_logs
 // <envoy_api_field_service.accesslog.v2.StreamAccessLogsMessage.http_logs>`.
@@ -38,7 +38,7 @@ message HttpGrpcAccessLogConfig {
   repeated string additional_response_trailers_to_log = 4;
 }
 
-// Configuration for the built-in *envoy.tcp_grpc_access_log* type. This configuration will
+// Configuration for the built-in *envoy.access_loggers.tcp_grpc* type. This configuration will
 // populate *StreamAccessLogsMessage.tcp_logs*.
 // [#extension: envoy.access_loggers.tcp_grpc]
 message TcpGrpcAccessLogConfig {

--- a/generated_api_shadow/envoy/config/accesslog/v2/file.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v2/file.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.acces
 // [#extension: envoy.access_loggers.file]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`
-// that writes log entries directly to a file. Configures the built-in *envoy.file_access_log*
+// that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
 // AccessLog.
 message FileAccessLog {
   // A path to a local file to which to write the access log entries.

--- a/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
@@ -26,9 +26,9 @@ message AccessLog {
   // The name of the access log implementation to instantiate. The name must
   // match a statically registered access log. Current built-in loggers include:
   //
-  // #. "envoy.file_access_log"
-  // #. "envoy.http_grpc_access_log"
-  // #. "envoy.tcp_grpc_access_log"
+  // #. "envoy.access_loggers.file"
+  // #. "envoy.access_loggers.http_grpc"
+  // #. "envoy.access_loggers.tcp_grpc"
   string name = 1;
 
   // Filter which is used to determine if the access log needs to be written.
@@ -37,11 +37,11 @@ message AccessLog {
   // Custom configuration that depends on the access log being instantiated. Built-in
   // configurations include:
   //
-  // #. "envoy.file_access_log": :ref:`FileAccessLog
+  // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_extensions.access_loggers.file.v3.FileAccessLog>`
-  // #. "envoy.http_grpc_access_log": :ref:`HttpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.http_grpc": :ref:`HttpGrpcAccessLogConfig
   //    <envoy_api_msg_extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig>`
-  // #. "envoy.tcp_grpc_access_log": :ref:`TcpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.tcp_grpc": :ref:`TcpGrpcAccessLogConfig
   //    <envoy_api_msg_extensions.access_loggers.grpc.v3.TcpGrpcAccessLogConfig>`
   oneof config_type {
     google.protobuf.Struct hidden_envoy_deprecated_config = 3 [deprecated = true];

--- a/generated_api_shadow/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/generated_api_shadow/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -23,9 +23,9 @@ message AccessLog {
   // The name of the access log implementation to instantiate. The name must
   // match a statically registered access log. Current built-in loggers include:
   //
-  // #. "envoy.file_access_log"
-  // #. "envoy.http_grpc_access_log"
-  // #. "envoy.tcp_grpc_access_log"
+  // #. "envoy.access_loggers.file"
+  // #. "envoy.access_loggers.http_grpc"
+  // #. "envoy.access_loggers.tcp_grpc"
   string name = 1;
 
   // Filter which is used to determine if the access log needs to be written.
@@ -34,11 +34,11 @@ message AccessLog {
   // Custom configuration that depends on the access log being instantiated. Built-in
   // configurations include:
   //
-  // #. "envoy.file_access_log": :ref:`FileAccessLog
+  // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_config.accesslog.v2.FileAccessLog>`
-  // #. "envoy.http_grpc_access_log": :ref:`HttpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.http_grpc": :ref:`HttpGrpcAccessLogConfig
   //    <envoy_api_msg_config.accesslog.v2.HttpGrpcAccessLogConfig>`
-  // #. "envoy.tcp_grpc_access_log": :ref:`TcpGrpcAccessLogConfig
+  // #. "envoy.access_loggers.tcp_grpc": :ref:`TcpGrpcAccessLogConfig
   //    <envoy_api_msg_config.accesslog.v2.TcpGrpcAccessLogConfig>`
   oneof config_type {
     google.protobuf.Struct config = 3 [deprecated = true];

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 // [#extension: envoy.access_loggers.file]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`
-// that writes log entries directly to a file. Configures the built-in *envoy.file_access_log*
+// that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
 // AccessLog.
 message FileAccessLog {
   option (udpa.annotations.versioning).previous_message_type =

--- a/generated_api_shadow/envoy/extensions/access_loggers/grpc/v3/als.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/grpc/v3/als.proto
@@ -17,7 +17,7 @@ option java_multiple_files = true;
 
 // [#protodoc-title: gRPC Access Log Service (ALS)]
 
-// Configuration for the built-in *envoy.http_grpc_access_log*
+// Configuration for the built-in *envoy.access_loggers.http_grpc*
 // :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`. This configuration will
 // populate :ref:`StreamAccessLogsMessage.http_logs
 // <envoy_api_field_service.accesslog.v3.StreamAccessLogsMessage.http_logs>`.
@@ -41,7 +41,7 @@ message HttpGrpcAccessLogConfig {
   repeated string additional_response_trailers_to_log = 4;
 }
 
-// Configuration for the built-in *envoy.tcp_grpc_access_log* type. This configuration will
+// Configuration for the built-in *envoy.access_loggers.tcp_grpc* type. This configuration will
 // populate *StreamAccessLogsMessage.tcp_logs*.
 // [#extension: envoy.access_loggers.tcp_grpc]
 message TcpGrpcAccessLogConfig {

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -81,7 +81,8 @@ FileAccessLogFactory::convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
 /**
  * Static registration for the file access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(FileAccessLogFactory, Server::Configuration::AccessLogInstanceFactory);
+REGISTER_FACTORY(FileAccessLogFactory,
+                 Server::Configuration::AccessLogInstanceFactory){"envoy.file_access_log"};
 
 } // namespace File
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -44,7 +44,8 @@ std::string HttpGrpcAccessLogFactory::name() const { return AccessLogNames::get(
 /**
  * Static registration for the HTTP gRPC access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(HttpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory);
+REGISTER_FACTORY(HttpGrpcAccessLogFactory,
+                 Server::Configuration::AccessLogInstanceFactory){"envoy.http_grpc_access_log"};
 
 } // namespace HttpGrpc
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -43,7 +43,8 @@ std::string TcpGrpcAccessLogFactory::name() const { return AccessLogNames::get()
 /**
  * Static registration for the TCP gRPC access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(TcpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory);
+REGISTER_FACTORY(TcpGrpcAccessLogFactory,
+                 Server::Configuration::AccessLogInstanceFactory){"envoy.tcp_grpc_access_log"};
 
 } // namespace TcpGrpc
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/well_known_names.h
+++ b/source/extensions/access_loggers/well_known_names.h
@@ -15,11 +15,11 @@ namespace AccessLoggers {
 class AccessLogNameValues {
 public:
   // File access log
-  const std::string File = "envoy.file_access_log";
+  const std::string File = "envoy.access_loggers.file";
   // HTTP gRPC access log
-  const std::string HttpGrpc = "envoy.http_grpc_access_log";
+  const std::string HttpGrpc = "envoy.access_loggers.http_grpc";
   // TCP gRPC access log
-  const std::string TcpGrpc = "envoy.tcp_grpc_access_log";
+  const std::string TcpGrpc = "envoy.access_loggers.tcp_grpc";
 };
 
 using AccessLogNames = ConstSingleton<AccessLogNameValues>;

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -53,6 +53,8 @@ envoy_cc_test(
     deps = [
         "//source/common/access_log:access_log_lib",
         "//source/extensions/access_loggers/file:config",
+        "//source/extensions/access_loggers/grpc:http_config",
+        "//source/extensions/access_loggers/grpc:tcp_config",
         "//test/common/stream_info:test_util",
         "//test/common/upstream:utility_lib",
         "//test/mocks/access_log:access_log_mocks",

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -9,6 +9,7 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/access_log/access_log_impl.h"
+#include "common/config/utility.h"
 #include "common/protobuf/message_validator_impl.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/runtime/uuid_util.h"
@@ -65,7 +66,7 @@ public:
 
 TEST_F(AccessLogImplTest, LogMoreData) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -88,7 +89,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, DownstreamDisconnect) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -110,7 +111,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RouteName) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -137,7 +138,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, EnvoyUpstreamServiceTime) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -156,7 +157,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, NoFilter) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -176,7 +177,7 @@ TEST_F(AccessLogImplTest, UpstreamHost) {
   stream_info_.upstream_host_ = Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234");
 
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -193,7 +194,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, WithFilterMiss) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   or_filter:
     filters:
@@ -225,7 +226,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, WithFilterHit) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
     or_filter:
       filters:
@@ -268,7 +269,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RuntimeFilter) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   runtime_filter:
     runtime_key: access_log.test_key
@@ -307,7 +308,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   runtime_filter:
     runtime_key: access_log.test_key
@@ -349,7 +350,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2IndependentRandomness) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   runtime_filter:
     runtime_key: access_log.test_key
@@ -383,7 +384,7 @@ TEST_F(AccessLogImplTest, PathRewrite) {
   request_headers_ = {{":method", "GET"}, {":path", "/foo"}, {"x-envoy-original-path", "/bar"}};
 
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -400,7 +401,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HealthCheckTrue) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   not_health_check_filter: {}
 typed_config:
@@ -419,7 +420,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HealthCheckFalse) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   not_health_check_filter: {}
 typed_config:
@@ -446,7 +447,7 @@ TEST_F(AccessLogImplTest, RequestTracing) {
   UuidUtils::setTraceableUuid(sample_tracing_guid, UuidTraceStatus::Sampled);
 
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   traceable_filter: {}
 typed_config:
@@ -480,7 +481,7 @@ TEST(AccessLogImplTestCtor, FiltersMissingInOrAndFilter) {
 
   {
     const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   or_filter: {}
 typed_config:
@@ -494,7 +495,7 @@ typed_config:
 
   {
     const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   and_filter: {}
 typed_config:
@@ -509,7 +510,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, AndFilter) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   and_filter:
     filters:
@@ -545,7 +546,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, OrFilter) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   or_filter:
     filters:
@@ -580,7 +581,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, MultipleOperators) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   and_filter:
     filters:
@@ -691,7 +692,7 @@ status_code_filter:
 
 TEST_F(AccessLogImplTest, StatusCodeLessThan) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   status_code_filter:
     comparison:
@@ -719,7 +720,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderPresence) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   header_filter:
     header:
@@ -741,7 +742,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderExactMatch) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   header_filter:
     header:
@@ -770,7 +771,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderRegexMatch) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   header_filter:
     header:
@@ -805,7 +806,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderRangeMatch) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   header_filter:
     header:
@@ -850,7 +851,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterAnyFlag) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   response_flag_filter: {}
 typed_config:
@@ -870,7 +871,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterSpecificFlag) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   response_flag_filter:
     flags:
@@ -896,7 +897,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterSeveralFlags) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   response_flag_filter:
     flags:
@@ -923,7 +924,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterAllFlagsInPGV) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   response_flag_filter:
     flags:
@@ -945,7 +946,7 @@ filter:
       - URX
       - SI
       - IH
-      - DPE      
+      - DPE
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -988,7 +989,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterUnsupportedFlag) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   response_flag_filter:
     flags:
@@ -1006,7 +1007,7 @@ typed_config:
       "[\"embedded message failed validation\"] | caused by "
       "ResponseFlagFilterValidationError.Flags[i]: [\"value must be in list \" [\"LH\" \"UH\" "
       "\"UT\" \"LR\" \"UR\" \"UF\" \"UC\" \"UO\" \"NR\" \"DI\" \"FI\" \"RL\" \"UAEX\" \"RLSE\" "
-      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"envoy.file_access_log\"\nfilter {\n  "
+      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"envoy.access_loggers.file\"\nfilter {\n  "
       "response_flag_filter {\n    flags: \"UnsupportedFlag\"\n  }\n}\ntyped_config {\n  "
       "[type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog] {\n    path: \"/dev/null\"\n  "
       "}\n}\n");
@@ -1014,7 +1015,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ValidateTypedConfig) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   response_flag_filter:
     flags:
@@ -1032,7 +1033,7 @@ typed_config:
       "[\"embedded message failed validation\"] | caused by "
       "ResponseFlagFilterValidationError.Flags[i]: [\"value must be in list \" [\"LH\" \"UH\" "
       "\"UT\" \"LR\" \"UR\" \"UF\" \"UC\" \"UO\" \"NR\" \"DI\" \"FI\" \"RL\" \"UAEX\" \"RLSE\" "
-      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"envoy.file_access_log\"\nfilter {\n  "
+      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"envoy.access_loggers.file\"\nfilter {\n  "
       "response_flag_filter {\n    flags: \"UnsupportedFlag\"\n  }\n}\ntyped_config {\n  "
       "[type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog] {\n    path: \"/dev/null\"\n  "
       "}\n}\n");
@@ -1040,7 +1041,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterValues) {
   const std::string yaml_template = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     statuses:
@@ -1071,7 +1072,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterUnsupportedValue) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     statuses:
@@ -1087,7 +1088,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterBlock) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     statuses:
@@ -1108,7 +1109,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHttpCodes) {
   const std::string yaml_template = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     statuses:
@@ -1140,7 +1141,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterNoCode) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     statuses:
@@ -1159,7 +1160,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterExclude) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     exclude: true
@@ -1184,7 +1185,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterExcludeFalse) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     exclude: false
@@ -1206,7 +1207,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHeader) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   grpc_status_filter:
     statuses:
@@ -1250,7 +1251,7 @@ TEST_F(AccessLogImplTest, TestHeaderFilterPresence) {
   Registry::RegisterFactory<TestHeaderFilterFactory, ExtensionFilterFactory> registered;
 
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   extension_filter:
     name: test_header_filter
@@ -1326,7 +1327,7 @@ TEST_F(AccessLogImplTest, SampleExtensionFilter) {
   Registry::RegisterFactory<SampleExtensionFilterFactory, ExtensionFilterFactory> registered;
 
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   extension_filter:
     name: sample_extension_filter
@@ -1354,7 +1355,7 @@ typed_config:
 TEST_F(AccessLogImplTest, UnregisteredExtensionFilter) {
   {
     const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   extension_filter:
     name: unregistered_extension_filter
@@ -1373,7 +1374,7 @@ typed_config:
 
   {
     const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 filter:
   extension_filter:
     name: bar
@@ -1384,6 +1385,36 @@ typed_config:
 
     EXPECT_THROW(AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_),
                  EnvoyException);
+  }
+}
+
+// Test that the deprecated extension names still function.
+TEST_F(AccessLogImplTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  {
+    envoy::config::accesslog::v3::AccessLog config;
+    config.set_name("envoy.file_access_log");
+
+    EXPECT_NO_THROW(
+        Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
+            config));
+  }
+
+  {
+    envoy::config::accesslog::v3::AccessLog config;
+    config.set_name("envoy.http_grpc_access_log");
+
+    EXPECT_NO_THROW(
+        Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
+            config));
+  }
+
+  {
+    envoy::config::accesslog::v3::AccessLog config;
+    config.set_name("envoy.tcp_grpc_access_log");
+
+    EXPECT_NO_THROW(
+        Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
+            config));
   }
 }
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -38,7 +38,7 @@ namespace {
 absl::optional<envoy::config::accesslog::v3::AccessLog> testUpstreamLog() {
   // Custom format without timestamps or durations.
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   format: "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE%
@@ -280,7 +280,7 @@ TEST_F(RouterUpstreamLogTest, LogHeaders) {
 // Test timestamps and durations are emitted.
 TEST_F(RouterUpstreamLogTest, LogTimestampsAndDurations) {
   const std::string yaml = R"EOF(
-name: envoy.file_access_log
+name: envoy.access_loggers.file
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   format: "[%START_TIME%] %REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -50,7 +50,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
           access_log:
-          - name: envoy.file_access_log
+          - name: envoy.access_loggers.file
             typed_config:
               "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
               path: /dev/null

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -117,7 +117,7 @@ const std::string ConfigHelper::HTTP_PROXY_CONFIG = BASE_CONFIG + R"EOF(
             name: envoy.router
           codec_type: HTTP1
           access_log:
-            name: envoy.file_access_log
+            name: envoy.access_loggers.file
             filter:
               not_health_check_filter:  {}
             typed_config:

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
@@ -43,7 +43,7 @@ public:
             envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                 hcm) {
           auto* access_log = hcm.add_access_log();
-          access_log->set_name("envoy.http_grpc_access_log");
+          access_log->set_name("envoy.access_loggers.http_grpc");
 
           envoy::extensions::access_loggers::grpc::v3::HttpGrpcAccessLogConfig config;
           auto* common_config = config.mutable_common_config();

--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -60,7 +60,7 @@ public:
           MessageUtil::anyConvert<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
               *config_blob);
       auto* access_log = tcp_proxy_config.add_access_log();
-      access_log->set_name("envoy.tcp_grpc_access_log");
+      access_log->set_name("envoy.access_loggers.tcp_grpc");
       envoy::extensions::access_loggers::grpc::v3::TcpGrpcAccessLogConfig access_log_config;
       auto* common_config = access_log_config.mutable_common_config();
       common_config->set_log_name("foo");

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -877,7 +877,7 @@ http_filters:
 - name: envoy.http_dynamo_filter
   config: {}
 access_log:
-- name: envoy.file_access_log
+- name: envoy.access_loggers.file
   typed_config:
     "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
     path: "/dev/null"
@@ -906,7 +906,7 @@ http_filters:
 - name: envoy.http_dynamo_filter
   typed_config: {}
 access_log:
-- name: envoy.file_access_log
+- name: envoy.access_loggers.file
   typed_config:
     "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
     path: "/dev/null"
@@ -936,7 +936,7 @@ http_filters:
 - name: envoy.http_dynamo_filter
   typed_config: {}
 access_log:
-- name: envoy.file_access_log
+- name: envoy.access_loggers.file
   typed_config:
     "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
     path: "/dev/null"

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -330,7 +330,7 @@ name: envoy.router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
-    name: envoy.file_access_log
+    name: envoy.access_loggers.file
     filter:
       not_health_check_filter: {}
     typed_config:
@@ -455,7 +455,7 @@ name: envoy.router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
-    name: envoy.http_grpc_access_log
+    name: envoy.access_loggers.http_grpc
     filter:
       not_health_check_filter: {}
     typed_config:

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -248,7 +248,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
         envoy::config::filter::network::tcp_proxy::v2::TcpProxy)>(*config_blob);
 
     auto* access_log = tcp_proxy_config.add_access_log();
-    access_log->set_name("envoy.file_access_log");
+    access_log->set_name("envoy.access_loggers.file");
     envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
     access_log_config.set_path(access_log_path);
     access_log_config.set_format(


### PR DESCRIPTION
Modifies the well-known-names of the built-in access loggers to
use the same name as the extension build system.

(This is the first in a series, but I expect whatever changes may be
requested here will apply to all the rest, so I'm going to hold the others
back.)

Risk Level: low, previous name is still accepted
Testing: added test to prove factory accepts old names
Docs Changes: updated names
Release Notes: updated
Deprecated: old names are logged as deprecated

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
