### PR TITLE
jwt_authn: update base64 flavour in payload forward docs

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/README.md
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/README.md
@@ -28,7 +28,7 @@ If a custom location is desired, `from_headers` or `from_params` can be used to 
 
 ## HTTP header to pass successfully verified JWT
 
-If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64 encoded JWT payload in JSON.
+If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64url-encoded JWT payload in JSON.
 
 
 ## Further header options

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -165,7 +165,7 @@ message JwtProvider {
   // This field specifies the header name to forward a successfully verified JWT payload to the
   // backend. The forwarded data is::
   //
-  //    base64_encoded(jwt_payload_in_JSON)
+  //    base64url_encoded(jwt_payload_in_JSON)
   //
   // If it is not specified, the payload will not be forwarded.
   string forward_payload_header = 8;

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/README.md
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/README.md
@@ -28,7 +28,7 @@ If a custom location is desired, `from_headers` or `from_params` can be used to 
 
 ## HTTP header to pass successfully verified JWT
 
-If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64 encoded JWT payload in JSON.
+If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64url-encoded JWT payload in JSON.
 
 
 ## Further header options

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -167,7 +167,7 @@ message JwtProvider {
   // This field specifies the header name to forward a successfully verified JWT payload to the
   // backend. The forwarded data is::
   //
-  //    base64_encoded(jwt_payload_in_JSON)
+  //    base64url_encoded(jwt_payload_in_JSON)
   //
   // If it is not specified, the payload will not be forwarded.
   string forward_payload_header = 8;

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -114,7 +114,7 @@ Above example uses config inline string to specify JWKS. The JWT token will be e
 
 JWT payload will be added to the request header as following format::
 
-    x-jwt-payload: base64_encoded(jwt_payload_in_JSON)
+    x-jwt-payload: base64url_encoded(jwt_payload_in_JSON)
 
 RequirementRule
 ~~~~~~~~~~~~~~~

--- a/generated_api_shadow/envoy/config/filter/http/jwt_authn/v2alpha/README.md
+++ b/generated_api_shadow/envoy/config/filter/http/jwt_authn/v2alpha/README.md
@@ -28,7 +28,7 @@ If a custom location is desired, `from_headers` or `from_params` can be used to 
 
 ## HTTP header to pass successfully verified JWT
 
-If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64 encoded JWT payload in JSON.
+If a JWT is valid, its payload will be passed to the backend in a new HTTP header specified in `forward_payload_header` field. Its value is base64url-encoded JWT payload in JSON.
 
 
 ## Further header options

--- a/generated_api_shadow/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/generated_api_shadow/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -165,7 +165,7 @@ message JwtProvider {
   // This field specifies the header name to forward a successfully verified JWT payload to the
   // backend. The forwarded data is::
   //
-  //    base64_encoded(jwt_payload_in_JSON)
+  //    base64url_encoded(jwt_payload_in_JSON)
   //
   // If it is not specified, the payload will not be forwarded.
   string forward_payload_header = 8;

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -167,7 +167,7 @@ message JwtProvider {
   // This field specifies the header name to forward a successfully verified JWT payload to the
   // backend. The forwarded data is::
   //
-  //    base64_encoded(jwt_payload_in_JSON)
+  //    base64url_encoded(jwt_payload_in_JSON)
   //
   // If it is not specified, the payload will not be forwarded.
   string forward_payload_header = 8;


### PR DESCRIPTION
**Description:**
Modifies the jwt_authn docs to make it clear that the JWT payload
forwarded to the backend service is encoded with base64url and not
regular base64.

**Risk Level:**
Low

**Testing:**
All of the test tokens in the [test suite](https://github.com/envoyproxy/envoy/blob/master/test/extensions/filters/http/jwt_authn/test_common.h) are base64url flavoured.

**Docs Changes:**
See description.

**Release Notes:**
N/A

