### PR TITLE
connection_manager: Fix not passing enough arguments to logger

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1659,7 +1659,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
 
   chargeStats(headers);
 
-  ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):\n{}", *this, end_stream);
+  ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):\n{}", *this, end_stream,
+                   headers);
 
   // Now actually encode via the codec.
   stream_info_.onFirstDownstreamTxByteSent();


### PR DESCRIPTION
Description: In control plane tests I discovered this error showing up:
```
[*** LOG ERROR ***] [2020-02-19 10:16:52] [http] argument index out of range
```
I traced this error to this change: https://github.com/envoyproxy/envoy/commit/6d69def257c0bc820223b335cfaa7dac2bbbfee1#diff-d70ea2d9706e0246700148b2e2bb63ceL1625-R1642

Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A