### PR TITLE
doc: Event RunType

### DIFF
--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -186,8 +186,8 @@ public:
    *              run() will return.
    */
   enum class RunType {
-    Block,       // Executes any events that have been activated, then exit.
-    NonBlock,    // Waits for any pending events to activate, executes them,
+    Block,       // Runs the event-loop until there are no pending events.
+    NonBlock,    // Checks for any pending events to activate, executes them,
                  // then exits. Exits immediately if there are no pending or
                  // active events.
     RunUntilExit // Runs the event-loop until loopExit() is called, blocking


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Description:
See http://www.wangafu.net/~nickm/libevent-book/Ref3_eventloop.html
Pseudocode
while (any events are registered with the loop,
        or EVLOOP_NO_EXIT_ON_EMPTY was set) {

    if (EVLOOP_NONBLOCK was set, or any events are already active)
        If any registered events have triggered, mark them active.
    else
        Wait until at least one event has triggered, and mark it active.
...
}

Risk Level: LOW
Testing: 
Docs Changes: 
Release Notes:

