### PR TITLE
assertions: add new class of known issue assertions

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -212,8 +212,8 @@ config_setting(
 )
 
 config_setting(
-    name = "debug_known_issues",
-    values = {"define": "known_issues=debug"},
+    name = "include_known_issue_asserts",
+    values = {"define": "include_known_issue_asserts=true"},
 )
 
 config_setting(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -212,8 +212,8 @@ config_setting(
 )
 
 config_setting(
-    name = "include_known_issue_asserts",
-    values = {"define": "include_known_issue_asserts=true"},
+    name = "disable_known_issue_asserts",
+    values = {"define": "disable_known_issue_asserts=true"},
 )
 
 config_setting(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -212,6 +212,11 @@ config_setting(
 )
 
 config_setting(
+    name = "debug_known_issues",
+    values = {"define": "known_issues=debug"},
+)
+
+config_setting(
     name = "enable_perf_annotation",
     values = {"define": "perf_annotation=enabled"},
 )

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -449,6 +449,8 @@ The following optional features can be enabled on the Bazel build command-line:
   Otherwise, the linker will fail to resolve symbols that are included via the `linktamp` rule, which is only available to binary targets.
   This is being tracked as a feature in: https://github.com/envoyproxy/envoy/issues/6859.
 * Process logging for Android applications can be enabled with `--define logger=android`.
+* Debugging known issues with `--include_known_issue_asserts=true`.
+  A KNOWN_ISSUE_ASSERT is an assertion that should pass (like all assertions), but sometimes fails for some as-yet unidentified or unresolved reason. Because it is known to potentially fail, it will be compiled out even when DEBUG is true, unless this flag is set. This allows Envoy to be run in production with assertions generally enabled, without crashing for known issues. KNOWN_ISSUE_ASSERT should only be used for newly-discovered issues that represent benign violations of expectations.
 
 ## Disabling extensions
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -449,7 +449,7 @@ The following optional features can be enabled on the Bazel build command-line:
   Otherwise, the linker will fail to resolve symbols that are included via the `linktamp` rule, which is only available to binary targets.
   This is being tracked as a feature in: https://github.com/envoyproxy/envoy/issues/6859.
 * Process logging for Android applications can be enabled with `--define logger=android`.
-* Debugging known issues with `--include_known_issue_asserts=true`.
+* Debugging known issues with `--define include_known_issue_asserts=true`.
   A KNOWN_ISSUE_ASSERT is an assertion that should pass (like all assertions), but sometimes fails for some as-yet unidentified or unresolved reason. Because it is known to potentially fail, it will be compiled out even when DEBUG is true, unless this flag is set. This allows Envoy to be run in production with assertions generally enabled, without crashing for known issues. KNOWN_ISSUE_ASSERT should only be used for newly-discovered issues that represent benign violations of expectations.
 
 ## Disabling extensions

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -449,8 +449,8 @@ The following optional features can be enabled on the Bazel build command-line:
   Otherwise, the linker will fail to resolve symbols that are included via the `linktamp` rule, which is only available to binary targets.
   This is being tracked as a feature in: https://github.com/envoyproxy/envoy/issues/6859.
 * Process logging for Android applications can be enabled with `--define logger=android`.
-* Debugging known issues with `--define include_known_issue_asserts=true`.
-  A KNOWN_ISSUE_ASSERT is an assertion that should pass (like all assertions), but sometimes fails for some as-yet unidentified or unresolved reason. Because it is known to potentially fail, it will be compiled out even when DEBUG is true, unless this flag is set. This allows Envoy to be run in production with assertions generally enabled, without crashing for known issues. KNOWN_ISSUE_ASSERT should only be used for newly-discovered issues that represent benign violations of expectations.
+* Debugging known issues with `--define disable_known_issue_asserts=true`.
+  A KNOWN_ISSUE_ASSERT is an assertion that should pass (like all assertions), but sometimes fails for some as-yet unidentified or unresolved reason. Because it is known to potentially fail, it can be compiled out even when DEBUG is true, when this flag is set. This allows Envoy to be run in production with assertions generally enabled, without crashing for known issues. KNOWN_ISSUE_ASSERT should only be used for newly-discovered issues that represent benign violations of expectations.
 
 ## Disabling extensions
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -449,7 +449,7 @@ The following optional features can be enabled on the Bazel build command-line:
   Otherwise, the linker will fail to resolve symbols that are included via the `linktamp` rule, which is only available to binary targets.
   This is being tracked as a feature in: https://github.com/envoyproxy/envoy/issues/6859.
 * Process logging for Android applications can be enabled with `--define logger=android`.
-* Debugging known issues with `--define disable_known_issue_asserts=true`.
+* Excluding assertions for known issues with `--define disable_known_issue_asserts=true`.
   A KNOWN_ISSUE_ASSERT is an assertion that should pass (like all assertions), but sometimes fails for some as-yet unidentified or unresolved reason. Because it is known to potentially fail, it can be compiled out even when DEBUG is true, when this flag is set. This allows Envoy to be run in production with assertions generally enabled, without crashing for known issues. KNOWN_ISSUE_ASSERT should only be used for newly-discovered issues that represent benign violations of expectations.
 
 ## Disabling extensions

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -69,6 +69,9 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
                "//conditions:default": [],
            }) + select({
+               repository + "//bazel:debug_known_issues": ["-DENVOY_DEBUG_KNOWN_ISSUES=1"],
+               "//conditions:default": [],
+            }) + select({
                # APPLE_USE_RFC_3542 is needed to support IPV6_PKTINFO in MAC OS.
                repository + "//bazel:apple": ["-D__APPLE_USE_RFC_3542"],
                "//conditions:default": [],

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -71,7 +71,7 @@ def envoy_copts(repository, test = False):
            }) + select({
                repository + "//bazel:disable_known_issue_asserts": ["-DENVOY_DISABLE_KNOWN_ISSUE_ASSERTS"],
                "//conditions:default": [],
-            }) + select({
+           }) + select({
                # APPLE_USE_RFC_3542 is needed to support IPV6_PKTINFO in MAC OS.
                repository + "//bazel:apple": ["-D__APPLE_USE_RFC_3542"],
                "//conditions:default": [],

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -69,7 +69,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
                "//conditions:default": [],
            }) + select({
-               repository + "//bazel:debug_known_issues": ["-DENVOY_DEBUG_KNOWN_ISSUES=1"],
+               repository + "//bazel:include_known_issue_asserts": ["-DENVOY_DEBUG_KNOWN_ISSUES=1"],
                "//conditions:default": [],
             }) + select({
                # APPLE_USE_RFC_3542 is needed to support IPV6_PKTINFO in MAC OS.

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -69,7 +69,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
                "//conditions:default": [],
            }) + select({
-               repository + "//bazel:include_known_issue_asserts": ["-DENVOY_DEBUG_KNOWN_ISSUES=1"],
+               repository + "//bazel:disable_known_issue_asserts": ["-DENVOY_DISABLE_KNOWN_ISSUE_ASSERTS"],
                "//conditions:default": [],
             }) + select({
                # APPLE_USE_RFC_3542 is needed to support IPV6_PKTINFO in MAC OS.

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -74,6 +74,24 @@ void invokeDebugAssertionFailureRecordAction_ForAssertMacroUseOnly();
  */
 #define SECURITY_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort(), DETAILS)
 
+#if defined(ENVOY_DEBUG_KNOWN_ISSUES)
+/**
+ * Assert macro for an as-yet unidentified issue. Even with ASSERTS compiled in, it will be
+ * excluded, unless ENVOY_DEBUG_KNOWN_ISSUES is defined. It represents a condition that
+ * should always pass but that sometimes fails for an unknown reason. The macro allows it to
+ * be temporarily compiled out while the failure is triaged and investigated.
+ */
+#define KNOWN_ISSUE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort() DETAILS)
+#else
+// This non-implementation ensures that its argument is a valid expression that can be statically
+// casted to a bool, but the expression is never evaluated and will be compiled away.
+#define KNOWN_ISSUE_ASSERT(X, ...)                                                                 \
+  do {                                                                                             \
+    constexpr bool __assert_dummy_variable = false && static_cast<bool>(X);                        \
+    (void)__assert_dummy_variable;                                                                 \
+  } while (false)
+#endif // defined(ENVOY_DEBUG_KNOWN_ISSUES)
+
 #if !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
 
 #if !defined(NDEBUG) // If this is a debug build.

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -99,7 +99,7 @@ void invokeDebugAssertionFailureRecordAction_ForAssertMacroUseOnly();
     (void)__assert_dummy_variable;                                                                 \
   } while (false)
 
-#if defined(ENVOY_DEBUG_KNOWN_ISSUES)
+#if !defined(ENVOY_DISABLE_KNOWN_ISSUE_ASSERTS)
 /**
  * Assert wrapper for an as-yet unidentified issue. Even with ASSERTS compiled in, it will be
  * excluded, unless ENVOY_DEBUG_KNOWN_ISSUES is defined. It represents a condition that

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -106,7 +106,7 @@ void invokeDebugAssertionFailureRecordAction_ForAssertMacroUseOnly();
  * should always pass but that sometimes fails for an unknown reason. The macro allows it to
  * be temporarily compiled out while the failure is triaged and investigated.
  */
-#define KNOWN_ISSUE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort() DETAILS)
+#define KNOWN_ISSUE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort(), DETAILS)
 #else
 // This non-implementation ensures that its argument is a valid expression that can be statically
 // casted to a bool, but the expression is never evaluated and will be compiled away.

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -101,8 +101,8 @@ void invokeDebugAssertionFailureRecordAction_ForAssertMacroUseOnly();
 
 #if !defined(ENVOY_DISABLE_KNOWN_ISSUE_ASSERTS)
 /**
- * Assert wrapper for an as-yet unidentified issue. Even with ASSERTS compiled in, it will be
- * excluded, unless ENVOY_DEBUG_KNOWN_ISSUES is defined. It represents a condition that
+ * Assert wrapper for an as-yet unidentified issue. Even with ASSERTs compiled in, it may be
+ * excluded, by defining ENVOY_DISABLE_KNOWN_ISSUE_ASSERTS. It represents a condition that
  * should always pass but that sometimes fails for an unknown reason. The macro allows it to
  * be temporarily compiled out while the failure is triaged and investigated.
  */

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -15,7 +15,7 @@ namespace Tls {
 
 ContextManagerImpl::~ContextManagerImpl() {
   removeEmptyContexts();
-  ASSERT(contexts_.empty());
+  KNOWN_ISSUE_ASSERT(contexts_.empty(), "issue https://github.com/envoyproxy/envoy/issues/10030");
 }
 
 void ContextManagerImpl::removeEmptyContexts() {

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -15,7 +15,7 @@ namespace Tls {
 
 ContextManagerImpl::~ContextManagerImpl() {
   removeEmptyContexts();
-  KNOWN_ISSUE_ASSERT(contexts_.empty(), "issue https://github.com/envoyproxy/envoy/issues/10030");
+  KNOWN_ISSUE_ASSERT(contexts_.empty(), "https://github.com/envoyproxy/envoy/issues/10030");
 }
 
 void ContextManagerImpl::removeEmptyContexts() {

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1086,6 +1086,7 @@ transcoded
 transcoder
 transcoding
 transferral
+triaged
 trie
 tuple
 tuples


### PR DESCRIPTION
Description: Adds a new class of assertions, KNOWN_ISSUE_ASSERT, that may be compiled out even when other assertions are compiled in. The intent is to allow assertions to generally be compiled into releases, but to exclude instances that are known to fail for as-yet unknown or unresolved reasons. When the issue has been triaged and resolved, a KNOWN_ISSUE_ASSERT should generally become a regular ASSERT or RELEASE_ASSERT again.
Risk Level: Moderate
Testing: Built and ran locally with various combinations of build flags.

Signed-off-by: Mike Schore mike.schore@gmail.com