### PR TITLE
Add server.memory_physical_bytes stats

### DIFF
--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -11,7 +11,7 @@ option java_multiple_files = true;
 // Proto representation of the internal memory consumption of an Envoy instance. These represent
 // values extracted from an internal TCMalloc instance. For more information, see the section of the
 // docs entitled ["Generic Tcmalloc Status"](https://gperftools.github.io/gperftools/tcmalloc.html).
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Memory {
   // The number of bytes allocated by the heap for Envoy. This is an alias for
   // `generic.current_allocated_bytes`.
@@ -34,4 +34,8 @@ message Memory {
   // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias
   // for `tcmalloc.current_total_thread_cache_bytes`.
   uint64 total_thread_cache = 5;
+
+  // The number of bytes of the physical memory usage by the allocator. This is an alias for
+  // `generic.total_physical_bytes`.
+  uint64 total_physical_bytes = 6;
 }

--- a/api/envoy/admin/v3/memory.proto
+++ b/api/envoy/admin/v3/memory.proto
@@ -13,7 +13,7 @@ option java_multiple_files = true;
 // Proto representation of the internal memory consumption of an Envoy instance. These represent
 // values extracted from an internal TCMalloc instance. For more information, see the section of the
 // docs entitled ["Generic Tcmalloc Status"](https://gperftools.github.io/gperftools/tcmalloc.html).
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Memory {
   option (udpa.annotations.versioning).previous_message_type = "envoy.admin.v2alpha.Memory";
 
@@ -38,4 +38,8 @@ message Memory {
   // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias
   // for `tcmalloc.current_total_thread_cache_bytes`.
   uint64 total_thread_cache = 5;
+
+  // The number of bytes of the physical memory usage by the allocator. This is an alias for
+  // `generic.total_physical_bytes`.
+  uint64 total_physical_bytes = 6;
 }

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -18,6 +18,7 @@ Server related statistics are rooted at *server.* with following statistics:
   concurrency, Gauge, Number of worker threads
   memory_allocated, Gauge, Current amount of allocated memory in bytes. Total of both new and old Envoy processes on hot restart.
   memory_heap_size, Gauge, Current reserved heap size in bytes. New Envoy process heap size on hot restart.
+  memory_physical_ize, Gauge, Current estimate of total bytes of the physical memory. New Envoy process physical memory size on hot restart.
   live, Gauge, "1 if the server is not currently draining, 0 otherwise"
   state, Gauge, Current :ref:`State <envoy_api_enum_admin.v2alpha.ServerInfo.state>` of the Server.
   parent_connections, Gauge, Total connections of the old Envoy process on hot restart

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -18,7 +18,7 @@ Server related statistics are rooted at *server.* with following statistics:
   concurrency, Gauge, Number of worker threads
   memory_allocated, Gauge, Current amount of allocated memory in bytes. Total of both new and old Envoy processes on hot restart.
   memory_heap_size, Gauge, Current reserved heap size in bytes. New Envoy process heap size on hot restart.
-  memory_physical_ize, Gauge, Current estimate of total bytes of the physical memory. New Envoy process physical memory size on hot restart.
+  memory_physical_size, Gauge, Current estimate of total bytes of the physical memory. New Envoy process physical memory size on hot restart.
   live, Gauge, "1 if the server is not currently draining, 0 otherwise"
   state, Gauge, Current :ref:`State <envoy_api_enum_admin.v2alpha.ServerInfo.state>` of the Server.
   parent_connections, Gauge, Total connections of the old Envoy process on hot restart

--- a/generated_api_shadow/envoy/admin/v2alpha/memory.proto
+++ b/generated_api_shadow/envoy/admin/v2alpha/memory.proto
@@ -11,7 +11,7 @@ option java_multiple_files = true;
 // Proto representation of the internal memory consumption of an Envoy instance. These represent
 // values extracted from an internal TCMalloc instance. For more information, see the section of the
 // docs entitled ["Generic Tcmalloc Status"](https://gperftools.github.io/gperftools/tcmalloc.html).
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Memory {
   // The number of bytes allocated by the heap for Envoy. This is an alias for
   // `generic.current_allocated_bytes`.
@@ -34,4 +34,8 @@ message Memory {
   // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias
   // for `tcmalloc.current_total_thread_cache_bytes`.
   uint64 total_thread_cache = 5;
+
+  // The number of bytes of the physical memory usage by the allocator. This is an alias for
+  // `generic.total_physical_bytes`.
+  uint64 total_physical_bytes = 6;
 }

--- a/generated_api_shadow/envoy/admin/v3/memory.proto
+++ b/generated_api_shadow/envoy/admin/v3/memory.proto
@@ -13,7 +13,7 @@ option java_multiple_files = true;
 // Proto representation of the internal memory consumption of an Envoy instance. These represent
 // values extracted from an internal TCMalloc instance. For more information, see the section of the
 // docs entitled ["Generic Tcmalloc Status"](https://gperftools.github.io/gperftools/tcmalloc.html).
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Memory {
   option (udpa.annotations.versioning).previous_message_type = "envoy.admin.v2alpha.Memory";
 
@@ -38,4 +38,8 @@ message Memory {
   // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias
   // for `tcmalloc.current_total_thread_cache_bytes`.
   uint64 total_thread_cache = 5;
+
+  // The number of bytes of the physical memory usage by the allocator. This is an alias for
+  // `generic.total_physical_bytes`.
+  uint64 total_physical_bytes = 6;
 }

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -68,6 +68,7 @@ uint64_t Stats::totalThreadCacheBytes() { return 0; }
 uint64_t Stats::totalCurrentlyReserved() { return 0; }
 uint64_t Stats::totalPageHeapUnmapped() { return 0; }
 uint64_t Stats::totalPageHeapFree() { return 0; }
+uint64_t Stats::totalPhysicalBytes() { return 0; }
 void Stats::dumpStatsToLog() {}
 
 } // namespace Memory

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -853,6 +853,7 @@ Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap& response
   memory.set_total_thread_cache(Memory::Stats::totalThreadCacheBytes());
   memory.set_pageheap_unmapped(Memory::Stats::totalPageHeapUnmapped());
   memory.set_pageheap_free(Memory::Stats::totalPageHeapFree());
+  memory.set_total_physical_bytes(Memory::Stats::totalPhysicalBytes());
   response.add(MessageUtil::getJsonStringFromMessage(memory, true, true)); // pretty-print
   return Http::Code::OK;
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -194,6 +194,7 @@ void InstanceImpl::updateServerStats() {
   server_stats_->memory_allocated_.set(Memory::Stats::totalCurrentlyAllocated() +
                                        parent_stats.parent_memory_allocated_);
   server_stats_->memory_heap_size_.set(Memory::Stats::totalCurrentlyReserved());
+  server_stats_->memory_physical_size_.set(Memory::Stats::totalPhysicalBytes());
   server_stats_->parent_connections_.set(parent_stats.parent_connections_);
   server_stats_->total_connections_.set(listener_manager_->numConnections() +
                                         parent_stats.parent_connections_);

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -62,6 +62,7 @@ namespace Server {
   GAUGE(live, NeverImport)                                                                         \
   GAUGE(memory_allocated, Accumulate)                                                              \
   GAUGE(memory_heap_size, Accumulate)                                                              \
+  GAUGE(memory_physical_size, Accumulate)                                                          \
   GAUGE(parent_connections, Accumulate)                                                            \
   GAUGE(state, NeverImport)                                                                        \
   GAUGE(stats_recent_lookups, NeverImport)                                                         \

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -46,7 +46,7 @@ common_tls_context:
   validation_context:
     trusted_ca:
       filename: {{ test_rundir }}/test/config/integration/certs/cacert.pem
-    match_subject_alt_names:
+    match_subject_alt_names: 
       exact: "spiffe://lyft.com/backend-team"
       exact: "lyft.com"
       exact: "www.lyft.com"
@@ -57,7 +57,7 @@ common_tls_context:
   validation_context:
     trusted_ca:
       filename: {{ test_rundir }}/test/config/integration/certs/cacert.pem
-    match_subject_alt_names:
+    match_subject_alt_names: 
       exact: "spiffe://lyft.com/backend-team"
       exact: "lyft.com"
       exact: "www.lyft.com"

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -46,7 +46,7 @@ common_tls_context:
   validation_context:
     trusted_ca:
       filename: {{ test_rundir }}/test/config/integration/certs/cacert.pem
-    match_subject_alt_names: 
+    match_subject_alt_names:
       exact: "spiffe://lyft.com/backend-team"
       exact: "lyft.com"
       exact: "www.lyft.com"
@@ -57,7 +57,7 @@ common_tls_context:
   validation_context:
     trusted_ca:
       filename: {{ test_rundir }}/test/config/integration/certs/cacert.pem
-    match_subject_alt_names: 
+    match_subject_alt_names:
       exact: "spiffe://lyft.com/backend-team"
       exact: "lyft.com"
       exact: "www.lyft.com"
@@ -737,6 +737,7 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
       {"server.memory_allocated", "server.memory_allocated"},
       {"http.admin.downstream_cx_http2_active", "http.downstream_cx_http2_active"},
       {"server.memory_heap_size", "server.memory_heap_size"},
+      {"server.memory_physical_size", "server.memory_physical_size"},
       {"listener_manager.total_listeners_draining", "listener_manager.total_listeners_draining"},
       {"filesystem.write_total_buffered", "filesystem.write_total_buffered"},
       {"http.admin.downstream_cx_ssl_active", "http.downstream_cx_ssl_active"},


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

Description: 
Currently, envoy exposes only the two stats of `server.memory_allocated` and `server.memory_heap_size`, but in fact the former is only the memory used by envoy itself and does not contain the TCmalloc cache. Although the latter contains the TCmalloc cache, it actually contains the area of memory that has been released, and neither stats really reflects the real memory usage of envoy. So I'd like to add a new server.memory_physical_bytes stats equal to the generic.total_physical_bytes in TCmalloc. This stats can truly reflect the memory that Envoy occupies

Risk Level: low
Testing: N/A
Docs Changes: yes
Release Notes:  N/A
[Optional Fixes #Issue] #10153
[Optional Deprecated:]
