### PR TITLE
docs: Clarify meaning of per_try_timeout.

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -242,7 +242,8 @@ Setting this header on egress requests will cause Envoy to set a *per try* timeo
 requests. This timeout must be <= the global route timeout (see
 :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`) or it is ignored. This allows a
 caller to set a tight per try timeout to allow for retries while maintaining a reasonable overall
-timeout.
+timeout. This timeout only applies before any part of the response is sent to the downstream,
+which normally happens after the upstream has sent response headers.
 
 x-envoy-hedge-on-per-try-timeout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/root/faq/configuration/timeouts.rst
+++ b/docs/root/faq/configuration/timeouts.rst
@@ -75,9 +75,8 @@ stream timeouts already introduced above.
   and does the same thing.
 * The route :ref:`per_try_timeout <envoy_api_field_route.RetryPolicy.per_try_timeout>` can be
   configured when using retries so that individual tries using a shorter timeout than the overall
-  request timeout described above. This type of timeout will not work with streaming APIs (in which
-  retries are typically not possible) but is useful for decreasing the tail latency of non-streaming
-  APIs.
+  request timeout described above. This timeout only applies before any part of the response
+  is sent to the downstream, which normally happens after the upstream has sent response headers.
 
 TCP
 ---


### PR DESCRIPTION
Clarify that this timeout only applies before the response to downstream
begins, and thus it works fine for streaming APIs.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

Risk Level: Low
Testing: doc-only change
