### PR TITLE
network filters: use new style names

### DIFF
--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -236,7 +236,7 @@ message RedisProxy {
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in
 // :ref:`typed_extension_protocol_options<envoy_api_field_Cluster.typed_extension_protocol_options>`,
-// keyed by the name `envoy.redis_proxy`.
+// keyed by the name `envoy.filters.network.redis_proxy`.
 message RedisProtocolOptions {
   // Upstream server password as defined by the `requirepass` directive
   // <https://redis.io/topics/config>`_ in the server's configuration file.

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -237,7 +237,7 @@ message RedisProxy {
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in
 // :ref:`typed_extension_protocol_options<envoy_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`,
-// keyed by the name `envoy.redis_proxy`.
+// keyed by the name `envoy.filters.network.redis_proxy`.
 message RedisProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions";

--- a/configs/envoy_double_proxy_v2.template.yaml
+++ b/configs/envoy_double_proxy_v2.template.yaml
@@ -27,7 +27,7 @@
     use_proxy_proto: true
     {%endif -%}
     filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         codec_type: AUTO

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -33,7 +33,7 @@
     {%endif%}
   {%endif %}
     filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         codec_type: AUTO

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -9,7 +9,7 @@
   traffic_direction: INBOUND
   filter_chains:
   - filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         codec_type: AUTO
@@ -109,7 +109,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: AUTO
@@ -175,7 +175,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: AUTO
@@ -237,7 +237,7 @@ static_resources:
         port_value: 9901
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: AUTO
@@ -313,18 +313,18 @@ static_resources:
         port_value: 9003
     filter_chains:
     - filters:
-      - name: envoy.tcp_proxy
+      - name: envoy.filters.network.tcp_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           stat_prefix: mongo_{{ key }}
           cluster: mongo_{{ key }}
-      - name: envoy.mongo_proxy
+      - name: envoy.filters.network.mongo_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.mongo_proxy.v2.MongoProxy
           stat_prefix: "{{ key }}"
           access_log: "/var/log/envoy/mongo_{{ key }}.log"
       {% if value.get('ratelimit', False) %}
-      - name: envoy.ratelimit
+      - name: envoy.filters.network.ratelimit
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.ratelimit.v3.RateLimit
           stat_prefix: "{{ key }}"

--- a/configs/freebind/freebind.yaml
+++ b/configs/freebind/freebind.yaml
@@ -15,7 +15,7 @@ static_resources:
     freebind: true
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -15,7 +15,7 @@ static_resources:
         port_value: 10000
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/configs/original-dst-cluster/proxy_config.yaml
+++ b/configs/original-dst-cluster/proxy_config.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 10000
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/configs/using_deprecated_config.v2.yaml
+++ b/configs/using_deprecated_config.v2.yaml
@@ -15,7 +15,7 @@ static_resources:
         port_value: 10000
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/docs/root/configuration/best_practices/edge.rst
+++ b/docs/root/configuration/best_practices/edge.rst
@@ -76,7 +76,7 @@ The following is a YAML example of the above recommendation.
         # Uncomment if Envoy is behind a load balancer that exposes client IP address using the PROXY protocol.
         # use_proxy_proto: true
         filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: ingress_http

--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -51,7 +51,7 @@ host when forwarding. See the example below within the configured routes.
           port_value: 10000
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: ingress_http

--- a/docs/root/configuration/http/http_filters/grpc_http1_reverse_bridge_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_http1_reverse_bridge_filter.rst
@@ -59,7 +59,7 @@ How to disable HTTP/1.1 reverse bridge filter per route
           port_value: 80
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             access_log:

--- a/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
@@ -105,7 +105,7 @@ gRPC or RESTful JSON requests to localhost:51051.
         socket_address: { address: 0.0.0.0, port_value: 51051 }
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: grpc_json

--- a/docs/root/configuration/listeners/network_filters/client_ssl_auth_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/client_ssl_auth_filter.rst
@@ -5,7 +5,7 @@ Client TLS authentication
 
 * Client TLS authentication filter :ref:`architecture overview <arch_overview_ssl_auth_filter>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.client_ssl_auth.v2.ClientSslAuth>`
-* This filter should be configured with the name *envoy.client_ssl_auth*.
+* This filter should be configured with the name *envoy.filters.network.client_ssl_auth*.
 
 .. _config_network_filters_client_ssl_auth_stats:
 

--- a/docs/root/configuration/listeners/network_filters/echo_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/echo_filter.rst
@@ -5,6 +5,6 @@ Echo
 
 The echo is a trivial network filter mainly meant to demonstrate the network filter API. If
 installed it will echo (write) all received data back to the connected downstream client. 
-This filter should be configured with the name *envoy.echo*.
+This filter should be configured with the name *envoy.filters.network.echo*.
 
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`

--- a/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
@@ -5,7 +5,7 @@ External Authorization
 
 * External authorization :ref:`architecture overview <arch_overview_ext_authz>`
 * :ref:`Network filter v2 API reference <envoy_api_msg_config.filter.network.ext_authz.v2.ExtAuthz>`
-* This filter should be configured with the name *envoy.ext_authz*.
+* This filter should be configured with the name *envoy.filters.network.ext_authz*.
 
 The external authorization network filter calls an external authorization service to check if the
 incoming request is authorized or not. If the request is deemed unauthorized by the network filter
@@ -31,7 +31,7 @@ A sample filter configuration could be:
 .. code-block:: yaml
 
   filters:
-    - name: envoy.ext_authz
+    - name: envoy.filters.network.ext_authz
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthz
         stat_prefix: ext_authz

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -40,7 +40,7 @@ in the configuration snippet below:
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.kafka_broker.v2alpha1.KafkaBroker
           stat_prefix: exampleprefix
-      - name: envoy.tcp_proxy
+      - name: envoy.filters.network.tcp_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           stat_prefix: tcp

--- a/docs/root/configuration/listeners/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/mongo_proxy_filter.rst
@@ -5,7 +5,7 @@ Mongo proxy
 
 * MongoDB :ref:`architecture overview <arch_overview_mongo>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.mongo_proxy.v2.MongoProxy>`
-* This filter should be configured with the name *envoy.mongo_proxy*.
+* This filter should be configured with the name *envoy.filters.network.mongo_proxy*.
 
 .. _config_network_filters_mongo_proxy_fault_injection:
 

--- a/docs/root/configuration/listeners/network_filters/mysql_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/mysql_proxy_filter.rst
@@ -36,7 +36,7 @@ in the configuration snippet below:
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.mysql_proxy.v1alpha1.MySQLProxy
         stat_prefix: mysql
-    - name: envoy.tcp_proxy
+    - name: envoy.filters.network.tcp_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
         stat_prefix: tcp
@@ -118,7 +118,7 @@ _catalog_ table in the _productdb_ database.
                           exact: update
               principals:
               - any: true
-    - name: envoy.tcp_proxy
+    - name: envoy.filters.network.tcp_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
         stat_prefix: tcp

--- a/docs/root/configuration/listeners/network_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/rate_limit_filter.rst
@@ -5,7 +5,7 @@ Rate limit
 
 * Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.rate_limit.v2.RateLimit>`
-* This filter should be configured with the name *envoy.ratelimit*.
+* This filter should be configured with the name *envoy.filters.network.ratelimit*.
 
 .. note::
   Local rate limiting is also supported via the :ref:`local rate limit filter

--- a/docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
@@ -5,7 +5,7 @@ Redis proxy
 
 * Redis :ref:`architecture overview <arch_overview_redis>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.redis_proxy.v2.RedisProxy>`
-* This filter should be configured with the name *envoy.redis_proxy*.
+* This filter should be configured with the name *envoy.filters.network.redis_proxy*.
 
 .. _config_network_filters_redis_proxy_stats:
 

--- a/docs/root/configuration/listeners/network_filters/tcp_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/tcp_proxy_filter.rst
@@ -5,7 +5,7 @@ TCP proxy
 
 * TCP proxy :ref:`architecture overview <arch_overview_tcp_proxy>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.tcp_proxy.v2.TcpProxy>`
-* This filter should be configured with the name *envoy.tcp_proxy*.
+* This filter should be configured with the name *envoy.filters.network.tcp_proxy*.
 
 .. _config_network_filters_tcp_proxy_dynamic_cluster:
 

--- a/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
@@ -31,7 +31,7 @@ in the configuration snippet below:
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.zookeeper_proxy.v1alpha1.ZooKeeperProxy
         stat_prefix: zookeeper
-    - name: envoy.tcp_proxy
+    - name: envoy.filters.network.tcp_proxy
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
         stat_prefix: tcp

--- a/docs/root/configuration/overview/examples.rst
+++ b/docs/root/configuration/overview/examples.rst
@@ -23,7 +23,7 @@ A minimal fully static bootstrap config is provided below:
         socket_address: { address: 127.0.0.1, port_value: 10000 }
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: ingress_http
@@ -75,7 +75,7 @@ on 127.0.0.1:5678 is provided below:
         socket_address: { address: 127.0.0.1, port_value: 10000 }
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: ingress_http
@@ -215,7 +215,7 @@ The management server could respond to LDS requests with:
         port_value: 10000
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/docs/root/faq/configuration/flow_control.rst
+++ b/docs/root/faq/configuration/flow_control.rst
@@ -46,7 +46,7 @@ the only one which needs to be amended is the listener
           portValue: 0
       filterChains:
         filters:
-          name: envoy.http_connection_manager
+          name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             http2_protocol_options:

--- a/docs/root/faq/configuration/sni.rst
+++ b/docs/root/faq/configuration/sni.rst
@@ -32,7 +32,7 @@ The following is a YAML example of the above requirement.
           - certificate_chain: { filename: "example_com_cert.pem" }
             private_key: { filename: "example_com_key.pem" }
     filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         stat_prefix: ingress_http
@@ -54,7 +54,7 @@ The following is a YAML example of the above requirement.
           - certificate_chain: { filename: "api_example_com_cert.pem" }
             private_key: { filename: "api_example_com_key.pem" }
     filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         stat_prefix: ingress_http

--- a/docs/root/intro/arch_overview/security/ssl.rst
+++ b/docs/root/intro/arch_overview/security/ssl.rst
@@ -78,7 +78,7 @@ Example configuration
       address: { socket_address: { address: 127.0.0.1, port_value: 10000 } }
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           # ...
         transport_socket:
           name: envoy.transport_sockets.tls

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -15,8 +15,8 @@ Deprecated items below are listed in chronological order.
 * The previous behavior for upstream connection pool circuit breaking described
   `here <https://www.envoyproxy.io/docs/envoy/v1.13.0/intro/arch_overview/upstream/circuit_breaking>`_ has
   been deprecated in favor of the new behavior described :ref:`here <arch_overview_circuit_break>`.
-* Access Logger, Stats Sink, and Tracer names have been deprecated in favor of the extension name
-  from the envoy build system.
+* Access Logger, Network Filter, Stats Sink, and Tracer names have been deprecated in favor of the
+  extension name from the envoy build system.
 
   .. csv-table::
     :header: Canonical Names, Deprecated Names
@@ -25,6 +25,14 @@ Deprecated items below are listed in chronological order.
     envoy.access_loggers.file, envoy.file_access_log
     envoy.access_loggers.http_grpc, envoy.http_grpc_access_log
     envoy.access_loggers.tcp_grpc, envoy.tcp_grpc_access_log
+    envoy.filters.network.client_ssl_auth, envoy.client_ssl_auth
+    envoy.filters.network.echo, envoy.echo
+    envoy.filters.network.ext_authz, envoy.ext_authz
+    envoy.filters.network.http_connection_manager, envoy.http_connection_manager
+    envoy.filters.network.mongo_proxy, envoy.mongo_proxy
+    envoy.filters.network.ratelimit, envoy.ratelimit
+    envoy.filters.network.redis_proxy, envoy.redis_proxy
+    envoy.filters.network.tcp_proxy, envoy.tcp_proxy
     envoy.stat_sinks.dog_statsd, envoy.dog_statsd
     envoy.stat_sinks.metrics_service, envoy.metrics_service
     envoy.stat_sinks.statsd, envoy.statsd

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,8 @@ Version history
   minimum.
 * config: use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 * http: fixing a bug in HTTP/1.0 responses where Connection: keep-alive was not appended for connections which were kept alive.
+* network filters: network filter extensions use the "envoy.filters.network" name space. A mapping
+  of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * rbac: added :ref:`url_path <envoy_api_field_config.rbac.v2.Permission.url_path>` for matching URL path without the query and fragment string.
 * retry: added a retry predicate that :ref:`rejects hosts based on metadata. <envoy_api_field_route.RetryPolicy.retry_host_predicate>`
 * router: added :ref:`auto_san_validation <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_san_validation>` to support overrriding SAN validation to transport socket for new upstream connections based on the downstream HTTP host/authority header.

--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -68,7 +68,7 @@ The specification of the :ref:`listeners <envoy_api_file_envoy/api/v2/listener/l
           socket_address: { address: 0.0.0.0, port_value: 10000 }
         filter_chains:
         - filters:
-          - name: envoy.http_connection_manager
+          - name: envoy.filters.network.http_connection_manager
             typed_config:
               "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
               stat_prefix: ingress_http

--- a/examples/cors/backend/front-envoy.yaml
+++ b/examples/cors/backend/front-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/cors/backend/service-envoy.yaml
+++ b/examples/cors/backend/service-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/cors/frontend/front-envoy.yaml
+++ b/examples/cors/frontend/front-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/cors/frontend/service-envoy.yaml
+++ b/examples/cors/frontend/service-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/csrf/crosssite/front-envoy.yaml
+++ b/examples/csrf/crosssite/front-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/csrf/service-envoy.yaml
+++ b/examples/csrf/service-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 9211
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/front-proxy/front-envoy.yaml
+++ b/examples/front-proxy/front-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/front-proxy/service-envoy.yaml
+++ b/examples/front-proxy/service-envoy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/grpc-bridge/client/envoy-proxy.yaml
+++ b/examples/grpc-bridge/client/envoy-proxy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 9911
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/grpc-bridge/server/envoy-proxy.yaml
+++ b/examples/grpc-bridge/server/envoy-proxy.yaml
@@ -6,7 +6,7 @@ static_resources:
         port_value: 8811
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           generate_request_id: true

--- a/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: INBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto
@@ -35,7 +35,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: INBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: auto

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           generate_request_id: true

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: INBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           tracing: {}
@@ -36,7 +36,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           tracing: {}

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: INBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           tracing: {}

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -7,7 +7,7 @@ static_resources:
         port_value: 80
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/examples/mysql/envoy.yaml
+++ b/examples/mysql/envoy.yaml
@@ -11,7 +11,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.mysql_proxy.v1alpha1.MySQLProxy
           stat_prefix: egress_mysql
-      - name: envoy.tcp_proxy
+      - name: envoy.filters.network.tcp_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           stat_prefix: mysql_tcp

--- a/examples/redis/envoy.yaml
+++ b/examples/redis/envoy.yaml
@@ -7,7 +7,7 @@ static_resources:
         port_value: 1999
     filter_chains:
     - filters:
-      - name: envoy.redis_proxy
+      - name: envoy.filters.network.redis_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           stat_prefix: egress_redis

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           generate_request_id: true

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: INBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           tracing: {}
@@ -36,7 +36,7 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           tracing: {}

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -7,7 +7,7 @@ static_resources:
     traffic_direction: INBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           tracing: {}

--- a/generated_api_shadow/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/generated_api_shadow/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -236,7 +236,7 @@ message RedisProxy {
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in
 // :ref:`typed_extension_protocol_options<envoy_api_field_Cluster.typed_extension_protocol_options>`,
-// keyed by the name `envoy.redis_proxy`.
+// keyed by the name `envoy.filters.network.redis_proxy`.
 message RedisProtocolOptions {
   // Upstream server password as defined by the `requirepass` directive
   // <https://redis.io/topics/config>`_ in the server's configuration file.

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -251,7 +251,7 @@ message RedisProxy {
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in
 // :ref:`typed_extension_protocol_options<envoy_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`,
-// keyed by the name `envoy.redis_proxy`.
+// keyed by the name `envoy.filters.network.redis_proxy`.
 message RedisProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions";

--- a/source/extensions/filters/network/client_ssl_auth/config.cc
+++ b/source/extensions/filters/network/client_ssl_auth/config.cc
@@ -30,7 +30,7 @@ Network::FilterFactoryCb ClientSslAuthConfigFactory::createFilterFactoryFromProt
  * Static registration for the client SSL auth filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(ClientSslAuthConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory);
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.client_ssl_auth"};
 
 } // namespace ClientSslAuth
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/echo/config.cc
+++ b/source/extensions/filters/network/echo/config.cc
@@ -35,7 +35,8 @@ private:
 /**
  * Static registration for the echo filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(EchoConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory);
+REGISTER_FACTORY(EchoConfigFactory,
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.echo"};
 
 } // namespace Echo
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -42,7 +42,8 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
 /**
  * Static registration for the external authorization filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(ExtAuthzConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory);
+REGISTER_FACTORY(ExtAuthzConfigFactory,
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.ext_authz"};
 
 } // namespace ExtAuthz
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -138,7 +138,8 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoTyped(
  * Static registration for the HTTP connection manager filter.
  */
 REGISTER_FACTORY(HttpConnectionManagerFilterConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory);
+                 Server::Configuration::NamedNetworkFilterConfigFactory){
+    "envoy.http_connection_manager"};
 
 InternalAddressConfig::InternalAddressConfig(
     const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -46,7 +46,7 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
  * Static registration for the mongo filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(MongoProxyFilterConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory);
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.mongo_proxy"};
 
 } // namespace MongoProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -42,7 +42,8 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(RateLimitConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory);
+REGISTER_FACTORY(RateLimitConfigFactory,
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.ratelimit"};
 
 } // namespace RateLimitFilter
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -102,7 +102,7 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
  * Static registration for the redis filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(RedisProxyFilterConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory);
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.redis_proxy"};
 
 } // namespace RedisProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/tcp_proxy/config.cc
+++ b/source/extensions/filters/network/tcp_proxy/config.cc
@@ -30,7 +30,8 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the tcp_proxy filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(ConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory);
+REGISTER_FACTORY(ConfigFactory,
+                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.tcp_proxy"};
 
 } // namespace TcpProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -13,27 +13,27 @@ namespace NetworkFilters {
 class NetworkFilterNameValues {
 public:
   // Client ssl auth filter
-  const std::string ClientSslAuth = "envoy.client_ssl_auth";
+  const std::string ClientSslAuth = "envoy.filters.network.client_ssl_auth";
   // Echo filter
-  const std::string Echo = "envoy.echo";
+  const std::string Echo = "envoy.filters.network.echo";
   // Dubbo proxy filter
   const std::string DubboProxy = "envoy.filters.network.dubbo_proxy";
   // HTTP connection manager filter
-  const std::string HttpConnectionManager = "envoy.http_connection_manager";
+  const std::string HttpConnectionManager = "envoy.filters.network.http_connection_manager";
   // Local rate limit filter
   const std::string LocalRateLimit = "envoy.filters.network.local_ratelimit";
   // Mongo proxy filter
-  const std::string MongoProxy = "envoy.mongo_proxy";
+  const std::string MongoProxy = "envoy.filters.network.mongo_proxy";
   // MySQL proxy filter
   const std::string MySQLProxy = "envoy.filters.network.mysql_proxy";
   // Rate limit filter
-  const std::string RateLimit = "envoy.ratelimit";
+  const std::string RateLimit = "envoy.filters.network.ratelimit";
   // Redis proxy filter
-  const std::string RedisProxy = "envoy.redis_proxy";
+  const std::string RedisProxy = "envoy.filters.network.redis_proxy";
   // TCP proxy filter
-  const std::string TcpProxy = "envoy.tcp_proxy";
+  const std::string TcpProxy = "envoy.filters.network.tcp_proxy";
   // Authorization filter
-  const std::string ExtAuthorization = "envoy.ext_authz";
+  const std::string ExtAuthorization = "envoy.filters.network.ext_authz";
   // Kafka Broker filter
   const std::string KafkaBroker = "envoy.filters.network.kafka_broker";
   // Thrift proxy filter

--- a/test/config/integration/google_com_proxy_port_0.v2.yaml
+++ b/test/config/integration/google_com_proxy_port_0.v2.yaml
@@ -14,7 +14,7 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: ingress_http

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -7,7 +7,7 @@ static_resources:
     reuse_port: {{ reuse_port }}
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           drain_timeout: 5s
@@ -75,7 +75,7 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.redis_proxy
+      - name: envoy.filters.network.redis_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           settings:

--- a/test/config/integration/server_unix_listener.yaml
+++ b/test/config/integration/server_unix_listener.yaml
@@ -5,7 +5,7 @@ static_resources:
         path: "{{ socket_dir }}/unix-sockets.listener_0"
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           http_filters:

--- a/test/config/integration/server_xds.lds.typed_struct.yaml
+++ b/test/config/integration/server_xds.lds.typed_struct.yaml
@@ -8,7 +8,7 @@ resources:
       port_value: 0
   filter_chains:
   - filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/udpa.type.v1.TypedStruct
         type_url: "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager"

--- a/test/config/integration/server_xds.lds.with_unknown_field.typed_struct.yaml
+++ b/test/config/integration/server_xds.lds.with_unknown_field.typed_struct.yaml
@@ -8,7 +8,7 @@ resources:
       port_value: 0
   filter_chains:
   - filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/udpa.type.v1.TypedStruct
         type_url: "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager"

--- a/test/config/integration/server_xds.lds.with_unknown_field.yaml
+++ b/test/config/integration/server_xds.lds.with_unknown_field.yaml
@@ -8,7 +8,7 @@ resources:
       port_value: 0
   filter_chains:
   - filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         codec_type: HTTP2

--- a/test/config/integration/server_xds.lds.yaml
+++ b/test/config/integration/server_xds.lds.yaml
@@ -8,7 +8,7 @@ resources:
       port_value: 0
   filter_chains:
   - filters:
-    - name: envoy.http_connection_manager
+    - name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
         codec_type: HTTP2

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -99,7 +99,7 @@ static_resources:
 const std::string ConfigHelper::TCP_PROXY_CONFIG = BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.tcp_proxy
+        name: envoy.filters.network.tcp_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           stat_prefix: tcp_stats
@@ -109,7 +109,7 @@ const std::string ConfigHelper::TCP_PROXY_CONFIG = BASE_CONFIG + R"EOF(
 const std::string ConfigHelper::HTTP_PROXY_CONFIG = BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.http_connection_manager
+        name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test
@@ -143,7 +143,7 @@ const std::string ConfigHelper::QUIC_HTTP_PROXY_CONFIG = BASE_UDP_LISTENER_CONFI
       transport_socket:
         name: envoy.transport_sockets.quic
       filters:
-        name: envoy.http_connection_manager
+        name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test
@@ -258,7 +258,7 @@ static_resources:
         port_value: 0
     filter_chains:
       filters:
-        name: envoy.http_connection_manager
+        name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test
@@ -575,7 +575,7 @@ void ConfigHelper::setBufferLimits(uint32_t upstream_buffer_limit,
     cluster->mutable_per_connection_buffer_limit_bytes()->set_value(upstream_buffer_limit);
   }
 
-  auto filter = getFilterFromListener("envoy.http_connection_manager");
+  auto filter = getFilterFromListener("envoy.filters.network.http_connection_manager");
   if (filter) {
     envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
         hcm_config;
@@ -684,7 +684,7 @@ void ConfigHelper::addSslConfig(const ServerSslOptions& options) {
 }
 
 bool ConfigHelper::setAccessLog(const std::string& filename, absl::string_view format) {
-  if (getFilterFromListener("envoy.http_connection_manager") == nullptr) {
+  if (getFilterFromListener("envoy.filters.network.http_connection_manager") == nullptr) {
     return false;
   }
   // Replace /dev/null with a real path for the file access log.
@@ -775,7 +775,7 @@ void ConfigHelper::addNetworkFilter(const std::string& filter_yaml) {
 bool ConfigHelper::loadHttpConnectionManager(
     envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager& hcm) {
   RELEASE_ASSERT(!finalized_, "");
-  auto* hcm_filter = getFilterFromListener("envoy.http_connection_manager");
+  auto* hcm_filter = getFilterFromListener("envoy.filters.network.http_connection_manager");
   if (hcm_filter) {
     auto* config = hcm_filter->mutable_typed_config();
     hcm = MessageUtil::anyConvert<
@@ -790,8 +790,8 @@ void ConfigHelper::storeHttpConnectionManager(
     const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
         hcm) {
   RELEASE_ASSERT(!finalized_, "");
-  auto* hcm_config_any =
-      getFilterFromListener("envoy.http_connection_manager")->mutable_typed_config();
+  auto* hcm_config_any = getFilterFromListener("envoy.filters.network.http_connection_manager")
+                             ->mutable_typed_config();
 
   hcm_config_any->PackFrom(hcm);
 }
@@ -828,7 +828,7 @@ void ConfigHelper::setLds(absl::string_view version_info) {
 }
 
 void ConfigHelper::setOutboundFramesLimits(uint32_t max_all_frames, uint32_t max_control_frames) {
-  auto filter = getFilterFromListener("envoy.http_connection_manager");
+  auto filter = getFilterFromListener("envoy.filters.network.http_connection_manager");
   if (filter) {
     envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
         hcm_config;

--- a/test/extensions/clusters/aggregate/cluster_integration_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_integration_test.cc
@@ -76,7 +76,7 @@ static_resources:
         port_value: 0
     filter_chains:
       filters:
-        name: envoy.http_connection_manager
+        name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test

--- a/test/extensions/clusters/redis/redis_cluster_integration_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_integration_test.cc
@@ -34,7 +34,7 @@ static_resources:
         port_value: 0
     filter_chains:
       filters:
-        name: envoy.redis_proxy
+        name: envoy.filters.network.redis_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           stat_prefix: redis_stats
@@ -116,7 +116,7 @@ const std::string& testConfigWithReadPolicy() {
 const std::string& testConfigWithAuth() {
   CONSTRUCT_ON_FIRST_USE(std::string, testConfig() + R"EOF(
       typed_extension_protocol_options:
-        envoy.redis_proxy:
+        envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
           auth_password: { inline_string: somepassword }
 )EOF");

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -20,7 +20,7 @@ public:
     return fmt::format(ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.http_connection_manager
+        name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: metadata_test

--- a/test/extensions/filters/network/client_ssl_auth/config_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/config_test.cc
@@ -104,6 +104,16 @@ TEST(ClientSslAuthConfigFactoryTest, DoubleRegistrationTest) {
       fmt::format("Double registration for name: '{}'", NetworkFilterNames::get().ClientSslAuth));
 }
 
+// Test that the deprecated extension name still functions.
+TEST(ClientSslAuthConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.client_ssl_auth";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace ClientSslAuth
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -51,6 +51,16 @@ TEST(ExtAuthzFilterConfigTest, ExtAuthzCorrectProto) {
   cb(connection);
 }
 
+// Test that the deprecated extension name still functions.
+TEST(ExtAuthzConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.ext_authz";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace ExtAuthz
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -956,6 +956,16 @@ access_log:
                           "bad_type: Cannot find field");
 }
 
+// Test that the deprecated extension name still functions.
+TEST_F(HttpConnectionManagerConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.http_connection_manager";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 class FilterChainTest : public HttpConnectionManagerConfigTest {
 public:
   const std::string basic_config_ = R"EOF(

--- a/test/extensions/filters/network/kafka/broker/integration_test/envoy_config_yaml.j2
+++ b/test/extensions/filters/network/kafka/broker/integration_test/envoy_config_yaml.j2
@@ -10,7 +10,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.kafka_broker.v2alpha1.KafkaBroker
           stat_prefix: testfilter
-      - name: envoy.tcp_proxy
+      - name: envoy.filters.network.tcp_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           stat_prefix: ingress_tcp

--- a/test/extensions/filters/network/mongo_proxy/config_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/config_test.cc
@@ -221,6 +221,16 @@ TEST(MongoFilterConfigTest, CorrectFaultConfigurationInProto) {
   cb(connection);
 }
 
+// Test that the deprecated extension name still functions.
+TEST(MongoFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.mongo_proxy";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace MongoProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml
@@ -29,7 +29,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.config.filter.network.mysql_proxy.v1alpha1.MySQLProxy
               stat_prefix: mysql_stats
-          - name: envoy.tcp_proxy
+          - name: envoy.filters.network.tcp_proxy
             typed_config:
               "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
               stat_prefix: tcp_stats

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -83,6 +83,16 @@ ip_white_list: '12'
                           "ip_white_list: Cannot find field");
 }
 
+// Test that the deprecated extension name still functions.
+TEST(RateLimitFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.ratelimit";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace RateLimitFilter
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -43,7 +43,7 @@ public:
                   principals:
                     - not_id:
                         any: true
-       -  name: envoy.echo
+       -  name: envoy.filters.network.echo
           config:
 )EOF";
   }

--- a/test/extensions/filters/network/redis_proxy/config_test.cc
+++ b/test/extensions/filters/network/redis_proxy/config_test.cc
@@ -169,6 +169,16 @@ settings:
   cb(connection);
 }
 
+// Test that the deprecated extension name still functions.
+TEST(RedisProxyFilterConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.redis_proxy";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace RedisProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -52,7 +52,7 @@ static_resources:
         port_value: 0
     filter_chains:
       filters:
-        name: envoy.redis_proxy
+        name: envoy.filters.network.redis_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           stat_prefix: redis_stats
@@ -142,7 +142,7 @@ static_resources:
         port_value: 0
     filter_chains:
       filters:
-        name: envoy.redis_proxy
+        name: envoy.filters.network.redis_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           stat_prefix: redis_stats
@@ -201,7 +201,7 @@ static_resources:
     - name: cluster_0
       type: STATIC
       typed_extension_protocol_options:
-        envoy.redis_proxy:
+        envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
           auth_password: { inline_string: cluster_0_password }
       lb_policy: RANDOM
@@ -218,7 +218,7 @@ static_resources:
       type: STATIC
       lb_policy: RANDOM
       typed_extension_protocol_options:
-        envoy.redis_proxy:
+        envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
           auth_password: { inline_string: cluster_1_password }
       load_assignment:
@@ -233,7 +233,7 @@ static_resources:
     - name: cluster_2
       type: STATIC
       typed_extension_protocol_options:
-        envoy.redis_proxy:
+        envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
           auth_password: { inline_string: cluster_2_password }
       lb_policy: RANDOM
@@ -254,7 +254,7 @@ static_resources:
         port_value: 0
     filter_chains:
       filters:
-        name: envoy.redis_proxy
+        name: envoy.filters.network.redis_proxy
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
           stat_prefix: redis_stats

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -125,6 +125,16 @@ TEST(ConfigTest, ConfigTest) {
   cb(connection);
 }
 
+// Test that the deprecated extension name still functions.
+TEST(ConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.tcp_proxy";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace TcpProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -88,7 +88,7 @@ AdsIntegrationTest::buildListener(const std::string& name, const std::string& ro
           port_value: 0
       filter_chains:
         filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: {}
@@ -112,7 +112,7 @@ AdsIntegrationTest::buildRedisListener(const std::string& name, const std::strin
           port_value: 0
       filter_chains:
         filters:
-        - name: envoy.redis_proxy
+        - name: envoy.filters.network.redis_proxy
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
             settings: 

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -17,13 +17,13 @@ public:
     echo_config = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.ratelimit
+        name: envoy.filters.network.ratelimit
         config:
           domain: foo
           stats_prefix: name
           descriptors: [{"key": "foo", "value": "bar"}]
       filters:
-        name: envoy.echo
+        name: envoy.filters.network.echo
         config:
       )EOF";
   }
@@ -70,7 +70,7 @@ address:
     port_value: 0
 filter_chains:
 - filters:
-  - name: envoy.echo
+  - name: envoy.filters.network.echo
   )EOF",
                                                        GetParam());
 

--- a/test/integration/filter_manager_integration_test.cc
+++ b/test/integration/filter_manager_integration_test.cc
@@ -42,7 +42,8 @@ const std::regex invalid_param_name_regex() { return std::regex{"[^a-zA-Z0-9_]"}
  * Integration test with one of auxiliary filters (listed above)
  * added to the head of the filter chain.
  *
- * Shared by tests for "envoy.echo", "envoy.tcp_proxy" and "envoy.http_connection_manager".
+ * Shared by tests for "envoy.filters.network.echo", "envoy.filters.network.tcp_proxy" and
+ * "envoy.filters.network.http_connection_manager".
  */
 class TestWithAuxiliaryFilter {
 public:
@@ -55,8 +56,9 @@ protected:
   /**
    * Returns configuration for a given auxiliary filter.
    *
-   * Assuming that representative configurations differ in the context of "envoy.echo",
-   * "envoy.tcp_proxy" and "envoy.http_connection_manager".
+   * Assuming that representative configurations differ in the context of
+   * "envoy.filters.network.echo", "envoy.filters.network.tcp_proxy" and
+   * "envoy.filters.network.http_connection_manager".
    */
   virtual std::string filterConfig(const std::string& auxiliary_filter_name) PURE;
 
@@ -125,7 +127,7 @@ private:
 };
 
 /**
- * Base class for "envoy.echo" and "envoy.tcp_proxy" tests.
+ * Base class for "envoy.filters.network.echo" and "envoy.filters.network.tcp_proxy" tests.
  *
  * Inherits from BaseIntegrationTest; parameterized with IP version and auxiliary filter.
  */
@@ -170,7 +172,7 @@ protected:
 };
 
 /**
- * Integration test with an auxiliary filter in front of "envoy.echo".
+ * Integration test with an auxiliary filter in front of "envoy.filters.network.echo".
  */
 class InjectDataWithEchoFilterIntegrationTest : public InjectDataToFilterChainIntegrationTest {
 public:
@@ -178,7 +180,7 @@ public:
     return ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-      - name: envoy.echo
+      - name: envoy.filters.network.echo
       )EOF";
   }
 
@@ -203,7 +205,7 @@ TEST_P(InjectDataWithEchoFilterIntegrationTest, UsageOfInjectDataMethodsShouldBe
 }
 
 /**
- * Integration test with an auxiliary filter in front of "envoy.tcp_proxy".
+ * Integration test with an auxiliary filter in front of "envoy.filters.network.tcp_proxy".
  */
 class InjectDataWithTcpProxyFilterIntegrationTest : public InjectDataToFilterChainIntegrationTest {
 public:
@@ -248,7 +250,8 @@ TEST_P(InjectDataWithTcpProxyFilterIntegrationTest, UsageOfInjectDataMethodsShou
 }
 
 /**
- * Integration test with an auxiliary filter in front of "envoy.http_connection_manager".
+ * Integration test with an auxiliary filter in front of
+ * "envoy.filters.network.http_connection_manager".
  *
  * Inherits from HttpIntegrationTest;
  * parameterized with IP version, downstream HTTP version and auxiliary filter.

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -65,7 +65,7 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -387,15 +387,15 @@ address:
     port_value: 1234
 filter_chains:
 - filters:
-  - name: envoy.tcp_proxy
+  - name: envoy.filters.network.tcp_proxy
     config: {}
   - name: unknown_but_will_not_be_processed
     config: {}
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
-                          EnvoyException,
-                          "Error: envoy.tcp_proxy must be the terminal network filter.");
+  EXPECT_THROW_WITH_REGEX(
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true), EnvoyException,
+      "Error: envoy.filters.network.tcp_proxy must be the terminal network filter.");
 }
 
 TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterName) {
@@ -3115,7 +3115,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, Metadata) {
     filter_chains:
     - filter_chain_match:
       filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         config:
           stat_prefix: metadata_test
           route_config:

--- a/test/server/server_corpus/google_com_proxy.v2.pb_text
+++ b/test/server/server_corpus/google_com_proxy.v2.pb_text
@@ -9,7 +9,7 @@ static_resources {
     }
     filter_chains {
       filters {
-        name: "envoy.http_connection_manager"
+        name: "envoy.filters.network.http_connection_manager"
         config {
           fields {
             key: "http_filters"

--- a/test/server/test_data/static_validation/network_filter_unknown_field.yaml
+++ b/test/server/test_data/static_validation/network_filter_unknown_field.yaml
@@ -7,7 +7,7 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           codec_type: HTTP2


### PR DESCRIPTION
Modifies the well-known-names of the built-in network filters
to use the same names as the extension build system.

Risk Level: low, previous name is still accepted
Testing: existing tests + deprecated tests for old names
Docs Changes: updated names
Release Notes: updated
Deprecated: old names are logged as deprecated

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
