### PR TITLE
[build] clean up absl external deps

### DIFF
--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -93,10 +93,12 @@ envoy_cc_library(
 envoy_cc_library(
     name = "header_map_interface",
     hdrs = ["header_map.h"],
+    external_deps = [
+        "abseil_inlined_vector",
+    ],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
-        "@com_google_absl//absl/container:inlined_vector",
     ],
 )
 

--- a/tools/clang_tools/api_booster/BUILD
+++ b/tools/clang_tools/api_booster/BUILD
@@ -23,9 +23,9 @@ clang_tools_cc_library(
     name = "proto_cxx_utils_lib",
     srcs = ["proto_cxx_utils.cc"],
     hdrs = ["proto_cxx_utils.h"],
-    deps = [
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:optional",
+    external_deps = [
+        "abseil_strings",
+        "abseil_optional",
     ],
 )
 

--- a/tools/clang_tools/api_booster/BUILD
+++ b/tools/clang_tools/api_booster/BUILD
@@ -23,9 +23,9 @@ clang_tools_cc_library(
     name = "proto_cxx_utils_lib",
     srcs = ["proto_cxx_utils.cc"],
     hdrs = ["proto_cxx_utils.h"],
-    external_deps = [
-        "abseil_strings",
-        "abseil_optional",
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
     ],
 )
 


### PR DESCRIPTION
Cleans up abseil dependencies to go through external deps via the paths defined in `bazel/repositories.bzl`

Fixes #10147 
