### PR TITLE
http: more header map refactor

### DIFF
--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -64,9 +64,10 @@ public:
    * Evaluate whether an access log should be written based on request and response data.
    * @return TRUE if the log should be written.
    */
-  virtual bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                        const Http::HeaderMap& response_headers,
-                        const Http::HeaderMap& response_trailers) PURE;
+  virtual bool evaluate(const StreamInfo::StreamInfo& info,
+                        const Http::RequestHeaderMap& request_headers,
+                        const Http::ResponseHeaderMap& response_headers,
+                        const Http::ResponseTrailerMap& response_trailers) PURE;
 };
 
 using FilterPtr = std::unique_ptr<Filter>;
@@ -86,8 +87,9 @@ public:
    * @param stream_info supplies additional information about the request not
    * contained in the request headers.
    */
-  virtual void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                   const Http::HeaderMap* response_trailers,
+  virtual void log(const Http::RequestHeaderMap* request_headers,
+                   const Http::ResponseHeaderMap* response_headers,
+                   const Http::ResponseTrailerMap* response_trailers,
                    const StreamInfo::StreamInfo& stream_info) PURE;
 };
 
@@ -109,9 +111,9 @@ public:
    * @param stream_info supplies the stream info.
    * @return std::string string containing the complete formatted access log line.
    */
-  virtual std::string format(const Http::HeaderMap& request_headers,
-                             const Http::HeaderMap& response_headers,
-                             const Http::HeaderMap& response_trailers,
+  virtual std::string format(const Http::RequestHeaderMap& request_headers,
+                             const Http::ResponseHeaderMap& response_headers,
+                             const Http::ResponseTrailerMap& response_trailers,
                              const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
@@ -133,9 +135,9 @@ public:
    * @param stream_info supplies the stream info.
    * @return std::string containing a single value extracted from the given headers/trailers/stream.
    */
-  virtual std::string format(const Http::HeaderMap& request_headers,
-                             const Http::HeaderMap& response_headers,
-                             const Http::HeaderMap& response_trailers,
+  virtual std::string format(const Http::RequestHeaderMap& request_headers,
+                             const Http::ResponseHeaderMap& response_headers,
+                             const Http::ResponseTrailerMap& response_trailers,
                              const StreamInfo::StreamInfo& stream_info) const PURE;
   /**
    * Extract a value from the provided headers/trailers/stream, preserving the value's type.
@@ -146,9 +148,9 @@ public:
    * @return ProtobufWkt::Value containing a single value extracted from the given
    *         headers/trailers/stream.
    */
-  virtual ProtobufWkt::Value formatValue(const Http::HeaderMap& request_headers,
-                                         const Http::HeaderMap& response_headers,
-                                         const Http::HeaderMap& response_trailers,
+  virtual ProtobufWkt::Value formatValue(const Http::RequestHeaderMap& request_headers,
+                                         const Http::ResponseHeaderMap& response_headers,
+                                         const Http::ResponseTrailerMap& response_trailers,
                                          const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -304,7 +304,7 @@ public:
    *
    * @return a reference to the newly created trailers map.
    */
-  virtual HeaderMap& addDecodedTrailers() PURE;
+  virtual RequestTrailerMap& addDecodedTrailers() PURE;
 
   /**
    * Create a locally generated response using the provided response_code and body_text parameters.
@@ -642,7 +642,7 @@ public:
    *
    * @return a reference to the newly created trailers map.
    */
-  virtual HeaderMap& addEncodedTrailers() PURE;
+  virtual ResponseTrailerMap& addEncodedTrailers() PURE;
 
   /**
    * Adds new metadata to be encoded.

--- a/include/envoy/http/hash_policy.h
+++ b/include/envoy/http/hash_policy.h
@@ -36,8 +36,8 @@ public:
    * returned if for example the specified HTTP header does not exist.
    */
   virtual absl::optional<uint64_t>
-  generateHash(const Network::Address::Instance* downstream_address, const HeaderMap& headers,
-               AddCookieCallback add_cookie) const PURE;
+  generateHash(const Network::Address::Instance* downstream_address,
+               const RequestHeaderMap& headers, AddCookieCallback add_cookie) const PURE;
 };
 
 } // namespace Http

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -624,18 +624,28 @@ using HeaderMapPtr = std::unique_ptr<HeaderMap>;
 
 /**
  * Typed derived classes for all header map types.
- * TODO(mattklein123): In future changes we will be differentiating the implementation between
- *   these classes to both fix bugs and improve performance.
- * TODO(mattklein123): Virtual inheritance is currently required due to a layered implementation.
- *   Consider also removing virtual inheritance once we finish the typed header refactor.
  */
-class RequestHeaderMap : public virtual HeaderMap {};
+
+// Base class for both request and response headers.
+class RequestOrResponseHeaderMap : public virtual HeaderMap {};
+
+// Request headers.
+class RequestHeaderMap : public RequestOrResponseHeaderMap {};
 using RequestHeaderMapPtr = std::unique_ptr<RequestHeaderMap>;
+
+// Request trailers.
 class RequestTrailerMap : public virtual HeaderMap {};
 using RequestTrailerMapPtr = std::unique_ptr<RequestTrailerMap>;
-class ResponseHeaderMap : public virtual HeaderMap {};
+
+// Base class for both response headers and trailers.
+class ResponseHeaderOrTrailerMap : public virtual HeaderMap {};
+
+// Response headers.
+class ResponseHeaderMap : public RequestOrResponseHeaderMap, public ResponseHeaderOrTrailerMap {};
 using ResponseHeaderMapPtr = std::unique_ptr<ResponseHeaderMap>;
-class ResponseTrailerMap : public virtual HeaderMap {};
+
+// Response trailers.
+class ResponseTrailerMap : public virtual HeaderMap, public ResponseHeaderOrTrailerMap {};
 using ResponseTrailerMapPtr = std::unique_ptr<ResponseTrailerMap>;
 
 /**
@@ -650,7 +660,7 @@ class HeaderMatcher {
 public:
   virtual ~HeaderMatcher() = default;
 
-  /*
+  /**
    * Check whether header matcher matches any headers in a given HeaderMap.
    */
   virtual bool matchesHeaders(const HeaderMap& headers) const PURE;

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -48,7 +48,7 @@ public:
    * @param headers supplies the response headers, which may be modified during this call.
    * @param stream_info holds additional information about the request.
    */
-  virtual void finalizeResponseHeaders(Http::HeaderMap& headers,
+  virtual void finalizeResponseHeaders(Http::ResponseHeaderMap& headers,
                                        const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
@@ -71,7 +71,7 @@ public:
    * @return std::string the redirect URL if this DirectResponseEntry is a redirect,
    *         or an empty string otherwise.
    */
-  virtual std::string newPath(const Http::HeaderMap& headers) const PURE;
+  virtual std::string newPath(const Http::RequestHeaderMap& headers) const PURE;
 
   /**
    * Returns the response body to send with direct responses.
@@ -87,7 +87,7 @@ public:
    * @param headers supplies the request headers, which may be modified during this call.
    * @param insert_envoy_original_path insert x-envoy-original-path header?
    */
-  virtual void rewritePathHeader(Http::HeaderMap& headers,
+  virtual void rewritePathHeader(Http::RequestHeaderMap& headers,
                                  bool insert_envoy_original_path) const PURE;
 
   /**
@@ -264,7 +264,7 @@ public:
    *         in the future. Otherwise a retry should not take place and the callback will never be
    *         called. Calling code should proceed with error handling.
    */
-  virtual RetryStatus shouldRetryHeaders(const Http::HeaderMap& response_headers,
+  virtual RetryStatus shouldRetryHeaders(const Http::ResponseHeaderMap& response_headers,
                                          DoRetryCallback callback) PURE;
 
   /**
@@ -275,7 +275,7 @@ public:
    * @param response_headers supplies the response headers.
    * @return bool true if a retry would be warranted based on the retry policy.
    */
-  virtual bool wouldRetryFromHeaders(const Http::HeaderMap& response_headers) PURE;
+  virtual bool wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_headers) PURE;
 
   /**
    * Determine whether a request should be retried after a reset based on the reason for the reset.
@@ -615,7 +615,7 @@ public:
    * @param stream_info holds additional information about the request.
    * @param insert_envoy_original_path insert x-envoy-original-path header if path rewritten?
    */
-  virtual void finalizeRequestHeaders(Http::HeaderMap& headers,
+  virtual void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
                                       const StreamInfo::StreamInfo& stream_info,
                                       bool insert_envoy_original_path) const PURE;
 
@@ -921,7 +921,7 @@ public:
    *        allows stable choices between calls if desired.
    * @return the route or nullptr if there is no matching route for the request.
    */
-  virtual RouteConstSharedPtr route(const Http::HeaderMap& headers,
+  virtual RouteConstSharedPtr route(const Http::RequestHeaderMap& headers,
                                     const StreamInfo::StreamInfo& stream_info,
                                     uint64_t random_value) const PURE;
 

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -48,7 +48,7 @@ public:
    * @return Http::HeaderMap& to be used by handler to parse header information sent with the
    * request.
    */
-  virtual const Http::HeaderMap& getRequestHeaders() const PURE;
+  virtual const Http::RequestHeaderMap& getRequestHeaders() const PURE;
 };
 
 /**
@@ -58,7 +58,7 @@ public:
  * done in the RouteConfigProviderManagerImpl constructor in source/common/router/rds_impl.cc.
  */
 #define MAKE_ADMIN_HANDLER(X)                                                                      \
-  [this](absl::string_view path_and_query, Http::HeaderMap& response_headers,                      \
+  [this](absl::string_view path_and_query, Http::ResponseHeaderMap& response_headers,              \
          Buffer::Instance& data, Server::AdminStream& admin_stream) -> Http::Code {                \
     return X(path_and_query, response_headers, data, admin_stream);                                \
   }
@@ -80,9 +80,9 @@ public:
    * its data.
    * @return Http::Code the response code.
    */
-  using HandlerCb =
-      std::function<Http::Code(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                               Buffer::Instance& response, AdminStream& admin_stream)>;
+  using HandlerCb = std::function<Http::Code(
+      absl::string_view path_and_query, Http::ResponseHeaderMap& response_headers,
+      Buffer::Instance& response, AdminStream& admin_stream)>;
 
   /**
    * Add an admin handler.
@@ -139,7 +139,7 @@ public:
    * @return Http::Code The HTTP response code from the admin request.
    */
   virtual Http::Code request(absl::string_view path_and_query, absl::string_view method,
-                             Http::HeaderMap& response_headers, std::string& body) PURE;
+                             Http::ResponseHeaderMap& response_headers, std::string& body) PURE;
 
   /**
    * Add this Admin's listener to the provided handler, if the listener exists.

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -514,12 +514,12 @@ public:
   /**
    * @param headers request headers.
    */
-  virtual void setRequestHeaders(const Http::HeaderMap& headers) PURE;
+  virtual void setRequestHeaders(const Http::RequestHeaderMap& headers) PURE;
 
   /**
    * @return request headers.
    */
-  virtual const Http::HeaderMap* getRequestHeaders() const PURE;
+  virtual const Http::RequestHeaderMap* getRequestHeaders() const PURE;
 };
 
 } // namespace StreamInfo

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -46,7 +46,7 @@ struct Decision {
  * The context for the custom tag to obtain the tag value.
  */
 struct CustomTagContext {
-  const Http::HeaderMap* request_headers;
+  const Http::RequestHeaderMap* request_headers;
   const StreamInfo::StreamInfo& stream_info;
 };
 
@@ -140,7 +140,7 @@ public:
    * (implementation-specific) trace.
    * @param request_headers the headers to which propagation context will be added
    */
-  virtual void injectContext(Http::HeaderMap& request_headers) PURE;
+  virtual void injectContext(Http::RequestHeaderMap& request_headers) PURE;
 
   /**
    * Create and start a child Span, with this Span as its parent in the trace.
@@ -170,7 +170,7 @@ public:
   /**
    * Start driver specific span.
    */
-  virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+  virtual SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
                             const std::string& operation_name, SystemTime start_time,
                             const Tracing::Decision tracing_decision) PURE;
 };
@@ -185,7 +185,7 @@ class HttpTracer {
 public:
   virtual ~HttpTracer() = default;
 
-  virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+  virtual SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
                             const StreamInfo::StreamInfo& stream_info,
                             const Tracing::Decision tracing_decision) PURE;
 };

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -44,7 +44,7 @@ public:
    * @return const Http::HeaderMap* the incoming headers or nullptr to use during load
    * balancing.
    */
-  virtual const Http::HeaderMap* downstreamHeaders() const PURE;
+  virtual const Http::RequestHeaderMap* downstreamHeaders() const PURE;
 
   /**
    * Called to retrieve a reference to the priority load data that should be used when selecting a

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -90,9 +90,9 @@ public:
   FormatterImpl(const std::string& format);
 
   // Formatter::format
-  std::string format(const Http::HeaderMap& request_headers,
-                     const Http::HeaderMap& response_headers,
-                     const Http::HeaderMap& response_trailers,
+  std::string format(const Http::RequestHeaderMap& request_headers,
+                     const Http::ResponseHeaderMap& response_headers,
+                     const Http::ResponseTrailerMap& response_trailers,
                      const StreamInfo::StreamInfo& stream_info) const override;
 
 private:
@@ -105,18 +105,18 @@ public:
                     bool preserve_types);
 
   // Formatter::format
-  std::string format(const Http::HeaderMap& request_headers,
-                     const Http::HeaderMap& response_headers,
-                     const Http::HeaderMap& response_trailers,
+  std::string format(const Http::RequestHeaderMap& request_headers,
+                     const Http::ResponseHeaderMap& response_headers,
+                     const Http::ResponseTrailerMap& response_trailers,
                      const StreamInfo::StreamInfo& stream_info) const override;
 
 private:
   const bool preserve_types_;
   std::map<const std::string, const std::vector<FormatterProviderPtr>> json_output_format_;
 
-  ProtobufWkt::Struct toStruct(const Http::HeaderMap& request_headers,
-                               const Http::HeaderMap& response_headers,
-                               const Http::HeaderMap& response_trailers,
+  ProtobufWkt::Struct toStruct(const Http::RequestHeaderMap& request_headers,
+                               const Http::ResponseHeaderMap& response_headers,
+                               const Http::ResponseTrailerMap& response_trailers,
                                const StreamInfo::StreamInfo& stream_info) const;
 };
 
@@ -129,10 +129,10 @@ public:
   PlainStringFormatter(const std::string& str);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
-                     const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -168,10 +168,10 @@ public:
                          absl::optional<size_t> max_length);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap& request_headers, const Http::HeaderMap&,
-                     const Http::HeaderMap&, const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap& request_headers, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 };
 
@@ -184,10 +184,10 @@ public:
                           absl::optional<size_t> max_length);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap& response_headers,
-                     const Http::HeaderMap&, const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap& response_headers,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 };
 
@@ -200,11 +200,11 @@ public:
                            absl::optional<size_t> max_length);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
-                     const Http::HeaderMap& response_trailers,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap& response_trailers,
                      const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 };
 
@@ -216,10 +216,10 @@ public:
   StreamInfoFormatter(const std::string& field_name);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
-                     const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 
   class FieldExtractor {
@@ -262,10 +262,10 @@ public:
                            const std::vector<std::string>& path, absl::optional<size_t> max_length);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
-                     const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 };
 
@@ -277,10 +277,10 @@ public:
   FilterStateFormatter(const std::string& key, absl::optional<size_t> max_length);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
-                     const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -298,10 +298,10 @@ public:
   StartTimeFormatter(const std::string& format);
 
   // FormatterProvider
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
-                     const StreamInfo::StreamInfo&) const override;
-  ProtobufWkt::Value formatValue(const Http::HeaderMap&, const Http::HeaderMap&,
-                                 const Http::HeaderMap&,
+  std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&,
                                  const StreamInfo::StreamInfo&) const override;
 
 private:

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -91,15 +91,16 @@ FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLog
 }
 
 bool TraceableRequestFilter::evaluate(const StreamInfo::StreamInfo& info,
-                                      const Http::HeaderMap& request_headers,
-                                      const Http::HeaderMap&, const Http::HeaderMap&) {
+                                      const Http::RequestHeaderMap& request_headers,
+                                      const Http::ResponseHeaderMap&,
+                                      const Http::ResponseTrailerMap&) {
   Tracing::Decision decision = Tracing::HttpTracerUtility::isTracing(info, request_headers);
 
   return decision.traced && decision.reason == Tracing::Reason::ServiceForced;
 }
 
-bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap&,
-                                const Http::HeaderMap&, const Http::HeaderMap&) {
+bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
+                                const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
   if (!info.responseCode()) {
     return compareAgainstValue(0ULL);
   }
@@ -107,8 +108,8 @@ bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::
   return compareAgainstValue(info.responseCode().value());
 }
 
-bool DurationFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap&,
-                              const Http::HeaderMap&, const Http::HeaderMap&) {
+bool DurationFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
+                              const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
   absl::optional<std::chrono::nanoseconds> final = info.requestComplete();
   ASSERT(final);
 
@@ -122,8 +123,9 @@ RuntimeFilter::RuntimeFilter(const envoy::config::accesslog::v3::RuntimeFilter& 
       percent_(config.percent_sampled()),
       use_independent_randomness_(config.use_independent_randomness()) {}
 
-bool RuntimeFilter::evaluate(const StreamInfo::StreamInfo&, const Http::HeaderMap& request_headers,
-                             const Http::HeaderMap&, const Http::HeaderMap&) {
+bool RuntimeFilter::evaluate(const StreamInfo::StreamInfo&,
+                             const Http::RequestHeaderMap& request_headers,
+                             const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
   const Http::HeaderEntry* uuid = request_headers.RequestId();
   uint64_t random_value;
   // TODO(dnoe): Migrate uuidModBy to take string_view (#6580)
@@ -158,9 +160,10 @@ AndFilter::AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
                      ProtobufMessage::ValidationVisitor& validation_visitor)
     : OperatorFilter(config.filters(), runtime, random, validation_visitor) {}
 
-bool OrFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                        const Http::HeaderMap& response_headers,
-                        const Http::HeaderMap& response_trailers) {
+bool OrFilter::evaluate(const StreamInfo::StreamInfo& info,
+                        const Http::RequestHeaderMap& request_headers,
+                        const Http::ResponseHeaderMap& response_headers,
+                        const Http::ResponseTrailerMap& response_trailers) {
   bool result = false;
   for (auto& filter : filters_) {
     result |= filter->evaluate(info, request_headers, response_headers, response_trailers);
@@ -173,9 +176,10 @@ bool OrFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMa
   return result;
 }
 
-bool AndFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                         const Http::HeaderMap& response_headers,
-                         const Http::HeaderMap& response_trailers) {
+bool AndFilter::evaluate(const StreamInfo::StreamInfo& info,
+                         const Http::RequestHeaderMap& request_headers,
+                         const Http::ResponseHeaderMap& response_headers,
+                         const Http::ResponseTrailerMap& response_trailers) {
   bool result = true;
   for (auto& filter : filters_) {
     result &= filter->evaluate(info, request_headers, response_headers, response_trailers);
@@ -188,16 +192,18 @@ bool AndFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderM
   return result;
 }
 
-bool NotHealthCheckFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap&,
-                                    const Http::HeaderMap&, const Http::HeaderMap&) {
+bool NotHealthCheckFilter::evaluate(const StreamInfo::StreamInfo& info,
+                                    const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                    const Http::ResponseTrailerMap&) {
   return !info.healthCheck();
 }
 
 HeaderFilter::HeaderFilter(const envoy::config::accesslog::v3::HeaderFilter& config)
     : header_data_(std::make_unique<Http::HeaderUtility::HeaderData>(config.header())) {}
 
-bool HeaderFilter::evaluate(const StreamInfo::StreamInfo&, const Http::HeaderMap& request_headers,
-                            const Http::HeaderMap&, const Http::HeaderMap&) {
+bool HeaderFilter::evaluate(const StreamInfo::StreamInfo&,
+                            const Http::RequestHeaderMap& request_headers,
+                            const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
   return Http::HeaderUtility::matchHeaders(request_headers, *header_data_);
 }
 
@@ -212,8 +218,8 @@ ResponseFlagFilter::ResponseFlagFilter(
   }
 }
 
-bool ResponseFlagFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap&,
-                                  const Http::HeaderMap&, const Http::HeaderMap&) {
+bool ResponseFlagFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
+                                  const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
   if (configured_flags_ != 0) {
     return info.intersectResponseFlags(configured_flags_);
   }
@@ -228,9 +234,9 @@ GrpcStatusFilter::GrpcStatusFilter(const envoy::config::accesslog::v3::GrpcStatu
   exclude_ = config.exclude();
 }
 
-bool GrpcStatusFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap&,
-                                const Http::HeaderMap& response_headers,
-                                const Http::HeaderMap& response_trailers) {
+bool GrpcStatusFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
+                                const Http::ResponseHeaderMap& response_headers,
+                                const Http::ResponseTrailerMap& response_trailers) {
 
   Grpc::Status::GrpcStatus status = Grpc::Status::WellKnownGrpcStatus::Unknown;
   const auto& optional_status =

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -58,9 +58,9 @@ public:
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 };
 
 /**
@@ -73,9 +73,9 @@ public:
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 };
 
 /**
@@ -102,9 +102,9 @@ public:
             ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 };
 
 /**
@@ -117,9 +117,9 @@ public:
            ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 };
 
 /**
@@ -130,9 +130,9 @@ public:
   NotHealthCheckFilter() = default;
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 };
 
 /**
@@ -141,9 +141,9 @@ public:
 class TraceableRequestFilter : public Filter {
 public:
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 };
 
 /**
@@ -155,9 +155,9 @@ public:
                 Runtime::RandomGenerator& random);
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 
 private:
   Runtime::Loader& runtime_;
@@ -175,9 +175,9 @@ public:
   HeaderFilter(const envoy::config::accesslog::v3::HeaderFilter& config);
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 
 private:
   const Http::HeaderUtility::HeaderDataPtr header_data_;
@@ -191,9 +191,9 @@ public:
   ResponseFlagFilter(const envoy::config::accesslog::v3::ResponseFlagFilter& config);
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 
 private:
   uint64_t configured_flags_{};
@@ -212,9 +212,9 @@ public:
   GrpcStatusFilter(const envoy::config::accesslog::v3::GrpcStatusFilter& config);
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-                const Http::HeaderMap& response_headers,
-                const Http::HeaderMap& response_trailers) override;
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) override;
 
 private:
   GrpcStatusHashSet statuses_;

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -25,7 +25,7 @@
 namespace Envoy {
 namespace Grpc {
 
-bool Common::hasGrpcContentType(const Http::HeaderMap& headers) {
+bool Common::hasGrpcContentType(const Http::RequestOrResponseHeaderMap& headers) {
   const Http::HeaderEntry* content_type = headers.ContentType();
   // Content type is gRPC if it is exactly "application/grpc" or starts with
   // "application/grpc+". Specifically, something like application/grpc-web is not gRPC.
@@ -37,7 +37,7 @@ bool Common::hasGrpcContentType(const Http::HeaderMap& headers) {
                   .getStringView()[Http::Headers::get().ContentTypeValues.Grpc.size()] == '+');
 }
 
-bool Common::isGrpcResponseHeader(const Http::HeaderMap& headers, bool end_stream) {
+bool Common::isGrpcResponseHeader(const Http::ResponseHeaderMap& headers, bool end_stream) {
   if (end_stream) {
     // Trailers-only response, only grpc-status is required.
     return headers.GrpcStatus() != nullptr;
@@ -48,8 +48,8 @@ bool Common::isGrpcResponseHeader(const Http::HeaderMap& headers, bool end_strea
   return hasGrpcContentType(headers);
 }
 
-absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& trailers,
-                                                         bool allow_user_defined) {
+absl::optional<Status::GrpcStatus>
+Common::getGrpcStatus(const Http::ResponseHeaderOrTrailerMap& trailers, bool allow_user_defined) {
   const Http::HeaderEntry* grpc_status_header = trailers.GrpcStatus();
   uint64_t grpc_status_code;
 
@@ -63,8 +63,8 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& 
   return {static_cast<Status::GrpcStatus>(grpc_status_code)};
 }
 
-absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& trailers,
-                                                         const Http::HeaderMap& headers,
+absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::ResponseTrailerMap& trailers,
+                                                         const Http::ResponseHeaderMap& headers,
                                                          const StreamInfo::StreamInfo& info,
                                                          bool allow_user_defined) {
   // The gRPC specification does not guarantee a gRPC status code will be returned from a gRPC
@@ -91,7 +91,7 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& 
   return absl::nullopt;
 }
 
-std::string Common::getGrpcMessage(const Http::HeaderMap& trailers) {
+std::string Common::getGrpcMessage(const Http::ResponseHeaderOrTrailerMap& trailers) {
   const auto entry = trailers.GrpcMessage();
   return entry ? std::string(entry->value().getStringView()) : EMPTY_STRING;
 }
@@ -156,7 +156,7 @@ Buffer::InstancePtr Common::serializeMessage(const Protobuf::Message& message) {
   return body;
 }
 
-std::chrono::milliseconds Common::getGrpcTimeout(const Http::HeaderMap& request_headers) {
+std::chrono::milliseconds Common::getGrpcTimeout(const Http::RequestHeaderMap& request_headers) {
   std::chrono::milliseconds timeout(0);
   const Http::HeaderEntry* header_grpc_timeout_entry = request_headers.GrpcTimeout();
   if (header_grpc_timeout_entry) {
@@ -198,7 +198,8 @@ std::chrono::milliseconds Common::getGrpcTimeout(const Http::HeaderMap& request_
   return timeout;
 }
 
-void Common::toGrpcTimeout(const std::chrono::milliseconds& timeout, Http::HeaderMap& headers) {
+void Common::toGrpcTimeout(const std::chrono::milliseconds& timeout,
+                           Http::RequestHeaderMap& headers) {
   uint64_t time = timeout.count();
   static const char units[] = "mSMH";
   const char* unit = units; // start with milliseconds

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -34,14 +34,14 @@ public:
    * @param headers the headers to parse.
    * @return bool indicating whether content-type is gRPC.
    */
-  static bool hasGrpcContentType(const Http::HeaderMap& headers);
+  static bool hasGrpcContentType(const Http::RequestOrResponseHeaderMap& headers);
 
   /**
    * @param headers the headers to parse.
    * @param bool indicating whether the header is at end_stream.
    * @return bool indicating whether the header is a gRPC response header
    */
-  static bool isGrpcResponseHeader(const Http::HeaderMap& headers, bool end_stream);
+  static bool isGrpcResponseHeader(const Http::ResponseHeaderMap& headers, bool end_stream);
 
   /**
    * Returns the GrpcStatus code from a given set of trailers, if present.
@@ -51,8 +51,8 @@ public:
    * @return absl::optional<Status::GrpcStatus> the parsed status code or InvalidCode if no valid
    * status is found.
    */
-  static absl::optional<Status::GrpcStatus> getGrpcStatus(const Http::HeaderMap& trailers,
-                                                          bool allow_user_defined = false);
+  static absl::optional<Status::GrpcStatus>
+  getGrpcStatus(const Http::ResponseHeaderOrTrailerMap& trailers, bool allow_user_defined = false);
 
   /**
    * Returns the GrpcStatus code from the set of trailers, headers, and StreamInfo, if present.
@@ -63,8 +63,8 @@ public:
    * @return absl::optional<Status::GrpcStatus> the parsed status code or absl::nullopt if no status
    * is found
    */
-  static absl::optional<Status::GrpcStatus> getGrpcStatus(const Http::HeaderMap& trailers,
-                                                          const Http::HeaderMap& headers,
+  static absl::optional<Status::GrpcStatus> getGrpcStatus(const Http::ResponseTrailerMap& trailers,
+                                                          const Http::ResponseHeaderMap& headers,
                                                           const StreamInfo::StreamInfo& info,
                                                           bool allow_user_defined = false);
 
@@ -74,7 +74,7 @@ public:
    * @return std::string the gRPC status message or empty string if grpc-message is not present in
    *         trailers.
    */
-  static std::string getGrpcMessage(const Http::HeaderMap& trailers);
+  static std::string getGrpcMessage(const Http::ResponseHeaderOrTrailerMap& trailers);
 
   /**
    * Returns the decoded google.rpc.Status message from a given set of trailers, if present.
@@ -93,7 +93,7 @@ public:
    * @return std::chrono::milliseconds the duration in milliseconds. A zero value corresponding to
    *         infinity is returned if 'grpc-timeout' is missing or malformed.
    */
-  static std::chrono::milliseconds getGrpcTimeout(const Http::HeaderMap& request_headers);
+  static std::chrono::milliseconds getGrpcTimeout(const Http::RequestHeaderMap& request_headers);
 
   /**
    * Encode 'timeout' into 'grpc-timeout' format in the grpc-timeout header.
@@ -101,7 +101,8 @@ public:
    * @param headers the HeaderMap in which the grpc-timeout header will be set with the timeout in
    * 'grpc-timeout' format, up to 8 decimal digits and a letter indicating the unit.
    */
-  static void toGrpcTimeout(const std::chrono::milliseconds& timeout, Http::HeaderMap& headers);
+  static void toGrpcTimeout(const std::chrono::milliseconds& timeout,
+                            Http::RequestHeaderMap& headers);
 
   /**
    * Serialize protobuf message with gRPC frame header.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -159,7 +159,7 @@ private:
   };
 
   struct NullConfig : public Router::Config {
-    Router::RouteConstSharedPtr route(const Http::HeaderMap&, const StreamInfo::StreamInfo&,
+    Router::RouteConstSharedPtr route(const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                                       uint64_t) const override {
       return nullptr;
     }
@@ -214,9 +214,10 @@ private:
       return Http::Code::InternalServerError;
     }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
-    void finalizeRequestHeaders(Http::HeaderMap&, const StreamInfo::StreamInfo&,
+    void finalizeRequestHeaders(Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                                 bool) const override {}
-    void finalizeResponseHeaders(Http::HeaderMap&, const StreamInfo::StreamInfo&) const override {}
+    void finalizeResponseHeaders(Http::ResponseHeaderMap&,
+                                 const StreamInfo::StreamInfo&) const override {}
     const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
     const Router::HedgePolicy& hedgePolicy() const override { return hedge_policy_; }
     const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
@@ -326,7 +327,7 @@ private:
   Tracing::Span& activeSpan() override { return active_span_; }
   const Tracing::Config& tracingConfig() override { return tracing_config_; }
   void continueDecoding() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  HeaderMap& addDecodedTrailers() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  RequestTrailerMap& addDecodedTrailers() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void addDecodedData(Buffer::Instance&, bool) override {
     // This should only be called if the user has set up buffering. The request is already fully
     // buffered. Note that this is only called via the async client's internal use of the router

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -670,7 +670,7 @@ void ConnectionManagerImpl::ActiveStream::addAccessLogHandler(
   access_log_handlers_.push_back(handler);
 }
 
-void ConnectionManagerImpl::ActiveStream::chargeStats(const HeaderMap& headers) {
+void ConnectionManagerImpl::ActiveStream::chargeStats(const ResponseHeaderMap& headers) {
   uint64_t response_code = Utility::getResponseStatus(headers);
   stream_info_.response_code_ = response_code;
 
@@ -1168,7 +1168,7 @@ void ConnectionManagerImpl::ActiveStream::decodeData(
   }
 }
 
-HeaderMap& ConnectionManagerImpl::ActiveStream::addDecodedTrailers() {
+RequestTrailerMap& ConnectionManagerImpl::ActiveStream::addDecodedTrailers() {
   // Trailers can only be added during the last data frame (i.e. end_stream = true).
   ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
 
@@ -1700,7 +1700,7 @@ void ConnectionManagerImpl::ActiveStream::encodeMetadata(ActiveStreamEncoderFilt
   }
 }
 
-HeaderMap& ConnectionManagerImpl::ActiveStream::addEncodedTrailers() {
+ResponseTrailerMap& ConnectionManagerImpl::ActiveStream::addEncodedTrailers() {
   // Trailers can only be added during the last data frame (i.e. end_stream = true).
   ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
 
@@ -2217,7 +2217,7 @@ void ConnectionManagerImpl::ActiveStreamDecoderFilter::handleMetadataAfterHeader
   iterate_from_current_filter_ = saved_state;
 }
 
-HeaderMap& ConnectionManagerImpl::ActiveStreamDecoderFilter::addDecodedTrailers() {
+RequestTrailerMap& ConnectionManagerImpl::ActiveStreamDecoderFilter::addDecodedTrailers() {
   return parent_.addDecodedTrailers();
 }
 
@@ -2396,7 +2396,7 @@ void ConnectionManagerImpl::ActiveStreamEncoderFilter::injectEncodedDataToFilter
                      ActiveStream::FilterIterationStartState::CanStartFromCurrent);
 }
 
-HeaderMap& ConnectionManagerImpl::ActiveStreamEncoderFilter::addEncodedTrailers() {
+ResponseTrailerMap& ConnectionManagerImpl::ActiveStreamEncoderFilter::addEncodedTrailers() {
   return parent_.addEncodedTrailers();
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -265,7 +265,7 @@ private:
     // Http::StreamDecoderFilterCallbacks
     void addDecodedData(Buffer::Instance& data, bool streaming) override;
     void injectDecodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
-    HeaderMap& addDecodedTrailers() override;
+    RequestTrailerMap& addDecodedTrailers() override;
     MetadataMapVector& addDecodedMetadata() override;
     void continueDecoding() override;
     const Buffer::Instance* decodingBuffer() override {
@@ -378,7 +378,7 @@ private:
     // Http::StreamEncoderFilterCallbacks
     void addEncodedData(Buffer::Instance& data, bool streaming) override;
     void injectEncodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
-    HeaderMap& addEncodedTrailers() override;
+    ResponseTrailerMap& addEncodedTrailers() override;
     void addEncodedMetadata(MetadataMapPtr&& metadata_map) override;
     void onEncoderFilterAboveWriteBufferHighWatermark() override;
     void onEncoderFilterBelowWriteBufferLowWatermark() override;
@@ -450,7 +450,7 @@ private:
 
     void addStreamDecoderFilterWorker(StreamDecoderFilterSharedPtr filter, bool dual_filter);
     void addStreamEncoderFilterWorker(StreamEncoderFilterSharedPtr filter, bool dual_filter);
-    void chargeStats(const HeaderMap& headers);
+    void chargeStats(const ResponseHeaderMap& headers);
     // Returns the encoder filter to start iteration with.
     std::list<ActiveStreamEncoderFilterPtr>::iterator
     commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_stream,
@@ -461,7 +461,7 @@ private:
                        FilterIterationStartState filter_iteration_start_state);
     const Network::Connection* connection();
     void addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::Instance& data, bool streaming);
-    HeaderMap& addDecodedTrailers();
+    RequestTrailerMap& addDecodedTrailers();
     MetadataMapVector& addDecodedMetadata();
     void decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHeaderMap& headers,
                        bool end_stream);
@@ -474,7 +474,7 @@ private:
     void disarmRequestTimeout();
     void maybeEndDecode(bool end_stream);
     void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
-    HeaderMap& addEncodedTrailers();
+    ResponseTrailerMap& addEncodedTrailers();
     void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
                         const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                         bool is_head_request,

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -57,9 +57,9 @@ ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
 }
 
 Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequestHeaders(
-    HeaderMap& request_headers, Network::Connection& connection, ConnectionManagerConfig& config,
-    const Router::Config& route_config, Runtime::RandomGenerator& random,
-    const LocalInfo::LocalInfo& local_info) {
+    RequestHeaderMap& request_headers, Network::Connection& connection,
+    ConnectionManagerConfig& config, const Router::Config& route_config,
+    Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info) {
   // If this is a Upgrade request, do not remove the Connection and Upgrade headers,
   // as we forward them verbatim to the upstream hosts.
   if (Utility::isUpgrade(request_headers)) {
@@ -230,7 +230,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   return final_remote_address;
 }
 
-void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_headers,
+void ConnectionManagerUtility::mutateTracingRequestHeader(RequestHeaderMap& request_headers,
                                                           Runtime::Loader& runtime,
                                                           ConnectionManagerConfig& config,
                                                           const Router::Route* route) {
@@ -279,7 +279,7 @@ void ConnectionManagerUtility::mutateTracingRequestHeader(HeaderMap& request_hea
   request_headers.setRequestId(x_request_id);
 }
 
-void ConnectionManagerUtility::mutateXfccRequestHeader(HeaderMap& request_headers,
+void ConnectionManagerUtility::mutateXfccRequestHeader(RequestHeaderMap& request_headers,
                                                        Network::Connection& connection,
                                                        ConnectionManagerConfig& config) {
   // When AlwaysForwardOnly is set, always forward the XFCC header without modification.
@@ -365,8 +365,8 @@ void ConnectionManagerUtility::mutateXfccRequestHeader(HeaderMap& request_header
   }
 }
 
-void ConnectionManagerUtility::mutateResponseHeaders(HeaderMap& response_headers,
-                                                     const HeaderMap* request_headers,
+void ConnectionManagerUtility::mutateResponseHeaders(ResponseHeaderMap& response_headers,
+                                                     const RequestHeaderMap* request_headers,
                                                      const std::string& via) {
   if (request_headers != nullptr && Utility::isUpgrade(*request_headers) &&
       Utility::isUpgrade(response_headers)) {
@@ -397,8 +397,7 @@ void ConnectionManagerUtility::mutateResponseHeaders(HeaderMap& response_headers
   }
 }
 
-/* static */
-bool ConnectionManagerUtility::maybeNormalizePath(HeaderMap& request_headers,
+bool ConnectionManagerUtility::maybeNormalizePath(RequestHeaderMap& request_headers,
                                                   const ConnectionManagerConfig& config) {
   ASSERT(request_headers.Path());
   bool is_valid_path = true;

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -51,27 +51,30 @@ public:
    *         existence of the x-forwarded-for header. Again see the method for more details.
    */
   static Network::Address::InstanceConstSharedPtr
-  mutateRequestHeaders(HeaderMap& request_headers, Network::Connection& connection,
+  mutateRequestHeaders(RequestHeaderMap& request_headers, Network::Connection& connection,
                        ConnectionManagerConfig& config, const Router::Config& route_config,
                        Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info);
 
-  static void mutateResponseHeaders(HeaderMap& response_headers, const HeaderMap* request_headers,
+  static void mutateResponseHeaders(ResponseHeaderMap& response_headers,
+                                    const RequestHeaderMap* request_headers,
                                     const std::string& via);
 
   // Sanitize the path in the header map if forced by config.
   // Side affect: the string view of Path header is invalidated.
   // Return false if error happens during the sanitization.
-  static bool maybeNormalizePath(HeaderMap& request_headers, const ConnectionManagerConfig& config);
+  static bool maybeNormalizePath(RequestHeaderMap& request_headers,
+                                 const ConnectionManagerConfig& config);
 
   /**
    * Mutate request headers if request needs to be traced.
    */
-  static void mutateTracingRequestHeader(HeaderMap& request_headers, Runtime::Loader& runtime,
-                                         ConnectionManagerConfig& config,
+  static void mutateTracingRequestHeader(RequestHeaderMap& request_headers,
+                                         Runtime::Loader& runtime, ConnectionManagerConfig& config,
                                          const Router::Route* route);
 
 private:
-  static void mutateXfccRequestHeader(HeaderMap& request_headers, Network::Connection& connection,
+  static void mutateXfccRequestHeader(RequestHeaderMap& request_headers,
+                                      Network::Connection& connection,
                                       ConnectionManagerConfig& config);
 };
 

--- a/source/common/http/date_provider.h
+++ b/source/common/http/date_provider.h
@@ -17,7 +17,7 @@ public:
    * Set the Date header potentially using a cached value.
    * @param headers supplies the headers to fill.
    */
-  virtual void setDateHeader(HeaderMap& headers) PURE;
+  virtual void setDateHeader(ResponseHeaderMap& headers) PURE;
 };
 
 } // namespace Http

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -25,11 +25,11 @@ void TlsCachingDateProviderImpl::onRefreshDate() {
   refresh_timer_->enableTimer(std::chrono::milliseconds(500));
 }
 
-void TlsCachingDateProviderImpl::setDateHeader(HeaderMap& headers) {
+void TlsCachingDateProviderImpl::setDateHeader(ResponseHeaderMap& headers) {
   headers.setDate(tls_->getTyped<ThreadLocalCachedDate>().date_string_);
 }
 
-void SlowDateProviderImpl::setDateHeader(HeaderMap& headers) {
+void SlowDateProviderImpl::setDateHeader(ResponseHeaderMap& headers) {
   headers.setDate(date_formatter_.now(time_source_));
 }
 

--- a/source/common/http/date_provider_impl.h
+++ b/source/common/http/date_provider_impl.h
@@ -35,7 +35,7 @@ public:
   TlsCachingDateProviderImpl(Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator& tls);
 
   // Http::DateProvider
-  void setDateHeader(HeaderMap& headers) override;
+  void setDateHeader(ResponseHeaderMap& headers) override;
 
 private:
   struct ThreadLocalCachedDate : public ThreadLocal::ThreadLocalObject {
@@ -58,7 +58,7 @@ class SlowDateProviderImpl : public DateProviderImplBase {
 
 public:
   // Http::DateProvider
-  void setDateHeader(HeaderMap& headers) override;
+  void setDateHeader(ResponseHeaderMap& headers) override;
 };
 
 } // namespace Http

--- a/source/common/http/hash_policy.cc
+++ b/source/common/http/hash_policy.cc
@@ -24,7 +24,8 @@ public:
   HeaderHashMethod(const std::string& header_name, bool terminal)
       : HashMethodImplBase(terminal), header_name_(header_name) {}
 
-  absl::optional<uint64_t> evaluate(const Network::Address::Instance*, const HeaderMap& headers,
+  absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
+                                    const RequestHeaderMap& headers,
                                     const HashPolicy::AddCookieCallback) const override {
     absl::optional<uint64_t> hash;
 
@@ -45,7 +46,8 @@ public:
                    const absl::optional<std::chrono::seconds>& ttl, bool terminal)
       : HashMethodImplBase(terminal), key_(key), path_(path), ttl_(ttl) {}
 
-  absl::optional<uint64_t> evaluate(const Network::Address::Instance*, const HeaderMap& headers,
+  absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
+                                    const RequestHeaderMap& headers,
                                     const HashPolicy::AddCookieCallback add_cookie) const override {
     absl::optional<uint64_t> hash;
     std::string value = Utility::parseCookieValue(headers, key_);
@@ -70,7 +72,7 @@ public:
   IpHashMethod(bool terminal) : HashMethodImplBase(terminal) {}
 
   absl::optional<uint64_t> evaluate(const Network::Address::Instance* downstream_addr,
-                                    const HeaderMap&,
+                                    const RequestHeaderMap&,
                                     const HashPolicy::AddCookieCallback) const override {
     if (downstream_addr == nullptr) {
       return absl::nullopt;
@@ -92,7 +94,8 @@ public:
   QueryParameterHashMethod(const std::string& parameter_name, bool terminal)
       : HashMethodImplBase(terminal), parameter_name_(parameter_name) {}
 
-  absl::optional<uint64_t> evaluate(const Network::Address::Instance*, const HeaderMap& headers,
+  absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
+                                    const RequestHeaderMap& headers,
                                     const HashPolicy::AddCookieCallback) const override {
     absl::optional<uint64_t> hash;
 
@@ -151,7 +154,8 @@ HashPolicyImpl::HashPolicyImpl(
 
 absl::optional<uint64_t>
 HashPolicyImpl::generateHash(const Network::Address::Instance* downstream_addr,
-                             const HeaderMap& headers, const AddCookieCallback add_cookie) const {
+                             const RequestHeaderMap& headers,
+                             const AddCookieCallback add_cookie) const {
   absl::optional<uint64_t> hash;
   for (const HashMethodPtr& hash_impl : hash_impls_) {
     const absl::optional<uint64_t> new_hash =

--- a/source/common/http/hash_policy.h
+++ b/source/common/http/hash_policy.h
@@ -17,14 +17,14 @@ public:
 
   // Http::HashPolicy
   absl::optional<uint64_t> generateHash(const Network::Address::Instance* downstream_addr,
-                                        const HeaderMap& headers,
+                                        const RequestHeaderMap& headers,
                                         const AddCookieCallback add_cookie) const override;
 
   class HashMethod {
   public:
     virtual ~HashMethod() = default;
     virtual absl::optional<uint64_t> evaluate(const Network::Address::Instance* downstream_addr,
-                                              const HeaderMap& headers,
+                                              const RequestHeaderMap& headers,
                                               const AddCookieCallback add_cookie) const PURE;
 
     // If the method is a terminal method, ignore rest of the hash policy chain.

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -166,14 +166,14 @@ void HeaderUtility::addHeaders(HeaderMap& headers, const HeaderMap& headers_to_a
       &headers);
 }
 
-bool HeaderUtility::isEnvoyInternalRequest(const HeaderMap& headers) {
+bool HeaderUtility::isEnvoyInternalRequest(const RequestHeaderMap& headers) {
   const HeaderEntry* internal_request_header = headers.EnvoyInternalRequest();
   return internal_request_header != nullptr &&
          internal_request_header->value() == Headers::get().EnvoyInternalRequestValues.True;
 }
 
 absl::optional<std::reference_wrapper<const absl::string_view>>
-HeaderUtility::requestHeadersValid(const HeaderMap& headers) {
+HeaderUtility::requestHeadersValid(const RequestHeaderMap& headers) {
   // Make sure the host is valid.
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.strict_authority_validation") &&
       headers.Host() && !HeaderUtility::authorityIsValid(headers.Host()->value().getStringView())) {

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -112,7 +112,7 @@ public:
   /**
    * @brief a helper function to determine if the headers represent an envoy internal request
    */
-  static bool isEnvoyInternalRequest(const HeaderMap& headers);
+  static bool isEnvoyInternalRequest(const RequestHeaderMap& headers);
 
   /**
    * Determines if request headers pass Envoy validity checks.
@@ -120,7 +120,7 @@ public:
    * @return details of the error if an error is present, otherwise absl::nullopt
    */
   static absl::optional<std::reference_wrapper<const absl::string_view>>
-  requestHeadersValid(const HeaderMap& headers);
+  requestHeadersValid(const RequestHeaderMap& headers);
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -102,7 +102,8 @@ void ResponseEncoderImpl::encode100ContinueHeaders(const ResponseHeaderMap& head
   processing_100_continue_ = false;
 }
 
-void StreamEncoderImpl::encodeHeadersBase(const HeaderMap& headers, bool end_stream) {
+void StreamEncoderImpl::encodeHeadersBase(const RequestOrResponseHeaderMap& headers,
+                                          bool end_stream) {
   bool saw_content_length = false;
   headers.iterate(
       [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -65,7 +65,7 @@ public:
 protected:
   StreamEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter);
   void setIsContentLengthAllowed(bool value) { is_content_length_allowed_ = value; }
-  void encodeHeadersBase(const HeaderMap& headers, bool end_stream);
+  void encodeHeadersBase(const RequestOrResponseHeaderMap& headers, bool end_stream);
   void encodeTrailersBase(const HeaderMap& headers);
 
   static const std::string CRLF;

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -28,7 +28,7 @@ absl::optional<std::string> canonicalizePath(absl::string_view original_path) {
 } // namespace
 
 /* static */
-bool PathUtil::canonicalPath(HeaderMap& headers) {
+bool PathUtil::canonicalPath(RequestHeaderMap& headers) {
   const auto original_path = headers.Path()->value().getStringView();
   // canonicalPath is supposed to apply on path component in URL instead of :path header
   const auto query_pos = original_path.find('?');
@@ -53,7 +53,7 @@ bool PathUtil::canonicalPath(HeaderMap& headers) {
   return true;
 }
 
-void PathUtil::mergeSlashes(HeaderMap& headers) {
+void PathUtil::mergeSlashes(RequestHeaderMap& headers) {
   const auto original_path = headers.Path()->value().getStringView();
   // Only operate on path component in URL.
   const absl::string_view::size_type query_start = original_path.find('?');

--- a/source/common/http/path_utility.h
+++ b/source/common/http/path_utility.h
@@ -14,9 +14,9 @@ class PathUtil {
 public:
   // Returns if the normalization succeeds.
   // If it is successful, the path header in header path will be updated with the normalized path.
-  static bool canonicalPath(HeaderMap& headers);
+  static bool canonicalPath(RequestHeaderMap& headers);
   // Merges two or more adjacent slashes in path part of URI into one.
-  static void mergeSlashes(HeaderMap& headers);
+  static void mergeSlashes(RequestHeaderMap& headers);
   // Removes the query and/or fragment string (if present) from the input path.
   // For example, this function returns "/data" for the input path "/data#fragment?param=value".
   static absl::string_view removeQueryAndFragment(const absl::string_view path);

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -26,7 +26,7 @@ void UserAgent::completeConnectionLength(Stats::Timespan& span) {
       .recordValue(span.elapsed().count());
 }
 
-void UserAgent::initializeFromHeaders(const HeaderMap& headers, const std::string& prefix,
+void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, const std::string& prefix,
                                       Stats::Scope& scope) {
   // We assume that the user-agent is consistent based on the first request.
   if (type_ != Type::NotInitialized) {

--- a/source/common/http/user_agent.h
+++ b/source/common/http/user_agent.h
@@ -46,7 +46,7 @@ public:
    * @param prefix supplies the stat prefix for the UA stats.
    * @param scope supplies the backing stat scope.
    */
-  void initializeFromHeaders(const HeaderMap& headers, const std::string& prefix,
+  void initializeFromHeaders(const RequestHeaderMap& headers, const std::string& prefix,
                              Stats::Scope& scope);
 
   /**

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -66,21 +66,21 @@ private:
  * @param headers supplies the headers to append to.
  * @param remote_address supplies the remote address to append.
  */
-void appendXff(HeaderMap& headers, const Network::Address::Instance& remote_address);
+void appendXff(RequestHeaderMap& headers, const Network::Address::Instance& remote_address);
 
 /**
  * Append to via header.
  * @param headers supplies the headers to append to.
  * @param via supplies the via header to append.
  */
-void appendVia(HeaderMap& headers, const std::string& via);
+void appendVia(RequestOrResponseHeaderMap& headers, const std::string& via);
 
 /**
  * Creates an SSL (https) redirect path based on the input host and path headers.
  * @param headers supplies the request headers.
  * @return std::string the redirect path.
  */
-std::string createSslRedirectPath(const HeaderMap& headers);
+std::string createSslRedirectPath(const RequestHeaderMap& headers);
 
 /**
  * Parse a URL into query parameters.
@@ -161,7 +161,7 @@ bool isH2UpgradeRequest(const HeaderMap& headers);
  * - Connection: Upgrade
  * - Upgrade: websocket
  */
-bool isWebSocketUpgradeRequest(const HeaderMap& headers);
+bool isWebSocketUpgradeRequest(const RequestHeaderMap& headers);
 
 /**
  * @return Http2Settings An Http2Settings populated from the
@@ -228,7 +228,7 @@ struct GetLastAddressFromXffInfo {
  * @return GetLastAddressFromXffInfo information about the last address in the XFF header.
  *         @see GetLastAddressFromXffInfo for more information.
  */
-GetLastAddressFromXffInfo getLastAddressFromXFF(const Http::HeaderMap& request_headers,
+GetLastAddressFromXffInfo getLastAddressFromXFF(const Http::RequestHeaderMap& request_headers,
                                                 uint32_t num_to_skip = 0);
 
 /**

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -59,7 +59,7 @@ convertInternalRedirectAction(const envoy::config::route::v3::RouteAction& route
 
 } // namespace
 
-std::string SslRedirector::newPath(const Http::HeaderMap& headers) const {
+std::string SslRedirector::newPath(const Http::RequestHeaderMap& headers) const {
   return Http::Utility::createSslRedirectPath(headers);
 }
 
@@ -422,7 +422,7 @@ bool RouteEntryImplBase::evaluateTlsContextMatch(const StreamInfo::StreamInfo& s
   return matches;
 }
 
-bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers,
+bool RouteEntryImplBase::matchRoute(const Http::RequestHeaderMap& headers,
                                     const StreamInfo::StreamInfo& stream_info,
                                     uint64_t random_value) const {
   bool matches = true;
@@ -457,7 +457,7 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers,
 
 const std::string& RouteEntryImplBase::clusterName() const { return cluster_name_; }
 
-void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
+void RouteEntryImplBase::finalizeRequestHeaders(Http::RequestHeaderMap& headers,
                                                 const StreamInfo::StreamInfo& stream_info,
                                                 bool insert_envoy_original_path) const {
   if (!vhost_.globalRouteConfig().mostSpecificHeaderMutationsWins()) {
@@ -491,7 +491,7 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
   }
 }
 
-void RouteEntryImplBase::finalizeResponseHeaders(Http::HeaderMap& headers,
+void RouteEntryImplBase::finalizeResponseHeaders(Http::ResponseHeaderMap& headers,
                                                  const StreamInfo::StreamInfo& stream_info) const {
   if (!vhost_.globalRouteConfig().mostSpecificHeaderMutationsWins()) {
     // Append user-specified request headers from most to least specific: route-level headers,
@@ -528,7 +528,7 @@ RouteEntryImplBase::loadRuntimeData(const envoy::config::route::v3::RouteMatch& 
 // parameters) that should be replaced by the rewrite. A "regex_rewrite"
 // applies to the entire path (excluding query parameters), regardless of what
 // portion was matched.
-void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
+void RouteEntryImplBase::finalizePathHeader(Http::RequestHeaderMap& headers,
                                             absl::string_view matched_path,
                                             bool insert_envoy_original_path) const {
   const auto& rewrite = getPathRewrite();
@@ -558,7 +558,7 @@ void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
   }
 }
 
-absl::string_view RouteEntryImplBase::processRequestHost(const Http::HeaderMap& headers,
+absl::string_view RouteEntryImplBase::processRequestHost(const Http::RequestHeaderMap& headers,
                                                          absl::string_view new_scheme,
                                                          absl::string_view new_port) const {
 
@@ -597,7 +597,7 @@ absl::string_view RouteEntryImplBase::processRequestHost(const Http::HeaderMap& 
   return request_host;
 }
 
-std::string RouteEntryImplBase::newPath(const Http::HeaderMap& headers) const {
+std::string RouteEntryImplBase::newPath(const Http::RequestHeaderMap& headers) const {
   ASSERT(isDirectResponse());
 
   absl::string_view final_scheme;
@@ -832,12 +832,12 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(
     : RouteEntryImplBase(vhost, route, factory_context, validator), prefix_(route.match().prefix()),
       path_matcher_(Matchers::PathMatcher::createPrefix(prefix_, !case_sensitive_)) {}
 
-void PrefixRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
+void PrefixRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                              bool insert_envoy_original_path) const {
   finalizePathHeader(headers, prefix_, insert_envoy_original_path);
 }
 
-RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::HeaderMap& headers,
+RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
                                                   const StreamInfo::StreamInfo& stream_info,
                                                   uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
@@ -854,12 +854,12 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
     : RouteEntryImplBase(vhost, route, factory_context, validator), path_(route.match().path()),
       path_matcher_(Matchers::PathMatcher::createExact(path_, !case_sensitive_)) {}
 
-void PathRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
+void PathRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                            bool insert_envoy_original_path) const {
   finalizePathHeader(headers, path_, insert_envoy_original_path);
 }
 
-RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
+RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
                                                 const StreamInfo::StreamInfo& stream_info,
                                                 uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
@@ -889,7 +889,7 @@ RegexRouteEntryImpl::RegexRouteEntryImpl(
   }
 }
 
-void RegexRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
+void RegexRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                             bool insert_envoy_original_path) const {
   const absl::string_view path =
       Http::PathUtil::removeQueryAndFragment(headers.Path()->value().getStringView());
@@ -899,7 +899,7 @@ void RegexRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
   finalizePathHeader(headers, path, insert_envoy_original_path);
 }
 
-RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::HeaderMap& headers,
+RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
                                                  const StreamInfo::StreamInfo& stream_info,
                                                  uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
@@ -1085,7 +1085,7 @@ RouteMatcher::RouteMatcher(const envoy::config::route::v3::RouteConfiguration& r
   }
 }
 
-RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& headers,
+RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::RequestHeaderMap& headers,
                                                          const StreamInfo::StreamInfo& stream_info,
                                                          uint64_t random_value) const {
   // No x-forwarded-proto header. This normally only happens when ActiveStream::decodeHeaders
@@ -1115,7 +1115,7 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& 
   return nullptr;
 }
 
-const VirtualHostImpl* RouteMatcher::findVirtualHost(const Http::HeaderMap& headers) const {
+const VirtualHostImpl* RouteMatcher::findVirtualHost(const Http::RequestHeaderMap& headers) const {
   // Fast path the case where we only have a default virtual host.
   if (virtual_hosts_.empty() && wildcard_virtual_host_suffixes_.empty() &&
       wildcard_virtual_host_prefixes_.empty()) {
@@ -1154,7 +1154,7 @@ const VirtualHostImpl* RouteMatcher::findVirtualHost(const Http::HeaderMap& head
   return default_virtual_host_.get();
 }
 
-RouteConstSharedPtr RouteMatcher::route(const Http::HeaderMap& headers,
+RouteConstSharedPtr RouteMatcher::route(const Http::RequestHeaderMap& headers,
                                         const StreamInfo::StreamInfo& stream_info,
                                         uint64_t random_value) const {
   const VirtualHostImpl* virtual_host = findVirtualHost(headers);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -50,7 +50,7 @@ public:
    *        allows stable choices between calls if desired.
    * @return true if input headers match this object.
    */
-  virtual RouteConstSharedPtr matches(const Http::HeaderMap& headers,
+  virtual RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
                                       const StreamInfo::StreamInfo& stream_info,
                                       uint64_t random_value) const PURE;
 };
@@ -77,9 +77,10 @@ using RouteEntryImplBaseConstSharedPtr = std::shared_ptr<const RouteEntryImplBas
 class SslRedirector : public DirectResponseEntry {
 public:
   // Router::DirectResponseEntry
-  void finalizeResponseHeaders(Http::HeaderMap&, const StreamInfo::StreamInfo&) const override {}
-  std::string newPath(const Http::HeaderMap& headers) const override;
-  void rewritePathHeader(Http::HeaderMap&, bool) const override {}
+  void finalizeResponseHeaders(Http::ResponseHeaderMap&,
+                               const StreamInfo::StreamInfo&) const override {}
+  std::string newPath(const Http::RequestHeaderMap& headers) const override;
+  void rewritePathHeader(Http::RequestHeaderMap&, bool) const override {}
   Http::Code responseCode() const override { return Http::Code::MovedPermanently; }
   const std::string& responseBody() const override { return EMPTY_STRING; }
   const std::string& routeName() const override { return route_name_; }
@@ -159,7 +160,7 @@ public:
                   Server::Configuration::ServerFactoryContext& factory_context,
                   ProtobufMessage::ValidationVisitor& validator, bool validate_clusters);
 
-  RouteConstSharedPtr getRouteFromEntries(const Http::HeaderMap& headers,
+  RouteConstSharedPtr getRouteFromEntries(const Http::RequestHeaderMap& headers,
                                           const StreamInfo::StreamInfo& stream_info,
                                           uint64_t random_value) const;
   const VirtualCluster* virtualClusterFromEntries(const Http::HeaderMap& headers) const;
@@ -397,7 +398,7 @@ public:
     return !host_redirect_.empty() || !path_redirect_.empty() || !prefix_rewrite_redirect_.empty();
   }
 
-  bool matchRoute(const Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
+  bool matchRoute(const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
                   uint64_t random_value) const;
   void validateClusters(Upstream::ClusterManager& cm) const;
 
@@ -408,9 +409,10 @@ public:
   }
   const std::string& routeName() const override { return route_name_; }
   const CorsPolicy* corsPolicy() const override { return cors_policy_.get(); }
-  void finalizeRequestHeaders(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
+  void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
+                              const StreamInfo::StreamInfo& stream_info,
                               bool insert_envoy_original_path) const override;
-  void finalizeResponseHeaders(Http::HeaderMap& headers,
+  void finalizeResponseHeaders(Http::ResponseHeaderMap& headers,
                                const StreamInfo::StreamInfo& stream_info) const override;
   const Http::HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
 
@@ -455,10 +457,11 @@ public:
   uint32_t maxInternalRedirects() const override { return max_internal_redirects_; }
 
   // Router::DirectResponseEntry
-  std::string newPath(const Http::HeaderMap& headers) const override;
-  absl::string_view processRequestHost(const Http::HeaderMap& headers, absl::string_view new_scheme,
+  std::string newPath(const Http::RequestHeaderMap& headers) const override;
+  absl::string_view processRequestHost(const Http::RequestHeaderMap& headers,
+                                       absl::string_view new_scheme,
                                        absl::string_view new_port) const;
-  void rewritePathHeader(Http::HeaderMap&, bool) const override {}
+  void rewritePathHeader(Http::RequestHeaderMap&, bool) const override {}
   Http::Code responseCode() const override { return direct_response_code_.value(); }
   const std::string& responseBody() const override { return direct_response_body_; }
 
@@ -486,7 +489,7 @@ protected:
     return (isRedirect()) ? prefix_rewrite_redirect_ : prefix_rewrite_;
   }
 
-  void finalizePathHeader(Http::HeaderMap& headers, absl::string_view matched_path,
+  void finalizePathHeader(Http::RequestHeaderMap& headers, absl::string_view matched_path,
                           bool insert_envoy_original_path) const;
 
 private:
@@ -507,11 +510,12 @@ private:
       return parent_->clusterNotFoundResponseCode();
     }
 
-    void finalizeRequestHeaders(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
+    void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
+                                const StreamInfo::StreamInfo& stream_info,
                                 bool insert_envoy_original_path) const override {
       return parent_->finalizeRequestHeaders(headers, stream_info, insert_envoy_original_path);
     }
-    void finalizeResponseHeaders(Http::HeaderMap& headers,
+    void finalizeResponseHeaders(Http::ResponseHeaderMap& headers,
                                  const StreamInfo::StreamInfo& stream_info) const override {
       return parent_->finalizeResponseHeaders(headers, stream_info);
     }
@@ -612,12 +616,13 @@ private:
       return DynamicRouteEntry::metadataMatchCriteria();
     }
 
-    void finalizeRequestHeaders(Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
+    void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
+                                const StreamInfo::StreamInfo& stream_info,
                                 bool insert_envoy_original_path) const override {
       request_headers_parser_->evaluateHeaders(headers, stream_info);
       DynamicRouteEntry::finalizeRequestHeaders(headers, stream_info, insert_envoy_original_path);
     }
-    void finalizeResponseHeaders(Http::HeaderMap& headers,
+    void finalizeResponseHeaders(Http::ResponseHeaderMap& headers,
                                  const StreamInfo::StreamInfo& stream_info) const override {
       response_headers_parser_->evaluateHeaders(headers, stream_info);
       DynamicRouteEntry::finalizeResponseHeaders(headers, stream_info);
@@ -732,12 +737,13 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Prefix; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::HeaderMap& headers,
+  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
   // Router::DirectResponseEntry
-  void rewritePathHeader(Http::HeaderMap& headers, bool insert_envoy_original_path) const override;
+  void rewritePathHeader(Http::RequestHeaderMap& headers,
+                         bool insert_envoy_original_path) const override;
 
 private:
   const std::string prefix_;
@@ -758,12 +764,13 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Exact; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::HeaderMap& headers,
+  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
   // Router::DirectResponseEntry
-  void rewritePathHeader(Http::HeaderMap& headers, bool insert_envoy_original_path) const override;
+  void rewritePathHeader(Http::RequestHeaderMap& headers,
+                         bool insert_envoy_original_path) const override;
 
 private:
   const std::string path_;
@@ -784,12 +791,13 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Regex; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::HeaderMap& headers,
+  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
   // Router::DirectResponseEntry
-  void rewritePathHeader(Http::HeaderMap& headers, bool insert_envoy_original_path) const override;
+  void rewritePathHeader(Http::RequestHeaderMap& headers,
+                         bool insert_envoy_original_path) const override;
 
 private:
   Regex::CompiledMatcherPtr regex_;
@@ -807,10 +815,10 @@ public:
                Server::Configuration::ServerFactoryContext& factory_context,
                ProtobufMessage::ValidationVisitor& validator, bool validate_clusters);
 
-  RouteConstSharedPtr route(const Http::HeaderMap& headers,
+  RouteConstSharedPtr route(const Http::RequestHeaderMap& headers,
                             const StreamInfo::StreamInfo& stream_info, uint64_t random_value) const;
 
-  const VirtualHostImpl* findVirtualHost(const Http::HeaderMap& headers) const;
+  const VirtualHostImpl* findVirtualHost(const Http::RequestHeaderMap& headers) const;
 
 private:
   using WildcardVirtualHosts =
@@ -848,12 +856,12 @@ public:
   const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
   const HeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
 
-  bool virtualHostExists(const Http::HeaderMap& headers) const {
+  bool virtualHostExists(const Http::RequestHeaderMap& headers) const {
     return route_matcher_->findVirtualHost(headers) != nullptr;
   }
 
   // Router::Config
-  RouteConstSharedPtr route(const Http::HeaderMap& headers,
+  RouteConstSharedPtr route(const Http::RequestHeaderMap& headers,
                             const StreamInfo::StreamInfo& stream_info,
                             uint64_t random_value) const override {
     return route_matcher_->route(headers, stream_info, random_value);
@@ -888,7 +896,7 @@ private:
 class NullConfigImpl : public Config {
 public:
   // Router::Config
-  RouteConstSharedPtr route(const Http::HeaderMap&, const StreamInfo::StreamInfo&,
+  RouteConstSharedPtr route(const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                             uint64_t) const override {
     return nullptr;
   }

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -318,11 +318,13 @@ StreamInfoHeaderFormatter::StreamInfoHeaderFormatter(absl::string_view field_nam
     }
     field_extractor_ = [this, pattern](const Envoy::StreamInfo::StreamInfo& stream_info) {
       const auto& formatters = start_time_formatters_.at(pattern);
-      Http::HeaderMapImpl empty_map;
+      static const Http::RequestHeaderMapImpl empty_request_headers;
+      static const Http::ResponseHeaderMapImpl empty_response_headers;
+      static const Http::ResponseTrailerMapImpl empty_response_trailers;
       std::string formatted;
       for (const auto& formatter : formatters) {
-        absl::StrAppend(&formatted,
-                        formatter->format(empty_map, empty_map, empty_map, stream_info));
+        absl::StrAppend(&formatted, formatter->format(empty_request_headers, empty_response_headers,
+                                                      empty_response_trailers, stream_info));
       }
       return formatted;
     };

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -290,7 +290,7 @@ void RdsRouteConfigProviderImpl::onConfigUpdate() {
     auto found = aliases.find(it->alias_);
     if (found != aliases.end()) {
       // TODO(dmitri-d) HeaderMapImpl is expensive, need to profile this
-      Http::HeaderMapImpl host_header;
+      Http::RequestHeaderMapImpl host_header;
       host_header.setHost(VhdsSubscription::aliasToDomainName(it->alias_));
       const bool host_exists = config->virtualHostExists(host_header);
       auto current_cb = it->cb_;

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -32,7 +32,7 @@ const uint32_t RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED;
 const uint32_t RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE;
 
 RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
-                                     Http::HeaderMap& request_headers,
+                                     Http::RequestHeaderMap& request_headers,
                                      const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                      Runtime::RandomGenerator& random,
                                      Event::Dispatcher& dispatcher,
@@ -52,7 +52,8 @@ RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
   return ret;
 }
 
-RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
+RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy,
+                               Http::RequestHeaderMap& request_headers,
                                const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                Upstream::ResourcePriority priority)
@@ -243,7 +244,7 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
   return RetryStatus::Yes;
 }
 
-RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::HeaderMap& response_headers,
+RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::ResponseHeaderMap& response_headers,
                                                DoRetryCallback callback) {
   return shouldRetry(wouldRetryFromHeaders(response_headers), callback);
 }
@@ -264,7 +265,7 @@ RetryStatus RetryStateImpl::shouldHedgeRetryPerTryTimeout(DoRetryCallback callba
   return shouldRetry(true, callback);
 }
 
-bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_headers) {
+bool RetryStateImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_headers) {
   if (response_headers.EnvoyOverloaded() != nullptr) {
     return false;
   }

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -24,7 +24,8 @@ namespace Router {
  */
 class RetryStateImpl : public RetryState {
 public:
-  static RetryStatePtr create(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
+  static RetryStatePtr create(const RetryPolicy& route_policy,
+                              Http::RequestHeaderMap& request_headers,
                               const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                               Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                               Upstream::ResourcePriority priority);
@@ -50,11 +51,11 @@ public:
 
   // Router::RetryState
   bool enabled() override { return retry_on_ != 0; }
-  RetryStatus shouldRetryHeaders(const Http::HeaderMap& response_headers,
+  RetryStatus shouldRetryHeaders(const Http::ResponseHeaderMap& response_headers,
                                  DoRetryCallback callback) override;
   // Returns true if the retry policy would retry the passed headers. Does not
   // take into account circuit breaking or remaining tries.
-  bool wouldRetryFromHeaders(const Http::HeaderMap& response_headers) override;
+  bool wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_headers) override;
   RetryStatus shouldRetryReset(const Http::StreamResetReason reset_reason,
                                DoRetryCallback callback) override;
   RetryStatus shouldHedgeRetryPerTryTimeout(DoRetryCallback callback) override;
@@ -85,7 +86,7 @@ public:
   uint32_t hostSelectionMaxAttempts() const override { return host_selection_max_attempts_; }
 
 private:
-  RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
+  RetryStateImpl(const RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
                  const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                  Upstream::ResourcePriority priority);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -45,7 +45,7 @@ constexpr char NumInternalRedirectsFilterStateName[] = "num_internal_redirects";
 
 uint32_t getLength(const Buffer::Instance* instance) { return instance ? instance->length() : 0; }
 
-bool schemeIsHttp(const Http::HeaderMap& downstream_headers,
+bool schemeIsHttp(const Http::RequestHeaderMap& downstream_headers,
                   const Network::Connection& connection) {
   if (downstream_headers.ForwardedProto() &&
       downstream_headers.ForwardedProto()->value().getStringView() ==
@@ -58,7 +58,7 @@ bool schemeIsHttp(const Http::HeaderMap& downstream_headers,
   return false;
 }
 
-bool convertRequestHeadersForInternalRedirect(Http::HeaderMap& downstream_headers,
+bool convertRequestHeadersForInternalRedirect(Http::RequestHeaderMap& downstream_headers,
                                               StreamInfo::FilterState& filter_state,
                                               uint32_t max_internal_redirects,
                                               const Http::HeaderEntry& internal_redirect,
@@ -127,7 +127,7 @@ uint64_t percentageOfTimeout(const std::chrono::milliseconds response_time,
 
 } // namespace
 
-void FilterUtility::setUpstreamScheme(Http::HeaderMap& headers, bool use_secure_transport) {
+void FilterUtility::setUpstreamScheme(Http::RequestHeaderMap& headers, bool use_secure_transport) {
   if (use_secure_transport) {
     headers.setReferenceScheme(Http::Headers::get().SchemeValues.Https);
   } else {
@@ -155,7 +155,7 @@ bool FilterUtility::shouldShadow(const ShadowPolicy& policy, Runtime::Loader& ru
 }
 
 FilterUtility::TimeoutData
-FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_headers,
+FilterUtility::finalTimeout(const RouteEntry& route, Http::RequestHeaderMap& request_headers,
                             bool insert_envoy_expected_request_timeout_ms, bool grpc_request,
                             bool per_try_timeout_hedging_enabled,
                             bool respect_expected_rq_timeout) {
@@ -264,8 +264,9 @@ bool FilterUtility::trySetGlobalTimeout(const Http::HeaderEntry* header_timeout_
   return false;
 }
 
-FilterUtility::HedgingParams FilterUtility::finalHedgingParams(const RouteEntry& route,
-                                                               Http::HeaderMap& request_headers) {
+FilterUtility::HedgingParams
+FilterUtility::finalHedgingParams(const RouteEntry& route,
+                                  Http::RequestHeaderMap& request_headers) {
   HedgingParams hedging_params;
   hedging_params.hedge_on_per_try_timeout_ = route.hedgePolicy().hedgeOnPerTryTimeout();
 
@@ -292,7 +293,7 @@ Filter::~Filter() {
 }
 
 const FilterUtility::StrictHeaderChecker::HeaderCheckResult
-FilterUtility::StrictHeaderChecker::checkHeader(Http::HeaderMap& headers,
+FilterUtility::StrictHeaderChecker::checkHeader(Http::RequestHeaderMap& headers,
                                                 const Http::LowerCaseString& target_header) {
   if (target_header == Http::Headers::get().EnvoyUpstreamRequestTimeoutMs) {
     return isInteger(headers.EnvoyUpstreamRequestTimeoutMs());
@@ -315,7 +316,7 @@ Stats::StatName Filter::upstreamZone(Upstream::HostDescriptionConstSharedPtr ups
 }
 
 void Filter::chargeUpstreamCode(uint64_t response_status_code,
-                                const Http::HeaderMap& response_headers,
+                                const Http::ResponseHeaderMap& response_headers,
                                 Upstream::HostDescriptionConstSharedPtr upstream_host,
                                 bool dropped) {
   // Passing the response_status_code explicitly is an optimization to avoid
@@ -370,7 +371,7 @@ void Filter::chargeUpstreamCode(Http::Code code,
                                 Upstream::HostDescriptionConstSharedPtr upstream_host,
                                 bool dropped) {
   const uint64_t response_status_code = enumToInt(code);
-  const auto fake_response_headers = Http::createHeaderMap<Http::HeaderMapImpl>(
+  const auto fake_response_headers = Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
       {{Http::Headers::get().Status, std::to_string(response_status_code)}});
   chargeUpstreamCode(response_status_code, *fake_response_headers, upstream_host, dropped);
 }
@@ -426,7 +427,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     callbacks_->sendLocalReply(
         direct_response->responseCode(), direct_response->responseBody(),
         [this, direct_response,
-         &request_headers = headers](Http::HeaderMap& response_headers) -> void {
+         &request_headers = headers](Http::ResponseHeaderMap& response_headers) -> void {
           const auto new_path = direct_response->newPath(request_headers);
           // See https://tools.ietf.org/html/rfc7231#section-7.1.2.
           const auto add_location =
@@ -505,7 +506,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, true);
     callbacks_->sendLocalReply(
         Http::Code::ServiceUnavailable, "maintenance mode",
-        [modify_headers, this](Http::HeaderMap& headers) {
+        [modify_headers, this](Http::ResponseHeaderMap& headers) {
           if (!config_.suppress_envoy_headers_) {
             headers.setReferenceEnvoyOverloaded(Http::Headers::get().EnvoyOverloadedValues.True);
           }
@@ -948,7 +949,7 @@ void Filter::onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_
 
     callbacks_->sendLocalReply(
         code, body,
-        [dropped, this](Http::HeaderMap& headers) {
+        [dropped, this](Http::ResponseHeaderMap& headers) {
           if (dropped && !config_.suppress_envoy_headers_) {
             headers.setReferenceEnvoyOverloaded(Http::Headers::get().EnvoyOverloadedValues.True);
           }
@@ -1359,7 +1360,8 @@ bool Filter::setupRetry() {
   return true;
 }
 
-bool Filter::setupRedirect(const Http::HeaderMap& headers, UpstreamRequest& upstream_request) {
+bool Filter::setupRedirect(const Http::ResponseHeaderMap& headers,
+                           UpstreamRequest& upstream_request) {
   ENVOY_STREAM_LOG(debug, "attempting internal redirect", *callbacks_);
   const Http::HeaderEntry* location = headers.Location();
 
@@ -1785,7 +1787,7 @@ void Filter::UpstreamRequest::onPoolReady(Http::RequestEncoder& request_encoder,
 }
 
 RetryStatePtr
-ProdFilter::createRetryState(const RetryPolicy& policy, Http::HeaderMap& request_headers,
+ProdFilter::createRetryState(const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
                              const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                              Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                              Upstream::ResourcePriority priority) {

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -240,9 +240,11 @@ struct StreamInfoImpl : public StreamInfo {
     return upstream_transport_failure_reason_;
   }
 
-  void setRequestHeaders(const Http::HeaderMap& headers) override { request_headers_ = &headers; }
+  void setRequestHeaders(const Http::RequestHeaderMap& headers) override {
+    request_headers_ = &headers;
+  }
 
-  const Http::HeaderMap* getRequestHeaders() const override { return request_headers_; }
+  const Http::RequestHeaderMap* getRequestHeaders() const override { return request_headers_; }
 
   void dumpState(std::ostream& os, int indent_level = 0) const {
     const char* spaces = spacesForLevel(indent_level);
@@ -282,7 +284,7 @@ private:
   Ssl::ConnectionInfoConstSharedPtr downstream_ssl_info_;
   Ssl::ConnectionInfoConstSharedPtr upstream_ssl_info_;
   std::string requested_server_name_;
-  const Http::HeaderMap* request_headers_{};
+  const Http::RequestHeaderMap* request_headers_{};
   UpstreamTiming upstream_timing_;
   std::string upstream_transport_failure_reason_;
 };

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -35,7 +35,7 @@ static std::string valueOrDefault(const Http::HeaderEntry* header, const char* d
   return header ? std::string(header->value().getStringView()) : default_value;
 }
 
-static std::string buildUrl(const Http::HeaderMap& request_headers,
+static std::string buildUrl(const Http::RequestHeaderMap& request_headers,
                             const uint32_t max_path_length) {
   std::string path(request_headers.EnvoyOriginalPath()
                        ? request_headers.EnvoyOriginalPath()->value().getStringView()
@@ -64,7 +64,7 @@ const std::string& HttpTracerUtility::toString(OperationName operation_name) {
 }
 
 Decision HttpTracerUtility::isTracing(const StreamInfo::StreamInfo& stream_info,
-                                      const Http::HeaderMap& request_headers) {
+                                      const Http::RequestHeaderMap& request_headers) {
   // Exclude health check requests immediately.
   if (stream_info.healthCheck()) {
     return {Reason::HealthCheck, false};
@@ -97,14 +97,14 @@ static void addTagIfNotNull(Span& span, const std::string& tag, const Http::Head
   }
 }
 
-static void addGrpcRequestTags(Span& span, const Http::HeaderMap& headers) {
+static void addGrpcRequestTags(Span& span, const Http::RequestHeaderMap& headers) {
   addTagIfNotNull(span, Tracing::Tags::get().GrpcPath, headers.Path());
   addTagIfNotNull(span, Tracing::Tags::get().GrpcAuthority, headers.Host());
   addTagIfNotNull(span, Tracing::Tags::get().GrpcContentType, headers.ContentType());
   addTagIfNotNull(span, Tracing::Tags::get().GrpcTimeout, headers.GrpcTimeout());
 }
 
-static void addGrpcResponseTags(Span& span, const Http::HeaderMap& headers) {
+template <class T> static void addGrpcResponseTags(Span& span, const T& headers) {
   addTagIfNotNull(span, Tracing::Tags::get().GrpcStatusCode, headers.GrpcStatus());
   addTagIfNotNull(span, Tracing::Tags::get().GrpcMessage, headers.GrpcMessage());
   // Set error tag when status is not OK.
@@ -153,9 +153,10 @@ static void annotateVerbose(Span& span, const StreamInfo::StreamInfo& stream_inf
   }
 }
 
-void HttpTracerUtility::finalizeDownstreamSpan(Span& span, const Http::HeaderMap* request_headers,
-                                               const Http::HeaderMap* response_headers,
-                                               const Http::HeaderMap* response_trailers,
+void HttpTracerUtility::finalizeDownstreamSpan(Span& span,
+                                               const Http::RequestHeaderMap* request_headers,
+                                               const Http::ResponseHeaderMap* response_headers,
+                                               const Http::ResponseTrailerMap* response_trailers,
                                                const StreamInfo::StreamInfo& stream_info,
                                                const Config& tracing_config) {
   // Pre response data.
@@ -208,8 +209,9 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span, const Http::HeaderMap
   span.finishSpan();
 }
 
-void HttpTracerUtility::finalizeUpstreamSpan(Span& span, const Http::HeaderMap* response_headers,
-                                             const Http::HeaderMap* response_trailers,
+void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
+                                             const Http::ResponseHeaderMap* response_headers,
+                                             const Http::ResponseTrailerMap* response_trailers,
                                              const StreamInfo::StreamInfo& stream_info,
                                              const Config& tracing_config) {
   span.setTag(Tracing::Tags::get().HttpProtocol,
@@ -225,8 +227,8 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span, const Http::HeaderMap* 
   span.finishSpan();
 }
 
-void HttpTracerUtility::setCommonTags(Span& span, const Http::HeaderMap* response_headers,
-                                      const Http::HeaderMap* response_trailers,
+void HttpTracerUtility::setCommonTags(Span& span, const Http::ResponseHeaderMap* response_headers,
+                                      const Http::ResponseTrailerMap* response_trailers,
                                       const StreamInfo::StreamInfo& stream_info,
                                       const Config& tracing_config) {
 
@@ -276,7 +278,7 @@ HttpTracerUtility::createCustomTag(const envoy::type::tracing::v3::CustomTag& ta
 HttpTracerImpl::HttpTracerImpl(DriverPtr&& driver, const LocalInfo::LocalInfo& local_info)
     : driver_(std::move(driver)), local_info_(local_info) {}
 
-SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request_headers,
+SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
                                   const StreamInfo::StreamInfo& stream_info,
                                   const Tracing::Decision tracing_decision) {
   std::string span_name = HttpTracerUtility::toString(config.operationName());

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -107,15 +107,15 @@ public:
    * @return decision if request is traceable or not and Reason why.
    **/
   static Decision isTracing(const StreamInfo::StreamInfo& stream_info,
-                            const Http::HeaderMap& request_headers);
+                            const Http::RequestHeaderMap& request_headers);
 
   /**
    * Adds information obtained from the downstream request headers as tags to the active span.
    * Then finishes the span.
    */
-  static void finalizeDownstreamSpan(Span& span, const Http::HeaderMap* request_headers,
-                                     const Http::HeaderMap* response_headers,
-                                     const Http::HeaderMap* response_trailers,
+  static void finalizeDownstreamSpan(Span& span, const Http::RequestHeaderMap* request_headers,
+                                     const Http::ResponseHeaderMap* response_headers,
+                                     const Http::ResponseTrailerMap* response_trailers,
                                      const StreamInfo::StreamInfo& stream_info,
                                      const Config& tracing_config);
 
@@ -123,8 +123,8 @@ public:
    * Adds information obtained from the upstream request headers as tags to the active span.
    * Then finishes the span.
    */
-  static void finalizeUpstreamSpan(Span& span, const Http::HeaderMap* response_headers,
-                                   const Http::HeaderMap* response_trailers,
+  static void finalizeUpstreamSpan(Span& span, const Http::ResponseHeaderMap* response_headers,
+                                   const Http::ResponseTrailerMap* response_trailers,
                                    const StreamInfo::StreamInfo& stream_info,
                                    const Config& tracing_config);
 
@@ -135,8 +135,8 @@ public:
   static CustomTagConstSharedPtr createCustomTag(const envoy::type::tracing::v3::CustomTag& tag);
 
 private:
-  static void setCommonTags(Span& span, const Http::HeaderMap* response_headers,
-                            const Http::HeaderMap* response_trailers,
+  static void setCommonTags(Span& span, const Http::ResponseHeaderMap* response_headers,
+                            const Http::ResponseTrailerMap* response_trailers,
                             const StreamInfo::StreamInfo& stream_info,
                             const Config& tracing_config);
 
@@ -167,7 +167,7 @@ public:
   void setTag(absl::string_view, absl::string_view) override {}
   void log(SystemTime, const std::string&) override {}
   void finishSpan() override {}
-  void injectContext(Http::HeaderMap&) override {}
+  void injectContext(Http::RequestHeaderMap&) override {}
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }
@@ -177,7 +177,7 @@ public:
 class HttpNullTracer : public HttpTracer {
 public:
   // Tracing::HttpTracer
-  SpanPtr startSpan(const Config&, Http::HeaderMap&, const StreamInfo::StreamInfo&,
+  SpanPtr startSpan(const Config&, Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                     const Tracing::Decision) override {
     return SpanPtr{new NullSpan()};
   }
@@ -188,7 +188,7 @@ public:
   HttpTracerImpl(DriverPtr&& driver, const LocalInfo::LocalInfo& local_info);
 
   // Tracing::HttpTracer
-  SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
                     const StreamInfo::StreamInfo& stream_info,
                     const Tracing::Decision tracing_decision) override;
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -120,7 +120,7 @@ private:
     ConnectionCallbackImpl connection_callback_impl_{*this};
     HttpHealthCheckerImpl& parent_;
     Http::CodecClientPtr client_;
-    Http::HeaderMapPtr response_headers_;
+    Http::ResponseHeaderMapPtr response_headers_;
     const std::string& hostname_;
     const Http::Protocol protocol_;
     Network::Address::InstanceConstSharedPtr local_address_;

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -144,7 +144,7 @@ public:
 
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
 
-  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
+  const Http::RequestHeaderMap* downstreamHeaders() const override { return nullptr; }
 
   const HealthyAndDegradedLoad&
   determinePriorityLoad(const PrioritySet&,

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -144,7 +144,7 @@ private:
     const Network::Connection* downstreamConnection() const override {
       return wrapped_->downstreamConnection();
     }
-    const Http::HeaderMap* downstreamHeaders() const override {
+    const Http::RequestHeaderMap* downstreamHeaders() const override {
       return wrapped_->downstreamHeaders();
     }
     const HealthyAndDegradedLoad&

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -128,7 +128,7 @@ void MainCommonBase::adminRequest(absl::string_view path_and_query, absl::string
   std::string path_and_query_buf = std::string(path_and_query);
   std::string method_buf = std::string(method);
   server_->dispatcher().post([this, path_and_query_buf, method_buf, handler]() {
-    Http::HeaderMapImpl response_headers;
+    Http::ResponseHeaderMapImpl response_headers;
     std::string body;
     server_->admin().request(path_and_query_buf, method_buf, response_headers, body);
     handler(response_headers, body);

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -48,7 +48,7 @@ public:
   Server::Instance* server() { return server_.get(); }
 
   using AdminRequestFn =
-      std::function<void(const Http::HeaderMap& response_headers, absl::string_view body)>;
+      std::function<void(const Http::ResponseHeaderMap& response_headers, absl::string_view body)>;
 
   // Makes an admin-console request by path, calling handler() when complete.
   // The caller can initiate this from any thread, but it posts the request

--- a/source/extensions/access_loggers/common/access_log_base.cc
+++ b/source/extensions/access_loggers/common/access_log_base.cc
@@ -8,18 +8,21 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace Common {
 
-void ImplBase::log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                   const Http::HeaderMap* response_trailers,
+void ImplBase::log(const Http::RequestHeaderMap* request_headers,
+                   const Http::ResponseHeaderMap* response_headers,
+                   const Http::ResponseTrailerMap* response_trailers,
                    const StreamInfo::StreamInfo& stream_info) {
-  ConstSingleton<Http::HeaderMapImpl> empty_headers;
+  ConstSingleton<Http::RequestHeaderMapImpl> empty_request_headers;
+  ConstSingleton<Http::ResponseHeaderMapImpl> empty_response_headers;
+  ConstSingleton<Http::ResponseTrailerMapImpl> empty_response_trailers;
   if (!request_headers) {
-    request_headers = &empty_headers.get();
+    request_headers = &empty_request_headers.get();
   }
   if (!response_headers) {
-    response_headers = &empty_headers.get();
+    response_headers = &empty_response_headers.get();
   }
   if (!response_trailers) {
-    response_trailers = &empty_headers.get();
+    response_trailers = &empty_response_trailers.get();
   }
   if (filter_ &&
       !filter_->evaluate(stream_info, *request_headers, *response_headers, *response_trailers)) {

--- a/source/extensions/access_loggers/common/access_log_base.h
+++ b/source/extensions/access_loggers/common/access_log_base.h
@@ -27,8 +27,9 @@ public:
   /**
    * Log a completed request if the underlying AccessLog `filter_` allows it.
    */
-  void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-           const Http::HeaderMap* response_trailers,
+  void log(const Http::RequestHeaderMap* request_headers,
+           const Http::ResponseHeaderMap* response_headers,
+           const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info) override;
 
 private:
@@ -40,9 +41,9 @@ private:
    * @param stream_info supplies additional information about the request not
    * contained in the request headers.
    */
-  virtual void emitLog(const Http::HeaderMap& request_headers,
-                       const Http::HeaderMap& response_headers,
-                       const Http::HeaderMap& response_trailers,
+  virtual void emitLog(const Http::RequestHeaderMap& request_headers,
+                       const Http::ResponseHeaderMap& response_headers,
+                       const Http::ResponseTrailerMap& response_trailers,
                        const StreamInfo::StreamInfo& stream_info) PURE;
 
   AccessLog::FilterPtr filter_;

--- a/source/extensions/access_loggers/file/file_access_log_impl.cc
+++ b/source/extensions/access_loggers/file/file_access_log_impl.cc
@@ -12,9 +12,9 @@ FileAccessLog::FileAccessLog(const std::string& access_log_path, AccessLog::Filt
   log_file_ = log_manager.createAccessLog(access_log_path);
 }
 
-void FileAccessLog::emitLog(const Http::HeaderMap& request_headers,
-                            const Http::HeaderMap& response_headers,
-                            const Http::HeaderMap& response_trailers,
+void FileAccessLog::emitLog(const Http::RequestHeaderMap& request_headers,
+                            const Http::ResponseHeaderMap& response_headers,
+                            const Http::ResponseTrailerMap& response_trailers,
                             const StreamInfo::StreamInfo& stream_info) {
   log_file_->write(
       formatter_->format(request_headers, response_headers, response_trailers, stream_info));

--- a/source/extensions/access_loggers/file/file_access_log_impl.h
+++ b/source/extensions/access_loggers/file/file_access_log_impl.h
@@ -17,8 +17,9 @@ public:
 
 private:
   // Common::ImplBase
-  void emitLog(const Http::HeaderMap& request_headers, const Http::HeaderMap& response_headers,
-               const Http::HeaderMap& response_trailers,
+  void emitLog(const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers,
                const StreamInfo::StreamInfo& stream_info) override;
 
   AccessLog::AccessLogFileSharedPtr log_file_;

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -43,9 +43,9 @@ HttpGrpcAccessLog::HttpGrpcAccessLog(
   });
 }
 
-void HttpGrpcAccessLog::emitLog(const Http::HeaderMap& request_headers,
-                                const Http::HeaderMap& response_headers,
-                                const Http::HeaderMap& response_trailers,
+void HttpGrpcAccessLog::emitLog(const Http::RequestHeaderMap& request_headers,
+                                const Http::ResponseHeaderMap& response_headers,
+                                const Http::ResponseTrailerMap& response_trailers,
                                 const StreamInfo::StreamInfo& stream_info) {
   // Common log properties.
   // TODO(mattklein123): Populate sample_rate field.

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.h
@@ -43,8 +43,9 @@ private:
   };
 
   // Common::ImplBase
-  void emitLog(const Http::HeaderMap& request_headers, const Http::HeaderMap& response_headers,
-               const Http::HeaderMap& response_trailers,
+  void emitLog(const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers,
                const StreamInfo::StreamInfo& stream_info) override;
 
   const envoy::extensions::access_loggers::grpc::v3::HttpGrpcAccessLogConfig config_;

--- a/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
@@ -29,8 +29,9 @@ TcpGrpcAccessLog::TcpGrpcAccessLog(
   });
 }
 
-void TcpGrpcAccessLog::emitLog(const Http::HeaderMap&, const Http::HeaderMap&,
-                               const Http::HeaderMap&, const StreamInfo::StreamInfo& stream_info) {
+void TcpGrpcAccessLog::emitLog(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                               const Http::ResponseTrailerMap&,
+                               const StreamInfo::StreamInfo& stream_info) {
   // Common log properties.
   envoy::data::accesslog::v3::TCPAccessLogEntry log_entry;
   GrpcCommon::Utility::extractCommonAccessLogProperties(*log_entry.mutable_common_properties(),

--- a/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.h
@@ -43,8 +43,9 @@ private:
   };
 
   // Common::ImplBase
-  void emitLog(const Http::HeaderMap& request_headers, const Http::HeaderMap& response_headers,
-               const Http::HeaderMap& response_trailers,
+  void emitLog(const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers,
                const StreamInfo::StreamInfo& stream_info) override;
 
   const envoy::extensions::access_loggers::grpc::v3::TcpGrpcAccessLogConfig config_;

--- a/source/extensions/clusters/aggregate/lb_context.h
+++ b/source/extensions/clusters/aggregate/lb_context.h
@@ -32,7 +32,7 @@ public:
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override {
     return context_->metadataMatchCriteria();
   }
-  const Http::HeaderMap* downstreamHeaders() const override {
+  const Http::RequestHeaderMap* downstreamHeaders() const override {
     return context_->downstreamHeaders();
   }
   const Upstream::HealthyAndDegradedLoad&

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -11,7 +11,8 @@ namespace Extensions {
 namespace Common {
 namespace Aws {
 
-std::map<std::string, std::string> Utility::canonicalizeHeaders(const Http::HeaderMap& headers) {
+std::map<std::string, std::string>
+Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers) {
   std::map<std::string, std::string> out;
   headers.iterate(
       [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {

--- a/source/extensions/common/aws/utility.h
+++ b/source/extensions/common/aws/utility.h
@@ -15,7 +15,8 @@ public:
    * @param headers a header map to canonicalize.
    * @return a std::map of canonicalized headers to be used in building a canonical request.
    */
-  static std::map<std::string, std::string> canonicalizeHeaders(const Http::HeaderMap& headers);
+  static std::map<std::string, std::string>
+  canonicalizeHeaders(const Http::RequestHeaderMap& headers);
 
   /**
    * Creates an AWS Signature V4 canonical request string.

--- a/source/extensions/common/tap/tap_matcher.h
+++ b/source/extensions/common/tap/tap_matcher.h
@@ -73,7 +73,7 @@ public:
    * @param statuses supplies the per-stream-request match status vector which must be the same
    *                 size as the match tree vector (see above).
    */
-  virtual void onHttpRequestHeaders(const Http::HeaderMap& request_headers,
+  virtual void onHttpRequestHeaders(const Http::RequestHeaderMap& request_headers,
                                     MatchStatusVector& statuses) const PURE;
 
   /**
@@ -82,7 +82,7 @@ public:
    * @param statuses supplies the per-stream-request match status vector which must be the same
    *                 size as the match tree vector (see above).
    */
-  virtual void onHttpRequestTrailers(const Http::HeaderMap& request_trailers,
+  virtual void onHttpRequestTrailers(const Http::RequestTrailerMap& request_trailers,
                                      MatchStatusVector& statuses) const PURE;
 
   /**
@@ -91,7 +91,7 @@ public:
    * @param statuses supplies the per-stream-request match status vector which must be the same
    *                 size as the match tree vector (see above).
    */
-  virtual void onHttpResponseHeaders(const Http::HeaderMap& response_headers,
+  virtual void onHttpResponseHeaders(const Http::ResponseHeaderMap& response_headers,
                                      MatchStatusVector& statuses) const PURE;
 
   /**
@@ -100,7 +100,7 @@ public:
    * @param statuses supplies the per-stream-request match status vector which must be the same
    *                 size as the match tree vector (see above).
    */
-  virtual void onHttpResponseTrailers(const Http::HeaderMap& response_trailers,
+  virtual void onHttpResponseTrailers(const Http::ResponseTrailerMap& response_trailers,
                                       MatchStatusVector& statuses) const PURE;
 
   /**
@@ -134,25 +134,25 @@ public:
     updateLocalStatus(statuses,
                       [](Matcher& m, MatchStatusVector& statuses) { m.onNewStream(statuses); });
   }
-  void onHttpRequestHeaders(const Http::HeaderMap& request_headers,
+  void onHttpRequestHeaders(const Http::RequestHeaderMap& request_headers,
                             MatchStatusVector& statuses) const override {
     updateLocalStatus(statuses, [&request_headers](Matcher& m, MatchStatusVector& statuses) {
       m.onHttpRequestHeaders(request_headers, statuses);
     });
   }
-  void onHttpRequestTrailers(const Http::HeaderMap& request_trailers,
+  void onHttpRequestTrailers(const Http::RequestTrailerMap& request_trailers,
                              MatchStatusVector& statuses) const override {
     updateLocalStatus(statuses, [&request_trailers](Matcher& m, MatchStatusVector& statuses) {
       m.onHttpRequestTrailers(request_trailers, statuses);
     });
   }
-  void onHttpResponseHeaders(const Http::HeaderMap& response_headers,
+  void onHttpResponseHeaders(const Http::ResponseHeaderMap& response_headers,
                              MatchStatusVector& statuses) const override {
     updateLocalStatus(statuses, [&response_headers](Matcher& m, MatchStatusVector& statuses) {
       m.onHttpResponseHeaders(response_headers, statuses);
     });
   }
-  void onHttpResponseTrailers(const Http::HeaderMap& response_trailers,
+  void onHttpResponseTrailers(const Http::ResponseTrailerMap& response_trailers,
                               MatchStatusVector& statuses) const override {
     updateLocalStatus(statuses, [&response_trailers](Matcher& m, MatchStatusVector& statuses) {
       m.onHttpResponseTrailers(response_trailers, statuses);
@@ -208,10 +208,10 @@ public:
 
   // Extensions::Common::Tap::Matcher
   void onNewStream(MatchStatusVector&) const override {}
-  void onHttpRequestHeaders(const Http::HeaderMap&, MatchStatusVector&) const override {}
-  void onHttpRequestTrailers(const Http::HeaderMap&, MatchStatusVector&) const override {}
-  void onHttpResponseHeaders(const Http::HeaderMap&, MatchStatusVector&) const override {}
-  void onHttpResponseTrailers(const Http::HeaderMap&, MatchStatusVector&) const override {}
+  void onHttpRequestHeaders(const Http::RequestHeaderMap&, MatchStatusVector&) const override {}
+  void onHttpRequestTrailers(const Http::RequestTrailerMap&, MatchStatusVector&) const override {}
+  void onHttpResponseHeaders(const Http::ResponseHeaderMap&, MatchStatusVector&) const override {}
+  void onHttpResponseTrailers(const Http::ResponseTrailerMap&, MatchStatusVector&) const override {}
 };
 
 /**
@@ -250,7 +250,7 @@ public:
   using HttpHeaderMatcherBase::HttpHeaderMatcherBase;
 
   // Extensions::Common::Tap::Matcher
-  void onHttpRequestHeaders(const Http::HeaderMap& request_headers,
+  void onHttpRequestHeaders(const Http::RequestHeaderMap& request_headers,
                             MatchStatusVector& statuses) const override {
     matchHeaders(request_headers, statuses);
   }
@@ -264,7 +264,7 @@ public:
   using HttpHeaderMatcherBase::HttpHeaderMatcherBase;
 
   // Extensions::Common::Tap::Matcher
-  void onHttpRequestTrailers(const Http::HeaderMap& request_trailers,
+  void onHttpRequestTrailers(const Http::RequestTrailerMap& request_trailers,
                              MatchStatusVector& statuses) const override {
     matchHeaders(request_trailers, statuses);
   }
@@ -278,7 +278,7 @@ public:
   using HttpHeaderMatcherBase::HttpHeaderMatcherBase;
 
   // Extensions::Common::Tap::Matcher
-  void onHttpResponseHeaders(const Http::HeaderMap& response_headers,
+  void onHttpResponseHeaders(const Http::ResponseHeaderMap& response_headers,
                              MatchStatusVector& statuses) const override {
     matchHeaders(response_headers, statuses);
   }
@@ -292,7 +292,7 @@ public:
   using HttpHeaderMatcherBase::HttpHeaderMatcherBase;
 
   // Extensions::Common::Tap::Matcher
-  void onHttpResponseTrailers(const Http::HeaderMap& response_trailers,
+  void onHttpResponseTrailers(const Http::ResponseTrailerMap& response_trailers,
                               MatchStatusVector& statuses) const override {
     matchHeaders(response_trailers, statuses);
   }

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -13,14 +13,14 @@ namespace Filters {
 namespace Common {
 namespace Expr {
 
-namespace {
-
 absl::optional<CelValue> convertHeaderEntry(const Http::HeaderEntry* header) {
   if (header == nullptr) {
     return {};
   }
   return CelValue::CreateStringView(header->value().getStringView());
 }
+
+namespace {
 
 absl::optional<CelValue> extractSslInfo(const Ssl::ConnectionInfo& ssl_info,
                                         absl::string_view value) {
@@ -51,14 +51,6 @@ absl::optional<CelValue> extractSslInfo(const Ssl::ConnectionInfo& ssl_info,
 }
 
 } // namespace
-
-absl::optional<CelValue> HeadersWrapper::operator[](CelValue key) const {
-  if (value_ == nullptr || !key.IsString()) {
-    return {};
-  }
-  auto out = value_->get(Http::LowerCaseString(std::string(key.StringOrDie().value())));
-  return convertHeaderEntry(out);
-}
 
 absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
   if (!key.IsString()) {
@@ -144,8 +136,9 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
     return CelValue::CreateInt64(info_.responseFlags());
   } else if (value == GrpcStatus) {
     auto const& optional_status = Grpc::Common::getGrpcStatus(
-        trailers_.value_ ? *trailers_.value_ : ConstSingleton<Http::HeaderMapImpl>::get(),
-        headers_.value_ ? *headers_.value_ : ConstSingleton<Http::HeaderMapImpl>::get(), info_);
+        trailers_.value_ ? *trailers_.value_ : ConstSingleton<Http::ResponseTrailerMapImpl>::get(),
+        headers_.value_ ? *headers_.value_ : ConstSingleton<Http::ResponseHeaderMapImpl>::get(),
+        info_);
     if (optional_status.has_value()) {
       return CelValue::CreateInt64(optional_status.value());
     }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -69,10 +69,18 @@ constexpr absl::string_view Upstream = "upstream";
 
 class RequestWrapper;
 
-class HeadersWrapper : public google::api::expr::runtime::CelMap {
+absl::optional<CelValue> convertHeaderEntry(const Http::HeaderEntry* header);
+
+template <class T> class HeadersWrapper : public google::api::expr::runtime::CelMap {
 public:
-  HeadersWrapper(const Http::HeaderMap* value) : value_(value) {}
-  absl::optional<CelValue> operator[](CelValue key) const override;
+  HeadersWrapper(const T* value) : value_(value) {}
+  absl::optional<CelValue> operator[](CelValue key) const override {
+    if (value_ == nullptr || !key.IsString()) {
+      return {};
+    }
+    auto out = value_->get(Http::LowerCaseString(std::string(key.StringOrDie().value())));
+    return convertHeaderEntry(out);
+  }
   int size() const override { return value_ == nullptr ? 0 : value_->size(); }
   bool empty() const override { return value_ == nullptr ? true : value_->empty(); }
   const google::api::expr::runtime::CelList* ListKeys() const override {
@@ -82,7 +90,7 @@ public:
 private:
   friend class RequestWrapper;
   friend class ResponseWrapper;
-  const Http::HeaderMap* value_;
+  const T* value_;
 };
 
 class BaseWrapper : public google::api::expr::runtime::CelMap,
@@ -98,25 +106,25 @@ public:
 
 class RequestWrapper : public BaseWrapper {
 public:
-  RequestWrapper(const Http::HeaderMap* headers, const StreamInfo::StreamInfo& info)
+  RequestWrapper(const Http::RequestHeaderMap* headers, const StreamInfo::StreamInfo& info)
       : headers_(headers), info_(info) {}
   absl::optional<CelValue> operator[](CelValue key) const override;
 
 private:
-  const HeadersWrapper headers_;
+  const HeadersWrapper<Http::RequestHeaderMap> headers_;
   const StreamInfo::StreamInfo& info_;
 };
 
 class ResponseWrapper : public BaseWrapper {
 public:
-  ResponseWrapper(const Http::HeaderMap* headers, const Http::HeaderMap* trailers,
+  ResponseWrapper(const Http::ResponseHeaderMap* headers, const Http::ResponseTrailerMap* trailers,
                   const StreamInfo::StreamInfo& info)
       : headers_(headers), trailers_(trailers), info_(info) {}
   absl::optional<CelValue> operator[](CelValue key) const override;
 
 private:
-  const HeadersWrapper headers_;
-  const HeadersWrapper trailers_;
+  const HeadersWrapper<Http::ResponseHeaderMap> headers_;
+  const HeadersWrapper<Http::ResponseTrailerMap> trailers_;
   const StreamInfo::StreamInfo& info_;
 };
 

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -12,9 +12,9 @@ namespace Common {
 namespace Expr {
 
 ActivationPtr createActivation(const StreamInfo::StreamInfo& info,
-                               const Http::HeaderMap* request_headers,
-                               const Http::HeaderMap* response_headers,
-                               const Http::HeaderMap* response_trailers) {
+                               const Http::RequestHeaderMap* request_headers,
+                               const Http::ResponseHeaderMap* response_headers,
+                               const Http::ResponseTrailerMap* response_trailers) {
   auto activation = std::make_unique<Activation>();
   activation->InsertValueProducer(Request, std::make_unique<RequestWrapper>(request_headers, info));
   activation->InsertValueProducer(
@@ -67,9 +67,9 @@ ExpressionPtr createExpression(Builder& builder, const google::api::expr::v1alph
 
 absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena* arena,
                                   const StreamInfo::StreamInfo& info,
-                                  const Http::HeaderMap* request_headers,
-                                  const Http::HeaderMap* response_headers,
-                                  const Http::HeaderMap* response_trailers) {
+                                  const Http::RequestHeaderMap* request_headers,
+                                  const Http::ResponseHeaderMap* response_headers,
+                                  const Http::ResponseTrailerMap* response_trailers) {
   auto activation = createActivation(info, request_headers, response_headers, response_trailers);
   auto eval_status = expr.Evaluate(*activation.get(), arena);
   if (!eval_status.ok()) {
@@ -80,7 +80,7 @@ absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena* arena
 }
 
 bool matches(const Expression& expr, const StreamInfo::StreamInfo& info,
-             const Http::HeaderMap& headers) {
+             const Http::RequestHeaderMap& headers) {
   Protobuf::Arena arena;
   auto eval_status = Expr::evaluate(expr, &arena, info, &headers, nullptr, nullptr);
   if (!eval_status.has_value()) {

--- a/source/extensions/filters/common/expr/evaluator.h
+++ b/source/extensions/filters/common/expr/evaluator.h
@@ -26,9 +26,9 @@ using ExpressionPtr = std::unique_ptr<Expression>;
 // Creates an activation providing the common context attributes.
 // The activation lazily creates wrappers during an evaluation using the evaluation arena.
 ActivationPtr createActivation(const StreamInfo::StreamInfo& info,
-                               const Http::HeaderMap* request_headers,
-                               const Http::HeaderMap* response_headers,
-                               const Http::HeaderMap* response_trailers);
+                               const Http::RequestHeaderMap* request_headers,
+                               const Http::ResponseHeaderMap* response_headers,
+                               const Http::ResponseTrailerMap* response_trailers);
 
 // Creates an expression builder. The optional arena is used to enable constant folding
 // for intermediate evaluation results.
@@ -43,14 +43,14 @@ ExpressionPtr createExpression(Builder& builder, const google::api::expr::v1alph
 // results and potentially the final value.
 absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena* arena,
                                   const StreamInfo::StreamInfo& info,
-                                  const Http::HeaderMap* request_headers,
-                                  const Http::HeaderMap* response_headers,
-                                  const Http::HeaderMap* response_trailers);
+                                  const Http::RequestHeaderMap* request_headers,
+                                  const Http::ResponseHeaderMap* response_headers,
+                                  const Http::ResponseTrailerMap* response_trailers);
 
 // Evaluates an expression and returns true if the expression evaluates to "true".
 // Returns false if the expression fails to evaluate.
 bool matches(const Expression& expr, const StreamInfo::StreamInfo& info,
-             const Http::HeaderMap& headers);
+             const Http::RequestHeaderMap& headers);
 
 // Thrown when there is an CEL library error.
 class CelException : public EnvoyException {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -102,7 +102,7 @@ void CheckRequestUtils::setRequestTime(envoy::service::auth::v3::AttributeContex
 void CheckRequestUtils::setHttpRequest(
     envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq, uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
-    const Envoy::Http::HeaderMap& headers, uint64_t max_request_bytes) {
+    const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes) {
   httpreq.set_id(std::to_string(stream_id));
   httpreq.set_method(getHeaderStr(headers.Method()));
   httpreq.set_path(getHeaderStr(headers.Path()));
@@ -144,7 +144,7 @@ void CheckRequestUtils::setHttpRequest(
 void CheckRequestUtils::setAttrContextRequest(
     envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
-    const Envoy::Http::HeaderMap& headers, uint64_t max_request_bytes) {
+    const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes) {
   setRequestTime(req, stream_info);
   setHttpRequest(*req.mutable_http(), stream_id, stream_info, decoding_buffer, headers,
                  max_request_bytes);
@@ -152,7 +152,7 @@ void CheckRequestUtils::setAttrContextRequest(
 
 void CheckRequestUtils::createHttpCheck(
     const Envoy::Http::StreamDecoderFilterCallbacks* callbacks,
-    const Envoy::Http::HeaderMap& headers,
+    const Envoy::Http::RequestHeaderMap& headers,
     Protobuf::Map<std::string, std::string>&& context_extensions,
     envoy::config::core::v3::Metadata&& metadata_context,
     envoy::service::auth::v3::CheckRequest& request, uint64_t max_request_bytes,

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -49,7 +49,7 @@ public:
    * @param include_peer_certificate whether to include the peer certificate in the check request.
    */
   static void createHttpCheck(const Envoy::Http::StreamDecoderFilterCallbacks* callbacks,
-                              const Envoy::Http::HeaderMap& headers,
+                              const Envoy::Http::RequestHeaderMap& headers,
                               Protobuf::Map<std::string, std::string>&& context_extensions,
                               envoy::config::core::v3::Metadata&& metadata_context,
                               envoy::service::auth::v3::CheckRequest& request,
@@ -75,12 +75,13 @@ private:
   static void setHttpRequest(envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq,
                              const uint64_t stream_id, const StreamInfo::StreamInfo& stream_info,
                              const Buffer::Instance* decoding_buffer,
-                             const Envoy::Http::HeaderMap& headers, uint64_t max_request_bytes);
+                             const Envoy::Http::RequestHeaderMap& headers,
+                             uint64_t max_request_bytes);
   static void setAttrContextRequest(envoy::service::auth::v3::AttributeContext::Request& req,
                                     const uint64_t stream_id,
                                     const StreamInfo::StreamInfo& stream_info,
                                     const Buffer::Instance* decoding_buffer,
-                                    const Envoy::Http::HeaderMap& headers,
+                                    const Envoy::Http::RequestHeaderMap& headers,
                                     uint64_t max_request_bytes);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -41,8 +41,8 @@ public:
    * Called when a limit request is complete. The resulting status,
    * response headers and request headers to be forwarded to the upstream are supplied.
    */
-  virtual void complete(LimitStatus status, Http::HeaderMapPtr&& response_headers_to_add,
-                        Http::HeaderMapPtr&& request_headers_to_add) PURE;
+  virtual void complete(LimitStatus status, Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                        Http::RequestHeaderMapPtr&& request_headers_to_add) PURE;
 };
 
 /**

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -75,16 +75,17 @@ void GrpcClientImpl::onSuccess(
     span.setTag(Constants::get().TraceStatus, Constants::get().TraceOk);
   }
 
-  Http::HeaderMapPtr response_headers_to_add, request_headers_to_add;
+  Http::ResponseHeaderMapPtr response_headers_to_add;
+  Http::RequestHeaderMapPtr request_headers_to_add;
   if (!response->response_headers_to_add().empty()) {
-    response_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
+    response_headers_to_add = std::make_unique<Http::ResponseHeaderMapImpl>();
     for (const auto& h : response->response_headers_to_add()) {
       response_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
   }
 
   if (!response->request_headers_to_add().empty()) {
-    request_headers_to_add = std::make_unique<Http::HeaderMapImpl>();
+    request_headers_to_add = std::make_unique<Http::RequestHeaderMapImpl>();
     for (const auto& h : response->request_headers_to_add()) {
       request_headers_to_add->addCopy(Http::LowerCaseString(h.key()), h.value());
     }

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -29,7 +29,8 @@ public:
    * @param effective_policy_id  it will be filled by the matching policy's ID,
    *                   which is used to identity the source of the allow/deny.
    */
-  virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  virtual bool allowed(const Network::Connection& connection,
+                       const Envoy::Http::RequestHeaderMap& headers,
                        const StreamInfo::StreamInfo& info,
                        std::string* effective_policy_id) const PURE;
 

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -27,7 +27,7 @@ RoleBasedAccessControlEngineImpl::RoleBasedAccessControlEngineImpl(
 }
 
 bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connection,
-                                               const Envoy::Http::HeaderMap& headers,
+                                               const Envoy::Http::RequestHeaderMap& headers,
                                                const StreamInfo::StreamInfo& info,
                                                std::string* effective_policy_id) const {
   bool matched = false;
@@ -51,7 +51,7 @@ bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connec
 bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connection,
                                                const StreamInfo::StreamInfo& info,
                                                std::string* effective_policy_id) const {
-  static const Http::HeaderMapImpl* empty_header = new Http::HeaderMapImpl();
+  static const Http::RequestHeaderMapImpl* empty_header = new Http::RequestHeaderMapImpl();
   return allowed(connection, *empty_header, info, effective_policy_id);
 }
 

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -15,7 +15,7 @@ class RoleBasedAccessControlEngineImpl : public RoleBasedAccessControlEngine, No
 public:
   RoleBasedAccessControlEngineImpl(const envoy::config::rbac::v3::RBAC& rules);
 
-  bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool allowed(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo& info, std::string* effective_policy_id) const override;
 
   bool allowed(const Network::Connection& connection, const StreamInfo::StreamInfo& info,

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -40,7 +40,8 @@ public:
    *                   there are none headers available.
    * @param metadata   the additional information about the action/principal.
    */
-  virtual bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  virtual bool matches(const Network::Connection& connection,
+                       const Envoy::Http::RequestHeaderMap& headers,
                        const StreamInfo::StreamInfo& info) const PURE;
 
   /**
@@ -61,7 +62,7 @@ public:
  */
 class AlwaysMatcher : public Matcher {
 public:
-  bool matches(const Network::Connection&, const Envoy::Http::HeaderMap&,
+  bool matches(const Network::Connection&, const Envoy::Http::RequestHeaderMap&,
                const StreamInfo::StreamInfo&) const override {
     return true;
   }
@@ -76,7 +77,7 @@ public:
   AndMatcher(const envoy::config::rbac::v3::Permission::Set& rules);
   AndMatcher(const envoy::config::rbac::v3::Principal::Set& ids);
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -94,7 +95,7 @@ public:
   OrMatcher(const Protobuf::RepeatedPtrField<envoy::config::rbac::v3::Permission>& rules);
   OrMatcher(const Protobuf::RepeatedPtrField<envoy::config::rbac::v3::Principal>& ids);
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -108,7 +109,7 @@ public:
   NotMatcher(const envoy::config::rbac::v3::Principal& principal)
       : matcher_(Matcher::create(principal)) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -123,7 +124,7 @@ class HeaderMatcher : public Matcher {
 public:
   HeaderMatcher(const envoy::config::route::v3::HeaderMatcher& matcher) : header_(matcher) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -139,7 +140,7 @@ public:
   IPMatcher(const envoy::config::core::v3::CidrRange& range, bool destination)
       : range_(Network::Address::CidrRange::create(range)), destination_(destination) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -154,7 +155,7 @@ class PortMatcher : public Matcher {
 public:
   PortMatcher(const uint32_t port) : port_(port) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -172,7 +173,7 @@ public:
                      ? absl::make_optional<Matchers::StringMatcherImpl>(auth.principal_name())
                      : absl::nullopt) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -194,7 +195,7 @@ public:
     }
   }
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:
@@ -209,7 +210,7 @@ class MetadataMatcher : public Matcher {
 public:
   MetadataMatcher(const Envoy::Matchers::MetadataMatcher& matcher) : matcher_(matcher) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo& info) const override;
 
 private:
@@ -225,7 +226,7 @@ public:
   RequestedServerNameMatcher(const envoy::type::matcher::v3::StringMatcher& requested_server_name)
       : Envoy::Matchers::StringMatcherImpl(requested_server_name) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 };
 
@@ -238,7 +239,7 @@ public:
   PathMatcher(const envoy::type::matcher::v3::PathMatcher& path_matcher)
       : path_matcher_(path_matcher) {}
 
-  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+  bool matches(const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
                const StreamInfo::StreamInfo&) const override;
 
 private:

--- a/source/extensions/filters/http/buffer/buffer_filter.h
+++ b/source/extensions/filters/http/buffer/buffer_filter.h
@@ -67,7 +67,7 @@ private:
   BufferFilterConfigSharedPtr config_;
   const BufferFilterSettings* settings_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
-  Http::HeaderMap* request_headers_{};
+  Http::RequestHeaderMap* request_headers_{};
   uint64_t content_length_{};
   bool config_initialized_{};
 };

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -21,7 +21,7 @@ struct RcDetailsValues {
 using RcDetails = ConstSingleton<RcDetailsValues>;
 
 namespace {
-bool isModifyMethod(const Http::HeaderMap& headers) {
+bool isModifyMethod(const Http::RequestHeaderMap& headers) {
   const Envoy::Http::HeaderEntry* method = headers.Method();
   if (method == nullptr) {
     return false;
@@ -43,7 +43,7 @@ absl::string_view hostAndPort(const Http::HeaderEntry* header) {
   return EMPTY_STRING;
 }
 
-absl::string_view sourceOriginValue(const Http::HeaderMap& headers) {
+absl::string_view sourceOriginValue(const Http::RequestHeaderMap& headers) {
   const absl::string_view origin = hostAndPort(headers.Origin());
   if (origin != EMPTY_STRING) {
     return origin;
@@ -51,7 +51,7 @@ absl::string_view sourceOriginValue(const Http::HeaderMap& headers) {
   return hostAndPort(headers.Referer());
 }
 
-absl::string_view targetOriginValue(const Http::HeaderMap& headers) {
+absl::string_view targetOriginValue(const Http::RequestHeaderMap& headers) {
   return hostAndPort(headers.Host());
 }
 
@@ -122,7 +122,7 @@ void CsrfFilter::determinePolicy() {
   }
 }
 
-bool CsrfFilter::isValid(const absl::string_view source_origin, Http::HeaderMap& headers) {
+bool CsrfFilter::isValid(const absl::string_view source_origin, Http::RequestHeaderMap& headers) {
   const absl::string_view target_origin = targetOriginValue(headers);
   if (source_origin == target_origin) {
     return true;

--- a/source/extensions/filters/http/csrf/csrf_filter.h
+++ b/source/extensions/filters/http/csrf/csrf_filter.h
@@ -110,7 +110,7 @@ public:
 
 private:
   void determinePolicy();
-  bool isValid(const absl::string_view source_origin, Http::HeaderMap& headers);
+  bool isValid(const absl::string_view source_origin, Http::RequestHeaderMap& headers);
 
   Http::StreamDecoderFilterCallbacks* callbacks_{};
   CsrfFilterConfigSharedPtr config_;

--- a/source/extensions/filters/http/dynamo/dynamo_filter.h
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.h
@@ -75,7 +75,7 @@ private:
   RequestParser::TableDescriptor table_descriptor_{"", true};
   std::string error_type_{};
   MonotonicTime start_decode_;
-  Http::HeaderMap* response_headers_;
+  Http::ResponseHeaderMap* response_headers_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   TimeSource& time_source_;

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -31,7 +31,7 @@ void FilterConfigPerRoute::merge(const FilterConfigPerRoute& other) {
   }
 }
 
-void Filter::initiateCall(const Http::HeaderMap& headers) {
+void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   if (filter_return_ == FilterReturn::StopDecoding) {
     return;
   }

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -220,7 +220,7 @@ public:
 
 private:
   void addResponseHeaders(Http::HeaderMap& header_map, const Http::HeaderVector& headers);
-  void initiateCall(const Http::HeaderMap& headers);
+  void initiateCall(const Http::RequestHeaderMap& headers);
   void continueDecoding();
   bool isBufferFull();
 
@@ -238,7 +238,7 @@ private:
   FilterConfigSharedPtr config_;
   Filters::Common::ExtAuthz::ClientPtr client_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
-  Http::HeaderMap* request_headers_;
+  Http::RequestHeaderMap* request_headers_;
   State state_{State::NotStarted};
   FilterReturn filter_return_{FilterReturn::ContinueDecoding};
   Upstream::ClusterInfoConstSharedPtr cluster_;

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -173,7 +173,7 @@ Http::FilterHeadersStatus FaultFilter::decodeHeaders(Http::RequestHeaderMap& hea
   return Http::FilterHeadersStatus::Continue;
 }
 
-void FaultFilter::maybeSetupResponseRateLimit(const Http::HeaderMap& request_headers) {
+void FaultFilter::maybeSetupResponseRateLimit(const Http::RequestHeaderMap& request_headers) {
   if (fault_settings_->responseRateLimit() == nullptr) {
     return;
   }
@@ -244,7 +244,7 @@ bool FaultFilter::isAbortEnabled() {
 }
 
 absl::optional<std::chrono::milliseconds>
-FaultFilter::delayDuration(const Http::HeaderMap& request_headers) {
+FaultFilter::delayDuration(const Http::RequestHeaderMap& request_headers) {
   absl::optional<std::chrono::milliseconds> ret;
 
   if (!isDelayEnabled()) {
@@ -382,7 +382,7 @@ bool FaultFilter::matchesTargetUpstreamCluster() {
   return matches;
 }
 
-bool FaultFilter::matchesDownstreamNodes(const Http::HeaderMap& headers) {
+bool FaultFilter::matchesDownstreamNodes(const Http::RequestHeaderMap& headers) {
   if (fault_settings_->downstreamNodes().empty()) {
     return true;
   }

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -246,13 +246,14 @@ private:
   void postDelayInjection();
   void abortWithHTTPStatus();
   bool matchesTargetUpstreamCluster();
-  bool matchesDownstreamNodes(const Http::HeaderMap& headers);
+  bool matchesDownstreamNodes(const Http::RequestHeaderMap& headers);
   bool isAbortEnabled();
   bool isDelayEnabled();
-  absl::optional<std::chrono::milliseconds> delayDuration(const Http::HeaderMap& request_headers);
+  absl::optional<std::chrono::milliseconds>
+  delayDuration(const Http::RequestHeaderMap& request_headers);
   uint64_t abortHttpStatus();
   void maybeIncActiveFaults();
-  void maybeSetupResponseRateLimit(const Http::HeaderMap& request_headers);
+  void maybeSetupResponseRateLimit(const Http::RequestHeaderMap& request_headers);
 
   FaultFilterConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -18,11 +18,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1Bridge {
 
-void Http1BridgeFilter::chargeStat(const Http::HeaderMap& headers) {
-  context_.chargeStat(*cluster_, Grpc::Context::Protocol::Grpc, *request_names_,
-                      headers.GrpcStatus());
-}
-
 Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   const bool grpc_request = Grpc::Common::hasGrpcContentType(headers);
   if (grpc_request) {
@@ -96,7 +91,7 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::ResponseTrail
   return Http::FilterTrailersStatus::Continue;
 }
 
-void Http1BridgeFilter::setupStatTracking(const Http::HeaderMap& headers) {
+void Http1BridgeFilter::setupStatTracking(const Http::RequestHeaderMap& headers) {
   cluster_ = decoder_callbacks_->clusterInfo();
   if (!cluster_) {
     return;

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -18,6 +18,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1Bridge {
 
+void Http1BridgeFilter::chargeStat(const Http::ResponseHeaderOrTrailerMap& headers) {
+  context_.chargeStat(*cluster_, Grpc::Context::Protocol::Grpc, *request_names_,
+                      headers.GrpcStatus());
+}
+
 Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   const bool grpc_request = Grpc::Common::hasGrpcContentType(headers);
   if (grpc_request) {

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -50,12 +50,15 @@ public:
   bool doStatTracking() const { return request_names_.has_value(); }
 
 private:
-  void chargeStat(const Http::HeaderMap& headers);
-  void setupStatTracking(const Http::HeaderMap& headers);
+  template <class T> void chargeStat(const T& headers) {
+    context_.chargeStat(*cluster_, Grpc::Context::Protocol::Grpc, *request_names_,
+                        headers.GrpcStatus());
+  }
+  void setupStatTracking(const Http::RequestHeaderMap& headers);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
-  Http::HeaderMap* response_headers_{};
+  Http::ResponseHeaderMap* response_headers_{};
   bool do_bridging_{};
   Upstream::ClusterInfoConstSharedPtr cluster_;
   absl::optional<Grpc::Context::RequestNames> request_names_;

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -50,10 +50,7 @@ public:
   bool doStatTracking() const { return request_names_.has_value(); }
 
 private:
-  template <class T> void chargeStat(const T& headers) {
-    context_.chargeStat(*cluster_, Grpc::Context::Protocol::Grpc, *request_names_,
-                        headers.GrpcStatus());
-  }
+  void chargeStat(const Http::ResponseHeaderOrTrailerMap& headers);
   void setupStatTracking(const Http::RequestHeaderMap& headers);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -26,7 +26,7 @@ struct RcDetailsValues {
 using RcDetails = ConstSingleton<RcDetailsValues>;
 
 namespace {
-Grpc::Status::GrpcStatus grpcStatusFromHeaders(Http::HeaderMap& headers) {
+Grpc::Status::GrpcStatus grpcStatusFromHeaders(Http::ResponseHeaderMap& headers) {
   const auto http_response_status = Http::Utility::getResponseStatus(headers);
 
   // Notably, we treat an upstream 200 as a successful response. This differs
@@ -39,7 +39,7 @@ Grpc::Status::GrpcStatus grpcStatusFromHeaders(Http::HeaderMap& headers) {
   }
 }
 
-std::string badContentTypeMessage(const Http::HeaderMap& headers) {
+std::string badContentTypeMessage(const Http::ResponseHeaderMap& headers) {
   if (headers.ContentType() != nullptr) {
     return fmt::format(
         "envoy reverse bridge: upstream responded with unsupported content-type {}, status code {}",
@@ -51,7 +51,7 @@ std::string badContentTypeMessage(const Http::HeaderMap& headers) {
   }
 }
 
-void adjustContentLength(Http::HeaderMap& headers,
+void adjustContentLength(Http::RequestOrResponseHeaderMap& headers,
                          const std::function<uint64_t(uint64_t value)>& adjustment) {
   auto length_header = headers.ContentLength();
   if (length_header != nullptr) {

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -204,7 +204,7 @@ bool JsonTranscoderConfig::matchIncomingRequestInfo() const {
 bool JsonTranscoderConfig::convertGrpcStatus() const { return convert_grpc_status_; }
 
 ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
-    const Http::HeaderMap& headers, ZeroCopyInputStream& request_input,
+    const Http::RequestHeaderMap& headers, ZeroCopyInputStream& request_input,
     google::grpc::transcoding::TranscoderInputStream& response_input,
     std::unique_ptr<Transcoder>& transcoder, const Protobuf::MethodDescriptor*& method_descriptor) {
   if (Grpc::Common::hasGrpcContentType(headers)) {
@@ -460,9 +460,7 @@ Http::FilterDataStatus JsonTranscoderFilter::encodeData(Buffer::Instance& data, 
   return Http::FilterDataStatus::Continue;
 }
 
-// TODO(mattklein123): In future header refactor changes the HeaderMap interface will not have
-// all of the O(1) headers so we will have to refactor this further.
-void JsonTranscoderFilter::doTrailers(Http::HeaderMap& headers_or_trailers) {
+void JsonTranscoderFilter::doTrailers(Http::ResponseHeaderOrTrailerMap& headers_or_trailers) {
   if (error_ || !transcoder_) {
     return;
   }
@@ -537,8 +535,8 @@ bool JsonTranscoderFilter::readToBuffer(Protobuf::io::ZeroCopyInputStream& strea
   return false;
 }
 
-void JsonTranscoderFilter::buildResponseFromHttpBodyOutput(Http::HeaderMap& response_headers,
-                                                           Buffer::Instance& data) {
+void JsonTranscoderFilter::buildResponseFromHttpBodyOutput(
+    Http::ResponseHeaderMap& response_headers, Buffer::Instance& data) {
   std::vector<Grpc::Frame> frames;
   decoder_.decode(data, frames);
   if (frames.empty()) {
@@ -562,7 +560,7 @@ void JsonTranscoderFilter::buildResponseFromHttpBodyOutput(Http::HeaderMap& resp
 }
 
 bool JsonTranscoderFilter::maybeConvertGrpcStatus(Grpc::Status::GrpcStatus grpc_status,
-                                                  Http::HeaderMap& trailers) {
+                                                  Http::ResponseHeaderOrTrailerMap& trailers) {
   if (!config_.convertGrpcStatus()) {
     return false;
   }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -64,7 +64,8 @@ public:
    * @return status whether the Transcoder instance are successfully created or not
    */
   ProtobufUtil::Status
-  createTranscoder(const Http::HeaderMap& headers, Protobuf::io::ZeroCopyInputStream& request_input,
+  createTranscoder(const Http::RequestHeaderMap& headers,
+                   Protobuf::io::ZeroCopyInputStream& request_input,
                    google::grpc::transcoding::TranscoderInputStream& response_input,
                    std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
                    const Protobuf::MethodDescriptor*& method_descriptor);
@@ -146,10 +147,12 @@ public:
 
 private:
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
-  void buildResponseFromHttpBodyOutput(Http::HeaderMap& response_headers, Buffer::Instance& data);
-  bool maybeConvertGrpcStatus(Grpc::Status::GrpcStatus grpc_status, Http::HeaderMap& trailers);
+  void buildResponseFromHttpBodyOutput(Http::ResponseHeaderMap& response_headers,
+                                       Buffer::Instance& data);
+  bool maybeConvertGrpcStatus(Grpc::Status::GrpcStatus grpc_status,
+                              Http::ResponseHeaderOrTrailerMap& trailers);
   bool hasHttpBodyAsOutputType();
-  void doTrailers(Http::HeaderMap& headers_or_trailers);
+  void doTrailers(Http::ResponseHeaderOrTrailerMap& headers_or_trailers);
 
   JsonTranscoderConfig& config_;
   std::unique_ptr<google::grpc::transcoding::Transcoder> transcoder_;
@@ -158,7 +161,7 @@ private:
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{nullptr};
   const Protobuf::MethodDescriptor* method_{nullptr};
-  Http::HeaderMap* response_headers_{nullptr};
+  Http::ResponseHeaderMap* response_headers_{nullptr};
   Grpc::Decoder decoder_;
 
   bool error_{false};

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -38,7 +38,7 @@ const absl::flat_hash_set<std::string>& GrpcWebFilter::gRpcWebContentTypes() con
   return *types;
 }
 
-bool GrpcWebFilter::isGrpcWebRequest(const Http::HeaderMap& headers) {
+bool GrpcWebFilter::isGrpcWebRequest(const Http::RequestHeaderMap& headers) {
   const Http::HeaderEntry* content_type = headers.ContentType();
   if (content_type != nullptr) {
     return gRpcWebContentTypes().count(content_type->value().getStringView()) > 0;
@@ -227,17 +227,12 @@ Http::FilterTrailersStatus GrpcWebFilter::encodeTrailers(Http::ResponseTrailerMa
   return Http::FilterTrailersStatus::Continue;
 }
 
-void GrpcWebFilter::setupStatTracking(const Http::HeaderMap& headers) {
+void GrpcWebFilter::setupStatTracking(const Http::RequestHeaderMap& headers) {
   cluster_ = decoder_callbacks_->clusterInfo();
   if (!cluster_) {
     return;
   }
   request_names_ = context_.resolveServiceAndMethod(headers.Path());
-}
-
-void GrpcWebFilter::chargeStat(const Http::HeaderMap& headers) {
-  context_.chargeStat(*cluster_, Grpc::Context::Protocol::GrpcWeb, *request_names_,
-                      headers.GrpcStatus());
 }
 
 } // namespace GrpcWeb

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -235,6 +235,11 @@ void GrpcWebFilter::setupStatTracking(const Http::RequestHeaderMap& headers) {
   request_names_ = context_.resolveServiceAndMethod(headers.Path());
 }
 
+void GrpcWebFilter::chargeStat(const Http::ResponseHeaderOrTrailerMap& headers) {
+  context_.chargeStat(*cluster_, Grpc::Context::Protocol::GrpcWeb, *request_names_,
+                      headers.GrpcStatus());
+}
+
 } // namespace GrpcWeb
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.h
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.h
@@ -55,9 +55,12 @@ public:
 private:
   friend class GrpcWebFilterTest;
 
-  void chargeStat(const Http::HeaderMap& headers);
-  void setupStatTracking(const Http::HeaderMap& headers);
-  bool isGrpcWebRequest(const Http::HeaderMap& headers);
+  template <class T> void chargeStat(const T& headers) {
+    context_.chargeStat(*cluster_, Grpc::Context::Protocol::GrpcWeb, *request_names_,
+                        headers.GrpcStatus());
+  }
+  void setupStatTracking(const Http::RequestHeaderMap& headers);
+  bool isGrpcWebRequest(const Http::RequestHeaderMap& headers);
 
   static const uint8_t GRPC_WEB_TRAILER;
   const absl::flat_hash_set<std::string>& gRpcWebContentTypes() const;

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.h
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.h
@@ -55,10 +55,7 @@ public:
 private:
   friend class GrpcWebFilterTest;
 
-  template <class T> void chargeStat(const T& headers) {
-    context_.chargeStat(*cluster_, Grpc::Context::Protocol::GrpcWeb, *request_names_,
-                        headers.GrpcStatus());
-  }
+  void chargeStat(const Http::ResponseHeaderOrTrailerMap& headers);
   void setupStatTracking(const Http::RequestHeaderMap& headers);
   bool isGrpcWebRequest(const Http::RequestHeaderMap& headers);
 

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -147,15 +147,15 @@ private:
   // the logic in these private member functions would be available in another class.
   friend class GzipFilterTest;
 
-  bool hasCacheControlNoTransform(Http::HeaderMap& headers) const;
-  bool isAcceptEncodingAllowed(Http::HeaderMap& headers) const;
-  bool isContentTypeAllowed(Http::HeaderMap& headers) const;
-  bool isEtagAllowed(Http::HeaderMap& headers) const;
-  bool isMinimumContentLength(Http::HeaderMap& headers) const;
-  bool isTransferEncodingAllowed(Http::HeaderMap& headers) const;
+  bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) const;
+  bool isAcceptEncodingAllowed(Http::RequestHeaderMap& headers) const;
+  bool isContentTypeAllowed(Http::ResponseHeaderMap& headers) const;
+  bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
+  bool isMinimumContentLength(Http::ResponseHeaderMap& headers) const;
+  bool isTransferEncodingAllowed(Http::ResponseHeaderMap& headers) const;
 
-  void sanitizeEtagHeader(Http::HeaderMap& headers);
-  void insertVaryHeader(Http::HeaderMap& headers);
+  void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
+  void insertVaryHeader(Http::ResponseHeaderMap& headers);
 
   bool skip_compression_;
   Buffer::OwnedImpl compressed_data_;

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -92,7 +92,7 @@ public:
       const std::vector<const envoy::extensions::filters::http::jwt_authn::v3::JwtProvider*>&
           providers);
 
-  std::vector<JwtLocationConstPtr> extract(const Http::HeaderMap& headers) const override;
+  std::vector<JwtLocationConstPtr> extract(const Http::RequestHeaderMap& headers) const override;
 
   void sanitizePayloadHeaders(Http::HeaderMap& headers) const override;
 
@@ -179,7 +179,8 @@ void ExtractorImpl::addQueryParamConfig(const std::string& issuer, const std::st
   param_location_spec.specified_issuers_.insert(issuer);
 }
 
-std::vector<JwtLocationConstPtr> ExtractorImpl::extract(const Http::HeaderMap& headers) const {
+std::vector<JwtLocationConstPtr>
+ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
   std::vector<JwtLocationConstPtr> tokens;
 
   // Check header locations first

--- a/source/extensions/filters/http/jwt_authn/extractor.h
+++ b/source/extensions/filters/http/jwt_authn/extractor.h
@@ -74,7 +74,8 @@ public:
    * @param headers is the HTTP request headers.
    * @return list of extracted Jwt location info.
    */
-  virtual std::vector<JwtLocationConstPtr> extract(const Http::HeaderMap& headers) const PURE;
+  virtual std::vector<JwtLocationConstPtr>
+  extract(const Http::RequestHeaderMap& headers) const PURE;
 
   /**
    * Remove headers that configured to send JWT payloads.

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -16,7 +16,7 @@ namespace JwtAuthn {
 
 namespace {
 
-bool isCorsPreflightRequest(const Http::HeaderMap& headers) {
+bool isCorsPreflightRequest(const Http::RequestHeaderMap& headers) {
   return headers.Method() &&
          headers.Method()->value().getStringView() == Http::Headers::get().MethodValues.Options &&
          headers.Origin() && !headers.Origin()->value().empty() &&

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -66,7 +66,7 @@ public:
   virtual bool bypassCorsPreflightRequest() const PURE;
 
   // Finds the matcher that matched the header
-  virtual const Verifier* findVerifier(const Http::HeaderMap& headers,
+  virtual const Verifier* findVerifier(const Http::RequestHeaderMap& headers,
                                        const StreamInfo::FilterState& filter_state) const PURE;
 };
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
@@ -104,7 +104,7 @@ public:
 
   bool bypassCorsPreflightRequest() const override { return proto_config_.bypass_cors_preflight(); }
 
-  virtual const Verifier* findVerifier(const Http::HeaderMap& headers,
+  virtual const Verifier* findVerifier(const Http::RequestHeaderMap& headers,
                                        const StreamInfo::FilterState& filter_state) const override {
     for (const auto& pair : rule_pairs_) {
       if (pair.matcher_->matches(headers)) {

--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -35,7 +35,7 @@ public:
   }
 
   // Check match for HeaderMatcher and QueryParameterMatcher
-  bool matchRoute(const Http::HeaderMap& headers) const {
+  bool matchRoute(const Http::RequestHeaderMap& headers) const {
     bool matches = true;
     // TODO(potatop): matching on RouteMatch runtime is not implemented.
 
@@ -65,7 +65,7 @@ public:
       : BaseMatcherImpl(rule), prefix_(rule.match().prefix()),
         path_matcher_(Matchers::PathMatcher::createPrefix(prefix_, !case_sensitive_)) {}
 
-  bool matches(const Http::HeaderMap& headers) const override {
+  bool matches(const Http::RequestHeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers) &&
         path_matcher_->match(headers.Path()->value().getStringView())) {
       ENVOY_LOG(debug, "Prefix requirement '{}' matched.", prefix_);
@@ -89,7 +89,7 @@ public:
       : BaseMatcherImpl(rule), path_(rule.match().path()),
         path_matcher_(Matchers::PathMatcher::createExact(path_, !case_sensitive_)) {}
 
-  bool matches(const Http::HeaderMap& headers) const override {
+  bool matches(const Http::RequestHeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers) &&
         path_matcher_->match(headers.Path()->value().getStringView())) {
       ENVOY_LOG(debug, "Path requirement '{}' matched.", path_);
@@ -125,7 +125,7 @@ public:
     }
   }
 
-  bool matches(const Http::HeaderMap& headers) const override {
+  bool matches(const Http::RequestHeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers)) {
       const Http::HeaderString& path = headers.Path()->value();
       const absl::string_view query_string = Http::Utility::findQueryStringStart(path);

--- a/source/extensions/filters/http/jwt_authn/matcher.h
+++ b/source/extensions/filters/http/jwt_authn/matcher.h
@@ -25,7 +25,7 @@ public:
    *                   there are none headers available.
    * @return  true if request is a match, false otherwise.
    */
-  virtual bool matches(const Http::HeaderMap& headers) const PURE;
+  virtual bool matches(const Http::RequestHeaderMap& headers) const PURE;
 
   /**
    * Factory method to create a shared instance of a matcher based on the rule defined.

--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -29,10 +29,11 @@ struct CompletionState {
 
 class ContextImpl : public Verifier::Context {
 public:
-  ContextImpl(Http::HeaderMap& headers, Tracing::Span& parent_span, Verifier::Callbacks* callback)
+  ContextImpl(Http::RequestHeaderMap& headers, Tracing::Span& parent_span,
+              Verifier::Callbacks* callback)
       : headers_(headers), parent_span_(parent_span), callback_(callback) {}
 
-  Http::HeaderMap& headers() const override { return headers_; }
+  Http::RequestHeaderMap& headers() const override { return headers_; }
 
   Tracing::Span& parentSpan() const override { return parent_span_; }
 
@@ -64,7 +65,7 @@ public:
   }
 
 private:
-  Http::HeaderMap& headers_;
+  Http::RequestHeaderMap& headers_;
   Tracing::Span& parent_span_;
   Verifier::Callbacks* callback_;
   std::unordered_map<const Verifier*, CompletionState> completion_states_;
@@ -395,8 +396,8 @@ VerifierConstPtr innerCreate(const JwtRequirement& requirement,
 
 } // namespace
 
-ContextSharedPtr Verifier::createContext(Http::HeaderMap& headers, Tracing::Span& parent_span,
-                                         Callbacks* callback) {
+ContextSharedPtr Verifier::createContext(Http::RequestHeaderMap& headers,
+                                         Tracing::Span& parent_span, Callbacks* callback) {
   return std::make_shared<ContextImpl>(headers, parent_span, callback);
 }
 

--- a/source/extensions/filters/http/jwt_authn/verifier.h
+++ b/source/extensions/filters/http/jwt_authn/verifier.h
@@ -87,7 +87,7 @@ public:
       const AuthFactory& factory);
 
   // Factory method for creating verifier contexts.
-  static ContextSharedPtr createContext(Http::HeaderMap& headers, Tracing::Span& parent_span,
+  static ContextSharedPtr createContext(Http::RequestHeaderMap& headers, Tracing::Span& parent_span,
                                         Callbacks* callback);
 };
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -25,7 +25,7 @@ struct RcDetailsValues {
 };
 using RcDetails = ConstSingleton<RcDetailsValues>;
 
-void Filter::initiateCall(const Http::HeaderMap& headers) {
+void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   const bool is_internal_request = Http::HeaderUtility::isEnvoyInternalRequest(headers);
   if ((is_internal_request && config_->requestType() == FilterRequestType::External) ||
       (!is_internal_request && config_->requestType() == FilterRequestType::Internal)) {
@@ -125,8 +125,8 @@ void Filter::onDestroy() {
 }
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
-                      Http::HeaderMapPtr&& response_headers_to_add,
-                      Http::HeaderMapPtr&& request_headers_to_add) {
+                      Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                      Http::RequestHeaderMapPtr&& request_headers_to_add) {
   state_ = State::Complete;
   response_headers_to_add_ = std::move(response_headers_to_add);
   Http::HeaderMapPtr req_headers_to_add = std::move(request_headers_to_add);
@@ -154,7 +154,7 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
                                            false};
     httpContext().codeStats().chargeResponseStat(info);
     if (response_headers_to_add_ == nullptr) {
-      response_headers_to_add_ = std::make_unique<Http::HeaderMapImpl>();
+      response_headers_to_add_ = std::make_unique<Http::ResponseHeaderMapImpl>();
     }
     response_headers_to_add_->setReferenceEnvoyRateLimited(
         Http::Headers::get().EnvoyRateLimitedValues.True);

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -117,11 +117,11 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& response_headers_to_add,
-                Http::HeaderMapPtr&& request_headers_to_add) override;
+                Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                Http::RequestHeaderMapPtr&& request_headers_to_add) override;
 
 private:
-  void initiateCall(const Http::HeaderMap& headers);
+  void initiateCall(const Http::RequestHeaderMap& headers);
   void populateRateLimitDescriptors(const Router::RateLimitPolicy& rate_limit_policy,
                                     std::vector<Envoy::RateLimit::Descriptor>& descriptors,
                                     const Router::RouteEntry* route_entry,
@@ -139,8 +139,8 @@ private:
   State state_{State::NotStarted};
   Upstream::ClusterInfoConstSharedPtr cluster_;
   bool initiating_call_{};
-  Http::HeaderMapPtr response_headers_to_add_;
-  Http::HeaderMap* request_headers_{};
+  Http::ResponseHeaderMapPtr response_headers_to_add_;
+  Http::RequestHeaderMap* request_headers_{};
 };
 
 } // namespace RateLimitFilter

--- a/source/extensions/filters/http/tap/tap_config.h
+++ b/source/extensions/filters/http/tap/tap_config.h
@@ -22,7 +22,7 @@ public:
   /**
    * Called when request headers are received.
    */
-  virtual void onRequestHeaders(const Http::HeaderMap& headers) PURE;
+  virtual void onRequestHeaders(const Http::RequestHeaderMap& headers) PURE;
 
   /**
    * Called when request body is received.
@@ -32,12 +32,12 @@ public:
   /**
    * Called when request trailers are received.
    */
-  virtual void onRequestTrailers(const Http::HeaderMap& trailers) PURE;
+  virtual void onRequestTrailers(const Http::RequestTrailerMap& trailers) PURE;
 
   /**
    * Called when response headers are received.
    */
-  virtual void onResponseHeaders(const Http::HeaderMap& headers) PURE;
+  virtual void onResponseHeaders(const Http::ResponseHeaderMap& headers) PURE;
 
   /**
    * Called when response body is received.
@@ -47,7 +47,7 @@ public:
   /**
    * Called when response trailers are received.
    */
-  virtual void onResponseTrailers(const Http::HeaderMap& headers) PURE;
+  virtual void onResponseTrailers(const Http::ResponseTrailerMap& headers) PURE;
 
   /**
    * Called when the request is being destroyed and is being logged.

--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -41,7 +41,7 @@ void HttpPerRequestTapperImpl::streamRequestHeaders() {
   sink_handle_->submitTrace(std::move(trace));
 }
 
-void HttpPerRequestTapperImpl::onRequestHeaders(const Http::HeaderMap& headers) {
+void HttpPerRequestTapperImpl::onRequestHeaders(const Http::RequestHeaderMap& headers) {
   request_headers_ = &headers;
   config_->rootMatcher().onHttpRequestHeaders(headers, statuses_);
   if (config_->streaming() && config_->rootMatcher().matchStatus(statuses_).matches_) {
@@ -74,7 +74,7 @@ void HttpPerRequestTapperImpl::streamRequestTrailers() {
   }
 }
 
-void HttpPerRequestTapperImpl::onRequestTrailers(const Http::HeaderMap& trailers) {
+void HttpPerRequestTapperImpl::onRequestTrailers(const Http::RequestTrailerMap& trailers) {
   request_trailers_ = &trailers;
   config_->rootMatcher().onHttpRequestTrailers(trailers, statuses_);
   if (config_->streaming() && config_->rootMatcher().matchStatus(statuses_).matches_) {
@@ -97,7 +97,7 @@ void HttpPerRequestTapperImpl::streamResponseHeaders() {
   sink_handle_->submitTrace(std::move(trace));
 }
 
-void HttpPerRequestTapperImpl::onResponseHeaders(const Http::HeaderMap& headers) {
+void HttpPerRequestTapperImpl::onResponseHeaders(const Http::ResponseHeaderMap& headers) {
   response_headers_ = &headers;
   config_->rootMatcher().onHttpResponseHeaders(headers, statuses_);
   if (config_->streaming() && config_->rootMatcher().matchStatus(statuses_).matches_) {
@@ -126,7 +126,7 @@ void HttpPerRequestTapperImpl::onResponseBody(const Buffer::Instance& data) {
          &envoy::data::tap::v3::HttpBufferedTrace::mutable_response);
 }
 
-void HttpPerRequestTapperImpl::onResponseTrailers(const Http::HeaderMap& trailers) {
+void HttpPerRequestTapperImpl::onResponseTrailers(const Http::ResponseTrailerMap& trailers) {
   response_trailers_ = &trailers;
   config_->rootMatcher().onHttpResponseTrailers(trailers, statuses_);
   if (config_->streaming() && config_->rootMatcher().matchStatus(statuses_).matches_) {

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -36,12 +36,12 @@ public:
   }
 
   // TapFilter::HttpPerRequestTapper
-  void onRequestHeaders(const Http::HeaderMap& headers) override;
+  void onRequestHeaders(const Http::RequestHeaderMap& headers) override;
   void onRequestBody(const Buffer::Instance& data) override;
-  void onRequestTrailers(const Http::HeaderMap& headers) override;
-  void onResponseHeaders(const Http::HeaderMap& headers) override;
+  void onRequestTrailers(const Http::RequestTrailerMap& headers) override;
+  void onResponseHeaders(const Http::ResponseHeaderMap& headers) override;
   void onResponseBody(const Buffer::Instance& data) override;
-  void onResponseTrailers(const Http::HeaderMap& headers) override;
+  void onResponseTrailers(const Http::ResponseTrailerMap& headers) override;
   bool onDestroyLog() override;
 
 private:
@@ -78,10 +78,10 @@ private:
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr sink_handle_;
   Extensions::Common::Tap::Matcher::MatchStatusVector statuses_;
   bool started_streaming_trace_{};
-  const Http::HeaderMap* request_headers_{};
+  const Http::RequestHeaderMap* request_headers_{};
   const Http::HeaderMap* request_trailers_{};
-  const Http::HeaderMap* response_headers_{};
-  const Http::HeaderMap* response_trailers_{};
+  const Http::ResponseHeaderMap* response_headers_{};
+  const Http::ResponseTrailerMap* response_trailers_{};
   // Must be a shared_ptr because of submitTrace().
   Extensions::Common::Tap::TraceWrapperPtr buffered_streamed_request_body_;
   Extensions::Common::Tap::TraceWrapperPtr buffered_streamed_response_body_;

--- a/source/extensions/filters/http/tap/tap_filter.cc
+++ b/source/extensions/filters/http/tap/tap_filter.cc
@@ -69,8 +69,8 @@ Http::FilterTrailersStatus Filter::encodeTrailers(Http::ResponseTrailerMap& trai
   return Http::FilterTrailersStatus::Continue;
 }
 
-void Filter::log(const Http::HeaderMap*, const Http::HeaderMap*, const Http::HeaderMap*,
-                 const StreamInfo::StreamInfo&) {
+void Filter::log(const Http::RequestHeaderMap*, const Http::ResponseHeaderMap*,
+                 const Http::ResponseTrailerMap*, const StreamInfo::StreamInfo&) {
   if (tapper_ != nullptr && tapper_->onDestroyLog()) {
     config_->stats().rq_tapped_.inc();
   }

--- a/source/extensions/filters/http/tap/tap_filter.h
+++ b/source/extensions/filters/http/tap/tap_filter.h
@@ -106,8 +106,9 @@ public:
   void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks&) override {}
 
   // AccessLog::Instance
-  void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-           const Http::HeaderMap* response_trailers,
+  void log(const Http::RequestHeaderMap* request_headers,
+           const Http::ResponseHeaderMap* response_headers,
+           const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info) override;
 
 private:

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -69,8 +69,8 @@ void Filter::onEvent(Network::ConnectionEvent event) {
   }
 }
 
-void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::HeaderMapPtr&&,
-                      Http::HeaderMapPtr&&) {
+void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::ResponseHeaderMapPtr&&,
+                      Http::RequestHeaderMapPtr&&) {
   status_ = Status::Complete;
   config_->stats().active_.dec();
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -92,8 +92,8 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& response_headers_to_add,
-                Http::HeaderMapPtr&& request_headers_to_add) override;
+                Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                Http::RequestHeaderMapPtr&& request_headers_to_add) override;
 
 private:
   enum class Status { NotStarted, Calling, Complete };

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -58,8 +58,8 @@ void Filter::onDestroy() {
 }
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
-                      Http::HeaderMapPtr&& response_headers_to_add,
-                      Http::HeaderMapPtr&& request_headers_to_add) {
+                      Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                      Http::RequestHeaderMapPtr&& request_headers_to_add) {
   // TODO(zuercher): Store headers to append to a response. Adding them to a local reply (over
   // limit or error) is a matter of modifying the callbacks to allow it. Adding them to an upstream
   // response requires either response (aka encoder) filters or some other mechanism.

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -78,8 +78,8 @@ public:
 
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
-                Http::HeaderMapPtr&& response_headers_to_add,
-                Http::HeaderMapPtr&& request_headers_to_add) override;
+                Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                Http::RequestHeaderMapPtr&& request_headers_to_add) override;
 
 private:
   void initiateCall(const ThriftProxy::MessageMetadata& metadata);

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -283,7 +283,7 @@ HystrixSink::HystrixSink(Server::Instance& server, const uint64_t num_buckets)
 }
 
 Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
-                                                  Http::HeaderMap& response_headers,
+                                                  Http::ResponseHeaderMap& response_headers,
                                                   Buffer::Instance&,
                                                   Server::AdminStream& admin_stream) {
 

--- a/source/extensions/stat_sinks/hystrix/hystrix.h
+++ b/source/extensions/stat_sinks/hystrix/hystrix.h
@@ -48,7 +48,7 @@ using ClusterStatsCachePtr = std::unique_ptr<ClusterStatsCache>;
 class HystrixSink : public Stats::Sink, public Logger::Loggable<Logger::Id::hystrix> {
 public:
   HystrixSink(Server::Instance& server, uint64_t num_buckets);
-  Http::Code handlerHystrixEventStream(absl::string_view, Http::HeaderMap& response_headers,
+  Http::Code handlerHystrixEventStream(absl::string_view, Http::ResponseHeaderMap& response_headers,
                                        Buffer::Instance&, Server::AdminStream& admin_stream);
   void flush(Stats::MetricSnapshot& snapshot) override;
   void onHistogramComplete(const Stats::Histogram&, uint64_t) override{};

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -36,7 +36,7 @@ private:
 
 class OpenTracingHTTPHeadersReader : public opentracing::HTTPHeadersReader {
 public:
-  explicit OpenTracingHTTPHeadersReader(const Http::HeaderMap& request_headers)
+  explicit OpenTracingHTTPHeadersReader(const Http::RequestHeaderMap& request_headers)
       : request_headers_(request_headers) {}
 
   using OpenTracingCb = std::function<opentracing::expected<void>(opentracing::string_view,
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  const Http::HeaderMap& request_headers_;
+  const Http::RequestHeaderMap& request_headers_;
 
   static Http::HeaderMap::Iterate headerMapCallback(const Http::HeaderEntry& header,
                                                     void* context) {
@@ -104,7 +104,7 @@ void OpenTracingSpan::log(SystemTime timestamp, const std::string& event) {
   finish_options_.log_records.emplace_back(std::move(record));
 }
 
-void OpenTracingSpan::injectContext(Http::HeaderMap& request_headers) {
+void OpenTracingSpan::injectContext(Http::RequestHeaderMap& request_headers) {
   if (driver_.propagationMode() == OpenTracingDriver::PropagationMode::SingleHeader) {
     // Inject the span context using Envoy's single-header format.
     std::ostringstream oss;
@@ -147,7 +147,7 @@ OpenTracingDriver::OpenTracingDriver(Stats::Store& stats)
     : tracer_stats_{OPENTRACING_TRACER_STATS(POOL_COUNTER_PREFIX(stats, "tracing.opentracing."))} {}
 
 Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
-                                              Http::HeaderMap& request_headers,
+                                              Http::RequestHeaderMap& request_headers,
                                               const std::string& operation_name,
                                               SystemTime start_time,
                                               const Tracing::Decision tracing_decision) {

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -36,7 +36,7 @@ public:
   void setOperation(absl::string_view operation) override;
   void setTag(absl::string_view name, const absl::string_view) override;
   void log(SystemTime timestamp, const std::string& event) override;
-  void injectContext(Http::HeaderMap& request_headers) override;
+  void injectContext(Http::RequestHeaderMap& request_headers) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
                               SystemTime start_time) override;
   void setSampled(bool) override;
@@ -58,7 +58,7 @@ public:
   explicit OpenTracingDriver(Stats::Store& stats);
 
   // Tracer::TracingDriver
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
@@ -23,7 +23,7 @@ public:
   /**
    * Implements the abstract Driver's startSpan operation.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -100,7 +100,7 @@ void Span::finishSpan() {
   broker_.send(json);
 } // namespace XRay
 
-void Span::injectContext(Http::HeaderMap& request_headers) {
+void Span::injectContext(Http::RequestHeaderMap& request_headers) {
   const std::string xray_header_value =
       fmt::format("root={};parent={};sampled={}", traceId(), Id(), sampled() ? "1" : "0");
 

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -102,7 +102,7 @@ public:
   /**
    * Adds X-Ray trace header to the set of outgoing headers.
    */
-  void injectContext(Http::HeaderMap& request_headers) override;
+  void injectContext(Http::RequestHeaderMap& request_headers) override;
 
   /**
    * Gets the start time of this Span.

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -58,7 +58,8 @@ Driver::Driver(const XRayConfiguration& config, Server::Instance& server)
   });
 }
 
-Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
+Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
+                                   Http::RequestHeaderMap& request_headers,
                                    const std::string& operation_name, Envoy::SystemTime start_time,
                                    const Tracing::Decision tracing_decision) {
   // First thing is to determine whether this request will be sampled or not.

--- a/source/extensions/tracers/xray/xray_tracer_impl.h
+++ b/source/extensions/tracers/xray/xray_tracer_impl.h
@@ -18,7 +18,7 @@ class Driver : public Tracing::Driver, public Logger::Loggable<Logger::Id::traci
 public:
   Driver(const XRay::XRayConfiguration& config, Server::Instance& server);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, Envoy::SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -29,7 +29,7 @@ bool getSamplingFlags(char c, const Tracing::Decision tracing_decision) {
 
 } // namespace
 
-SpanContextExtractor::SpanContextExtractor(Http::HeaderMap& request_headers)
+SpanContextExtractor::SpanContextExtractor(Http::RequestHeaderMap& request_headers)
     : request_headers_(request_headers) {}
 
 SpanContextExtractor::~SpanContextExtractor() = default;

--- a/source/extensions/tracers/zipkin/span_context_extractor.h
+++ b/source/extensions/tracers/zipkin/span_context_extractor.h
@@ -22,7 +22,7 @@ struct ExtractorException : public EnvoyException {
  */
 class SpanContextExtractor {
 public:
-  SpanContextExtractor(Http::HeaderMap& request_headers);
+  SpanContextExtractor(Http::RequestHeaderMap& request_headers);
   ~SpanContextExtractor();
   bool extractSampled(const Tracing::Decision tracing_decision);
   std::pair<SpanContext, bool> extractSpanContext(bool is_sampled);
@@ -35,7 +35,7 @@ private:
    */
   std::pair<SpanContext, bool> extractSpanContextFromB3SingleFormat(bool is_sampled);
   bool tryExtractSampledFromB3SingleFormat();
-  const Http::HeaderMap& request_headers_;
+  const Http::RequestHeaderMap& request_headers_;
 };
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -36,7 +36,7 @@ void ZipkinSpan::log(SystemTime timestamp, const std::string& event) {
   span_.log(timestamp, event);
 }
 
-void ZipkinSpan::injectContext(Http::HeaderMap& request_headers) {
+void ZipkinSpan::injectContext(Http::RequestHeaderMap& request_headers) {
   // Set the trace-id and span-id headers properly, based on the newly-created span structure.
   request_headers.setReferenceKey(ZipkinCoreConstants::get().X_B3_TRACE_ID,
                                   span_.traceIdAsHexString());
@@ -100,8 +100,9 @@ Driver::Driver(const envoy::config::trace::v3::ZipkinConfig& zipkin_config,
   });
 }
 
-Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
-                                   const std::string&, SystemTime start_time,
+Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
+                                   Http::RequestHeaderMap& request_headers, const std::string&,
+                                   SystemTime start_time,
                                    const Tracing::Decision tracing_decision) {
   Tracer& tracer = *tls_->getTyped<TlsTracer>().tracer_;
   SpanPtr new_zipkin_span;

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -66,7 +66,7 @@ public:
 
   void log(SystemTime timestamp, const std::string& event) override;
 
-  void injectContext(Http::HeaderMap& request_headers) override;
+  void injectContext(Http::RequestHeaderMap& request_headers) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& name,
                               SystemTime start_time) override;
 
@@ -109,7 +109,7 @@ public:
    * Thus, this implementation of the virtual function startSpan() ignores the operation name
    * ("ingress" or "egress") passed by the caller.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config&, Http::HeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config&, Http::RequestHeaderMap& request_headers,
                              const std::string&, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/server/config_validation/admin.cc
+++ b/source/server/config_validation/admin.cc
@@ -20,7 +20,7 @@ void ValidationAdmin::startHttpListener(const std::string&, const std::string&,
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 
-Http::Code ValidationAdmin::request(absl::string_view, absl::string_view, Http::HeaderMap&,
+Http::Code ValidationAdmin::request(absl::string_view, absl::string_view, Http::ResponseHeaderMap&,
                                     std::string&) {
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }

--- a/source/server/config_validation/admin.h
+++ b/source/server/config_validation/admin.h
@@ -25,7 +25,7 @@ public:
                          const Network::Socket::OptionsSharedPtr&,
                          Stats::ScopePtr&& listener_scope) override;
   Http::Code request(absl::string_view path_and_query, absl::string_view method,
-                     Http::HeaderMap& response_headers, std::string& body) override;
+                     Http::ResponseHeaderMap& response_headers, std::string& body) override;
   void addListenerToHandler(Network::ConnectionHandler* handler) override;
 
 private:

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -63,8 +63,9 @@ class AdminImpl : public Admin,
 public:
   AdminImpl(const std::string& profile_path, Server::Instance& server);
 
-  Http::Code runCallback(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                         Buffer::Instance& response, AdminStream& admin_stream);
+  Http::Code runCallback(absl::string_view path_and_query,
+                         Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                         AdminStream& admin_stream);
   const Network::Socket& socket() override { return *socket_; }
   Network::Socket& mutable_socket() { return *socket_; }
 
@@ -156,7 +157,7 @@ public:
   bool shouldNormalizePath() const override { return true; }
   bool shouldMergeSlashes() const override { return true; }
   Http::Code request(absl::string_view path_and_query, absl::string_view method,
-                     Http::HeaderMap& response_headers, std::string& body) override;
+                     Http::ResponseHeaderMap& response_headers, std::string& body) override;
   void closeSocket();
   void addListenerToHandler(Network::ConnectionHandler* handler) override;
   Server::Instance& server() { return server_; }
@@ -273,75 +274,88 @@ private:
   /**
    * URL handlers.
    */
-  Http::Code handlerAdminHome(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                              Buffer::Instance& response, AdminStream&);
-  Http::Code handlerCerts(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response, AdminStream&);
-  Http::Code handlerClusters(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                             Buffer::Instance& response, AdminStream&);
-  Http::Code handlerConfigDump(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+  Http::Code handlerAdminHome(absl::string_view path_and_query,
+                              Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                              AdminStream&);
+  Http::Code handlerCerts(absl::string_view path_and_query,
+                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                          AdminStream&);
+  Http::Code handlerClusters(absl::string_view path_and_query,
+                             Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                             AdminStream&);
+  Http::Code handlerConfigDump(absl::string_view path_and_query,
+                               Http::ResponseHeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&) const;
-  Http::Code handlerContention(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+  Http::Code handlerContention(absl::string_view path_and_query,
+                               Http::ResponseHeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&);
-  Http::Code handlerCpuProfiler(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+  Http::Code handlerCpuProfiler(absl::string_view path_and_query,
+                                Http::ResponseHeaderMap& response_headers,
                                 Buffer::Instance& response, AdminStream&);
   Http::Code handlerHeapProfiler(absl::string_view path_and_query,
-                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                 AdminStream&);
+                                 Http::ResponseHeaderMap& response_headers,
+                                 Buffer::Instance& response, AdminStream&);
   Http::Code handlerHealthcheckFail(absl::string_view path_and_query,
-                                    Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                    AdminStream&);
+                                    Http::ResponseHeaderMap& response_headers,
+                                    Buffer::Instance& response, AdminStream&);
   Http::Code handlerHealthcheckOk(absl::string_view path_and_query,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                  AdminStream&);
-  Http::Code handlerHelp(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                         Buffer::Instance& response, AdminStream&);
+                                  Http::ResponseHeaderMap& response_headers,
+                                  Buffer::Instance& response, AdminStream&);
+  Http::Code handlerHelp(absl::string_view path_and_query,
+                         Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                         AdminStream&);
   Http::Code handlerHotRestartVersion(absl::string_view path_and_query,
-                                      Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                      AdminStream&);
+                                      Http::ResponseHeaderMap& response_headers,
+                                      Buffer::Instance& response, AdminStream&);
   Http::Code handlerListenerInfo(absl::string_view path_and_query,
-                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                 AdminStream&);
-  Http::Code handlerLogging(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                            Buffer::Instance& response, AdminStream&);
-  Http::Code handlerMemory(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                           Buffer::Instance& response, AdminStream&);
+                                 Http::ResponseHeaderMap& response_headers,
+                                 Buffer::Instance& response, AdminStream&);
+  Http::Code handlerLogging(absl::string_view path_and_query,
+                            Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                            AdminStream&);
+  Http::Code handlerMemory(absl::string_view path_and_query,
+                           Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                           AdminStream&);
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response, AdminStream&);
   Http::Code handlerQuitQuitQuit(absl::string_view path_and_query,
-                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                 AdminStream&);
+                                 Http::ResponseHeaderMap& response_headers,
+                                 Buffer::Instance& response, AdminStream&);
   Http::Code handlerDrainListeners(absl::string_view path_and_query,
-                                   Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                   AdminStream&);
+                                   Http::ResponseHeaderMap& response_headers,
+                                   Buffer::Instance& response, AdminStream&);
   Http::Code handlerResetCounters(absl::string_view path_and_query,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                  AdminStream&);
+                                  Http::ResponseHeaderMap& response_headers,
+                                  Buffer::Instance& response, AdminStream&);
   Http::Code handlerStatsRecentLookups(absl::string_view path_and_query,
-                                       Http::HeaderMap& response_headers,
+                                       Http::ResponseHeaderMap& response_headers,
                                        Buffer::Instance& response, AdminStream&);
   Http::Code handlerStatsRecentLookupsClear(absl::string_view path_and_query,
-                                            Http::HeaderMap& response_headers,
+                                            Http::ResponseHeaderMap& response_headers,
                                             Buffer::Instance& response, AdminStream&);
   Http::Code handlerStatsRecentLookupsDisable(absl::string_view path_and_query,
-                                              Http::HeaderMap& response_headers,
+                                              Http::ResponseHeaderMap& response_headers,
                                               Buffer::Instance& response, AdminStream&);
   Http::Code handlerStatsRecentLookupsEnable(absl::string_view path_and_query,
-                                             Http::HeaderMap& response_headers,
+                                             Http::ResponseHeaderMap& response_headers,
                                              Buffer::Instance& response, AdminStream&);
-  Http::Code handlerServerInfo(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+  Http::Code handlerServerInfo(absl::string_view path_and_query,
+                               Http::ResponseHeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&);
-  Http::Code handlerReady(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response, AdminStream&);
-  Http::Code handlerStats(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response, AdminStream&);
+  Http::Code handlerReady(absl::string_view path_and_query,
+                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                          AdminStream&);
+  Http::Code handlerStats(absl::string_view path_and_query,
+                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                          AdminStream&);
   Http::Code handlerPrometheusStats(absl::string_view path_and_query,
-                                    Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                    AdminStream&);
-  Http::Code handlerRuntime(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                            Buffer::Instance& response, AdminStream&);
+                                    Http::ResponseHeaderMap& response_headers,
+                                    Buffer::Instance& response, AdminStream&);
+  Http::Code handlerRuntime(absl::string_view path_and_query,
+                            Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                            AdminStream&);
   Http::Code handlerRuntimeModify(absl::string_view path_and_query,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                  AdminStream&);
+                                  Http::ResponseHeaderMap& response_headers,
+                                  Buffer::Instance& response, AdminStream&);
   bool isFormUrlEncoded(const Http::HeaderEntry* content_type) const;
 
   class AdminListenSocketFactory : public Network::ListenSocketFactory {
@@ -480,7 +494,7 @@ public:
   void addOnDestroyCallback(std::function<void()> cb) override;
   Http::StreamDecoderFilterCallbacks& getDecoderFilterCallbacks() const override;
   const Buffer::Instance* getRequestBody() const override;
-  const Http::HeaderMap& getRequestHeaders() const override;
+  const Http::RequestHeaderMap& getRequestHeaders() const override;
 
 private:
   /**
@@ -493,7 +507,7 @@ private:
   // to add a callback that will notify them when the reference is no
   // longer valid.
   Http::StreamDecoderFilterCallbacks* callbacks_{};
-  Http::HeaderMap* request_headers_{};
+  Http::RequestHeaderMap* request_headers_{};
   std::list<std::function<void()>> on_destroy_callbacks_;
   bool end_stream_on_complete_ = true;
 };

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -411,7 +411,7 @@ typed_config:
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
 
-  Http::TestHeaderMapImpl header_map{};
+  Http::TestRequestHeaderMapImpl header_map{};
   stream_info_.health_check_request_ = true;
   EXPECT_CALL(*file_, write(_)).Times(0);
 
@@ -430,7 +430,7 @@ typed_config:
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
 
-  Http::TestHeaderMapImpl header_map{};
+  Http::TestRequestHeaderMapImpl header_map{};
   EXPECT_CALL(*file_, write(_));
 
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
@@ -458,19 +458,19 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
 
   {
-    Http::TestHeaderMapImpl forced_header{{"x-request-id", force_tracing_guid}};
+    Http::TestRequestHeaderMapImpl forced_header{{"x-request-id", force_tracing_guid}};
     EXPECT_CALL(*file_, write(_));
     log->log(&forced_header, &response_headers_, &response_trailers_, stream_info_);
   }
 
   {
-    Http::TestHeaderMapImpl not_traceable{{"x-request-id", not_traceable_guid}};
+    Http::TestRequestHeaderMapImpl not_traceable{{"x-request-id", not_traceable_guid}};
     EXPECT_CALL(*file_, write(_)).Times(0);
     log->log(&not_traceable, &response_headers_, &response_trailers_, stream_info_);
   }
 
   {
-    Http::TestHeaderMapImpl sampled_header{{"x-request-id", sample_tracing_guid}};
+    Http::TestRequestHeaderMapImpl sampled_header{{"x-request-id", sample_tracing_guid}};
     EXPECT_CALL(*file_, write(_)).Times(0);
     log->log(&sampled_header, &response_headers_, &response_trailers_, stream_info_);
   }
@@ -531,14 +531,14 @@ typed_config:
 
   {
     EXPECT_CALL(*file_, write(_));
-    Http::TestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
+    Http::TestRequestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
 
     log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
   }
 
   {
     EXPECT_CALL(*file_, write(_)).Times(0);
-    Http::TestHeaderMapImpl header_map{};
+    Http::TestRequestHeaderMapImpl header_map{};
     stream_info_.health_check_request_ = true;
     log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
   }
@@ -567,14 +567,14 @@ typed_config:
 
   {
     EXPECT_CALL(*file_, write(_));
-    Http::TestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
+    Http::TestRequestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
 
     log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
   }
 
   {
     EXPECT_CALL(*file_, write(_));
-    Http::TestHeaderMapImpl header_map{{"user-agent", "Envoy/HC"}};
+    Http::TestRequestHeaderMapImpl header_map{{"user-agent", "Envoy/HC"}};
     log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
   }
 }
@@ -610,14 +610,14 @@ typed_config:
 
   {
     EXPECT_CALL(*file_, write(_));
-    Http::TestHeaderMapImpl header_map{};
+    Http::TestRequestHeaderMapImpl header_map{};
 
     log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
   }
 
   {
     EXPECT_CALL(*file_, write(_)).Times(0);
-    Http::TestHeaderMapImpl header_map{};
+    Http::TestRequestHeaderMapImpl header_map{};
     stream_info_.health_check_request_ = true;
 
     log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
@@ -1282,8 +1282,8 @@ public:
   SampleExtensionFilter(uint32_t sample_rate) : sample_rate_(sample_rate) {}
 
   // AccessLog::Filter
-  bool evaluate(const StreamInfo::StreamInfo&, const Http::HeaderMap&, const Http::HeaderMap&,
-                const Http::HeaderMap&) override {
+  bool evaluate(const StreamInfo::StreamInfo&, const Http::RequestHeaderMap&,
+                const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) override {
     if (current_++ == 0) {
       return true;
     }

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -16,84 +16,87 @@ namespace Envoy {
 namespace Grpc {
 
 TEST(GrpcContextTest, GetGrpcStatus) {
-  Http::TestHeaderMapImpl ok_trailers{{"grpc-status", "0"}};
+  Http::TestResponseHeaderMapImpl ok_trailers{{"grpc-status", "0"}};
   EXPECT_EQ(Status::Ok, Common::getGrpcStatus(ok_trailers).value());
 
-  Http::TestHeaderMapImpl no_status_trailers{{"foo", "bar"}};
+  Http::TestResponseHeaderMapImpl no_status_trailers{{"foo", "bar"}};
   EXPECT_FALSE(Common::getGrpcStatus(no_status_trailers));
 
-  Http::TestHeaderMapImpl aborted_trailers{{"grpc-status", "10"}};
+  Http::TestResponseHeaderMapImpl aborted_trailers{{"grpc-status", "10"}};
   EXPECT_EQ(Status::Aborted, Common::getGrpcStatus(aborted_trailers).value());
 
-  Http::TestHeaderMapImpl unauth_trailers{{"grpc-status", "16"}};
+  Http::TestResponseHeaderMapImpl unauth_trailers{{"grpc-status", "16"}};
   EXPECT_EQ(Status::Unauthenticated, Common::getGrpcStatus(unauth_trailers).value());
 
-  Http::TestHeaderMapImpl invalid_trailers{{"grpc-status", "-1"}};
+  Http::TestResponseHeaderMapImpl invalid_trailers{{"grpc-status", "-1"}};
   EXPECT_EQ(Status::InvalidCode, Common::getGrpcStatus(invalid_trailers).value());
 
-  Http::TestHeaderMapImpl user_defined_invalid_trailers{{"grpc-status", "1024"}};
+  Http::TestResponseHeaderMapImpl user_defined_invalid_trailers{{"grpc-status", "1024"}};
   EXPECT_EQ(Status::InvalidCode, Common::getGrpcStatus(invalid_trailers).value());
 
-  Http::TestHeaderMapImpl user_defined_trailers{{"grpc-status", "1024"}};
+  Http::TestResponseHeaderMapImpl user_defined_trailers{{"grpc-status", "1024"}};
   EXPECT_EQ(1024, Common::getGrpcStatus(user_defined_trailers, true).value());
 }
 
 TEST(GrpcContextTest, GetGrpcStatusWithFallbacks) {
-  Http::TestHeaderMapImpl ok_status{{"grpc-status", "0"}};
-  Http::TestHeaderMapImpl no_status{{"foo", "bar"}};
+  Http::TestResponseHeaderMapImpl ok_status_headers{{"grpc-status", "0"}};
+  Http::TestResponseHeaderMapImpl no_status_headers{{"foo", "bar"}};
+  Http::TestResponseTrailerMapImpl ok_status_trailers{{"grpc-status", "0"}};
+  Http::TestResponseTrailerMapImpl no_status_trailers{{"foo", "bar"}};
   NiceMock<StreamInfo::MockStreamInfo> info;
   EXPECT_CALL(info, responseCode()).WillRepeatedly(testing::Return(404));
 
-  EXPECT_EQ(Status::Ok, Common::getGrpcStatus(ok_status, no_status, info).value());
+  EXPECT_EQ(Status::Ok, Common::getGrpcStatus(ok_status_trailers, no_status_headers, info).value());
 
-  EXPECT_EQ(Status::Ok, Common::getGrpcStatus(no_status, ok_status, info).value());
+  EXPECT_EQ(Status::Ok, Common::getGrpcStatus(no_status_trailers, ok_status_headers, info).value());
 
-  EXPECT_EQ(Status::Unimplemented, Common::getGrpcStatus(no_status, no_status, info).value());
+  EXPECT_EQ(Status::Unimplemented,
+            Common::getGrpcStatus(no_status_trailers, no_status_headers, info).value());
 
   NiceMock<StreamInfo::MockStreamInfo> info_without_code;
-  EXPECT_FALSE(Common::getGrpcStatus(no_status, no_status, info_without_code));
+  EXPECT_FALSE(Common::getGrpcStatus(no_status_trailers, no_status_headers, info_without_code));
 }
 
 TEST(GrpcContextTest, GetGrpcMessage) {
-  Http::TestHeaderMapImpl empty_trailers;
+  Http::TestResponseTrailerMapImpl empty_trailers;
   EXPECT_EQ("", Common::getGrpcMessage(empty_trailers));
 
-  Http::TestHeaderMapImpl error_trailers{{"grpc-message", "Some error"}};
+  Http::TestResponseTrailerMapImpl error_trailers{{"grpc-message", "Some error"}};
   EXPECT_EQ("Some error", Common::getGrpcMessage(error_trailers));
 
-  Http::TestHeaderMapImpl empty_error_trailers{{"grpc-message", ""}};
+  Http::TestResponseTrailerMapImpl empty_error_trailers{{"grpc-message", ""}};
   EXPECT_EQ("", Common::getGrpcMessage(empty_error_trailers));
 }
 
 TEST(GrpcContextTest, GetGrpcTimeout) {
-  Http::TestHeaderMapImpl empty_headers;
+  Http::TestRequestHeaderMapImpl empty_headers;
   EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(empty_headers));
 
-  Http::TestHeaderMapImpl empty_grpc_timeout{{"grpc-timeout", ""}};
+  Http::TestRequestHeaderMapImpl empty_grpc_timeout{{"grpc-timeout", ""}};
   EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(empty_grpc_timeout));
 
-  Http::TestHeaderMapImpl missing_unit{{"grpc-timeout", "123"}};
+  Http::TestRequestHeaderMapImpl missing_unit{{"grpc-timeout", "123"}};
   EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(missing_unit));
 
-  Http::TestHeaderMapImpl illegal_unit{{"grpc-timeout", "123F"}};
+  Http::TestRequestHeaderMapImpl illegal_unit{{"grpc-timeout", "123F"}};
   EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(illegal_unit));
 
-  Http::TestHeaderMapImpl unit_hours{{"grpc-timeout", "1H"}};
+  Http::TestRequestHeaderMapImpl unit_hours{{"grpc-timeout", "1H"}};
   EXPECT_EQ(std::chrono::milliseconds(60 * 60 * 1000), Common::getGrpcTimeout(unit_hours));
 
-  Http::TestHeaderMapImpl unit_minutes{{"grpc-timeout", "1M"}};
+  Http::TestRequestHeaderMapImpl unit_minutes{{"grpc-timeout", "1M"}};
   EXPECT_EQ(std::chrono::milliseconds(60 * 1000), Common::getGrpcTimeout(unit_minutes));
 
-  Http::TestHeaderMapImpl unit_seconds{{"grpc-timeout", "1S"}};
+  Http::TestRequestHeaderMapImpl unit_seconds{{"grpc-timeout", "1S"}};
   EXPECT_EQ(std::chrono::milliseconds(1000), Common::getGrpcTimeout(unit_seconds));
 
-  Http::TestHeaderMapImpl unit_milliseconds{{"grpc-timeout", "12345678m"}};
+  Http::TestRequestHeaderMapImpl unit_milliseconds{{"grpc-timeout", "12345678m"}};
   EXPECT_EQ(std::chrono::milliseconds(12345678), Common::getGrpcTimeout(unit_milliseconds));
 
-  Http::TestHeaderMapImpl unit_microseconds{{"grpc-timeout", "1000001u"}};
+  Http::TestRequestHeaderMapImpl unit_microseconds{{"grpc-timeout", "1000001u"}};
   EXPECT_EQ(std::chrono::milliseconds(1001), Common::getGrpcTimeout(unit_microseconds));
 
-  Http::TestHeaderMapImpl unit_nanoseconds{{"grpc-timeout", "12345678n"}};
+  Http::TestRequestHeaderMapImpl unit_nanoseconds{{"grpc-timeout", "12345678n"}};
   EXPECT_EQ(std::chrono::milliseconds(13), Common::getGrpcTimeout(unit_nanoseconds));
 
   // Max 8 digits and no leading whitespace or +- signs are not enforced on decode,
@@ -123,7 +126,7 @@ TEST(GrpcCommonTest, GrpcStatusDetailsBin) {
 }
 
 TEST(GrpcContextTest, ToGrpcTimeout) {
-  Http::TestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
 
   Common::toGrpcTimeout(std::chrono::milliseconds(0UL), headers);
   EXPECT_EQ("0m", headers.GrpcTimeout()->value().getStringView());
@@ -265,11 +268,11 @@ TEST(GrpcContextTest, HttpToGrpcStatus) {
 
 TEST(GrpcContextTest, HasGrpcContentType) {
   {
-    Http::TestHeaderMapImpl headers{};
+    Http::TestRequestHeaderMapImpl headers{};
     EXPECT_FALSE(Common::hasGrpcContentType(headers));
   }
   auto isGrpcContentType = [](const std::string& s) {
-    Http::TestHeaderMapImpl headers{{"content-type", s}};
+    Http::TestRequestHeaderMapImpl headers{{"content-type", s}};
     return Common::hasGrpcContentType(headers);
   };
   EXPECT_FALSE(isGrpcContentType(""));
@@ -283,17 +286,17 @@ TEST(GrpcContextTest, HasGrpcContentType) {
 }
 
 TEST(GrpcContextTest, IsGrpcResponseHeader) {
-  Http::TestHeaderMapImpl grpc_status_only{{":status", "500"}, {"grpc-status", "14"}};
+  Http::TestResponseHeaderMapImpl grpc_status_only{{":status", "500"}, {"grpc-status", "14"}};
   EXPECT_TRUE(Common::isGrpcResponseHeader(grpc_status_only, true));
   EXPECT_FALSE(Common::isGrpcResponseHeader(grpc_status_only, false));
 
-  Http::TestHeaderMapImpl grpc_response_header{{":status", "200"},
-                                               {"content-type", "application/grpc"}};
+  Http::TestResponseHeaderMapImpl grpc_response_header{{":status", "200"},
+                                                       {"content-type", "application/grpc"}};
   EXPECT_FALSE(Common::isGrpcResponseHeader(grpc_response_header, true));
   EXPECT_TRUE(Common::isGrpcResponseHeader(grpc_response_header, false));
 
-  Http::TestHeaderMapImpl json_response_header{{":status", "200"},
-                                               {"content-type", "application/json"}};
+  Http::TestResponseHeaderMapImpl json_response_header{{":status", "200"},
+                                                       {"content-type", "application/json"}};
   EXPECT_FALSE(Common::isGrpcResponseHeader(json_response_header, true));
   EXPECT_FALSE(Common::isGrpcResponseHeader(json_response_header, false));
 }

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -39,7 +39,7 @@ TEST(GrpcContextTest, ChargeStats) {
   EXPECT_EQ(3U, cluster.stats_store_.counter("grpc.service.method.request_message_count").value());
   EXPECT_EQ(4U, cluster.stats_store_.counter("grpc.service.method.response_message_count").value());
 
-  Http::TestHeaderMapImpl trailers;
+  Http::TestResponseTrailerMapImpl trailers;
   trailers.setGrpcStatus("0");
   const Http::HeaderEntry* status = trailers.GrpcStatus();
   context.chargeStat(cluster, Context::Protocol::Grpc, request_names, status);
@@ -60,7 +60,7 @@ TEST(GrpcContextTest, ChargeStats) {
 TEST(GrpcContextTest, ResolveServiceAndMethod) {
   std::string service;
   std::string method;
-  Http::HeaderMapImpl headers;
+  Http::RequestHeaderMapImpl headers;
   headers.setPath("/service_name/method_name?a=b");
   const Http::HeaderEntry* path = headers.Path();
   Stats::TestSymbolTable symbol_table;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -62,7 +62,7 @@ public:
   void expectResponseHeaders(MockAsyncClientStreamCallbacks& callbacks, uint64_t code,
                              bool end_stream) {
     EXPECT_CALL(callbacks, onHeaders_(_, end_stream))
-        .WillOnce(Invoke([code](HeaderMap& headers, bool) -> void {
+        .WillOnce(Invoke([code](ResponseHeaderMap& headers, bool) -> void {
           EXPECT_EQ(std::to_string(code), headers.Status()->value().getStringView());
         }));
   }

--- a/test/common/http/common.cc
+++ b/test/common/http/common.cc
@@ -5,7 +5,7 @@
 #include "envoy/http/header_map.h"
 
 namespace Envoy {
-void HttpTestUtility::addDefaultHeaders(Http::HeaderMap& headers,
+void HttpTestUtility::addDefaultHeaders(Http::RequestHeaderMap& headers,
                                         const std::string default_method) {
   headers.setScheme("http");
   headers.setMethod(default_method);

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -62,6 +62,7 @@ struct ConnPoolCallbacks : public Http::ConnectionPool::Callbacks {
  */
 class HttpTestUtility {
 public:
-  static void addDefaultHeaders(Http::HeaderMap& headers, const std::string default_method = "GET");
+  static void addDefaultHeaders(Http::RequestHeaderMap& headers,
+                                const std::string default_method = "GET");
 };
 } // namespace Envoy

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -255,11 +255,11 @@ public:
     conn_manager_->onData(fake_input, false);
   }
 
-  HeaderMap* sendResponseHeaders(ResponseHeaderMapPtr&& response_headers) {
-    HeaderMap* altered_response_headers = nullptr;
+  ResponseHeaderMap* sendResponseHeaders(ResponseHeaderMapPtr&& response_headers) {
+    ResponseHeaderMap* altered_response_headers = nullptr;
 
     EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, _))
-        .WillOnce(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+        .WillOnce(Invoke([&](ResponseHeaderMap& headers, bool) -> FilterHeadersStatus {
           altered_response_headers = &headers;
           return FilterHeadersStatus::Continue;
         }));
@@ -414,7 +414,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
 
   EXPECT_CALL(*filter, decodeHeaders(_, true))
       .Times(2)
-      .WillRepeatedly(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillRepeatedly(Invoke([&](RequestHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_NE(nullptr, headers.ForwardedFor());
         EXPECT_EQ("http", headers.ForwardedProto()->value().getStringView());
         if (headers.Path()->value() == "/healthcheck") {
@@ -479,7 +479,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponse) {
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(*filter, decodeHeaders(_, true))
-      .WillRepeatedly(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillRepeatedly(Invoke([&](RequestHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_NE(nullptr, headers.ForwardedFor());
         EXPECT_EQ("http", headers.ForwardedProto()->value().getStringView());
         return FilterHeadersStatus::StopIteration;
@@ -609,7 +609,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderOverwritten) {
   setUpEncoderAndDecoder(false, false);
 
   sendRequestHeadersAndData();
-  const HeaderMap* altered_headers = sendResponseHeaders(
+  const ResponseHeaderMap* altered_headers = sendResponseHeaders(
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   EXPECT_EQ("custom-value", altered_headers->Server()->value().getStringView());
 }
@@ -621,7 +621,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderAppendPresent) {
   setUpEncoderAndDecoder(false, false);
 
   sendRequestHeadersAndData();
-  const HeaderMap* altered_headers = sendResponseHeaders(
+  const ResponseHeaderMap* altered_headers = sendResponseHeaders(
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   EXPECT_EQ("foo", altered_headers->Server()->value().getStringView());
 }
@@ -633,7 +633,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderAppendAbsent) {
   setUpEncoderAndDecoder(false, false);
 
   sendRequestHeadersAndData();
-  const HeaderMap* altered_headers =
+  const ResponseHeaderMap* altered_headers =
       sendResponseHeaders(ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}});
   EXPECT_EQ("custom-value", altered_headers->Server()->value().getStringView());
 }
@@ -645,7 +645,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderPassthroughPresent) {
   setUpEncoderAndDecoder(false, false);
 
   sendRequestHeadersAndData();
-  const HeaderMap* altered_headers = sendResponseHeaders(
+  const ResponseHeaderMap* altered_headers = sendResponseHeaders(
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   EXPECT_EQ("foo", altered_headers->Server()->value().getStringView());
 }
@@ -657,7 +657,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderPassthroughAbsent) {
   setUpEncoderAndDecoder(false, false);
 
   sendRequestHeadersAndData();
-  const HeaderMap* altered_headers =
+  const ResponseHeaderMap* altered_headers =
       sendResponseHeaders(ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}});
   EXPECT_TRUE(altered_headers->Server() == nullptr);
 }
@@ -685,7 +685,7 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
 
   EXPECT_CALL(*filter, encodeHeaders(_, true));
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("404", headers.Status()->value().getStringView());
         EXPECT_EQ("absolute_path_rejected",
                   filter->decoder_callbacks_->streamInfo().responseCodeDetails().value());
@@ -724,7 +724,7 @@ TEST_F(HttpConnectionManagerImplTest, PathFailedtoSanitize) {
 
   EXPECT_CALL(*filter, encodeHeaders(_, true));
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("400", headers.Status()->value().getStringView());
         EXPECT_EQ("path_normalization_failed",
                   filter->decoder_callbacks_->streamInfo().responseCodeDetails().value());
@@ -752,7 +752,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterShouldUseSantizedPath) {
       }));
 
   EXPECT_CALL(*filter, decodeHeaders(_, true))
-      .WillRepeatedly(Invoke([&](HeaderMap& header_map, bool) -> FilterHeadersStatus {
+      .WillRepeatedly(Invoke([&](RequestHeaderMap& header_map, bool) -> FilterHeadersStatus {
         EXPECT_EQ(normalized_path, header_map.Path()->value().getStringView());
         return FilterHeadersStatus::StopIteration;
       }));
@@ -795,8 +795,8 @@ TEST_F(HttpConnectionManagerImplTest, RouteShouldUseSantizedPath) {
   EXPECT_CALL(route->route_entry_, clusterName()).WillRepeatedly(ReturnRef(fake_cluster_name));
 
   EXPECT_CALL(*route_config_provider_.route_config_, route(_, _, _))
-      .WillOnce(
-          Invoke([&](const Http::HeaderMap& header_map, const StreamInfo::StreamInfo&, uint64_t) {
+      .WillOnce(Invoke(
+          [&](const Http::RequestHeaderMap& header_map, const StreamInfo::StreamInfo&, uint64_t) {
             EXPECT_EQ(normalized_path, header_map.Path()->value().getStringView());
             return route;
           }));
@@ -954,7 +954,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
 
   // Should be no 'x-envoy-decorator-operation' response header.
   EXPECT_CALL(encoder, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(nullptr, headers.EnvoyDecoratorOperation());
       }));
 
@@ -1022,7 +1022,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 
   // Verify decorator operation response header has been defined.
   EXPECT_CALL(encoder, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("testOp", headers.EnvoyDecoratorOperation()->value().getStringView());
       }));
 
@@ -1088,7 +1088,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 
   // Verify decorator operation response header has NOT been defined (i.e. not propagated).
   EXPECT_CALL(encoder, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(nullptr, headers.EnvoyDecoratorOperation());
       }));
 
@@ -1155,7 +1155,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   // Should be no 'x-envoy-decorator-operation' response header, as decorator
   // was overridden by request header.
   EXPECT_CALL(encoder, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(nullptr, headers.EnvoyDecoratorOperation());
       }));
 
@@ -1233,7 +1233,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   }));
 
   EXPECT_CALL(*filter, decodeHeaders(_, true))
-      .WillOnce(Invoke([](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([](RequestHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_NE(nullptr, headers.EnvoyDecoratorOperation());
         // Verify that decorator operation has been set as request header.
         EXPECT_EQ("testOp", headers.EnvoyDecoratorOperation()->value().getStringView());
@@ -1316,7 +1316,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
 
   // Verify that decorator operation has NOT been set as request header (propagate is false)
   EXPECT_CALL(*filter, decodeHeaders(_, true))
-      .WillOnce(Invoke([](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([](RequestHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_EQ(nullptr, headers.EnvoyDecoratorOperation());
         return FilterHeadersStatus::StopIteration;
       }));
@@ -1737,7 +1737,7 @@ TEST_F(HttpConnectionManagerImplTest, NoPath) {
   }));
 
   EXPECT_CALL(encoder, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("404", headers.Status()->value().getStringView());
       }));
 
@@ -1788,7 +1788,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutGlobal) {
 
   // 408 direct response after timeout.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("408", headers.Status()->value().getStringView());
       }));
   std::string response_body;
@@ -1870,7 +1870,7 @@ TEST_F(HttpConnectionManagerImplTest, TestStreamIdleAccessLog) {
 
   // 408 direct response after timeout.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("408", headers.Status()->value().getStringView());
       }));
 
@@ -1977,7 +1977,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterDownstreamHeaders
 
   // 408 direct response after timeout.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("408", headers.Status()->value().getStringView());
       }));
   std::string response_body;
@@ -2049,7 +2049,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterDownstreamHeaders
 
   // 408 direct response after timeout.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("408", headers.Status()->value().getStringView());
       }));
   std::string response_body;
@@ -2100,7 +2100,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterUpstreamHeaders) 
 
   // 200 upstream response.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("200", headers.Status()->value().getStringView());
       }));
 
@@ -2168,7 +2168,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterBidiData) {
 
   // 200 upstream response.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("200", headers.Status()->value().getStringView());
       }));
 
@@ -2233,7 +2233,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutCallbackDisarmsAndReturns408
     EXPECT_CALL(*request_timer, disableTimer()).Times(AtLeast(1));
 
     EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-        .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+        .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
           EXPECT_EQ("408", headers.Status()->value().getStringView());
         }));
     EXPECT_CALL(response_encoder_, encodeData(_, true)).WillOnce(AddBufferToString(&response_body));
@@ -2414,7 +2414,7 @@ TEST_F(HttpConnectionManagerImplTest, RejectWebSocketOnNonWebSocketRoute) {
   }));
 
   EXPECT_CALL(encoder, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("403", headers.Status()->value().getStringView());
       }));
 
@@ -2433,7 +2433,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
   EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
 
   EXPECT_CALL(*filter, decodeHeaders(_, false))
-      .WillRepeatedly(Invoke([&](HeaderMap&, bool) -> FilterHeadersStatus {
+      .WillRepeatedly(Invoke([&](RequestHeaderMap&, bool) -> FilterHeadersStatus {
         return FilterHeadersStatus::StopIteration;
       }));
 
@@ -2443,7 +2443,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
 
   NiceMock<MockResponseEncoder> encoder;
   EXPECT_CALL(encoder, encodeHeaders(_, false))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Connection());
         EXPECT_EQ("upgrade", headers.Connection()->value().getStringView());
       }));
@@ -2493,7 +2493,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
       }));
 
   EXPECT_CALL(*filter, decodeHeaders(_, true))
-      .WillOnce(Invoke([](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([](RequestHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_NE(nullptr, headers.ForwardedFor());
         EXPECT_EQ("https", headers.ForwardedProto()->value().getStringView());
         return FilterHeadersStatus::StopIteration;
@@ -2552,7 +2552,7 @@ TEST_F(HttpConnectionManagerImplTest, ResponseBeforeRequestComplete) {
   conn_manager_->onData(fake_input, false);
 
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Server());
         EXPECT_EQ("envoy-server-test", headers.Server()->value().getStringView());
       }));
@@ -2584,7 +2584,7 @@ TEST_F(HttpConnectionManagerImplTest, DisconnectOnProxyConnectionDisconnect) {
   conn_manager_->onData(fake_input, false);
 
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Connection());
         EXPECT_EQ("close", headers.Connection()->value().getStringView());
         EXPECT_EQ(nullptr, headers.ProxyConnection());
@@ -2627,7 +2627,7 @@ TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
   // Start the response
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   EXPECT_CALL(encoder, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Server());
         EXPECT_EQ("", headers.Server()->value().getStringView());
       }));
@@ -2969,7 +2969,7 @@ TEST_F(HttpConnectionManagerImplTest, IntermediateBufferingEarlyResponse) {
 
   // Mimic a decoder filter that trapped data and now sends on the headers.
   EXPECT_CALL(*decoder_filters_[1], decodeHeaders(_, false))
-      .WillOnce(Invoke([&](HeaderMap&, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([&](RequestHeaderMap&, bool) -> FilterHeadersStatus {
         // Now filter 2 will send a complete response.
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         decoder_filters_[1]->callbacks_->encodeHeaders(std::move(response_headers), true);
@@ -3966,7 +3966,7 @@ TEST_F(HttpConnectionManagerImplTest, HitResponseBufferLimitsBeforeHeaders) {
   std::string response_body;
   // The 500 goes directly to the encoder.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> FilterHeadersStatus {
         // Make sure this is a 500
         EXPECT_EQ("500", headers.Status()->value().getStringView());
         // Make sure Envoy standard sanitization has been applied.
@@ -4032,7 +4032,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterHeadReply) {
       }));
 
   EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, true))
-      .WillOnce(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([&](ResponseHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_EQ("11", headers.ContentLength()->value().getStringView());
         return FilterHeadersStatus::Continue;
       }));
@@ -4070,7 +4070,7 @@ TEST_F(HttpConnectionManagerImplTest, ResetWithStoppedFilter) {
       }));
 
   EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, false))
-      .WillOnce(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([&](ResponseHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_EQ("11", headers.ContentLength()->value().getStringView());
         return FilterHeadersStatus::Continue;
       }));
@@ -4782,7 +4782,7 @@ TEST_F(HttpConnectionManagerImplTest, NoNewStreamWhenOverloaded) {
 
   // 503 direct response when overloaded.
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("503", headers.Status()->value().getStringView());
       }));
   std::string response_body;
@@ -4820,7 +4820,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenOverloaded) {
   }));
 
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("close", headers.Connection()->value().getStringView());
       }));
 
@@ -4939,7 +4939,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenDraining) {
   }));
 
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("close", headers.Connection()->value().getStringView());
       }));
 
@@ -5213,7 +5213,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponseUsingHttp3) {
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
   EXPECT_CALL(*filter, decodeHeaders(_, true))
-      .WillOnce(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
+      .WillOnce(Invoke([&](RequestHeaderMap& headers, bool) -> FilterHeadersStatus {
         EXPECT_NE(nullptr, headers.ForwardedFor());
         EXPECT_EQ("http", headers.ForwardedProto()->value().getStringView());
         return FilterHeadersStatus::StopIteration;

--- a/test/common/http/date_provider_impl_test.cc
+++ b/test/common/http/date_provider_impl_test.cc
@@ -22,7 +22,7 @@ TEST(DateProviderImplTest, All) {
   EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(500), _));
 
   TlsCachingDateProviderImpl provider(dispatcher, tls);
-  HeaderMapImpl headers;
+  ResponseHeaderMapImpl headers;
   provider.setDateHeader(headers);
   EXPECT_NE(nullptr, headers.Date());
 

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -72,7 +72,7 @@ BENCHMARK(HeaderMapImplGet)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
  */
 static void HeaderMapImplGetInline(benchmark::State& state) {
   const std::string value("01234567890123456789");
-  HeaderMapImpl headers;
+  RequestHeaderMapImpl headers;
   addDummyHeaders(headers, state.range(0));
   headers.setReferenceConnection(value);
   size_t size = 0;
@@ -89,7 +89,7 @@ BENCHMARK(HeaderMapImplGetInline)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
  */
 static void HeaderMapImplSetInlineMacro(benchmark::State& state) {
   const std::string value("01234567890123456789");
-  HeaderMapImpl headers;
+  RequestHeaderMapImpl headers;
   addDummyHeaders(headers, state.range(0));
   for (auto _ : state) {
     headers.setReferenceConnection(value);
@@ -104,7 +104,7 @@ BENCHMARK(HeaderMapImplSetInlineMacro)->Arg(0)->Arg(1)->Arg(10)->Arg(50);
  */
 static void HeaderMapImplSetInlineInteger(benchmark::State& state) {
   uint64_t value = 12345;
-  HeaderMapImpl headers;
+  RequestHeaderMapImpl headers;
   addDummyHeaders(headers, state.range(0));
   for (auto _ : state) {
     headers.setConnection(value);

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -14,6 +14,11 @@ using ::testing::InSequence;
 namespace Envoy {
 namespace Http {
 
+class VerifiedHeaderMapImpl : public HeaderMapImpl {
+public:
+  void verifyByteSize() override { verifyByteSizeInternalForTest(); }
+};
+
 TEST(HeaderStringTest, All) {
   // Static LowerCaseString constructor
   {
@@ -339,7 +344,7 @@ TEST(HeaderStringTest, All) {
 }
 
 TEST(HeaderMapImplTest, InlineInsert) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   EXPECT_TRUE(headers.empty());
   EXPECT_EQ(0, headers.size());
   EXPECT_EQ(nullptr, headers.Host());
@@ -353,7 +358,7 @@ TEST(HeaderMapImplTest, InlineInsert) {
 
 TEST(HeaderMapImplTest, InlineAppend) {
   {
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     // Create via header and append.
     headers.setVia("");
     headers.appendVia("1.0 fred", ",");
@@ -363,7 +368,7 @@ TEST(HeaderMapImplTest, InlineAppend) {
   }
   {
     // Append to via header without explicitly creating first.
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.appendVia("1.0 fred", ",");
     EXPECT_EQ(headers.Via()->value().getStringView(), "1.0 fred");
     headers.appendVia("1.1 nowhere.com", ",");
@@ -371,7 +376,7 @@ TEST(HeaderMapImplTest, InlineAppend) {
   }
   {
     // Custom delimiter.
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.setVia("");
     headers.appendVia("1.0 fred", ", ");
     EXPECT_EQ(headers.Via()->value().getStringView(), "1.0 fred");
@@ -380,7 +385,7 @@ TEST(HeaderMapImplTest, InlineAppend) {
   }
   {
     // Append and then later set.
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.appendVia("1.0 fred", ",");
     headers.appendVia("1.1 nowhere.com", ",");
     EXPECT_EQ(headers.Via()->value().getStringView(), "1.0 fred,1.1 nowhere.com");
@@ -389,7 +394,7 @@ TEST(HeaderMapImplTest, InlineAppend) {
   }
   {
     // Set and then append. This mimics how GrpcTimeout is set.
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.setGrpcTimeout(42);
     EXPECT_EQ(headers.GrpcTimeout()->value().getStringView(), "42");
     headers.appendGrpcTimeout("s", "");
@@ -398,7 +403,7 @@ TEST(HeaderMapImplTest, InlineAppend) {
 }
 
 TEST(HeaderMapImplTest, MoveIntoInline) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   HeaderString key;
   key.setCopy(Headers::get().CacheControl.get());
   HeaderString value;
@@ -417,7 +422,7 @@ TEST(HeaderMapImplTest, MoveIntoInline) {
 }
 
 TEST(HeaderMapImplTest, Remove) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
 
   // Add random header and then remove by name.
   LowerCaseString static_key("hello");
@@ -462,7 +467,7 @@ TEST(HeaderMapImplTest, RemoveRegex) {
   LowerCaseString key2 = LowerCaseString(" x-prefix-foo");
   LowerCaseString key4 = LowerCaseString("y-x-prefix-foo");
 
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   headers.addReference(key1, "value");
   headers.addReference(key2, "value");
   headers.addReference(key3, "value");
@@ -492,7 +497,7 @@ TEST(HeaderMapImplTest, RemoveRegex) {
 }
 
 TEST(HeaderMapImplTest, SetRemovesAllValues) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
 
   LowerCaseString key1("hello");
   LowerCaseString key2("olleh");
@@ -548,7 +553,7 @@ TEST(HeaderMapImplTest, SetRemovesAllValues) {
 
 TEST(HeaderMapImplTest, DoubleInlineAdd) {
   {
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     const std::string foo("foo");
     const std::string bar("bar");
     headers.addReference(Headers::get().ContentLength, foo);
@@ -557,21 +562,21 @@ TEST(HeaderMapImplTest, DoubleInlineAdd) {
     EXPECT_EQ(1UL, headers.size());
   }
   {
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.addReferenceKey(Headers::get().ContentLength, "foo");
     headers.addReferenceKey(Headers::get().ContentLength, "bar");
     EXPECT_EQ("foo,bar", headers.ContentLength()->value().getStringView());
     EXPECT_EQ(1UL, headers.size());
   }
   {
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.addReferenceKey(Headers::get().ContentLength, 5);
     headers.addReferenceKey(Headers::get().ContentLength, 6);
     EXPECT_EQ("5,6", headers.ContentLength()->value().getStringView());
     EXPECT_EQ(1UL, headers.size());
   }
   {
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     const std::string foo("foo");
     headers.addReference(Headers::get().ContentLength, foo);
     headers.addReferenceKey(Headers::get().ContentLength, 6);
@@ -583,7 +588,7 @@ TEST(HeaderMapImplTest, DoubleInlineAdd) {
 // Per https://github.com/envoyproxy/envoy/issues/7488 make sure we don't
 // combine set-cookie headers
 TEST(HeaderMapImplTest, DoubleCookieAdd) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   const std::string foo("foo");
   const std::string bar("bar");
   const LowerCaseString& set_cookie = Http::Headers::get().SetCookie;
@@ -599,7 +604,7 @@ TEST(HeaderMapImplTest, DoubleCookieAdd) {
 }
 
 TEST(HeaderMapImplTest, DoubleInlineSet) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   headers.setReferenceKey(Headers::get().ContentType, "blah");
   headers.setReferenceKey(Headers::get().ContentType, "text/html");
   EXPECT_EQ("text/html", headers.ContentType()->value().getStringView());
@@ -607,7 +612,7 @@ TEST(HeaderMapImplTest, DoubleInlineSet) {
 }
 
 TEST(HeaderMapImplTest, AddReferenceKey) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   LowerCaseString foo("hello");
   headers.addReferenceKey(foo, "world");
   EXPECT_NE("world", headers.get(foo)->value().getStringView().data());
@@ -615,7 +620,7 @@ TEST(HeaderMapImplTest, AddReferenceKey) {
 }
 
 TEST(HeaderMapImplTest, SetReferenceKey) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   LowerCaseString foo("hello");
   headers.setReferenceKey(foo, "world");
   EXPECT_NE("world", headers.get(foo)->value().getStringView().data());
@@ -627,7 +632,7 @@ TEST(HeaderMapImplTest, SetReferenceKey) {
 }
 
 TEST(HeaderMapImplTest, SetCopy) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   LowerCaseString foo("hello");
   headers.setCopy(foo, "world");
   EXPECT_EQ("world", headers.get(foo)->value().getStringView());
@@ -679,7 +684,7 @@ TEST(HeaderMapImplTest, SetCopy) {
 }
 
 TEST(HeaderMapImplTest, AddCopy) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
 
   // Start with a string value.
   std::unique_ptr<LowerCaseString> lcKeyPtr(new LowerCaseString("hello"));
@@ -750,8 +755,8 @@ TEST(HeaderMapImplTest, AddCopy) {
 }
 
 TEST(HeaderMapImplTest, Equality) {
-  TestHeaderMapImpl headers1;
-  TestHeaderMapImpl headers2;
+  VerifiedHeaderMapImpl headers1;
+  VerifiedHeaderMapImpl headers2;
   EXPECT_EQ(headers1, headers2);
 
   headers1.addCopy(LowerCaseString("hello"), "world");
@@ -762,7 +767,7 @@ TEST(HeaderMapImplTest, Equality) {
 }
 
 TEST(HeaderMapImplTest, LargeCharInHeader) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   LowerCaseString static_key("\x90hello");
   std::string ref_value("value");
   headers.addReference(static_key, ref_value);
@@ -770,7 +775,7 @@ TEST(HeaderMapImplTest, LargeCharInHeader) {
 }
 
 TEST(HeaderMapImplTest, Iterate) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   headers.addCopy(LowerCaseString("hello"), "world");
   headers.addCopy(LowerCaseString("foo"), "xxx");
   headers.addCopy(LowerCaseString("world"), "hello");
@@ -794,7 +799,7 @@ TEST(HeaderMapImplTest, Iterate) {
 }
 
 TEST(HeaderMapImplTest, IterateReverse) {
-  TestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   headers.addCopy(LowerCaseString("hello"), "world");
   headers.addCopy(LowerCaseString("foo"), "bar");
   LowerCaseString world_key("world");
@@ -821,7 +826,7 @@ TEST(HeaderMapImplTest, IterateReverse) {
 }
 
 TEST(HeaderMapImplTest, Lookup) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   headers.addCopy(LowerCaseString("hello"), "world");
   headers.setContentLength(5);
 
@@ -849,7 +854,7 @@ TEST(HeaderMapImplTest, Lookup) {
 
 TEST(HeaderMapImplTest, Get) {
   {
-    auto headers = createHeaderMap<HeaderMapImpl>(
+    auto headers = createHeaderMap<VerifiedHeaderMapImpl>(
         {{Headers::get().Path, "/"}, {LowerCaseString("hello"), "world"}});
     EXPECT_EQ("/", headers->get(LowerCaseString(":path"))->value().getStringView());
     EXPECT_EQ("world", headers->get(LowerCaseString("hello"))->value().getStringView());
@@ -857,7 +862,7 @@ TEST(HeaderMapImplTest, Get) {
   }
 
   {
-    auto headers = createHeaderMap<HeaderMapImpl>(
+    auto headers = createHeaderMap<VerifiedHeaderMapImpl>(
         {{Headers::get().Path, "/"}, {LowerCaseString("hello"), "world"}});
     // There is not HeaderMap method to set a header and copy both the key and value.
     headers->setReferenceKey(LowerCaseString(":path"), "/new_path");
@@ -872,7 +877,7 @@ TEST(HeaderMapImplTest, Get) {
 TEST(HeaderMapImplTest, TestAppendHeader) {
   // Test appending to a string with a value.
   {
-    TestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     LowerCaseString foo("key1");
     headers.addCopy(foo, "some;");
     headers.appendCopy(foo, "test");
@@ -881,7 +886,7 @@ TEST(HeaderMapImplTest, TestAppendHeader) {
 
   // Test appending to an empty string.
   {
-    TestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     LowerCaseString key2("key2");
     headers.appendCopy(key2, "my tag data");
     EXPECT_EQ(headers.get(key2)->value().getStringView(), "my tag data");
@@ -889,7 +894,7 @@ TEST(HeaderMapImplTest, TestAppendHeader) {
 
   // Test empty data case.
   {
-    TestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     LowerCaseString key3("key3");
     headers.addCopy(key3, "empty");
     headers.appendCopy(key3, "");
@@ -898,7 +903,7 @@ TEST(HeaderMapImplTest, TestAppendHeader) {
   // Regression test for appending to an empty string with a short string, then
   // setting integer.
   {
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     const std::string empty;
     headers.setPath(empty);
     // Append with default delimiter.
@@ -909,7 +914,7 @@ TEST(HeaderMapImplTest, TestAppendHeader) {
   }
   // Test append for inline headers using this method and append##name.
   {
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     headers.addCopy(Headers::get().Via, "1.0 fred");
     EXPECT_EQ(headers.Via()->value().getStringView(), "1.0 fred");
     headers.appendCopy(Headers::get().Via, "1.1 p.example.net");
@@ -939,7 +944,7 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
 
   {
     LowerCaseString foo("hello");
-    Http::TestHeaderMapImpl headers{};
+    Http::VerifiedHeaderMapImpl headers{};
     EXPECT_EQ(0UL, headers.size());
     EXPECT_TRUE(headers.empty());
 
@@ -1093,11 +1098,12 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
 
   // Starting with a normal header
   {
-    auto headers = createHeaderMap<HeaderMapImpl>({{Headers::get().ContentType, "text/plain"},
-                                                   {Headers::get().Method, "GET"},
-                                                   {Headers::get().Path, "/"},
-                                                   {LowerCaseString("hello"), "world"},
-                                                   {Headers::get().Host, "host"}});
+    auto headers =
+        createHeaderMap<VerifiedHeaderMapImpl>({{Headers::get().ContentType, "text/plain"},
+                                                {Headers::get().Method, "GET"},
+                                                {Headers::get().Path, "/"},
+                                                {LowerCaseString("hello"), "world"},
+                                                {Headers::get().Host, "host"}});
 
     InSequence seq;
     EXPECT_CALL(cb, Call(":method", "GET"));
@@ -1117,11 +1123,12 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
 
   // Starting with a pseudo-header
   {
-    auto headers = createHeaderMap<HeaderMapImpl>({{Headers::get().Path, "/"},
-                                                   {Headers::get().ContentType, "text/plain"},
-                                                   {Headers::get().Method, "GET"},
-                                                   {LowerCaseString("hello"), "world"},
-                                                   {Headers::get().Host, "host"}});
+    auto headers =
+        createHeaderMap<VerifiedHeaderMapImpl>({{Headers::get().Path, "/"},
+                                                {Headers::get().ContentType, "text/plain"},
+                                                {Headers::get().Method, "GET"},
+                                                {LowerCaseString("hello"), "world"},
+                                                {Headers::get().Host, "host"}});
 
     InSequence seq;
     EXPECT_CALL(cb, Call(":path", "/"));
@@ -1176,14 +1183,14 @@ TEST(HeaderMapImplTest, HostHeader) {
 }
 
 TEST(HeaderMapImplTest, TestInlineHeaderAdd) {
-  TestRequestHeaderMapImpl foo;
+  VerifiedHeaderMapImpl foo;
   foo.addCopy(LowerCaseString(":path"), "GET");
   EXPECT_EQ(foo.size(), 1);
   EXPECT_TRUE(foo.Path() != nullptr);
 }
 
 TEST(HeaderMapImplTest, ClearHeaderMap) {
-  TestRequestHeaderMapImpl headers;
+  VerifiedHeaderMapImpl headers;
   LowerCaseString static_key("hello");
   std::string ref_value("value");
 
@@ -1226,14 +1233,14 @@ TEST(HeaderMapImplTest, ClearHeaderMap) {
 // Validates byte size is properly accounted for in different inline header setting scenarios.
 TEST(HeaderMapImplTest, InlineHeaderByteSize) {
   {
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     std::string foo = "foo";
     headers.setHost(foo);
     EXPECT_EQ(headers.byteSize(), 13);
   }
   {
     // Overwrite an inline headers with set.
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     std::string foo = "foo";
     headers.setHost(foo);
     std::string big_foo = "big_foo";
@@ -1242,7 +1249,7 @@ TEST(HeaderMapImplTest, InlineHeaderByteSize) {
   }
   {
     // Overwrite an inline headers with setReference and clear.
-    TestRequestHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     std::string foo = "foo";
     headers.setHost(foo);
     std::string big_foo = "big_foo";
@@ -1253,7 +1260,7 @@ TEST(HeaderMapImplTest, InlineHeaderByteSize) {
   }
   {
     // Overwrite an inline headers with set integer value.
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     uint64_t status = 200;
     headers.setStatus(status);
     EXPECT_EQ(headers.byteSize(), 10);
@@ -1265,7 +1272,7 @@ TEST(HeaderMapImplTest, InlineHeaderByteSize) {
   }
   {
     // Set an inline header, remove, and rewrite.
-    TestResponseHeaderMapImpl headers;
+    VerifiedHeaderMapImpl headers;
     uint64_t status = 200;
     headers.setStatus(status);
     EXPECT_EQ(headers.byteSize(), 10);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -711,7 +711,7 @@ TEST_P(Http2CodecImplFlowControlTest, TestFlowControlInPendingSendData) {
 
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
-  TestHeaderMapImpl expected_headers;
+  TestRequestHeaderMapImpl expected_headers;
   HttpTestUtility::addDefaultHeaders(expected_headers);
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   request_encoder_->encodeHeaders(request_headers, false);
@@ -811,7 +811,7 @@ TEST_P(Http2CodecImplFlowControlTest, EarlyResetRestoresWindow) {
 
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
-  TestHeaderMapImpl expected_headers;
+  TestRequestHeaderMapImpl expected_headers;
   HttpTestUtility::addDefaultHeaders(expected_headers);
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   request_encoder_->encodeHeaders(request_headers, false);
@@ -870,7 +870,7 @@ TEST_P(Http2CodecImplFlowControlTest, FlowControlPendingRecvData) {
 
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
-  TestHeaderMapImpl expected_headers;
+  TestRequestHeaderMapImpl expected_headers;
   HttpTestUtility::addDefaultHeaders(expected_headers);
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   request_encoder_->encodeHeaders(request_headers, false);

--- a/test/common/http/http2/frame_replay_test.cc
+++ b/test/common/http/http2/frame_replay_test.cc
@@ -62,7 +62,7 @@ TEST_F(RequestFrameCommentTest, SimpleExampleHuffman) {
   codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection);
   codec.write(WellKnownFrames::defaultSettingsFrame(), connection);
   codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection);
-  TestHeaderMapImpl expected_headers;
+  TestRequestHeaderMapImpl expected_headers;
   HttpTestUtility::addDefaultHeaders(expected_headers);
   expected_headers.addCopy("foo", "barbaz");
   EXPECT_CALL(codec.request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
@@ -138,7 +138,7 @@ TEST_F(RequestFrameCommentTest, SimpleExamplePlain) {
   codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection);
   codec.write(WellKnownFrames::defaultSettingsFrame(), connection);
   codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection);
-  TestHeaderMapImpl expected_headers;
+  TestRequestHeaderMapImpl expected_headers;
   HttpTestUtility::addDefaultHeaders(expected_headers);
   expected_headers.addCopy("foo", "barbaz");
   EXPECT_CALL(codec.request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), true));

--- a/test/common/http/path_utility_test.cc
+++ b/test/common/http/path_utility_test.cc
@@ -18,7 +18,7 @@ public:
     headers_.setPath(path_value);
     return *headers_.Path();
   }
-  HeaderMapImpl headers_;
+  RequestHeaderMapImpl headers_;
 };
 
 // Already normalized path don't change.

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -37,8 +37,9 @@ TEST(UserAgentTest, All) {
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa iOS bbb"}}, "test.", stat_store);
-    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
+    ua.initializeFromHeaders(TestRequestHeaderMapImpl{{"user-agent", "aaa iOS bbb"}}, "test.",
+                             stat_store);
+    ua.initializeFromHeaders(TestRequestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
                              stat_store);
     ua.completeConnectionLength(span);
   }
@@ -56,7 +57,7 @@ TEST(UserAgentTest, All) {
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
+    ua.initializeFromHeaders(TestRequestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
                              stat_store);
     ua.completeConnectionLength(span);
     ua.onConnectionDestroy(Network::ConnectionEvent::RemoteClose, true);
@@ -64,8 +65,9 @@ TEST(UserAgentTest, All) {
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa bbb"}}, "test.", stat_store);
-    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
+    ua.initializeFromHeaders(TestRequestHeaderMapImpl{{"user-agent", "aaa bbb"}}, "test.",
+                             stat_store);
+    ua.initializeFromHeaders(TestRequestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
                              stat_store);
     ua.completeConnectionLength(span);
     ua.onConnectionDestroy(Network::ConnectionEvent::RemoteClose, false);
@@ -73,7 +75,7 @@ TEST(UserAgentTest, All) {
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(TestHeaderMapImpl{}, "test.", stat_store);
+    ua.initializeFromHeaders(TestRequestHeaderMapImpl{}, "test.", stat_store);
     ua.completeConnectionLength(span);
   }
 }

--- a/test/common/http/utility_fuzz_test.cc
+++ b/test/common/http/utility_fuzz_test.cc
@@ -28,7 +28,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::UtilityTestCase& input) {
   case test::common::http::UtilityTestCase::kGetLastAddressFromXff: {
     const auto& get_last_address_from_xff = input.get_last_address_from_xff();
     // Use the production HeaderMapImpl to avoid timeouts from TestHeaderMapImpl asserts.
-    Http::HeaderMapImpl headers;
+    Http::RequestHeaderMapImpl headers;
     headers.addCopy(Http::LowerCaseString("x-forwarded-for"),
                     replaceInvalidCharacters(get_last_address_from_xff.xff()));
     // Take num_to_skip modulo 32 to avoid wasting time in lala land.

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -41,49 +41,55 @@ TEST(HttpUtility, parseQueryString) {
 }
 
 TEST(HttpUtility, getResponseStatus) {
-  EXPECT_THROW(Utility::getResponseStatus(TestHeaderMapImpl{}), CodecClientException);
-  EXPECT_EQ(200U, Utility::getResponseStatus(TestHeaderMapImpl{{":status", "200"}}));
+  EXPECT_THROW(Utility::getResponseStatus(TestResponseHeaderMapImpl{}), CodecClientException);
+  EXPECT_EQ(200U, Utility::getResponseStatus(TestResponseHeaderMapImpl{{":status", "200"}}));
 }
 
 TEST(HttpUtility, isWebSocketUpgradeRequest) {
-  EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(TestHeaderMapImpl{}));
-  EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(TestHeaderMapImpl{{"connection", "upgrade"}}));
-  EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(TestHeaderMapImpl{{"upgrade", "websocket"}}));
+  EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(TestRequestHeaderMapImpl{}));
+  EXPECT_FALSE(
+      Utility::isWebSocketUpgradeRequest(TestRequestHeaderMapImpl{{"connection", "upgrade"}}));
+  EXPECT_FALSE(
+      Utility::isWebSocketUpgradeRequest(TestRequestHeaderMapImpl{{"upgrade", "websocket"}}));
   EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(
-      TestHeaderMapImpl{{"Connection", "close"}, {"Upgrade", "websocket"}}));
+      TestRequestHeaderMapImpl{{"Connection", "close"}, {"Upgrade", "websocket"}}));
   EXPECT_FALSE(Utility::isUpgrade(
-      TestHeaderMapImpl{{"Connection", "IsNotAnUpgrade"}, {"Upgrade", "websocket"}}));
+      TestRequestHeaderMapImpl{{"Connection", "IsNotAnUpgrade"}, {"Upgrade", "websocket"}}));
 
   EXPECT_TRUE(Utility::isWebSocketUpgradeRequest(
-      TestHeaderMapImpl{{"Connection", "upgrade"}, {"Upgrade", "websocket"}}));
+      TestRequestHeaderMapImpl{{"Connection", "upgrade"}, {"Upgrade", "websocket"}}));
   EXPECT_TRUE(Utility::isWebSocketUpgradeRequest(
-      TestHeaderMapImpl{{"connection", "upgrade"}, {"upgrade", "websocket"}}));
+      TestRequestHeaderMapImpl{{"connection", "upgrade"}, {"upgrade", "websocket"}}));
   EXPECT_TRUE(Utility::isWebSocketUpgradeRequest(
-      TestHeaderMapImpl{{"connection", "Upgrade"}, {"upgrade", "WebSocket"}}));
+      TestRequestHeaderMapImpl{{"connection", "Upgrade"}, {"upgrade", "WebSocket"}}));
 }
 
 TEST(HttpUtility, isUpgrade) {
-  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{}));
-  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{{"connection", "upgrade"}}));
-  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{{"upgrade", "foo"}}));
-  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{{"Connection", "close"}, {"Upgrade", "foo"}}));
+  EXPECT_FALSE(Utility::isUpgrade(TestRequestHeaderMapImpl{}));
+  EXPECT_FALSE(Utility::isUpgrade(TestRequestHeaderMapImpl{{"connection", "upgrade"}}));
+  EXPECT_FALSE(Utility::isUpgrade(TestRequestHeaderMapImpl{{"upgrade", "foo"}}));
   EXPECT_FALSE(
-      Utility::isUpgrade(TestHeaderMapImpl{{"Connection", "IsNotAnUpgrade"}, {"Upgrade", "foo"}}));
+      Utility::isUpgrade(TestRequestHeaderMapImpl{{"Connection", "close"}, {"Upgrade", "foo"}}));
   EXPECT_FALSE(Utility::isUpgrade(
-      TestHeaderMapImpl{{"Connection", "Is Not An Upgrade"}, {"Upgrade", "foo"}}));
+      TestRequestHeaderMapImpl{{"Connection", "IsNotAnUpgrade"}, {"Upgrade", "foo"}}));
+  EXPECT_FALSE(Utility::isUpgrade(
+      TestRequestHeaderMapImpl{{"Connection", "Is Not An Upgrade"}, {"Upgrade", "foo"}}));
 
-  EXPECT_TRUE(Utility::isUpgrade(TestHeaderMapImpl{{"Connection", "upgrade"}, {"Upgrade", "foo"}}));
-  EXPECT_TRUE(Utility::isUpgrade(TestHeaderMapImpl{{"connection", "upgrade"}, {"upgrade", "foo"}}));
-  EXPECT_TRUE(Utility::isUpgrade(TestHeaderMapImpl{{"connection", "Upgrade"}, {"upgrade", "FoO"}}));
+  EXPECT_TRUE(
+      Utility::isUpgrade(TestRequestHeaderMapImpl{{"Connection", "upgrade"}, {"Upgrade", "foo"}}));
+  EXPECT_TRUE(
+      Utility::isUpgrade(TestRequestHeaderMapImpl{{"connection", "upgrade"}, {"upgrade", "foo"}}));
+  EXPECT_TRUE(
+      Utility::isUpgrade(TestRequestHeaderMapImpl{{"connection", "Upgrade"}, {"upgrade", "FoO"}}));
   EXPECT_TRUE(Utility::isUpgrade(
-      TestHeaderMapImpl{{"connection", "keep-alive, Upgrade"}, {"upgrade", "FOO"}}));
+      TestRequestHeaderMapImpl{{"connection", "keep-alive, Upgrade"}, {"upgrade", "FOO"}}));
 }
 
 // Start with H1 style websocket request headers. Transform to H2 and back.
 TEST(HttpUtility, H1H2H1Request) {
-  TestHeaderMapImpl converted_headers = {
+  TestRequestHeaderMapImpl converted_headers = {
       {":method", "GET"}, {"Upgrade", "foo"}, {"Connection", "upgrade"}};
-  const TestHeaderMapImpl original_headers(converted_headers);
+  const TestRequestHeaderMapImpl original_headers(converted_headers);
 
   ASSERT_TRUE(Utility::isUpgrade(converted_headers));
   ASSERT_FALSE(Utility::isH2UpgradeRequest(converted_headers));
@@ -100,8 +106,8 @@ TEST(HttpUtility, H1H2H1Request) {
 
 // Start with H2 style websocket request headers. Transform to H1 and back.
 TEST(HttpUtility, H2H1H2Request) {
-  TestHeaderMapImpl converted_headers = {{":method", "CONNECT"}, {":protocol", "websocket"}};
-  const TestHeaderMapImpl original_headers(converted_headers);
+  TestRequestHeaderMapImpl converted_headers = {{":method", "CONNECT"}, {":protocol", "websocket"}};
+  const TestRequestHeaderMapImpl original_headers(converted_headers);
 
   ASSERT_FALSE(Utility::isUpgrade(converted_headers));
   ASSERT_TRUE(Utility::isH2UpgradeRequest(converted_headers));
@@ -119,9 +125,9 @@ TEST(HttpUtility, H2H1H2Request) {
 
 // Start with H1 style websocket response headers. Transform to H2 and back.
 TEST(HttpUtility, H1H2H1Response) {
-  TestHeaderMapImpl converted_headers = {
+  TestResponseHeaderMapImpl converted_headers = {
       {":status", "101"}, {"upgrade", "websocket"}, {"connection", "upgrade"}};
-  const TestHeaderMapImpl original_headers(converted_headers);
+  const TestResponseHeaderMapImpl original_headers(converted_headers);
 
   ASSERT_TRUE(Utility::isUpgrade(converted_headers));
   Utility::transformUpgradeResponseFromH1toH2(converted_headers);
@@ -137,10 +143,10 @@ TEST(HttpUtility, H1H2H1Response) {
 // identical. Because the headers are always added in a set order, the original
 // header order may not be preserved.
 TEST(HttpUtility, OrderNotPreserved) {
-  TestHeaderMapImpl expected_headers = {
+  TestRequestHeaderMapImpl expected_headers = {
       {":method", "GET"}, {"Upgrade", "foo"}, {"Connection", "upgrade"}};
 
-  TestHeaderMapImpl converted_headers = {
+  TestRequestHeaderMapImpl converted_headers = {
       {":method", "GET"}, {"Connection", "upgrade"}, {"Upgrade", "foo"}};
 
   Utility::transformUpgradeRequestFromH1toH2(converted_headers);
@@ -153,10 +159,10 @@ TEST(HttpUtility, OrderNotPreserved) {
 // POST. This is a documented weakness in Envoy docs and can be addressed with
 // a custom x-envoy-original-method header if it is ever needed.
 TEST(HttpUtility, MethodNotPreserved) {
-  TestHeaderMapImpl expected_headers = {
+  TestRequestHeaderMapImpl expected_headers = {
       {":method", "GET"}, {"Upgrade", "foo"}, {"Connection", "upgrade"}};
 
-  TestHeaderMapImpl converted_headers = {
+  TestRequestHeaderMapImpl converted_headers = {
       {":method", "POST"}, {"Upgrade", "foo"}, {"Connection", "upgrade"}};
 
   Utility::transformUpgradeRequestFromH1toH2(converted_headers);
@@ -183,20 +189,20 @@ TEST(HttpUtility, ContentLengthMangling) {
 
   // Content-Length of 0 is removed on the response path.
   {
-    TestHeaderMapImpl response_headers = {{":status", "101"},
-                                          {"upgrade", "websocket"},
-                                          {"connection", "upgrade"},
-                                          {"content-length", "0"}};
+    TestResponseHeaderMapImpl response_headers = {{":status", "101"},
+                                                  {"upgrade", "websocket"},
+                                                  {"connection", "upgrade"},
+                                                  {"content-length", "0"}};
     Utility::transformUpgradeResponseFromH1toH2(response_headers);
     EXPECT_TRUE(response_headers.ContentLength() == nullptr);
   }
 
   // Non-zero Content-Length is not removed on the response path.
   {
-    TestHeaderMapImpl response_headers = {{":status", "101"},
-                                          {"upgrade", "websocket"},
-                                          {"connection", "upgrade"},
-                                          {"content-length", "1"}};
+    TestResponseHeaderMapImpl response_headers = {{":status", "101"},
+                                                  {"upgrade", "websocket"},
+                                                  {"connection", "upgrade"},
+                                                  {"content-length", "1"}};
     Utility::transformUpgradeResponseFromH1toH2(response_headers);
     EXPECT_FALSE(response_headers.ContentLength() == nullptr);
   }
@@ -204,21 +210,21 @@ TEST(HttpUtility, ContentLengthMangling) {
 
 TEST(HttpUtility, appendXff) {
   {
-    TestHeaderMapImpl headers;
+    TestRequestHeaderMapImpl headers;
     Network::Address::Ipv4Instance address("127.0.0.1");
     Utility::appendXff(headers, address);
     EXPECT_EQ("127.0.0.1", headers.get_("x-forwarded-for"));
   }
 
   {
-    TestHeaderMapImpl headers{{"x-forwarded-for", "10.0.0.1"}};
+    TestRequestHeaderMapImpl headers{{"x-forwarded-for", "10.0.0.1"}};
     Network::Address::Ipv4Instance address("127.0.0.1");
     Utility::appendXff(headers, address);
     EXPECT_EQ("10.0.0.1,127.0.0.1", headers.get_("x-forwarded-for"));
   }
 
   {
-    TestHeaderMapImpl headers{{"x-forwarded-for", "10.0.0.1"}};
+    TestRequestHeaderMapImpl headers{{"x-forwarded-for", "10.0.0.1"}};
     Network::Address::PipeInstance address("/foo");
     Utility::appendXff(headers, address);
     EXPECT_EQ("10.0.0.1", headers.get_("x-forwarded-for"));
@@ -227,13 +233,13 @@ TEST(HttpUtility, appendXff) {
 
 TEST(HttpUtility, appendVia) {
   {
-    TestHeaderMapImpl headers;
+    TestResponseHeaderMapImpl headers;
     Utility::appendVia(headers, "foo");
     EXPECT_EQ("foo", headers.get_("via"));
   }
 
   {
-    TestHeaderMapImpl headers{{"via", "foo"}};
+    TestResponseHeaderMapImpl headers{{"via", "foo"}};
     Utility::appendVia(headers, "bar");
     EXPECT_EQ("foo, bar", headers.get_("via"));
   }
@@ -241,7 +247,7 @@ TEST(HttpUtility, appendVia) {
 
 TEST(HttpUtility, createSslRedirectPath) {
   {
-    TestHeaderMapImpl headers{{":authority", "www.lyft.com"}, {":path", "/hello"}};
+    TestRequestHeaderMapImpl headers{{":authority", "www.lyft.com"}, {":path", "/hello"}};
     EXPECT_EQ("https://www.lyft.com/hello", Utility::createSslRedirectPath(headers));
   }
 }
@@ -456,7 +462,7 @@ TEST(HttpUtility, SendLocalGrpcReply) {
   bool is_reset = false;
 
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.Status()->value().getStringView(), "200");
         EXPECT_NE(headers.GrpcStatus(), nullptr);
         EXPECT_EQ(headers.GrpcStatus()->value().getStringView(),
@@ -482,7 +488,7 @@ TEST(HttpUtility, SendLocalGrpcReplyWithUpstreamJsonPayload) {
   )EOF";
 
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.Status()->value().getStringView(), "200");
         EXPECT_NE(headers.GrpcStatus(), nullptr);
         EXPECT_EQ(headers.GrpcStatus()->value().getStringView(),
@@ -499,7 +505,7 @@ TEST(HttpUtility, RateLimitedGrpcStatus) {
   MockStreamDecoderFilterCallbacks callbacks;
 
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(headers.GrpcStatus(), nullptr);
         EXPECT_EQ(headers.GrpcStatus()->value().getStringView(),
                   std::to_string(enumToInt(Grpc::Status::WellKnownGrpcStatus::Unavailable)));
@@ -508,7 +514,7 @@ TEST(HttpUtility, RateLimitedGrpcStatus) {
                           false);
 
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(headers.GrpcStatus(), nullptr);
         EXPECT_EQ(headers.GrpcStatus()->value().getStringView(),
                   std::to_string(enumToInt(Grpc::Status::WellKnownGrpcStatus::ResourceExhausted)));
@@ -535,7 +541,7 @@ TEST(HttpUtility, SendLocalReplyHeadRequest) {
   MockStreamDecoderFilterCallbacks callbacks;
   bool is_reset = false;
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.ContentLength()->value().getStringView(),
                   fmt::format("{}", strlen("large")));
       }));

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -825,7 +825,7 @@ TEST(HeaderParserTest, TestParseInternal) {
       new NiceMock<Envoy::Upstream::MockHostDescription>());
   ON_CALL(stream_info, upstreamHost()).WillByDefault(Return(host));
 
-  Http::HeaderMapImpl request_headers;
+  Http::RequestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::LowerCaseString(std::string("x-request-id")), 123);
   ON_CALL(stream_info, getRequestHeaders()).WillByDefault(Return(&request_headers));
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -112,7 +112,7 @@ http_filters:
     outer_init_manager_.initialize(init_watcher_);
   }
 
-  RouteConstSharedPtr route(Http::TestHeaderMapImpl headers) {
+  RouteConstSharedPtr route(Http::TestRequestHeaderMapImpl headers) {
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
     headers.addCopy("x-forwarded-proto", "http");
     return rds_->config()->route(headers, stream_info, 0);

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -35,11 +35,11 @@ public:
   }
 
   void setup() {
-    Http::TestHeaderMapImpl headers;
+    Http::TestRequestHeaderMapImpl headers;
     setup(headers);
   }
 
-  void setup(Http::HeaderMap& request_headers) {
+  void setup(Http::RequestHeaderMap& request_headers) {
     state_ = RetryStateImpl::create(policy_, request_headers, cluster_, runtime_, random_,
                                     dispatcher_, Upstream::ResourcePriority::Default);
   }
@@ -973,11 +973,11 @@ TEST_F(RouterRetryStateImplTest, NoPreferredOverLimitExceeded) {
                                                  {"x-envoy-max-retries", "1"}};
   setup(request_headers);
 
-  Http::TestHeaderMapImpl bad_response_headers{{":status", "503"}};
+  Http::TestResponseHeaderMapImpl bad_response_headers{{":status", "503"}};
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(bad_response_headers, callback_));
 
-  Http::TestHeaderMapImpl good_response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl good_response_headers{{":status", "200"}};
   EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(good_response_headers, callback_));
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -68,9 +68,9 @@ actions:
                           "value length must be at least");
 }
 
-static Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::string& path,
-                                          const std::string& method) {
-  return Http::TestHeaderMapImpl{
+static Http::TestRequestHeaderMapImpl genHeaders(const std::string& host, const std::string& path,
+                                                 const std::string& method) {
+  return Http::TestRequestHeaderMapImpl{
       {":authority", host}, {":path", path}, {":method", method}, {"x-forwarded-proto", "http"}};
 }
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -60,8 +60,9 @@ public:
   using Filter::Filter;
 
   // Filter
-  RetryStatePtr createRetryState(const RetryPolicy&, Http::HeaderMap&, const Upstream::ClusterInfo&,
-                                 Runtime::Loader&, Runtime::RandomGenerator&, Event::Dispatcher&,
+  RetryStatePtr createRetryState(const RetryPolicy&, Http::RequestHeaderMap&,
+                                 const Upstream::ClusterInfo&, Runtime::Loader&,
+                                 Runtime::RandomGenerator&, Event::Dispatcher&,
                                  Upstream::ResourcePriority) override {
     EXPECT_EQ(nullptr, retry_state_);
     retry_state_ = new NiceMock<MockRetryState>();

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -225,7 +225,7 @@ TEST_F(StreamInfoImplTest, RequestHeadersTest) {
   StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem());
   EXPECT_FALSE(stream_info.getRequestHeaders());
 
-  Http::HeaderMapImpl headers;
+  Http::RequestHeaderMapImpl headers;
   stream_info.setRequestHeaders(headers);
   EXPECT_EQ(&headers, stream_info.getRequestHeaders());
 }

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -201,9 +201,11 @@ public:
     return upstream_transport_failure_reason_;
   }
 
-  void setRequestHeaders(const Http::HeaderMap& headers) override { request_headers_ = &headers; }
+  void setRequestHeaders(const Http::RequestHeaderMap& headers) override {
+    request_headers_ = &headers;
+  }
 
-  const Http::HeaderMap* getRequestHeaders() const override { return request_headers_; }
+  const Http::RequestHeaderMap* getRequestHeaders() const override { return request_headers_; }
 
   Event::TimeSystem& timeSystem() { return test_time_.timeSystem(); }
 
@@ -241,7 +243,7 @@ public:
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
   std::string requested_server_name_;
   std::string upstream_transport_failure_reason_;
-  const Http::HeaderMap* request_headers_{};
+  const Http::RequestHeaderMap* request_headers_{};
   Envoy::Event::SimulatedTimeSystem test_time_;
 };
 

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -48,18 +48,18 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
   std::string forced_guid = random.uuid();
   UuidUtils::setTraceableUuid(forced_guid, UuidTraceStatus::Forced);
-  Http::TestHeaderMapImpl forced_header{{"x-request-id", forced_guid}};
+  Http::TestRequestHeaderMapImpl forced_header{{"x-request-id", forced_guid}};
 
   std::string sampled_guid = random.uuid();
   UuidUtils::setTraceableUuid(sampled_guid, UuidTraceStatus::Sampled);
-  Http::TestHeaderMapImpl sampled_header{{"x-request-id", sampled_guid}};
+  Http::TestRequestHeaderMapImpl sampled_header{{"x-request-id", sampled_guid}};
 
   std::string client_guid = random.uuid();
   UuidUtils::setTraceableUuid(client_guid, UuidTraceStatus::Client);
-  Http::TestHeaderMapImpl client_header{{"x-request-id", client_guid}};
+  Http::TestRequestHeaderMapImpl client_header{{"x-request-id", client_guid}};
 
-  Http::TestHeaderMapImpl not_traceable_header{{"x-request-id", not_traceable_guid}};
-  Http::TestHeaderMapImpl empty_header{};
+  Http::TestRequestHeaderMapImpl not_traceable_header{{"x-request-id", not_traceable_guid}};
+  Http::TestRequestHeaderMapImpl empty_header{};
 
   // Force traced.
   {
@@ -81,7 +81,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
   // Health Check request.
   {
-    Http::TestHeaderMapImpl traceable_header_hc{{"x-request-id", forced_guid}};
+    Http::TestRequestHeaderMapImpl traceable_header_hc{{"x-request-id", forced_guid}};
     EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(true));
 
     Decision result = HttpTracerUtility::isTracing(stream_info, traceable_header_hc);
@@ -100,7 +100,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
   // No request id.
   {
-    Http::TestHeaderMapImpl headers;
+    Http::TestRequestHeaderMapImpl headers;
     EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(false));
     Decision result = HttpTracerUtility::isTracing(stream_info, headers);
     EXPECT_EQ(Reason::NotTraceableRequestId, result.reason);
@@ -109,7 +109,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
   // Broken request id.
   {
-    Http::TestHeaderMapImpl headers{{"x-request-id", "not-real-x-request-id"}};
+    Http::TestRequestHeaderMapImpl headers{{"x-request-id", "not-real-x-request-id"}};
     EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(false));
     Decision result = HttpTracerUtility::isTracing(stream_info, headers);
     EXPECT_EQ(Reason::NotTraceableRequestId, result.reason);
@@ -350,12 +350,12 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
 }
 
 TEST_F(HttpConnManFinalizerImplTest, UnixDomainSocketPeerAddressTag) {
-  Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
-                                          {":path", "/test"},
-                                          {":method", "GET"},
-                                          {"x-forwarded-proto", "https"}};
-  Http::TestHeaderMapImpl response_headers;
-  Http::TestHeaderMapImpl response_trailers;
+  Http::TestRequestHeaderMapImpl request_headers{{"x-request-id", "id"},
+                                                 {":path", "/test"},
+                                                 {":method", "GET"},
+                                                 {"x-forwarded-proto", "https"}};
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
   const std::string path_{TestEnvironment::unixDomainSocketPath("foo")};
   const auto remote_address = Network::Utility::resolveUrl("unix://" + path_);
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1046,7 +1046,7 @@ TEST_F(HttpHealthCheckerImplTest, ZeroRetryInterval) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
         EXPECT_EQ(headers.Scheme()->value().getStringView(),
@@ -1125,7 +1125,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
         EXPECT_EQ(headers.Scheme()->value().getStringView(),
@@ -1160,7 +1160,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServicePrefixPatternCheck) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
         EXPECT_EQ(headers.Scheme()->value().getStringView(),
@@ -1195,7 +1195,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceExactPatternCheck) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
         EXPECT_EQ(headers.Scheme()->value().getStringView(),
@@ -1230,7 +1230,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceRegexPatternCheck) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
         EXPECT_EQ(headers.Scheme()->value().getStringView(),
@@ -1266,7 +1266,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValue) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
       }));
@@ -1329,7 +1329,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillRepeatedly(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillRepeatedly(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.get(header_ok)->value().getStringView(), value_ok);
         EXPECT_EQ(headers.get(header_cool)->value().getStringView(), value_cool);
         EXPECT_EQ(headers.get(header_awesome)->value().getStringView(), value_awesome);
@@ -1391,8 +1391,9 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillRepeatedly(Invoke(
-          [&](const Http::HeaderMap& headers, bool) { EXPECT_EQ(headers.UserAgent(), nullptr); }));
+      .WillRepeatedly(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
+        EXPECT_EQ(headers.UserAgent(), nullptr);
+      }));
   health_checker_->start();
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("health_check.max_interval", _));
@@ -2324,7 +2325,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAltPort) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
       }));
@@ -2520,7 +2521,7 @@ TEST_F(HttpHealthCheckerImplTest, DEPRECATED_FEATURE_TEST(ServiceNameMatch)) {
   expectStreamCreate(0);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+      .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
         EXPECT_EQ(headers.Host()->value().getStringView(), host);
         EXPECT_EQ(headers.Path()->value().getStringView(), path);
         EXPECT_EQ(headers.Scheme()->value().getStringView(),
@@ -3672,7 +3673,7 @@ public:
     expectHealthcheckStart(0);
 
     EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, false))
-        .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
+        .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) {
           EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
                     headers.ContentType()->value().getStringView());
           EXPECT_EQ(std::string("/grpc.health.v1.Health/Check"),

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -44,17 +44,20 @@ public:
   TestLoadBalancerContext(const Network::Connection* connection, const std::string& key,
                           const std::string& value)
       : connection_(connection) {
-    downstream_headers_ = Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{key, value}}};
+    downstream_headers_ =
+        Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{{key, value}}};
   }
 
   // Upstream::LoadBalancerContext
   absl::optional<uint64_t> computeHashKey() override { return 0; }
   const Network::Connection* downstreamConnection() const override { return connection_; }
-  const Http::HeaderMap* downstreamHeaders() const override { return downstream_headers_.get(); }
+  const Http::RequestHeaderMap* downstreamHeaders() const override {
+    return downstream_headers_.get();
+  }
 
   absl::optional<uint64_t> hash_key_;
   const Network::Connection* connection_;
-  Http::HeaderMapPtr downstream_headers_;
+  Http::RequestHeaderMapPtr downstream_headers_;
 };
 
 class OriginalDstClusterTest : public testing::Test {

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -110,7 +110,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return {}; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return matches_.get(); }
-  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
+  const Http::RequestHeaderMap* downstreamHeaders() const override { return nullptr; }
 
 private:
   const std::shared_ptr<Router::MetadataMatchCriteria> matches_;

--- a/test/extensions/access_loggers/common/access_log_base_test.cc
+++ b/test/extensions/access_loggers/common/access_log_base_test.cc
@@ -23,8 +23,8 @@ public:
   int count() { return count_; };
 
 private:
-  void emitLog(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
-               const StreamInfo::StreamInfo&) override {
+  void emitLog(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+               const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&) override {
     count_++;
   }
 

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -123,7 +123,7 @@ public:
   Upstream::LoadBalancerFactorySharedPtr lb_factory_;
   Upstream::LoadBalancerPtr lb_;
   NiceMock<Upstream::MockLoadBalancerContext> lb_context_;
-  Http::TestHeaderMapImpl downstream_headers_;
+  Http::TestRequestHeaderMapImpl downstream_headers_;
   Extensions::Common::DynamicForwardProxy::DnsCache::UpdateCallbacks* update_callbacks_{};
   absl::flat_hash_map<std::string,
                       std::shared_ptr<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>>

--- a/test/extensions/common/aws/utility_test.cc
+++ b/test/extensions/common/aws/utility_test.cc
@@ -15,7 +15,7 @@ namespace {
 
 // Headers must be in alphabetical order by virtue of std::map
 TEST(UtilityTest, CanonicalizeHeadersInAlphabeticalOrder) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {"d", "d_value"}, {"f", "f_value"}, {"b", "b_value"},
       {"e", "e_value"}, {"c", "c_value"}, {"a", "a_value"},
   };
@@ -26,7 +26,7 @@ TEST(UtilityTest, CanonicalizeHeadersInAlphabeticalOrder) {
 
 // HTTP pseudo-headers should be ignored
 TEST(UtilityTest, CanonicalizeHeadersSkippingPseudoHeaders) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":path", "path_value"},
       {":method", "GET"},
       {"normal", "normal_value"},
@@ -37,7 +37,7 @@ TEST(UtilityTest, CanonicalizeHeadersSkippingPseudoHeaders) {
 
 // Repeated headers are joined with commas
 TEST(UtilityTest, CanonicalizeHeadersJoiningDuplicatesWithCommas) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {"a", "a_value1"},
       {"a", "a_value2"},
       {"a", "a_value3"},
@@ -48,7 +48,7 @@ TEST(UtilityTest, CanonicalizeHeadersJoiningDuplicatesWithCommas) {
 
 // We canonicalize the :authority header as host
 TEST(UtilityTest, CanonicalizeHeadersAuthorityToHost) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":authority", "authority_value"},
   };
   const auto map = Utility::canonicalizeHeaders(headers);
@@ -57,13 +57,13 @@ TEST(UtilityTest, CanonicalizeHeadersAuthorityToHost) {
 
 // Ports 80 and 443 are omitted from the host headers
 TEST(UtilityTest, CanonicalizeHeadersRemovingDefaultPortsFromHost) {
-  Http::TestHeaderMapImpl headers_port80{
+  Http::TestRequestHeaderMapImpl headers_port80{
       {":authority", "example.com:80"},
   };
   const auto map_port80 = Utility::canonicalizeHeaders(headers_port80);
   EXPECT_THAT(map_port80, ElementsAre(Pair("host", "example.com")));
 
-  Http::TestHeaderMapImpl headers_port443{
+  Http::TestRequestHeaderMapImpl headers_port443{
       {":authority", "example.com:443"},
   };
   const auto map_port443 = Utility::canonicalizeHeaders(headers_port443);
@@ -72,7 +72,7 @@ TEST(UtilityTest, CanonicalizeHeadersRemovingDefaultPortsFromHost) {
 
 // Whitespace is trimmed from headers
 TEST(UtilityTest, CanonicalizeHeadersTrimmingWhitespace) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {"leading", "    leading value"},
       {"trailing", "trailing value    "},
       {"internal", "internal    value"},

--- a/test/extensions/common/tap/common.h
+++ b/test/extensions/common/tap/common.h
@@ -53,13 +53,17 @@ public:
 
   MOCK_METHOD(void, onNewStream, (MatchStatusVector & statuses), (const));
   MOCK_METHOD(void, onHttpRequestHeaders,
-              (const Http::HeaderMap& request_headers, MatchStatusVector& statuses), (const));
+              (const Http::RequestHeaderMap& request_headers, MatchStatusVector& statuses),
+              (const));
   MOCK_METHOD(void, onHttpRequestTrailers,
-              (const Http::HeaderMap& request_trailers, MatchStatusVector& statuses), (const));
+              (const Http::RequestTrailerMap& request_trailers, MatchStatusVector& statuses),
+              (const));
   MOCK_METHOD(void, onHttpResponseHeaders,
-              (const Http::HeaderMap& response_headers, MatchStatusVector& statuses), (const));
+              (const Http::ResponseHeaderMap& response_headers, MatchStatusVector& statuses),
+              (const));
   MOCK_METHOD(void, onHttpResponseTrailers,
-              (const Http::HeaderMap& response_trailers, MatchStatusVector& statuses), (const));
+              (const Http::ResponseTrailerMap& response_trailers, MatchStatusVector& statuses),
+              (const));
 };
 
 } // namespace Tap

--- a/test/extensions/common/tap/tap_matcher_test.cc
+++ b/test/extensions/common/tap/tap_matcher_test.cc
@@ -19,7 +19,10 @@ public:
   std::vector<MatcherPtr> matchers_;
   Matcher::MatchStatusVector statuses_;
   envoy::config::tap::v3::MatchPredicate config_;
-  Http::TestHeaderMapImpl headers_;
+  Http::TestRequestHeaderMapImpl request_headers_;
+  Http::TestRequestTrailerMapImpl request_trailers_;
+  Http::TestResponseHeaderMapImpl response_headers_;
+  Http::TestResponseTrailerMapImpl response_trailers_;
 };
 
 TEST_F(TapMatcherTest, Any) {
@@ -34,13 +37,13 @@ any_match: true
   statuses_.resize(matchers_.size());
   matchers_[0]->onNewStream(statuses_);
   EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpRequestHeaders(headers_, statuses_);
+  matchers_[0]->onHttpRequestHeaders(request_headers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpRequestTrailers(headers_, statuses_);
+  matchers_[0]->onHttpRequestTrailers(request_trailers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpResponseHeaders(headers_, statuses_);
+  matchers_[0]->onHttpResponseHeaders(response_headers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpResponseTrailers(headers_, statuses_);
+  matchers_[0]->onHttpResponseTrailers(response_trailers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{true, false}), matchers_[0]->matchStatus(statuses_));
 }
 
@@ -57,13 +60,13 @@ not_match:
   statuses_.resize(matchers_.size());
   matchers_[0]->onNewStream(statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpRequestHeaders(headers_, statuses_);
+  matchers_[0]->onHttpRequestHeaders(request_headers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpRequestTrailers(headers_, statuses_);
+  matchers_[0]->onHttpRequestTrailers(request_trailers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpResponseHeaders(headers_, statuses_);
+  matchers_[0]->onHttpResponseHeaders(response_headers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpResponseTrailers(headers_, statuses_);
+  matchers_[0]->onHttpResponseTrailers(response_trailers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
 }
 
@@ -84,13 +87,13 @@ and_match:
   statuses_.resize(matchers_.size());
   matchers_[0]->onNewStream(statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, true}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpRequestHeaders(headers_, statuses_);
+  matchers_[0]->onHttpRequestHeaders(request_headers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, true}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpRequestTrailers(headers_, statuses_);
+  matchers_[0]->onHttpRequestTrailers(request_trailers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, true}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpResponseHeaders(headers_, statuses_);
+  matchers_[0]->onHttpResponseHeaders(response_headers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
-  matchers_[0]->onHttpResponseTrailers(headers_, statuses_);
+  matchers_[0]->onHttpResponseTrailers(response_trailers_, statuses_);
   EXPECT_EQ((Matcher::MatchStatus{false, false}), matchers_[0]->matchStatus(statuses_));
 }
 

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -23,7 +23,7 @@ namespace {
 constexpr absl::string_view Undefined = "undefined";
 
 TEST(Context, EmptyHeadersAttributes) {
-  HeadersWrapper headers(nullptr);
+  HeadersWrapper<Http::RequestHeaderMap> headers(nullptr);
   auto header = headers[CelValue::CreateStringView(Referer)];
   EXPECT_FALSE(header.has_value());
   EXPECT_EQ(0, headers.size());
@@ -33,7 +33,7 @@ TEST(Context, EmptyHeadersAttributes) {
 TEST(Context, RequestAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   NiceMock<StreamInfo::MockStreamInfo> empty_info;
-  Http::TestHeaderMapImpl header_map{
+  Http::TestRequestHeaderMapImpl header_map{
       {":method", "POST"},           {":scheme", "http"},      {":path", "/meow?yes=1"},
       {":authority", "kittens.com"}, {"referer", "dogs.com"},  {"user-agent", "envoy-mobile"},
       {"content-length", "10"},      {"x-request-id", "blah"},
@@ -195,7 +195,7 @@ TEST(Context, RequestAttributes) {
 
 TEST(Context, RequestFallbackAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
-  Http::TestHeaderMapImpl header_map{
+  Http::TestRequestHeaderMapImpl header_map{
       {":method", "POST"},
       {":scheme", "http"},
       {":path", "/meow?yes=1"},
@@ -225,8 +225,8 @@ TEST(Context, ResponseAttributes) {
   const std::string header_name = "test-header";
   const std::string trailer_name = "test-trailer";
   const std::string grpc_status = "grpc-status";
-  Http::TestHeaderMapImpl header_map{{header_name, "a"}};
-  Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}, {grpc_status, "8"}};
+  Http::TestResponseHeaderMapImpl header_map{{header_name, "a"}};
+  Http::TestResponseTrailerMapImpl trailer_map{{trailer_name, "b"}, {grpc_status, "8"}};
   ResponseWrapper response(&header_map, &trailer_map, info);
   ResponseWrapper empty_response(nullptr, nullptr, empty_info);
 
@@ -323,8 +323,8 @@ TEST(Context, ResponseAttributes) {
   }
 
   {
-    Http::TestHeaderMapImpl header_map{{header_name, "a"}, {grpc_status, "7"}};
-    Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+    Http::TestResponseHeaderMapImpl header_map{{header_name, "a"}, {grpc_status, "7"}};
+    Http::TestResponseTrailerMapImpl trailer_map{{trailer_name, "b"}};
     ResponseWrapper response_header_status(&header_map, &trailer_map, info);
     auto value = response_header_status[CelValue::CreateStringView(GrpcStatus)];
     EXPECT_TRUE(value.has_value());
@@ -332,8 +332,8 @@ TEST(Context, ResponseAttributes) {
     EXPECT_EQ(0x7, value.value().Int64OrDie());
   }
   {
-    Http::TestHeaderMapImpl header_map{{header_name, "a"}};
-    Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+    Http::TestResponseHeaderMapImpl header_map{{header_name, "a"}};
+    Http::TestResponseTrailerMapImpl trailer_map{{trailer_name, "b"}};
     ResponseWrapper response_no_status(&header_map, &trailer_map, info);
     auto value = response_no_status[CelValue::CreateStringView(GrpcStatus)];
     EXPECT_TRUE(value.has_value());
@@ -342,8 +342,8 @@ TEST(Context, ResponseAttributes) {
   }
   {
     NiceMock<StreamInfo::MockStreamInfo> info_without_code;
-    Http::TestHeaderMapImpl header_map{{header_name, "a"}};
-    Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+    Http::TestResponseHeaderMapImpl header_map{{header_name, "a"}};
+    Http::TestResponseTrailerMapImpl trailer_map{{trailer_name, "b"}};
     ResponseWrapper response_no_status(&header_map, &trailer_map, info_without_code);
     auto value = response_no_status[CelValue::CreateStringView(GrpcStatus)];
     EXPECT_FALSE(value.has_value());

--- a/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
@@ -36,7 +36,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::common::expr::EvaluatorTest
   auto request_headers = Fuzz::fromHeaders<Http::TestRequestHeaderMapImpl>(input.request_headers());
   auto response_headers =
       Fuzz::fromHeaders<Http::TestResponseHeaderMapImpl>(input.response_headers());
-  auto response_trailers = Fuzz::fromHeaders<Http::TestHeaderMapImpl>(input.trailers());
+  auto response_trailers = Fuzz::fromHeaders<Http::TestResponseTrailerMapImpl>(input.trailers());
 
   try {
     // Create the CEL expression.

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -167,7 +167,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttp) {
 // Verify that check request object has only a portion of the request data.
 TEST_F(CheckRequestUtilsTest, BasicHttpWithPartialBody) {
   const uint64_t size = 4049;
-  Http::HeaderMapImpl headers_;
+  Http::RequestHeaderMapImpl headers_;
   envoy::service::auth::v3::CheckRequest request_;
 
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
@@ -185,7 +185,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithPartialBody) {
 
 // Verify that check request object has all the request data.
 TEST_F(CheckRequestUtilsTest, BasicHttpWithFullBody) {
-  Http::HeaderMapImpl headers_;
+  Http::RequestHeaderMapImpl headers_;
   envoy::service::auth::v3::CheckRequest request_;
 
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -35,14 +35,14 @@ namespace {
 
 class MockRequestCallbacks : public RequestCallbacks {
 public:
-  void complete(LimitStatus status, Http::HeaderMapPtr&& response_headers_to_add,
-                Http::HeaderMapPtr&& request_headers_to_add) override {
+  void complete(LimitStatus status, Http::ResponseHeaderMapPtr&& response_headers_to_add,
+                Http::RequestHeaderMapPtr&& request_headers_to_add) override {
     complete_(status, response_headers_to_add.get(), request_headers_to_add.get());
   }
 
   MOCK_METHOD(void, complete_,
-              (LimitStatus status, const Http::HeaderMap* response_headers_to_add,
-               const Http::HeaderMap* request_headers_to_add));
+              (LimitStatus status, const Http::ResponseHeaderMap* response_headers_to_add,
+               const Http::RequestHeaderMap* request_headers_to_add));
 };
 
 class RateLimitGrpcClientTest : public testing::Test {

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -27,7 +27,7 @@ namespace {
 void checkEngine(
     const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expected,
     const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
-    const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
+    const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::RequestHeaderMapImpl(),
     const envoy::config::core::v3::Metadata& metadata = envoy::config::core::v3::Metadata(),
     std::string* policy_id = nullptr) {
   NiceMock<StreamInfo::MockStreamInfo> info;
@@ -280,7 +280,7 @@ TEST(RoleBasedAccessControlEngineImpl, HeaderCondition) {
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
-  Envoy::Http::HeaderMapImpl headers;
+  Envoy::Http::RequestHeaderMapImpl headers;
   Envoy::Http::LowerCaseString key("foo");
   std::string value = "bar";
   headers.setReference(key, value);
@@ -321,7 +321,7 @@ TEST(RoleBasedAccessControlEngineImpl, MetadataCondition) {
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
-  Envoy::Http::HeaderMapImpl headers;
+  Envoy::Http::RequestHeaderMapImpl headers;
 
   auto label = MessageUtil::keyValueStruct("label", "prod");
   envoy::config::core::v3::Metadata metadata;

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -28,7 +28,7 @@ namespace {
 void checkMatcher(
     const RBAC::Matcher& matcher, bool expected,
     const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
-    const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
+    const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::RequestHeaderMapImpl(),
     const envoy::config::core::v3::Metadata& metadata = envoy::config::core::v3::Metadata()) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   EXPECT_CALL(Const(info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
@@ -142,7 +142,7 @@ TEST(HeaderMatcher, HeaderMatcher) {
   config.set_name("foo");
   config.set_exact_match("bar");
 
-  Envoy::Http::HeaderMapImpl headers;
+  Envoy::Http::RequestHeaderMapImpl headers;
   Envoy::Http::LowerCaseString key("foo");
   std::string value = "bar";
   headers.setReference(key, value);
@@ -287,7 +287,7 @@ TEST(AuthenticatedMatcher, NoSSL) {
 
 TEST(MetadataMatcher, MetadataMatcher) {
   Envoy::Network::MockConnection conn;
-  Envoy::Http::HeaderMapImpl header;
+  Envoy::Http::RequestHeaderMapImpl header;
 
   auto label = MessageUtil::keyValueStruct("label", "prod");
   envoy::config::core::v3::Metadata metadata;
@@ -376,7 +376,7 @@ TEST(RequestedServerNameMatcher, EmptyRequestedServerName) {
 }
 
 TEST(PathMatcher, NoPathInHeader) {
-  Envoy::Http::HeaderMapImpl headers;
+  Envoy::Http::RequestHeaderMapImpl headers;
   envoy::type::matcher::v3::PathMatcher matcher;
   matcher.mutable_path()->mutable_safe_regex()->mutable_google_re2();
   matcher.mutable_path()->mutable_safe_regex()->set_regex(".*");
@@ -388,7 +388,7 @@ TEST(PathMatcher, NoPathInHeader) {
 }
 
 TEST(PathMatcher, ValidPathInHeader) {
-  Envoy::Http::HeaderMapImpl headers;
+  Envoy::Http::RequestHeaderMapImpl headers;
   envoy::type::matcher::v3::PathMatcher matcher;
   matcher.mutable_path()->set_exact("/exact");
 

--- a/test/extensions/filters/common/rbac/mocks.h
+++ b/test/extensions/filters/common/rbac/mocks.h
@@ -18,7 +18,7 @@ public:
       : RoleBasedAccessControlEngineImpl(rules){};
 
   MOCK_METHOD(bool, allowed,
-              (const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
+              (const Envoy::Network::Connection&, const Envoy::Http::RequestHeaderMap&,
                const StreamInfo::StreamInfo&, std::string* effective_policy_id),
               (const));
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -188,7 +188,7 @@ TEST_F(HttpFilterTest, ErrorFailClose) {
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const Http::ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.Status()->value().getStringView(),
                   std::to_string(enumToInt(Http::Code::Forbidden)));
       }));
@@ -225,7 +225,7 @@ TEST_F(HttpFilterTest, ErrorCustomStatusCode) {
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, true))
-      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) -> void {
+      .WillOnce(Invoke([&](const Http::ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.Status()->value().getStringView(),
                   std::to_string(enumToInt(Http::Code::ServiceUnavailable)));
       }));

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -207,7 +207,7 @@ TEST_F(ReverseBridgeTest, GrpcRequestNoManageFrameHeader) {
 
   {
     // Last call should also not modify the buffer.
-    Http::TestRequestTrailerMapImpl trailers;
+    Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;
@@ -280,7 +280,7 @@ TEST_F(ReverseBridgeTest, GrpcRequest) {
   }
   {
     // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
-    Http::TestRequestTrailerMapImpl trailers;
+    Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;
@@ -362,7 +362,7 @@ TEST_F(ReverseBridgeTest, GrpcRequestNoContentLength) {
   }
   {
     // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
-    Http::TestRequestTrailerMapImpl trailers;
+    Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;
@@ -438,7 +438,7 @@ TEST_F(ReverseBridgeTest, GrpcRequestInternalError) {
   }
   {
     // Last call should prefix the buffer with the size and insert the appropriate gRPC status.
-    Http::TestRequestTrailerMapImpl trailers;
+    Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;
@@ -654,7 +654,7 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteEnabled) {
   }
   {
     // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
-    Http::TestRequestTrailerMapImpl trailers;
+    Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -616,7 +616,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryError) {
   Buffer::OwnedImpl request_data{"{\"theme\": \"Children\""};
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false))
-      .WillOnce(Invoke([](Http::HeaderMap& headers, bool end_stream) {
+      .WillOnce(Invoke([](Http::ResponseHeaderMap& headers, bool end_stream) {
         EXPECT_EQ("400", headers.Status()->value().getStringView());
         EXPECT_FALSE(end_stream);
       }));

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -37,29 +37,31 @@ protected:
   }
 
   // GzipFilter private member functions
-  void sanitizeEtagHeader(Http::HeaderMap& headers) { filter_->sanitizeEtagHeader(headers); }
+  void sanitizeEtagHeader(Http::ResponseHeaderMap& headers) {
+    filter_->sanitizeEtagHeader(headers);
+  }
 
-  void insertVaryHeader(Http::HeaderMap& headers) { filter_->insertVaryHeader(headers); }
+  void insertVaryHeader(Http::ResponseHeaderMap& headers) { filter_->insertVaryHeader(headers); }
 
-  bool isContentTypeAllowed(Http::HeaderMap& headers) {
+  bool isContentTypeAllowed(Http::ResponseHeaderMap& headers) {
     return filter_->isContentTypeAllowed(headers);
   }
 
-  bool isEtagAllowed(Http::HeaderMap& headers) { return filter_->isEtagAllowed(headers); }
+  bool isEtagAllowed(Http::ResponseHeaderMap& headers) { return filter_->isEtagAllowed(headers); }
 
-  bool hasCacheControlNoTransform(Http::HeaderMap& headers) {
+  bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) {
     return filter_->hasCacheControlNoTransform(headers);
   }
 
-  bool isAcceptEncodingAllowed(Http::HeaderMap& headers) {
+  bool isAcceptEncodingAllowed(Http::RequestHeaderMap& headers) {
     return filter_->isAcceptEncodingAllowed(headers);
   }
 
-  bool isMinimumContentLength(Http::HeaderMap& headers) {
+  bool isMinimumContentLength(Http::ResponseHeaderMap& headers) {
     return filter_->isMinimumContentLength(headers);
   }
 
-  bool isTransferEncodingAllowed(Http::HeaderMap& headers) {
+  bool isTransferEncodingAllowed(Http::ResponseHeaderMap& headers) {
     return filter_->isTransferEncodingAllowed(headers);
   }
 
@@ -250,15 +252,15 @@ TEST_F(GzipFilterTest, AcceptanceGzipEncodingWithTrailers) {
 // Verifies isAcceptEncodingAllowed function.
 TEST_F(GzipFilterTest, hasCacheControlNoTransform) {
   {
-    Http::TestRequestHeaderMapImpl headers = {{"cache-control", "no-cache"}};
+    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "no-cache"}};
     EXPECT_FALSE(hasCacheControlNoTransform(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"cache-control", "no-transform"}};
+    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "no-transform"}};
     EXPECT_TRUE(hasCacheControlNoTransform(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"cache-control", "No-Transform"}};
+    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "No-Transform"}};
     EXPECT_TRUE(hasCacheControlNoTransform(headers));
   }
 }
@@ -408,33 +410,33 @@ TEST_F(GzipFilterTest, AcceptEncodingCompression) {
 // Verifies isMinimumContentLength function.
 TEST_F(GzipFilterTest, isMinimumContentLength) {
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-length", "31"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-length", "31"}};
     EXPECT_TRUE(isMinimumContentLength(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-length", "29"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-length", "29"}};
     EXPECT_FALSE(isMinimumContentLength(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
     EXPECT_TRUE(isMinimumContentLength(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
     EXPECT_TRUE(isMinimumContentLength(headers));
   }
 
   setUpFilter(R"EOF({"content_length": 500})EOF");
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-length", "501"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-length", "501"}};
     EXPECT_TRUE(isMinimumContentLength(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
     EXPECT_TRUE(isMinimumContentLength(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-length", "499"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-length", "499"}};
     EXPECT_FALSE(isMinimumContentLength(headers));
   }
 }
@@ -456,51 +458,51 @@ TEST_F(GzipFilterTest, ContentLengthCompression) {
 TEST_F(GzipFilterTest, isContentTypeAllowed) {
 
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "text/html"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/html"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "text/xml"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/xml"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "text/plain"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/plain"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "application/javascript"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/javascript"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "image/svg+xml"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/svg+xml"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "application/json;charset=utf-8"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/json;charset=utf-8"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "application/json"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/json"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "application/xhtml+xml"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/xhtml+xml"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "Application/XHTML+XML"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "Application/XHTML+XML"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
     EXPECT_FALSE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {};
+    Http::TestResponseHeaderMapImpl headers = {};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "\ttext/html\t"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "\ttext/html\t"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
 
@@ -515,23 +517,23 @@ TEST_F(GzipFilterTest, isContentTypeAllowed) {
   )EOF");
 
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "xyz/svg+xml"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "xyz/svg+xml"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {};
+    Http::TestResponseHeaderMapImpl headers = {};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "xyz/false"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "xyz/false"}};
     EXPECT_FALSE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
     EXPECT_FALSE(isContentTypeAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"content-type", "test/insensitive"}};
+    Http::TestResponseHeaderMapImpl headers = {{"content-type", "test/insensitive"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));
   }
 }
@@ -569,18 +571,18 @@ TEST_F(GzipFilterTest, ContentTypeCompression) {
 TEST_F(GzipFilterTest, sanitizeEtagHeader) {
   {
     std::string etag_header{R"EOF(W/"686897696a7c876b7e")EOF"};
-    Http::TestRequestHeaderMapImpl headers = {{"etag", etag_header}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", etag_header}};
     sanitizeEtagHeader(headers);
     EXPECT_EQ(etag_header, headers.get_("etag"));
   }
   {
     std::string etag_header{R"EOF(w/"686897696a7c876b7e")EOF"};
-    Http::TestRequestHeaderMapImpl headers = {{"etag", etag_header}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", etag_header}};
     sanitizeEtagHeader(headers);
     EXPECT_EQ(etag_header, headers.get_("etag"));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
     sanitizeEtagHeader(headers);
     EXPECT_FALSE(headers.has("etag"));
   }
@@ -589,34 +591,34 @@ TEST_F(GzipFilterTest, sanitizeEtagHeader) {
 // Verifies isEtagAllowed function.
 TEST_F(GzipFilterTest, isEtagAllowed) {
   {
-    Http::TestRequestHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
     EXPECT_TRUE(isEtagAllowed(headers));
     EXPECT_EQ(0, stats_.counter("test.gzip.not_compressed_etag").value());
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
     EXPECT_TRUE(isEtagAllowed(headers));
     EXPECT_EQ(0, stats_.counter("test.gzip.not_compressed_etag").value());
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {};
+    Http::TestResponseHeaderMapImpl headers = {};
     EXPECT_TRUE(isEtagAllowed(headers));
     EXPECT_EQ(0, stats_.counter("test.gzip.not_compressed_etag").value());
   }
 
   setUpFilter(R"EOF({ "disable_on_etag_header": true })EOF");
   {
-    Http::TestRequestHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
     EXPECT_FALSE(isEtagAllowed(headers));
     EXPECT_EQ(1, stats_.counter("test.gzip.not_compressed_etag").value());
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
+    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
     EXPECT_FALSE(isEtagAllowed(headers));
     EXPECT_EQ(2, stats_.counter("test.gzip.not_compressed_etag").value());
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {};
+    Http::TestResponseHeaderMapImpl headers = {};
     EXPECT_TRUE(isEtagAllowed(headers));
     EXPECT_EQ(2, stats_.counter("test.gzip.not_compressed_etag").value());
   }
@@ -645,35 +647,35 @@ TEST_F(GzipFilterTest, EtagCompression) {
 // Verifies isTransferEncodingAllowed function.
 TEST_F(GzipFilterTest, isTransferEncodingAllowed) {
   {
-    Http::TestRequestHeaderMapImpl headers = {};
+    Http::TestResponseHeaderMapImpl headers = {};
     EXPECT_TRUE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
     EXPECT_TRUE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
     EXPECT_TRUE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "deflate"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "deflate"}};
     EXPECT_FALSE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "Deflate"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Deflate"}};
     EXPECT_FALSE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "gzip"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "gzip"}};
     EXPECT_FALSE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", "gzip, chunked"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "gzip, chunked"}};
     EXPECT_FALSE(isTransferEncodingAllowed(headers));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"transfer-encoding", " gzip\t,  chunked\t"}};
+    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", " gzip\t,  chunked\t"}};
     EXPECT_FALSE(isTransferEncodingAllowed(headers));
   }
 }
@@ -718,27 +720,27 @@ TEST_F(GzipFilterTest, EmptyResponse) {
 // Verifies insertVaryHeader function.
 TEST_F(GzipFilterTest, insertVaryHeader) {
   {
-    Http::TestRequestHeaderMapImpl headers = {};
+    Http::TestResponseHeaderMapImpl headers = {};
     insertVaryHeader(headers);
     EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"vary", "Cookie"}};
+    Http::TestResponseHeaderMapImpl headers = {{"vary", "Cookie"}};
     insertVaryHeader(headers);
     EXPECT_EQ("Cookie, Accept-Encoding", headers.get_("vary"));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"vary", "accept-encoding"}};
+    Http::TestResponseHeaderMapImpl headers = {{"vary", "accept-encoding"}};
     insertVaryHeader(headers);
     EXPECT_EQ("accept-encoding, Accept-Encoding", headers.get_("vary"));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"vary", "Accept-Encoding, Cookie"}};
+    Http::TestResponseHeaderMapImpl headers = {{"vary", "Accept-Encoding, Cookie"}};
     insertVaryHeader(headers);
     EXPECT_EQ("Accept-Encoding, Cookie", headers.get_("vary"));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = {{"vary", "Accept-Encoding"}};
+    Http::TestResponseHeaderMapImpl headers = {{"vary", "Accept-Encoding"}};
     insertVaryHeader(headers);
     EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
   }

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -96,10 +96,10 @@ TEST_F(AllVerifierTest, TestAllAllow) {
   createVerifier();
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(2);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, "a"}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, "a"}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
-  headers = Http::TestHeaderMapImpl{};
+  headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -117,14 +117,14 @@ protected:
 
 TEST_F(AllowFailedInSingleRequirementTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -132,7 +132,7 @@ TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
 
 TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // As requirement has nothing except allow_missing_or_failed, it will
@@ -143,7 +143,7 @@ TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
 TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -152,7 +152,8 @@ TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
 
 TEST_F(AllowFailedInSingleRequirementTest, GoodAndBadJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, ExpiredToken}};
+  auto headers =
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -177,14 +178,14 @@ requires_any:
 
 TEST_F(AllowFailedInOrListTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInOrListTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -193,7 +194,7 @@ TEST_F(AllowFailedInOrListTest, BadJwt) {
 TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -203,7 +204,7 @@ TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
 TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -214,8 +215,8 @@ TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
 
 TEST_F(AllowFailedInOrListTest, BadAndGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}, {kOtherHeader, OtherGoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken},
+                                                {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -241,14 +242,14 @@ requires_all:
 
 TEST_F(AllowFailedInAndListTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInAndListTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -256,7 +257,7 @@ TEST_F(AllowFailedInAndListTest, BadJwt) {
 
 TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {kExampleHeader, GoodToken},
   };
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -267,7 +268,7 @@ TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
 TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -278,7 +279,7 @@ TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
 TEST_F(AllowFailedInAndListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -309,14 +310,14 @@ requires_all:
 
 TEST_F(AllowFailedInAndOfOrListTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -324,7 +325,7 @@ TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -332,7 +333,7 @@ TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kOtherHeader));
@@ -340,8 +341,8 @@ TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
 
 TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}, {kOtherHeader, OtherGoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken},
+                                                {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -351,7 +352,7 @@ TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
 TEST_F(AllowFailedInAndOfOrListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -376,7 +377,7 @@ requires_any:
 
 TEST_F(AllowMissingInOrListTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -384,7 +385,7 @@ TEST_F(AllowMissingInOrListTest, NoJwt) {
 TEST_F(AllowMissingInOrListTest, BadJwt) {
   // Bad JWT should fail.
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -392,7 +393,7 @@ TEST_F(AllowMissingInOrListTest, BadJwt) {
 
 TEST_F(AllowMissingInOrListTest, OtherGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   // x-other JWT should be ignored.
@@ -401,8 +402,8 @@ TEST_F(AllowMissingInOrListTest, OtherGoodJwt) {
 
 TEST_F(AllowMissingInOrListTest, BadAndGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
-  auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, NonExistKidToken}, {kOtherHeader, OtherGoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken},
+                                                {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -427,7 +428,7 @@ requires_all:
 
 TEST_F(AllowMissingInAndListTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -435,7 +436,7 @@ TEST_F(AllowMissingInAndListTest, NoJwt) {
 TEST_F(AllowMissingInAndListTest, BadJwt) {
   // Bad JWT should fail.
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -444,7 +445,7 @@ TEST_F(AllowMissingInAndListTest, BadJwt) {
 TEST_F(AllowMissingInAndListTest, GoodJwt) {
   // Bad JWT should fail.
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -454,7 +455,7 @@ TEST_F(AllowMissingInAndListTest, TwoGoodJwts) {
   // Bad JWT should fail.
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -484,7 +485,7 @@ requires_all:
 
 TEST_F(AllowMissingInAndOfOrListTest, NoJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -492,7 +493,7 @@ TEST_F(AllowMissingInAndOfOrListTest, NoJwt) {
 TEST_F(AllowMissingInAndOfOrListTest, BadJwt) {
   // Bad JWT should fail.
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));
@@ -500,7 +501,7 @@ TEST_F(AllowMissingInAndOfOrListTest, BadJwt) {
 
 TEST_F(AllowMissingInAndOfOrListTest, OneGoodJwt) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -509,7 +510,7 @@ TEST_F(AllowMissingInAndOfOrListTest, OneGoodJwt) {
 TEST_F(AllowMissingInAndOfOrListTest, TwoGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -519,7 +520,8 @@ TEST_F(AllowMissingInAndOfOrListTest, TwoGoodJwts) {
 TEST_F(AllowMissingInAndOfOrListTest, GoodAndBadJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
   // Use the token with example.com issuer for x-other.
-  auto headers = Http::TestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, GoodToken}};
+  auto headers =
+      Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputSuccess(kExampleHeader));
@@ -528,8 +530,8 @@ TEST_F(AllowMissingInAndOfOrListTest, GoodAndBadJwts) {
 
 TEST_F(AllowMissingInAndOfOrListTest, BadAndGoodJwts) {
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
-  auto headers =
-      Http::TestHeaderMapImpl{{kExampleHeader, ExpiredToken}, {kOtherHeader, OtherGoodToken}};
+  auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken},
+                                                {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_THAT(headers, JwtOutputFailedOrIgnore(kExampleHeader));

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -9,7 +9,7 @@
 
 using envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication;
 using envoy::extensions::filters::http::jwt_authn::v3::JwtProvider;
-using Envoy::Http::TestHeaderMapImpl;
+using Envoy::Http::TestRequestHeaderMapImpl;
 
 namespace Envoy {
 namespace Extensions {
@@ -74,28 +74,28 @@ public:
 
 // Test not token in the request headers
 TEST_F(ExtractorTest, TestNoToken) {
-  auto headers = TestHeaderMapImpl{};
+  auto headers = TestRequestHeaderMapImpl{};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 0);
 }
 
 // Test the token in the wrong header.
 TEST_F(ExtractorTest, TestWrongHeaderToken) {
-  auto headers = TestHeaderMapImpl{{"wrong-token-header", "jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{"wrong-token-header", "jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 0);
 }
 
 // Test the token in the wrong query parameter.
 TEST_F(ExtractorTest, TestWrongParamToken) {
-  auto headers = TestHeaderMapImpl{{":path", "/path?wrong_token=jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/path?wrong_token=jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 0);
 }
 
 // Test extracting token from the default header location: "Authorization"
 TEST_F(ExtractorTest, TestDefaultHeaderLocation) {
-  auto headers = TestHeaderMapImpl{{"Authorization", "Bearer jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{"Authorization", "Bearer jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -119,7 +119,7 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocation) {
 // using an actual (correctly-formatted) JWT:
 TEST_F(ExtractorTest, TestDefaultHeaderLocationWithValidJWT) {
   auto headers =
-      TestHeaderMapImpl{{absl::StrCat("Authorization"), absl::StrCat("Bearer ", GoodToken)}};
+      TestRequestHeaderMapImpl{{absl::StrCat("Authorization"), absl::StrCat("Bearer ", GoodToken)}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -130,7 +130,7 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocationWithValidJWT) {
 
 // Test extracting token from the default query parameter: "access_token"
 TEST_F(ExtractorTest, TestDefaultParamLocation) {
-  auto headers = TestHeaderMapImpl{{":path", "/path?access_token=jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/path?access_token=jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -150,7 +150,7 @@ TEST_F(ExtractorTest, TestDefaultParamLocation) {
 
 // Test extracting token from the custom header: "token-header"
 TEST_F(ExtractorTest, TestCustomHeaderToken) {
-  auto headers = TestHeaderMapImpl{{"token-header", "jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{"token-header", "jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -173,7 +173,7 @@ TEST_F(ExtractorTest, TestCustomHeaderToken) {
 // Test extracting token from the custom header: "prefix-header"
 // value prefix doesn't match. It has to be either "AAA" or "AAABBB".
 TEST_F(ExtractorTest, TestPrefixHeaderNotMatch) {
-  auto headers = TestHeaderMapImpl{{"prefix-header", "jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{"prefix-header", "jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 0);
 }
@@ -181,7 +181,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderNotMatch) {
 // Test extracting token from the custom header: "prefix-header"
 // The value matches both prefix values: "AAA" or "AAABBB".
 TEST_F(ExtractorTest, TestPrefixHeaderMatch) {
-  auto headers = TestHeaderMapImpl{{"prefix-header", "AAABBBjwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{"prefix-header", "AAABBBjwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 2);
 
@@ -201,7 +201,8 @@ TEST_F(ExtractorTest, TestPrefixHeaderMatch) {
 // Test extracting token from the custom header: "prefix-header"
 // The value is found after the "CCCDDD", then between the '=' and the ','.
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch1) {
-  auto headers = TestHeaderMapImpl{{"prefix-header", "preamble CCCDDD=jwt_token,extra=more"}};
+  auto headers =
+      TestRequestHeaderMapImpl{{"prefix-header", "preamble CCCDDD=jwt_token,extra=more"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -212,7 +213,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch1) {
 
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
   auto headers =
-      TestHeaderMapImpl{{"prefix-header", "CCCDDD=\"and0X3Rva2Vu\",comment=\"fish tag\""}};
+      TestRequestHeaderMapImpl{{"prefix-header", "CCCDDD=\"and0X3Rva2Vu\",comment=\"fish tag\""}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -222,7 +223,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
 }
 
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch3) {
-  auto headers = TestHeaderMapImpl{
+  auto headers = TestRequestHeaderMapImpl{
       {"prefix-header", "creds={\"authLevel\": \"20\", \"CCCDDD\": \"and0X3Rva2Vu\"}"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 2);
@@ -238,7 +239,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch3) {
 
 // Test extracting token from the custom query parameter: "token_param"
 TEST_F(ExtractorTest, TestCustomParamToken) {
-  auto headers = TestHeaderMapImpl{{":path", "/path?token_param=jwt_token"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/path?token_param=jwt_token"}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 
@@ -257,7 +258,7 @@ TEST_F(ExtractorTest, TestCustomParamToken) {
 
 // Test extracting multiple tokens.
 TEST_F(ExtractorTest, TestMultipleTokens) {
-  auto headers = TestHeaderMapImpl{
+  auto headers = TestRequestHeaderMapImpl{
       {":path", "/path?token_param=token3&access_token=token4"},
       {"token-header", "token2"},
       {"authorization", "Bearer token1"},
@@ -275,7 +276,7 @@ TEST_F(ExtractorTest, TestMultipleTokens) {
 
 // Test selected extraction of multiple tokens.
 TEST_F(ExtractorTest, TestExtractParam) {
-  auto headers = TestHeaderMapImpl{
+  auto headers = TestRequestHeaderMapImpl{
       {":path", "/path?token_param=token3&access_token=token4"},
       {"token-header", "token2"},
       {"authorization", "Bearer token1"},

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -42,14 +42,14 @@ rules:
 
   StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filter_conf->findVerifier(
-                  Http::TestHeaderMapImpl{
+                  Http::TestRequestHeaderMapImpl{
                       {":method", "GET"},
                       {":path", "/path1"},
                   },
                   filter_state) != nullptr);
 
   EXPECT_TRUE(filter_conf->findVerifier(
-                  Http::TestHeaderMapImpl{
+                  Http::TestRequestHeaderMapImpl{
                       {":method", "GET"},
                       {":path", "/path2"},
                   },
@@ -130,28 +130,32 @@ filter_state_rules:
 
   // Empty filter_state
   StreamInfo::FilterStateImpl filter_state1(StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_TRUE(filter_conf->findVerifier(Http::TestHeaderMapImpl(), filter_state1) == nullptr);
+  EXPECT_TRUE(filter_conf->findVerifier(Http::TestRequestHeaderMapImpl(), filter_state1) ==
+              nullptr);
 
   // Wrong selector
   StreamInfo::FilterStateImpl filter_state2(StreamInfo::FilterState::LifeSpan::FilterChain);
   filter_state2.setData(
       "jwt_selector", std::make_unique<Router::StringAccessorImpl>("wrong_selector"),
       StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_TRUE(filter_conf->findVerifier(Http::TestHeaderMapImpl(), filter_state2) == nullptr);
+  EXPECT_TRUE(filter_conf->findVerifier(Http::TestRequestHeaderMapImpl(), filter_state2) ==
+              nullptr);
 
   // correct selector
   StreamInfo::FilterStateImpl filter_state3(StreamInfo::FilterState::LifeSpan::FilterChain);
   filter_state3.setData("jwt_selector", std::make_unique<Router::StringAccessorImpl>("selector1"),
                         StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_TRUE(filter_conf->findVerifier(Http::TestHeaderMapImpl(), filter_state3) != nullptr);
+  EXPECT_TRUE(filter_conf->findVerifier(Http::TestRequestHeaderMapImpl(), filter_state3) !=
+              nullptr);
 
   // correct selector
   StreamInfo::FilterStateImpl filter_state4(StreamInfo::FilterState::LifeSpan::FilterChain);
   filter_state4.setData("jwt_selector", std::make_unique<Router::StringAccessorImpl>("selector2"),
                         StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_TRUE(filter_conf->findVerifier(Http::TestHeaderMapImpl(), filter_state4) != nullptr);
+  EXPECT_TRUE(filter_conf->findVerifier(Http::TestRequestHeaderMapImpl(), filter_state4) !=
+              nullptr);
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -26,7 +26,7 @@ namespace {
 
 class MockMatcher : public Matcher {
 public:
-  MOCK_METHOD(bool, matches, (const Http::HeaderMap& headers), (const));
+  MOCK_METHOD(bool, matches, (const Http::RequestHeaderMap& headers), (const));
 };
 
 JwtAuthnFilterStats generateMockStats(Stats::Scope& scope) {
@@ -42,7 +42,7 @@ public:
   }
 
   MOCK_METHOD(const Verifier*, findVerifier,
-              (const Http::HeaderMap& headers, const StreamInfo::FilterState& filter_state),
+              (const Http::RequestHeaderMap& headers, const StreamInfo::FilterState& filter_state),
               (const));
   MOCK_METHOD(bool, bypassCorsPreflightRequest, (), (const));
   MOCK_METHOD(JwtAuthnFilterStats&, stats, ());

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -174,7 +174,7 @@ rules:
   }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"sec-istio-auth-userinfo", ""},
   };
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -211,7 +211,7 @@ rules:
   createVerifier();
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -228,7 +228,7 @@ TEST_F(GroupVerifierTest, TestRequiresAll) {
   }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -247,7 +247,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllBadFormat) {
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtBadFormat)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -271,7 +271,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllMissing) {
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -295,7 +295,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllBothFailed) {
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -317,7 +317,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyFirstAuthOK) {
   }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -338,7 +338,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyLastAuthOk) {
   }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -359,7 +359,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyAllAuthFailed) {
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
   };
@@ -380,7 +380,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllFirstAnyIsOk) {
   }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -398,7 +398,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllLastAnyIsOk) {
   }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -413,7 +413,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyIsOk) {
   // AsyncMockVerifier doesn't set payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_1"](Status::Ok);
@@ -430,7 +430,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyFailed) {
 
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwksFetchFail)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_1"](Status::JwksFetchFail);
@@ -448,7 +448,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllFailed) {
 
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
@@ -463,7 +463,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyFirstAllIsOk) {
   // AsyncMockVerifier doesn't set payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_2"](Status::Ok);
@@ -479,7 +479,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyLastAllIsOk) {
       std::vector<std::string>{"provider_1", "provider_2", "provider_3", "provider_4"});
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_3"](Status::Ok);
@@ -495,7 +495,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllAreOk) {
       std::vector<std::string>{"provider_1", "provider_2", "provider_3", "provider_4"});
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks["provider_1"](Status::Ok);
@@ -525,7 +525,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowAll) {
   mock_auths_[allowfailed] = std::move(mock_auth);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
 
-  auto headers = Http::TestHeaderMapImpl{};
+  auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   callbacks[allowfailed](Status::Ok);

--- a/test/extensions/filters/http/jwt_authn/matcher_test.cc
+++ b/test/extensions/filters/http/jwt_authn/matcher_test.cc
@@ -9,7 +9,7 @@
 #include "test/test_common/utility.h"
 
 using envoy::extensions::filters::http::jwt_authn::v3::RequirementRule;
-using Envoy::Http::TestHeaderMapImpl;
+using Envoy::Http::TestRequestHeaderMapImpl;
 
 namespace Envoy {
 namespace Extensions {
@@ -27,15 +27,15 @@ TEST_F(MatcherTest, TestMatchPrefix) {
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/match/this"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/match/this"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/MATCH"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/MATCH"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/matching"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/matching"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/matc"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/matc"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/no"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/no"}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 
@@ -45,15 +45,15 @@ TEST_F(MatcherTest, TestMatchRegex) {
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/but"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/but"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/mat?ok=bye"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/mat?ok=bye"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/maut"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/maut"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/cut"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/cut"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/mut/"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/mut/"}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 
@@ -67,15 +67,15 @@ match:
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/but"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/but"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/mat?ok=bye"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/mat?ok=bye"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/maut"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/maut"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/cut"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/cut"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/mut/"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/mut/"}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 
@@ -86,17 +86,17 @@ TEST_F(MatcherTest, TestMatchPath) {
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/match"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/match"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/MATCH"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/MATCH"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/match?ok=bye"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/match?ok=bye"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/matc"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/matc"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/match/"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/match/"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/matching"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/matching"}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 
@@ -109,15 +109,15 @@ TEST_F(MatcherTest, TestMatchQuery) {
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/boo?foo=bar"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/boo?foo=bar"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/boo?ok=bye"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/boo?ok=bye"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/foo?bar=bar"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/foo?bar=bar"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/boo?foo"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/boo?foo"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/boo?bar=foo"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/boo?bar=foo"}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 
@@ -129,15 +129,15 @@ TEST_F(MatcherTest, TestMatchHeader) {
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/"}, {"a", ""}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/"}, {"a", ""}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/"}, {"a", "some"}, {"b", ""}};
+  headers = TestRequestHeaderMapImpl{{":path", "/"}, {"a", "some"}, {"b", ""}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/"}, {"aa", ""}};
+  headers = TestRequestHeaderMapImpl{{":path", "/"}, {"aa", ""}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/"}, {"", ""}};
+  headers = TestRequestHeaderMapImpl{{":path", "/"}, {"", ""}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 
@@ -150,15 +150,15 @@ TEST_F(MatcherTest, TestMatchPathAndHeader) {
   RequirementRule rule;
   TestUtility::loadFromYaml(config, rule);
   MatcherConstPtr matcher = Matcher::create(rule);
-  auto headers = TestHeaderMapImpl{{":path", "/boo?foo=bar"}};
+  auto headers = TestRequestHeaderMapImpl{{":path", "/boo?foo=bar"}};
   EXPECT_TRUE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/boo?ok=bye"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/boo?ok=bye"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/foo?bar=bar"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/foo?bar=bar"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/boo?foo"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/boo?foo"}};
   EXPECT_FALSE(matcher->matches(headers));
-  headers = TestHeaderMapImpl{{":path", "/boo?bar=foo"}};
+  headers = TestRequestHeaderMapImpl{{":path", "/boo?bar=foo"}};
   EXPECT_FALSE(matcher->matches(headers));
 }
 

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -53,7 +53,8 @@ public:
 
 class MockExtractor : public Extractor {
 public:
-  MOCK_METHOD(std::vector<JwtLocationConstPtr>, extract, (const Http::HeaderMap& headers), (const));
+  MOCK_METHOD(std::vector<JwtLocationConstPtr>, extract, (const Http::RequestHeaderMap& headers),
+              (const));
   MOCK_METHOD(void, sanitizePayloadHeaders, (Http::HeaderMap & headers), (const));
 };
 

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -61,7 +61,7 @@ TEST_F(ProviderVerifierTest, TestOkJWT) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
 
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {"sec-istio-auth-userinfo", ""},
   };
@@ -89,7 +89,7 @@ TEST_F(ProviderVerifierTest, TestSpanPassedDown) {
                      .setChildSpanName("JWT Remote PubKey Fetch");
   EXPECT_CALL(mock_factory_ctx_.cluster_manager_.async_client_, send_(_, _, Eq(options))).Times(1);
 
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {"sec-istio-auth-userinfo", ""},
   };
@@ -103,7 +103,7 @@ TEST_F(ProviderVerifierTest, TestMissedJWT) {
 
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
 
-  auto headers = Http::TestHeaderMapImpl{{"sec-istio-auth-userinfo", ""}};
+  auto headers = Http::TestRequestHeaderMapImpl{{"sec-istio-auth-userinfo", ""}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
   EXPECT_FALSE(headers.has("sec-istio-auth-userinfo"));
@@ -138,7 +138,7 @@ rules:
 
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
 
-  auto headers = Http::TestHeaderMapImpl{
+  auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -164,9 +164,11 @@ TEST_F(ProviderVerifierTest, TestRequiresProviderWithAudiences) {
           Invoke([](const Status& status) { ASSERT_EQ(status, Status::JwtAudienceNotAllowed); }))
       .WillOnce(Invoke([](const Status& status) { ASSERT_EQ(status, Status::Ok); }));
 
-  auto headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  auto headers =
+      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
   verifier_->verify(Verifier::createContext(headers, parent_span_, &mock_cb_));
-  headers = Http::TestHeaderMapImpl{{"Authorization", "Bearer " + std::string(InvalidAudToken)}};
+  headers =
+      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(InvalidAudToken)}};
   verifier_->verify(Verifier::createContext(headers, parent_span_, &mock_cb_));
 }
 

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -267,8 +267,8 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithHeaders) {
 
   request_callbacks_->complete(
       Filters::Common::RateLimit::LimitStatus::OK,
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl(*rl_headers)},
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl(*request_headers_to_add)});
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl(*rl_headers)},
+      Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl(*request_headers_to_add)});
   Http::TestHeaderMapImpl expected_headers(*rl_headers);
   Http::TestResponseHeaderMapImpl response_headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
@@ -415,7 +415,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponse) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
-  Http::HeaderMapPtr h{new Http::TestHeaderMapImpl()};
+  Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "429"},
       {"x-envoy-ratelimited", Http::Headers::get().EnvoyRateLimitedValues.True}};
@@ -468,8 +468,8 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithHeaders) {
   Http::HeaderMapPtr request_headers_to_add{
       new Http::TestHeaderMapImpl{{"x-rls-rate-limited", "true"}}};
 
-  Http::HeaderMapPtr h{new Http::TestHeaderMapImpl(*rl_headers)};
-  Http::HeaderMapPtr uh{new Http::TestHeaderMapImpl(*request_headers_to_add)};
+  Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl(*rl_headers)};
+  Http::RequestHeaderMapPtr uh{new Http::TestRequestHeaderMapImpl(*request_headers_to_add)};
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, std::move(h),
                                std::move(uh));
 
@@ -498,7 +498,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseRuntimeDisabled) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("ratelimit.http_filter_enforcing", 100))
       .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_, continueDecoding());
-  Http::HeaderMapPtr h{new Http::TestHeaderMapImpl()};
+  Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, std::move(h),
                                nullptr);
 

--- a/test/extensions/filters/http/tap/tap_filter_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_test.cc
@@ -28,12 +28,12 @@ public:
 
 class MockHttpPerRequestTapper : public HttpPerRequestTapper {
 public:
-  MOCK_METHOD(void, onRequestHeaders, (const Http::HeaderMap& headers));
+  MOCK_METHOD(void, onRequestHeaders, (const Http::RequestHeaderMap& headers));
   MOCK_METHOD(void, onRequestBody, (const Buffer::Instance& data));
-  MOCK_METHOD(void, onRequestTrailers, (const Http::HeaderMap& headers));
-  MOCK_METHOD(void, onResponseHeaders, (const Http::HeaderMap& headers));
+  MOCK_METHOD(void, onRequestTrailers, (const Http::RequestTrailerMap& headers));
+  MOCK_METHOD(void, onResponseHeaders, (const Http::ResponseHeaderMap& headers));
   MOCK_METHOD(void, onResponseBody, (const Buffer::Instance& data));
-  MOCK_METHOD(void, onResponseTrailers, (const Http::HeaderMap& headers));
+  MOCK_METHOD(void, onResponseTrailers, (const Http::ResponseTrailerMap& headers));
   MOCK_METHOD(bool, onDestroyLog, ());
 };
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -399,7 +399,7 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponseWithHeaders) {
   EXPECT_CALL(filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
 
-  Http::HeaderMapPtr h{new Http::TestHeaderMapImpl(*rl_headers)};
+  Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl(*rl_headers)};
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, std::move(h),
                                nullptr);
 

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -506,7 +506,7 @@ TEST_F(HystrixSinkTest, HystrixEventStreamHandler) {
   // This value doesn't matter in handlerHystrixEventStream
   absl::string_view path_and_query;
 
-  Http::HeaderMapImpl response_headers;
+  Http::ResponseHeaderMapImpl response_headers;
 
   NiceMock<Server::MockAdminStream> admin_stream_mock;
   NiceMock<Network::MockConnection> connection_mock;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -485,8 +485,8 @@ TEST_F(LightStepDriverTest, SpawnChild) {
       config_, request_headers_, operation_name_, start_time_, {Tracing::Reason::Sampling, true});
   Tracing::SpanPtr childViaSpawn = parent->spawnChild(config_, operation_name_, start_time_);
 
-  Http::TestHeaderMapImpl base1{{":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
-  Http::TestHeaderMapImpl base2{{":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
+  Http::TestRequestHeaderMapImpl base1{{":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
+  Http::TestRequestHeaderMapImpl base2{{":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
 
   childViaHeaders->injectContext(base1);
   childViaSpawn->injectContext(base2);

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -207,7 +207,7 @@ void testIncomingHeaders(
 
   const std::string operation_name{"my_operation_2"};
   SystemTime start_time;
-  Http::TestHeaderMapImpl injected_headers;
+  Http::TestRequestHeaderMapImpl injected_headers;
   {
     Tracing::SpanPtr span = driver->startSpan(config, request_headers, operation_name, start_time,
                                               {Tracing::Reason::Sampling, false});

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -141,7 +141,7 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
   Tracer tracer{span_name, std::move(broker_), server_.timeSource()};
   auto span = tracer.startSpan(operation_name, server_.timeSource().systemTime(),
                                absl::nullopt /*headers*/);
-  Http::HeaderMapImpl request_headers;
+  Http::RequestHeaderMapImpl request_headers;
   span->injectContext(request_headers);
   auto* header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
   ASSERT_NE(header, nullptr);
@@ -154,7 +154,7 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
   constexpr auto span_name = "my span";
   Tracer tracer{span_name, std::move(broker_), server_.timeSource()};
   auto span = tracer.createNonSampledSpan();
-  Http::HeaderMapImpl request_headers;
+  Http::RequestHeaderMapImpl request_headers;
   span->injectContext(request_headers);
   auto* header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
   ASSERT_NE(header, nullptr);

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -101,16 +101,16 @@ void AutonomousUpstream::createUdpListenerFilterChain(Network::UdpListenerFilter
 
 void AutonomousUpstream::setLastRequestHeaders(const Http::HeaderMap& headers) {
   Thread::LockGuard lock(headers_lock_);
-  last_request_headers_ = std::make_unique<Http::TestHeaderMapImpl>(headers);
+  last_request_headers_ = std::make_unique<Http::TestRequestHeaderMapImpl>(headers);
 }
 
-std::unique_ptr<Http::TestHeaderMapImpl> AutonomousUpstream::lastRequestHeaders() {
+std::unique_ptr<Http::TestRequestHeaderMapImpl> AutonomousUpstream::lastRequestHeaders() {
   Thread::LockGuard lock(headers_lock_);
   return std::move(last_request_headers_);
 }
 
 void AutonomousUpstream::setResponseHeaders(
-    std::unique_ptr<Http::TestHeaderMapImpl>&& response_headers) {
+    std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers) {
   Thread::LockGuard lock(headers_lock_);
   response_headers_ = std::move(response_headers);
 }

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -55,7 +55,7 @@ public:
                      bool allow_incomplete_streams)
       : FakeUpstream(address, type, time_system),
         allow_incomplete_streams_(allow_incomplete_streams),
-        response_headers_(std::make_unique<Http::TestHeaderMapImpl>(
+        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
             Http::TestHeaderMapImpl({{":status", "200"}}))) {}
 
   AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory, uint32_t port,
@@ -63,7 +63,7 @@ public:
                      Event::TestTimeSystem& time_system, bool allow_incomplete_streams)
       : FakeUpstream(std::move(transport_socket_factory), port, type, version, time_system),
         allow_incomplete_streams_(allow_incomplete_streams),
-        response_headers_(std::make_unique<Http::TestHeaderMapImpl>(
+        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
             Http::TestHeaderMapImpl({{":status", "200"}}))) {}
 
   ~AutonomousUpstream() override;
@@ -75,15 +75,15 @@ public:
                                     Network::UdpReadFilterCallbacks& callbacks) override;
 
   void setLastRequestHeaders(const Http::HeaderMap& headers);
-  std::unique_ptr<Http::TestHeaderMapImpl> lastRequestHeaders();
-  void setResponseHeaders(std::unique_ptr<Http::TestHeaderMapImpl>&& response_headers);
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> lastRequestHeaders();
+  void setResponseHeaders(std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers);
   Http::TestHeaderMapImpl responseHeaders();
   const bool allow_incomplete_streams_{false};
 
 private:
   Thread::MutexBasicLockable headers_lock_;
-  std::unique_ptr<Http::TestHeaderMapImpl> last_request_headers_;
-  std::unique_ptr<Http::TestHeaderMapImpl> response_headers_;
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> last_request_headers_;
+  std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers_;
   std::vector<AutonomousHttpConnectionPtr> http_connections_;
   std::vector<SharedConnectionWrapperPtr> shared_connections_;
 };

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -64,9 +64,9 @@ public:
   void encodeTrailers(const Http::HeaderMap& trailers);
   void encodeResetStream();
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector);
-  const Http::HeaderMap& headers() { return *headers_; }
+  const Http::RequestHeaderMap& headers() { return *headers_; }
   void setAddServedByHeader(bool add_header) { add_served_by_header_ = add_header; }
-  const Http::HeaderMapPtr& trailers() { return trailers_; }
+  const Http::RequestTrailerMapPtr& trailers() { return trailers_; }
   bool receivedData() { return received_data_; }
 
   ABSL_MUST_USE_RESULT
@@ -175,14 +175,14 @@ public:
   }
 
 protected:
-  Http::HeaderMapPtr headers_;
+  Http::RequestHeaderMapPtr headers_;
 
 private:
   FakeHttpConnection& parent_;
   Http::ResponseEncoder& encoder_;
   Thread::MutexBasicLockable lock_;
   Thread::CondVar decoder_event_;
-  Http::HeaderMapPtr trailers_;
+  Http::RequestTrailerMapPtr trailers_;
   bool end_stream_{};
   Buffer::OwnedImpl body_;
   bool saw_reset_{};

--- a/test/integration/filters/add_trailers_filter.cc
+++ b/test/integration/filters/add_trailers_filter.cc
@@ -15,7 +15,8 @@ class AddTrailersStreamFilter : public Http::PassThroughFilter {
 public:
   Http::FilterDataStatus decodeData(Buffer::Instance&, bool end_stream) override {
     if (end_stream) {
-      decoder_callbacks_->addDecodedTrailers().setGrpcMessage("decode");
+      decoder_callbacks_->addDecodedTrailers().addCopy(Http::LowerCaseString("grpc-message"),
+                                                       "decode");
     }
 
     return Http::FilterDataStatus::Continue;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -331,8 +331,8 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
 }
 
 void HttpIntegrationTest::sendRequestAndVerifyResponse(
-    const Http::TestHeaderMapImpl& request_headers, const int request_size,
-    const Http::TestHeaderMapImpl& response_headers, const int response_size,
+    const Http::TestRequestHeaderMapImpl& request_headers, const int request_size,
+    const Http::TestResponseHeaderMapImpl& response_headers, const int response_size,
     const int backend_idx) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
@@ -346,13 +346,13 @@ void HttpIntegrationTest::sendRequestAndVerifyResponse(
 
 void HttpIntegrationTest::verifyResponse(IntegrationStreamDecoderPtr response,
                                          const std::string& response_code,
-                                         const Http::TestHeaderMapImpl& expected_headers,
+                                         const Http::TestResponseHeaderMapImpl& expected_headers,
                                          const std::string& expected_body) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ(response_code, response->headers().Status()->value().getStringView());
   expected_headers.iterate(
       [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-        auto response_headers = static_cast<Http::HeaderMap*>(context);
+        auto response_headers = static_cast<Http::ResponseHeaderMap*>(context);
         const Http::HeaderEntry* entry =
             response_headers->get(Http::LowerCaseString{std::string(header.key().getStringView())});
         EXPECT_NE(entry, nullptr);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -150,15 +150,15 @@ protected:
   // Verifies the response_headers contains the expected_headers, and response body matches given
   // body string.
   void verifyResponse(IntegrationStreamDecoderPtr response, const std::string& response_code,
-                      const Http::TestHeaderMapImpl& expected_headers,
+                      const Http::TestResponseHeaderMapImpl& expected_headers,
                       const std::string& expected_body);
 
   // Helper that sends a request to Envoy, and verifies if Envoy response headers and body size is
   // the same as the expected headers map.
   // Requires the "http" port has been registered.
-  void sendRequestAndVerifyResponse(const Http::TestHeaderMapImpl& request_headers,
+  void sendRequestAndVerifyResponse(const Http::TestRequestHeaderMapImpl& request_headers,
                                     const int request_size,
-                                    const Http::TestHeaderMapImpl& response_headers,
+                                    const Http::TestResponseHeaderMapImpl& response_headers,
                                     const int response_size, const int backend_idx);
 
   // Check for completion of upstream_request_, and a simple "200" response.

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -41,9 +41,9 @@ public:
   bool complete() { return saw_end_stream_; }
   bool reset() { return saw_reset_; }
   Http::StreamResetReason reset_reason() { return reset_reason_; }
-  const Http::HeaderMap* continue_headers() { return continue_headers_.get(); }
-  const Http::HeaderMap& headers() { return *headers_; }
-  const Http::HeaderMapPtr& trailers() { return trailers_; }
+  const Http::ResponseHeaderMap* continue_headers() { return continue_headers_.get(); }
+  const Http::ResponseHeaderMap& headers() { return *headers_; }
+  const Http::ResponseTrailerMapPtr& trailers() { return trailers_; }
   const Http::MetadataMap& metadata_map() { return *metadata_map_; }
   uint64_t keyCount(std::string key) { return duplicated_metadata_key_count_[key]; }
   void waitForContinueHeaders();
@@ -73,9 +73,9 @@ public:
 
 private:
   Event::Dispatcher& dispatcher_;
-  Http::HeaderMapPtr continue_headers_;
-  Http::HeaderMapPtr headers_;
-  Http::HeaderMapPtr trailers_;
+  Http::ResponseHeaderMapPtr continue_headers_;
+  Http::ResponseHeaderMapPtr headers_;
+  Http::ResponseTrailerMapPtr trailers_;
   Http::MetadataMapPtr metadata_map_{new Http::MetadataMap()};
   std::unordered_map<std::string, uint64_t> duplicated_metadata_key_count_;
   bool waiting_for_end_stream_{};

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -490,7 +490,7 @@ TEST_P(IntegrationTest, Http09Enabled) {
   EXPECT_THAT(response, HasSubstr("connection: close"));
   EXPECT_THAT(response, Not(HasSubstr("transfer-encoding: chunked\r\n")));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "default.com");
@@ -509,7 +509,7 @@ TEST_P(IntegrationTest, Http10Enabled) {
   EXPECT_THAT(response, HasSubstr("connection: close"));
   EXPECT_THAT(response, Not(HasSubstr("transfer-encoding: chunked\r\n")));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "default.com");
@@ -535,7 +535,7 @@ TEST_P(IntegrationTest, TestInlineHeaders) {
                                 &response, true);
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 200 OK\r\n"));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
@@ -566,7 +566,7 @@ TEST_P(IntegrationTest, Http10WithHostandKeepAliveAndLwsNoContentLength) {
   EXPECT_THAT(response, Not(HasSubstr("content-length:")));
   EXPECT_THAT(response, Not(HasSubstr("transfer-encoding: chunked\r\n")));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
@@ -577,7 +577,7 @@ TEST_P(IntegrationTest, Http10WithHostandKeepAliveAndContentLengthAndLws) {
   config_helper_.addConfigModifier(&setAllowHttp10WithDefaultHost);
   initialize();
   reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
-      ->setResponseHeaders(std::make_unique<Http::TestHeaderMapImpl>(
+      ->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(
           Http::TestHeaderMapImpl({{":status", "200"}, {"content-length", "10"}})));
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -211,7 +211,10 @@ typed_config:
   response->waitForEndStream();
 
   if (upstreamProtocol() == FakeHttpConnection::Type::HTTP2) {
-    EXPECT_EQ("decode", upstream_request_->trailers()->GrpcMessage()->value().getStringView());
+    EXPECT_EQ("decode", upstream_request_->trailers()
+                            ->get(Http::LowerCaseString("grpc-message"))
+                            ->value()
+                            .getStringView());
   }
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().Status()->value().getStringView());

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -75,7 +75,7 @@ protected:
     return new_stream;
   }
 
-  Http::TestHeaderMapImpl redirect_response_{
+  Http::TestResponseHeaderMapImpl redirect_response_{
       {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
 
   std::vector<FakeHttpConnectionPtr> upstream_connections_;

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -27,7 +27,7 @@ public:
   BufferingStreamDecoder(std::function<void()> on_complete_cb) : on_complete_cb_(on_complete_cb) {}
 
   bool complete() { return complete_; }
-  const Http::HeaderMap& headers() { return *headers_; }
+  const Http::ResponseHeaderMap& headers() { return *headers_; }
   const std::string& body() { return body_; }
 
   // Http::StreamDecoder
@@ -48,7 +48,7 @@ public:
 private:
   void onComplete();
 
-  Http::HeaderMapPtr headers_;
+  Http::ResponseHeaderMapPtr headers_;
   std::string body_;
   bool complete_{};
   std::function<void()> on_complete_cb_;

--- a/test/integration/websocket_integration_test.h
+++ b/test/integration/websocket_integration_test.h
@@ -21,11 +21,10 @@ protected:
                       const Http::TestResponseHeaderMapImpl& upgrade_response_headers);
   void sendBidirectionalData();
 
-  void validateUpgradeRequestHeaders(const Http::HeaderMap& proxied_request_headers,
-                                     const Http::HeaderMap& original_request_headers);
-  void validateUpgradeResponseHeaders(const Http::HeaderMap& proxied_response_headers,
-                                      const Http::HeaderMap& original_response_headers);
-  void commonValidate(Http::HeaderMap& proxied_headers, const Http::HeaderMap& original_headers);
+  void validateUpgradeRequestHeaders(const Http::RequestHeaderMap& proxied_request_headers,
+                                     const Http::RequestHeaderMap& original_request_headers);
+  void validateUpgradeResponseHeaders(const Http::ResponseHeaderMap& proxied_response_headers,
+                                      const Http::ResponseHeaderMap& original_response_headers);
 
   ABSL_MUST_USE_RESULT
   testing::AssertionResult waitForUpstreamDisconnectOrReset() {

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -28,8 +28,9 @@ public:
 
   // AccessLog::Filter
   MOCK_METHOD(bool, evaluate,
-              (const StreamInfo::StreamInfo& info, const Http::HeaderMap& request_headers,
-               const Http::HeaderMap& response_headers, const Http::HeaderMap& response_trailers));
+              (const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers));
 };
 
 class MockAccessLogManager : public AccessLogManager {
@@ -51,8 +52,9 @@ public:
 
   // AccessLog::Instance
   MOCK_METHOD(void, log,
-              (const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-               const Http::HeaderMap* response_trailers,
+              (const Http::RequestHeaderMap* request_headers,
+               const Http::ResponseHeaderMap* response_headers,
+               const Http::ResponseTrailerMap* response_trailers,
                const StreamInfo::StreamInfo& stream_info));
 };
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -174,7 +174,7 @@ public:
   MOCK_METHOD(void, continueDecoding, ());
   MOCK_METHOD(void, addDecodedData, (Buffer::Instance & data, bool streaming));
   MOCK_METHOD(void, injectDecodedDataToFilterChain, (Buffer::Instance & data, bool end_stream));
-  MOCK_METHOD(HeaderMap&, addDecodedTrailers, ());
+  MOCK_METHOD(RequestTrailerMap&, addDecodedTrailers, ());
   MOCK_METHOD(MetadataMapVector&, addDecodedMetadata, ());
   MOCK_METHOD(const Buffer::Instance*, decodingBuffer, ());
   MOCK_METHOD(void, modifyDecodingBuffer, (std::function<void(Buffer::Instance&)>));
@@ -228,7 +228,7 @@ public:
   // Http::StreamEncoderFilterCallbacks
   MOCK_METHOD(void, addEncodedData, (Buffer::Instance & data, bool streaming));
   MOCK_METHOD(void, injectEncodedDataToFilterChain, (Buffer::Instance & data, bool end_stream));
-  MOCK_METHOD(HeaderMap&, addEncodedTrailers, ());
+  MOCK_METHOD(ResponseTrailerMap&, addEncodedTrailers, ());
   MOCK_METHOD(void, addEncodedMetadata, (Http::MetadataMapPtr &&));
   MOCK_METHOD(void, continueEncoding, ());
   MOCK_METHOD(const Buffer::Instance*, encodingBuffer, ());

--- a/test/mocks/http/mocks_test.cc
+++ b/test/mocks/http/mocks_test.cc
@@ -52,7 +52,7 @@ TEST(HeaderValueOfTest, LowerCaseString) {
 }
 
 TEST(HttpStatusIsTest, CheckStatus) {
-  TestHeaderMapImpl header_map;
+  TestResponseHeaderMapImpl header_map;
   const auto status_matcher = HttpStatusIs(200);
 
   EXPECT_THAT(header_map, Not(status_matcher));

--- a/test/mocks/http/stream_encoder.cc
+++ b/test/mocks/http/stream_encoder.cc
@@ -13,28 +13,30 @@ MockStreamEncoder::MockStreamEncoder() {
 MockStreamEncoder::~MockStreamEncoder() = default;
 
 MockRequestEncoder::MockRequestEncoder() {
-  ON_CALL(*this, encodeHeaders(_, _)).WillByDefault(Invoke([](const HeaderMap& headers, bool) {
-    // Check for passing response headers as request headers in a test.
-    // TODO(mattklein123): In future changes this will become impossible once the header/trailer
-    // implementation classes are split.
-    ASSERT(headers.Status() == nullptr);
-    // Check to see that method is not-null. Path can be null for CONNECT and authority can be null
-    // at the codec level.
-    ASSERT(headers.Method() != nullptr);
-  }));
+  ON_CALL(*this, encodeHeaders(_, _))
+      .WillByDefault(Invoke([](const RequestHeaderMap& headers, bool) {
+        // Check for passing response headers as request headers in a test.
+        // TODO(mattklein123): In future changes this will become impossible once the header/trailer
+        // implementation classes are split.
+        ASSERT(headers.Status() == nullptr);
+        // Check to see that method is not-null. Path can be null for CONNECT and authority can be
+        // null at the codec level.
+        ASSERT(headers.Method() != nullptr);
+      }));
 }
 MockRequestEncoder::~MockRequestEncoder() = default;
 
 MockResponseEncoder::MockResponseEncoder() {
-  ON_CALL(*this, encodeHeaders(_, _)).WillByDefault(Invoke([](const HeaderMap& headers, bool) {
-    // Check for passing request headers as response headers in a test.
-    // TODO(mattklein123): In future changes this will become impossible once the header/trailer
-    // implementation classes are split.
-    ASSERT(headers.Status() != nullptr);
-    ASSERT(headers.Path() == nullptr);
-    ASSERT(headers.Method() == nullptr);
-    ASSERT(headers.Host() == nullptr);
-  }));
+  ON_CALL(*this, encodeHeaders(_, _))
+      .WillByDefault(Invoke([](const ResponseHeaderMap& headers, bool) {
+        // Check for passing request headers as response headers in a test.
+        // TODO(mattklein123): In future changes this will become impossible once the header/trailer
+        // implementation classes are split.
+        ASSERT(headers.Status() != nullptr);
+        ASSERT(headers.Path() == nullptr);
+        ASSERT(headers.Method() == nullptr);
+        ASSERT(headers.Host() == nullptr);
+      }));
 }
 MockResponseEncoder::~MockResponseEncoder() = default;
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -46,10 +46,11 @@ public:
 
   // DirectResponseEntry
   MOCK_METHOD(void, finalizeResponseHeaders,
-              (Http::HeaderMap & headers, const StreamInfo::StreamInfo& stream_info), (const));
-  MOCK_METHOD(std::string, newPath, (const Http::HeaderMap& headers), (const));
-  MOCK_METHOD(void, rewritePathHeader, (Http::HeaderMap & headers, bool insert_envoy_original_path),
+              (Http::ResponseHeaderMap & headers, const StreamInfo::StreamInfo& stream_info),
               (const));
+  MOCK_METHOD(std::string, newPath, (const Http::RequestHeaderMap& headers), (const));
+  MOCK_METHOD(void, rewritePathHeader,
+              (Http::RequestHeaderMap & headers, bool insert_envoy_original_path), (const));
   MOCK_METHOD(Http::Code, responseCode, (), (const));
   MOCK_METHOD(const std::string&, responseBody, (), (const));
   MOCK_METHOD(const std::string&, routeName, (), (const));
@@ -140,8 +141,8 @@ public:
 
   MOCK_METHOD(bool, enabled, ());
   MOCK_METHOD(RetryStatus, shouldRetryHeaders,
-              (const Http::HeaderMap& response_headers, DoRetryCallback callback));
-  MOCK_METHOD(bool, wouldRetryFromHeaders, (const Http::HeaderMap& response_headers));
+              (const Http::ResponseHeaderMap& response_headers, DoRetryCallback callback));
+  MOCK_METHOD(bool, wouldRetryFromHeaders, (const Http::ResponseHeaderMap& response_headers));
   MOCK_METHOD(RetryStatus, shouldRetryReset,
               (const Http::StreamResetReason reset_reason, DoRetryCallback callback));
   MOCK_METHOD(RetryStatus, shouldHedgeRetryPerTryTimeout, (DoRetryCallback callback));
@@ -260,8 +261,8 @@ public:
 
   // Http::HashPolicy
   MOCK_METHOD(absl::optional<uint64_t>, generateHash,
-              (const Network::Address::Instance* downstream_address, const Http::HeaderMap& headers,
-               const AddCookieCallback add_cookie),
+              (const Network::Address::Instance* downstream_address,
+               const Http::RequestHeaderMap& headers, const AddCookieCallback add_cookie),
               (const));
 };
 
@@ -311,11 +312,12 @@ public:
   MOCK_METHOD(const std::string&, clusterName, (), (const));
   MOCK_METHOD(Http::Code, clusterNotFoundResponseCode, (), (const));
   MOCK_METHOD(void, finalizeRequestHeaders,
-              (Http::HeaderMap & headers, const StreamInfo::StreamInfo& stream_info,
+              (Http::RequestHeaderMap & headers, const StreamInfo::StreamInfo& stream_info,
                bool insert_envoy_original_path),
               (const));
   MOCK_METHOD(void, finalizeResponseHeaders,
-              (Http::HeaderMap & headers, const StreamInfo::StreamInfo& stream_info), (const));
+              (Http::ResponseHeaderMap & headers, const StreamInfo::StreamInfo& stream_info),
+              (const));
   MOCK_METHOD(const Http::HashPolicy*, hashPolicy, (), (const));
   MOCK_METHOD(const HedgePolicy&, hedgePolicy, (), (const));
   MOCK_METHOD(const Router::MetadataMatchCriteria*, metadataMatchCriteria, (), (const));
@@ -413,7 +415,8 @@ public:
 
   // Router::Config
   MOCK_METHOD(RouteConstSharedPtr, route,
-              (const Http::HeaderMap&, const Envoy::StreamInfo::StreamInfo&, uint64_t random_value),
+              (const Http::RequestHeaderMap&, const Envoy::StreamInfo::StreamInfo&,
+               uint64_t random_value),
               (const));
   MOCK_METHOD(const std::list<Http::LowerCaseString>&, internalOnlyHeaders, (), (const));
   MOCK_METHOD(const std::string&, name, (), (const));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -156,7 +156,7 @@ public:
                Stats::ScopePtr&& listener_scope));
   MOCK_METHOD(Http::Code, request,
               (absl::string_view path_and_query, absl::string_view method,
-               Http::HeaderMap& response_headers, std::string& body));
+               Http::ResponseHeaderMap& response_headers, std::string& body));
   MOCK_METHOD(void, addListenerToHandler, (Network::ConnectionHandler * handler));
 
   NiceMock<MockConfigTracker> config_tracker_;
@@ -170,7 +170,7 @@ public:
   MOCK_METHOD(void, setEndStreamOnComplete, (bool));
   MOCK_METHOD(void, addOnDestroyCallback, (std::function<void()>));
   MOCK_METHOD(const Buffer::Instance*, getRequestBody, (), (const));
-  MOCK_METHOD(Http::HeaderMap&, getRequestHeaders, (), (const));
+  MOCK_METHOD(Http::RequestHeaderMap&, getRequestHeaders, (), (const));
   MOCK_METHOD(NiceMock<Http::MockStreamDecoderFilterCallbacks>&, getDecoderFilterCallbacks, (),
               (const));
 };

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -87,8 +87,8 @@ public:
   MOCK_METHOD(const std::string&, requestedServerName, (), (const));
   MOCK_METHOD(void, setUpstreamTransportFailureReason, (absl::string_view));
   MOCK_METHOD(const std::string&, upstreamTransportFailureReason, (), (const));
-  MOCK_METHOD(void, setRequestHeaders, (const Http::HeaderMap&));
-  MOCK_METHOD(const Http::HeaderMap*, getRequestHeaders, (), (const));
+  MOCK_METHOD(void, setRequestHeaders, (const Http::RequestHeaderMap&));
+  MOCK_METHOD(const Http::RequestHeaderMap*, getRequestHeaders, (), (const));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -34,7 +34,7 @@ public:
   MOCK_METHOD(void, setTag, (absl::string_view name, absl::string_view value));
   MOCK_METHOD(void, log, (SystemTime timestamp, const std::string& event));
   MOCK_METHOD(void, finishSpan, ());
-  MOCK_METHOD(void, injectContext, (Http::HeaderMap & request_headers));
+  MOCK_METHOD(void, injectContext, (Http::RequestHeaderMap & request_headers));
   MOCK_METHOD(void, setSampled, (const bool sampled));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
@@ -51,7 +51,7 @@ public:
   MockHttpTracer();
   ~MockHttpTracer() override;
 
-  SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
                     const StreamInfo::StreamInfo& stream_info,
                     const Tracing::Decision tracing_decision) override {
     return SpanPtr{startSpan_(config, request_headers, stream_info, tracing_decision)};
@@ -68,7 +68,7 @@ public:
   MockDriver();
   ~MockDriver() override;
 
-  SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
                     const std::string& operation_name, SystemTime start_time,
                     const Tracing::Decision tracing_decision) override {
     return SpanPtr{

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -13,7 +13,7 @@ public:
   MOCK_METHOD(absl::optional<uint64_t>, computeHashKey, ());
   MOCK_METHOD(Router::MetadataMatchCriteria*, metadataMatchCriteria, ());
   MOCK_METHOD(const Network::Connection*, downstreamConnection, (), (const));
-  MOCK_METHOD(const Http::HeaderMap*, downstreamHeaders, (), (const));
+  MOCK_METHOD(const Http::RequestHeaderMap*, downstreamHeaders, (), (const));
   MOCK_METHOD(const HealthyAndDegradedLoad&, determinePriorityLoad,
               (const PrioritySet&, const HealthyAndDegradedLoad&));
   MOCK_METHOD(bool, shouldSelectAnotherHost, (const Host&));


### PR DESCRIPTION
This is another change to use typed headers in a lot of places.
Although there are a huge number of lines changed, this should
have no functional impact. The next change will need a lot of
review but should be a small amount of lines and does the actual
final interface split.

Risk Level: Very low
Testing: Existing/fixed tests
Docs Changes: N/A
Release Notes: N/A
