### PR TITLE
test: Plumb the flaky flag from envoy_cc_test to the native.cc_test

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -159,7 +159,8 @@ def envoy_cc_test(
         shard_count = None,
         coverage = True,
         local = False,
-        size = "medium"):
+        size = "medium",
+        flaky = False):
     if coverage:
         coverage_tags = tags + ["coverage_test_lib"]
     else:
@@ -195,6 +196,7 @@ def envoy_cc_test(
         local = local,
         shard_count = shard_count,
         size = size,
+        flaky = flaky,
     )
 
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified


### PR DESCRIPTION
This flag allows test to temporarily be marked flaky while test flakiness is being diagnosed and fixed, to reduce the likelihood of CI failing.

See https://docs.bazel.build/versions/2.0.0/be/common-definitions.html#common-attributes-tests for more info about the `flaky` flag.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
