### PR TITLE
Update jwt_verify_lib to 2020-02-11

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -177,10 +177,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/releases/download/cpp-3.2.0/msgpack-3.2.0.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "b6e04123e801dc8204d9bcab5716ec92a510a770546fca823e6f399dc920479d",
-        strip_prefix = "jwt_verify_lib-2d8dfd2dd5b715536af2531e107bde995796f749",
-        # 2020-01-08
-        urls = ["https://github.com/google/jwt_verify_lib/archive/2d8dfd2dd5b715536af2531e107bde995796f749.tar.gz"],
+        sha256 = "d422a6eadd4bcdd0f9b122cd843a4015f8b18aebea6e1deb004bd4d401a8ef92",
+        strip_prefix = "jwt_verify_lib-40e2cc938f4bcd059a97dc6c73f59ecfa5a71bac",
+        # 2020-02-11
+        urls = ["https://github.com/google/jwt_verify_lib/archive/40e2cc938f4bcd059a97dc6c73f59ecfa5a71bac.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "ef26268c54c8084d17654ba2ed5140bffeffd2a040a895ffb22a6cca3f6c613f",


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Description:
Jwt_verify_lib added PEM public key type support.  But Envoy jwt_authn http filter only uses JWKS type.  It is not using PEM type.   This PR just updates its SHA to the latest,  did not bring any essential changes .

Risk Level: Low
Testing: Unit-test 
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue]
[Optional Deprecated:]
