### PR TITLE
test: Add bazel build extension for benchmarks for benchmark targets

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -11,6 +11,7 @@ load("//bazel:envoy_internal.bzl", "envoy_select_force_libcpp")
 exports_files([
     "gen_sh_test_runner.sh",
     "sh_test_wrapper.sh",
+    "test_for_benchmark_wrapper.sh",
 ])
 
 genrule(

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -21,6 +21,7 @@ load(
 )
 load(
     ":envoy_test.bzl",
+    _envoy_cc_benchmark_binary_and_test = "envoy_cc_benchmark_binary_and_test",
     _envoy_cc_fuzz_test = "envoy_cc_fuzz_test",
     _envoy_cc_mock = "envoy_cc_mock",
     _envoy_cc_test = "envoy_cc_test",
@@ -185,5 +186,6 @@ envoy_cc_mock = _envoy_cc_mock
 envoy_cc_test = _envoy_cc_test
 envoy_cc_test_binary = _envoy_cc_test_binary
 envoy_cc_test_library = _envoy_cc_test_library
+envoy_cc_benchmark_binary_and_test = _envoy_cc_benchmark_binary_and_test
 envoy_py_test_binary = _envoy_py_test_binary
 envoy_sh_test = _envoy_sh_test

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -21,7 +21,8 @@ load(
 )
 load(
     ":envoy_test.bzl",
-    _envoy_cc_benchmark_binary_and_test = "envoy_cc_benchmark_binary_and_test",
+    _envoy_benchmark_test = "envoy_benchmark_test",
+    _envoy_cc_benchmark_binary = "envoy_cc_benchmark_binary",
     _envoy_cc_fuzz_test = "envoy_cc_fuzz_test",
     _envoy_cc_mock = "envoy_cc_mock",
     _envoy_cc_test = "envoy_cc_test",
@@ -186,6 +187,7 @@ envoy_cc_mock = _envoy_cc_mock
 envoy_cc_test = _envoy_cc_test
 envoy_cc_test_binary = _envoy_cc_test_binary
 envoy_cc_test_library = _envoy_cc_test_library
-envoy_cc_benchmark_binary_and_test = _envoy_cc_benchmark_binary_and_test
+envoy_cc_benchmark_binary = _envoy_cc_benchmark_binary
+envoy_benchmark_test = _envoy_benchmark_test
 envoy_py_test_binary = _envoy_py_test_binary
 envoy_sh_test = _envoy_sh_test

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -242,7 +242,7 @@ def envoy_cc_test_binary(
     )
 
 # Envoy benchmark binaries should be specified with this function.
-def envoy_cc_benchmark_binary_and_test(
+def envoy_cc_benchmark_binary(
         name,
         deps = [],
         **kargs):
@@ -251,11 +251,17 @@ def envoy_cc_benchmark_binary_and_test(
         deps = deps + ["//test/benchmark:main"],
         **kargs
     )
+
+# Tests to validate that Envoy benchmarks run successfully should be specified with this function.
+def envoy_benchmark_test(
+        name,
+        benchmark_binary,
+        data = []):
     native.sh_test(
-        name = name + "_test",
+        name = name,
         srcs = ["//bazel:test_for_benchmark_wrapper.sh"],
-        data = [":" + name],
-        args = ["%s/%s" % (native.package_name(), name), "--benchmark_min_time=0.00001"],
+        data = [":" + benchmark_binary] + data,
+        args = ["%s/%s" % (native.package_name(), benchmark_binary)],
     )
 
 # Envoy Python test binaries should be specified with this function.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -241,6 +241,23 @@ def envoy_cc_test_binary(
         **kargs
     )
 
+# Envoy benchmark binaries should be specified with this function.
+def envoy_cc_benchmark_binary_and_test(
+        name,
+        deps = [],
+        **kargs):
+    envoy_cc_test_binary(
+        name,
+        deps = deps + ["//test/benchmark:main"],
+        **kargs
+    )
+    native.sh_test(
+        name = name + "_test",
+        srcs = ["//bazel:test_for_benchmark_wrapper.sh"],
+        data = [":" + name],
+        args = ["%s/%s" % (native.package_name(), name), "--benchmark_min_time=0.00001"],
+    )
+
 # Envoy Python test binaries should be specified with this function.
 def envoy_py_test_binary(
         name,

--- a/bazel/test_for_benchmark_wrapper.sh
+++ b/bazel/test_for_benchmark_wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+HEAPCHECK= "$@"

--- a/bazel/test_for_benchmark_wrapper.sh
+++ b/bazel/test_for_benchmark_wrapper.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-HEAPCHECK= "$@"
+# Set the benchmark time to a tiny value since we just want to know if the benchmark runs to completion.
+HEAPCHECK= "$@" --benchmark_min_time=0.00001

--- a/test/benchmark/BUILD
+++ b/test/benchmark/BUILD
@@ -1,0 +1,22 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_test_library(
+    name = "main",
+    srcs = ["main.cc"],
+    external_deps = [
+        "abseil_symbolize",
+        "benchmark",
+    ],
+    deps = select({
+        "//bazel:disable_signal_trace": [],
+        "//conditions:default": ["//source/common/signal:sigaction_lib"],
+    }),
+)

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -8,6 +8,8 @@
 
 #include "benchmark/benchmark.h"
 
+#include "absl/debugging/symbolize.h"
+
 // Boilerplate main(), which discovers benchmarks and runs them.
 int main(int argc, char** argv) {
 #ifndef __APPLE__

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -1,0 +1,26 @@
+// NOLINT(namespace-envoy)
+// This is an Envoy driver for benchmarks.
+
+#ifdef ENVOY_HANDLE_SIGNALS
+#include "common/signal/signal_action.h"
+
+#endif
+
+#include "benchmark/benchmark.h"
+
+// Boilerplate main(), which discovers benchmarks and runs them.
+int main(int argc, char** argv) {
+#ifndef __APPLE__
+  absl::InitializeSymbolizer(argv[0]);
+#endif
+#ifdef ENVOY_HANDLE_SIGNALS
+  // Enabled by default. Control with "bazel --define=signal_trace=disabled"
+  Envoy::SignalAction handle_sigs;
+#endif
+
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
     "envoy_proto_library",
 )
@@ -78,7 +78,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "access_log_formatter_speed_test",
     srcs = ["access_log_formatter_speed_test.cc"],
     external_deps = [

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
@@ -78,7 +79,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "access_log_formatter_speed_test",
     srcs = ["access_log_formatter_speed_test.cc"],
     external_deps = [
@@ -93,4 +94,9 @@ envoy_cc_benchmark_binary_and_test(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:printers_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "access_log_formatter_speed_test_benchmark_test",
+    benchmark_binary = "access_log_formatter_speed_test",
 )

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -8,16 +8,44 @@
 
 namespace {
 
-static std::unique_ptr<Envoy::AccessLog::FormatterImpl> formatter;
-static std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter;
-static std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter;
-static std::unique_ptr<Envoy::TestStreamInfo> stream_info;
+std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> MakeJsonFormatter(bool typed) {
+  std::unordered_map<std::string, std::string> JsonLogFormat = {
+      {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
+      {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
+      {"method", "%REQ(:METHOD)%"},
+      {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
+      {"protocol", "%PROTOCOL%"},
+      {"respoinse_code", "%RESPONSE_CODE%"},
+      {"bytes_sent", "%BYTES_SENT%"},
+      {"duration", "%DURATION%"},
+      {"referer", "%REQ(REFERER)%"},
+      {"user-agent", "%REQ(USER-AGENT)%"}};
+
+  return std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, typed);
+}
+
+std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
+  auto stream_info = std::make_unique<Envoy::TestStreamInfo>();
+  stream_info->setDownstreamRemoteAddress(
+      std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
+  return stream_info;
+}
 
 } // namespace
 
 namespace Envoy {
 
 static void BM_AccessLogFormatter(benchmark::State& state) {
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  static const char* LogFormat =
+      "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
+      "%REQ(:METHOD)% "
+      "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% "
+      "s%RESPONSE_CODE% %BYTES_SENT% %DURATION% %REQ(REFERER)% \"%REQ(USER-AGENT)%\" - - -\n";
+
+  std::unique_ptr<Envoy::AccessLog::FormatterImpl> formatter =
+      std::make_unique<Envoy::AccessLog::FormatterImpl>(LogFormat);
+
   size_t output_bytes = 0;
   Http::TestHeaderMapImpl request_headers;
   Http::TestHeaderMapImpl response_headers;
@@ -32,6 +60,9 @@ static void BM_AccessLogFormatter(benchmark::State& state) {
 BENCHMARK(BM_AccessLogFormatter);
 
 static void BM_JsonAccessLogFormatter(benchmark::State& state) {
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter = MakeJsonFormatter(false);
+
   size_t output_bytes = 0;
   Http::TestHeaderMapImpl request_headers;
   Http::TestHeaderMapImpl response_headers;
@@ -46,6 +77,10 @@ static void BM_JsonAccessLogFormatter(benchmark::State& state) {
 BENCHMARK(BM_JsonAccessLogFormatter);
 
 static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter =
+      MakeJsonFormatter(true);
+
   size_t output_bytes = 0;
   Http::TestHeaderMapImpl request_headers;
   Http::TestHeaderMapImpl response_headers;
@@ -60,39 +95,3 @@ static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
 BENCHMARK(BM_TypedJsonAccessLogFormatter);
 
 } // namespace Envoy
-
-// Hack to initialize the global variables used by the benchmarks above.
-class GlobalInitialize {
-public:
-  GlobalInitialize() {
-    static const char* LogFormat =
-        "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
-        "%REQ(:METHOD)% "
-        "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% "
-        "s%RESPONSE_CODE% %BYTES_SENT% %DURATION% %REQ(REFERER)% \"%REQ(USER-AGENT)%\" - - -\n";
-
-    formatter = std::make_unique<Envoy::AccessLog::FormatterImpl>(LogFormat);
-
-    std::unordered_map<std::string, std::string> JsonLogFormat = {
-        {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
-        {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
-        {"method", "%REQ(:METHOD)%"},
-        {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
-        {"protocol", "%PROTOCOL%"},
-        {"respoinse_code", "%RESPONSE_CODE%"},
-        {"bytes_sent", "%BYTES_SENT%"},
-        {"duration", "%DURATION%"},
-        {"referer", "%REQ(REFERER)%"},
-        {"user-agent", "%REQ(USER-AGENT)%"}};
-
-    json_formatter = std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, false);
-    typed_json_formatter =
-        std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, true);
-
-    stream_info = std::make_unique<Envoy::TestStreamInfo>();
-    stream_info->setDownstreamRemoteAddress(
-        std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
-  }
-};
-
-GlobalInitialize initialize;

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -61,37 +61,38 @@ BENCHMARK(BM_TypedJsonAccessLogFormatter);
 
 } // namespace Envoy
 
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  static const char* LogFormat =
-      "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
-      "%REQ(:METHOD)% "
-      "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% "
-      "s%RESPONSE_CODE% %BYTES_SENT% %DURATION% %REQ(REFERER)% \"%REQ(USER-AGENT)%\" - - -\n";
+// Hack to initialize the global variables used by the benchmarks above.
+class GlobalInitialize {
+public:
+  GlobalInitialize() {
+    static const char* LogFormat =
+        "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
+        "%REQ(:METHOD)% "
+        "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% "
+        "s%RESPONSE_CODE% %BYTES_SENT% %DURATION% %REQ(REFERER)% \"%REQ(USER-AGENT)%\" - - -\n";
 
-  formatter = std::make_unique<Envoy::AccessLog::FormatterImpl>(LogFormat);
+    formatter = std::make_unique<Envoy::AccessLog::FormatterImpl>(LogFormat);
 
-  std::unordered_map<std::string, std::string> JsonLogFormat = {
-      {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
-      {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
-      {"method", "%REQ(:METHOD)%"},
-      {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
-      {"protocol", "%PROTOCOL%"},
-      {"respoinse_code", "%RESPONSE_CODE%"},
-      {"bytes_sent", "%BYTES_SENT%"},
-      {"duration", "%DURATION%"},
-      {"referer", "%REQ(REFERER)%"},
-      {"user-agent", "%REQ(USER-AGENT)%"}};
+    std::unordered_map<std::string, std::string> JsonLogFormat = {
+        {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
+        {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
+        {"method", "%REQ(:METHOD)%"},
+        {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
+        {"protocol", "%PROTOCOL%"},
+        {"respoinse_code", "%RESPONSE_CODE%"},
+        {"bytes_sent", "%BYTES_SENT%"},
+        {"duration", "%DURATION%"},
+        {"referer", "%REQ(REFERER)%"},
+        {"user-agent", "%REQ(USER-AGENT)%"}};
 
-  json_formatter = std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, false);
-  typed_json_formatter = std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, true);
+    json_formatter = std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, false);
+    typed_json_formatter =
+        std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, true);
 
-  stream_info = std::make_unique<Envoy::TestStreamInfo>();
-  stream_info->setDownstreamRemoteAddress(
-      std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
+    stream_info = std::make_unique<Envoy::TestStreamInfo>();
+    stream_info->setDownstreamRemoteAddress(
+        std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
   }
-  benchmark::RunSpecifiedBenchmarks();
-}
+};
+
+GlobalInitialize initialize;

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
@@ -91,7 +92,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "buffer_speed_test",
     srcs = ["buffer_speed_test.cc"],
     external_deps = [
@@ -100,4 +101,9 @@ envoy_cc_benchmark_binary_and_test(
     deps = [
         "//source/common/buffer:buffer_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "buffer_speed_test_benchmark_test",
+    benchmark_binary = "buffer_speed_test",
 )

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
@@ -91,7 +91,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "buffer_speed_test",
     srcs = ["buffer_speed_test.cc"],
     external_deps = [

--- a/test/common/buffer/buffer_speed_test.cc
+++ b/test/common/buffer/buffer_speed_test.cc
@@ -366,13 +366,3 @@ BENCHMARK(BufferStartsWithMatch)
     ->Args({65536, 4096});
 
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -221,7 +221,7 @@ envoy_cc_test(
     deps = ["//source/common/common:callback_impl_lib"],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "utility_speed_test",
     srcs = ["utility_speed_test.cc"],
     external_deps = [

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
@@ -221,7 +222,7 @@ envoy_cc_test(
     deps = ["//source/common/common:callback_impl_lib"],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "utility_speed_test",
     srcs = ["utility_speed_test.cc"],
     external_deps = [
@@ -232,6 +233,11 @@ envoy_cc_benchmark_binary_and_test(
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "utility_speed_test_benchmark_test",
+    benchmark_binary = "utility_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -275,12 +275,3 @@ static void BM_IntervalSet50ToVector(benchmark::State& state) {
 }
 BENCHMARK(BM_IntervalSet50ToVector);
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -246,8 +246,8 @@ static void BM_IntervalSetInsert17(benchmark::State& state) {
     interval_set.insert(3, 6);
     interval_set.insert(3, 20);
     interval_set.insert(3, 22);
-    interval_set.insert(-2, 23);
-    interval_set.insert(-3, 24);
+    interval_set.insert(23, 9223372036854775806UL);
+    interval_set.insert(24, 9223372036854775805UL);
   }
 }
 BENCHMARK(BM_IntervalSetInsert17);

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
@@ -106,7 +106,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "codes_speed_test",
     srcs = ["codes_speed_test.cc"],
     external_deps = [
@@ -257,7 +257,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "header_map_impl_speed_test",
     srcs = ["header_map_impl_speed_test.cc"],
     external_deps = [

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
@@ -106,7 +107,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "codes_speed_test",
     srcs = ["codes_speed_test.cc"],
     external_deps = [
@@ -117,6 +118,11 @@ envoy_cc_benchmark_binary_and_test(
         "//source/common/stats:isolated_store_lib",
         "//source/common/stats:stats_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "codes_speed_test_benchmark_test",
+    benchmark_binary = "codes_speed_test",
 )
 
 envoy_cc_test_library(
@@ -257,7 +263,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "header_map_impl_speed_test",
     srcs = ["header_map_impl_speed_test.cc"],
     external_deps = [
@@ -266,6 +272,11 @@ envoy_cc_benchmark_binary_and_test(
     deps = [
         "//source/common/http:header_map_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "header_map_impl_speed_test_benchmark_test",
+    benchmark_binary = "header_map_impl_speed_test",
 )
 
 envoy_proto_library(

--- a/test/common/http/codes_speed_test.cc
+++ b/test/common/http/codes_speed_test.cc
@@ -111,13 +111,3 @@ static void BM_ResponseTimingRealSymtab(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ResponseTimingRealSymtab);
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -222,13 +222,3 @@ BENCHMARK(HeaderMapImplPopulate);
 
 } // namespace Http
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -2,8 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -42,7 +42,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "address_impl_speed_test",
     srcs = ["address_impl_speed_test.cc"],
     external_deps = [
@@ -284,7 +284,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "lc_trie_speed_test",
     srcs = ["lc_trie_speed_test.cc"],
     external_deps = [

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
@@ -42,7 +43,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "address_impl_speed_test",
     srcs = ["address_impl_speed_test.cc"],
     external_deps = [
@@ -51,6 +52,11 @@ envoy_cc_benchmark_binary_and_test(
     deps = [
         "//source/common/network:address_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "address_impl_speed_test_benchmark_test",
+    benchmark_binary = "address_impl_speed_test",
 )
 
 envoy_cc_test(
@@ -284,7 +290,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "lc_trie_speed_test",
     srcs = ["lc_trie_speed_test.cc"],
     external_deps = [
@@ -294,6 +300,11 @@ envoy_cc_benchmark_binary_and_test(
         "//source/common/network:lc_trie_lib",
         "//source/common/network:utility_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "lc_trie_speed_test_benchmark_test",
+    benchmark_binary = "lc_trie_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/network/address_impl_speed_test.cc
+++ b/test/common/network/address_impl_speed_test.cc
@@ -36,13 +36,3 @@ BENCHMARK(Ipv6InstanceCreate);
 } // namespace Address
 } // namespace Network
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/network/lc_trie_speed_test.cc
+++ b/test/common/network/lc_trie_speed_test.cc
@@ -5,30 +5,61 @@
 
 namespace {
 
-std::vector<Envoy::Network::Address::InstanceConstSharedPtr> addresses;
+struct AddressInputs {
+  AddressInputs() {
+    // Random test addresses from RFC 5737 netblocks
+    static const std::string test_addresses[] = {
+        "192.0.2.225",   "198.51.100.55", "198.51.100.105", "192.0.2.150",   "203.0.113.162",
+        "203.0.113.110", "203.0.113.99",  "198.51.100.23",  "198.51.100.24", "203.0.113.12"};
+    for (const auto& address : test_addresses) {
+      addresses_.push_back(Envoy::Network::Utility::parseInternetAddress(address));
+    }
+  }
 
-std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>> tag_data;
+  std::vector<Envoy::Network::Address::InstanceConstSharedPtr> addresses_;
+};
 
-std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
-    tag_data_nested_prefixes;
+struct CidrInputs {
+  CidrInputs() {
+    // Construct three sets of prefixes: one consisting of 1,024 addresses in an
+    // RFC 5737 netblock, another consisting of those same addresses plus
+    // 0.0.0.0/0 (to exercise the LC Trie's support for nested prefixes),
+    // and finally a set containing only 0.0.0.0/0.
+    for (int i = 0; i < 32; i++) {
+      for (int j = 0; j < 32; j++) {
+        tag_data_.emplace_back(
+            std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+                {"tag_1",
+                 {Envoy::Network::Address::CidrRange::create(
+                     fmt::format("192.0.{}.{}/32", i, j))}}));
+      }
+    }
+    tag_data_nested_prefixes_ = tag_data_;
+    tag_data_nested_prefixes_.emplace_back(
+        std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+            {"tag_0", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
+    tag_data_minimal_.emplace_back(
+        std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+            {"tag_1", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
+  }
 
-std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
-    tag_data_minimal;
-
-std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie;
-
-std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_nested_prefixes;
-
-std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_minimal;
+  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>> tag_data_;
+  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
+      tag_data_nested_prefixes_;
+  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
+      tag_data_minimal_;
+};
 
 } // namespace
 
 namespace Envoy {
 
 static void BM_LcTrieConstruct(benchmark::State& state) {
+  CidrInputs inputs;
+
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(inputs.tag_data_);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -36,9 +67,12 @@ static void BM_LcTrieConstruct(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstruct);
 
 static void BM_LcTrieConstructNested(benchmark::State& state) {
+  CidrInputs inputs;
+
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_nested_prefixes);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(
+        inputs.tag_data_nested_prefixes_);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -46,10 +80,11 @@ static void BM_LcTrieConstructNested(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstructNested);
 
 static void BM_LcTrieConstructMinimal(benchmark::State& state) {
+  CidrInputs inputs;
 
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_minimal);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(inputs.tag_data_minimal_);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -57,12 +92,17 @@ static void BM_LcTrieConstructMinimal(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstructMinimal);
 
 static void BM_LcTrieLookup(benchmark::State& state) {
+  CidrInputs cidr_inputs;
+  AddressInputs address_inputs;
+  std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie =
+      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(cidr_inputs.tag_data_);
+
   static size_t i = 0;
   size_t output_tags = 0;
   for (auto _ : state) {
     i++;
-    i %= addresses.size();
-    output_tags += lc_trie->getData(addresses[i]).size();
+    i %= address_inputs.addresses_.size();
+    output_tags += lc_trie->getData(address_inputs.addresses_[i]).size();
   }
   benchmark::DoNotOptimize(output_tags);
 }
@@ -70,12 +110,18 @@ static void BM_LcTrieLookup(benchmark::State& state) {
 BENCHMARK(BM_LcTrieLookup);
 
 static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
+  CidrInputs cidr_inputs;
+  AddressInputs address_inputs;
+  std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_nested_prefixes =
+      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(
+          cidr_inputs.tag_data_nested_prefixes_);
+
   static size_t i = 0;
   size_t output_tags = 0;
   for (auto _ : state) {
     i++;
-    i %= addresses.size();
-    output_tags += lc_trie_nested_prefixes->getData(addresses[i]).size();
+    i %= address_inputs.addresses_.size();
+    output_tags += lc_trie_nested_prefixes->getData(address_inputs.addresses_[i]).size();
   }
   benchmark::DoNotOptimize(output_tags);
 }
@@ -83,12 +129,17 @@ static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
 BENCHMARK(BM_LcTrieLookupWithNestedPrefixes);
 
 static void BM_LcTrieLookupMinimal(benchmark::State& state) {
+  CidrInputs cidr_inputs;
+  AddressInputs address_inputs;
+  std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_minimal =
+      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(cidr_inputs.tag_data_minimal_);
+
   static size_t i = 0;
   size_t output_tags = 0;
   for (auto _ : state) {
     i++;
-    i %= addresses.size();
-    output_tags += lc_trie_minimal->getData(addresses[i]).size();
+    i %= address_inputs.addresses_.size();
+    output_tags += lc_trie_minimal->getData(address_inputs.addresses_[i]).size();
   }
   benchmark::DoNotOptimize(output_tags);
 }
@@ -96,46 +147,3 @@ static void BM_LcTrieLookupMinimal(benchmark::State& state) {
 BENCHMARK(BM_LcTrieLookupMinimal);
 
 } // namespace Envoy
-
-// Hack to initialize the global variables used by the benchmarks above.
-class GlobalInitialize {
-public:
-  GlobalInitialize() {
-    // Random test addresses from RFC 5737 netblocks
-    static const std::string test_addresses[] = {
-        "192.0.2.225",   "198.51.100.55", "198.51.100.105", "192.0.2.150",   "203.0.113.162",
-        "203.0.113.110", "203.0.113.99",  "198.51.100.23",  "198.51.100.24", "203.0.113.12"};
-    for (const auto& address : test_addresses) {
-      addresses.push_back(Envoy::Network::Utility::parseInternetAddress(address));
-    }
-
-    // Construct three sets of prefixes: one consisting of 1,024 addresses in an
-    // RFC 5737 netblock, another consisting of those same addresses plus
-    // 0.0.0.0/0 (to exercise the LC Trie's support for nested prefixes),
-    // and finally a set containing only 0.0.0.0/0.
-    for (int i = 0; i < 32; i++) {
-      for (int j = 0; j < 32; j++) {
-        tag_data.emplace_back(
-            std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-                {"tag_1",
-                 {Envoy::Network::Address::CidrRange::create(
-                     fmt::format("192.0.{}.{}/32", i, j))}}));
-      }
-    }
-    tag_data_nested_prefixes = tag_data;
-    tag_data_nested_prefixes.emplace_back(
-        std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-            {"tag_0", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
-    tag_data_minimal.emplace_back(
-        std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-            {"tag_1", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
-
-    lc_trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data);
-    lc_trie_nested_prefixes =
-        std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_nested_prefixes);
-    lc_trie_minimal =
-        std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_minimal);
-  }
-};
-
-GlobalInitialize initialize;

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_binary",
@@ -196,7 +197,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "thread_local_store_speed_test",
     srcs = ["thread_local_store_speed_test.cc"],
     external_deps = [
@@ -214,4 +215,9 @@ envoy_cc_benchmark_binary_and_test(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/metrics/v2:pkg_cc_proto",
     ],
+)
+
+envoy_benchmark_test(
+    name = "thread_local_store_speed_test_benchmark_test",
+    benchmark_binary = "thread_local_store_speed_test",
 )

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -2,6 +2,7 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_binary",
@@ -195,7 +196,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "thread_local_store_speed_test",
     srcs = ["thread_local_store_speed_test.cc"],
     external_deps = [

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -41,6 +41,9 @@ public:
     if (tls_) {
       tls_->shutdownGlobalThreading();
     }
+    if (dispatcher_) {
+      dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    }
   }
 
   void accessCounters() {

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -50,6 +50,9 @@ public:
   }
 
   void initThreading() {
+    if (!Envoy::Event::Libevent::Global::initialized()) {
+      Envoy::Event::Libevent::Global::initialize();
+    }
     dispatcher_ = api_->allocateDispatcher();
     tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
     store_.initializeThreading(*dispatcher_, *tls_);
@@ -95,14 +98,3 @@ BENCHMARK(BM_StatsWithTls);
 
 // TODO(jmarantz): add multi-threaded variant of this test, that aggressively
 // looks up stats in multiple threads to try to trigger contention issues.
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  Envoy::Event::Libevent::Global::initialize();
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -2,7 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
@@ -326,7 +327,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_cc_benchmark_binary(
     name = "load_balancer_benchmark",
     srcs = ["load_balancer_benchmark.cc"],
     external_deps = [
@@ -342,6 +343,11 @@ envoy_cc_benchmark_binary_and_test(
         "//test/test_common:printers_lib",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
     ],
+)
+
+envoy_benchmark_test(
+    name = "load_balancer_benchmark_test",
+    benchmark_binary = "load_balancer_benchmark",
 )
 
 envoy_cc_test(

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -2,8 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -326,7 +326,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "load_balancer_benchmark",
     srcs = ["load_balancer_benchmark.cc"],
     external_deps = [

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -40,6 +40,12 @@ public:
                                     {}, hosts, {}, absl::nullopt);
   }
 
+  Envoy::Thread::MutexBasicLockable lock_;
+  // Reduce default log level to warn while running this benchmark to avoid problems due to
+  // excessive debug logging in upstream_impl.cc
+  Envoy::Logger::Context logging_context_{spdlog::level::warn,
+                                          Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock_, false};
+
   PrioritySetImpl priority_set_;
   PrioritySetImpl local_priority_set_;
   Stats::IsolatedStoreImpl stats_store_;
@@ -482,13 +488,3 @@ BENCHMARK(BM_MaglevLoadBalancerWeighted)
 } // namespace
 } // namespace Upstream
 } // namespace Envoy
-
-class GlobalInitialize {
-  Envoy::Thread::MutexBasicLockable lock_;
-  // Reduce default log level to warn while running this benchmark to avoid problems due to
-  // excessive debug logging in upstream_impl.cc
-  Envoy::Logger::Context logging_context_{spdlog::level::warn,
-                                          Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock_, false};
-};
-
-GlobalInitialize initialize;

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -483,17 +483,12 @@ BENCHMARK(BM_MaglevLoadBalancerWeighted)
 } // namespace Upstream
 } // namespace Envoy
 
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  // TODO(mattklein123): Provide a common bazel benchmark wrapper much like we do for normal tests,
-  // fuzz, etc.
-  Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_context(spdlog::level::warn,
-                                         Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
+class GlobalInitialize {
+  Envoy::Thread::MutexBasicLockable lock_;
+  // Reduce default log level to warn while running this benchmark to avoid problems due to
+  // excessive debug logging in upstream_impl.cc
+  Envoy::Logger::Context logging_context_{spdlog::level::warn,
+                                          Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock_, false};
+};
 
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}
+GlobalInitialize initialize;

--- a/test/extensions/extensions_build_system.bzl
+++ b/test/extensions/extensions_build_system.bzl
@@ -1,4 +1,4 @@
-load("//bazel:envoy_build_system.bzl", "envoy_cc_benchmark_binary_and_test", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library")
+load("//bazel:envoy_build_system.bzl", "envoy_benchmark_test", "envoy_cc_benchmark_binary", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library")
 load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
 
 # All extension tests should use this version of envoy_cc_test(). It allows compiling out
@@ -40,11 +40,20 @@ def envoy_extension_cc_test_binary(
 
     envoy_cc_test_binary(name, **kwargs)
 
-def envoy_extension_benchmark_binary_and_test(
+def envoy_extension_cc_benchmark_binary(
         name,
         extension_name,
         **kwargs):
     if not extension_name in EXTENSIONS:
         return
 
-    envoy_cc_benchmark_binary_and_test(name, **kwargs)
+    envoy_cc_benchmark_binary(name, **kwargs)
+
+def envoy_extension_benchmark_test(
+        name,
+        extension_name,
+        **kwargs):
+    if not extension_name in EXTENSIONS:
+        return
+
+    envoy_benchmark_test(name, **kwargs)

--- a/test/extensions/extensions_build_system.bzl
+++ b/test/extensions/extensions_build_system.bzl
@@ -1,4 +1,4 @@
-load("//bazel:envoy_build_system.bzl", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_benchmark_binary_and_test", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library")
 load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
 
 # All extension tests should use this version of envoy_cc_test(). It allows compiling out
@@ -39,3 +39,12 @@ def envoy_extension_cc_test_binary(
         return
 
     envoy_cc_test_binary(name, **kwargs)
+
+def envoy_extension_benchmark_binary_and_test(
+        name,
+        extension_name,
+        **kwargs):
+    if not extension_name in EXTENSIONS:
+        return
+
+    envoy_cc_benchmark_binary_and_test(name, **kwargs)

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -2,9 +2,9 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -23,7 +23,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary_and_test(
     name = "tls_inspector_benchmark",
     srcs = ["tls_inspector_benchmark.cc"],
     external_deps = [

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -2,10 +2,14 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary_and_test",
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_benchmark_test",
+    "envoy_extension_cc_benchmark_binary",
 )
 
 envoy_package()
@@ -23,9 +27,10 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_benchmark_binary_and_test(
+envoy_extension_cc_benchmark_binary(
     name = "tls_inspector_benchmark",
     srcs = ["tls_inspector_benchmark.cc"],
+    extension_name = "envoy.filters.listener.tls_inspector",
     external_deps = [
         "benchmark",
     ],
@@ -38,6 +43,12 @@ envoy_cc_benchmark_binary_and_test(
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",
     ],
+)
+
+envoy_extension_benchmark_test(
+    name = "tls_inspector_benchmark_test",
+    benchmark_binary = "tls_inspector_benchmark",
+    extension_name = "envoy.filters.listener.tls_inspector",
 )
 
 envoy_cc_library(

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -97,16 +97,3 @@ BENCHMARK(BM_TlsInspector)->Unit(benchmark::kMicrosecond);
 } // namespace ListenerFilters
 } // namespace Extensions
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_context(spdlog::level::warn,
-                                         Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
-
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -79,7 +79,7 @@ static void BM_TlsInspector(benchmark::State& state) {
   for (auto _ : state) {
     Filter filter(cfg);
     filter.onAccept(cb);
-    dispatcher.file_event_callback_(Event::FileReadyType::Read);
+    RELEASE_ASSERT(dispatcher.file_event_callback_ == nullptr, "");
     RELEASE_ASSERT(socket.detectedTransportProtocol() == "tls", "");
     RELEASE_ASSERT(socket.requestedServerName() == "example.com", "");
     RELEASE_ASSERT(socket.requestedApplicationProtocols().size() == 2 &&

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -7,8 +7,8 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_benchmark_binary_and_test",
     "envoy_extension_cc_test",
-    "envoy_extension_cc_test_binary",
 )
 
 envoy_package()
@@ -101,7 +101,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test_binary(
+envoy_extension_benchmark_binary_and_test(
     name = "command_lookup_speed_test",
     srcs = ["command_lookup_speed_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
@@ -143,7 +143,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test_binary(
+envoy_extension_benchmark_binary_and_test(
     name = "command_split_speed_test",
     srcs = ["command_split_speed_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -7,7 +7,8 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_extension_benchmark_binary_and_test",
+    "envoy_extension_benchmark_test",
+    "envoy_extension_cc_benchmark_binary",
     "envoy_extension_cc_test",
 )
 
@@ -101,7 +102,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_benchmark_binary_and_test(
+envoy_extension_cc_benchmark_binary(
     name = "command_lookup_speed_test",
     srcs = ["command_lookup_speed_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
@@ -116,6 +117,12 @@ envoy_extension_benchmark_binary_and_test(
         "//test/test_common:printers_lib",
         "//test/test_common:simulated_time_system_lib",
     ],
+)
+
+envoy_extension_benchmark_test(
+    name = "command_lookup_speed_test_benchmark_test",
+    benchmark_binary = "command_lookup_speed_test",
+    extension_name = "envoy.filters.network.redis_proxy",
 )
 
 envoy_extension_cc_test(
@@ -143,7 +150,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_benchmark_binary_and_test(
+envoy_extension_cc_benchmark_binary(
     name = "command_split_speed_test",
     srcs = ["command_split_speed_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
@@ -159,4 +166,10 @@ envoy_extension_benchmark_binary_and_test(
         "//test/test_common:printers_lib",
         "//test/test_common:simulated_time_system_lib",
     ],
+)
+
+envoy_extension_benchmark_test(
+    name = "command_split_speed_test_benchmark_test",
+    benchmark_binary = "command_split_speed_test",
+    extension_name = "envoy.filters.network.redis_proxy",
 )

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -85,13 +85,3 @@ static void BM_MakeRequests(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_MakeRequests);
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/filters/network/redis_proxy/command_split_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_split_speed_test.cc
@@ -130,13 +130,3 @@ static void BM_Split_CreateVariant(benchmark::State& state) {
   state.counters["use_count"] = request.use_count();
 }
 BENCHMARK(BM_Split_CreateVariant)->Ranges({{1, 100}, {64, 8 << 14}});
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/filters/network/redis_proxy/command_split_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_split_speed_test.cc
@@ -49,7 +49,7 @@ public:
   void createShared(Common::Redis::RespValueSharedPtr request) {
     for (uint64_t i = 1; i < request->asArray().size(); i += 2) {
       auto single_set = std::make_shared<const Common::Redis::RespValue>(
-          request, Common::Redis::Utility::SetRequest::instance(), i, i + 2);
+          request, Common::Redis::Utility::SetRequest::instance(), i, i + 1);
     }
   }
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -2,9 +2,10 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_select_hot_restart",
@@ -382,7 +383,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "filter_chain_benchmark_test",
     srcs = ["filter_chain_benchmark_test.cc"],
     external_deps = [
@@ -398,4 +399,9 @@ envoy_cc_test_binary(
         # tranport socket config registration
         "//source/extensions/transport_sockets/tls:config",
     ],
+)
+
+envoy_benchmark_test(
+    name = "filter_chain_benchmark_test_benchmark_test",
+    benchmark_binary = "filter_chain_benchmark_test",
 )

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -248,4 +248,3 @@ clang-format on
 */
 } // namespace Server
 } // namespace Envoy
-BENCHMARK_MAIN();

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -208,8 +208,9 @@ std::string TestEnvironment::substitute(const std::string& str,
   const std::unordered_map<std::string, std::string> path_map = {
       {"test_tmpdir", TestEnvironment::temporaryDirectory()},
       {"test_udsdir", TestEnvironment::unixDomainSocketDirectory()},
-      {"test_rundir", TestEnvironment::runfilesDirectory()},
+      {"test_rundir", runfiles_ != nullptr ? TestEnvironment::runfilesDirectory() : "invalid"},
   };
+
   std::string out_json_string = str;
   for (const auto& it : path_map) {
     const std::regex port_regex("\\{\\{ " + it.first + " \\}\\}");


### PR DESCRIPTION
Description: Add bazel build extensions for benchmarks targets and tests for benchmark targets that expands to a benchmark binary with an implicit dependency on //test/benchmark:main. The new benchmark main registers a signal handler that prints the failure stack on failure, in addition to doing benchmark initialization, flag parsing and running the selected benchmarks.

Also, fix existing benchmarks that didn't use to complete successfully.
Risk Level: n/a
Testing: adds test targets to provide basic coverage for existing benchmarks.
Docs Changes: n/a
Release Notes: n/a
Fixes #9539, #9540, #9541