### PR TITLE
stack_decode.py: Adjust to work with Python < 3.7

### DIFF
--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     rununder = subprocess.Popen(sys.argv[1:],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
-                                text=True)
+                                universal_newlines=True)
     decode_stacktrace_log(sys.argv[1], rununder.stdout)
     rununder.wait()
     sys.exit(rununder.returncode)  # Pass back test pass/fail result


### PR DESCRIPTION
Description: Adjust `stack_decode.py` to also work with Python older than 3.7. This is motivated by fact that the `envoyproxy/envoy-build-ubuntu` Docker image still has Python 3.5; and refuses to run `stack_decode.py`, saying
```
TypeError: __init__() got an unexpected keyword argument 'text'
```

Risk Level: Low
Testing: I verified that `stack_decode.py` now runs in the `envoyproxy/envoy-build-ubuntu@sha256:3788a87461f2b3dc8048ad0ce5df40438a56e0a8f1a4ab0f61b4ef0d8c11ff1f` Docker image.
Docs Changes: None
Release Notes: None