### PR TITLE
Update gRPC SHA

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -109,9 +109,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gperftools/gperftools/archive/fc00474ddc21fff618fc3f009b46590e241e425e.tar.gz"],
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "ffbe61269160ea745e487f79b0fd06b6edd3d50c6d9123f053b5634737cf2f69",
-        strip_prefix = "grpc-1.25.0",
-        urls = ["https://github.com/grpc/grpc/archive/v1.25.0.tar.gz"],
+        sha256 = "bbc8f020f4e85ec029b047fab939b8c81f3d67254b5c724e1003a2bc49ddd123",
+        strip_prefix = "grpc-d8f4928fa779f6005a7fe55a176bdb373b0f910f",
+        urls = ["https://github.com/grpc/grpc/archive/d8f4928fa779f6005a7fe55a176bdb373b0f910f.tar.gz"],
     ),
     com_github_luajit_luajit = dict(
         sha256 = "409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -109,6 +109,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gperftools/gperftools/archive/fc00474ddc21fff618fc3f009b46590e241e425e.tar.gz"],
     ),
     com_github_grpc_grpc = dict(
+        # TODO(JimmyCYJ): Bump to release 1.27
+        # This sha is specifically chosen to fix gRPC STS call credential options.
         sha256 = "bbc8f020f4e85ec029b047fab939b8c81f3d67254b5c724e1003a2bc49ddd123",
         strip_prefix = "grpc-d8f4928fa779f6005a7fe55a176bdb373b0f910f",
         urls = ["https://github.com/grpc/grpc/archive/d8f4928fa779f6005a7fe55a176bdb373b0f910f.tar.gz"],

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -110,7 +110,7 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_github_grpc_grpc = dict(
         # TODO(JimmyCYJ): Bump to release 1.27
-        # This sha is specifically chosen to fix gRPC STS call credential options.
+        # This sha on grpc:v1.25.x branch is specifically chosen to fix gRPC STS call credential options.
         sha256 = "bbc8f020f4e85ec029b047fab939b8c81f3d67254b5c724e1003a2bc49ddd123",
         strip_prefix = "grpc-d8f4928fa779f6005a7fe55a176bdb373b0f910f",
         urls = ["https://github.com/grpc/grpc/archive/d8f4928fa779f6005a7fe55a176bdb373b0f910f.tar.gz"],


### PR DESCRIPTION
Signed-off-by: Jimmy Chen <jimmychen.0102@gmail.com>

Description: Update gRPC SHA to pick a gRPC STS fix for gRPC 1.25 https://github.com/grpc/grpc/commit/d8f4928fa779f6005a7fe55a176bdb373b0f910f

Risk Level: Low
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue] https://github.com/istio/istio/issues/20133
[Optional Deprecated:]
