### PR TITLE
route checker tool: add response headers

### DIFF
--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -331,6 +331,7 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
     if (!headers_finalized_) {
       tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
                                                                true);
+      tool_config.route_->routeEntry()->finalizeResponseHeaders(*tool_config.headers_, stream_info);
       headers_finalized_ = true;
     }
 
@@ -362,6 +363,7 @@ bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::str
     if (!headers_finalized_) {
       tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
                                                                true);
+      tool_config.route_->routeEntry()->finalizeResponseHeaders(*tool_config.headers_, stream_info);
       headers_finalized_ = true;
     }
 
@@ -387,8 +389,16 @@ bool RouterCheckTool::compareRewriteHost(
 
 bool RouterCheckTool::compareRedirectPath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
+  Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
+                                                factory_context_->dispatcher().timeSource());
   if (tool_config.route_->directResponseEntry() != nullptr) {
-    tool_config.route_->directResponseEntry()->rewritePathHeader(*tool_config.headers_, true);
+    if (!headers_finalized_) {
+      tool_config.route_->directResponseEntry()->rewritePathHeader(*tool_config.headers_, true);
+      tool_config.route_->directResponseEntry()->finalizeResponseHeaders(*tool_config.headers_,
+                                                                         stream_info);
+      headers_finalized_ = true;
+    }
+
     actual = tool_config.route_->directResponseEntry()->newPath(*tool_config.headers_);
   }
 
@@ -436,8 +446,13 @@ bool RouterCheckTool::compareCustomHeaderField(ToolConfig& tool_config, const st
                                                 factory_context_->dispatcher().timeSource());
   stream_info.setDownstreamRemoteAddress(Network::Utility::getCanonicalIpv4LoopbackAddress());
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
-                                                             true);
+    if (!headers_finalized_) {
+      tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, stream_info,
+                                                               true);
+      tool_config.route_->routeEntry()->finalizeResponseHeaders(*tool_config.headers_, stream_info);
+      headers_finalized_ = true;
+    }
+
     actual = tool_config.headers_->get_(field);
   }
   return compareResults(actual, expected, "custom_header");

--- a/test/tools/router_check/test/config/TestRoutes.golden.proto.json
+++ b/test/tools/router_check/test/config/TestRoutes.golden.proto.json
@@ -324,6 +324,28 @@
           }
         ]
       }
+    },
+    {
+      "test_name": "Header_Fields Response",
+      "input": {
+        "authority": "www.lyft.com",
+        "path": "/ping",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "",
+        "host_rewrite": "",
+        "path_redirect": "http://www.lyft.com/ping",
+        "path_rewrite": "",
+        "virtual_cluster_name": "",
+        "virtual_host_name": "",
+        "header_fields": [
+          {
+            "key": "content-type",
+            "value": "text/plain"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test/tools/router_check/test/config/TestRoutes.yaml
+++ b/test/tools/router_check/test/config/TestRoutes.yaml
@@ -13,6 +13,16 @@ virtual_hosts:
           cluster: www2
           prefix_rewrite: /api/new_endpoint
       - match:
+          prefix: /ping
+        direct_response:
+          status: 200
+          body:
+            inline_string: "Success!"
+        response_headers_to_add:
+          - header:
+              key: "content-type"
+              value: "text/plain"
+      - match:
           path: /
         route:
           cluster: root_www2
@@ -20,7 +30,6 @@ virtual_hosts:
           prefix: /
         route:
           cluster: www2
-
   - name: www2_staging
     domains:
       - www-staging.lyft.net


### PR DESCRIPTION
Signed-off-by: Lisa Lu <lisalu@lyft.com>

Description: This change lets the route checker tool incorporate the proper response headers when doing route validation. It allows users to test how "response_headers_to_add" is configured in their route definitions.
Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A
Fixes #10072 