### PR TITLE
tls: follow dns matching semantics in match subject alt names

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -288,15 +288,15 @@ message CertificateValidationContext {
 
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
-  // 
-  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be 
-  // configured with exact match type in the string matcher.For example if the certificate has 
+  //
+  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // configured with exact match type in the string matcher.For example if the certificate has
   // "*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
-  // 
+  //
   // .. code-block:: yaml
   //
-  // match_subject_alt_names: 
+  // match_subject_alt_names:
   //   exact: "app.example.com"
   //
   // .. attention::

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -290,8 +290,8 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
-  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`.
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com",
   // it should be configured as shown below.
   //
   // .. code-block:: yaml

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -289,8 +289,8 @@ message CertificateValidationContext {
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
-  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher.For example if the certificate has
+  // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
+  // configured with exact match type in the string matcher. For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
   //

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -288,6 +288,16 @@ message CertificateValidationContext {
 
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
+  // 
+  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be 
+  // configured with exact match type in the string matcher.For example if the certificate has 
+  // "*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
+  // as shown below.
+  // 
+  // .. code-block:: yaml
+  //
+  // match_subject_alt_names: 
+  //   exact: "app.example.com"
   //
   // .. attention::
   //

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -291,7 +291,7 @@ message CertificateValidationContext {
   //
   // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the string matcher.For example if the certificate has
-  // "*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
+  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
   //
   // .. code-block:: yaml

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -290,14 +290,14 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher. For example if the certificate has
-  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
-  // as shown below.
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // it should be configured as shown below.
   //
   // .. code-block:: yaml
   //
   // match_subject_alt_names:
-  //   exact: "app.example.com"
+  //   exact: "api.example.com"
   //
   // .. attention::
   //

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -296,7 +296,7 @@ message CertificateValidationContext {
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
-  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the string matcher.For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -297,8 +297,8 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`. 
-  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`.
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com",
   // it should be configured as shown below.
   //
   // .. code-block:: yaml

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -295,6 +295,16 @@ message CertificateValidationContext {
 
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
+  // 
+  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be 
+  // configured with exact match type in the string matcher.For example if the certificate has 
+  // "*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
+  // as shown below.
+  // 
+  // .. code-block:: yaml
+  //
+  // match_subject_alt_names: 
+  //   exact: "app.example.com"
   //
   // .. attention::
   //

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -297,14 +297,14 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher. For example if the certificate has
-  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
-  // as shown below.
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // it should be configured as shown below.
   //
   // .. code-block:: yaml
   //
   // match_subject_alt_names:
-  //   exact: "app.example.com"
+  //   exact: "api.example.com"
   //
   // .. attention::
   //

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -295,15 +295,15 @@ message CertificateValidationContext {
 
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
-  // 
-  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be 
-  // configured with exact match type in the string matcher.For example if the certificate has 
+  //
+  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // configured with exact match type in the string matcher.For example if the certificate has
   // "*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
-  // 
+  //
   // .. code-block:: yaml
   //
-  // match_subject_alt_names: 
+  // match_subject_alt_names:
   //   exact: "app.example.com"
   //
   // .. attention::

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -297,7 +297,7 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`. 
   // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
   // it should be configured as shown below.
   //

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -298,7 +298,7 @@ message CertificateValidationContext {
   //
   // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the string matcher.For example if the certificate has
-  // "*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
+  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
   //
   // .. code-block:: yaml

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -297,7 +297,7 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher.For example if the certificate has
+  // configured with exact match type in the string matcher. For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
   //

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -290,8 +290,8 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
-  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`.
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com",
   // it should be configured as shown below.
   //
   // .. code-block:: yaml

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -290,14 +290,14 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher. For example if the certificate has
-  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
-  // as shown below.
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // it should be configured as shown below.
   //
   // .. code-block:: yaml
   //
   // match_subject_alt_names:
-  //   exact: "app.example.com"
+  //   exact: "api.example.com"
   //
   // .. attention::
   //

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -289,7 +289,7 @@ message CertificateValidationContext {
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
-  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the string matcher.For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -290,7 +290,7 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher.For example if the certificate has
+  // configured with exact match type in the string matcher. For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
   //

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -289,6 +289,16 @@ message CertificateValidationContext {
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
+  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // configured with exact match type in the string matcher.For example if the certificate has
+  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
+  // as shown below.
+  //
+  // .. code-block:: yaml
+  //
+  // match_subject_alt_names:
+  //   exact: "app.example.com"
+  //
   // .. attention::
   //
   //   Subject Alternative Names are easily spoofable and verifying only them is insecure,

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -302,14 +302,14 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher. For example if the certificate has
-  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
-  // as shown below.
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // it should be configured as shown below.
   //
   // .. code-block:: yaml
   //
   // match_subject_alt_names:
-  //   exact: "app.example.com"
+  //   exact: "api.example.com"
   //
   // .. attention::
   //

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -301,6 +301,16 @@ message CertificateValidationContext {
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
+  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // configured with exact match type in the string matcher.For example if the certificate has
+  // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
+  // as shown below.
+  //
+  // .. code-block:: yaml
+  //
+  // match_subject_alt_names:
+  //   exact: "app.example.com"
+  //
   // .. attention::
   //
   //   Subject Alternative Names are easily spoofable and verifying only them is insecure,

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -302,7 +302,7 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the string matcher.For example if the certificate has
+  // configured with exact match type in the string matcher. For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.
   //

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -302,8 +302,8 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`. 
-  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`.
+  // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com",
   // it should be configured as shown below.
   //
   // .. code-block:: yaml

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -302,7 +302,7 @@ message CertificateValidationContext {
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
-  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>`. 
+  // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`. 
   // For example if the certificate has "\*.example.com" as DNS SAN entry, to allow only "api.example.com", 
   // it should be configured as shown below.
   //

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -301,7 +301,7 @@ message CertificateValidationContext {
   // An optional list of Subject Alternative name matchers. Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified matches.
   //
-  // When a certificatee has wildcard DNS SAN entries, to match a specific client, it should be
+  // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the string matcher.For example if the certificate has
   // "\*.example.com" as DNS service entry, to allow only "api.example.com", it should be configured
   // as shown below.

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -79,6 +79,8 @@ public:
   bool match(const absl::string_view value) const override;
   bool match(const ProtobufWkt::Value& value) const override;
 
+  const envoy::type::matcher::v3::StringMatcher& matcher() const { return matcher_; }
+
 private:
   const envoy::type::matcher::v3::StringMatcher matcher_;
   Regex::CompiledMatcherPtr regex_;

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -690,7 +690,11 @@ bool ContextImpl::matchSubjectAltName(
   for (const GENERAL_NAME* general_name : san_names.get()) {
     const std::string san = generalNameAsString(general_name);
     for (auto& config_san_matcher : subject_alt_name_matchers) {
-      if (config_san_matcher.match(san)) {
+      if (general_name->type == GEN_DNS &&
+                  config_san_matcher.matcher().match_pattern_case() ==
+                      envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact
+              ? dnsNameMatch(config_san_matcher.matcher().exact(), san.c_str())
+              : config_san_matcher.match(san)) {
         return true;
       }
     }

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -690,6 +690,7 @@ bool ContextImpl::matchSubjectAltName(
   for (const GENERAL_NAME* general_name : san_names.get()) {
     const std::string san = generalNameAsString(general_name);
     for (auto& config_san_matcher : subject_alt_name_matchers) {
+      // For DNS SAN, if it exact, we have to follow DNS matching semantics.
       if (general_name->type == GEN_DNS &&
                   config_san_matcher.matcher().match_pattern_case() ==
                       envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -690,7 +690,7 @@ bool ContextImpl::matchSubjectAltName(
   for (const GENERAL_NAME* general_name : san_names.get()) {
     const std::string san = generalNameAsString(general_name);
     for (auto& config_san_matcher : subject_alt_name_matchers) {
-      // For DNS SAN, if it exact, we have to follow DNS matching semantics.
+      // For DNS SAN, if the StringMatcher type is exact, we have to follow DNS matching semantics.
       if (general_name->type == GEN_DNS &&
                   config_san_matcher.matcher().match_pattern_case() ==
                       envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -358,7 +358,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+  Http::TestHeaderMapImpl header{{"x-header-name-1", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
                                          default_remote_address_);

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -358,7 +358,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name-1", "test_value"}};
+  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
                                          default_remote_address_);

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -75,6 +75,17 @@ TEST_F(SslContextImplTest, TestMatchSubjectAltNameDNSMatched) {
   EXPECT_TRUE(ContextImpl::matchSubjectAltName(cert.get(), subject_alt_name_matchers));
 }
 
+TEST_F(SslContextImplTest, TestMatchSubjectAltNameWildcardDNSMatched) {
+  bssl::UniquePtr<X509> cert = readCertFromFile(TestEnvironment::substitute(
+      "{{ test_rundir "
+      "}}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_cert.pem"));
+  envoy::type::matcher::v3::StringMatcher matcher;
+  matcher.set_exact("api.example.com");
+  std::vector<Matchers::StringMatcherImpl> subject_alt_name_matchers;
+  subject_alt_name_matchers.push_back(Matchers::StringMatcherImpl(matcher));
+  EXPECT_TRUE(ContextImpl::matchSubjectAltName(cert.get(), subject_alt_name_matchers));
+}
+
 TEST_F(SslContextImplTest, TestVerifySubjectAltNameURIMatched) {
   bssl::UniquePtr<X509> cert = readCertFromFile(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"));


### PR DESCRIPTION
For match subject alt names, for exact match cases, follow dns matching semantics which allows wild card processing.
Risk Level: Low
Testing: Added
Docs Changes: N/A
Release Notes: N/A

