### PR TITLE
HTTP2: add error details on some NGHTTP2 errors.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -279,7 +279,7 @@ void ConnectionManagerImpl::handleCodecException(const char* error) {
 
   // In the protocol error case, we need to reset all streams now. The connection might stick around
   // long enough for a pending stream to come back and try to encode.
-  resetAllStreams(StreamInfo::ResponseFlag::DownstreamProtocolError);
+  resetAllStreams(StreamResetReason::LocalReset);
 
   // HTTP/1.1 codec has already sent a 400 response if possible. HTTP/2 codec has already sent
   // GOAWAY.
@@ -378,8 +378,7 @@ Network::FilterStatus ConnectionManagerImpl::onNewConnection() {
   return Network::FilterStatus::StopIteration;
 }
 
-void ConnectionManagerImpl::resetAllStreams(
-    absl::optional<StreamInfo::ResponseFlag> response_flag) {
+void ConnectionManagerImpl::resetAllStreams(StreamResetReason reason) {
   while (!streams_.empty()) {
     // Mimic a downstream reset in this case. We must also remove callbacks here. Though we are
     // about to close the connection and will disable further reads, it is possible that flushing
@@ -391,14 +390,7 @@ void ConnectionManagerImpl::resetAllStreams(
     // codec but there are no easy answers and this seems simpler.
     auto& stream = *streams_.front();
     stream.response_encoder_->getStream().removeCallbacks(stream);
-    stream.onResetStream(StreamResetReason::ConnectionTermination, absl::string_view());
-    if (response_flag.has_value()) {
-      stream.stream_info_.setResponseFlag(response_flag.value());
-      if (*response_flag == StreamInfo::ResponseFlag::DownstreamProtocolError) {
-        stream.stream_info_.setResponseCodeDetails(
-            stream.response_encoder_->getStream().responseDetails());
-      }
-    }
+    stream.onResetStream(reason, stream.response_encoder_->getStream().responseDetails());
   }
 }
 
@@ -439,7 +431,7 @@ void ConnectionManagerImpl::onEvent(Network::ConnectionEvent event) {
 
     stats_.named_.downstream_cx_destroy_active_rq_.inc();
     user_agent_.onConnectionDestroy(event, true);
-    resetAllStreams(absl::nullopt);
+    resetAllStreams(StreamResetReason::ConnectionTermination);
   }
 }
 
@@ -1870,7 +1862,8 @@ bool ConnectionManagerImpl::ActiveStream::handleDataIfStopAll(ActiveStreamFilter
   return false;
 }
 
-void ConnectionManagerImpl::ActiveStream::onResetStream(StreamResetReason, absl::string_view) {
+void ConnectionManagerImpl::ActiveStream::onResetStream(StreamResetReason reason,
+                                                        absl::string_view) {
   // NOTE: This function gets called in all of the following cases:
   //       1) We TX an app level reset
   //       2) The codec TX a codec level reset
@@ -1879,6 +1872,16 @@ void ConnectionManagerImpl::ActiveStream::onResetStream(StreamResetReason, absl:
   ENVOY_STREAM_LOG(debug, "stream reset", *this);
   connection_manager_.stats_.named_.downstream_rq_rx_reset_.inc();
   connection_manager_.doDeferredStreamDestroy(*this);
+
+  // We interpret a LocalReset as a downstream protocol error. As far
+  // as I can tell this interpretation is correct in today's code
+  // (2020-02-10). However, mapping between StreamResetReason and
+  // ResponseFlag is fragile, because somebody may use LocalReset for
+  // something that is not a DownstreamProtocolError.
+  if (reason == StreamResetReason::LocalReset) {
+    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamProtocolError);
+    stream_info_.setResponseCodeDetails(response_encoder_->getStream().responseDetails());
+  }
 }
 
 void ConnectionManagerImpl::ActiveStream::onAboveWriteBufferHighWatermark() {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -736,7 +736,7 @@ private:
    */
   void doEndStream(ActiveStream& stream);
 
-  void resetAllStreams(absl::optional<StreamInfo::ResponseFlag> response_flag);
+  void resetAllStreams(StreamResetReason reason);
   void onIdleTimeout();
   void onConnectionDurationTimeout();
   void onDrainTimeout();

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -25,6 +25,26 @@ namespace Envoy {
 namespace Http {
 namespace Http2 {
 
+class Http2ResponseCodeDetailValues {
+  const absl::string_view NgHttp2ErrHttpHeader = "http2.nghttp2_err_http_header";
+  const absl::string_view NgHttp2ErrHttpMessaging = "http2.nghttp2_err_http_messaging";
+  const absl::string_view NgHttp2ErrUnknown = "http2.nghttp2_err_unknown";
+
+public:
+  const absl::string_view strerror(int error_code) const {
+    switch (error_code) {
+    case NGHTTP2_ERR_HTTP_HEADER:
+      return NgHttp2ErrHttpHeader;
+    case NGHTTP2_ERR_HTTP_MESSAGING:
+      return NgHttp2ErrHttpMessaging;
+    default:
+      return NgHttp2ErrUnknown;
+    }
+  }
+};
+
+using Http2ResponseCodeDetails = ConstSingleton<Http2ResponseCodeDetailValues>;
+
 bool Utility::reconstituteCrumbledCookies(const HeaderString& key, const HeaderString& value,
                                           HeaderString& cookies) {
   if (key != Headers::get().Cookie.get().c_str()) {
@@ -620,13 +640,18 @@ int ConnectionImpl::onInvalidFrame(int32_t stream_id, int error_code) {
   ENVOY_CONN_LOG(debug, "invalid frame: {} on stream {}", connection_, nghttp2_strerror(error_code),
                  stream_id);
 
+  // Set details of ERROR_CODE in the stream whenever we have one.
+  StreamImpl* stream = getStream(stream_id);
+  if (stream != nullptr) {
+    stream->setDetails(Http2ResponseCodeDetails::get().strerror(error_code));
+  }
+
   if (error_code == NGHTTP2_ERR_HTTP_HEADER || error_code == NGHTTP2_ERR_HTTP_MESSAGING) {
     stats_.rx_messaging_error_.inc();
 
     if (stream_error_on_invalid_http_messaging_) {
       // The stream is about to be closed due to an invalid header or messaging. Don't kill the
       // entire connection if one stream has bad headers or messaging.
-      StreamImpl* stream = getStream(stream_id);
       if (stream != nullptr) {
         // See comment below in onStreamClose() for why we do this.
         stream->reset_due_to_messaging_error_ = true;

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -176,6 +176,15 @@ protected:
     const Network::Address::InstanceConstSharedPtr& connectionLocalAddress() override {
       return parent_.connection_.localAddress();
     }
+    absl::string_view responseDetails() override { return details_; }
+
+    void setDetails(absl::string_view details) {
+      // Figure out whether we can guarantee that details_ is set at
+      // most once. It is probably a mistake to call setDetails()
+      // twice. For now assert that details_ is empty.
+      ASSERT(details_.empty());
+      details_ = details;
+    }
 
     void setWriteBufferWatermarks(uint32_t low_watermark, uint32_t high_watermark) {
       pending_recv_data_.setWatermarks(low_watermark, high_watermark);
@@ -230,6 +239,7 @@ protected:
     bool pending_receive_buffer_high_watermark_called_ : 1;
     bool pending_send_buffer_high_watermark_called_ : 1;
     bool reset_due_to_messaging_error_ : 1;
+    absl::string_view details_;
   };
 
   using StreamImplPtr = std::unique_ptr<StreamImpl>;

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -131,6 +131,14 @@ public:
     reinterpret_cast<uint8_t*>(data.linearize(data.length()))[index % data.length()] = new_value;
   }
 
+  void expectDetailsRequest(const absl::string_view details) {
+    EXPECT_EQ(details, request_encoder_->getStream().responseDetails());
+  }
+
+  void expectDetailsResponse(const absl::string_view details) {
+    EXPECT_EQ(details, response_encoder_->getStream().responseDetails());
+  }
+
   const Http2SettingsTuple client_settings_;
   const Http2SettingsTuple server_settings_;
   bool allow_metadata_ = false;
@@ -308,6 +316,7 @@ TEST_P(Http2CodecImplTest, InvalidContinueWithFinAllowed) {
   client_wrapper_.dispatch(Buffer::OwnedImpl(), *client_);
 
   EXPECT_EQ(1, stats_store_.counter("http2.rx_messaging_error").value());
+  expectDetailsRequest("http2.nghttp2_err_http_messaging");
 }
 
 TEST_P(Http2CodecImplTest, InvalidRepeatContinue) {
@@ -355,6 +364,7 @@ TEST_P(Http2CodecImplTest, InvalidRepeatContinueAllowed) {
   client_wrapper_.dispatch(Buffer::OwnedImpl(), *client_);
 
   EXPECT_EQ(1, stats_store_.counter("http2.rx_messaging_error").value());
+  expectDetailsRequest("http2.nghttp2_err_http_messaging");
 };
 
 TEST_P(Http2CodecImplTest, Invalid103) {
@@ -434,6 +444,7 @@ TEST_P(Http2CodecImplTest, Invalid204WithContentLengthAllowed) {
   client_wrapper_.dispatch(Buffer::OwnedImpl(), *client_);
 
   EXPECT_EQ(1, stats_store_.counter("http2.rx_messaging_error").value());
+  expectDetailsRequest("http2.nghttp2_err_http_header");
 };
 
 TEST_P(Http2CodecImplTest, RefusedStreamReset) {
@@ -474,6 +485,7 @@ TEST_P(Http2CodecImplTest, InvalidHeadersFrameAllowed) {
   EXPECT_CALL(server_stream_callbacks_, onResetStream(StreamResetReason::LocalReset, _));
   EXPECT_CALL(request_callbacks, onResetStream(StreamResetReason::RemoteReset, _));
   server_wrapper_.dispatch(Buffer::OwnedImpl(), *server_);
+  expectDetailsResponse("http2.nghttp2_err_http_messaging");
 }
 
 TEST_P(Http2CodecImplTest, TrailingHeaders) {

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1760,6 +1760,7 @@ TEST_P(Http2FloodMitigationTest, WindowUpdate) {
 
 // Verify that the HTTP/2 connection is terminated upon receiving invalid HEADERS frame.
 TEST_P(Http2FloodMitigationTest, ZerolenHeader) {
+  useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   beginSession();
 
   // Send invalid request.
@@ -1772,10 +1773,14 @@ TEST_P(Http2FloodMitigationTest, ZerolenHeader) {
   EXPECT_EQ(1, test_server_->counter("http2.rx_messaging_error")->value());
   EXPECT_EQ(1,
             test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.nghttp2_err_http_header"));
+  // expect Downstream Protocol Error
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
 }
 
 // Verify that only the offending stream is terminated upon receiving invalid HEADERS frame.
 TEST_P(Http2FloodMitigationTest, ZerolenHeaderAllowed) {
+  useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) -> void {
@@ -1806,6 +1811,9 @@ TEST_P(Http2FloodMitigationTest, ZerolenHeaderAllowed) {
   EXPECT_EQ(1, test_server_->counter("http2.rx_messaging_error")->value());
   EXPECT_EQ(0,
             test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.nghttp2_err_http_header"));
+  // expect Downstream Protocol Error
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Add wiring to propagate error details from the http2 codec to the
access log.  Such wiring inserts a DownstreamProtocolError response
flag (appearing as "DPE" in the log) and a string with details of the
error.  Currently, this mechanism is only triggered by the
onInvalidFrame callback.

Before this change, DownstreamProtocolError was handled
inconsistently.  If stream_error_on_invalid_http_messaging, we closed
the stream but did not log a DPE.  Otherwise, we closed all streams
and logged a DPE.  The current code reports a DPE in all cases.

Signed-off-by: Matteo Frigo <matteof@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: add error details on some NGHTTP2 errors
Risk Level: low
Testing: unit tests of the new error codes, integration tests that verify that the access log has the expected output
Docs Changes: none
Release Notes: none
[Optional Fixes #Issue]
[Optional Deprecated:]
