### PR TITLE
router: rate_limit descriptor fix

### DIFF
--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -121,11 +121,11 @@ void RateLimitPolicyEntryImpl::populateDescriptors(
   RateLimit::Descriptor descriptor;
   bool valid_descriptor = false;
   for (const RateLimitActionPtr& action : actions_) {
-    if(action->populateDescriptor(route, descriptor, local_service_cluster, headers,
-                                        remote_address)) {
-        valid_descriptor = true;
-      }
+    if (action->populateDescriptor(route, descriptor, local_service_cluster, headers,
+                                   remote_address)) {
+      valid_descriptor = true;
     }
+  }
   if (valid_descriptor) {
     descriptors.emplace_back(descriptor);
   }

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -119,12 +119,14 @@ void RateLimitPolicyEntryImpl::populateDescriptors(
     const std::string& local_service_cluster, const Http::HeaderMap& headers,
     const Network::Address::Instance& remote_address) const {
   RateLimit::Descriptor descriptor;
-  bool result = false;
+  bool valid_descriptor = false;
   for (const RateLimitActionPtr& action : actions_) {
-    result = result || action->populateDescriptor(route, descriptor, local_service_cluster, headers,
-                                                  remote_address);
+    if(action->populateDescriptor(route, descriptor, local_service_cluster, headers,
+                                        remote_address)) {
+        valid_descriptor = true;
+      }
     }
-  if (result) {
+  if (valid_descriptor) {
     descriptors.emplace_back(descriptor);
   }
 }

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -119,15 +119,11 @@ void RateLimitPolicyEntryImpl::populateDescriptors(
     const std::string& local_service_cluster, const Http::HeaderMap& headers,
     const Network::Address::Instance& remote_address) const {
   RateLimit::Descriptor descriptor;
-  bool result = true;
+  bool result = false;
   for (const RateLimitActionPtr& action : actions_) {
-    result = result && action->populateDescriptor(route, descriptor, local_service_cluster, headers,
+    result = result || action->populateDescriptor(route, descriptor, local_service_cluster, headers,
                                                   remote_address);
-    if (!result) {
-      break;
     }
-  }
-
   if (result) {
     descriptors.emplace_back(descriptor);
   }

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -366,7 +366,7 @@ actions:
               testing::ContainerEq(descriptors_));
 }
 
-// Verify if descriptors are added if atleast one request header matches
+// Verify if descriptors are added if at-least one request header matches
 TEST_F(RateLimitPolicyEntryTest, RequestHeadersPartialMatch) {
   const std::string yaml = R"EOF(
 actions:

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -522,8 +522,9 @@ actions:
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
                                          default_remote_address_);
-  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"destination_cluster", "fake_cluster"}}}}),
-              testing::ContainerEq(descriptors_));
+  EXPECT_THAT(
+      std::vector<Envoy::RateLimit::Descriptor>({{{{"destination_cluster", "fake_cluster"}}}}),
+      testing::ContainerEq(descriptors_));
 }
 
 } // namespace

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -366,7 +366,7 @@ actions:
               testing::ContainerEq(descriptors_));
 }
 
-// Verify if descriptors are added if at-least one request header matches
+// Validate that a descriptor is added if at least one request header has value.
 TEST_F(RateLimitPolicyEntryTest, RequestHeadersPartialMatch) {
   const std::string yaml = R"EOF(
 actions:

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -70,7 +70,7 @@ public:
     codec_client_ = makeHttpConnection(std::move(conn));
     Http::TestRequestHeaderMapImpl headers{
         {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
-        {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}, {"x-forwarded-client-cert": nullptr}};
+        {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
     response_ = codec_client_->makeRequestWithBody(headers, request_size_);
   }
 

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -70,7 +70,7 @@ public:
     codec_client_ = makeHttpConnection(std::move(conn));
     Http::TestRequestHeaderMapImpl headers{
         {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
-        {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
+        {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}, {"x-forwarded-client-cert": nullptr}};
     response_ = codec_client_->makeRequestWithBody(headers, request_size_);
   }
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: It resolves - https://github.com/envoyproxy/envoy/issues/10124 by ensuring the descriptors get populated if there is one matching header in the request.
Risk Level: low
Testing: unit test added
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue] Fixes #10124 
[Optional Deprecated:]
