### PR TITLE
rbac: add dns sans to rbac debug log

### DIFF
--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -54,18 +54,21 @@ RoleBasedAccessControlRouteSpecificFilterConfig::RoleBasedAccessControlRouteSpec
 
 Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::HeaderMap& headers,
                                                                       bool) {
-  ENVOY_LOG(debug,
-            "checking request: remoteAddress: {}, localAddress: {}, ssl: {}, headers: {}, "
-            "dynamicMetadata: {}",
-            callbacks_->connection()->remoteAddress()->asString(),
-            callbacks_->connection()->localAddress()->asString(),
-            callbacks_->connection()->ssl()
-                ? "uriSanPeerCertificate: " +
-                      absl::StrJoin(callbacks_->connection()->ssl()->uriSanPeerCertificate(), ",") +
-                      ", subjectPeerCertificate: " +
-                      callbacks_->connection()->ssl()->subjectPeerCertificate()
-                : "none",
-            headers, callbacks_->streamInfo().dynamicMetadata().DebugString());
+  ENVOY_LOG(
+      debug,
+      "checking request: remoteAddress: {}, localAddress: {}, ssl: {}, headers: {}, "
+      "dynamicMetadata: {}",
+      callbacks_->connection()->remoteAddress()->asString(),
+      callbacks_->connection()->localAddress()->asString(),
+      callbacks_->connection()->ssl()
+          ? "uriSanPeerCertificate: " +
+                absl::StrJoin(callbacks_->connection()->ssl()->uriSanPeerCertificate(), ",") +
+                ", dnsSanPeerCertificate: " +
+                absl::StrJoin(callbacks_->connection()->ssl()->dnsSansPeerCertificate(), ",") +
+                ", subjectPeerCertificate: " +
+                callbacks_->connection()->ssl()->subjectPeerCertificate()
+          : "none",
+      headers, callbacks_->streamInfo().dynamicMetadata().DebugString());
 
   std::string effective_policy_id;
   const auto shadow_engine =

--- a/source/extensions/filters/network/rbac/rbac_filter.cc
+++ b/source/extensions/filters/network/rbac/rbac_filter.cc
@@ -31,6 +31,8 @@ Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bo
       callbacks_->connection().ssl()
           ? "uriSanPeerCertificate: " +
                 absl::StrJoin(callbacks_->connection().ssl()->uriSanPeerCertificate(), ",") +
+                ", dnsSanPeerCertificate: " +
+                absl::StrJoin(callbacks_->connection().ssl()->dnsSansPeerCertificate(), ",") +
                 ", subjectPeerCertificate: " +
                 callbacks_->connection().ssl()->subjectPeerCertificate()
           : "none",


### PR DESCRIPTION
Description: Now we support matching against DNS SANs for rbac. This PR enhances the debug log to print dns sans as well.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/a

