### PR TITLE
Add client capability for not supporting overprovisioning.

### DIFF
--- a/api/envoy/api/v2/endpoint.proto
+++ b/api/envoy/api/v2/endpoint.proto
@@ -95,7 +95,7 @@ message ClusterLoadAssignment {
     // graceful failover as :ref:`overprovisioning factor
     // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
     // [#not-implemented-hide:]
-    bool disable_overprovisioning = 5 [deprecated=true];
+    bool disable_overprovisioning = 5 [deprecated = true];
   }
 
   // Name of the cluster. This will be the :ref:`service_name

--- a/api/envoy/api/v2/endpoint.proto
+++ b/api/envoy/api/v2/endpoint.proto
@@ -94,9 +94,8 @@ message ClusterLoadAssignment {
     // localities as endpoints become unhealthy. Otherwise Envoy will perform
     // graceful failover as :ref:`overprovisioning factor
     // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
-    // [#next-major-version: Unify with overprovisioning config as a single message.]
     // [#not-implemented-hide:]
-    bool disable_overprovisioning = 5;
+    bool disable_overprovisioning = 5 [deprecated=true];
   }
 
   // Name of the cluster. This will be the :ref:`service_name

--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -50,7 +50,9 @@ message ClusterLoadAssignment {
       type.v3.FractionalPercent drop_percentage = 2;
     }
 
-    reserved 1;
+    reserved 1, 5;
+
+    reserved "disable_overprovisioning";
 
     // Action to trim the overall incoming traffic to protect the upstream
     // hosts. This action allows protection in case the hosts are unable to
@@ -94,17 +96,6 @@ message ClusterLoadAssignment {
     // are considered stale and should be marked unhealthy.
     // Defaults to 0 which means endpoints never go stale.
     google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration = {gt {}}];
-
-    // The flag to disable overprovisioning. If it is set to true,
-    // :ref:`overprovisioning factor
-    // <arch_overview_load_balancing_overprovisioning_factor>` will be ignored
-    // and Envoy will not perform graceful failover between priority levels or
-    // localities as endpoints become unhealthy. Otherwise Envoy will perform
-    // graceful failover as :ref:`overprovisioning factor
-    // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
-    // [#next-major-version: Unify with overprovisioning config as a single message.]
-    // [#not-implemented-hide:]
-    bool disable_overprovisioning = 5;
   }
 
   // Name of the cluster. This will be the :ref:`service_name

--- a/docs/root/api/client_features.rst
+++ b/docs/root/api/client_features.rst
@@ -10,19 +10,14 @@ Client features use reverse DNS naming scheme, for example `com.acme.feature`.
 Currently Defined Client Features
 ---------------------------------
 
-+------------------------------------------------+-------------------------------------------------+
-| Client Feature Name                            | Description                                     |
-+================================================+=================================================+
-| envoy.config.require-any-fields-contain-struct | This feature indicates that xDS client requires |
-|                                                | that the configuration entries of type          |
-|                                                | *google.protobuf.Any* contain messages of type  |
-|                                                | *udpa.type.v1.TypedStruct* only                 |
-+------------------------------------------------+-------------------------------------------------+
-| envoy.lb.does_not_support_overprovisioning     | This feature indicates that the client does not |
-|                                                | support overprovisioning for priority failover  |
-|                                                | and locality weighting as configured by the     |
-|                                                | :ref:`overprovisioning_factor<envoy_api_field_endpoint.ClusterLoadAssignment.Policy.overprovisioning_factor>` |
-|                                                | field. If graceful failover functionality is    |
-|                                                | required, it must be supplied by the management |
-|                                                | server.                                         |
-+------------------------------------------------+-------------------------------------------------+
++------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| Client Feature Name                            | Description                                                                                          |
++================================================+======================================================================================================+
+| envoy.config.require-any-fields-contain-struct | This feature indicates that xDS client requires that the configuration entries of type               |
+|                                                | *google.protobuf.Any* contain messages of type *udpa.type.v1.TypedStruct* only.                      |
++------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| envoy.lb.does_not_support_overprovisioning     | This feature indicates that the client does not support overprovisioning for priority failover and   |
+|                                                | locality weighting as configured by the                                                              |
+|                                                | :ref:`overprovisioning_factor<envoy_api_field_ClusterLoadAssignment.Policy.overprovisioning_factor>` |
+|                                                | field. If graceful failover functionality is required, it must be supplied by the management server. |
++------------------------------------------------+------------------------------------------------------------------------------------------------------+

--- a/docs/root/api/client_features.rst
+++ b/docs/root/api/client_features.rst
@@ -10,14 +10,11 @@ Client features use reverse DNS naming scheme, for example `com.acme.feature`.
 Currently Defined Client Features
 ---------------------------------
 
-+------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| Client Feature Name                            | Description                                                                                          |
-+================================================+======================================================================================================+
-| envoy.config.require-any-fields-contain-struct | This feature indicates that xDS client requires that the configuration entries of type               |
-|                                                | *google.protobuf.Any* contain messages of type *udpa.type.v1.TypedStruct* only.                      |
-+------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| envoy.lb.does_not_support_overprovisioning     | This feature indicates that the client does not support overprovisioning for priority failover and   |
-|                                                | locality weighting as configured by the                                                              |
-|                                                | :ref:`overprovisioning_factor<envoy_api_field_ClusterLoadAssignment.Policy.overprovisioning_factor>` |
-|                                                | field. If graceful failover functionality is required, it must be supplied by the management server. |
-+------------------------------------------------+------------------------------------------------------------------------------------------------------+
+- **envoy.config.require-any-fields-contain-struct**: This feature indicates that xDS client
+  requires that the configuration entries of type  *google.protobuf.Any* contain messages of type
+  *udpa.type.v1.TypedStruct* only.
+- **envoy.lb.does_not_support_overprovisioning**: This feature indicates that the client does not
+  support overprovisioning for priority failover and locality weighting as configured by the
+  :ref:`overprovisioning_factor<envoy_api_field_ClusterLoadAssignment.Policy.overprovisioning_factor>`
+  field. If graceful failover functionality is required, it must be supplied by the management
+  server.

--- a/docs/root/api/client_features.rst
+++ b/docs/root/api/client_features.rst
@@ -18,3 +18,11 @@ Currently Defined Client Features
 |                                                | *google.protobuf.Any* contain messages of type  |
 |                                                | *udpa.type.v1.TypedStruct* only                 |
 +------------------------------------------------+-------------------------------------------------+
+| envoy.lb.does_not_support_overprovisioning     | This feature indicates that the client does not |
+|                                                | support overprovisioning for priority failover  |
+|                                                | and locality weighting as configured by the     |
+|                                                | :ref:`overprovisioning_factor<envoy_api_field_endpoint.ClusterLoadAssignment.Policy.overprovisioning_factor>` |
+|                                                | field. If graceful failover functionality is    |
+|                                                | required, it must be supplied by the management |
+|                                                | server.                                         |
++------------------------------------------------+-------------------------------------------------+

--- a/generated_api_shadow/envoy/api/v2/endpoint.proto
+++ b/generated_api_shadow/envoy/api/v2/endpoint.proto
@@ -94,9 +94,8 @@ message ClusterLoadAssignment {
     // localities as endpoints become unhealthy. Otherwise Envoy will perform
     // graceful failover as :ref:`overprovisioning factor
     // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
-    // [#next-major-version: Unify with overprovisioning config as a single message.]
     // [#not-implemented-hide:]
-    bool disable_overprovisioning = 5;
+    bool disable_overprovisioning = 5 [deprecated = true];
   }
 
   // Name of the cluster. This will be the :ref:`service_name

--- a/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
+++ b/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
@@ -102,9 +102,8 @@ message ClusterLoadAssignment {
     // localities as endpoints become unhealthy. Otherwise Envoy will perform
     // graceful failover as :ref:`overprovisioning factor
     // <arch_overview_load_balancing_overprovisioning_factor>` suggests.
-    // [#next-major-version: Unify with overprovisioning config as a single message.]
     // [#not-implemented-hide:]
-    bool disable_overprovisioning = 5;
+    bool hidden_envoy_deprecated_disable_overprovisioning = 5 [deprecated = true];
   }
 
   // Name of the cluster. This will be the :ref:`service_name


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Description: Add client capability for not supporting overprovisioning.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A

This should eliminate the need for #8093.  And we can remove the `disable_overprovisioning` flag added in #8080, since it never got used.  (I can add that to this PR if you'd like.)

@htuch @alyssawilk @snowp