### PR TITLE
docs: typo fixes in grpc-json transcoder example

### DIFF
--- a/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
@@ -121,9 +121,9 @@ gRPC or RESTful JSON requests to localhost:51051.
                 - match: { prefix: "/helloworld.Greeter" }
                   route: { cluster: grpc, timeout: { seconds: 60 } }
             http_filters:
-            - name: envoy.
-              "@type": type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder
+            - name: envoy.grpc_json_transcoder
               typed_config:
+                "@type": type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder
                 proto_descriptor: "/tmp/envoy/proto.pb"
                 services: ["helloworld.Greeter"]
                 print_options:


### PR DESCRIPTION
Description: Correct the name of the http filter and move the config type annotation to the correct place.
Risk Level: Low
Testing: N/A
Docs Changes: See Description
Release Notes: N/A