### PR TITLE
gzip: add force load factory declaration

### DIFF
--- a/source/extensions/filters/http/gzip/config.h
+++ b/source/extensions/filters/http/gzip/config.h
@@ -26,6 +26,8 @@ private:
                                     Server::Configuration::FactoryContext& context) override;
 };
 
+DECLARE_FACTORY(GzipFilterFactory);
+
 } // namespace Gzip
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
Adds a force load factory declaration so that this filter can be force-loaded by Envoy Mobile.

Risk Level: Low
Testing: Done locally, and CI
Docs Changes: None
Release Notes: None

Signed-off-by: Michael Rebello <me@michaelrebello.com>