### PR TITLE
config: remove ApiTypeOracle assert

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -13,7 +13,6 @@ envoy_cc_library(
     srcs = ["api_type_oracle.cc"],
     hdrs = ["api_type_oracle.h"],
     deps = [
-        "//source/common/common:assert_lib",
         "//source/common/protobuf",
         "@com_github_cncf_udpa//udpa/annotations:pkg_cc_proto",
     ],
@@ -353,6 +352,7 @@ envoy_cc_library(
     hdrs = ["version_converter.h"],
     deps = [
         ":api_type_oracle_lib",
+        "//source/common/common:assert_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:well_known_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -13,8 +13,6 @@ envoy_cc_library(
     srcs = ["api_type_oracle.cc"],
     hdrs = ["api_type_oracle.h"],
     deps = [
-        "//source/common/common:assert_lib",
-        "//source/common/common:logger_lib",
         "//source/common/protobuf",
         "@com_github_cncf_udpa//udpa/annotations:pkg_cc_proto",
     ],

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -13,7 +13,7 @@ envoy_cc_library(
     srcs = ["api_type_oracle.cc"],
     hdrs = ["api_type_oracle.h"],
     deps = [
-        "//source/common/common:logger_lib",
+        "//source/common/common:assert_lib",
         "//source/common/protobuf",
         "@com_github_cncf_udpa//udpa/annotations:pkg_cc_proto",
     ],

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     srcs = ["api_type_oracle.cc"],
     hdrs = ["api_type_oracle.h"],
     deps = [
+        "//source/common/common:logger_lib",
         "//source/common/protobuf",
         "@com_github_cncf_udpa//udpa/annotations:pkg_cc_proto",
     ],

--- a/source/common/config/api_type_oracle.cc
+++ b/source/common/config/api_type_oracle.cc
@@ -1,8 +1,5 @@
 #include "common/config/api_type_oracle.h"
 
-#include "common/common/assert.h"
-#include "common/common/logger.h"
-
 #include "udpa/annotations/versioning.pb.h"
 
 namespace Envoy {
@@ -20,7 +17,6 @@ ApiTypeOracle::getEarlierVersionDescriptor(const std::string& message_type) {
     const Protobuf::Descriptor* earlier_desc =
         Protobuf::DescriptorPool::generated_pool()->FindMessageTypeByName(
             desc->options().GetExtension(udpa::annotations::versioning).previous_message_type());
-    ASSERT(earlier_desc != nullptr);
     return earlier_desc;
   }
 


### PR DESCRIPTION
This assert currently validates that the return value is non-null. However, call sites actually [guard against `nullptr`](https://github.com/envoyproxy/envoy/pull/9618/files#diff-17967d56376bf9821edb17b67b8a7e63R228-R230) and treat it as a valid codepath.

In Envoy Mobile, we're hitting this assert because we use the v3 configuration and don't include all the v2 protos when building the library. Removing the v2 fallback protos in this scenario can be a valid optimization.

Given the above example and the fact that callers explicitly guard against `nullptr`, this assert should be removed and this codepath considered valid.

Risk Level: Low
Testing: Built Envoy / Envoy Mobile locally + CI
Docs Changes: None
Release Notes: None

Signed-off-by: Michael Rebello <me@michaelrebello.com>