### PR TITLE
squash: const member variables

### DIFF
--- a/source/extensions/filters/http/squash/squash_filter.h
+++ b/source/extensions/filters/http/squash/squash_filter.h
@@ -40,15 +40,15 @@ private:
   static std::string replaceEnv(const std::string& attachment_template);
 
   // The name of the squash server cluster.
-  std::string cluster_name_;
+  const std::string cluster_name_;
   // The attachment body sent to squash server on create attachment.
-  std::string attachment_json_;
+  const std::string attachment_json_;
   // The total amount of time for an attachment to reach a final state (attached or error).
-  std::chrono::milliseconds attachment_timeout_;
+  const std::chrono::milliseconds attachment_timeout_;
   // How frequently should we poll the attachment state with the squash server.
-  std::chrono::milliseconds attachment_poll_period_;
+  const std::chrono::milliseconds attachment_poll_period_;
   // The timeout for individual requests to the squash server.
-  std::chrono::milliseconds request_timeout_;
+  const std::chrono::milliseconds request_timeout_;
 
   // Defines the pattern for interpolating environment variables in to the attachment.
   const static std::regex ENV_REGEX;
@@ -68,8 +68,8 @@ public:
   void onFailure(Http::AsyncClient::FailureReason f) override { on_fail_(f); }
 
 private:
-  std::function<void(Http::ResponseMessagePtr&&)> on_success_;
-  std::function<void(Http::AsyncClient::FailureReason)> on_fail_;
+  const std::function<void(Http::ResponseMessagePtr&&)> on_success_;
+  const std::function<void(Http::AsyncClient::FailureReason)> on_fail_;
 };
 
 class SquashFilter : public Http::StreamDecoderFilter,


### PR DESCRIPTION
minor drive-by fix, these member variables are only set once on construction and accessed through `const` getters

Signed-off-by: Derek Argueta <darguetap@gmail.com>