### PR TITLE
docs: fix incorrect description

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -232,7 +232,7 @@ modify different aspects of the server:
 
     Generally only used during development.
 
-.. http:post:: /memory
+.. http:get:: /memory
 
   Prints current memory allocation / heap usage, in bytes. Useful in lieu of printing all `/stats` and filtering to get the memory-related statistics.
 


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

Description:  `/memory` should be `GET`, not `POST`
Risk Level: low
Testing: N/A
Docs Changes: yes
Release Notes: N/A
[Optional Fixes #Issue] N/A
[Optional Deprecated:]  N/A
