### PR TITLE
[release/v1.12] string matcher: add ignore_case to StringMatcher (#9868)

### DIFF
--- a/api/envoy/type/matcher/string.proto
+++ b/api/envoy/type/matcher/string.proto
@@ -13,7 +13,7 @@ import "validate/validate.proto";
 // [#protodoc-title: StringMatcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message StringMatcher {
   oneof match_pattern {
     option (validate.required) = true;
@@ -59,6 +59,11 @@ message StringMatcher {
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
   }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
 }
 
 // Specifies a list of ways to match a string.

--- a/api/envoy/type/matcher/v3alpha/string.proto
+++ b/api/envoy/type/matcher/v3alpha/string.proto
@@ -13,7 +13,7 @@ import "validate/validate.proto";
 // [#protodoc-title: StringMatcher]
 
 // Specifies the way to match a string.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message StringMatcher {
   reserved 4;
 
@@ -48,6 +48,11 @@ message StringMatcher {
     // The input string must match the regular expression specified here.
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
   }
+
+  // If true, indicates the exact/prefix/suffix matching should be case insensitive. This has no
+  // effect for the safe_regex match.
+  // For example, the matcher *data* will match both input string *Data* and *data* if set to true.
+  bool ignore_case = 6;
 }
 
 // Specifies a list of ways to match a string.

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -60,8 +60,14 @@ bool DoubleMatcher::match(const ProtobufWkt::Value& value) const {
 StringMatcherImpl::StringMatcherImpl(const envoy::type::matcher::StringMatcher& matcher)
     : matcher_(matcher) {
   if (matcher.match_pattern_case() == envoy::type::matcher::StringMatcher::kRegex) {
+    if (matcher.ignore_case()) {
+      throw EnvoyException("ignore_case has no effect for regex.");
+    }
     regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher(matcher_.regex());
   } else if (matcher.match_pattern_case() == envoy::type::matcher::StringMatcher::kSafeRegex) {
+    if (matcher.ignore_case()) {
+      throw EnvoyException("ignore_case has no effect for safe_regex.");
+    }
     regex_ = Regex::Utility::parseRegex(matcher_.safe_regex());
   }
 }
@@ -77,11 +83,14 @@ bool StringMatcherImpl::match(const ProtobufWkt::Value& value) const {
 bool StringMatcherImpl::match(const absl::string_view value) const {
   switch (matcher_.match_pattern_case()) {
   case envoy::type::matcher::StringMatcher::kExact:
-    return matcher_.exact() == value;
+    return matcher_.ignore_case() ? absl::EqualsIgnoreCase(value, matcher_.exact())
+                                  : value == matcher_.exact();
   case envoy::type::matcher::StringMatcher::kPrefix:
-    return absl::StartsWith(value, matcher_.prefix());
+    return matcher_.ignore_case() ? absl::StartsWithIgnoreCase(value, matcher_.prefix())
+                                  : absl::StartsWith(value, matcher_.prefix());
   case envoy::type::matcher::StringMatcher::kSuffix:
-    return absl::EndsWith(value, matcher_.suffix());
+    return matcher_.ignore_case() ? absl::EndsWithIgnoreCase(value, matcher_.suffix())
+                                  : absl::EndsWith(value, matcher_.suffix());
   case envoy::type::matcher::StringMatcher::kRegex:
   case envoy::type::matcher::StringMatcher::kSafeRegex:
     return regex_->match(value);

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -113,6 +113,7 @@ envoy_cc_test(
         "//source/common/common:matchers_lib",
         "//source/common/config:metadata_lib",
         "//source/common/protobuf:utility_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
         "@envoy_api//envoy/type/matcher:pkg_cc_proto",
     ],


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: cherry-pick https://github.com/envoyproxy/envoy/pull/9868 to 1.12
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
