### PR TITLE
[fuzz] fix filter fuzz bugs

### DIFF
--- a/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -38,7 +38,8 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
+  string request_type = 3
+      [(validate.rules).string = {in: "internal" in: "external" in: "both" in: ""}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -38,7 +38,7 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3;
+  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -40,7 +40,8 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
+  string request_type = 3
+      [(validate.rules).string = {in: "internal" in: "external" in: "both" in: ""}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -40,7 +40,7 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3;
+  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/generated_api_shadow/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/generated_api_shadow/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -38,7 +38,8 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
+  string request_type = 3
+      [(validate.rules).string = {in: "internal" in: "external" in: "both" in: ""}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/generated_api_shadow/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/generated_api_shadow/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -38,7 +38,7 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3;
+  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/generated_api_shadow/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -40,7 +40,8 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
+  string request_type = 3
+      [(validate.rules).string = {in: "internal" in: "external" in: "both" in: ""}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/generated_api_shadow/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -40,7 +40,7 @@ message RateLimit {
   // :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   // request is considered external. The filter defaults to *both*, and it will apply to all request
   // types.
-  string request_type = 3;
+  string request_type = 3 [(validate.rules).string = {in: "internal" in: "external" in: "both"}];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/test/extensions/filters/http/common/fuzz/BUILD
+++ b/test/extensions/filters/http/common/fuzz/BUILD
@@ -38,5 +38,7 @@ envoy_cc_fuzz_test(
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/server:server_mocks",
+        "@envoy_api//envoy/service/auth/v3:pkg_cc_proto",
+        "@envoy_api//envoy/service/auth/v2alpha:pkg_cc_proto",
     ] + envoy_all_extensions(),
 )

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5167332043522048
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5167332043522048
@@ -1,0 +1,10 @@
+config {
+  name: "envoy.gzip"
+}
+data {
+  headers {
+    headers {
+      value: "\002\000"
+    }
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5661692476522496
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5661692476522496
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.ext_authz"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz"
+    value: " \001"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5710239968264192
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5710239968264192
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.rate_limit"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit"
+    value: "\n\020envoy.rate_limit\032>type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC:\007\022\005\n\003\n\0012"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5762605081952256
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5762605081952256
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.tap"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap"
+    value: "\n,\n*\n(envoy.filters.http.dynamic_forward_proxy"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -40,6 +40,7 @@ public:
     // Ext-authz setup
     prepareExtAuthz();
     prepareCache();
+    prepareTap();
   }
 
   void prepareExtAuthz() {
@@ -57,6 +58,11 @@ public:
     // Prepare expectations for dynamic forward proxy.
     ON_CALL(factory_context_.dispatcher_, createDnsResolver(_, _))
         .WillByDefault(testing::Return(resolver_));
+  }
+
+  void prepareTap() {
+    ON_CALL(factory_context_.admin_, addHandler(_, _, _, _, _)).WillByDefault(testing::Return(true));
+    ON_CALL(factory_context_.admin_, removeHandler(_)).WillByDefault(testing::Return(true));
   }
 
   // This executes the decode methods to be fuzzed.

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -61,7 +61,8 @@ public:
   }
 
   void prepareTap() {
-    ON_CALL(factory_context_.admin_, addHandler(_, _, _, _, _)).WillByDefault(testing::Return(true));
+    ON_CALL(factory_context_.admin_, addHandler(_, _, _, _, _))
+        .WillByDefault(testing::Return(true));
     ON_CALL(factory_context_.admin_, removeHandler(_)).WillByDefault(testing::Return(true));
   }
 


### PR DESCRIPTION
Fixes some config related bugs that came up from the fuzzer.
* Validations on `request_type` in `RateLimit` proto. 
* Admin handler mocking issues
* Linking issue for grpc service auth definitions
* Invalid header characters fixed by validating input

Fixes: 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20851
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20845
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20839

Testing: regression corpus entries added

Signed-off-by: Asra Ali <asraa@google.com>
