### PR TITLE
runtime: Add support for setting default value when parsing string value

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,6 +14,7 @@ Version history
 * router: added :ref:`auto_san_validation <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_san_validation>` to support overrriding SAN validation to transport socket for new upstream connections based on the downstream HTTP host/authority header.
 * router: added the ability to match a route based on whether a downstream TLS connection certificate has been
   :ref:`validated <envoy_api_field_route.RouteMatch.TlsContextMatchOptions.validated>`.
+* runtime: allows for the ability to set default values when parsing strings.
 * sds: added :ref:`GenericSecret <envoy_api_msg_auth.GenericSecret>` to support secret of generic type.
 * stat sinks: stat sink extensions use the "envoy.stat_sinks" name space. A mapping of extension
   names is available in the :ref:`deprecated <deprecated>` documentation.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,7 +14,6 @@ Version history
 * router: added :ref:`auto_san_validation <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_san_validation>` to support overrriding SAN validation to transport socket for new upstream connections based on the downstream HTTP host/authority header.
 * router: added the ability to match a route based on whether a downstream TLS connection certificate has been
   :ref:`validated <envoy_api_field_route.RouteMatch.TlsContextMatchOptions.validated>`.
-* runtime: allows for the ability to set default values when parsing strings.
 * sds: added :ref:`GenericSecret <envoy_api_msg_auth.GenericSecret>` to support secret of generic type.
 * stat sinks: stat sink extensions use the "envoy.stat_sinks" name space. A mapping of extension
   names is available in the :ref:`deprecated <deprecated>` documentation.

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -210,7 +210,8 @@ public:
    * @param key supplies the key to fetch.
    * @return const std::string& the value or empty string if the key does not exist.
    */
-  virtual const std::string& get(absl::string_view key) const PURE;
+  virtual const std::string& get(absl::string_view key,
+                                 const std::string& default_value) const PURE;
 
   /**
    * Returns whether the key has any value set.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -233,11 +233,12 @@ bool SnapshotImpl::featureEnabled(absl::string_view key, uint64_t default_value,
   return featureEnabled(key, default_value, random_value, 100);
 }
 
-const std::string& SnapshotImpl::get(absl::string_view key) const {
+const std::string& SnapshotImpl::get(absl::string_view key,
+                                     const std::string& default_value) const {
   ASSERT(!isRuntimeFeature(key)); // Make sure runtime guarding is only used for getBoolean
   auto entry = key.empty() ? values_.end() : values_.find(key);
   if (entry == values_.end()) {
-    return EMPTY_STRING;
+    return default_value;
   } else {
     return entry->second.raw_string_value_;
   }

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -21,7 +21,6 @@
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/common/assert.h"
-#include "common/common/empty_string.h"
 #include "common/common/logger.h"
 #include "common/common/thread.h"
 #include "common/init/target_impl.h"
@@ -93,7 +92,7 @@ public:
   bool featureEnabled(absl::string_view key,
                       const envoy::type::v3::FractionalPercent& default_value,
                       uint64_t random_value) const override;
-  const std::string& get(absl::string_view key) const override;
+  const std::string& get(absl::string_view key, const std::string& default_value) const override;
   uint64_t getInteger(absl::string_view key, uint64_t default_value) const override;
   double getDouble(absl::string_view key, double default_value) const override;
   bool getBoolean(absl::string_view key, bool value) const override;

--- a/test/mocks/runtime/mocks.cc
+++ b/test/mocks/runtime/mocks.cc
@@ -18,6 +18,7 @@ MockSnapshot::MockSnapshot() {
   ON_CALL(*this, getInteger(_, _)).WillByDefault(ReturnArg<1>());
   ON_CALL(*this, getDouble(_, _)).WillByDefault(ReturnArg<1>());
   ON_CALL(*this, getBoolean(_, _)).WillByDefault(ReturnArg<1>());
+  ON_CALL(*this, get(_, _)).WillByDefault(ReturnArg<1>());
   ON_CALL(*this, exists(_)).WillByDefault(Return(false));
 }
 

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -58,7 +58,8 @@ public:
               (absl::string_view key, const envoy::type::v3::FractionalPercent& default_value,
                uint64_t random_value),
               (const));
-  MOCK_METHOD(const std::string&, get, (absl::string_view key), (const));
+  MOCK_METHOD(const std::string&, get, (absl::string_view key, const std::string& default_value),
+              (const));
   MOCK_METHOD(bool, exists, (absl::string_view key), (const));
   MOCK_METHOD(uint64_t, getInteger, (absl::string_view key, uint64_t default_value), (const));
   MOCK_METHOD(double, getDouble, (absl::string_view key, double default_value), (const));

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -644,9 +644,9 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithOptionsOverride) {
 TEST_P(ServerInstanceImplTest, BootstrapRuntime) {
   options_.service_cluster_name_ = "some_service";
   initialize("test/server/test_data/server/runtime_bootstrap.yaml");
-  EXPECT_EQ("bar", server_->runtime().snapshot().get("foo"));
+  EXPECT_EQ("bar", server_->runtime().snapshot().get("foo", ""));
   // This should access via the override/some_service overlay.
-  EXPECT_EQ("fozz", server_->runtime().snapshot().get("fizz"));
+  EXPECT_EQ("fozz", server_->runtime().snapshot().get("fizz", ""));
   EXPECT_EQ("foobar", server_->runtime().snapshot().getLayers()[3]->name());
 }
 


### PR DESCRIPTION
Description: This change adds the ability to set a default value when calling `get(...)` in runtime. Prior to this change, if there was no entry matching the key, an empty string was returned. This change is to make the return value more flexible.
Risk Level: Low
Testing: Changed existing unit test result https://github.com/envoyproxy/envoy/blob/74ef62904c6e1e489862e433a9210c056faae746/test/common/runtime/runtime_impl_test.cc#L168
Docs Changes: N/A
Release Notes: N/A

