### PR TITLE
Fix Reference configurations example code

### DIFF
--- a/docs/root/install/ref_configs.rst
+++ b/docs/root/install/ref_configs.rst
@@ -34,7 +34,7 @@ To generate the example configurations run the following from the root of the re
 
   mkdir -p generated/configs
   bazel build //configs:example_configs
-  tar xvf $PWD/bazel-genfiles/configs/example_configs.tar -C generated/configs
+  tar xvf $PWD/bazel-out/k8-fastbuild/bin/configs/example_configs.tar -C generated/configs
 
 The previous command will produce three fully expanded configurations using some variables
 defined inside of `configgen.py`. See the comments inside of `configgen.py` for detailed


### PR DESCRIPTION
Description: On the Configuration Generator example that shows how to generate the provided configurations, the generated output by bazel is located in a different folder than the one specified in the example. This just changes that location
Risk Level: Low
Testing: No testing needed
Docs Changes: Location of generated config files

I used the `bazel` version specified in the repository as `2.0.0`. And the results were different from the ones in the documentation.

Let me know if there is anything else I can do.

Regards

