### PR TITLE
tsi: use zero copy grpc frame protector

### DIFF
--- a/source/extensions/transport_sockets/alts/grpc_tsi.h
+++ b/source/extensions/transport_sockets/alts/grpc_tsi.h
@@ -13,6 +13,7 @@
 #include "grpc/grpc_security.h"
 #include "src/core/tsi/alts/handshaker/alts_shared_resource.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
+#include "src/core/tsi/transport_security_grpc.h"
 #include "src/core/tsi/transport_security_interface.h"
 
 #ifndef _MSC_VER
@@ -26,7 +27,8 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Alts {
 
-using CFrameProtectorPtr = CSmartPtr<tsi_frame_protector, tsi_frame_protector_destroy>;
+using CFrameProtectorPtr =
+    CSmartPtr<tsi_zero_copy_grpc_protector, tsi_zero_copy_grpc_protector_destroy>;
 
 using CHandshakerResultPtr = CSmartPtr<tsi_handshaker_result, tsi_handshaker_result_destroy>;
 using CHandshakerPtr = CSmartPtr<tsi_handshaker, tsi_handshaker_destroy>;

--- a/source/extensions/transport_sockets/alts/tsi_frame_protector.cc
+++ b/source/extensions/transport_sockets/alts/tsi_frame_protector.cc
@@ -1,14 +1,16 @@
 #include "extensions/transport_sockets/alts/tsi_frame_protector.h"
 
+#include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
+
+#include "grpc/slice_buffer.h"
+#include "src/core/tsi/transport_security_grpc.h"
+#include "src/core/tsi/transport_security_interface.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
 namespace Alts {
-
-// TODO(lizan): tune size later
-static constexpr uint32_t BUFFER_SIZE = 16384;
 
 TsiFrameProtector::TsiFrameProtector(CFrameProtectorPtr&& frame_protector)
     : frame_protector_(std::move(frame_protector)) {}
@@ -16,34 +18,50 @@ TsiFrameProtector::TsiFrameProtector(CFrameProtectorPtr&& frame_protector)
 tsi_result TsiFrameProtector::protect(Buffer::Instance& input, Buffer::Instance& output) {
   ASSERT(frame_protector_);
 
-  unsigned char protected_buffer[BUFFER_SIZE];
-  while (input.length() > 0) {
-    auto* message_bytes = reinterpret_cast<unsigned char*>(input.linearize(input.length()));
-    size_t protected_buffer_size = BUFFER_SIZE;
-    size_t processed_message_size = input.length();
-    tsi_result result =
-        tsi_frame_protector_protect(frame_protector_.get(), message_bytes, &processed_message_size,
-                                    protected_buffer, &protected_buffer_size);
-    if (result != TSI_OK) {
-      ASSERT(result != TSI_INVALID_ARGUMENT && result != TSI_UNIMPLEMENTED);
-      return result;
-    }
-    output.add(protected_buffer, protected_buffer_size);
-    input.drain(processed_message_size);
+  if (input.length() == 0) {
+    return TSI_OK;
   }
 
-  // TSI may buffer some of the input internally. Flush its buffer to protected_buffer.
-  size_t still_pending_size;
-  do {
-    size_t protected_buffer_size = BUFFER_SIZE;
-    tsi_result result = tsi_frame_protector_protect_flush(
-        frame_protector_.get(), protected_buffer, &protected_buffer_size, &still_pending_size);
-    if (result != TSI_OK) {
-      ASSERT(result != TSI_INVALID_ARGUMENT && result != TSI_UNIMPLEMENTED);
-      return result;
-    }
-    output.add(protected_buffer, protected_buffer_size);
-  } while (still_pending_size > 0);
+  grpc_core::ExecCtx exec_ctx;
+  grpc_slice input_slice = grpc_slice_from_copied_buffer(
+      reinterpret_cast<char*>(input.linearize(input.length())), input.length());
+
+  grpc_slice_buffer message_buffer;
+  grpc_slice_buffer_init(&message_buffer);
+  grpc_slice_buffer_add(&message_buffer, input_slice);
+
+  grpc_slice_buffer protected_buffer;
+  grpc_slice_buffer_init(&protected_buffer);
+
+  tsi_result result = tsi_zero_copy_grpc_protector_protect(frame_protector_.get(), &message_buffer,
+                                                           &protected_buffer);
+
+  if (result != TSI_OK) {
+    ASSERT(result != TSI_INVALID_ARGUMENT && result != TSI_UNIMPLEMENTED);
+    grpc_slice_buffer_destroy(&message_buffer);
+    grpc_slice_buffer_destroy(&protected_buffer);
+    return result;
+  }
+
+  const size_t protected_data_length = protected_buffer.length;
+  char* protected_data = new char[protected_data_length];
+
+  grpc_slice_buffer_move_first_into_buffer(&protected_buffer, protected_data_length,
+                                           protected_data);
+
+  auto fragment = new Buffer::BufferFragmentImpl(
+      protected_data, protected_data_length,
+      [protected_data](const void*, size_t,
+                       const Envoy::Buffer::BufferFragmentImpl* this_fragment) {
+        delete[] protected_data;
+        delete this_fragment;
+      });
+
+  output.addBufferFragment(*fragment);
+  input.drain(input.length());
+
+  grpc_slice_buffer_destroy(&message_buffer);
+  grpc_slice_buffer_destroy(&protected_buffer);
 
   return TSI_OK;
 }
@@ -51,22 +69,50 @@ tsi_result TsiFrameProtector::protect(Buffer::Instance& input, Buffer::Instance&
 tsi_result TsiFrameProtector::unprotect(Buffer::Instance& input, Buffer::Instance& output) {
   ASSERT(frame_protector_);
 
-  unsigned char unprotected_buffer[BUFFER_SIZE];
-
-  while (input.length() > 0) {
-    auto* message_bytes = reinterpret_cast<unsigned char*>(input.linearize(input.length()));
-    size_t unprotected_buffer_size = BUFFER_SIZE;
-    size_t processed_message_size = input.length();
-    tsi_result result = tsi_frame_protector_unprotect(frame_protector_.get(), message_bytes,
-                                                      &processed_message_size, unprotected_buffer,
-                                                      &unprotected_buffer_size);
-    if (result != TSI_OK) {
-      ASSERT(result != TSI_INVALID_ARGUMENT && result != TSI_UNIMPLEMENTED);
-      return result;
-    }
-    output.add(unprotected_buffer, unprotected_buffer_size);
-    input.drain(processed_message_size);
+  if (input.length() == 0) {
+    return TSI_OK;
   }
+
+  grpc_core::ExecCtx exec_ctx;
+  grpc_slice input_slice = grpc_slice_from_copied_buffer(
+      reinterpret_cast<char*>(input.linearize(input.length())), input.length());
+
+  grpc_slice_buffer protected_buffer;
+  grpc_slice_buffer_init(&protected_buffer);
+  grpc_slice_buffer_add(&protected_buffer, input_slice);
+
+  grpc_slice_buffer unprotected_buffer;
+  grpc_slice_buffer_init(&unprotected_buffer);
+
+  tsi_result result = tsi_zero_copy_grpc_protector_unprotect(
+      frame_protector_.get(), &protected_buffer, &unprotected_buffer);
+
+  if (result != TSI_OK) {
+    ASSERT(result != TSI_INVALID_ARGUMENT && result != TSI_UNIMPLEMENTED);
+    grpc_slice_buffer_destroy(&protected_buffer);
+    grpc_slice_buffer_destroy(&unprotected_buffer);
+    return result;
+  }
+
+  const size_t unprotected_data_length = unprotected_buffer.length;
+  char* unprotected_data = new char[unprotected_data_length];
+
+  grpc_slice_buffer_move_first_into_buffer(&unprotected_buffer, unprotected_data_length,
+                                           unprotected_data);
+
+  auto fragment = new Buffer::BufferFragmentImpl(
+      unprotected_data, unprotected_data_length,
+      [unprotected_data](const void*, size_t,
+                         const Envoy::Buffer::BufferFragmentImpl* this_fragment) {
+        delete[] unprotected_data;
+        delete this_fragment;
+      });
+
+  output.addBufferFragment(*fragment);
+  input.drain(input.length());
+
+  grpc_slice_buffer_destroy(&protected_buffer);
+  grpc_slice_buffer_destroy(&unprotected_buffer);
 
   return TSI_OK;
 }

--- a/source/extensions/transport_sockets/alts/tsi_frame_protector.h
+++ b/source/extensions/transport_sockets/alts/tsi_frame_protector.h
@@ -13,8 +13,6 @@ namespace Alts {
  * A C++ wrapper for tsi_frame_protector interface.
  * For detail of tsi_frame_protector, see
  * https://github.com/grpc/grpc/blob/v1.10.0/src/core/tsi/transport_security_interface.h#L70
- *
- * TODO(lizan): migrate to tsi_zero_copy_grpc_protector for further optimization
  */
 class TsiFrameProtector final {
 public:

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -131,9 +131,10 @@ Network::PostIoAction TsiSocket::doHandshakeNextDone(NextResultPtr&& next_result
                    unused_byte_size);
 
     // returns TSI_OK assuming there is no fatal error. Asserting OK.
-    tsi_frame_protector* frame_protector;
-    status =
-        tsi_handshaker_result_create_frame_protector(handshaker_result, nullptr, &frame_protector);
+    tsi_zero_copy_grpc_protector* frame_protector;
+    grpc_core::ExecCtx exec_ctx;
+    status = tsi_handshaker_result_create_zero_copy_grpc_protector(handshaker_result, nullptr,
+                                                                   &frame_protector);
     ASSERT(status == TSI_OK);
     frame_protector_ = std::make_unique<TsiFrameProtector>(frame_protector);
 

--- a/test/extensions/transport_sockets/alts/tsi_frame_protector_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_frame_protector_test.cc
@@ -21,11 +21,11 @@ using namespace std::string_literals;
 class TsiFrameProtectorTest : public testing::Test {
 public:
   TsiFrameProtectorTest()
-      : raw_frame_protector_(tsi_create_fake_frame_protector(nullptr)),
+      : raw_frame_protector_(tsi_create_fake_zero_copy_grpc_protector(nullptr)),
         frame_protector_(CFrameProtectorPtr{raw_frame_protector_}) {}
 
 protected:
-  tsi_frame_protector* raw_frame_protector_;
+  tsi_zero_copy_grpc_protector* raw_frame_protector_;
   TsiFrameProtector frame_protector_;
 };
 
@@ -64,24 +64,9 @@ TEST_F(TsiFrameProtectorTest, Protect) {
 }
 
 TEST_F(TsiFrameProtectorTest, ProtectError) {
-  const tsi_frame_protector_vtable* vtable = raw_frame_protector_->vtable;
-  tsi_frame_protector_vtable mock_vtable = *raw_frame_protector_->vtable;
-  mock_vtable.protect = [](tsi_frame_protector*, const unsigned char*, size_t*, unsigned char*,
-                           size_t*) { return TSI_INTERNAL_ERROR; };
-  raw_frame_protector_->vtable = &mock_vtable;
-
-  Buffer::OwnedImpl input, encrypted;
-  input.add("foo");
-
-  EXPECT_EQ(TSI_INTERNAL_ERROR, frame_protector_.protect(input, encrypted));
-
-  raw_frame_protector_->vtable = vtable;
-}
-
-TEST_F(TsiFrameProtectorTest, ProtectFlushError) {
-  const tsi_frame_protector_vtable* vtable = raw_frame_protector_->vtable;
-  tsi_frame_protector_vtable mock_vtable = *raw_frame_protector_->vtable;
-  mock_vtable.protect_flush = [](tsi_frame_protector*, unsigned char*, size_t*, size_t*) {
+  const tsi_zero_copy_grpc_protector_vtable* vtable = raw_frame_protector_->vtable;
+  tsi_zero_copy_grpc_protector_vtable mock_vtable = *raw_frame_protector_->vtable;
+  mock_vtable.protect = [](tsi_zero_copy_grpc_protector*, grpc_slice_buffer*, grpc_slice_buffer*) {
     return TSI_INTERNAL_ERROR;
   };
   raw_frame_protector_->vtable = &mock_vtable;
@@ -125,10 +110,10 @@ TEST_F(TsiFrameProtectorTest, Unprotect) {
   }
 }
 TEST_F(TsiFrameProtectorTest, UnprotectError) {
-  const tsi_frame_protector_vtable* vtable = raw_frame_protector_->vtable;
-  tsi_frame_protector_vtable mock_vtable = *raw_frame_protector_->vtable;
-  mock_vtable.unprotect = [](tsi_frame_protector*, const unsigned char*, size_t*, unsigned char*,
-                             size_t*) { return TSI_INTERNAL_ERROR; };
+  const tsi_zero_copy_grpc_protector_vtable* vtable = raw_frame_protector_->vtable;
+  tsi_zero_copy_grpc_protector_vtable mock_vtable = *raw_frame_protector_->vtable;
+  mock_vtable.unprotect = [](tsi_zero_copy_grpc_protector*, grpc_slice_buffer*,
+                             grpc_slice_buffer*) { return TSI_INTERNAL_ERROR; };
   raw_frame_protector_->vtable = &mock_vtable;
 
   Buffer::OwnedImpl input, decrypted;


### PR DESCRIPTION
Description: Zero copy protector is more efficient but the main reason to use it is
the fact that we're using some protocols internally that don't work with
the default TSI protector, only with the zero copy one.

Risk Level: Low
Testing: unit tests updated, also tested in a real dev environment.
Docs Changes: n/a
Release Notes: n/a
Fixes #9956 
