### PR TITLE
Enable v8 build on Arm64 server

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -2,12 +2,12 @@
 
 set -e
 
-# This works only on Linux-{x86_64,s390x} and macOS-x86_64.
+# This works only on Linux-{x86_64,s390x,aarch64} and macOS-x86_64.
 case "$$(uname -s)-$$(uname -m)" in
-Linux-x86_64|Linux-s390x|Darwin-x86_64)
+Linux-x86_64|Linux-s390x|Linux-aarch64|Darwin-x86_64)
   ;;
 *)
-  echo "ERROR: wee8 is currently supported only on Linux-{x86_64,s390x} and macOS-x86_64." >&2
+  echo "ERROR: wee8 is currently supported only on Linux-{x86_64,s390x,aarch64} and macOS-x86_64." >&2
   exit 1
 esac
 
@@ -73,6 +73,10 @@ WEE8_BUILD_ARGS+=" v8_use_external_startup_data=false"
 # Disable read-only heap, since it's leaky and HEAPCHECK complains about it.
 # TODO(PiotrSikora): remove when fixed upstream.
 WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
+# Support Arm64
+if [[ `uname -m` == "aarch64" ]]; then
+  WEE8_BUILD_ARGS+=" target_cpu=\"arm64\""
+fi
 
 # Build wee8.
 if [[ "$$(uname -s)" == "Darwin" ]]; then
@@ -82,6 +86,7 @@ elif [[ "$$(uname -s)-$$(uname -m)" == "Linux-x86_64" ]]; then
   gn=buildtools/linux64/gn
   ninja=third_party/depot_tools/ninja
 else
+  # Using system default ninja & gn tools
   gn=$$(command -v gn)
   ninja=$$(command -v ninja)
 fi


### PR DESCRIPTION
This patch enable the v8 build on Arm64 native build environments for
envoy. There are some modifications about wee8 build scripts and wee8
patch as following:
Modify the corresponding varible in building scripts.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
