### PR TITLE
Install nghttp2 error callback in HTTP/2 codec.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1076,7 +1076,7 @@ ConnectionImpl::ClientHttp2Options::ClientHttp2Options(const Http2Settings& http
 }
 
 void ConnectionImpl::onError(int lib_error_code, const char* msg, size_t len) {
-  ENVOY_CONN_LOG(trace, "nghttp2 error: lib_error_code: {}, message: {}", connection_,
+  ENVOY_CONN_LOG(debug, "nghttp2 error: lib_error_code: {}, message: {}", connection_,
                  lib_error_code, absl::string_view(msg, len));
 }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -102,6 +102,8 @@ public:
       stream->runLowWatermarkCallbacks();
     }
   }
+  // nghttp2 error callback.
+  void onError(int lib_error_code, const char* msg, size_t len);
 
 protected:
   /**


### PR DESCRIPTION
This can facilitate debugging as the callback contains a pretty detailed
description of the protocol error, e.g. what header was missing or had
an invalid value.

Adding this saved me a ton of time when debugging a missing header 
issue, so I thought maybe this will be useful to upstream.

Signed-off-by: Oleg Shaldybin <olegsh@google.com>

Description: install nghttp2 error callback in HTTP/2 codec.
Risk Level: low.
Testing: made sure the log message is there and looks decent. 
Docs Changes: n/a
Release Notes: n/a
Fixes #7589
