### PR TITLE
test: use semantic names for access log extensions

### DIFF
--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -66,7 +66,7 @@ public:
 
 TEST_F(AccessLogImplTest, LogMoreData) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -89,7 +89,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, DownstreamDisconnect) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -111,7 +111,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RouteName) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -138,7 +138,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, EnvoyUpstreamServiceTime) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -157,7 +157,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, NoFilter) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -177,7 +177,7 @@ TEST_F(AccessLogImplTest, UpstreamHost) {
   stream_info_.upstream_host_ = Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234");
 
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -194,7 +194,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, WithFilterMiss) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   or_filter:
     filters:
@@ -226,7 +226,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, WithFilterHit) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
     or_filter:
       filters:
@@ -269,7 +269,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RuntimeFilter) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   runtime_filter:
     runtime_key: access_log.test_key
@@ -308,7 +308,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   runtime_filter:
     runtime_key: access_log.test_key
@@ -350,7 +350,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2IndependentRandomness) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   runtime_filter:
     runtime_key: access_log.test_key
@@ -384,7 +384,7 @@ TEST_F(AccessLogImplTest, PathRewrite) {
   request_headers_ = {{":method", "GET"}, {":path", "/foo"}, {"x-envoy-original-path", "/bar"}};
 
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   path: /dev/null
@@ -401,7 +401,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HealthCheckTrue) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   not_health_check_filter: {}
 typed_config:
@@ -420,7 +420,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HealthCheckFalse) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   not_health_check_filter: {}
 typed_config:
@@ -447,7 +447,7 @@ TEST_F(AccessLogImplTest, RequestTracing) {
   UuidUtils::setTraceableUuid(sample_tracing_guid, UuidTraceStatus::Sampled);
 
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   traceable_filter: {}
 typed_config:
@@ -481,7 +481,7 @@ TEST(AccessLogImplTestCtor, FiltersMissingInOrAndFilter) {
 
   {
     const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   or_filter: {}
 typed_config:
@@ -495,7 +495,7 @@ typed_config:
 
   {
     const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   and_filter: {}
 typed_config:
@@ -510,7 +510,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, AndFilter) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   and_filter:
     filters:
@@ -546,7 +546,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, OrFilter) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   or_filter:
     filters:
@@ -581,7 +581,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, MultipleOperators) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   and_filter:
     filters:
@@ -692,7 +692,7 @@ status_code_filter:
 
 TEST_F(AccessLogImplTest, StatusCodeLessThan) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   status_code_filter:
     comparison:
@@ -720,7 +720,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderPresence) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   header_filter:
     header:
@@ -742,7 +742,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderExactMatch) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   header_filter:
     header:
@@ -771,7 +771,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderRegexMatch) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   header_filter:
     header:
@@ -806,7 +806,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, HeaderRangeMatch) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   header_filter:
     header:
@@ -851,7 +851,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterAnyFlag) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   response_flag_filter: {}
 typed_config:
@@ -871,7 +871,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterSpecificFlag) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   response_flag_filter:
     flags:
@@ -897,7 +897,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterSeveralFlags) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   response_flag_filter:
     flags:
@@ -924,7 +924,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterAllFlagsInPGV) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   response_flag_filter:
     flags:
@@ -989,7 +989,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterUnsupportedFlag) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   response_flag_filter:
     flags:
@@ -1007,7 +1007,7 @@ typed_config:
       "[\"embedded message failed validation\"] | caused by "
       "ResponseFlagFilterValidationError.Flags[i]: [\"value must be in list \" [\"LH\" \"UH\" "
       "\"UT\" \"LR\" \"UR\" \"UF\" \"UC\" \"UO\" \"NR\" \"DI\" \"FI\" \"RL\" \"UAEX\" \"RLSE\" "
-      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"envoy.access_loggers.file\"\nfilter {\n  "
+      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"accesslog\"\nfilter {\n  "
       "response_flag_filter {\n    flags: \"UnsupportedFlag\"\n  }\n}\ntyped_config {\n  "
       "[type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog] {\n    path: \"/dev/null\"\n  "
       "}\n}\n");
@@ -1015,7 +1015,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, ValidateTypedConfig) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   response_flag_filter:
     flags:
@@ -1033,7 +1033,7 @@ typed_config:
       "[\"embedded message failed validation\"] | caused by "
       "ResponseFlagFilterValidationError.Flags[i]: [\"value must be in list \" [\"LH\" \"UH\" "
       "\"UT\" \"LR\" \"UR\" \"UF\" \"UC\" \"UO\" \"NR\" \"DI\" \"FI\" \"RL\" \"UAEX\" \"RLSE\" "
-      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"envoy.access_loggers.file\"\nfilter {\n  "
+      "\"DC\" \"URX\" \"SI\" \"IH\" \"DPE\"]]): name: \"accesslog\"\nfilter {\n  "
       "response_flag_filter {\n    flags: \"UnsupportedFlag\"\n  }\n}\ntyped_config {\n  "
       "[type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog] {\n    path: \"/dev/null\"\n  "
       "}\n}\n");
@@ -1041,7 +1041,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterValues) {
   const std::string yaml_template = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     statuses:
@@ -1072,7 +1072,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterUnsupportedValue) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     statuses:
@@ -1088,7 +1088,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterBlock) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     statuses:
@@ -1109,7 +1109,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHttpCodes) {
   const std::string yaml_template = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     statuses:
@@ -1141,7 +1141,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterNoCode) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     statuses:
@@ -1160,7 +1160,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterExclude) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     exclude: true
@@ -1185,7 +1185,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterExcludeFalse) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     exclude: false
@@ -1207,7 +1207,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHeader) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   grpc_status_filter:
     statuses:
@@ -1251,7 +1251,7 @@ TEST_F(AccessLogImplTest, TestHeaderFilterPresence) {
   Registry::RegisterFactory<TestHeaderFilterFactory, ExtensionFilterFactory> registered;
 
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   extension_filter:
     name: test_header_filter
@@ -1327,7 +1327,7 @@ TEST_F(AccessLogImplTest, SampleExtensionFilter) {
   Registry::RegisterFactory<SampleExtensionFilterFactory, ExtensionFilterFactory> registered;
 
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   extension_filter:
     name: sample_extension_filter
@@ -1355,7 +1355,7 @@ typed_config:
 TEST_F(AccessLogImplTest, UnregisteredExtensionFilter) {
   {
     const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   extension_filter:
     name: unregistered_extension_filter
@@ -1374,7 +1374,7 @@ typed_config:
 
   {
     const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 filter:
   extension_filter:
     name: bar
@@ -1390,6 +1390,15 @@ typed_config:
 
 // Test that the deprecated extension names still function.
 TEST_F(AccessLogImplTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  {
+    envoy::config::accesslog::v3::AccessLog config;
+    config.set_name("envoy.access_loggers.file");
+
+    EXPECT_NO_THROW(
+        Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
+            config));
+  }
+
   {
     envoy::config::accesslog::v3::AccessLog config;
     config.set_name("envoy.file_access_log");

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -38,7 +38,7 @@ namespace {
 absl::optional<envoy::config::accesslog::v3::AccessLog> testUpstreamLog() {
   // Custom format without timestamps or durations.
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   format: "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE%
@@ -283,7 +283,7 @@ TEST_F(RouterUpstreamLogTest, LogHeaders) {
 // Test timestamps and durations are emitted.
 TEST_F(RouterUpstreamLogTest, LogTimestampsAndDurations) {
   const std::string yaml = R"EOF(
-name: envoy.access_loggers.file
+name: accesslog
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
   format: "[%START_TIME%] %REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -50,7 +50,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
           access_log:
-          - name: envoy.access_loggers.file
+          - name: accesslog
             typed_config:
               "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
               path: /dev/null

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -117,7 +117,7 @@ const std::string ConfigHelper::HTTP_PROXY_CONFIG = BASE_CONFIG + R"EOF(
             name: envoy.router
           codec_type: HTTP1
           access_log:
-            name: envoy.access_loggers.file
+            name: accesslog
             filter:
               not_health_check_filter:  {}
             typed_config:

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
@@ -43,7 +43,7 @@ public:
             envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                 hcm) {
           auto* access_log = hcm.add_access_log();
-          access_log->set_name("envoy.access_loggers.http_grpc");
+          access_log->set_name("grpc_accesslog");
 
           envoy::extensions::access_loggers::grpc::v3::HttpGrpcAccessLogConfig config;
           auto* common_config = config.mutable_common_config();

--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -60,7 +60,7 @@ public:
           MessageUtil::anyConvert<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
               *config_blob);
       auto* access_log = tcp_proxy_config.add_access_log();
-      access_log->set_name("envoy.access_loggers.tcp_grpc");
+      access_log->set_name("grpc_accesslog");
       envoy::extensions::access_loggers::grpc::v3::TcpGrpcAccessLogConfig access_log_config;
       auto* common_config = access_log_config.mutable_common_config();
       common_config->set_log_name("foo");

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -877,7 +877,7 @@ http_filters:
 - name: envoy.http_dynamo_filter
   config: {}
 access_log:
-- name: envoy.access_loggers.file
+- name: accesslog
   typed_config:
     "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
     path: "/dev/null"
@@ -906,7 +906,7 @@ http_filters:
 - name: envoy.http_dynamo_filter
   typed_config: {}
 access_log:
-- name: envoy.access_loggers.file
+- name: accesslog
   typed_config:
     "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
     path: "/dev/null"
@@ -936,7 +936,7 @@ http_filters:
 - name: envoy.http_dynamo_filter
   typed_config: {}
 access_log:
-- name: envoy.access_loggers.file
+- name: accesslog
   typed_config:
     "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
     path: "/dev/null"

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -330,7 +330,7 @@ name: envoy.router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
-    name: envoy.access_loggers.file
+    name: accesslog
     filter:
       not_health_check_filter: {}
     typed_config:
@@ -455,7 +455,7 @@ name: envoy.router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
-    name: envoy.access_loggers.http_grpc
+    name: grpc_accesslog
     filter:
       not_health_check_filter: {}
     typed_config:

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -248,7 +248,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
         envoy::config::filter::network::tcp_proxy::v2::TcpProxy)>(*config_blob);
 
     auto* access_log = tcp_proxy_config.add_access_log();
-    access_log->set_name("envoy.access_loggers.file");
+    access_log->set_name("accesslog");
     envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
     access_log_config.set_path(access_log_path);
     access_log_config.set_format(


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: exercise semantic names for access log extensions
Risk Level: low
Testing: 
Docs Changes:
Release Notes:

/cc @zuercher 
