### PR TITLE
test: change ip_tagging to buffer for a test

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -146,7 +146,7 @@ envoy_cc_test(
         "//source/common/common:utility_lib",
         "//source/common/stats:stats_lib",
         "//source/extensions/filters/http:well_known_names",
-        "//source/extensions/filters/http/ip_tagging:config",
+        "//source/extensions/filters/http/buffer:config",
         "//source/server:options_lib",
         "//test/mocks/api:api_mocks",
         "//test/test_common:environment_lib",
@@ -155,8 +155,8 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/filter/http/ip_tagging/v2:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/filters/http/ip_tagging/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/filter/http/buffer/v2:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/buffer/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -8,16 +8,16 @@
 #include "envoy/admin/v3/server_info.pb.h"
 #include "envoy/common/exception.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
-#include "envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.h"
+#include "envoy/config/filter/http/buffer/v2/buffer.pb.h"
 #include "envoy/config/typed_config.h"
-#include "envoy/extensions/filters/http/ip_tagging/v3/ip_tagging.pb.h"
+#include "envoy/extensions/filters/http/buffer/v3/buffer.pb.h"
 #include "envoy/server/filter_config.h"
 
 #include "common/common/utility.h"
 
 #include "server/options_impl.h"
 
-#include "extensions/filters/http/ip_tagging/ip_tagging_filter.h"
+#include "extensions/filters/http/buffer/buffer_filter.h"
 #include "extensions/filters/http/well_known_names.h"
 
 #if defined(__linux__)
@@ -553,17 +553,17 @@ TEST(DisableExtensions, IsDisabled) {
 }
 
 TEST(FactoryByTypeTest, EarlierVersionConfigType) {
-  envoy::config::filter::http::ip_tagging::v2::IPTagging v2_config;
+  envoy::config::filter::http::buffer::v2::Buffer v2_config;
   auto factory = Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::
       getFactoryByType(v2_config.GetDescriptor()->full_name());
   EXPECT_NE(factory, nullptr);
-  EXPECT_EQ(factory->name(), Extensions::HttpFilters::HttpFilterNames::get().IpTagging);
+  EXPECT_EQ(factory->name(), Extensions::HttpFilters::HttpFilterNames::get().Buffer);
 
-  envoy::extensions::filters::http::ip_tagging::v3::IPTagging v3_config;
+  envoy::extensions::filters::http::buffer::v3::Buffer v3_config;
   factory = Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::
       getFactoryByType(v3_config.GetDescriptor()->full_name());
   EXPECT_NE(factory, nullptr);
-  EXPECT_EQ(factory->name(), Extensions::HttpFilters::HttpFilterNames::get().IpTagging);
+  EXPECT_EQ(factory->name(), Extensions::HttpFilters::HttpFilterNames::get().Buffer);
 
   ProtobufWkt::Any non_api_type;
   factory = Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: Switch to a core filter in a test. Some extensions are disabled, breaking the import of the test.
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none

