### PR TITLE
tracing: use X-Ray cluster_name if segment_name is not specified

### DIFF
--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -130,8 +130,8 @@ Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, Envoy::Sys
   span_ptr->setId(ticks);
   span_ptr->setName(segment_name_);
   span_ptr->setOperation(operation_name);
-  // even though we have a TimeSource member in the tracer, we
-  // assume the start_time argument has more precise value than
+  // Even though we have a TimeSource member in the tracer, we assume the start_time argument has a
+  // more precise value than calling the systemTime() at this point in time.
   span_ptr->setStartTime(start_time);
 
   if (xray_header) { // there's a previous span that this span should be based-on

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -122,16 +122,18 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& ope
   return child_span;
 }
 
-Tracing::SpanPtr Tracer::startSpan(const std::string& span_name, const std::string& operation_name,
-                                   Envoy::SystemTime start_time,
+Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name, Envoy::SystemTime start_time,
                                    const absl::optional<XRayHeader>& xray_header) {
 
   const auto ticks = time_source_.monotonicTime().time_since_epoch().count();
   auto span_ptr = std::make_unique<XRay::Span>(time_source_, *daemon_broker_);
   span_ptr->setId(ticks);
-  span_ptr->setName(span_name);
+  span_ptr->setName(segment_name_);
   span_ptr->setOperation(operation_name);
+  // even though we have a TimeSource member in the tracer, we
+  // assume the start_time argument has more precise value than
   span_ptr->setStartTime(start_time);
+
   if (xray_header) { // there's a previous span that this span should be based-on
     span_ptr->setParentId(xray_header->parent_id_);
     span_ptr->setTraceId(xray_header->trace_id_);
@@ -155,7 +157,7 @@ XRay::SpanPtr Tracer::createNonSampledSpan() const {
   auto span_ptr = std::make_unique<XRay::Span>(time_source_, *daemon_broker_);
   const auto ticks = time_source_.monotonicTime().time_since_epoch().count();
   span_ptr->setId(ticks);
-  span_ptr->setName("NotSampled");
+  span_ptr->setName(segment_name_);
   span_ptr->setTraceId(generateTraceId(time_source_.systemTime()));
   span_ptr->setSampled(false);
   return span_ptr;

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -166,8 +166,7 @@ public:
   /**
    * Starts a tracing span for X-Ray
    */
-  Tracing::SpanPtr startSpan(const std::string& span_name, const std::string& operation_name,
-                             Envoy::SystemTime start_time,
+  Tracing::SpanPtr startSpan(const std::string& operation_name, Envoy::SystemTime start_time,
                              const absl::optional<XRayHeader>& xray_header);
   /**
    * Creates a Span that is marked as not-sampled.

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -102,7 +102,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
 
   auto* tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer_.get();
   if (should_trace.value()) {
-    return tracer->startSpan(xray_config_.segment_name_, operation_name, start_time,
+    return tracer->startSpan(operation_name, start_time,
                              header ? absl::optional<XRayHeader>(xray_header) : absl::nullopt);
   }
 

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -66,8 +66,8 @@ TEST_F(XRayTracerTest, SerializeSpanTest) {
 
   EXPECT_CALL(*broker_, send(_)).WillOnce(Invoke(on_send));
   Tracer tracer{expected_span_name, std::move(broker_), server_.timeSource()};
-  auto span = tracer.startSpan(expected_span_name, expected_operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto span = tracer.startSpan(expected_operation_name, server_.timeSource().systemTime(),
+                               absl::nullopt /*headers*/);
   span->setTag("http.method", expected_http_method);
   span->setTag("http.url", expected_http_url);
   span->setTag("user_agent", expected_user_agent);
@@ -88,8 +88,8 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
   constexpr auto expected_operation_name = "Create";
   const auto& broker = *broker_;
   Tracer tracer{expected_span_name, std::move(broker_), server_.timeSource()};
-  auto parent_span = tracer.startSpan(expected_span_name, expected_operation_name,
-                                      server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto parent_span = tracer.startSpan(expected_operation_name, server_.timeSource().systemTime(),
+                                      absl::nullopt /*headers*/);
 
   const XRay::Span* xray_parent_span = static_cast<XRay::Span*>(parent_span.get());
   const std::string expected_parent_id = xray_parent_span->Id();
@@ -118,8 +118,7 @@ TEST_F(XRayTracerTest, UseExistingHeaderInformation) {
   constexpr auto operation_name = "my operation";
 
   Tracer tracer{span_name, std::move(broker_), server_.timeSource()};
-  auto span =
-      tracer.startSpan(span_name, operation_name, server_.timeSource().systemTime(), xray_header);
+  auto span = tracer.startSpan(operation_name, server_.timeSource().systemTime(), xray_header);
 
   const XRay::Span* xray_span = static_cast<XRay::Span*>(span.get());
   ASSERT_STREQ(xray_header.trace_id_.c_str(), xray_span->traceId().c_str());
@@ -131,7 +130,7 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
   constexpr auto operation_name = "my operation";
 
   Tracer tracer{span_name, std::move(broker_), server_.timeSource()};
-  auto span = tracer.startSpan(span_name, operation_name, server_.timeSource().systemTime(),
+  auto span = tracer.startSpan(operation_name, server_.timeSource().systemTime(),
                                absl::nullopt /*headers*/);
   Http::HeaderMapImpl request_headers;
   span->injectContext(request_headers);

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -13,6 +13,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::testing::ReturnRef;
+
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
@@ -88,6 +90,20 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
   // b) there are no sampling rules passed, so the default rules apply (1 req/sec and 5% after that
   // within that second)
   ASSERT_NE(span, nullptr);
+}
+
+TEST_F(XRayDriverTest, EmptySegmentNameDefaultToClusterName) {
+  const std::string cluster_name = "FooBar";
+  EXPECT_CALL(server_.local_info_, clusterName()).WillRepeatedly(ReturnRef(cluster_name));
+  XRayConfiguration config{"" /*daemon_endpoint*/, "", "" /*sampling_rules*/};
+  Driver driver(config, server_);
+
+  Tracing::Decision tracing_decision{Tracing::Reason::Sampling, true /*sampled*/};
+  Envoy::SystemTime start_time;
+  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+                               tracing_decision);
+  auto* xray_span = static_cast<XRay::Span*>(span.get());
+  ASSERT_STREQ(xray_span->name().c_str(), cluster_name.c_str());
 }
 
 } // namespace


### PR DESCRIPTION
If users do not specify the segment_name in the X-Ray tracer, the span's name should default to the cluster name.

Risk Level: Low
Testing: unit tests
[Fixes #10142]( https://github.com/envoyproxy/envoy/issues/10142)

