### PR TITLE
rbac: log requestedServerName in debug

### DIFF
--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -56,8 +56,9 @@ Http::FilterHeadersStatus
 RoleBasedAccessControlFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   ENVOY_LOG(
       debug,
-      "checking request: remoteAddress: {}, localAddress: {}, ssl: {}, headers: {}, "
-      "dynamicMetadata: {}",
+      "checking request: requestedServerName: {}, remoteAddress: {}, localAddress: {}, ssl: {}, "
+      "headers: {}, dynamicMetadata: {}",
+      callbacks_->connection()->requestedServerName(),
       callbacks_->connection()->remoteAddress()->asString(),
       callbacks_->connection()->localAddress()->asString(),
       callbacks_->connection()->ssl()


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

Somehow this is only logged in the RBAC network filter, should also log it in the HTTP filter.

Description:
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
