### PR TITLE
http: split header decoding into concrete types

### DIFF
--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -134,8 +134,6 @@ public:
 /**
  * Stream decoder used for receiving a request (client to server). Virtual inheritance is required
  * due to a parallel implementation split between the shared base class and the derived class.
- * TODO(mattklein123): In a future change the header types will be changed to differentiate from
- * the response path.
  */
 class RequestDecoder : public virtual StreamDecoder {
 public:
@@ -144,20 +142,18 @@ public:
    * @param headers supplies the decoded headers map.
    * @param end_stream supplies whether this is a header only request.
    */
-  virtual void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) PURE;
+  virtual void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) PURE;
 
   /**
    * Called with a decoded trailers frame. This implicitly ends the stream.
    * @param trailers supplies the decoded trailers.
    */
-  virtual void decodeTrailers(HeaderMapPtr&& trailers) PURE;
+  virtual void decodeTrailers(RequestTrailerMapPtr&& trailers) PURE;
 };
 
 /**
  * Stream decoder used for receiving a response (server to client). Virtual inheritance is required
  * due to a parallel implementation split between the shared base class and the derived class.
- * TODO(mattklein123): In a future change the header types will be changed to differentiate from
- * the request path.
  */
 class ResponseDecoder : public virtual StreamDecoder {
 public:
@@ -165,20 +161,20 @@ public:
    * Called with decoded 100-Continue headers.
    * @param headers supplies the decoded 100-Continue headers map.
    */
-  virtual void decode100ContinueHeaders(HeaderMapPtr&& headers) PURE;
+  virtual void decode100ContinueHeaders(ResponseHeaderMapPtr&& headers) PURE;
 
   /**
    * Called with decoded headers, optionally indicating end of stream.
    * @param headers supplies the decoded headers map.
    * @param end_stream supplies whether this is a header only response.
    */
-  virtual void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) PURE;
+  virtual void decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) PURE;
 
   /**
    * Called with a decoded trailers frame. This implicitly ends the stream.
    * @param trailers supplies the decoded trailers.
    */
-  virtual void decodeTrailers(HeaderMapPtr&& trailers) PURE;
+  virtual void decodeTrailers(ResponseTrailerMapPtr&& trailers) PURE;
 };
 
 /**

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -591,6 +591,22 @@ public:
 using HeaderMapPtr = std::unique_ptr<HeaderMap>;
 
 /**
+ * Typed derived classes for all header map types.
+ * TODO(mattklein123): In future changes we will be differentiating the implementation between
+ *   these classes to both fix bugs and improve performance.
+ * TODO(mattklein123): Virtual inheritance is currently required due to a layered implementation.
+ *   Consider also removing virtual inheritance once we finish the typed header refactor.
+ */
+class RequestHeaderMap : public virtual HeaderMap {};
+using RequestHeaderMapPtr = std::unique_ptr<RequestHeaderMap>;
+class RequestTrailerMap : public virtual HeaderMap {};
+using RequestTrailerMapPtr = std::unique_ptr<RequestTrailerMap>;
+class ResponseHeaderMap : public virtual HeaderMap {};
+using ResponseHeaderMapPtr = std::unique_ptr<ResponseHeaderMap>;
+class ResponseTrailerMap : public virtual HeaderMap {};
+using ResponseTrailerMapPtr = std::unique_ptr<ResponseTrailerMap>;
+
+/**
  * Convenient container type for storing Http::LowerCaseString and std::string key/value pairs.
  */
 using HeaderVector = std::vector<std::pair<LowerCaseString, std::string>>;

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -132,8 +132,7 @@ void CodecClient::onData(Buffer::Instance& data) {
     close();
 
     // Don't count 408 responses where we have no active requests as protocol errors
-    if (!active_requests_.empty() ||
-        Utility::getResponseStatus(e.headers()) != enumToInt(Code::RequestTimeout)) {
+    if (!active_requests_.empty() || e.responseCode() != Code::RequestTimeout) {
       protocol_error = true;
     }
   }

--- a/source/common/http/codec_wrappers.h
+++ b/source/common/http/codec_wrappers.h
@@ -11,11 +11,11 @@ namespace Http {
 class ResponseDecoderWrapper : public ResponseDecoder {
 public:
   // ResponseDecoder
-  void decode100ContinueHeaders(HeaderMapPtr&& headers) override {
+  void decode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override {
     inner_.decode100ContinueHeaders(std::move(headers));
   }
 
-  void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override {
+  void decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override {
     if (end_stream) {
       onPreDecodeComplete();
     }
@@ -39,7 +39,7 @@ public:
     }
   }
 
-  void decodeTrailers(HeaderMapPtr&& trailers) override {
+  void decodeTrailers(ResponseTrailerMapPtr&& trailers) override {
     onPreDecodeComplete();
     inner_.decodeTrailers(std::move(trailers));
     onDecodeComplete();

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -705,7 +705,8 @@ const Network::Connection* ConnectionManagerImpl::ActiveStream::connection() {
 //
 // TODO(alyssawilk) all the calls here should be audited for order priority,
 // e.g. many early returns do not currently handle connection: close properly.
-void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
+void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& headers,
+                                                        bool end_stream) {
   ScopeTrackerScopeState scope(this,
                                connection_manager_.read_callbacks_->connection().dispatcher());
   request_headers_ = std::move(headers);
@@ -1193,7 +1194,7 @@ MetadataMapVector& ConnectionManagerImpl::ActiveStream::addDecodedMetadata() {
   return *getRequestMetadataMapVector();
 }
 
-void ConnectionManagerImpl::ActiveStream::decodeTrailers(HeaderMapPtr&& trailers) {
+void ConnectionManagerImpl::ActiveStream::decodeTrailers(RequestTrailerMapPtr&& trailers) {
   ScopeTrackerScopeState scope(this,
                                connection_manager_.read_callbacks_->connection().dispatcher());
   resetIdleTimer();
@@ -2308,7 +2309,7 @@ bool ConnectionManagerImpl::ActiveStreamDecoderFilter::recreateStream() {
   // n.b. we do not currently change the codecs to point at the new stream
   // decoder because the decoder callbacks are complete. It would be good to
   // null out that pointer but should not be necessary.
-  HeaderMapPtr request_headers(std::move(parent_.request_headers_));
+  RequestHeaderMapPtr request_headers(std::move(parent_.request_headers_));
   ResponseEncoder* response_encoder = parent_.response_encoder_;
   parent_.response_encoder_ = nullptr;
   response_encoder->getStream().removeCallbacks(parent_);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -522,8 +522,8 @@ private:
     void decodeMetadata(MetadataMapPtr&&) override;
 
     // Http::RequestDecoder
-    void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeTrailers(HeaderMapPtr&& trailers) override;
+    void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override;
+    void decodeTrailers(RequestTrailerMapPtr&& trailers) override;
 
     // Http::FilterChainFactoryCallbacks
     void addStreamDecoderFilter(StreamDecoderFilterSharedPtr filter) override {
@@ -688,7 +688,7 @@ private:
     HeaderMapPtr response_headers_;
     Buffer::WatermarkBufferPtr buffered_response_data_;
     HeaderMapPtr response_trailers_{};
-    HeaderMapPtr request_headers_;
+    RequestHeaderMapPtr request_headers_;
     Buffer::WatermarkBufferPtr buffered_request_data_;
     HeaderMapPtr request_trailers_;
     std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;

--- a/source/common/http/exception.h
+++ b/source/common/http/exception.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "envoy/common/exception.h"
+#include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"
 
 namespace Envoy {
@@ -30,13 +31,13 @@ public:
  */
 class PrematureResponseException : public EnvoyException {
 public:
-  PrematureResponseException(HeaderMapPtr&& headers)
-      : EnvoyException(""), headers_(std::move(headers)) {}
+  PrematureResponseException(Http::Code response_code)
+      : EnvoyException(""), response_code_(response_code) {}
 
-  const HeaderMap& headers() { return *headers_; }
+  Http::Code responseCode() { return response_code_; }
 
 private:
-  HeaderMapPtr headers_;
+  const Http::Code response_code_;
 };
 
 /**

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -56,7 +56,7 @@ public:                                                                         
  * paths use O(1) direct access. In general, we try to copy as little as possible and allocate as
  * little as possible in any of the paths.
  */
-class HeaderMapImpl : public HeaderMap, NonCopyable {
+class HeaderMapImpl : public virtual HeaderMap, NonCopyable {
 public:
   HeaderMapImpl();
   explicit HeaderMapImpl(
@@ -239,6 +239,20 @@ protected:
 };
 
 using HeaderMapImplPtr = std::unique_ptr<HeaderMapImpl>;
+
+/**
+ * Typed derived classes for all header map types.
+ * TODO(mattklein123): In future changes we will be differentiating the implementation between
+ * these classes to both fix bugs and improve performance.
+ */
+class RequestHeaderMapImpl : public HeaderMapImpl, public RequestHeaderMap {};
+using RequestHeaderMapImplPtr = std::unique_ptr<RequestHeaderMapImpl>;
+class RequestTrailerMapImpl : public HeaderMapImpl, public RequestTrailerMap {};
+using RequestTrailerMapImplPtr = std::unique_ptr<RequestTrailerMapImpl>;
+class ResponseHeaderMapImpl : public HeaderMapImpl, public ResponseHeaderMap {};
+using ResponseHeaderMapImplPtr = std::unique_ptr<ResponseHeaderMapImpl>;
+class ResponseTrailerMapImpl : public HeaderMapImpl, public ResponseTrailerMap {};
+using ResponseTrailerMapImplPtr = std::unique_ptr<ResponseTrailerMapImpl>;
 
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -538,7 +538,7 @@ int ConnectionImpl::onHeadersCompleteBase() {
     // HTTP/1.1 or not.
     protocol_ = Protocol::Http10;
   }
-  auto& headers = headers();
+  HeaderMap& headers = headers();
   if (Utility::isUpgrade(headers)) {
     // Ignore h2c upgrade requests until we support them.
     // See https://github.com/envoyproxy/envoy/issues/7161 for details.
@@ -923,7 +923,7 @@ void ClientConnectionImpl::onMessageComplete() {
 
     if (deferred_end_stream_headers_) {
       response.decoder_->decodeHeaders(
-          absl::get<ResponseHeaderMapImplPtr>(std::move(headers_or_trailers_)), true);
+          std::move(absl::get<ResponseHeaderMapImplPtr>(headers_or_trailers_)), true);
       deferred_end_stream_headers_ = false;
     } else if (processing_trailers_) {
       response.decoder_->decodeTrailers(

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -372,7 +372,7 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
                                HeaderKeyFormatterPtr&& header_key_formatter, bool enable_trailers)
     : connection_(connection), stats_{ALL_HTTP1_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http1."))},
       header_key_formatter_(std::move(header_key_formatter)), processing_trailers_(false),
-      handling_upgrade_(false), reset_stream_called_(false),
+      handling_upgrade_(false), reset_stream_called_(false), deferred_end_stream_headers_(false),
       strict_header_validation_(
           Runtime::runtimeFeatureEnabled("envoy.reloadable_features.strict_header_validation")),
       connection_header_sanitization_(Runtime::runtimeFeatureEnabled(
@@ -392,12 +392,11 @@ void ConnectionImpl::completeLastHeader() {
 
   if (!current_header_field_.empty()) {
     toLowerTable().toLowerCase(current_header_field_.buffer(), current_header_field_.size());
-    current_header_map_->addViaMove(std::move(current_header_field_),
-                                    std::move(current_header_value_));
+    headers().addViaMove(std::move(current_header_field_), std::move(current_header_value_));
   }
 
   // Check if the number of headers exceeds the limit.
-  if (current_header_map_->size() > max_headers_count_) {
+  if (headers().size() > max_headers_count_) {
     error_code_ = Http::Code::RequestHeaderFieldsTooLarge;
     sendProtocolError(Http1ResponseCodeDetails::get().TooManyHeaders);
     const absl::string_view header_type =
@@ -494,9 +493,7 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
     return;
   }
 
-  if (!current_header_map_) {
-    current_header_map_ = std::make_unique<HeaderMapImpl>();
-  }
+  maybeAllocHeadersOrTrailers();
   // Work around a bug in http_parser where trailing whitespace is not trimmed
   // as the spec requires: https://tools.ietf.org/html/rfc7230#section-3.2.4
   const absl::string_view header_value = StringUtil::trim(absl::string_view(data, length));
@@ -520,7 +517,7 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
   current_header_value_.append(header_value.data(), header_value.length());
 
   const uint32_t total =
-      current_header_field_.size() + current_header_value_.size() + current_header_map_->byteSize();
+      current_header_field_.size() + current_header_value_.size() + headers().byteSize();
   if (total > (max_headers_kb_ * 1024)) {
     const absl::string_view header_type =
         processing_trailers_ ? Http1HeaderTypes::get().Trailers : Http1HeaderTypes::get().Headers;
@@ -541,33 +538,33 @@ int ConnectionImpl::onHeadersCompleteBase() {
     // HTTP/1.1 or not.
     protocol_ = Protocol::Http10;
   }
-  if (Utility::isUpgrade(*current_header_map_)) {
+  auto& headers = headers();
+  if (Utility::isUpgrade(headers)) {
     // Ignore h2c upgrade requests until we support them.
     // See https://github.com/envoyproxy/envoy/issues/7161 for details.
-    if (current_header_map_->Upgrade() &&
-        absl::EqualsIgnoreCase(current_header_map_->Upgrade()->value().getStringView(),
-                               Http::Headers::get().UpgradeValues.H2c)) {
+    if (headers.Upgrade() && absl::EqualsIgnoreCase(headers.Upgrade()->value().getStringView(),
+                                                    Http::Headers::get().UpgradeValues.H2c)) {
       ENVOY_CONN_LOG(trace, "removing unsupported h2c upgrade headers.", connection_);
-      current_header_map_->removeUpgrade();
-      if (current_header_map_->Connection()) {
+      headers.removeUpgrade();
+      if (headers.Connection()) {
         const auto& tokens_to_remove = caseUnorderdSetContainingUpgradeAndHttp2Settings();
         std::string new_value = StringUtil::removeTokens(
-            current_header_map_->Connection()->value().getStringView(), ",", tokens_to_remove, ",");
+            headers.Connection()->value().getStringView(), ",", tokens_to_remove, ",");
         if (new_value.empty()) {
-          current_header_map_->removeConnection();
+          headers.removeConnection();
         } else {
-          current_header_map_->setConnection(new_value);
+          headers.setConnection(new_value);
         }
       }
-      current_header_map_->remove(Headers::get().Http2Settings);
+      headers.remove(Headers::get().Http2Settings);
     } else {
       ENVOY_CONN_LOG(trace, "codec entering upgrade mode.", connection_);
       handling_upgrade_ = true;
     }
-  } else if (connection_header_sanitization_ && current_header_map_->Connection()) {
+  } else if (connection_header_sanitization_ && headers.Connection()) {
     // If we fail to sanitize the request, return a 400 to the client
-    if (!Utility::sanitizeConnectionHeader(*current_header_map_)) {
-      absl::string_view header_value = current_header_map_->Connection()->value().getStringView();
+    if (!Utility::sanitizeConnectionHeader(headers)) {
+      absl::string_view header_value = headers.Connection()->value().getStringView();
       ENVOY_CONN_LOG(debug, "Invalid nominated headers in Connection: {}", connection_,
                      header_value);
       error_code_ = Http::Code::BadRequest;
@@ -578,8 +575,8 @@ int ConnectionImpl::onHeadersCompleteBase() {
 
   // Per https://tools.ietf.org/html/rfc7230#section-3.3.1 Envoy should reject
   // transfer-codings it does not understand.
-  if (current_header_map_->TransferEncoding()) {
-    absl::string_view encoding = current_header_map_->TransferEncoding()->value().getStringView();
+  if (headers.TransferEncoding()) {
+    absl::string_view encoding = headers.TransferEncoding()->value().getStringView();
     if (Runtime::runtimeFeatureEnabled(
             "envoy.reloadable_features.reject_unsupported_transfer_encodings") &&
         encoding != Headers::get().TransferEncodingValues.Identity &&
@@ -590,9 +587,7 @@ int ConnectionImpl::onHeadersCompleteBase() {
     }
   }
 
-  int rc = onHeadersComplete(std::move(current_header_map_));
-  current_header_map_.reset();
-
+  int rc = onHeadersComplete();
   header_parsing_state_ = HeaderParsingState::Done;
 
   // Returning 2 informs http_parser to not expect a body or further data on this connection.
@@ -617,7 +612,7 @@ void ConnectionImpl::onMessageCompleteBase() {
     completeLastHeader();
   }
 
-  onMessageComplete(std::move(current_header_map_));
+  onMessageComplete();
 }
 
 void ConnectionImpl::onMessageBeginBase() {
@@ -626,9 +621,9 @@ void ConnectionImpl::onMessageBeginBase() {
   // protocol for each request. Envoy defaults to 1.1 but sets the protocol to 1.0 where applicable
   // in onHeadersCompleteBase
   protocol_ = Protocol::Http11;
-  ASSERT(!current_header_map_);
-  current_header_map_ = std::make_unique<HeaderMapImpl>();
+  processing_trailers_ = false;
   header_parsing_state_ = HeaderParsingState::Field;
+  maybeAllocHeadersOrTrailers();
   onMessageBegin();
 }
 
@@ -700,13 +695,13 @@ void ServerConnectionImpl::handlePath(HeaderMapImpl& headers, unsigned int metho
   active_request_->request_url_.clear();
 }
 
-int ServerConnectionImpl::onHeadersComplete(HeaderMapImplPtr&& headers) {
-  ENVOY_CONN_LOG(trace, "Server: onHeadersComplete size={}", connection_, headers->size());
-
+int ServerConnectionImpl::onHeadersComplete() {
   // Handle the case where response happens prior to request complete. It's up to upper layer code
   // to disconnect the connection but we shouldn't fire any more events since it doesn't make
   // sense.
   if (active_request_) {
+    auto& headers = absl::get<RequestHeaderMapImplPtr>(headers_or_trailers_);
+    ENVOY_CONN_LOG(trace, "Server: onHeadersComplete size={}", connection_, headers->size());
     const char* method_string = http_method_str(static_cast<http_method>(parser_.method));
 
     // Inform the response encoder about any HEAD method, so it can set content
@@ -743,9 +738,8 @@ int ServerConnectionImpl::onHeadersComplete(HeaderMapImplPtr&& headers) {
       if (connection_.state() != Network::Connection::State::Open) {
         http_parser_pause(&parser_, 1);
       }
-
     } else {
-      deferred_end_stream_headers_ = std::move(headers);
+      deferred_end_stream_headers_ = true;
     }
   }
 
@@ -775,15 +769,16 @@ void ServerConnectionImpl::onBody(const char* data, size_t length) {
   }
 }
 
-void ServerConnectionImpl::onMessageComplete(HeaderMapImplPtr&& trailers) {
+void ServerConnectionImpl::onMessageComplete() {
   if (active_request_) {
     active_request_->remote_complete_ = true;
     if (deferred_end_stream_headers_) {
-      active_request_->request_decoder_->decodeHeaders(std::move(deferred_end_stream_headers_),
-                                                       true);
-      deferred_end_stream_headers_.reset();
+      active_request_->request_decoder_->decodeHeaders(
+          std::move(absl::get<RequestHeaderMapImplPtr>(headers_or_trailers_)), true);
+      deferred_end_stream_headers_ = false;
     } else if (processing_trailers_) {
-      active_request_->request_decoder_->decodeTrailers(std::move(trailers));
+      active_request_->request_decoder_->decodeTrailers(
+          std::move(absl::get<RequestTrailerMapImplPtr>(headers_or_trailers_)));
     } else {
       Buffer::OwnedImpl buffer;
       active_request_->request_decoder_->decodeData(buffer, true);
@@ -866,23 +861,24 @@ void ClientConnectionImpl::onEncodeHeaders(const HeaderMap& headers) {
   }
 }
 
-int ClientConnectionImpl::onHeadersComplete(HeaderMapImplPtr&& headers) {
-  ENVOY_CONN_LOG(trace, "Client: onHeadersComplete size={}", connection_, headers->size());
-  headers->setStatus(parser_.status_code);
-
+int ClientConnectionImpl::onHeadersComplete() {
   // Handle the case where the client is closing a kept alive connection (by sending a 408
   // with a 'Connection: close' header). In this case we just let response flush out followed
   // by the remote close.
   if (pending_responses_.empty() && !resetStreamCalled()) {
-    throw PrematureResponseException(std::move(headers));
+    throw PrematureResponseException(static_cast<Http::Code>(parser_.status_code));
   } else if (!pending_responses_.empty()) {
+    auto& headers = absl::get<ResponseHeaderMapImplPtr>(headers_or_trailers_);
+    ENVOY_CONN_LOG(trace, "Client: onHeadersComplete size={}", connection_, headers->size());
+    headers->setStatus(parser_.status_code);
+
     if (parser_.status_code == 100) {
       // http-parser treats 100 continue headers as their own complete response.
       // Swallow the spurious onMessageComplete and continue processing.
       ignore_message_complete_for_100_continue_ = true;
       pending_responses_.front().decoder_->decode100ContinueHeaders(std::move(headers));
     } else if (cannotHaveBody()) {
-      deferred_end_stream_headers_ = std::move(headers);
+      deferred_end_stream_headers_ = true;
     } else {
       pending_responses_.front().decoder_->decodeHeaders(std::move(headers), false);
     }
@@ -902,7 +898,7 @@ void ClientConnectionImpl::onBody(const char* data, size_t length) {
   }
 }
 
-void ClientConnectionImpl::onMessageComplete(HeaderMapImplPtr&& trailers) {
+void ClientConnectionImpl::onMessageComplete() {
   ENVOY_CONN_LOG(trace, "message complete", connection_);
   if (ignore_message_complete_for_100_continue_) {
     ignore_message_complete_for_100_continue_ = false;
@@ -910,7 +906,7 @@ void ClientConnectionImpl::onMessageComplete(HeaderMapImplPtr&& trailers) {
   }
   if (!pending_responses_.empty()) {
     // After calling decodeData() with end stream set to true, we should no longer be able to reset.
-    PendingResponse response = pending_responses_.front();
+    PendingResponse response = std::move(pending_responses_.front());
     pending_responses_.pop_front();
 
     // Streams are responsible for unwinding any outstanding readDisable(true)
@@ -926,10 +922,12 @@ void ClientConnectionImpl::onMessageComplete(HeaderMapImplPtr&& trailers) {
     }
 
     if (deferred_end_stream_headers_) {
-      response.decoder_->decodeHeaders(std::move(deferred_end_stream_headers_), true);
-      deferred_end_stream_headers_.reset();
+      response.decoder_->decodeHeaders(
+          absl::get<ResponseHeaderMapImplPtr>(std::move(headers_or_trailers_)), true);
+      deferred_end_stream_headers_ = false;
     } else if (processing_trailers_) {
-      response.decoder_->decodeTrailers(std::move(trailers));
+      response.decoder_->decodeTrailers(
+          std::move(absl::get<ResponseTrailerMapImplPtr>(headers_or_trailers_)));
     } else {
       Buffer::OwnedImpl buffer;
       response.decoder_->decodeData(buffer, true);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -538,33 +538,34 @@ int ConnectionImpl::onHeadersCompleteBase() {
     // HTTP/1.1 or not.
     protocol_ = Protocol::Http10;
   }
-  HeaderMap& headers = headers();
-  if (Utility::isUpgrade(headers)) {
+  HeaderMap& current_headers = headers();
+  if (Utility::isUpgrade(current_headers)) {
     // Ignore h2c upgrade requests until we support them.
     // See https://github.com/envoyproxy/envoy/issues/7161 for details.
-    if (headers.Upgrade() && absl::EqualsIgnoreCase(headers.Upgrade()->value().getStringView(),
-                                                    Http::Headers::get().UpgradeValues.H2c)) {
+    if (current_headers.Upgrade() &&
+        absl::EqualsIgnoreCase(current_headers.Upgrade()->value().getStringView(),
+                               Http::Headers::get().UpgradeValues.H2c)) {
       ENVOY_CONN_LOG(trace, "removing unsupported h2c upgrade headers.", connection_);
-      headers.removeUpgrade();
-      if (headers.Connection()) {
+      current_headers.removeUpgrade();
+      if (current_headers.Connection()) {
         const auto& tokens_to_remove = caseUnorderdSetContainingUpgradeAndHttp2Settings();
         std::string new_value = StringUtil::removeTokens(
-            headers.Connection()->value().getStringView(), ",", tokens_to_remove, ",");
+            current_headers.Connection()->value().getStringView(), ",", tokens_to_remove, ",");
         if (new_value.empty()) {
-          headers.removeConnection();
+          current_headers.removeConnection();
         } else {
-          headers.setConnection(new_value);
+          current_headers.setConnection(new_value);
         }
       }
-      headers.remove(Headers::get().Http2Settings);
+      current_headers.remove(Headers::get().Http2Settings);
     } else {
       ENVOY_CONN_LOG(trace, "codec entering upgrade mode.", connection_);
       handling_upgrade_ = true;
     }
-  } else if (connection_header_sanitization_ && headers.Connection()) {
+  } else if (connection_header_sanitization_ && current_headers.Connection()) {
     // If we fail to sanitize the request, return a 400 to the client
-    if (!Utility::sanitizeConnectionHeader(headers)) {
-      absl::string_view header_value = headers.Connection()->value().getStringView();
+    if (!Utility::sanitizeConnectionHeader(current_headers)) {
+      absl::string_view header_value = current_headers.Connection()->value().getStringView();
       ENVOY_CONN_LOG(debug, "Invalid nominated headers in Connection: {}", connection_,
                      header_value);
       error_code_ = Http::Code::BadRequest;
@@ -575,8 +576,8 @@ int ConnectionImpl::onHeadersCompleteBase() {
 
   // Per https://tools.ietf.org/html/rfc7230#section-3.3.1 Envoy should reject
   // transfer-codings it does not understand.
-  if (headers.TransferEncoding()) {
-    absl::string_view encoding = headers.TransferEncoding()->value().getStringView();
+  if (current_headers.TransferEncoding()) {
+    absl::string_view encoding = current_headers.TransferEncoding()->value().getStringView();
     if (Runtime::runtimeFeatureEnabled(
             "envoy.reloadable_features.reject_unsupported_transfer_encodings") &&
         encoding != Headers::get().TransferEncodingValues.Identity &&

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -183,6 +183,12 @@ public:
   uint64_t bufferRemainingSize();
   void copyToBuffer(const char* data, uint64_t length);
   void reserveBuffer(uint64_t size);
+  void readDisable(bool disable) { connection_.readDisable(disable); }
+  uint32_t bufferLimit() { return connection_.bufferLimit(); }
+  virtual bool supports_http_10() { return false; }
+  bool maybeDirectDispatch(Buffer::Instance& data);
+  CodecStats& stats() { return stats_; }
+  bool enableTrailers() const { return enable_trailers_; }
 
   // Http::Connection
   void dispatch(Buffer::Instance& data) override;
@@ -192,16 +198,6 @@ public:
   bool wantsToWrite() override { return false; }
   void onUnderlyingConnectionAboveWriteBufferHighWatermark() override { onAboveHighWatermark(); }
   void onUnderlyingConnectionBelowWriteBufferLowWatermark() override { onBelowLowWatermark(); }
-
-  void readDisable(bool disable) { connection_.readDisable(disable); }
-  uint32_t bufferLimit() { return connection_.bufferLimit(); }
-  virtual bool supports_http_10() { return false; }
-
-  bool maybeDirectDispatch(Buffer::Instance& data);
-
-  CodecStats& stats() { return stats_; }
-
-  bool enableTrailers() const { return enable_trailers_; }
 
 protected:
   ConnectionImpl(Network::Connection& connection, Stats::Scope& stats, http_parser_type type,
@@ -213,18 +209,21 @@ protected:
   Network::Connection& connection_;
   CodecStats stats_;
   http_parser parser_;
-  HeaderMapPtr deferred_end_stream_headers_;
   Http::Code error_code_{Http::Code::BadRequest};
   const HeaderKeyFormatterPtr header_key_formatter_;
   bool processing_trailers_ : 1;
   bool handling_upgrade_ : 1;
   bool reset_stream_called_ : 1;
+  bool deferred_end_stream_headers_ : 1;
   const bool strict_header_validation_ : 1;
   const bool connection_header_sanitization_ : 1;
   const bool enable_trailers_ : 1;
 
 private:
   enum class HeaderParsingState { Field, Value, Done };
+
+  virtual HeaderMapImpl& headers() PURE;
+  virtual void maybeAllocHeadersOrTrailers() PURE;
 
   /**
    * Called in order to complete an in progress header decode.
@@ -273,7 +272,7 @@ private:
    * @return 0 if no error, 1 if there should be no body.
    */
   int onHeadersCompleteBase();
-  virtual int onHeadersComplete(HeaderMapImplPtr&& headers) PURE;
+  virtual int onHeadersComplete() PURE;
 
   /**
    * Called when body data is received.
@@ -286,7 +285,7 @@ private:
    * Called when the request/response is complete.
    */
   void onMessageCompleteBase();
-  virtual void onMessageComplete(HeaderMapImplPtr&& trailers) PURE;
+  virtual void onMessageComplete() PURE;
 
   /**
    * @see onResetStreamBase().
@@ -313,7 +312,6 @@ private:
   static http_parser_settings settings_;
   static const ToLowerTable& toLowerTable();
 
-  HeaderMapImplPtr current_header_map_;
   HeaderParsingState header_parsing_state_{HeaderParsingState::Field};
   HeaderString current_header_field_;
   HeaderString current_header_value_;
@@ -363,17 +361,42 @@ private:
   void onEncodeHeaders(const HeaderMap&) override {}
   void onMessageBegin() override;
   void onUrl(const char* data, size_t length) override;
-  int onHeadersComplete(HeaderMapImplPtr&& headers) override;
+  int onHeadersComplete() override;
   void onBody(const char* data, size_t length) override;
-  void onMessageComplete(HeaderMapImplPtr&& trailers) override;
+  void onMessageComplete() override;
   void onResetStream(StreamResetReason reason) override;
   void sendProtocolError(absl::string_view details) override;
   void onAboveHighWatermark() override;
   void onBelowLowWatermark() override;
+  HeaderMapImpl& headers() override {
+    if (absl::holds_alternative<RequestHeaderMapImplPtr>(headers_or_trailers_)) {
+      return *absl::get<RequestHeaderMapImplPtr>(headers_or_trailers_);
+    } else {
+      return *absl::get<RequestTrailerMapImplPtr>(headers_or_trailers_);
+    }
+  }
+  void maybeAllocHeadersOrTrailers() override {
+    if (!processing_trailers_) {
+      if (!absl::holds_alternative<RequestHeaderMapImplPtr>(headers_or_trailers_) ||
+          nullptr == absl::get<RequestHeaderMapImplPtr>(headers_or_trailers_)) {
+        headers_or_trailers_.emplace<RequestHeaderMapImplPtr>(
+            std::make_unique<RequestHeaderMapImpl>());
+      }
+    } else {
+      if (!absl::holds_alternative<RequestTrailerMapImplPtr>(headers_or_trailers_) ||
+          nullptr == absl::get<RequestTrailerMapImplPtr>(headers_or_trailers_)) {
+        headers_or_trailers_.emplace<RequestTrailerMapImplPtr>(
+            std::make_unique<RequestTrailerMapImpl>());
+      }
+    }
+  }
 
   ServerConnectionCallbacks& callbacks_;
   std::unique_ptr<ActiveRequest> active_request_;
   Http1Settings codec_settings_;
+  // TODO(mattklein123): This should be a member of ActiveRequest but this change needs dedicated
+  // thought as some of the reset and no header code paths make this difficult.
+  absl::variant<RequestHeaderMapImplPtr, RequestTrailerMapImplPtr> headers_or_trailers_;
 };
 
 /**
@@ -403,18 +426,43 @@ private:
   void onEncodeHeaders(const HeaderMap& headers) override;
   void onMessageBegin() override {}
   void onUrl(const char*, size_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  int onHeadersComplete(HeaderMapImplPtr&& headers) override;
+  int onHeadersComplete() override;
   void onBody(const char* data, size_t length) override;
-  void onMessageComplete(HeaderMapImplPtr&& trailers) override;
+  void onMessageComplete() override;
   void onResetStream(StreamResetReason reason) override;
   void sendProtocolError(absl::string_view details) override;
   void onAboveHighWatermark() override;
   void onBelowLowWatermark() override;
+  HeaderMapImpl& headers() override {
+    if (absl::holds_alternative<ResponseHeaderMapImplPtr>(headers_or_trailers_)) {
+      return *absl::get<ResponseHeaderMapImplPtr>(headers_or_trailers_);
+    } else {
+      return *absl::get<ResponseTrailerMapImplPtr>(headers_or_trailers_);
+    }
+  }
+  void maybeAllocHeadersOrTrailers() override {
+    if (!processing_trailers_) {
+      if (!absl::holds_alternative<ResponseHeaderMapImplPtr>(headers_or_trailers_) ||
+          nullptr == absl::get<ResponseHeaderMapImplPtr>(headers_or_trailers_)) {
+        headers_or_trailers_.emplace<ResponseHeaderMapImplPtr>(
+            std::make_unique<ResponseHeaderMapImpl>());
+      }
+    } else {
+      if (!absl::holds_alternative<ResponseTrailerMapImplPtr>(headers_or_trailers_) ||
+          nullptr == absl::get<ResponseTrailerMapImplPtr>(headers_or_trailers_)) {
+        headers_or_trailers_.emplace<ResponseTrailerMapImplPtr>(
+            std::make_unique<ResponseTrailerMapImpl>());
+      }
+    }
+  }
 
   std::unique_ptr<RequestEncoderImpl> request_encoder_;
   std::list<PendingResponse> pending_responses_;
   // Set true between receiving 100-Continue headers and receiving the spurious onMessageComplete.
   bool ignore_message_complete_for_100_continue_{};
+  // TODO(mattklein123): This should be a member of PendingResponse but this change needs dedicated
+  // thought as some of the reset and no header code paths make this difficult.
+  absl::variant<ResponseHeaderMapImplPtr, ResponseTrailerMapImplPtr> headers_or_trailers_;
 
   // The default limit of 80 KiB is the vanilla http_parser behaviour.
   static constexpr uint32_t MAX_RESPONSE_HEADERS_KB = 80;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -81,7 +81,7 @@ ConnPoolImpl::StreamWrapper::~StreamWrapper() {
 
 void ConnPoolImpl::StreamWrapper::onEncodeComplete() { encode_complete_ = true; }
 
-void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
+void ConnPoolImpl::StreamWrapper::decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
   // If Connection: close OR
   //    Http/1.0 and not Connection: keep-alive OR
   //    Proxy-Connection: close

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -45,7 +45,7 @@ protected:
     void onEncodeComplete() override;
 
     // StreamDecoderWrapper
-    void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
+    void decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
     void onPreDecodeComplete() override {}
     void onDecodeComplete() override;
 

--- a/source/common/http/http1/conn_pool_legacy.cc
+++ b/source/common/http/http1/conn_pool_legacy.cc
@@ -279,7 +279,7 @@ ConnPoolImpl::StreamWrapper::~StreamWrapper() {
 
 void ConnPoolImpl::StreamWrapper::onEncodeComplete() { encode_complete_ = true; }
 
-void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
+void ConnPoolImpl::StreamWrapper::decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
   // If Connection: close OR
   //    Http/1.0 and not Connection: keep-alive OR
   //    Proxy-Connection: close

--- a/source/common/http/http1/conn_pool_legacy.h
+++ b/source/common/http/http1/conn_pool_legacy.h
@@ -64,7 +64,7 @@ protected:
     void onEncodeComplete() override;
 
     // StreamDecoderWrapper
-    void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
+    void decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
     void onPreDecodeComplete() override {}
     void onDecodeComplete() override;
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -51,9 +51,8 @@ template <typename T> static T* remove_const(const void* object) {
 }
 
 ConnectionImpl::StreamImpl::StreamImpl(ConnectionImpl& parent, uint32_t buffer_limit)
-    : parent_(parent), headers_(new HeaderMapImpl()), local_end_stream_sent_(false),
-      remote_end_stream_(false), data_deferred_(false),
-      waiting_for_non_informational_headers_(false),
+    : parent_(parent), local_end_stream_sent_(false), remote_end_stream_(false),
+      data_deferred_(false), waiting_for_non_informational_headers_(false),
       pending_receive_buffer_high_watermark_called_(false),
       pending_send_buffer_high_watermark_called_(false), reset_due_to_messaging_error_(false) {
   if (buffer_limit > 0) {
@@ -128,8 +127,8 @@ void ConnectionImpl::StreamImpl::encodeTrailersBase(const HeaderMap& trailers) {
   if (pending_send_data_.length() > 0) {
     // In this case we want trailers to come after we release all pending body data that is
     // waiting on window updates. We need to save the trailers so that we can emit them later.
-    ASSERT(!pending_trailers_);
-    pending_trailers_ = std::make_unique<HeaderMapImpl>(trailers);
+    ASSERT(!pending_trailers_to_encode_);
+    pending_trailers_to_encode_ = std::make_unique<HeaderMapImpl>(trailers);
   } else {
     submitTrailers(trailers);
     parent_.sendPendingFrames();
@@ -186,31 +185,35 @@ void ConnectionImpl::StreamImpl::pendingRecvBufferLowWatermark() {
 }
 
 void ConnectionImpl::ClientStreamImpl::decodeHeaders() {
-  if (!upgrade_type_.empty() && headers_->Status()) {
-    Http::Utility::transformUpgradeResponseFromH2toH1(*headers_, upgrade_type_);
+  auto& headers = absl::get<ResponseHeaderMapImplPtr>(headers_or_trailers_);
+  if (!upgrade_type_.empty() && headers->Status()) {
+    Http::Utility::transformUpgradeResponseFromH2toH1(*headers, upgrade_type_);
   }
 
-  if (headers_->Status()->value() == "100") {
+  if (headers->Status()->value() == "100") {
     ASSERT(!remote_end_stream_);
-    response_decoder_.decode100ContinueHeaders(std::move(headers_));
+    response_decoder_.decode100ContinueHeaders(std::move(headers));
   } else {
-    response_decoder_.decodeHeaders(std::move(headers_), remote_end_stream_);
+    response_decoder_.decodeHeaders(std::move(headers), remote_end_stream_);
   }
 }
 
 void ConnectionImpl::ClientStreamImpl::decodeTrailers() {
-  response_decoder_.decodeTrailers(std::move(headers_));
+  response_decoder_.decodeTrailers(
+      std::move(absl::get<ResponseTrailerMapImplPtr>(headers_or_trailers_)));
 }
 
 void ConnectionImpl::ServerStreamImpl::decodeHeaders() {
-  if (Http::Utility::isH2UpgradeRequest(*headers_)) {
-    Http::Utility::transformUpgradeRequestFromH2toH1(*headers_);
+  auto& headers = absl::get<RequestHeaderMapImplPtr>(headers_or_trailers_);
+  if (Http::Utility::isH2UpgradeRequest(*headers)) {
+    Http::Utility::transformUpgradeRequestFromH2toH1(*headers);
   }
-  request_decoder_->decodeHeaders(std::move(headers_), remote_end_stream_);
+  request_decoder_->decodeHeaders(std::move(headers), remote_end_stream_);
 }
 
 void ConnectionImpl::ServerStreamImpl::decodeTrailers() {
-  request_decoder_->decodeTrailers(std::move(headers_));
+  request_decoder_->decodeTrailers(
+      std::move(absl::get<RequestTrailerMapImplPtr>(headers_or_trailers_)));
 }
 
 void ConnectionImpl::StreamImpl::pendingSendBufferHighWatermark() {
@@ -229,7 +232,7 @@ void ConnectionImpl::StreamImpl::pendingSendBufferLowWatermark() {
 
 void ConnectionImpl::StreamImpl::saveHeader(HeaderString&& name, HeaderString&& value) {
   if (!Utility::reconstituteCrumbledCookies(name, value, cookies_)) {
-    headers_->addViaMove(std::move(name), std::move(value));
+    headers().addViaMove(std::move(name), std::move(value));
   }
 }
 
@@ -258,11 +261,11 @@ ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* 
     *data_flags |= NGHTTP2_DATA_FLAG_NO_COPY;
     if (local_end_stream_ && pending_send_data_.length() <= length) {
       *data_flags |= NGHTTP2_DATA_FLAG_EOF;
-      if (pending_trailers_) {
+      if (pending_trailers_to_encode_) {
         // We need to tell the library to not set end stream so that we can emit the trailers.
         *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-        submitTrailers(*pending_trailers_);
-        pending_trailers_.reset();
+        submitTrailers(*pending_trailers_to_encode_);
+        pending_trailers_to_encode_.reset();
       }
     }
 
@@ -507,12 +510,12 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
     stream->remote_end_stream_ = frame->hd.flags & NGHTTP2_FLAG_END_STREAM;
     if (!stream->cookies_.empty()) {
       HeaderString key(Headers::get().Cookie);
-      stream->headers_->addViaMove(std::move(key), std::move(stream->cookies_));
+      stream->headers().addViaMove(std::move(key), std::move(stream->cookies_));
     }
 
     switch (frame->headers.cat) {
     case NGHTTP2_HCAT_RESPONSE: {
-      if (CodeUtility::is1xx(Http::Utility::getResponseStatus(*stream->headers_))) {
+      if (CodeUtility::is1xx(Http::Utility::getResponseStatus(stream->headers()))) {
         stream->waiting_for_non_informational_headers_ = true;
       }
       FALLTHRU;
@@ -559,7 +562,6 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
       NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
 
-    stream->headers_.reset();
     break;
   }
   case NGHTTP2_DATA: {
@@ -798,8 +800,8 @@ int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
   }
   stream->saveHeader(std::move(name), std::move(value));
 
-  if (stream->headers_->byteSize() > max_headers_kb_ * 1024 ||
-      stream->headers_->size() > max_headers_count_) {
+  if (stream->headers().byteSize() > max_headers_kb_ * 1024 ||
+      stream->headers().size() > max_headers_count_) {
     // This will cause the library to reset/close the stream.
     stats_.header_overflow_.inc();
     return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
@@ -1099,8 +1101,7 @@ int ClientConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
                  "");
   if (frame->headers.cat == NGHTTP2_HCAT_HEADERS) {
     StreamImpl* stream = getStream(frame->hd.stream_id);
-    ASSERT(!stream->headers_);
-    stream->headers_ = std::make_unique<HeaderMapImpl>();
+    stream->allocTrailers();
   }
 
   return 0;
@@ -1142,8 +1143,7 @@ int ServerConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
     ASSERT(frame->headers.cat == NGHTTP2_HCAT_HEADERS);
 
     StreamImpl* stream = getStream(frame->hd.stream_id);
-    ASSERT(!stream->headers_);
-    stream->headers_ = std::make_unique<HeaderMapImpl>();
+    stream->allocTrailers();
     return 0;
   }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1493,14 +1493,14 @@ Filter::UpstreamRequest::~UpstreamRequest() {
   }
 }
 
-void Filter::UpstreamRequest::decode100ContinueHeaders(Http::HeaderMapPtr&& headers) {
+void Filter::UpstreamRequest::decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) {
   ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
 
   ASSERT(100 == Http::Utility::getResponseStatus(*headers));
   parent_.onUpstream100ContinueHeaders(std::move(headers), *this);
 }
 
-void Filter::UpstreamRequest::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void Filter::UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
 
   // TODO(rodaine): This is actually measuring after the headers are parsed and not the first
@@ -1525,7 +1525,7 @@ void Filter::UpstreamRequest::decodeData(Buffer::Instance& data, bool end_stream
   parent_.onUpstreamData(data, *this, end_stream);
 }
 
-void Filter::UpstreamRequest::decodeTrailers(Http::HeaderMapPtr&& trailers) {
+void Filter::UpstreamRequest::decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) {
   ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
 
   maybeEndDecode(true);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -397,9 +397,9 @@ private:
     void decodeMetadata(Http::MetadataMapPtr&& metadata_map) override;
 
     // Http::ResponseDecoder
-    void decode100ContinueHeaders(Http::HeaderMapPtr&& headers) override;
-    void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
+    void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) override;
+    void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+    void decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) override;
 
     // Http::StreamCallbacks
     void onResetStream(Http::StreamResetReason reason,

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -199,7 +199,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onDeferredDelete() {
 }
 
 void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::decodeHeaders(
-    Http::HeaderMapPtr&& headers, bool end_stream) {
+    Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!response_headers_);
   response_headers_ = std::move(headers);
   if (end_stream) {
@@ -539,7 +539,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onDeferredDelete() {
 }
 
 void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::decodeHeaders(
-    Http::HeaderMapPtr&& headers, bool end_stream) {
+    Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   const auto http_response_status = Http::Utility::getResponseStatus(*headers);
   if (http_response_status != enumToInt(Http::Code::OK)) {
     // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md requires that
@@ -607,7 +607,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::decodeData(Buffer::Ins
 }
 
 void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::decodeTrailers(
-    Http::HeaderMapPtr&& trailers) {
+    Http::ResponseTrailerMapPtr&& trailers) {
   auto maybe_grpc_status = Grpc::Common::getGrpcStatus(*trailers);
   auto grpc_status =
       maybe_grpc_status

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -93,9 +93,9 @@ private:
     void decodeMetadata(Http::MetadataMapPtr&&) override {}
 
     // Http::ResponseDecoder
-    void decode100ContinueHeaders(Http::HeaderMapPtr&&) override {}
-    void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeTrailers(Http::HeaderMapPtr&&) override { onResponseComplete(); }
+    void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&&) override {}
+    void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+    void decodeTrailers(Http::ResponseTrailerMapPtr&&) override { onResponseComplete(); }
 
     // Http::StreamCallbacks
     void onResetStream(Http::StreamResetReason reason,
@@ -312,9 +312,9 @@ private:
     void decodeMetadata(Http::MetadataMapPtr&&) override {}
 
     // Http::ResponseDecoder
-    void decode100ContinueHeaders(Http::HeaderMapPtr&&) override {}
-    void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeTrailers(Http::HeaderMapPtr&&) override;
+    void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&&) override {}
+    void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+    void decodeTrailers(Http::ResponseTrailerMapPtr&&) override;
 
     // Http::StreamCallbacks
     void onResetStream(Http::StreamResetReason reason,

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.cc
@@ -105,7 +105,8 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
     return;
   }
   ASSERT(headers_decompressed());
-  response_decoder_->decodeHeaders(quicHeadersToEnvoyHeaders(header_list), /*end_stream=*/fin);
+  response_decoder_->decodeHeaders(
+      quicHeadersToEnvoyHeaders<Http::ResponseHeaderMapImpl>(header_list), /*end_stream=*/fin);
   if (fin) {
     end_stream_decoded_ = true;
   }
@@ -164,7 +165,8 @@ void EnvoyQuicClientStream::OnBodyAvailable() {
     // For Google QUIC implementation, trailers may arrived earlier and wait to
     // be consumed after reading all the body. Consume it here.
     // IETF QUIC shouldn't reach here because trailers are sent on same stream.
-    response_decoder_->decodeTrailers(spdyHeaderBlockToEnvoyHeaders(received_trailers()));
+    response_decoder_->decodeTrailers(
+        spdyHeaderBlockToEnvoyHeaders<Http::ResponseTrailerMapImpl>(received_trailers()));
     MarkTrailersConsumed();
   }
   OnFinRead();
@@ -180,7 +182,8 @@ void EnvoyQuicClientStream::OnTrailingHeadersComplete(bool fin, size_t frame_len
       !FinishedReadingTrailers()) {
     // Before QPack, trailers can arrive before body. Only decode trailers after finishing decoding
     // body.
-    response_decoder_->decodeTrailers(spdyHeaderBlockToEnvoyHeaders(received_trailers()));
+    response_decoder_->decodeTrailers(
+        spdyHeaderBlockToEnvoyHeaders<Http::ResponseTrailerMapImpl>(received_trailers()));
     MarkTrailersConsumed();
   }
 }

--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.cc
@@ -127,7 +127,8 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
                                                      const quic::QuicHeaderList& header_list) {
   quic::QuicSpdyServerStreamBase::OnInitialHeadersComplete(fin, frame_len, header_list);
   ASSERT(headers_decompressed());
-  request_decoder_->decodeHeaders(quicHeadersToEnvoyHeaders(header_list), /*end_stream=*/fin);
+  request_decoder_->decodeHeaders(
+      quicHeadersToEnvoyHeaders<Http::RequestHeaderMapImpl>(header_list), /*end_stream=*/fin);
   if (fin) {
     end_stream_decoded_ = true;
   }
@@ -186,7 +187,8 @@ void EnvoyQuicServerStream::OnBodyAvailable() {
     // For Google QUIC implementation, trailers may arrived earlier and wait to
     // be consumed after reading all the body. Consume it here.
     // IETF QUIC shouldn't reach here because trailers are sent on same stream.
-    request_decoder_->decodeTrailers(spdyHeaderBlockToEnvoyHeaders(received_trailers()));
+    request_decoder_->decodeTrailers(
+        spdyHeaderBlockToEnvoyHeaders<Http::RequestTrailerMapImpl>(received_trailers()));
     MarkTrailersConsumed();
   }
   OnFinRead();
@@ -201,7 +203,8 @@ void EnvoyQuicServerStream::OnTrailingHeadersComplete(bool fin, size_t frame_len
       !FinishedReadingTrailers()) {
     // Before QPack trailers can arrive before body. Only decode trailers after finishing decoding
     // body.
-    request_decoder_->decodeTrailers(spdyHeaderBlockToEnvoyHeaders(received_trailers()));
+    request_decoder_->decodeTrailers(
+        spdyHeaderBlockToEnvoyHeaders<Http::RequestTrailerMapImpl>(received_trailers()));
     MarkTrailersConsumed();
   }
 }

--- a/source/extensions/quic_listeners/quiche/envoy_quic_utils.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_utils.cc
@@ -45,26 +45,6 @@ quic::QuicSocketAddress envoyAddressInstanceToQuicSocketAddress(
   return quic::QuicSocketAddress(ss);
 }
 
-Http::HeaderMapImplPtr quicHeadersToEnvoyHeaders(const quic::QuicHeaderList& header_list) {
-  Http::HeaderMapImplPtr headers = std::make_unique<Http::HeaderMapImpl>();
-  for (const auto& entry : header_list) {
-    // TODO(danzh): Avoid copy by referencing entry as header_list is already validated by QUIC.
-    headers->addCopy(Http::LowerCaseString(entry.first), entry.second);
-  }
-  return headers;
-}
-
-Http::HeaderMapImplPtr spdyHeaderBlockToEnvoyHeaders(const spdy::SpdyHeaderBlock& header_block) {
-  Http::HeaderMapImplPtr headers = std::make_unique<Http::HeaderMapImpl>();
-  for (auto entry : header_block) {
-    // TODO(danzh): Avoid temporary strings and addCopy() with std::string_view.
-    std::string key(entry.first);
-    std::string value(entry.second);
-    headers->addCopy(Http::LowerCaseString(key), value);
-  }
-  return headers;
-}
-
 spdy::SpdyHeaderBlock envoyHeadersToSpdyHeaderBlock(const Http::HeaderMap& headers) {
   spdy::SpdyHeaderBlock header_block;
   headers.iterate(

--- a/test/BUILD
+++ b/test/BUILD
@@ -30,7 +30,6 @@ envoy_cc_test_library(
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
-        "//source/common/http/http2:codec_lib",
         "//source/exe:process_wide_lib",
         "//test/common/runtime:utility_lib",
         "//test/mocks/access_log:access_log_mocks",

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -119,8 +119,9 @@ TEST_F(AsyncClientImplTest, BasicStream) {
   stream->sendData(*body, true);
 
   response_decoder_->decode100ContinueHeaders(
-      HeaderMapPtr(new TestHeaderMapImpl{{":status", "100"}}));
-  response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "100"}}));
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
   response_decoder_->decodeData(*body, true);
 
   EXPECT_EQ(
@@ -154,7 +155,7 @@ TEST_F(AsyncClientImplTest, Basic) {
 
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, true);
 
@@ -200,7 +201,7 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(*child_span, finishSpan());
 
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, true);
 }
@@ -239,7 +240,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(*child_span, finishSpan());
 
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, true);
 }
@@ -279,7 +280,7 @@ TEST_F(AsyncClientImplTest, BasicHashPolicy) {
   options.setHashPolicy(hash_policy);
   client_.send(std::move(message_), callbacks_, options);
 
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, true);
 }
@@ -308,7 +309,7 @@ TEST_F(AsyncClientImplTest, Retry) {
 
   // Expect retry and retry timer create.
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "503"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "503"}});
   response_decoder_->decodeHeaders(std::move(response_headers), true);
 
   // Retry request.
@@ -326,7 +327,7 @@ TEST_F(AsyncClientImplTest, Retry) {
 
   // Normal response.
   expectSuccess(200);
-  HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers2), true);
 }
 
@@ -356,7 +357,7 @@ TEST_F(AsyncClientImplTest, RetryWithStream) {
 
   // Expect retry and retry timer create.
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "503"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "503"}});
   response_decoder_->decodeHeaders(std::move(response_headers), true);
 
   // Retry request.
@@ -375,7 +376,7 @@ TEST_F(AsyncClientImplTest, RetryWithStream) {
   // Normal response.
   expectResponseHeaders(stream_callbacks_, 200, true);
   EXPECT_CALL(stream_callbacks_, onComplete());
-  HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers2), true);
 }
 
@@ -429,11 +430,11 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
   stream2->sendData(*body2, true);
 
   // Finish stream 2.
-  HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "503"}});
+  ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
 
   // Finish stream 1.
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(*body, true);
 }
@@ -473,12 +474,12 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
   client_.send(std::move(message2), callbacks2, AsyncClient::RequestOptions());
 
   // Finish request 2.
-  HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "503"}});
+  ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
   EXPECT_CALL(callbacks2, onSuccess_(_));
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
 
   // Finish request 1.
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   expectSuccess(200);
   response_decoder_->decodeData(data, true);
@@ -529,12 +530,12 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
   stream->sendData(*body, true);
 
   // Finish stream.
-  HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder2->decodeHeaders(std::move(response_headers2), false);
   response_decoder2->decodeData(*body, true);
 
   // Finish request.
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   expectSuccess(200);
   response_decoder_->decodeData(data, true);
@@ -569,10 +570,11 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
   stream->sendData(*body, false);
   stream->sendTrailers(trailers);
 
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(*body, false);
-  response_decoder_->decodeTrailers(HeaderMapPtr{new TestHeaderMapImpl{{"some", "trailer"}}});
+  response_decoder_->decodeTrailers(
+      ResponseTrailerMapPtr{new TestResponseTrailerMapImpl{{"some", "trailer"}}});
 }
 
 TEST_F(AsyncClientImplTest, Trailers) {
@@ -592,10 +594,11 @@ TEST_F(AsyncClientImplTest, Trailers) {
   expectSuccess(200);
 
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, false);
-  response_decoder_->decodeTrailers(HeaderMapPtr{new TestHeaderMapImpl{{"some", "trailer"}}});
+  response_decoder_->decodeTrailers(
+      ResponseTrailerMapPtr{new TestResponseTrailerMapImpl{{"some", "trailer"}}});
 }
 
 TEST_F(AsyncClientImplTest, ImmediateReset) {
@@ -646,7 +649,8 @@ TEST_F(AsyncClientImplTest, LocalResetAfterStreamStart) {
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
-  response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
   response_decoder_->decodeData(*body, false);
 
   stream->reset();
@@ -679,7 +683,8 @@ TEST_F(AsyncClientImplTest, SendDataAfterRemoteClosure) {
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
 
-  response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
   response_decoder_->decodeData(*body, true);
 
   EXPECT_CALL(stream_encoder_, encodeData(_, _)).Times(0);
@@ -716,7 +721,8 @@ TEST_F(AsyncClientImplTest, SendTrailersRemoteClosure) {
   AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
 
-  response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
   response_decoder_->decodeData(*body, true);
 
   EXPECT_CALL(stream_encoder_, encodeTrailers(_)).Times(0);
@@ -757,7 +763,8 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
 
   Http::StreamDecoderFilterCallbacks* filter_callbacks =
       static_cast<Http::AsyncStreamImpl*>(stream);
-  filter_callbacks->encodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  filter_callbacks->encodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
 }
 
 TEST_F(AsyncClientImplTest, RemoteResetAfterStreamStart) {
@@ -789,7 +796,8 @@ TEST_F(AsyncClientImplTest, RemoteResetAfterStreamStart) {
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
-  response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
   response_decoder_->decodeData(*body, false);
 
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
@@ -808,7 +816,7 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
   EXPECT_CALL(callbacks_, onFailure(_));
 
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
-  HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
 }
@@ -1159,7 +1167,8 @@ TEST_F(AsyncClientImplTest, MultipleDataStream) {
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
-  response_decoder_->decodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
   response_decoder_->decodeData(*body, false);
 
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body2.get()), true));

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -205,7 +205,7 @@ public:
     EXPECT_CALL(*config_.codec_, dispatch(_))
         .WillOnce(InvokeWithoutArgs([this, &request_headers, end_stream] {
           decoder_ = &conn_manager_.newStream(encoder_);
-          auto headers = std::make_unique<TestHeaderMapImpl>(request_headers);
+          auto headers = std::make_unique<TestRequestHeaderMapImpl>(request_headers);
           if (headers->Method() == nullptr) {
             headers->setReferenceKey(Headers::get().Method, "GET");
           }
@@ -312,7 +312,7 @@ public:
                 }));
         EXPECT_CALL(*config_.codec_, dispatch(_))
             .WillOnce(InvokeWithoutArgs([this, &trailers_action] {
-              decoder_->decodeTrailers(std::make_unique<TestHeaderMapImpl>(
+              decoder_->decodeTrailers(std::make_unique<TestRequestTrailerMapImpl>(
                   Fuzz::fromHeaders(trailers_action.headers())));
             }));
         fakeOnData();

--- a/test/common/http/header_map_impl_fuzz_test.cc
+++ b/test/common/http/header_map_impl_fuzz_test.cc
@@ -136,8 +136,8 @@ DEFINE_PROTO_FUZZER(const test::common::http::HeaderMapImplFuzzTestCase& input) 
       break;
     }
     case test::common::http::Action::kCopy: {
-      header_map = std::make_unique<Http::HeaderMapImpl>(
-          *reinterpret_cast<Http::HeaderMap*>(header_map.get()));
+      header_map =
+          std::make_unique<Http::HeaderMapImpl>(*static_cast<Http::HeaderMap*>(header_map.get()));
       break;
     }
     case test::common::http::Action::kLookup: {

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -753,9 +753,10 @@ TEST_F(Http1ServerConnectionImplTest, CloseDuringHeadersComplete) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{{"content-length", "5"}, {":path", "/"}, {":method", "POST"}};
+  TestRequestHeaderMapImpl expected_headers{
+      {"content-length", "5"}, {":path", "/"}, {":method", "POST"}};
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), false))
-      .WillOnce(Invoke([&](Http::HeaderMapPtr&, bool) -> void {
+      .WillOnce(Invoke([&](Http::RequestHeaderMapPtr&, bool) -> void {
         connection_.state_ = Network::Connection::State::Closing;
       }));
   EXPECT_CALL(decoder, decodeData(_, _)).Times(0);

--- a/test/common/http/http1/conn_pool_legacy_test.cc
+++ b/test/common/http/http1/conn_pool_legacy_test.cc
@@ -187,8 +187,8 @@ struct ActiveTestRequest {
 
   void completeResponse(bool with_body) {
     // Test additional metric writes also.
-    Http::HeaderMapPtr response_headers(
-        new TestHeaderMapImpl{{":status", "200"}, {"x-envoy-upstream-canary", "true"}});
+    Http::ResponseHeaderMapPtr response_headers(
+        new TestResponseHeaderMapImpl{{":status", "200"}, {"x-envoy-upstream-canary", "true"}});
 
     inner_decoder_->decodeHeaders(std::move(response_headers), !with_body);
     if (with_body) {
@@ -581,14 +581,14 @@ TEST_F(Http1ConnPoolImplLegacyTest, MaxConnections) {
 
   callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                           true);
-  Http::HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  Http::ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
   conn_pool_.expectAndRunUpstreamReady();
   callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                            true);
   // N.B. clang_tidy insists that we use std::make_unique which can not infer std::initialize_list.
-  response_headers = std::make_unique<TestHeaderMapImpl>(
+  response_headers = std::make_unique<TestResponseHeaderMapImpl>(
       std::initializer_list<std::pair<std::string, std::string>>{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
@@ -635,7 +635,7 @@ TEST_F(Http1ConnPoolImplLegacyTest, ConnectionCloseWithoutHeader) {
 
   callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                           true);
-  Http::HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  Http::ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
   // Cause the connection to go away.
@@ -654,7 +654,7 @@ TEST_F(Http1ConnPoolImplLegacyTest, ConnectionCloseWithoutHeader) {
   callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                            true);
   // N.B. clang_tidy insists that we use std::make_unique which can not infer std::initialize_list.
-  response_headers = std::make_unique<TestHeaderMapImpl>(
+  response_headers = std::make_unique<TestResponseHeaderMapImpl>(
       std::initializer_list<std::pair<std::string, std::string>>{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
@@ -689,8 +689,8 @@ TEST_F(Http1ConnPoolImplLegacyTest, ConnectionCloseHeader) {
 
   // Response with 'connection: close' which should cause the connection to go away.
   EXPECT_CALL(conn_pool_, onClientDestroy());
-  Http::HeaderMapPtr response_headers(
-      new TestHeaderMapImpl{{":status", "200"}, {"Connection", "Close"}});
+  Http::ResponseHeaderMapPtr response_headers(
+      new TestResponseHeaderMapImpl{{":status", "200"}, {"Connection", "Close"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
   dispatcher_.clearDeferredDeleteList();
 
@@ -723,8 +723,8 @@ TEST_F(Http1ConnPoolImplLegacyTest, ProxyConnectionCloseHeader) {
 
   // Response with 'proxy-connection: close' which should cause the connection to go away.
   EXPECT_CALL(conn_pool_, onClientDestroy());
-  Http::HeaderMapPtr response_headers(
-      new TestHeaderMapImpl{{":status", "200"}, {"Proxy-Connection", "Close"}});
+  Http::ResponseHeaderMapPtr response_headers(
+      new TestResponseHeaderMapImpl{{":status", "200"}, {"Proxy-Connection", "Close"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
   dispatcher_.clearDeferredDeleteList();
 
@@ -757,8 +757,8 @@ TEST_F(Http1ConnPoolImplLegacyTest, Http10NoConnectionKeepAlive) {
 
   // Response without 'connection: keep-alive' which should cause the connection to go away.
   EXPECT_CALL(conn_pool_, onClientDestroy());
-  Http::HeaderMapPtr response_headers(
-      new TestHeaderMapImpl{{":protocol", "HTTP/1.0"}, {":status", "200"}});
+  Http::ResponseHeaderMapPtr response_headers(
+      new TestResponseHeaderMapImpl{{":protocol", "HTTP/1.0"}, {":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
   dispatcher_.clearDeferredDeleteList();
 
@@ -793,7 +793,7 @@ TEST_F(Http1ConnPoolImplLegacyTest, MaxRequestsPerConnection) {
 
   // Response with 'connection: close' which should cause the connection to go away.
   EXPECT_CALL(conn_pool_, onClientDestroy());
-  Http::HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
+  Http::ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
   dispatcher_.clearDeferredDeleteList();
 
@@ -897,7 +897,8 @@ TEST_F(Http1ConnPoolImplLegacyTest, RemoteCloseToCompleteResponse) {
   callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                           true);
 
-  inner_decoder->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, false);
+  inner_decoder->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
   Buffer::OwnedImpl dummy_data("12345");
   inner_decoder->decodeData(dummy_data, false);
 

--- a/test/common/http/http2/conn_pool_legacy_test.cc
+++ b/test/common/http/http2/conn_pool_legacy_test.cc
@@ -191,7 +191,8 @@ void Http2ConnPoolImplLegacyTest::completeRequest(ActiveTestRequest& r) {
   r.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                              true);
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
-  r.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 }
 
 void Http2ConnPoolImplLegacyTest::completeRequestCloseUpstream(size_t index, ActiveTestRequest& r) {
@@ -400,7 +401,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, VerifyConnectionTimingStats) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -425,7 +427,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, VerifyBufferLimits) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -445,14 +448,16 @@ TEST_F(Http2ConnPoolImplLegacyTest, RequestAndResponse) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   ActiveTestRequest r2(*this, 0, true);
   EXPECT_CALL(r2.inner_encoder_, encodeHeaders(_, true));
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -549,7 +554,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, DrainDisconnectDrainingWithActiveRequest) {
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
 
@@ -586,14 +592,16 @@ TEST_F(Http2ConnPoolImplLegacyTest, DrainPrimary) {
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(drained, ready());
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
@@ -610,7 +618,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, DrainPrimaryNoActiveRequest) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   expectClientCreate();
@@ -622,7 +631,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, DrainPrimaryNoActiveRequest) {
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   ReadyWatcher drained;
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
@@ -655,7 +665,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, ConnectTimeout) {
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -704,7 +715,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, GoAway) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].codec_client_->raiseGoAway();
 
@@ -715,7 +727,8 @@ TEST_F(Http2ConnPoolImplLegacyTest, GoAway) {
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -192,7 +192,8 @@ void Http2ConnPoolImplTest::completeRequest(ActiveTestRequest& r) {
   r.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                              true);
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
-  r.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 }
 
 void Http2ConnPoolImplTest::completeRequestCloseUpstream(size_t index, ActiveTestRequest& r) {
@@ -238,7 +239,8 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionReadyWithRequest) {
 
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
   EXPECT_CALL(*this, onClientDestroy());
-  r.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 }
 
 /**
@@ -260,7 +262,8 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionBusy) {
 
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
   EXPECT_CALL(*this, onClientDestroy());
-  r.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 }
 
 /**
@@ -613,7 +616,8 @@ TEST_F(Http2ConnPoolImplTest, VerifyConnectionTimingStats) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   EXPECT_CALL(cluster_->stats_store_,
               deliverHistogramToSinks(Property(&Stats::Metric::name, "upstream_cx_length_ms"), _));
@@ -638,7 +642,8 @@ TEST_F(Http2ConnPoolImplTest, VerifyBufferLimits) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -659,14 +664,16 @@ TEST_F(Http2ConnPoolImplTest, RequestAndResponse) {
                                               true);
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_active_.value());
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   ActiveTestRequest r2(*this, 0, true);
   EXPECT_CALL(r2.inner_encoder_, encodeHeaders(_, true));
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -768,7 +775,8 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectDrainingWithActiveRequest) {
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
 
@@ -807,14 +815,16 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimary) {
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(drained, ready());
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
@@ -834,7 +844,8 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimaryNoActiveRequest) {
                                               true);
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   expectClientCreate();
   ActiveTestRequest r2(*this, 1, false);
@@ -846,7 +857,8 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimaryNoActiveRequest) {
                                               true);
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   ReadyWatcher drained;
   EXPECT_CALL(drained, ready());
@@ -878,7 +890,8 @@ TEST_F(Http2ConnPoolImplTest, ConnectTimeout) {
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy());
@@ -927,7 +940,8 @@ TEST_F(Http2ConnPoolImplTest, GoAway) {
   r1.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
-  r1.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[0].codec_client_->raiseGoAway();
 
@@ -938,7 +952,8 @@ TEST_F(Http2ConnPoolImplTest, GoAway) {
   r2.callbacks_.outer_encoder_->encodeHeaders(TestHeaderMapImpl{{":path", "/"}, {":method", "GET"}},
                                               true);
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
-  r2.inner_decoder_->decodeHeaders(HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
 
   test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -147,14 +147,16 @@ public:
 
     EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
 
-    Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl(response_headers_init));
+    Http::ResponseHeaderMapPtr response_headers(
+        new Http::TestResponseHeaderMapImpl(response_headers_init));
     response_headers->setStatus(response_code);
 
     EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
                 putHttpResponseCode(response_code));
     response_decoder->decodeHeaders(std::move(response_headers), false);
 
-    Http::HeaderMapPtr response_trailers(new Http::TestHeaderMapImpl(response_trailers_init));
+    Http::ResponseTrailerMapPtr response_trailers(
+        new Http::TestResponseTrailerMapImpl(response_trailers_init));
     response_decoder->decodeTrailers(std::move(response_trailers));
   }
 
@@ -209,7 +211,8 @@ public:
 
     // Normal response.
     EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
-    Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
+    Http::ResponseHeaderMapPtr response_headers(
+        new Http::TestResponseHeaderMapImpl{{":status", "200"}});
     EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
                 putHttpResponseCode(200));
     response_decoder->decodeHeaders(std::move(response_headers), true);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -613,8 +613,8 @@ public:
                bool body = false, bool trailers = false,
                const absl::optional<std::string>& service_cluster = absl::optional<std::string>(),
                bool degraded = false) {
-    std::unique_ptr<Http::TestHeaderMapImpl> response_headers(
-        new Http::TestHeaderMapImpl{{":status", code}});
+    std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers(
+        new Http::TestResponseHeaderMapImpl{{":status", code}});
 
     if (degraded) {
       response_headers->setEnvoyDegraded(1);
@@ -640,7 +640,7 @@ public:
 
     if (trailers) {
       test_sessions_[index]->stream_response_callbacks_->decodeTrailers(
-          Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{"some", "trailer"}}});
+          Http::ResponseTrailerMapPtr{new Http::TestResponseTrailerMapImpl{{"some", "trailer"}}});
     }
   }
 
@@ -904,8 +904,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithSpurious100Continue) {
               enableTimer(std::chrono::milliseconds(45000), _));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
 
-  std::unique_ptr<Http::TestHeaderMapImpl> continue_headers(
-      new Http::TestHeaderMapImpl{{":status", "100"}});
+  std::unique_ptr<Http::TestResponseHeaderMapImpl> continue_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "100"}});
   test_sessions_[0]->stream_response_callbacks_->decode100ContinueHeaders(
       std::move(continue_headers));
 
@@ -1834,8 +1834,8 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutThenSuccess) {
   health_checker_->start();
 
   // Do a response that is not complete but includes headers.
-  std::unique_ptr<Http::TestHeaderMapImpl> response_headers(
-      new Http::TestHeaderMapImpl{{":status", "200"}});
+  std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
   test_sessions_[0]->stream_response_callbacks_->decodeHeaders(std::move(response_headers), false);
 
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
@@ -3629,7 +3629,7 @@ public:
   void respondResponseSpec(size_t index, ResponseSpec&& spec) {
     const bool trailers_empty = spec.trailers.empty();
     const bool end_stream_on_headers = spec.body_chunks.empty() && trailers_empty;
-    auto response_headers = std::make_unique<Http::TestHeaderMapImpl>();
+    auto response_headers = std::make_unique<Http::TestResponseHeaderMapImpl>();
     for (const auto& header : spec.response_headers) {
       response_headers->addCopy(header.first, header.second);
     }
@@ -3647,7 +3647,7 @@ public:
       }
     }
     if (!trailers_empty) {
-      auto trailers = std::make_unique<Http::TestHeaderMapImpl>();
+      auto trailers = std::make_unique<Http::TestResponseTrailerMapImpl>();
       for (const auto& header : spec.trailers) {
         trailers->addCopy(header.first, header.second);
       }
@@ -3738,7 +3738,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessResponseSplitBetweenChunks) {
   setupServiceNameHC(absl::nullopt);
   expectSingleHealthcheck(HealthTransition::Unchanged);
 
-  auto response_headers = std::make_unique<Http::TestHeaderMapImpl>(
+  auto response_headers = std::make_unique<Http::TestResponseHeaderMapImpl>(
       std::initializer_list<std::pair<std::string, std::string>>{
           {":status", "200"},
           {"content-type", "application/grpc"},
@@ -3757,7 +3757,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessResponseSplitBetweenChunks) {
     test_sessions_[0]->stream_response_callbacks_->decodeData(*chunk, false);
   }
 
-  auto trailers = std::make_unique<Http::TestHeaderMapImpl>(
+  auto trailers = std::make_unique<Http::TestResponseTrailerMapImpl>(
       std::initializer_list<std::pair<std::string, std::string>>{{"grpc-status", "0"}});
   test_sessions_[0]->stream_response_callbacks_->decodeTrailers(std::move(trailers));
 

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
@@ -188,7 +188,7 @@ TEST_P(EnvoyQuicClientSessionTest, NewStream) {
   headers.OnHeaderBlockEnd(/*uncompressed_header_bytes=*/0, /*compressed_header_bytes=*/0);
   // Response headers should be propagated to decoder.
   EXPECT_CALL(response_decoder, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ("200", decoded_headers->Status()->value().getStringView());
       }));
   stream.OnStreamHeaderList(/*fin=*/true, headers.uncompressed_header_bytes(), headers);

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
@@ -114,7 +114,7 @@ TEST_P(EnvoyQuicClientStreamTest, PostRequestAndResponse) {
   quic_stream_->encodeData(request_body_, true);
 
   EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& headers, bool) {
+      .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& headers, bool) {
         EXPECT_EQ("200", headers->Status()->value().getStringView());
       }));
   quic_stream_->OnStreamHeaderList(/*fin=*/false, response_headers_.uncompressed_header_bytes(),
@@ -145,7 +145,7 @@ TEST_P(EnvoyQuicClientStreamTest, PostRequestAndResponse) {
   quic_stream_->OnStreamFrame(frame);
 
   EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& headers) {
+      .WillOnce(Invoke([](const Http::ResponseTrailerMapPtr& headers) {
         Http::LowerCaseString key1("key1");
         Http::LowerCaseString key2(":final-offset");
         EXPECT_EQ("value1", headers->get(key1)->value().getStringView());
@@ -161,7 +161,7 @@ TEST_P(EnvoyQuicClientStreamTest, OutOfOrderTrailers) {
   }
   quic_stream_->encodeHeaders(request_headers_, true);
   EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& headers, bool) {
+      .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& headers, bool) {
         EXPECT_EQ("200", headers->Status()->value().getStringView());
       }));
   quic_stream_->OnStreamHeaderList(/*fin=*/false, response_headers_.uncompressed_header_bytes(),
@@ -194,7 +194,7 @@ TEST_P(EnvoyQuicClientStreamTest, OutOfOrderTrailers) {
       }));
 
   EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& headers) {
+      .WillOnce(Invoke([](const Http::ResponseTrailerMapPtr& headers) {
         Http::LowerCaseString key1("key1");
         Http::LowerCaseString key2(":final-offset");
         EXPECT_EQ("value1", headers->get(key1)->value().getStringView());

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
@@ -229,7 +229,7 @@ TEST_P(EnvoyQuicServerSessionTest, NewStream) {
   headers.OnHeaderBlockEnd(/*uncompressed_header_bytes=*/0, /*compressed_header_bytes=*/0);
   // Request headers should be propagated to decoder.
   EXPECT_CALL(request_decoder, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([&host](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([&host](const Http::RequestHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ(host, decoded_headers->Host()->value().getStringView());
         EXPECT_EQ("/", decoded_headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,
@@ -419,7 +419,7 @@ TEST_P(EnvoyQuicServerSessionTest, WriteUpdatesDelayCloseTimer) {
   request_headers.OnHeaderBlockEnd(/*uncompressed_header_bytes=*/0, /*compressed_header_bytes=*/0);
   // Request headers should be propagated to decoder.
   EXPECT_CALL(request_decoder, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([&host](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([&host](const Http::RequestHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ(host, decoded_headers->Host()->value().getStringView());
         EXPECT_EQ("/", decoded_headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,
@@ -514,7 +514,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlushCloseNoTimeout) {
   request_headers.OnHeaderBlockEnd(/*uncompressed_header_bytes=*/0, /*compressed_header_bytes=*/0);
   // Request headers should be propagated to decoder.
   EXPECT_CALL(request_decoder, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([&host](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([&host](const Http::RequestHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ(host, decoded_headers->Host()->value().getStringView());
         EXPECT_EQ("/", decoded_headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,
@@ -811,7 +811,7 @@ TEST_P(EnvoyQuicServerSessionTest, SendBufferWatermark) {
   request_headers.OnHeaderBlockEnd(/*uncompressed_header_bytes=*/0, /*compressed_header_bytes=*/0);
   // Request headers should be propagated to decoder.
   EXPECT_CALL(request_decoder, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([&host](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([&host](const Http::RequestHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ(host, decoded_headers->Host()->value().getStringView());
         EXPECT_EQ("/", decoded_headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,
@@ -844,7 +844,7 @@ TEST_P(EnvoyQuicServerSessionTest, SendBufferWatermark) {
   auto stream2 =
       dynamic_cast<EnvoyQuicServerStream*>(envoy_quic_session_.GetOrCreateStream(stream_id + 4));
   EXPECT_CALL(request_decoder2, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([&host](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([&host](const Http::RequestHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ(host, decoded_headers->Host()->value().getStringView());
         EXPECT_EQ("/", decoded_headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,
@@ -876,7 +876,7 @@ TEST_P(EnvoyQuicServerSessionTest, SendBufferWatermark) {
   auto stream3 =
       dynamic_cast<EnvoyQuicServerStream*>(envoy_quic_session_.GetOrCreateStream(stream_id + 8));
   EXPECT_CALL(request_decoder3, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([&host](const Http::HeaderMapPtr& decoded_headers, bool) {
+      .WillOnce(Invoke([&host](const Http::RequestHeaderMapPtr& decoded_headers, bool) {
         EXPECT_EQ(host, decoded_headers->Host()->value().getStringView());
         EXPECT_EQ("/", decoded_headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
@@ -100,7 +100,7 @@ public:
 
   size_t sendRequest(const std::string& payload, bool fin, size_t decoder_buffer_high_watermark) {
     EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
-        .WillOnce(Invoke([this](const Http::HeaderMapPtr& headers, bool) {
+        .WillOnce(Invoke([this](const Http::RequestHeaderMapPtr& headers, bool) {
           EXPECT_EQ(host_, headers->Host()->value().getStringView());
           EXPECT_EQ("/", headers->Path()->value().getStringView());
           EXPECT_EQ(Http::Headers::get().MethodValues.Post,
@@ -160,7 +160,7 @@ TEST_P(EnvoyQuicServerStreamTest, GetRequestAndResponse) {
                                    /*compressed_header_bytes=*/0);
 
   EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/true))
-      .WillOnce(Invoke([this](const Http::HeaderMapPtr& headers, bool) {
+      .WillOnce(Invoke([this](const Http::RequestHeaderMapPtr& headers, bool) {
         EXPECT_EQ(host_, headers->Host()->value().getStringView());
         EXPECT_EQ("/", headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Get,
@@ -180,7 +180,7 @@ TEST_P(EnvoyQuicServerStreamTest, PostRequestAndResponse) {
 TEST_P(EnvoyQuicServerStreamTest, DecodeHeadersBodyAndTrailers) {
   sendRequest(request_body_, false, request_body_.size() * 2);
   EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& headers) {
+      .WillOnce(Invoke([](const Http::RequestTrailerMapPtr& headers) {
         Http::LowerCaseString key1("key1");
         Http::LowerCaseString key2(":final-offset");
         EXPECT_EQ("value1", headers->get(key1)->value().getStringView());
@@ -196,7 +196,7 @@ TEST_P(EnvoyQuicServerStreamTest, OutOfOrderTrailers) {
     return;
   }
   EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
-      .WillOnce(Invoke([this](const Http::HeaderMapPtr& headers, bool) {
+      .WillOnce(Invoke([this](const Http::RequestHeaderMapPtr& headers, bool) {
         EXPECT_EQ(host_, headers->Host()->value().getStringView());
         EXPECT_EQ("/", headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Post,
@@ -218,7 +218,7 @@ TEST_P(EnvoyQuicServerStreamTest, OutOfOrderTrailers) {
       }));
 
   EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
-      .WillOnce(Invoke([](const Http::HeaderMapPtr& headers) {
+      .WillOnce(Invoke([](const Http::RequestTrailerMapPtr& headers) {
         Http::LowerCaseString key1("key1");
         Http::LowerCaseString key2(":final-offset");
         EXPECT_EQ("value1", headers->get(key1)->value().getStringView());
@@ -269,7 +269,7 @@ TEST_P(EnvoyQuicServerStreamTest, ReadDisableUponLargePost) {
 // Tests that ReadDisable() doesn't cause re-entry of OnBodyAvailable().
 TEST_P(EnvoyQuicServerStreamTest, ReadDisableAndReEnableImmediately) {
   EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
-      .WillOnce(Invoke([this](const Http::HeaderMapPtr& headers, bool) {
+      .WillOnce(Invoke([this](const Http::RequestHeaderMapPtr& headers, bool) {
         EXPECT_EQ(host_, headers->Host()->value().getStringView());
         EXPECT_EQ("/", headers->Path()->value().getStringView());
         EXPECT_EQ(Http::Headers::get().MethodValues.Post,

--- a/test/extensions/quic_listeners/quiche/envoy_quic_utils_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_utils_test.cc
@@ -48,7 +48,7 @@ TEST(EnvoyQuicUtilsTest, HeadersConversion) {
   headers_block[":host"] = "www.google.com";
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";
-  Http::HeaderMapImplPtr envoy_headers = spdyHeaderBlockToEnvoyHeaders(headers_block);
+  auto envoy_headers = spdyHeaderBlockToEnvoyHeaders<Http::RequestHeaderMapImpl>(headers_block);
   EXPECT_EQ(headers_block.size(), envoy_headers->size());
   EXPECT_EQ("www.google.com",
             envoy_headers->get(Http::LowerCaseString(":host"))->value().getStringView());
@@ -57,7 +57,7 @@ TEST(EnvoyQuicUtilsTest, HeadersConversion) {
   EXPECT_EQ("https", envoy_headers->get(Http::LowerCaseString(":scheme"))->value().getStringView());
 
   quic::QuicHeaderList quic_headers = quic::test::AsHeaderList(headers_block);
-  Http::HeaderMapImplPtr envoy_headers2 = quicHeadersToEnvoyHeaders(quic_headers);
+  auto envoy_headers2 = quicHeadersToEnvoyHeaders<Http::RequestHeaderMapImpl>(quic_headers);
   EXPECT_EQ(*envoy_headers, *envoy_headers2);
 }
 

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -104,7 +104,7 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
 
     // Send a headers-only request
     stream_decoder.decodeHeaders(
-        Http::HeaderMapPtr(new Http::TestHeaderMapImpl{
+        Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         true);
   });
@@ -128,7 +128,7 @@ TEST_P(ApiListenerIntegrationTest, DestroyWithActiveStreams) {
 
     // Send a headers-only request
     stream_decoder.decodeHeaders(
-        Http::HeaderMapPtr(new Http::TestHeaderMapImpl{
+        Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         false);
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -44,7 +44,7 @@ FakeStream::FakeStream(FakeHttpConnection& parent, Http::ResponseEncoder& encode
   encoder.getStream().addCallbacks(*this);
 }
 
-void FakeStream::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void FakeStream::decodeHeaders(Http::RequestHeaderMapPtr&& headers, bool end_stream) {
   Thread::LockGuard lock(lock_);
   headers_ = std::move(headers);
   setEndStream(end_stream);
@@ -59,7 +59,7 @@ void FakeStream::decodeData(Buffer::Instance& data, bool end_stream) {
   decoder_event_.notifyOne();
 }
 
-void FakeStream::decodeTrailers(Http::HeaderMapPtr&& trailers) {
+void FakeStream::decodeTrailers(Http::RequestTrailerMapPtr&& trailers) {
   Thread::LockGuard lock(lock_);
   setEndStream(true);
   trailers_ = std::move(trailers);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -156,8 +156,8 @@ public:
   void decodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) override;
 
   // Http::RequestDecoder
-  void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-  void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
+  void decodeHeaders(Http::RequestHeaderMapPtr&& headers, bool end_stream) override;
+  void decodeTrailers(Http::RequestTrailerMapPtr&& trailers) override;
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -94,14 +94,15 @@ void IntegrationStreamDecoder::waitForReset() {
   }
 }
 
-void IntegrationStreamDecoder::decode100ContinueHeaders(Http::HeaderMapPtr&& headers) {
+void IntegrationStreamDecoder::decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) {
   continue_headers_ = std::move(headers);
   if (waiting_for_continue_headers_) {
     dispatcher_.exit();
   }
 }
 
-void IntegrationStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void IntegrationStreamDecoder::decodeHeaders(Http::ResponseHeaderMapPtr&& headers,
+                                             bool end_stream) {
   saw_end_stream_ = end_stream;
   headers_ = std::move(headers);
   if ((end_stream && waiting_for_end_stream_) || waiting_for_headers_) {
@@ -123,7 +124,7 @@ void IntegrationStreamDecoder::decodeData(Buffer::Instance& data, bool end_strea
   }
 }
 
-void IntegrationStreamDecoder::decodeTrailers(Http::HeaderMapPtr&& trailers) {
+void IntegrationStreamDecoder::decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) {
   saw_end_stream_ = true;
   trailers_ = std::move(trailers);
   if (waiting_for_end_stream_) {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -57,11 +57,13 @@ public:
   void clearBody() { body_.clear(); }
 
   // Http::StreamDecoder
-  void decode100ContinueHeaders(Http::HeaderMapPtr&& headers) override;
-  void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
   void decodeData(Buffer::Instance& data, bool end_stream) override;
-  void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
   void decodeMetadata(Http::MetadataMapPtr&& metadata_map) override;
+
+  // Http::ResponseDecoder
+  void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) override;
+  void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) override;
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -27,7 +27,7 @@
 #include "absl/strings/match.h"
 
 namespace Envoy {
-void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void BufferingStreamDecoder::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!complete_);
   complete_ = end_stream;
   headers_ = std::move(headers);
@@ -45,7 +45,7 @@ void BufferingStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream)
   }
 }
 
-void BufferingStreamDecoder::decodeTrailers(Http::HeaderMapPtr&&) {
+void BufferingStreamDecoder::decodeTrailers(Http::ResponseTrailerMapPtr&&) {
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -31,11 +31,13 @@ public:
   const std::string& body() { return body_; }
 
   // Http::StreamDecoder
-  void decode100ContinueHeaders(Http::HeaderMapPtr&&) override {}
-  void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
   void decodeData(Buffer::Instance&, bool end_stream) override;
-  void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
   void decodeMetadata(Http::MetadataMapPtr&&) override {}
+
+  // Http::ResponseDecoder
+  void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&&) override {}
+  void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) override;
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/test/mocks/http/stream_decoder.cc
+++ b/test/mocks/http/stream_decoder.cc
@@ -10,7 +10,7 @@ MockStreamDecoder::MockStreamDecoder() = default;
 MockStreamDecoder::~MockStreamDecoder() = default;
 
 MockRequestDecoder::MockRequestDecoder() {
-  ON_CALL(*this, decodeHeaders_(_, _)).WillByDefault(Invoke([](HeaderMapPtr& headers, bool) {
+  ON_CALL(*this, decodeHeaders_(_, _)).WillByDefault(Invoke([](RequestHeaderMapPtr& headers, bool) {
     // Check for passing response headers as request headers in a test.
     // TODO(mattklein123): In future changes this will become impossible once the header/trailer
     // implementation classes are split.
@@ -23,15 +23,16 @@ MockRequestDecoder::MockRequestDecoder() {
 MockRequestDecoder::~MockRequestDecoder() = default;
 
 MockResponseDecoder::MockResponseDecoder() {
-  ON_CALL(*this, decodeHeaders_(_, _)).WillByDefault(Invoke([](HeaderMapPtr& headers, bool) {
-    // Check for passing request headers as response headers in a test.
-    // TODO(mattklein123): In future changes this will become impossible once the header/trailer
-    // implementation classes are split.
-    ASSERT(headers->Status() != nullptr);
-    ASSERT(headers->Path() == nullptr);
-    ASSERT(headers->Method() == nullptr);
-    ASSERT(headers->Host() == nullptr);
-  }));
+  ON_CALL(*this, decodeHeaders_(_, _))
+      .WillByDefault(Invoke([](ResponseHeaderMapPtr& headers, bool) {
+        // Check for passing request headers as response headers in a test.
+        // TODO(mattklein123): In future changes this will become impossible once the header/trailer
+        // implementation classes are split.
+        ASSERT(headers->Status() != nullptr);
+        ASSERT(headers->Path() == nullptr);
+        ASSERT(headers->Method() == nullptr);
+        ASSERT(headers->Host() == nullptr);
+      }));
 }
 MockResponseDecoder::~MockResponseDecoder() = default;
 

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -23,14 +23,14 @@ public:
   MockRequestDecoder();
   ~MockRequestDecoder();
 
-  void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override {
+  void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override {
     decodeHeaders_(headers, end_stream);
   }
-  void decodeTrailers(HeaderMapPtr&& trailers) override { decodeTrailers_(trailers); }
+  void decodeTrailers(RequestTrailerMapPtr&& trailers) override { decodeTrailers_(trailers); }
 
   // Http::RequestDecoder
-  MOCK_METHOD(void, decodeHeaders_, (HeaderMapPtr & headers, bool end_stream));
-  MOCK_METHOD(void, decodeTrailers_, (HeaderMapPtr & trailers));
+  MOCK_METHOD(void, decodeHeaders_, (RequestHeaderMapPtr & headers, bool end_stream));
+  MOCK_METHOD(void, decodeTrailers_, (RequestTrailerMapPtr & trailers));
 };
 
 class MockResponseDecoder : public MockStreamDecoder, public ResponseDecoder {
@@ -38,18 +38,18 @@ public:
   MockResponseDecoder();
   ~MockResponseDecoder();
 
-  void decode100ContinueHeaders(HeaderMapPtr&& headers) override {
+  void decode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override {
     decode100ContinueHeaders_(headers);
   }
-  void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override {
+  void decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override {
     decodeHeaders_(headers, end_stream);
   }
-  void decodeTrailers(HeaderMapPtr&& trailers) override { decodeTrailers_(trailers); }
+  void decodeTrailers(ResponseTrailerMapPtr&& trailers) override { decodeTrailers_(trailers); }
 
   // Http::ResponseDecoder
-  MOCK_METHOD(void, decode100ContinueHeaders_, (HeaderMapPtr & headers));
-  MOCK_METHOD(void, decodeHeaders_, (HeaderMapPtr & headers, bool end_stream));
-  MOCK_METHOD(void, decodeTrailers_, (HeaderMapPtr & trailers));
+  MOCK_METHOD(void, decode100ContinueHeaders_, (ResponseHeaderMapPtr & headers));
+  MOCK_METHOD(void, decodeHeaders_, (ResponseHeaderMapPtr & headers, bool end_stream));
+  MOCK_METHOD(void, decodeTrailers_, (ResponseTrailerMapPtr & trailers));
 };
 
 } // namespace Http

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -659,12 +659,43 @@ public:
   void verifyByteSize() override { ASSERT(cached_byte_size_ == byteSizeInternal()); }
 };
 
+/**
+ * Typed test implementations for all of the concrete header types.
+ */
+class TestRequestHeaderMapImpl : public TestHeaderMapImpl, public RequestHeaderMap {
+public:
+  TestRequestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values)
+      : TestHeaderMapImpl(values) {}
+  TestRequestHeaderMapImpl(const HeaderMap& rhs) : TestHeaderMapImpl(rhs) {}
+};
+class TestRequestTrailerMapImpl : public TestHeaderMapImpl, public RequestTrailerMap {
+public:
+  TestRequestTrailerMapImpl(
+      const std::initializer_list<std::pair<std::string, std::string>>& values)
+      : TestHeaderMapImpl(values) {}
+  TestRequestTrailerMapImpl(const HeaderMap& rhs) : TestHeaderMapImpl(rhs) {}
+};
+class TestResponseHeaderMapImpl : public TestHeaderMapImpl, public ResponseHeaderMap {
+public:
+  TestResponseHeaderMapImpl(
+      const std::initializer_list<std::pair<std::string, std::string>>& values)
+      : TestHeaderMapImpl(values) {}
+  TestResponseHeaderMapImpl() : TestHeaderMapImpl() {}
+};
+class TestResponseTrailerMapImpl : public TestHeaderMapImpl, public ResponseTrailerMap {
+public:
+  TestResponseTrailerMapImpl(
+      const std::initializer_list<std::pair<std::string, std::string>>& values)
+      : TestHeaderMapImpl(values) {}
+  TestResponseTrailerMapImpl() : TestHeaderMapImpl() {}
+};
+
 // Helper method to create a header map from an initializer list. Useful due to make_unique's
 // inability to infer the initializer list type.
-inline HeaderMapPtr
+template <class T>
+inline std::unique_ptr<T>
 makeHeaderMap(const std::initializer_list<std::pair<std::string, std::string>>& values) {
-  return std::make_unique<TestHeaderMapImpl,
-                          const std::initializer_list<std::pair<std::string, std::string>>&>(
+  return std::make_unique<T, const std::initializer_list<std::pair<std::string, std::string>>&>(
       values);
 }
 

--- a/test/test_runner.cc
+++ b/test/test_runner.cc
@@ -6,7 +6,6 @@
 #include "common/common/logger_delegates.h"
 #include "common/common/thread.h"
 #include "common/event/libevent.h"
-#include "common/http/http2/codec_impl.h"
 #include "common/runtime/runtime_features.h"
 
 #include "exe/process_wide.h"


### PR DESCRIPTION
This continues the refactor to used typed headers throughout
the code base. This change only implements the decoding path,
as encoding will require changing the HTTP filter interface.
This completes the minimum amount of changes that will allow
us to fix https://github.com/envoyproxy/envoy/issues/9873 in
a type safe and easy to understand way.

Risk Level: Medium (HTTP/1 codec changes, though good coverage)
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
