### PR TITLE
Avoid biasing towards earlier hosts for the weighted case.

### DIFF
--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -71,8 +71,8 @@ public:
   }
 
   /**
-   * Insert entry into queue with a given weight. The deadline will be multiples of (1 / weight)
-   *  that just larger than initial current time
+   * Insert entry into queue with a given weight only in refreshing stage. The deadline will be
+   *  multiples of (1 / weight) that just larger than initial current time
    * @param weight floating point weight.
    * @param entry shared pointer to entry, only a weak reference will be retained.
    */

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -71,8 +71,8 @@ public:
   }
 
   /**
-   * Insert entry into queue with a given weight. The deadline will be multiples of (1 / weight) that 
-   * just larger than initial current time
+   * Insert entry into queue with a given weight. The deadline will be multiples of (1 / weight)
+   *  that just larger than initial current time
    * @param weight floating point weight.
    * @param entry shared pointer to entry, only a weak reference will be retained.
    */

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -78,7 +78,7 @@ public:
    */
   void initial_add(double weight, std::shared_ptr<C> entry) {
     ASSERT(weight > 0);
-    double deadline = std::ceil(current_time_ * weight) / weight;
+    double deadline = (std::floor(current_time_ * weight) + 1.0) / weight;
     EDF_TRACE("Insertion {} in queue with deadline {} and weight {} and current_time {}.",
               static_cast<const void*>(entry.get()), deadline, weight, current_time_);
     queue_.push({deadline, order_offset_++, entry});

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -78,7 +78,7 @@ public:
    */
   void initial_add(double weight, std::shared_ptr<C> entry) {
     ASSERT(weight > 0);
-    double deadline = std::ceil((current_time_ - deadline) * weight) / weight;
+    double deadline = std::ceil(current_time_ * weight) / weight;
     EDF_TRACE("Insertion {} in queue with deadline {} and weight {} and current_time {}.",
               static_cast<const void*>(entry.get()), deadline, weight, current_time_);
     queue_.push({deadline, order_offset_++, entry});

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -717,7 +717,7 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
   const auto add_hosts_source = [this](HostsSource source, const HostVector& hosts) {
     // Nuke existing scheduler if it exists, and initiate initial deadline with a float ranges
     // [0.0, 1.0)
-    auto& scheduler = scheduler_[source] = Scheduler{seed_ % 1000000 / 1000000.0};
+    auto& scheduler = scheduler_[source] = Scheduler{};
     refreshHostSource(source);
 
     // Check if the original host weights are equal and skip EDF creation if they are. When all
@@ -728,7 +728,7 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
       return;
     }
 
-    scheduler.edf_ = std::make_unique<EdfScheduler<const Host>>();
+    scheduler.edf_ = std::make_unique<EdfScheduler<const Host>>(seed_ % 1000000 / 1000000.0);
 
     // Populate scheduler with host list.
     // TODO(mattklein123): We must build the EDF schedule even if all of the hosts are currently

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -727,7 +727,7 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
       return;
     }
 
-    // Current time is initialized as a float ranges [0.0, 1.0). 
+    // Current time is initialized as a float ranges [0.0, 1.0).
     // Accuracy 1e-5 is enough because (1 / 128) ^ 2 > 1e-5.
     // 128 is the largest host weight (see envoy.api.v2.endpoint.Endpoint.load_balancing_weight).
     scheduler.edf_ = std::make_unique<EdfScheduler<const Host>>(seed_ % 100000 / 100000.0);

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -728,8 +728,8 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
     }
 
     // Current time is initialized as a float ranges [0.0, 1.0).
-    // Accuracy 1e-5 is enough because (1 / 128) ^ 2 > 1e-5.
-    // 128 is the largest host weight (see envoy.api.v2.endpoint.Endpoint.load_balancing_weight).
+    // Accuracy 1e-5 is enough because (1 / 128) ^ 2 > 1e-5. 128 is the largest weight for hosts
+    // (see envoy.api.v2.endpoint.Endpoint.load_balancing_weight).
     scheduler.edf_ = std::make_unique<EdfScheduler<const Host>>(seed_ % 100000 / 100000.0);
 
     // Populate scheduler with host list.

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -916,6 +916,23 @@ TEST_P(RoundRobinLoadBalancerTest, WeightedSeed) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
 }
 
+// Validate that low weight hosts still have the corresponding oppotunity to be picked first.
+TEST_P(RoundRobinLoadBalancerTest, WeightedBiasAvoiding) {
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 98),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
+  hostSet().hosts_ = hostSet().healthy_hosts_;
+  // Initiate current_time to 0.49999, and makes two hosts' initial deadlines both 0.5.
+  EXPECT_CALL(random_, random()).WillRepeatedly(Return(49999));
+  init(false);
+  // Initial weights respected.
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+}
+
 TEST_P(RoundRobinLoadBalancerTest, MaxUnhealthyPanic) {
   hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80"),
                               makeTestHost(info_, "tcp://127.0.0.1:81")};

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -921,7 +921,7 @@ TEST_P(RoundRobinLoadBalancerTest, WeightedBiasAvoiding) {
   hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 98),
                               makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
   hostSet().hosts_ = hostSet().healthy_hosts_;
-  // Initiate current_time to 0.49999, and makes two hosts' initial deadlines both 0.5.
+  // Initiate current_time to 0.49999, and make two hosts' initial deadlines to be both 0.5.
   EXPECT_CALL(random_, random()).WillRepeatedly(Return(49999));
   init(false);
   // Initial weights respected.

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -916,7 +916,7 @@ TEST_P(RoundRobinLoadBalancerTest, WeightedSeed) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
 }
 
-// Validate that low weight hosts still have the corresponding oppotunity to be picked first.
+// Validate that low weight hosts still have the corresponding opportunity to be picked first.
 TEST_P(RoundRobinLoadBalancerTest, WeightedBiasAvoiding) {
   hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 98),
                               makeTestHost(info_, "tcp://127.0.0.1:81", 2)};


### PR DESCRIPTION
Description: Set current time to a float ranges [0.0, 1.0) and use initial_add to avoid biasing towards earlier hosts in the schedule across refreshes for the weighted case.

as it says in `source/common/upstream/load_nalancer_impl.cc:742` :

> TODO(htuch): Consider how we can avoid biasing towards earlier hosts in the schedule across refreshes for the weighted case.

We have made a significant bias when we have a large amount of hosts, different weights.

For example, we have `1000` hosts weighted `128` and `100` hosts weighted `10`.
After refresh, LB always visit the 128-weighted hosts first.
Since we have hosts up and down, the host list would refresh several times every hour, so the hosts weighted 10 are never called because of the biasing towards earlier hosts.

So we modify the initial deadline.

As we all know, WRR LB has a picking cycle. 
In a cycle, host weighted X would be picked X times.
In EDF algorithm, when current time walks from 0.0 to 1.0, a cycle passed.

So, we randomly pick a float ranges from 0.0 to 1.0, it's like a random pick in the cycle.
The first pick possibility for every hosts is proportional to its weight.

Random pick after refresh is still needed.
In non-weighted case, as we have many hosts with the same weight, a random initial current time doesn't works.

Risk Level: Medium
It could affect weighted round robin load balancing.

Testing: Existing tests

Docs Changes: n/a
