### PR TITLE
TestHeaderMapImplBase: avoid virtual call during construction

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -648,7 +648,7 @@ public:
   TestHeaderMapImplBase() = default;
   TestHeaderMapImplBase(const std::initializer_list<std::pair<std::string, std::string>>& values) {
     for (auto& value : values) {
-      addCopy(value.first, value.second);
+      header_map_.addCopy(LowerCaseString(value.first), value.second);
     }
   }
   TestHeaderMapImplBase(const TestHeaderMapImplBase& rhs)


### PR DESCRIPTION
Avoids clang tidy complaints I noticed while updating the Envoy dependency
to the latest in Nighthawk.

Risk Level: Low

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>
