### PR TITLE
stats: initialize store_ parameter on mock histograms

### DIFF
--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -209,7 +209,7 @@ public:
   uint32_t use_count() const override { return refcount_helper_.use_count(); }
 
   Unit unit_{Histogram::Unit::Unspecified};
-  Store* store_;
+  Store* store_{};
 
 private:
   RefcountHelper refcount_helper_;
@@ -237,7 +237,7 @@ public:
 
   bool used_;
   Unit unit_{Histogram::Unit::Unspecified};
-  Store* store_;
+  Store* store_{};
   std::shared_ptr<HistogramStatistics> histogram_stats_ =
       std::make_shared<HistogramStatisticsImpl>();
 


### PR DESCRIPTION
This ensures that the nullptr check in the recordValue default
handler makes sense, preventing UB when the handler is invoked
on a default constructed mock histogram.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
