### PR TITLE
Log: allow "-l warn" and protect against invalid arg values

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -16,6 +16,7 @@
 #include "server/options_impl_platform.h"
 
 #include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
 #include "spdlog/spdlog.h"
 #include "tclap/CmdLine.h"
 
@@ -235,14 +236,14 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   }
 }
 
-spdlog::level::level_enum OptionsImpl::parseAndValidateLogLevel(const std::string& log_level) {
+spdlog::level::level_enum OptionsImpl::parseAndValidateLogLevel(absl::string_view log_level) {
   if (log_level == "warn") {
     return spdlog::level::level_enum::warn;
   }
 
   size_t level_to_use = std::numeric_limits<size_t>::max();
   for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
-    if (log_level == spdlog::level::level_string_views[i]) {
+    if (std::string(log_level) == spdlog::level::level_string_views[i]) {
       level_to_use = i;
       break;
     }
@@ -257,9 +258,12 @@ spdlog::level::level_enum OptionsImpl::parseAndValidateLogLevel(const std::strin
 std::string OptionsImpl::allowedLogLevels() {
   std::string allowed_log_levels;
   for (auto level_string_view : spdlog::level::level_string_views) {
-    allowed_log_levels += fmt::format("[{}]", level_string_view);
+    if (level_string_view == spdlog::level::to_string_view(spdlog::level::warn)) {
+      allowed_log_levels += fmt::format("[{}|warn]", level_string_view);
+    } else {
+      allowed_log_levels += fmt::format("[{}]", level_string_view);
+    }
   }
-  allowed_log_levels += "[warn]";
   return allowed_log_levels;
 }
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -39,10 +39,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
                          const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level)
     : signal_handling_enabled_(true) {
-  std::string log_levels_string = "Log levels: ";
-  for (auto level_string_view : spdlog::level::level_string_views) {
-    log_levels_string += fmt::format("[{}]", level_string_view);
-  }
+  std::string log_levels_string = fmt::format("Log levels: {}", allowedLogLevels());
   log_levels_string +=
       fmt::format("\nDefault is [{}]", spdlog::level::level_string_views[default_log_level]);
 
@@ -255,6 +252,15 @@ spdlog::level::level_enum OptionsImpl::parseAndValidateLogLevel(const std::strin
     logError(fmt::format("error: invalid log level specified '{}'", log_level));
   }
   return static_cast<spdlog::level::level_enum>(level_to_use);
+}
+
+std::string OptionsImpl::allowedLogLevels() {
+  std::string allowed_log_levels;
+  for (auto level_string_view : spdlog::level::level_string_views) {
+    allowed_log_levels += fmt::format("[{}]", level_string_view);
+  }
+  allowed_log_levels += "[warn]";
+  return allowed_log_levels;
 }
 
 void OptionsImpl::parseComponentLogLevels(const std::string& component_log_levels) {

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -243,7 +243,8 @@ spdlog::level::level_enum OptionsImpl::parseAndValidateLogLevel(absl::string_vie
 
   size_t level_to_use = std::numeric_limits<size_t>::max();
   for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_string_views); i++) {
-    if (std::string(log_level) == spdlog::level::level_string_views[i]) {
+    spdlog::string_view_t spd_log_level = spdlog::level::level_string_views[i];
+    if (log_level == absl::string_view(spd_log_level.data(), spd_log_level.size())) {
       level_to_use = i;
       break;
     }

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -149,6 +149,7 @@ public:
 
 private:
   void logError(const std::string& error) const;
+  spdlog::level::level_enum parseAndValidateLogLevel(const std::string& log_level);
 
   uint64_t base_id_;
   uint32_t concurrency_;

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -150,7 +150,7 @@ public:
 
 private:
   void logError(const std::string& error) const;
-  spdlog::level::level_enum parseAndValidateLogLevel(const std::string& log_level);
+  spdlog::level::level_enum parseAndValidateLogLevel(absl::string_view log_level);
 
   uint64_t base_id_;
   uint32_t concurrency_;

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -146,6 +146,7 @@ public:
    * factories.
    */
   static void disableExtensions(const std::vector<std::string>&);
+  static std::string allowedLogLevels();
 
 private:
   void logError(const std::string& error) const;

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -347,7 +347,7 @@ TEST_F(OptionsImplTest, WarnIsValidLogLevel) {
 }
 
 TEST_F(OptionsImplTest, AllowedLogLevels) {
-  EXPECT_EQ("[trace][debug][info][warning][error][critical][off][warn]",
+  EXPECT_EQ("[trace][debug][info][warning|warn][error][critical][off]",
             OptionsImpl::allowedLogLevels());
 }
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -223,6 +223,7 @@ TEST_F(OptionsImplTest, DefaultParams) {
   EXPECT_EQ("", options->adminAddressPath());
   EXPECT_EQ(Network::Address::IpVersion::v4, options->localAddressIpVersion());
   EXPECT_EQ(Server::Mode::Serve, options->mode());
+  EXPECT_EQ(spdlog::level::warn, options->logLevel());
   EXPECT_FALSE(options->hotRestartDisabled());
   EXPECT_FALSE(options->cpusetThreadsEnabled());
 
@@ -305,10 +306,16 @@ TEST_F(OptionsImplTest, InvalidComponent) {
                           "error: invalid component specified 'blah'");
 }
 
-TEST_F(OptionsImplTest, InvalidLogLevel) {
+TEST_F(OptionsImplTest, InvalidComponentLogLevel) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
   EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("upstream:blah,connection:trace"),
                           MalformedArgvException, "error: invalid log level specified 'blah'");
+}
+
+TEST_F(OptionsImplTest, ComponentLogLevelContainsBlank) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
+  EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("upstream:,connection:trace"),
+                          MalformedArgvException, "error: invalid log level specified ''");
 }
 
 TEST_F(OptionsImplTest, InvalidComponentLogLevelStructure) {
@@ -322,6 +329,21 @@ TEST_F(OptionsImplTest, IncompleteComponentLogLevel) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
   EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("upstream"), MalformedArgvException,
                           "component log level not correctly specified 'upstream'");
+}
+
+TEST_F(OptionsImplTest, InvalidLogLevel) {
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy -l blah"), MalformedArgvException,
+                          "error: invalid log level specified 'blah'");
+}
+
+TEST_F(OptionsImplTest, ValidLogLevel) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy -l critical");
+  EXPECT_EQ(spdlog::level::level_enum::critical, options->logLevel());
+}
+
+TEST_F(OptionsImplTest, WarnIsValidLogLevel) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy -l warn");
+  EXPECT_EQ(spdlog::level::level_enum::warn, options->logLevel());
 }
 
 // Test that the test constructor comes up with the same default values as the main constructor.

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -346,6 +346,11 @@ TEST_F(OptionsImplTest, WarnIsValidLogLevel) {
   EXPECT_EQ(spdlog::level::level_enum::warn, options->logLevel());
 }
 
+TEST_F(OptionsImplTest, AllowedLogLevels) {
+  EXPECT_EQ("[trace][debug][info][warning][error][critical][off][warn]",
+            OptionsImpl::allowedLogLevels());
+}
+
 // Test that the test constructor comes up with the same default values as the main constructor.
 TEST_F(OptionsImplTest, SaneTestConstructor) {
   std::unique_ptr<OptionsImpl> regular_options_impl(createOptionsImpl("envoy"));


### PR DESCRIPTION
Description: allow `-l warn` to configure log level, and sanity check arg value.     
Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Fixes #9560 
