### PR TITLE
[WIP] fix segv when LRS is configured without --service-node

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -135,7 +135,10 @@ void AsyncStreamImpl::sendHeaders(HeaderMap& headers, bool end_stream) {
   is_grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
   headers.setReferenceEnvoyInternalRequest(Headers::get().EnvoyInternalRequestValues.True);
   if (send_xff_) {
-    Utility::appendXff(headers, *parent_.config_.local_info_.address());
+    const Network::Address::InstanceConstSharedPtr address = parent_.config_.local_info_.address();
+    if (address) {
+      Utility::appendXff(headers, *address);
+    }
   }
   router_.decodeHeaders(headers, end_stream);
   closeLocal(end_stream);

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -82,8 +82,9 @@ INSTANTIATE_TEST_SUITE_P(ValidConfigs, ValidationServerTest,
 // Just make sure that all configs can be ingested without a crash. Processing of config files
 // may not be successful, but there should be no crash.
 TEST_P(ValidationServerTest_1, RunWithoutCrash) {
-  validateConfig(options_, Network::Address::InstanceConstSharedPtr(), component_factory_,
-                 Thread::threadFactoryForTest(), Filesystem::fileSystemForTest());
+  auto local_address = Network::Utility::getLocalAddress(options_.localAddressIpVersion());
+  validateConfig(options_, local_address, component_factory_, Thread::threadFactoryForTest(),
+                 Filesystem::fileSystemForTest());
   SUCCEED();
 }
 


### PR DESCRIPTION
Signed-off-by: Bill Gallagher <bgallagher@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
