### PR TITLE
aws_request_signing: inherit from PassThroughDecoderFilter

### DIFF
--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
@@ -68,7 +68,7 @@ private:
 /**
  * HTTP AWS request signing auth filter.
  */
-class Filter : public Http::PassThroughFilter, Logger::Loggable<Logger::Id::filter> {
+class Filter : public Http::PassThroughDecoderFilter, Logger::Loggable<Logger::Id::filter> {
 public:
   Filter(const std::shared_ptr<FilterConfig>& config);
 

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -29,7 +29,7 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
       std::make_shared<FilterConfigImpl>(std::move(signer), stats_prefix, context.scope());
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter = std::make_shared<Filter>(filter_config);
-    callbacks.addStreamFilter(filter);
+    callbacks.addStreamDecoderFilter(filter);
   };
 }
 

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -31,7 +31,7 @@ region: us-west-2
 
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
-  EXPECT_CALL(filter_callbacks, addStreamFilter(_));
+  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);
 }
 


### PR DESCRIPTION
Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
