### PR TITLE
libevent: fix duplicate symbols on macOS

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -129,6 +129,14 @@ envoy_cmake_external(
     },
     lib_source = "@com_github_libevent_libevent//:all",
     static_libraries = select({
+        # OSX organization of libevent is different from Windows/Linux.
+        # Including libevent_core is a requirement on these platforms, but
+        # results in duplicate symbols when built on OSX.
+        # See https://github.com/lyft/envoy-mobile/issues/677 for details.
+        "//bazel:apple": [
+            "libevent.a",
+            "libevent_pthreads.a",
+        ],
         "//bazel:windows_x86_64": [
             "event.lib",
             "event_core.lib",
@@ -136,6 +144,7 @@ envoy_cmake_external(
         "//conditions:default": [
             "libevent.a",
             "libevent_pthreads.a",
+            "libevent_core.a",
         ],
     }),
 )

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -136,7 +136,6 @@ envoy_cmake_external(
         "//conditions:default": [
             "libevent.a",
             "libevent_pthreads.a",
-            "libevent_core.a",
         ],
     }),
 )

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -129,9 +129,9 @@ envoy_cmake_external(
     },
     lib_source = "@com_github_libevent_libevent//:all",
     static_libraries = select({
-        # OSX organization of libevent is different from Windows/Linux.
-        # Including libevent_core is a requirement on these platforms, but
-        # results in duplicate symbols when built on OSX.
+        # macOS organization of libevent is different from Windows/Linux.
+        # Including libevent_core is a requirement on those platforms, but
+        # results in duplicate symbols when built on macOS.
         # See https://github.com/lyft/envoy-mobile/issues/677 for details.
         "//bazel:apple": [
             "libevent.a",


### PR DESCRIPTION
We're seeing duplicate symbols in Envoy Mobile coming from `libevent`: https://github.com/lyft/envoy-mobile/issues/677.

A binary search (checking out different shas of Envoy and rebuilding, then searching for duplicate symbols in the dump) shows that this upstream PR caused the duplicated symbols to appear: https://github.com/envoyproxy/envoy/pull/9915, in particular [this commit](https://github.com/envoyproxy/envoy/pull/9915/commits/9dffdba4da45729aa3732d33494af8991a13ce22).

It appears that the `libevent_core.a` dependency is not needed for building, and was the source of the duplicate symbol. However, I'm not familiar with if/why this is necessary for win32, so maybe @wrowe can provide some context there.

Signed-off-by: Michael Rebello <me@michaelrebello.com>