### PR TITLE
Enable docker build on Arm64 platform

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -159,7 +159,8 @@ build:remote-msan --config=rbe-toolchain-msan
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L7
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu@sha256:3788a87461f2b3dc8048ad0ce5df40438a56e0a8f1a4ab0f61b4ef0d8c11ff1f
+build:docker-sandbox --experimental_docker_image_amd64=envoyproxy/envoy-build-ubuntu@sha256:3788a87461f2b3dc8048ad0ce5df40438a56e0a8f1a4ab0f61b4ef0d8c11ff1f
+build:docker-sandbox --experimental_docker_image_arm64=envoyproxy/envoy-build-ubuntu@sha256:c975adaf4afd5142df599cde34debc572e2fdf1cd51be1f0763738152b53b229
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,2 +1,6 @@
-ENVOY_BUILD_SHA=$(grep envoyproxy/envoy-build-ubuntu@sha256 $(dirname $0)/../.bazelrc | sed -e 's#.*envoyproxy/envoy-build-ubuntu@sha256:\(.*\)#\1#' | uniq)
+if [[ $(uname -m) == "x86_64" ]]; then
+	ENVOY_BUILD_SHA=$(grep experimental_docker_image_amd64 $(dirname $0)/../.bazelrc | sed -e 's#.*envoyproxy/envoy-build-ubuntu@sha256:\(.*\)#\1#' | uniq)
+elif [[ $(uname -m) == "aarch64" ]]; then
+	ENVOY_BUILD_SHA=$(grep experimental_docker_image_arm64 $(dirname $0)/../.bazelrc | sed -e 's#.*envoyproxy/envoy-build-ubuntu@sha256:\(.*\)#\1#' | uniq)
+fi
 [[ $(wc -l <<< "${ENVOY_BUILD_SHA}" | awk '{$1=$1};1') == 1 ]] || (echo ".bazelrc envoyproxy/envoy-build-ubuntu hashes are inconsistent!" && exit 1)


### PR DESCRIPTION
For supporting docker build tools on Arm64 platform, some modification
was done in this patch.
1. Add arm64 envoy-build-tools image's sha256 value in bazelrc.
2. Modify some script for supporting different platform.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
