### PR TITLE
fix typo error, fix #9985

### DIFF
--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -68,7 +68,7 @@ public:
   }
 
   /**
-   * @return the number of bytes available to be reserve()d.
+   * @return the number of bytes available to be reserved.
    * @note Read-only implementations of Slice should return zero from this method.
    */
   uint64_t reservableSize() const {


### PR DESCRIPTION
Description: Fix typo error in code comments.
Risk Level: Low
Testing: No need for testing.
Docs Changes: No need for docs change.
Release Notes:N/A
Fix #9985
