### PR TITLE
Update Mongo Filter max time stat to be compatible with Mongo v3.2+

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -11,6 +11,7 @@ Version history
 * ext_authz: disabled the use of lowercase string matcher for headers matching in HTTP-based `ext_authz`.
   Can be reverted temporarily by setting runtime feature `envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher` to false.
 * http: fixing a bug in HTTP/1.0 responses where Connection: keep-alive was not appended for connections which were kept alive.
+* mongo: the stat emitted for queries without a max time set in the :ref:`MongoDB filter<config_network_filters_mongo_proxy>` was modified to emit correctly for Mongo v3.2+.
 * network filters: network filter extensions use the "envoy.filters.network" name space. A mapping
   of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * rbac: added :ref:`url_path <envoy_api_field_config.rbac.v2.Permission.url_path>` for matching URL path without the query and fragment string.
@@ -35,7 +36,6 @@ Version history
   restart Envoy. The behavior will not switch until the connection pools are recreated. The new
   circuit breaker behavior is described :ref:`here <arch_overview_circuit_break>`.
 * upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`.
-* The stat emitted for queries without a max time set in the :ref:`MongoDB filter <config_network_filters_mongo_proxy>` was modified to emit correctly for Mongo v3.2+.
 
 1.13.0 (January 20, 2020)
 =========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -35,6 +35,7 @@ Version history
   restart Envoy. The behavior will not switch until the connection pools are recreated. The new
   circuit breaker behavior is described :ref:`here <arch_overview_circuit_break>`.
 * upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`.
+* The stat emitted for queries without a max time set in the :ref:`MongoDB filter <config_network_filters_mongo_proxy>` was modified to emit correctly for Mongo v3.2+.
 
 1.13.0 (January 20, 2020)
 =========================

--- a/source/extensions/filters/network/mongo_proxy/utility.cc
+++ b/source/extensions/filters/network/mongo_proxy/utility.cc
@@ -46,7 +46,10 @@ std::string QueryMessageInfo::parseCollection(const std::string& full_collection
 int32_t QueryMessageInfo::parseMaxTime(const QueryMessage& query) {
   const Bson::Field* field = query.query()->find("$maxTimeMS");
   if (!field) {
-    return 0;
+    field = query.query()->find("maxTimeMS");
+    if (!field) {
+        return 0;
+    }
   }
 
   if (field->type() == Bson::Field::Type::Int32) {

--- a/source/extensions/filters/network/mongo_proxy/utility.cc
+++ b/source/extensions/filters/network/mongo_proxy/utility.cc
@@ -48,7 +48,7 @@ int32_t QueryMessageInfo::parseMaxTime(const QueryMessage& query) {
   if (!field) {
     field = query.query()->find("maxTimeMS");
     if (!field) {
-        return 0;
+      return 0;
     }
   }
 

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -500,6 +500,21 @@ TEST_F(MongoProxyFilterTest, MaxTime) {
   EXPECT_EQ(0U, store_.counter("test.op_query_no_max_time").value());
 }
 
+TEST_F(MongoProxyFilterTest, MaxTimeCursor) {
+  initializeFilter();
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    QueryMessagePtr message(new QueryMessageImpl(0, 0));
+    message->fullCollectionName("db.test");
+    message->flags(0b1110010);
+    message->query(Bson::DocumentImpl::create()->addInt32("maxTimeMS", 500));
+    filter_->callbacks_->decodeQuery(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  EXPECT_EQ(0U, store_.counter("test.op_query_no_max_time").value());
+}
+
 TEST_F(MongoProxyFilterTest, DecodeError) {
   initializeFilter();
 

--- a/test/extensions/filters/network/mongo_proxy/utility_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/utility_test.cc
@@ -155,7 +155,7 @@ TEST(QueryMessageInfoTest, MaxTime) {
     QueryMessageInfo info(q);
     EXPECT_EQ(1212, info.max_time());
   }
-  
+
   {
     QueryMessageImpl q(0, 0);
     q.fullCollectionName("db.foo");

--- a/test/extensions/filters/network/mongo_proxy/utility_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/utility_test.cc
@@ -155,6 +155,14 @@ TEST(QueryMessageInfoTest, MaxTime) {
     QueryMessageInfo info(q);
     EXPECT_EQ(1212, info.max_time());
   }
+  
+  {
+    QueryMessageImpl q(0, 0);
+    q.fullCollectionName("db.foo");
+    q.query(Bson::DocumentImpl::create()->addInt64("maxTimeMS", 2400));
+    QueryMessageInfo info(q);
+    EXPECT_EQ(2400, info.max_time());
+  }
 }
 
 TEST(QueryMessageInfoTest, Command) {


### PR DESCRIPTION
Description: Background as to why this change is needed can be found [here](https://docs.google.com/document/d/15R9vU15EeCEKwba8WNceE5xIBtO1t6Ny86RrsgQ9jDk/edit). tl;dr The query_op_no_max_time stat is emitting for all Mongo queries made with Mongo v3.2+ because the `$` preceding the `$maxTimeMS` value in the Mongo logs has been dropped. This change looks up `maxTimeMS` as well as `$maxTimeMS` for OP_QUERY operations so that this stat is not erroneously emitting for later versions of Mongo.

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: Updated