### PR TITLE
network: Add new interface TransportSocketCallbacks::flushWriteBuffer()

### DIFF
--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -83,6 +83,11 @@ public:
    * @param event supplies the connection event
    */
   virtual void raiseEvent(ConnectionEvent event) PURE;
+
+  /**
+   * If the callbacks' write buffer is not empty, try to drain the buffer.
+   */
+  virtual void flushWriteBuffer() PURE;
 };
 
 /**

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -86,6 +86,7 @@ public:
 
   /**
    * If the callbacks' write buffer is not empty, try to drain the buffer.
+   * As of 2/20, used by Google.
    */
   virtual void flushWriteBuffer() PURE;
 };

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -353,9 +353,8 @@ void ConnectionImpl::raiseEvent(ConnectionEvent event) {
   // where no check of the write buffer is made. Provide an opportunity to flush
   // here. If connection write is not ready, this is harmless. We should only do
   // this if we're still open (the above callbacks may have closed).
-  if (state() == State::Open && event == ConnectionEvent::Connected &&
-      write_buffer_->length() > 0) {
-    onWriteReady();
+  if (event == ConnectionEvent::Connected) {
+    flushWriteBuffer();
   }
 }
 
@@ -650,6 +649,12 @@ bool ConnectionImpl::bothSidesHalfClosed() {
 
 absl::string_view ConnectionImpl::transportFailureReason() const {
   return transport_socket_->failureReason();
+}
+
+void ConnectionImpl::flushWriteBuffer() {
+  if (state() == State::Open && write_buffer_->length() > 0) {
+    onWriteReady();
+  }
 }
 
 ClientConnectionImpl::ClientConnectionImpl(

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -112,6 +112,7 @@ public:
   // fair sharing of CPU resources, the underlying event loop does not make any fairness guarantees.
   // Reconsider how to make fairness happen.
   void setReadBufferReady() override { file_event_->activate(Event::FileReadyType::Read); }
+  void flushWriteBuffer() override;
 
   // Obtain global next connection ID. This should only be used in tests.
   static uint64_t nextGlobalIdForTest() { return next_global_id_; }

--- a/source/extensions/transport_sockets/alts/noop_transport_socket_callbacks.h
+++ b/source/extensions/transport_sockets/alts/noop_transport_socket_callbacks.h
@@ -27,6 +27,7 @@ public:
    */
   void setReadBufferReady() override {}
   void raiseEvent(Network::ConnectionEvent) override {}
+  void flushWriteBuffer() override {}
 
 private:
   Network::TransportSocketCallbacks& parent_;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1789,6 +1789,7 @@ TEST_F(MockTransportConnectionImplTest, WriteReadyOnConnected) {
       .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
 }
 
+// Test the interface used by external consumers.
 TEST_F(MockTransportConnectionImplTest, FlushWriteBuffer) {
   InSequence s;
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1801,7 +1801,7 @@ TEST_F(MockTransportConnectionImplTest, FlushWriteBuffer) {
       .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, false}));
   connection_->write(buffer, false);
 
-  // A read event triggers underlying socke to ask for more data.
+  // A read event triggers underlying socket to ask for more data.
   EXPECT_CALL(*transport_socket_, doRead(_)).WillOnce(InvokeWithoutArgs([this] {
     transport_socket_callbacks_->flushWriteBuffer();
     return IoResult{PostIoAction::KeepOpen, 0, false};

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1789,6 +1789,29 @@ TEST_F(MockTransportConnectionImplTest, WriteReadyOnConnected) {
       .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
 }
 
+TEST_F(MockTransportConnectionImplTest, FlushWriteBuffer) {
+  InSequence s;
+
+  // Queue up some data in write buffer.
+  const std::string val("some data");
+  Buffer::OwnedImpl buffer(val);
+  EXPECT_CALL(*file_event_, activate(Event::FileReadyType::Write)).WillOnce(Invoke(file_ready_cb_));
+  EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, false}));
+  connection_->write(buffer, false);
+
+  // A read event triggers underlying socke to ask for more data.
+  EXPECT_CALL(*transport_socket_, doRead(_)).WillOnce(InvokeWithoutArgs([this] {
+    transport_socket_callbacks_->flushWriteBuffer();
+    return IoResult{PostIoAction::KeepOpen, 0, false};
+  }));
+  EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, false}));
+  file_ready_cb_(Event::FileReadyType::Read);
+  EXPECT_CALL(*transport_socket_, doWrite(_, true))
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
+}
+
 // Fixture for validating behavior after a connection is closed.
 class PostCloseConnectionImplTest : public MockTransportConnectionImplTest {
 protected:

--- a/test/extensions/transport_sockets/alts/noop_transport_socket_callbacks_test.cc
+++ b/test/extensions/transport_sockets/alts/noop_transport_socket_callbacks_test.cc
@@ -26,13 +26,16 @@ public:
   bool shouldDrainReadBuffer() override { return false; }
   void setReadBufferReady() override { set_read_buffer_ready_ = true; }
   void raiseEvent(Network::ConnectionEvent) override { event_raised_ = true; }
+  void flushWriteBuffer() override { write_buffer_flushed_ = true; }
 
   bool event_raised() const { return event_raised_; }
   bool set_read_buffer_ready() const { return set_read_buffer_ready_; }
+  bool write_buffer_flushed() const { return write_buffer_flushed_; }
 
 private:
   bool event_raised_{false};
   bool set_read_buffer_ready_{false};
+  bool write_buffer_flushed_{false};
   Network::IoHandlePtr io_handle_;
   Network::Connection& connection_;
 };
@@ -56,6 +59,8 @@ TEST_F(NoOpTransportSocketCallbacksTest, TestAllCallbacks) {
   EXPECT_FALSE(wrapper_callbacks_.set_read_buffer_ready());
   wrapped_callbacks_.raiseEvent(Network::ConnectionEvent::Connected);
   EXPECT_FALSE(wrapper_callbacks_.event_raised());
+  wrapped_callbacks_.flushWriteBuffer();
+  EXPECT_FALSE(wrapper_callbacks_.write_buffer_flushed());
 }
 
 } // namespace

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -404,6 +404,7 @@ public:
   MOCK_METHOD(bool, shouldDrainReadBuffer, ());
   MOCK_METHOD(void, setReadBufferReady, ());
   MOCK_METHOD(void, raiseEvent, (ConnectionEvent));
+  MOCK_METHOD(void, flushWriteBuffer, ());
 
   testing::NiceMock<MockConnection> connection_;
 };


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Add this new interface to allow transport socket to trigger connection to push write pipe line.

Currently the only way to trigger a write event from TransportSocket implementation is via callback's raiseEvent(Connected), but we might not want to raise Connected event to L4 filters when we want to flush connection's write buffer. 

Risk Level: low, not used in open source code
Testing: existing test passes.

