### PR TITLE
kafka: 2.4.0 support - add support for new message types added in 2.4

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -313,8 +313,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["http://us.mirrors.quenda.co/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"],
     ),
     kafka_python_client = dict(
-        sha256 = "81f24a5d297531495e0ccb931fbd6c4d1ec96583cf5a730579a3726e63f59c47",
-        strip_prefix = "kafka-python-1.4.7",
-        urls = ["https://github.com/dpkp/kafka-python/archive/1.4.7.tar.gz"],
+        sha256 = "454bf3aafef9348017192417b7f0828a347ec2eaf3efba59336f3a3b68f10094",
+        strip_prefix = "kafka-python-2.0.0",
+        urls = ["https://github.com/dpkp/kafka-python/archive/2.0.0.tar.gz"],
     ),
 )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -303,14 +303,14 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/protocolbuffers/upb/archive/8a3ae1ef3e3e3f26b45dec735c5776737fc7247f.tar.gz"],
     ),
     kafka_source = dict(
-        sha256 = "feaa32e5c42acf42bd587f8f0b1ccce679db227620da97eed013f4c44a44f64d",
-        strip_prefix = "kafka-2.3.1/clients/src/main/resources/common/message",
-        urls = ["https://github.com/apache/kafka/archive/2.3.1.zip"],
+        sha256 = "e7b748a62e432b5770db6dbb3b034c68c0ea212812cb51603ee7f3a8a35f06be",
+        strip_prefix = "kafka-2.4.0/clients/src/main/resources/common/message",
+        urls = ["https://github.com/apache/kafka/archive/2.4.0.zip"],
     ),
     kafka_server_binary = dict(
-        sha256 = "5a3ddd4148371284693370d56f6f66c7a86d86dd96c533447d2a94d176768d2e",
-        strip_prefix = "kafka_2.12-2.3.1",
-        urls = ["http://us.mirrors.quenda.co/apache/kafka/2.3.1/kafka_2.12-2.3.1.tgz"],
+        sha256 = "b9582bab0c3e8d131953b1afa72d6885ca1caae0061c2623071e7f396f2ccfee",
+        strip_prefix = "kafka_2.12-2.4.0",
+        urls = ["http://us.mirrors.quenda.co/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"],
     ),
     kafka_python_client = dict(
         sha256 = "81f24a5d297531495e0ccb931fbd6c4d1ec96583cf5a730579a3726e63f59c47",

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -5,7 +5,7 @@ Kafka Broker filter
 
 The Apache Kafka broker filter decodes the client protocol for
 `Apache Kafka <https://kafka.apache.org/>`_, both the requests and responses in the payload.
-The message versions in `Kafka 2.3.1 <http://kafka.apache.org/231/protocol.html#protocol_api_keys>`_
+The message versions in `Kafka 2.4.0 <http://kafka.apache.org/24/protocol.html#protocol_api_keys>`_
 are supported.
 The filter attempts not to influence the communication between client and brokers, so the messages
 that could not be decoded (due to Kafka client or broker running a newer version than supported by

--- a/source/extensions/filters/network/kafka/BUILD
+++ b/source/extensions/filters/network/kafka/BUILD
@@ -81,6 +81,7 @@ envoy_cc_library(
     deps = [
         ":kafka_request_lib",
         ":parser_lib",
+        ":tagged_fields_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
     ],
@@ -143,6 +144,7 @@ envoy_cc_library(
     deps = [
         ":kafka_response_lib",
         ":parser_lib",
+        ":tagged_fields_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
     ],

--- a/source/extensions/filters/network/kafka/kafka_request.h
+++ b/source/extensions/filters/network/kafka/kafka_request.h
@@ -11,6 +11,13 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
+/**
+ * Decides if request with given api key & version should have tagged fields in header.
+ * This method gets implemented in generated code through 'kafka_request_resolver_cc.j2'.
+ * @param api_key Kafka request key.
+ * @param api_version Kafka request's version.
+ * @return Whether tagged fields should be used for this request.
+ */
 bool requestUsesTaggedFieldsInHeader(const uint16_t api_key, const uint16_t api_version);
 
 /**

--- a/source/extensions/filters/network/kafka/kafka_request_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.cc
@@ -43,8 +43,11 @@ bool RequestHeaderDeserializer::ready() const {
 }
 
 RequestHeader RequestHeaderDeserializer::get() const {
-  // With current usage pattern, right now we do not need to capture tagged field values.
-  return common_part_deserializer_.get();
+  auto result = common_part_deserializer_.get();
+  if (tagged_fields_present_) {
+    result.tagged_fields_ = tagged_fields_deserializer_.get();
+  }
+  return result;
 }
 
 RequestParseResponse RequestHeaderParser::parse(absl::string_view& data) {

--- a/source/extensions/filters/network/kafka/kafka_request_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.cc
@@ -20,6 +20,33 @@ RequestParseResponse RequestStartParser::parse(absl::string_view& data) {
   }
 }
 
+uint32_t RequestHeaderDeserializer::feed(absl::string_view& data) {
+  uint32_t consumed = 0;
+
+  consumed += common_part_deserializer_.feed(data);
+  if (common_part_deserializer_.ready()) {
+    const auto request_header = common_part_deserializer_.get();
+    if (requestUsesTaggedFieldsInHeader(request_header.api_key_, request_header.api_version_)) {
+      tagged_fields_present_ = true;
+      consumed += tagged_fields_deserializer_.feed(data);
+    }
+  }
+
+  return consumed;
+}
+
+bool RequestHeaderDeserializer::ready() const {
+  // Header is only fully parsed after we have processed everything, including tagged fields (if
+  // they are present).
+  return common_part_deserializer_.ready() &&
+         (tagged_fields_present_ ? tagged_fields_deserializer_.ready() : true);
+}
+
+RequestHeader RequestHeaderDeserializer::get() const {
+  // With current usage pattern, right now we do not need to capture tagged field values.
+  return common_part_deserializer_.get();
+}
+
 RequestParseResponse RequestHeaderParser::parse(absl::string_view& data) {
   context_->remaining_request_size_ -= deserializer_->feed(data);
   // One of the two needs must have happened when feeding finishes:

--- a/source/extensions/filters/network/kafka/kafka_request_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_request_parser.h
@@ -23,8 +23,16 @@ using RequestParserSharedPtr = std::shared_ptr<RequestParser>;
  * Context that is shared between parsers that are handling the same single message.
  */
 struct RequestContext {
+
+  /**
+   * Bytes left to consume.
+   */
   uint32_t remaining_request_size_{0};
-  RequestHeader request_header_{};
+
+  /**
+   * Request header that gets filled in during the parse.
+   */
+  RequestHeader request_header_{-1, -1, -1, absl::nullopt};
 
   /**
    * Bytes left to consume.

--- a/source/extensions/filters/network/kafka/kafka_response_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.cc
@@ -22,22 +22,28 @@ ResponseParseResponse ResponseHeaderParser::parse(absl::string_view& data) {
     return ResponseParseResponse::stillWaiting();
   }
 
-  context_->remaining_response_size_ = length_deserializer_.get();
-  context_->remaining_response_size_ -= sizeof(context_->correlation_id_);
-  context_->correlation_id_ = correlation_id_deserializer_.get();
+  if (!context_->api_info_set_) {
+    // We have consumed first two response header fields: payload length and correlation id.
+    context_->remaining_response_size_ = length_deserializer_.get();
+    context_->remaining_response_size_ -= sizeof(context_->correlation_id_);
+    context_->correlation_id_ = correlation_id_deserializer_.get();
 
-  // We have correlation id now, so we can see what is the expected response api key & version.
-  if (-1 == context_->api_key_) {
+    // We have correlation id now, so we can see what is the expected response api key & version.
     const ExpectedResponseSpec spec = getResponseSpec(context_->correlation_id_);
     context_->api_key_ = spec.first;
     context_->api_version_ = spec.second;
+
+    // Mark that version data has been set, so we do not attempt to re-initialize again.
+    context_->api_info_set_ = true;
   }
 
   // Depending on response's api key & version, we might need to parse tagged fields element.
   if (responseUsesTaggedFieldsInHeader(context_->api_key_, context_->api_version_) &&
       18 != context_->api_key_) {
     context_->remaining_response_size_ -= tagged_fields_deserializer_.feed(data);
-    if (!tagged_fields_deserializer_.ready()) {
+    if (tagged_fields_deserializer_.ready()) {
+      context_->tagged_fields_ = tagged_fields_deserializer_.get();
+    } else {
       return ResponseParseResponse::stillWaiting();
     }
   }

--- a/source/extensions/filters/network/kafka/kafka_response_parser.cc
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.cc
@@ -38,8 +38,7 @@ ResponseParseResponse ResponseHeaderParser::parse(absl::string_view& data) {
   }
 
   // Depending on response's api key & version, we might need to parse tagged fields element.
-  if (responseUsesTaggedFieldsInHeader(context_->api_key_, context_->api_version_) &&
-      18 != context_->api_key_) {
+  if (responseUsesTaggedFieldsInHeader(context_->api_key_, context_->api_version_)) {
     context_->remaining_response_size_ -= tagged_fields_deserializer_.feed(data);
     if (tagged_fields_deserializer_.ready()) {
       context_->tagged_fields_ = tagged_fields_deserializer_.get();

--- a/source/extensions/filters/network/kafka/kafka_response_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.h
@@ -5,6 +5,7 @@
 
 #include "extensions/filters/network/kafka/kafka_response.h"
 #include "extensions/filters/network/kafka/parser.h"
+#include "extensions/filters/network/kafka/tagged_fields.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -23,7 +24,7 @@ struct ResponseContext {
   /**
    * Api key of response that's being parsed.
    */
-  int16_t api_key_;
+  int16_t api_key_ = -1;
 
   /**
    * Api version of response that's being parsed.
@@ -119,6 +120,7 @@ private:
 
   Int32Deserializer length_deserializer_;
   Int32Deserializer correlation_id_deserializer_;
+  TaggedFieldsDeserializer tagged_fields_deserializer_;
 };
 
 /**

--- a/source/extensions/filters/network/kafka/kafka_response_parser.h
+++ b/source/extensions/filters/network/kafka/kafka_response_parser.h
@@ -22,9 +22,14 @@ using ResponseParserSharedPtr = std::shared_ptr<ResponseParser>;
 struct ResponseContext {
 
   /**
+   * Whether the 'api_key_' & 'api_version_' fields have been initialized.
+   */
+  bool api_info_set_ = false;
+
+  /**
    * Api key of response that's being parsed.
    */
-  int16_t api_key_ = -1;
+  int16_t api_key_;
 
   /**
    * Api version of response that's being parsed.
@@ -42,6 +47,11 @@ struct ResponseContext {
   int32_t correlation_id_;
 
   /**
+   * Response's tagged fields.
+   */
+  TaggedFields tagged_fields_;
+
+  /**
    * Bytes left to consume.
    */
   uint32_t& remaining() { return remaining_response_size_; }
@@ -49,7 +59,9 @@ struct ResponseContext {
   /**
    * Returns data needed for construction of parse failure message.
    */
-  const ResponseMetadata asFailureData() const { return {api_key_, api_version_, correlation_id_}; }
+  const ResponseMetadata asFailureData() const {
+    return {api_key_, api_version_, correlation_id_, tagged_fields_};
+  }
 };
 
 using ResponseContextSharedPtr = std::shared_ptr<ResponseContext>;
@@ -168,7 +180,7 @@ public:
       if (0 == context_->remaining_response_size_) {
         // After a successful parse, there should be nothing left - we have consumed all the bytes.
         const ResponseMetadata metadata = {context_->api_key_, context_->api_version_,
-                                           context_->correlation_id_};
+                                           context_->correlation_id_, context_->tagged_fields_};
         const AbstractResponseSharedPtr response =
             std::make_shared<Response<ResponseType>>(metadata, deserializer_.get());
         return ResponseParseResponse::parsedMessage(response);

--- a/source/extensions/filters/network/kafka/protocol/complex_type_template.j2
+++ b/source/extensions/filters/network/kafka/protocol/complex_type_template.j2
@@ -25,38 +25,40 @@ struct {{ complex_type.name }} {
   {{ constructor['full_declaration'] }}{% endfor %}
 
   {# For every field that's used in version, just compute its size using an encoder. #}
-  {% if complex_type.fields|length > 0 %}
   uint32_t computeSize(const EncodingContext& encoder) const {
     const int16_t api_version = encoder.apiVersion();
-    uint32_t written{0};{% for field in complex_type.fields %}
-    if (api_version >= {{ field.version_usage[0] }}
-      && api_version < {{ field.version_usage[-1] + 1 }}) {
-      written += encoder.computeSize({{ field.name }}_);
-    }{% endfor %}
+    uint32_t written{0};
+
+    {% for spec in complex_type.compute_serialization_specs() %}
+    if (api_version >= {{ spec.versions[0] }} && api_version < {{ spec.versions[-1] + 1 }}) {
+      written += encoder.{{ spec.compute_size_method_name }}({{ spec.field.name }}_);
+    }
+    {% endfor %}
+
     return written;
   }
-  {% else %}
-  uint32_t computeSize(const EncodingContext&) const {
-    return 0;
+
+  uint32_t computeCompactSize(const EncodingContext& encoder) const {
+    return computeSize(encoder);
   }
-  {% endif %}
 
   {# For every field that's used in version, just serialize it. #}
-  {% if complex_type.fields|length > 0 %}
   uint32_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
     const int16_t api_version = encoder.apiVersion();
-    uint32_t written{0};{% for field in complex_type.fields %}
-    if (api_version >= {{ field.version_usage[0] }}
-      && api_version < {{ field.version_usage[-1] + 1 }}) {
-      written += encoder.encode({{ field.name }}_, dst);
-    }{% endfor %}
+    uint32_t written{0};
+
+    {% for spec in complex_type.compute_serialization_specs() %}
+    if (api_version >= {{ spec.versions[0] }} && api_version < {{ spec.versions[-1] + 1 }}) {
+      written += encoder.{{ spec.encode_method_name }}({{ spec.field.name }}_, dst);
+    }
+    {% endfor %}
+
     return written;
   }
-  {% else %}
-  uint32_t encode(Buffer::Instance&, EncodingContext&) const {
-    return 0;
+
+  uint32_t encodeCompact(Buffer::Instance& dst, EncodingContext& encoder) const {
+    return encode(dst, encoder);
   }
-  {% endif %}
 
   {% if complex_type.fields|length > 0 %}
   bool operator==(const {{ complex_type.name }}& rhs) const {
@@ -77,7 +79,7 @@ class {{ complex_type.name }}V{{ field_list.version }}Deserializer:
   public CompositeDeserializerWith{{ field_list.field_count() }}Delegates<
     {{ complex_type.name }}
     {% for field in field_list.used_fields() %},
-      {{ field.deserializer_name_in_version(field_list.version) }}
+      {{ field.deserializer_name_in_version(field_list.version, field_list.uses_compact_fields) }}
     {% endfor %}>{};
 {% endfor %}
 

--- a/source/extensions/filters/network/kafka/protocol/kafka_request_resolver_cc.j2
+++ b/source/extensions/filters/network/kafka/protocol/kafka_request_resolver_cc.j2
@@ -12,6 +12,24 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
+bool requestUsesTaggedFieldsInHeader(const uint16_t api_key, const uint16_t api_version) {
+  switch (api_key) {
+    {% for message_type in message_types %}
+    case {{ message_type.get_extra('api_key') }}:
+      switch (api_version) {
+        {% for flexible_version in message_type.flexible_versions %}
+        case {{ flexible_version }}:
+          return true;
+        {% endfor %}
+        default:
+          return false;
+      }
+    {% endfor %}
+    default:
+      return false;
+  }
+}
+
 /**
  * Creates a parser that corresponds to provided key and version.
  * If corresponding parser cannot be found (what means a newer version of Kafka protocol),

--- a/source/extensions/filters/network/kafka/protocol/kafka_request_resolver_cc.j2
+++ b/source/extensions/filters/network/kafka/protocol/kafka_request_resolver_cc.j2
@@ -12,6 +12,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
+// Implements declaration from 'kafka_request.h'.
 bool requestUsesTaggedFieldsInHeader(const uint16_t api_key, const uint16_t api_version) {
   switch (api_key) {
     {% for message_type in message_types %}

--- a/source/extensions/filters/network/kafka/protocol/kafka_response_resolver_cc.j2
+++ b/source/extensions/filters/network/kafka/protocol/kafka_response_resolver_cc.j2
@@ -11,15 +11,19 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
+// Implements declaration from 'kafka_response.h'.
 bool responseUsesTaggedFieldsInHeader(const uint16_t api_key, const uint16_t api_version) {
   switch (api_key) {
     {% for message_type in message_types %}
     case {{ message_type.get_extra('api_key') }}:
       switch (api_version) {
+        {# ApiVersions responses require special handling. #}
+        {% if message_type.get_extra('api_key') != 18 %}
         {% for flexible_version in message_type.flexible_versions %}
         case {{ flexible_version }}:
           return true;
         {% endfor %}
+        {% endif %}
         default:
           return false;
       }

--- a/source/extensions/filters/network/kafka/protocol/kafka_response_resolver_cc.j2
+++ b/source/extensions/filters/network/kafka/protocol/kafka_response_resolver_cc.j2
@@ -11,6 +11,24 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 
+bool responseUsesTaggedFieldsInHeader(const uint16_t api_key, const uint16_t api_version) {
+  switch (api_key) {
+    {% for message_type in message_types %}
+    case {{ message_type.get_extra('api_key') }}:
+      switch (api_version) {
+        {% for flexible_version in message_type.flexible_versions %}
+        case {{ flexible_version }}:
+          return true;
+        {% endfor %}
+        default:
+          return false;
+      }
+    {% endfor %}
+    default:
+      return false;
+  }
+}
+
 /**
  * Creates a parser that is going to process data specific for given response.
  * If corresponding parser cannot be found (what means a newer version of Kafka protocol),

--- a/source/extensions/filters/network/kafka/serialization/generator.py
+++ b/source/extensions/filters/network/kafka/serialization/generator.py
@@ -37,7 +37,7 @@ def get_field_counts():
   """
   Generate argument counts that should be processed by composite deserializers.
   """
-  return range(1, 11)
+  return range(1, 12)
 
 
 class RenderingHelper:

--- a/source/extensions/filters/network/kafka/tagged_fields.h
+++ b/source/extensions/filters/network/kafka/tagged_fields.h
@@ -79,7 +79,7 @@ public:
       ready_ = true;
     }
 
-    return consumed;
+    return consumed + data_consumed;
   };
 
   bool ready() const override { return ready_; };
@@ -100,7 +100,7 @@ private:
  */
 struct TaggedFields {
 
-  const std::vector<TaggedField> fields_;
+  std::vector<TaggedField> fields_;
 
   uint32_t computeCompactSize(const EncodingContext& encoder) const {
     uint32_t result{0};

--- a/test/extensions/filters/network/kafka/BUILD
+++ b/test/extensions/filters/network/kafka/BUILD
@@ -39,6 +39,7 @@ envoy_extension_cc_test(
     deps = [
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:serialization_lib",
+        "//source/extensions/filters/network/kafka:tagged_fields_lib",
         "//test/mocks/server:server_mocks",
     ],
 )

--- a/test/extensions/filters/network/kafka/broker/integration_test/zookeeper_properties.j2
+++ b/test/extensions/filters/network/kafka/broker/integration_test/zookeeper_properties.j2
@@ -1,3 +1,5 @@
 clientPort={{ data['zk_port'] }}
 dataDir={{ data['data_dir'] }}
 maxClientCnxns=0
+# ZK 3.5 tries to bind 8080 for introspection capacility - we do not need that.
+admin.enableServer=false

--- a/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
@@ -112,7 +112,7 @@ TEST_F(KafkaRequestParserTest, RequestDataParserShouldHandleDeserializerExceptio
     int32_t get() const override { throw std::runtime_error("should not be invoked at all"); };
   };
 
-  RequestContextSharedPtr request_context{new RequestContext{1024, {}}};
+  RequestContextSharedPtr request_context{new RequestContext{1024, {0, 0, 0, absl::nullopt}}};
   RequestDataParser<int32_t, ThrowingDeserializer> testee{request_context};
 
   absl::string_view data = putGarbageIntoBuffer();
@@ -146,7 +146,8 @@ TEST_F(KafkaRequestParserTest,
        RequestDataParserShouldHandleDeserializerReturningReadyButLeavingData) {
   // given
   const int32_t request_size = 1024; // There are still 1024 bytes to read to complete the request.
-  RequestContextSharedPtr request_context{new RequestContext{request_size, {}}};
+  RequestContextSharedPtr request_context{
+      new RequestContext{request_size, {0, 0, 0, absl::nullopt}}};
 
   RequestDataParser<int32_t, SomeBytesDeserializer> testee{request_context};
 

--- a/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
@@ -42,8 +42,13 @@ TEST_F(RequestCodecRequestTest, shouldHandle{{ message_type.name }}Messages) {
 
   {% for field_list in message_type.compute_field_lists() %}
   for (int i = 0; i < 100; ++i ) {
-    const RequestHeader header =
-      { {{ message_type.get_extra('api_key') }}, {{ field_list.version }}, correlation++, "id" };
+    const RequestHeader header = {
+      {{ message_type.get_extra('api_key') }},
+      {{ field_list.version }},
+      correlation++,
+      "id"
+      {% if field_list.uses_compact_fields %}, TaggedFields{ {TaggedField{10, Bytes{1, 2, 3, 4} } } } {% endif %}
+    };
     const {{ message_type.name }} data = { {{ field_list.example_value() }} };
     const RequestUnderTest request = {header, data};
     putMessageIntoBuffer(request);

--- a/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
@@ -42,12 +42,17 @@ TEST_F(RequestCodecRequestTest, shouldHandle{{ message_type.name }}Messages) {
 
   {% for field_list in message_type.compute_field_lists() %}
   for (int i = 0; i < 100; ++i ) {
+    {# Request header cannot contain tagged fields if request does not support them. #}
+    const TaggedFields tagged_fields = requestUsesTaggedFieldsInHeader(
+      {{ message_type.get_extra('api_key') }}, {{ field_list.version }}) ?
+        TaggedFields{ { TaggedField{ 10, Bytes{1, 2, 3, 4} } } }:
+        TaggedFields({});
     const RequestHeader header = {
       {{ message_type.get_extra('api_key') }},
       {{ field_list.version }},
       correlation++,
-      "id"
-      {% if field_list.uses_compact_fields %}, TaggedFields{ {TaggedField{10, Bytes{1, 2, 3, 4} } } } {% endif %}
+      "id",
+      tagged_fields
     };
     const {{ message_type.name }} data = { {{ field_list.example_value() }} };
     const RequestUnderTest request = {header, data};

--- a/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
@@ -64,6 +64,7 @@ TEST_F(RequestCodecRequestTest, shouldHandle{{ message_type.name }}Messages) {
   // then
   const std::vector<AbstractRequestSharedPtr>& received = callback->getCapturedMessages();
   ASSERT_EQ(received.size(), sent.size());
+  ASSERT_EQ(received.size(), correlation);
 
   for (size_t i = 0; i < received.size(); ++i) {
     const std::shared_ptr<RequestUnderTest> request =

--- a/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
@@ -45,11 +45,16 @@ TEST_F(ResponseCodecResponseTest, shouldHandle{{ message_type.name }}Messages) {
 
   {% for field_list in message_type.compute_field_lists() %}
   for (int i = 0; i < 100; ++i ) {
+    {# Response header cannot contain tagged fields if response does not support them. #}
+    const TaggedFields tagged_fields = responseUsesTaggedFieldsInHeader(
+      {{ message_type.get_extra('api_key') }}, {{ field_list.version }}) ?
+        TaggedFields{ { TaggedField{ 10, Bytes{1, 2, 3, 4} } } }:
+        TaggedFields({});
     const ResponseMetadata metadata = {
       {{ message_type.get_extra('api_key') }},
       {{ field_list.version }},
-      ++correlation_id
-      {% if field_list.uses_compact_fields and message_type.get_extra('api_key') != 18 %}, TaggedFields{ {TaggedField{10, Bytes{1, 2, 3, 4} } } } {% endif %}
+      ++correlation_id,
+      tagged_fields,
     };
     const {{ message_type.name }} data = { {{ field_list.example_value() }} };
     const ResponseUnderTest response = {metadata, data};

--- a/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
@@ -62,6 +62,7 @@ TEST_F(ResponseCodecResponseTest, shouldHandle{{ message_type.name }}Messages) {
   // then
   const std::vector<AbstractResponseSharedPtr>& received = callback->getCapturedMessages();
   ASSERT_EQ(received.size(), sent.size());
+  ASSERT_EQ(received.size(), correlation_id);
 
   for (size_t i = 0; i < received.size(); ++i) {
     const std::shared_ptr<ResponseUnderTest> response =

--- a/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
@@ -45,8 +45,12 @@ TEST_F(ResponseCodecResponseTest, shouldHandle{{ message_type.name }}Messages) {
 
   {% for field_list in message_type.compute_field_lists() %}
   for (int i = 0; i < 100; ++i ) {
-    const ResponseMetadata metadata =
-      { {{ message_type.get_extra('api_key') }}, {{ field_list.version }}, ++correlation_id };
+    const ResponseMetadata metadata = {
+      {{ message_type.get_extra('api_key') }},
+      {{ field_list.version }},
+      ++correlation_id
+      {% if field_list.uses_compact_fields and message_type.get_extra('api_key') != 18 %}, TaggedFields{ {TaggedField{10, Bytes{1, 2, 3, 4} } } } {% endif %}
+    };
     const {{ message_type.name }} data = { {{ field_list.example_value() }} };
     const ResponseUnderTest response = {metadata, data};
     putMessageIntoBuffer(response);

--- a/test/extensions/filters/network/kafka/request_codec_unit_test.cc
+++ b/test/extensions/filters/network/kafka/request_codec_unit_test.cc
@@ -139,7 +139,7 @@ TEST_F(RequestCodecUnitTest, shouldPassParsedMessageToCallbackAndInitializeNextP
   putGarbageIntoBuffer();
 
   const AbstractRequestSharedPtr parsed_message =
-      std::make_shared<Request<int32_t>>(RequestHeader(), 0);
+      std::make_shared<Request<int32_t>>(RequestHeader{0, 0, 0, absl::nullopt}, 0);
 
   MockParserSharedPtr parser1 = std::make_shared<MockParser>();
   EXPECT_CALL(*parser1, parse(_))
@@ -170,7 +170,7 @@ TEST_F(RequestCodecUnitTest, shouldPassParseFailureDataToCallback) {
   putGarbageIntoBuffer();
 
   const RequestParseFailureSharedPtr failure_data =
-      std::make_shared<RequestParseFailure>(RequestHeader());
+      std::make_shared<RequestParseFailure>(RequestHeader{0, 0, 0, absl::nullopt});
 
   MockParserSharedPtr parser = std::make_shared<MockParser>();
   auto consume_and_return = [&failure_data](absl::string_view& data) -> RequestParseResponse {

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -1,4 +1,5 @@
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
+#include "extensions/filters/network/kafka/tagged_fields.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -432,6 +433,23 @@ TEST(NullableCompactArrayDeserializer, ShouldConsumeNullArray) {
   const NullableArray<int32_t> value = absl::nullopt;
   serializeCompactThenDeserializeAndCheckEquality<
       NullableCompactArrayDeserializer<int32_t, Int32Deserializer>>(value);
+}
+
+// Tagged fields.
+
+TEST(TaggedFieldDeserializer, ShouldConsumeCorrectAmountOfData) {
+  const TaggedField value{200, Bytes{1, 2, 3, 4, 5, 6}};
+  serializeCompactThenDeserializeAndCheckEquality<TaggedFieldDeserializer>(value);
+}
+
+TEST(TaggedFieldsDeserializer, ShouldConsumeCorrectAmountOfData) {
+  std::vector<TaggedField> fields;
+  for (uint32_t i = 0; i < 200; ++i) {
+    const TaggedField tagged_field = {i, Bytes{1, 2, 3, 4}};
+    fields.push_back(tagged_field);
+  }
+  const TaggedFields value{fields};
+  serializeCompactThenDeserializeAndCheckEquality<TaggedFieldsDeserializer>(value);
 }
 
 } // namespace SerializationTest

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -1,5 +1,6 @@
-#include "test/extensions/filters/network/kafka/serialization_utilities.h"
 #include "extensions/filters/network/kafka/tagged_fields.h"
+
+#include "test/extensions/filters/network/kafka/serialization_utilities.h"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Description:
Provide Kafka codec support for new message types/versions added in 2.4.0.

In detail, we Kafka 2.4 added some new things in protocol:
* new data types (e.g. CompactString) & tagged fields (serialization code for these data types was added in https://github.com/envoyproxy/envoy/pull/9813)
* new message (request/response) versions that use the above.

This PR does the following:
* update the python-generator script (as the input format has changed a little - we have "common structs" and "tag references")
* update the request / response parsers - we need to process tagged fields that might be present in headers (this depends on message's api_key & api_version)

This PR relates to https://github.com/envoyproxy/envoy/issues/2852

Risk Level: Low
Testing: Automated unit tests; embedded integration test (ensures compatibility with 2.4 client); manual tests with Java Kafka 1.1 / 2.3 / 2.4 clients + 2.1 / 2.3 / 2.4 servers
Docs Changes: docs reference changed from 2.3 to 2.4 :)
Release Notes: N/A