### PR TITLE
tcp: refactors for HTTP-over-tcp

### DIFF
--- a/source/common/tcp_proxy/BUILD
+++ b/source/common/tcp_proxy/BUILD
@@ -10,8 +10,14 @@ envoy_package()
 
 envoy_cc_library(
     name = "tcp_proxy",
-    srcs = ["tcp_proxy.cc"],
-    hdrs = ["tcp_proxy.h"],
+    srcs = [
+        "tcp_proxy.cc",
+        "upstream.cc",
+    ],
+    hdrs = [
+        "tcp_proxy.h",
+        "upstream.h",
+    ],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -219,7 +219,7 @@ Filter::~Filter() {
   }
 
   ASSERT(upstream_handle_ == nullptr);
-  ASSERT(upstream_conn_data_ == nullptr);
+  ASSERT(upstream_ == nullptr);
 }
 
 TcpProxyStats Config::SharedConfig::generateStats(Stats::Scope& scope) {
@@ -256,15 +256,13 @@ void Filter::initialize(Network::ReadFilterCallbacks& callbacks, bool set_connec
 }
 
 void Filter::readDisableUpstream(bool disable) {
-  if (upstream_conn_data_ == nullptr ||
-      upstream_conn_data_->connection().state() != Network::Connection::State::Open) {
-    // Because we flush write downstream, we can have a case where upstream has already disconnected
-    // and we are waiting to flush. If we had a watermark event during this time we should no
-    // longer touch the upstream connection.
+  bool success = false;
+  if (upstream_) {
+    success = upstream_->readDisable(disable);
+  }
+  if (!success) {
     return;
   }
-
-  upstream_conn_data_->connection().readDisable(disable);
   if (disable) {
     read_callbacks_->upstreamHost()
         ->cluster()
@@ -367,7 +365,7 @@ void Filter::UpstreamCallbacks::drain(Drainer& drainer) {
 }
 
 Network::FilterStatus Filter::initializeUpstreamConnection() {
-  ASSERT(upstream_conn_data_ == nullptr);
+  ASSERT(upstream_ == nullptr);
 
   route_ = pickRoute();
 
@@ -424,13 +422,13 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
 
   // Because we never return open connections to the pool, this should either return a handle while
   // a connection completes or it invokes onPoolFailure inline. Either way, stop iteration.
-  upstream_handle_ = conn_pool->newConnection(*this);
+  upstream_handle_.reset(new TcpConnectionHandle(conn_pool->newConnection(*this)));
   return Network::FilterStatus::StopIteration;
 }
 
 void Filter::onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,
                            Upstream::HostDescriptionConstSharedPtr host) {
-  upstream_handle_ = nullptr;
+  upstream_handle_.reset();
 
   read_callbacks_->upstreamHost(host);
   getStreamInfo().onUpstreamHostSelected(host);
@@ -456,21 +454,17 @@ void Filter::onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,
 
 void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
                          Upstream::HostDescriptionConstSharedPtr host) {
-  upstream_handle_ = nullptr;
-  upstream_conn_data_ = std::move(conn_data);
+  upstream_handle_.reset();
+  getStreamInfo().setUpstreamLocalAddress(conn_data->connection().localAddress());
+  getStreamInfo().setUpstreamSslConnection(
+      conn_data->connection().streamInfo().downstreamSslConnection());
+  read_callbacks_->connection().streamInfo().setUpstreamFilterState(
+      conn_data->connection().streamInfo().filterState());
+
+  upstream_.reset(new TcpUpstream(std::move(conn_data), *upstream_callbacks_));
   read_callbacks_->upstreamHost(host);
 
-  upstream_conn_data_->addUpstreamCallbacks(*upstream_callbacks_);
-
-  Network::ClientConnection& connection = upstream_conn_data_->connection();
-
-  connection.enableHalfClose(true);
-
   getStreamInfo().onUpstreamHostSelected(host);
-  getStreamInfo().setUpstreamLocalAddress(connection.localAddress());
-  getStreamInfo().setUpstreamSslConnection(connection.streamInfo().downstreamSslConnection());
-  read_callbacks_->connection().streamInfo().setUpstreamFilterState(
-      connection.streamInfo().filterState());
 
   // Simulate the event that onPoolReady represents.
   upstream_callbacks_->onEvent(Network::ConnectionEvent::Connected);
@@ -492,40 +486,34 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
   ENVOY_CONN_LOG(trace, "downstream connection received {} bytes, end_stream={}",
                  read_callbacks_->connection(), data.length(), end_stream);
   getStreamInfo().addBytesReceived(data.length());
-  upstream_conn_data_->connection().write(data, end_stream);
+  if (upstream_) {
+    upstream_->encodeData(data, end_stream);
+  }
   ASSERT(0 == data.length());
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
   return Network::FilterStatus::StopIteration;
 }
 
 void Filter::onDownstreamEvent(Network::ConnectionEvent event) {
-  if (upstream_conn_data_) {
-    if (event == Network::ConnectionEvent::RemoteClose) {
-      upstream_conn_data_->connection().close(Network::ConnectionCloseType::FlushWrite);
-
-      // Events raised from the previous line may cause upstream_conn_data_ to be NULL if
-      // it was able to immediately flush all data.
-
-      if (upstream_conn_data_ != nullptr) {
-        if (upstream_conn_data_->connection().state() != Network::Connection::State::Closed) {
-          config_->drainManager().add(config_->sharedConfig(), std::move(upstream_conn_data_),
-                                      std::move(upstream_callbacks_), std::move(idle_timer_),
-                                      read_callbacks_->upstreamHost());
-        } else {
-          upstream_conn_data_.reset();
-        }
-      }
-    } else if (event == Network::ConnectionEvent::LocalClose) {
-      upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
-      upstream_conn_data_.reset();
+  if (upstream_) {
+    Tcp::ConnectionPool::ConnectionDataPtr conn_data(upstream_->onDownstreamEvent(event));
+    if (conn_data != nullptr &&
+        conn_data->connection().state() != Network::Connection::State::Closed) {
+      config_->drainManager().add(config_->sharedConfig(), std::move(conn_data),
+                                  std::move(upstream_callbacks_), std::move(idle_timer_),
+                                  read_callbacks_->upstreamHost());
+    }
+    if (event != Network::ConnectionEvent::Connected) {
+      upstream_.reset();
       disableIdleTimer();
     }
-  } else if (upstream_handle_) {
+  }
+  if (upstream_handle_) {
     if (event == Network::ConnectionEvent::LocalClose ||
         event == Network::ConnectionEvent::RemoteClose) {
       // Cancel the conn pool request and close any excess pending requests.
-      upstream_handle_->cancel(Tcp::ConnectionPool::CancelPolicy::CloseExcess);
-      upstream_handle_ = nullptr;
+      upstream_handle_->cancel();
+      upstream_handle_.reset();
     }
   }
 }
@@ -547,7 +535,7 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
 
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-    upstream_conn_data_.reset();
+    upstream_.reset();
     disableIdleTimer();
 
     if (connecting) {
@@ -583,10 +571,11 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
           [upstream_callbacks = upstream_callbacks_]() { upstream_callbacks->onIdleTimeout(); });
       resetIdleTimer();
       read_callbacks_->connection().addBytesSentCallback([this](uint64_t) { resetIdleTimer(); });
-      upstream_conn_data_->connection().addBytesSentCallback(
-          [upstream_callbacks = upstream_callbacks_](uint64_t) {
-            upstream_callbacks->onBytesSent();
-          });
+      if (upstream_) {
+        upstream_->addBytesSentCallback([upstream_callbacks = upstream_callbacks_](uint64_t) {
+          upstream_callbacks->onBytesSent();
+        });
+      }
     }
   }
 }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -498,7 +498,7 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
     upstream_->encodeData(data, end_stream);
   }
   // The upstream should consume all of the data.
-  // Before there is an upstream the connection should be readDisabled.  If the upstream is
+  // Before there is an upstream the connection should be readDisabled. If the upstream is
   // destroyed, there should be no further reads as well.
   ASSERT(0 == data.length());
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -17,7 +17,6 @@
 #include "envoy/stats/stats_macros.h"
 #include "envoy/stats/timespan.h"
 #include "envoy/stream_info/filter_state.h"
-#include "envoy/tcp/conn_pool.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/upstream.h"
 
@@ -27,6 +26,7 @@
 #include "common/network/hash_policy.h"
 #include "common/network/utility.h"
 #include "common/stream_info/stream_info_impl.h"
+#include "common/tcp_proxy/upstream.h"
 #include "common/upstream/load_balancer_impl.h"
 
 namespace Envoy {
@@ -346,12 +346,14 @@ protected:
   const ConfigSharedPtr config_;
   Upstream::ClusterManager& cluster_manager_;
   Network::ReadFilterCallbacks* read_callbacks_{};
-  Tcp::ConnectionPool::Cancellable* upstream_handle_{};
-  Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;
+
   DownstreamCallbacks downstream_callbacks_;
   Event::TimerPtr idle_timer_;
+
+  std::shared_ptr<ConnectionHandle> upstream_handle_;
   std::shared_ptr<UpstreamCallbacks> upstream_callbacks_; // shared_ptr required for passing as a
                                                           // read filter.
+  std::unique_ptr<GenericUpstream> upstream_;
   StreamInfo::StreamInfoImpl stream_info_;
   RouteConstSharedPtr route_;
   Network::TransportSocketOptionsSharedPtr transport_socket_options_;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -1,0 +1,50 @@
+#include "common/tcp_proxy/upstream.h"
+
+namespace Envoy {
+namespace TcpProxy {
+
+TcpUpstream::TcpUpstream(Tcp::ConnectionPool::ConnectionDataPtr&& data,
+                         Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks)
+    : upstream_conn_data_(std::move(data)) {
+  Network::ClientConnection& connection = upstream_conn_data_->connection();
+  connection.enableHalfClose(true);
+  upstream_conn_data_->addUpstreamCallbacks(upstream_callbacks);
+}
+
+bool TcpUpstream::readDisable(bool disable) {
+  if (upstream_conn_data_ == nullptr ||
+      upstream_conn_data_->connection().state() != Network::Connection::State::Open) {
+    // Because we flush write downstream, we can have a case where upstream has already disconnected
+    // and we are waiting to flush. If we had a watermark event during this time we should no
+    // longer touch the upstream connection.
+    return false;
+  }
+
+  upstream_conn_data_->connection().readDisable(disable);
+  return true;
+}
+
+void TcpUpstream::encodeData(Buffer::Instance& data, bool end_stream) {
+  upstream_conn_data_->connection().write(data, end_stream);
+}
+
+void TcpUpstream::addBytesSentCallback(Network::Connection::BytesSentCb cb) {
+  upstream_conn_data_->connection().addBytesSentCallback(cb);
+}
+
+Tcp::ConnectionPool::ConnectionData*
+TcpUpstream::onDownstreamEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::RemoteClose) {
+    // The close call may result in this object being deleted. Latch the
+    // connection locally so it can be returned for potential draining.
+    auto* conn_data = upstream_conn_data_.release();
+    conn_data->connection().close(Network::ConnectionCloseType::FlushWrite);
+    return conn_data;
+  } else if (event == Network::ConnectionEvent::LocalClose) {
+    upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
+  }
+  return nullptr;
+}
+
+} // namespace TcpProxy
+} // namespace Envoy

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -52,7 +52,7 @@ public:
   TcpUpstream(Tcp::ConnectionPool::ConnectionDataPtr&& data,
               Tcp::ConnectionPool::UpstreamCallbacks& callbacks);
 
-  // GenricUpstream
+  // GenericUpstream
   bool readDisable(bool disable) override;
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void addBytesSentCallback(Network::Connection::BytesSentCb cb) override;

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "envoy/network/connection.h"
+#include "envoy/tcp/conn_pool.h"
+#include "envoy/upstream/upstream.h"
+
+namespace Envoy {
+namespace TcpProxy {
+
+// Interface for a generic ConnectionHandle, which can wrapper a TcpConnectionHandle
+// or an HttpConnectionHandle
+class ConnectionHandle {
+public:
+  virtual ~ConnectionHandle() {}
+  // Cancel the conn pool request and close any excess pending requests.
+  virtual void cancel() PURE;
+};
+
+// An implementation of ConnectionHandle which works with the Tcp::ConnectionPool.
+class TcpConnectionHandle : public ConnectionHandle {
+public:
+  TcpConnectionHandle(Tcp::ConnectionPool::Cancellable* handle) : upstream_handle_(handle) {}
+
+  void cancel() override {
+    upstream_handle_->cancel(Tcp::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+
+private:
+  Tcp::ConnectionPool::Cancellable* upstream_handle_{};
+};
+
+// Interface for a generic Upstream, which can communicate with a Tcp or HTTP
+// upstream.
+class GenericUpstream {
+public:
+  virtual ~GenericUpstream() {}
+  // Calls readDisable on the upstream connection. Returns false if readDisable could not be
+  // performed (e.g. if the connection is closed)
+  virtual bool readDisable(bool disable) PURE;
+  // Encodes data upstream.
+  virtual void encodeData(Buffer::Instance& data, bool end_stream) PURE;
+  // Adds a callback to be called when the data is sent to the kernel.
+  virtual void addBytesSentCallback(Network::Connection::BytesSentCb cb) PURE;
+  // Called when a Network::ConnectionEvent is received on the downstream connection, to allow the
+  // upstream to do any cleanup.
+  virtual Tcp::ConnectionPool::ConnectionData*
+  onDownstreamEvent(Network::ConnectionEvent event) PURE;
+};
+
+class TcpUpstream : public GenericUpstream {
+public:
+  TcpUpstream(Tcp::ConnectionPool::ConnectionDataPtr&& data,
+              Tcp::ConnectionPool::UpstreamCallbacks& callbacks);
+
+  // GenricUpstream
+  bool readDisable(bool disable) override;
+  void encodeData(Buffer::Instance& data, bool end_stream) override;
+  void addBytesSentCallback(Network::Connection::BytesSentCb cb) override;
+  Tcp::ConnectionPool::ConnectionData* onDownstreamEvent(Network::ConnectionEvent event) override;
+
+private:
+  Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;
+};
+
+} // namespace TcpProxy
+} // namespace Envoy

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -7,7 +7,7 @@
 namespace Envoy {
 namespace TcpProxy {
 
-// Interface for a generic ConnectionHandle, which can wrapper a TcpConnectionHandle
+// Interface for a generic ConnectionHandle, which can wrap a TcpConnectionHandle
 // or an HttpConnectionHandle
 class ConnectionHandle {
 public:
@@ -29,7 +29,7 @@ private:
   Tcp::ConnectionPool::Cancellable* upstream_handle_{};
 };
 
-// Interface for a generic Upstream, which can communicate with a Tcp or HTTP
+// Interface for a generic Upstream, which can communicate with a TCP or HTTP
 // upstream.
 class GenericUpstream {
 public:


### PR DESCRIPTION
Pulling both the connection pool logic and interaction with upstream into generic APIs which can be reused for sending TCP data out over the HTTP connection pool.

Risk Level: High (intended no-op but it is a big refactor)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Part of #1630
