### PR TITLE
tracing: introduce `TracerFactoryContext` abstraction

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -268,7 +268,7 @@ envoy_cc_library(
     name = "tracer_config_interface",
     hdrs = ["tracer_config.h"],
     deps = [
-        ":instance_interface",
+        ":filter_config_interface",
         "//include/envoy/config:typed_config_interface",
         "//source/common/protobuf",
     ],

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -105,6 +105,11 @@ public:
 class ServerFactoryContext : public virtual CommonFactoryContext {
 public:
   ~ServerFactoryContext() override = default;
+
+  /**
+   * @return the server-wide grpc context.
+   */
+  virtual Grpc::Context& grpcContext() PURE;
 };
 
 /**

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -43,3 +43,13 @@ envoy_cc_library(
         "@envoy_api//envoy/type/tracing/v3:pkg_cc_proto",
     ],
 )
+
+envoy_cc_library(
+    name = "http_tracer_config_lib",
+    hdrs = [
+        "http_tracer_config_impl.h",
+    ],
+    deps = [
+        "//include/envoy/server:tracer_config_interface",
+    ],
+)

--- a/source/common/tracing/http_tracer_config_impl.h
+++ b/source/common/tracing/http_tracer_config_impl.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "envoy/protobuf/message_validator.h"
+#include "envoy/server/tracer_config.h"
+
+namespace Envoy {
+namespace Tracing {
+
+class TracerFactoryContextImpl : public Server::Configuration::TracerFactoryContext {
+public:
+  TracerFactoryContextImpl(Server::Configuration::ServerFactoryContext& server_factory_context,
+                           ProtobufMessage::ValidationVisitor& validation_visitor)
+      : server_factory_context_(server_factory_context), validation_visitor_(validation_visitor) {}
+  Server::Configuration::ServerFactoryContext& serverFactoryContext() override {
+    return server_factory_context_;
+  }
+  ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+    return validation_visitor_;
+  }
+
+private:
+  Server::Configuration::ServerFactoryContext& server_factory_context_;
+  ProtobufMessage::ValidationVisitor& validation_visitor_;
+};
+
+} // namespace Tracing
+} // namespace Envoy

--- a/source/extensions/tracers/common/BUILD
+++ b/source/extensions/tracers/common/BUILD
@@ -12,7 +12,6 @@ envoy_cc_library(
     name = "factory_base_lib",
     hdrs = ["factory_base.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//include/envoy/server:tracer_config_interface",
         "//source/common/config:utility_lib",
     ],

--- a/source/extensions/tracers/common/factory_base.h
+++ b/source/extensions/tracers/common/factory_base.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "envoy/server/instance.h"
 #include "envoy/server/tracer_config.h"
 
 namespace Envoy {
@@ -15,12 +14,12 @@ namespace Common {
 template <class ConfigProto> class FactoryBase : public Server::Configuration::TracerFactory {
 public:
   // Server::Configuration::TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const Protobuf::Message& config,
-                                          Server::Instance& server) override {
-    return createHttpTracerTyped(
-        MessageUtil::downcastAndValidate<const ConfigProto&>(
-            config, server.messageValidationContext().staticValidationVisitor()),
-        server);
+  Tracing::HttpTracerPtr
+  createHttpTracer(const Protobuf::Message& config,
+                   Server::Configuration::TracerFactoryContext& context) override {
+    return createHttpTracerTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                     config, context.messageValidationVisitor()),
+                                 context);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -33,8 +32,9 @@ protected:
   FactoryBase(const std::string& name) : name_(name) {}
 
 private:
-  virtual Tracing::HttpTracerPtr createHttpTracerTyped(const ConfigProto& proto_config,
-                                                       Server::Instance& server) PURE;
+  virtual Tracing::HttpTracerPtr
+  createHttpTracerTyped(const ConfigProto& proto_config,
+                        Server::Configuration::TracerFactoryContext& context) PURE;
 
   const std::string name_;
 };

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -2,7 +2,7 @@
 
 #include <sstream>
 
-#include "envoy/stats/store.h"
+#include "envoy/stats/scope.h"
 
 #include "common/common/assert.h"
 #include "common/common/base64.h"
@@ -143,8 +143,8 @@ Tracing::SpanPtr OpenTracingSpan::spawnChild(const Tracing::Config&, const std::
   return Tracing::SpanPtr{new OpenTracingSpan{driver_, std::move(ot_span)}};
 }
 
-OpenTracingDriver::OpenTracingDriver(Stats::Store& stats)
-    : tracer_stats_{OPENTRACING_TRACER_STATS(POOL_COUNTER_PREFIX(stats, "tracing.opentracing."))} {}
+OpenTracingDriver::OpenTracingDriver(Stats::Scope& scope)
+    : tracer_stats_{OPENTRACING_TRACER_STATS(POOL_COUNTER_PREFIX(scope, "tracing.opentracing."))} {}
 
 Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
                                               Http::RequestHeaderMap& request_headers,

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "envoy/stats/store.h"
+#include "envoy/stats/scope.h"
 #include "envoy/tracing/http_tracer.h"
 
 #include "common/common/logger.h"
@@ -55,7 +55,7 @@ private:
  */
 class OpenTracingDriver : public Tracing::Driver, protected Logger::Loggable<Logger::Id::tracing> {
 public:
-  explicit OpenTracingDriver(Stats::Store& stats);
+  explicit OpenTracingDriver(Stats::Scope& scope);
 
   // Tracer::TracingDriver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,

--- a/source/extensions/tracers/datadog/config.cc
+++ b/source/extensions/tracers/datadog/config.cc
@@ -20,11 +20,14 @@ namespace Datadog {
 DatadogTracerFactory::DatadogTracerFactory() : FactoryBase(TracerNames::get().Datadog) {}
 
 Tracing::HttpTracerPtr DatadogTracerFactory::createHttpTracerTyped(
-    const envoy::config::trace::v3::DatadogConfig& proto_config, Server::Instance& server) {
-  Tracing::DriverPtr datadog_driver =
-      std::make_unique<Driver>(proto_config, server.clusterManager(), server.stats(),
-                               server.threadLocal(), server.runtime());
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(datadog_driver), server.localInfo());
+    const envoy::config::trace::v3::DatadogConfig& proto_config,
+    Server::Configuration::TracerFactoryContext& context) {
+  Tracing::DriverPtr datadog_driver = std::make_unique<Driver>(
+      proto_config, context.serverFactoryContext().clusterManager(),
+      context.serverFactoryContext().scope(), context.serverFactoryContext().threadLocal(),
+      context.serverFactoryContext().runtime());
+  return std::make_unique<Tracing::HttpTracerImpl>(std::move(datadog_driver),
+                                                   context.serverFactoryContext().localInfo());
 }
 
 /**

--- a/source/extensions/tracers/datadog/config.h
+++ b/source/extensions/tracers/datadog/config.h
@@ -23,7 +23,7 @@ private:
   // FactoryBase
   Tracing::HttpTracerPtr
   createHttpTracerTyped(const envoy::config::trace::v3::DatadogConfig& proto_config,
-                        Server::Instance& server) override;
+                        Server::Configuration::TracerFactoryContext& context) override;
 };
 
 } // namespace Datadog

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -22,11 +22,11 @@ Driver::TlsTracer::TlsTracer(const std::shared_ptr<opentracing::Tracer>& tracer,
     : tracer_(tracer), reporter_(std::move(reporter)), driver_(driver) {}
 
 Driver::Driver(const envoy::config::trace::v3::DatadogConfig& datadog_config,
-               Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+               Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
                ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime)
-    : OpenTracingDriver{stats},
+    : OpenTracingDriver{scope},
       cm_(cluster_manager), tracer_stats_{DATADOG_TRACER_STATS(
-                                POOL_COUNTER_PREFIX(stats, "tracing.datadog."))},
+                                POOL_COUNTER_PREFIX(scope, "tracing.datadog."))},
       tls_(tls.allocateSlot()), runtime_(runtime) {
 
   Config::Utility::checkCluster(TracerNames::get().Datadog, datadog_config.collector_cluster(),

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.h
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.h
@@ -43,7 +43,7 @@ public:
    * Constructor. It adds itself and a newly-created Datadog::Tracer object to a thread-local store.
    */
   Driver(const envoy::config::trace::v3::DatadogConfig& datadog_config,
-         Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+         Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
          ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime);
 
   // Getters to return the DatadogDriver's key members.

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -19,12 +19,14 @@ DynamicOpenTracingTracerFactory::DynamicOpenTracingTracerFactory()
     : FactoryBase(TracerNames::get().DynamicOt) {}
 
 Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracerTyped(
-    const envoy::config::trace::v3::DynamicOtConfig& proto_config, Server::Instance& server) {
+    const envoy::config::trace::v3::DynamicOtConfig& proto_config,
+    Server::Configuration::TracerFactoryContext& context) {
   const std::string& library = proto_config.library();
   const std::string config = MessageUtil::getJsonStringFromMessage(proto_config.config());
-  Tracing::DriverPtr dynamic_driver =
-      std::make_unique<DynamicOpenTracingDriver>(server.stats(), library, config);
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(dynamic_driver), server.localInfo());
+  Tracing::DriverPtr dynamic_driver = std::make_unique<DynamicOpenTracingDriver>(
+      context.serverFactoryContext().scope(), library, config);
+  return std::make_unique<Tracing::HttpTracerImpl>(std::move(dynamic_driver),
+                                                   context.serverFactoryContext().localInfo());
 }
 
 /**

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -22,7 +22,7 @@ private:
   // FactoryBase
   Tracing::HttpTracerPtr
   createHttpTracerTyped(const envoy::config::trace::v3::DynamicOtConfig& configuration,
-                        Server::Instance& server) override;
+                        Server::Configuration::TracerFactoryContext& context) override;
 };
 
 } // namespace DynamicOt

--- a/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.cc
+++ b/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.cc
@@ -7,9 +7,9 @@ namespace Extensions {
 namespace Tracers {
 namespace DynamicOt {
 
-DynamicOpenTracingDriver::DynamicOpenTracingDriver(Stats::Store& stats, const std::string& library,
+DynamicOpenTracingDriver::DynamicOpenTracingDriver(Stats::Scope& scope, const std::string& library,
                                                    const std::string& tracer_config)
-    : OpenTracingDriver{stats} {
+    : OpenTracingDriver{scope} {
   std::string error_message;
   opentracing::expected<opentracing::DynamicTracingLibraryHandle> library_handle_maybe =
       opentracing::DynamicallyLoadTracingLibrary(library.c_str(), error_message);

--- a/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.h
+++ b/source/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.h
@@ -21,7 +21,7 @@ namespace DynamicOt {
  */
 class DynamicOpenTracingDriver : public Common::Ot::OpenTracingDriver {
 public:
-  DynamicOpenTracingDriver(Stats::Store& stats, const std::string& library,
+  DynamicOpenTracingDriver(Stats::Scope& scope, const std::string& library,
                            const std::string& tracer_config);
 
   static std::string formatErrorMessage(std::error_code error_code,

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -20,19 +20,23 @@ namespace Lightstep {
 LightstepTracerFactory::LightstepTracerFactory() : FactoryBase(TracerNames::get().Lightstep) {}
 
 Tracing::HttpTracerPtr LightstepTracerFactory::createHttpTracerTyped(
-    const envoy::config::trace::v3::LightstepConfig& proto_config, Server::Instance& server) {
+    const envoy::config::trace::v3::LightstepConfig& proto_config,
+    Server::Configuration::TracerFactoryContext& context) {
   auto opts = std::make_unique<lightstep::LightStepTracerOptions>();
-  const auto access_token_file =
-      server.api().fileSystem().fileReadToEnd(proto_config.access_token_file());
+  const auto access_token_file = context.serverFactoryContext().api().fileSystem().fileReadToEnd(
+      proto_config.access_token_file());
   const auto access_token_sv = StringUtil::rtrim(access_token_file);
   opts->access_token.assign(access_token_sv.data(), access_token_sv.size());
-  opts->component_name = server.localInfo().clusterName();
+  opts->component_name = context.serverFactoryContext().localInfo().clusterName();
 
   Tracing::DriverPtr lightstep_driver = std::make_unique<LightStepDriver>(
-      proto_config, server.clusterManager(), server.stats(), server.threadLocal(), server.runtime(),
-      std::move(opts), Common::Ot::OpenTracingDriver::PropagationMode::TracerNative,
-      server.grpcContext());
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver), server.localInfo());
+      proto_config, context.serverFactoryContext().clusterManager(),
+      context.serverFactoryContext().scope(), context.serverFactoryContext().threadLocal(),
+      context.serverFactoryContext().runtime(), std::move(opts),
+      Common::Ot::OpenTracingDriver::PropagationMode::TracerNative,
+      context.serverFactoryContext().grpcContext());
+  return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver),
+                                                   context.serverFactoryContext().localInfo());
 }
 
 /**

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -22,7 +22,7 @@ private:
   // FactoryBase
   Tracing::HttpTracerPtr
   createHttpTracerTyped(const envoy::config::trace::v3::LightstepConfig& proto_config,
-                        Server::Instance& server) override;
+                        Server::Configuration::TracerFactoryContext& context) override;
 };
 
 } // namespace Lightstep

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -133,15 +133,15 @@ void LightStepDriver::TlsLightStepTracer::enableTimer() {
 }
 
 LightStepDriver::LightStepDriver(const envoy::config::trace::v3::LightstepConfig& lightstep_config,
-                                 Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+                                 Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
                                  ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
                                  std::unique_ptr<lightstep::LightStepTracerOptions>&& options,
                                  PropagationMode propagation_mode, Grpc::Context& grpc_context)
-    : OpenTracingDriver{stats}, cm_{cluster_manager},
-      tracer_stats_{LIGHTSTEP_TRACER_STATS(POOL_COUNTER_PREFIX(stats, "tracing.lightstep."))},
+    : OpenTracingDriver{scope}, cm_{cluster_manager},
+      tracer_stats_{LIGHTSTEP_TRACER_STATS(POOL_COUNTER_PREFIX(scope, "tracing.lightstep."))},
       tls_{tls.allocateSlot()}, runtime_{runtime}, options_{std::move(options)},
       propagation_mode_{propagation_mode}, grpc_context_(grpc_context),
-      pool_(stats.symbolTable()), request_names_{pool_.add(lightstep::CollectorServiceFullName()),
+      pool_(scope.symbolTable()), request_names_{pool_.add(lightstep::CollectorServiceFullName()),
                                                  pool_.add(lightstep::CollectorMethodName())} {
 
   Config::Utility::checkCluster(TracerNames::get().Lightstep, lightstep_config.collector_cluster(),

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -54,7 +54,7 @@ public:
 class LightStepDriver : public Common::Ot::OpenTracingDriver {
 public:
   LightStepDriver(const envoy::config::trace::v3::LightstepConfig& lightstep_config,
-                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+                  Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
                   ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
                   std::unique_ptr<lightstep::LightStepTracerOptions>&& options,
                   PropagationMode propagation_mode, Grpc::Context& grpc_context);

--- a/source/extensions/tracers/opencensus/config.cc
+++ b/source/extensions/tracers/opencensus/config.cc
@@ -17,10 +17,13 @@ namespace OpenCensus {
 OpenCensusTracerFactory::OpenCensusTracerFactory() : FactoryBase(TracerNames::get().OpenCensus) {}
 
 Tracing::HttpTracerPtr OpenCensusTracerFactory::createHttpTracerTyped(
-    const envoy::config::trace::v3::OpenCensusConfig& proto_config, Server::Instance& server) {
+    const envoy::config::trace::v3::OpenCensusConfig& proto_config,
+    Server::Configuration::TracerFactoryContext& context) {
   Tracing::DriverPtr driver =
-      std::make_unique<Driver>(proto_config, server.localInfo(), server.api());
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(driver), server.localInfo());
+      std::make_unique<Driver>(proto_config, context.serverFactoryContext().localInfo(),
+                               context.serverFactoryContext().api());
+  return std::make_unique<Tracing::HttpTracerImpl>(std::move(driver),
+                                                   context.serverFactoryContext().localInfo());
 }
 
 /**

--- a/source/extensions/tracers/opencensus/config.h
+++ b/source/extensions/tracers/opencensus/config.h
@@ -24,7 +24,7 @@ private:
   // FactoryBase
   Tracing::HttpTracerPtr
   createHttpTracerTyped(const envoy::config::trace::v3::OpenCensusConfig& proto_config,
-                        Server::Instance& server) override;
+                        Server::Configuration::TracerFactoryContext& context) override;
 };
 
 } // namespace OpenCensus

--- a/source/extensions/tracers/xray/BUILD
+++ b/source/extensions/tracers/xray/BUILD
@@ -40,7 +40,7 @@ envoy_cc_library(
     deps = [
         ":daemon_cc_proto",
         "//include/envoy/common:time_interface",
-        "//include/envoy/server:instance_interface",
+        "//include/envoy/server:tracer_config_interface",
         "//include/envoy/tracing:http_tracer_interface",
         "//source/common/common:hex_lib",
         "//source/common/common:macros",

--- a/source/extensions/tracers/xray/config.h
+++ b/source/extensions/tracers/xray/config.h
@@ -23,7 +23,7 @@ public:
 private:
   Tracing::HttpTracerPtr
   createHttpTracerTyped(const envoy::config::trace::v3::XRayConfig& proto_config,
-                        Server::Instance& server) override;
+                        Server::Configuration::TracerFactoryContext& context) override;
 };
 
 } // namespace XRay

--- a/source/extensions/tracers/xray/xray_tracer_impl.h
+++ b/source/extensions/tracers/xray/xray_tracer_impl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "envoy/server/instance.h"
+#include "envoy/server/tracer_config.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"
 
@@ -16,7 +16,8 @@ namespace XRay {
 
 class Driver : public Tracing::Driver, public Logger::Loggable<Logger::Id::tracing> {
 public:
-  Driver(const XRay::XRayConfiguration& config, Server::Instance& server);
+  Driver(const XRay::XRayConfiguration& config,
+         Server::Configuration::TracerFactoryContext& context);
 
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, Envoy::SystemTime start_time,

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -18,12 +18,16 @@ namespace Zipkin {
 ZipkinTracerFactory::ZipkinTracerFactory() : FactoryBase(TracerNames::get().Zipkin) {}
 
 Tracing::HttpTracerPtr ZipkinTracerFactory::createHttpTracerTyped(
-    const envoy::config::trace::v3::ZipkinConfig& proto_config, Server::Instance& server) {
+    const envoy::config::trace::v3::ZipkinConfig& proto_config,
+    Server::Configuration::TracerFactoryContext& context) {
   Tracing::DriverPtr zipkin_driver = std::make_unique<Zipkin::Driver>(
-      proto_config, server.clusterManager(), server.stats(), server.threadLocal(), server.runtime(),
-      server.localInfo(), server.random(), server.timeSource());
+      proto_config, context.serverFactoryContext().clusterManager(),
+      context.serverFactoryContext().scope(), context.serverFactoryContext().threadLocal(),
+      context.serverFactoryContext().runtime(), context.serverFactoryContext().localInfo(),
+      context.serverFactoryContext().random(), context.serverFactoryContext().timeSource());
 
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(zipkin_driver), server.localInfo());
+  return std::make_unique<Tracing::HttpTracerImpl>(std::move(zipkin_driver),
+                                                   context.serverFactoryContext().localInfo());
 }
 
 /**

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -21,7 +21,7 @@ private:
   // FactoryBase
   Tracing::HttpTracerPtr
   createHttpTracerTyped(const envoy::config::trace::v3::ZipkinConfig& proto_config,
-                        Server::Instance& server) override;
+                        Server::Configuration::TracerFactoryContext& context) override;
 };
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -66,12 +66,12 @@ Driver::TlsTracer::TlsTracer(TracerPtr&& tracer, Driver& driver)
     : tracer_(std::move(tracer)), driver_(driver) {}
 
 Driver::Driver(const envoy::config::trace::v3::ZipkinConfig& zipkin_config,
-               Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+               Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
                ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
                const LocalInfo::LocalInfo& local_info, Runtime::RandomGenerator& random_generator,
                TimeSource& time_source)
     : cm_(cluster_manager), tracer_stats_{ZIPKIN_TRACER_STATS(
-                                POOL_COUNTER_PREFIX(stats, "tracing.zipkin."))},
+                                POOL_COUNTER_PREFIX(scope, "tracing.zipkin."))},
       tls_(tls.allocateSlot()), runtime_(runtime), local_info_(local_info),
       time_source_(time_source) {
   Config::Utility::checkCluster(TracerNames::get().Zipkin, zipkin_config.collector_cluster(), cm_);

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -94,7 +94,7 @@ public:
    * Also, it associates the given random-number generator to the Zipkin::Tracer object it creates.
    */
   Driver(const envoy::config::trace::v3::ZipkinConfig& zipkin_config,
-         Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+         Upstream::ClusterManager& cluster_manager, Stats::Scope& scope,
          ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
          const LocalInfo::LocalInfo& localinfo, Runtime::RandomGenerator& random_generator,
          TimeSource& time_source);

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "//source/common/network:socket_option_factory_lib",
         "//source/common/network:utility_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/tracing:http_tracer_config_lib",
         "//source/common/tracing:http_tracer_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -22,6 +22,7 @@
 #include "common/network/socket_option_factory.h"
 #include "common/protobuf/utility.h"
 #include "common/runtime/runtime_impl.h"
+#include "common/tracing/http_tracer_config_impl.h"
 #include "common/tracing/http_tracer_impl.h"
 
 namespace Envoy {
@@ -108,7 +109,10 @@ void MainImpl::initializeTracers(const envoy::config::trace::v3::Tracing& config
   auto& factory = Config::Utility::getAndCheckFactory<TracerFactory>(configuration.http());
   ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
       configuration.http(), server.messageValidationContext().staticValidationVisitor(), factory);
-  http_tracer_ = factory.createHttpTracer(*message, server);
+
+  Tracing::TracerFactoryContextImpl factory_context(
+      server.serverFactoryContext(), server.messageValidationContext().staticValidationVisitor());
+  http_tracer_ = factory.createHttpTracer(*message, factory_context);
 }
 
 void MainImpl::initializeStatsSinks(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -168,6 +168,7 @@ public:
   Admin& admin() override { return server_.admin(); }
   TimeSource& timeSource() override { return api().timeSource(); }
   Api::Api& api() override { return server_.api(); }
+  Grpc::Context& grpcContext() override { return server_.grpcContext(); }
 
   // Configuration::TransportSocketFactoryContext
   Ssl::ContextManager& sslContextManager() override { return server_.sslContextManager(); }

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -120,6 +120,7 @@ public:
               return Server::ProdListenerComponentFactory::createUdpListenerFilterFactoryList_(
                   filters, context);
             }));
+    ON_CALL(server_, serverFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
 
     try {
       main_config.initialize(bootstrap, server_, *cluster_manager_factory_);
@@ -134,6 +135,7 @@ public:
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
   NiceMock<Server::MockInstance> server_;
+  Server::ServerFactoryContextImpl server_factory_context_{server_};
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   OptionsImpl options_;
   std::unique_ptr<Upstream::ProdClusterManagerFactory> cluster_manager_factory_;

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -22,8 +22,8 @@ class TestDriver : public OpenTracingDriver {
 public:
   TestDriver(OpenTracingDriver::PropagationMode propagation_mode,
              const opentracing::mocktracer::PropagationOptions& propagation_options,
-             Stats::Store& stats)
-      : OpenTracingDriver{stats}, propagation_mode_{propagation_mode} {
+             Stats::Scope& scope)
+      : OpenTracingDriver{scope}, propagation_mode_{propagation_mode} {
     opentracing::mocktracer::MockTracerOptions options;
     auto recorder = new opentracing::mocktracer::InMemoryRecorder{};
     recorder_ = recorder;

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -20,10 +20,10 @@ namespace {
 
 TEST(DatadogTracerConfigTest, DatadogHttpTracer) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
-  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+  EXPECT_CALL(context.server_factory_context_.cluster_manager_, get(Eq("fake_cluster")))
       .WillRepeatedly(
-          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
-  ON_CALL(*context.server_factory_context_->cluster_manager_.thread_local_cluster_.cluster_.info_,
+          Return(&context.server_factory_context_.cluster_manager_.thread_local_cluster_));
+  ON_CALL(*context.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_,
           features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -19,10 +19,12 @@ namespace Datadog {
 namespace {
 
 TEST(DatadogTracerConfigTest, DatadogHttpTracer) {
-  NiceMock<Server::MockInstance> server;
-  EXPECT_CALL(server.cluster_manager_, get(Eq("fake_cluster")))
-      .WillRepeatedly(Return(&server.cluster_manager_.thread_local_cluster_));
-  ON_CALL(*server.cluster_manager_.thread_local_cluster_.cluster_.info_, features())
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+      .WillRepeatedly(
+          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
+  ON_CALL(*context.server_factory_context_->cluster_manager_.thread_local_cluster_.cluster_.info_,
+          features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
   const std::string yaml_string = R"EOF(
@@ -38,7 +40,7 @@ TEST(DatadogTracerConfigTest, DatadogHttpTracer) {
   DatadogTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr datadog_tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr datadog_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, datadog_tracer);
 }
 

--- a/test/extensions/tracers/dynamic_ot/config_test.cc
+++ b/test/extensions/tracers/dynamic_ot/config_test.cc
@@ -21,10 +21,12 @@ namespace DynamicOt {
 namespace {
 
 TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
-  NiceMock<Server::MockInstance> server;
-  EXPECT_CALL(server.cluster_manager_, get(Eq("fake_cluster")))
-      .WillRepeatedly(Return(&server.cluster_manager_.thread_local_cluster_));
-  ON_CALL(*server.cluster_manager_.thread_local_cluster_.cluster_.info_, features())
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+      .WillRepeatedly(
+          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
+  ON_CALL(*context.server_factory_context_->cluster_manager_.thread_local_cluster_.cluster_.info_,
+          features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
   const std::string yaml_string = fmt::sprintf(
@@ -43,7 +45,7 @@ TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
   DynamicOpenTracingTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  const Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, server);
+  const Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 }
 

--- a/test/extensions/tracers/dynamic_ot/config_test.cc
+++ b/test/extensions/tracers/dynamic_ot/config_test.cc
@@ -22,10 +22,10 @@ namespace {
 
 TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
-  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+  EXPECT_CALL(context.server_factory_context_.cluster_manager_, get(Eq("fake_cluster")))
       .WillRepeatedly(
-          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
-  ON_CALL(*context.server_factory_context_->cluster_manager_.thread_local_cluster_.cluster_.info_,
+          Return(&context.server_factory_context_.cluster_manager_.thread_local_cluster_));
+  ON_CALL(*context.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_,
           features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -19,10 +19,12 @@ namespace Lightstep {
 namespace {
 
 TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
-  NiceMock<Server::MockInstance> server;
-  EXPECT_CALL(server.cluster_manager_, get(Eq("fake_cluster")))
-      .WillRepeatedly(Return(&server.cluster_manager_.thread_local_cluster_));
-  ON_CALL(*server.cluster_manager_.thread_local_cluster_.cluster_.info_, features())
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+      .WillRepeatedly(
+          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
+  ON_CALL(*context.server_factory_context_->cluster_manager_.thread_local_cluster_.cluster_.info_,
+          features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
   const std::string yaml_string = R"EOF(
@@ -38,7 +40,7 @@ TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
   LightstepTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, lightstep_tracer);
 }
 

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -20,10 +20,10 @@ namespace {
 
 TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
-  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+  EXPECT_CALL(context.server_factory_context_.cluster_manager_, get(Eq("fake_cluster")))
       .WillRepeatedly(
-          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
-  ON_CALL(*context.server_factory_context_->cluster_manager_.thread_local_cluster_.cluster_.info_,
+          Return(&context.server_factory_context_.cluster_manager_.thread_local_cluster_));
+  ON_CALL(*context.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_,
           features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 

--- a/test/extensions/tracers/opencensus/config_test.cc
+++ b/test/extensions/tracers/opencensus/config_test.cc
@@ -17,7 +17,7 @@ namespace Tracers {
 namespace OpenCensus {
 
 TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracer) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
   const std::string yaml_string = R"EOF(
   http:
     name: envoy.tracers.opencensus
@@ -29,12 +29,12 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracer) {
   OpenCensusTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 }
 
 TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerWithTypedConfig) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
   const std::string yaml_string = R"EOF(
   http:
     name: envoy.tracers.opencensus
@@ -67,7 +67,7 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerWithTypedConfig) {
   OpenCensusTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 
   // Reset TraceParams back to default.
@@ -76,7 +76,7 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerWithTypedConfig) {
 }
 
 TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerGrpc) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
   const std::string yaml_string = R"EOF(
   http:
     name: envoy.tracers.opencensus
@@ -107,7 +107,7 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerGrpc) {
   OpenCensusTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 
   // Reset TraceParams back to default.

--- a/test/extensions/tracers/xray/config_test.cc
+++ b/test/extensions/tracers/xray/config_test.cc
@@ -54,7 +54,7 @@ TEST(XRayTracerConfigTest, XRayHttpTracerWithInvalidFileName) {
   EXPECT_CALL(file_system, fileReadToEnd("rules.json"))
       .WillRepeatedly(Throw(EnvoyException("failed to open file.")));
   EXPECT_CALL(api, fileSystem()).WillRepeatedly(ReturnRef(file_system));
-  EXPECT_CALL(*context.server_factory_context_, api()).WillRepeatedly(ReturnRef(api));
+  EXPECT_CALL(context.server_factory_context_, api()).WillRepeatedly(ReturnRef(api));
 
   const std::string yaml_string = R"EOF(
   http:

--- a/test/extensions/tracers/xray/config_test.cc
+++ b/test/extensions/tracers/xray/config_test.cc
@@ -20,7 +20,7 @@ namespace XRay {
 namespace {
 
 TEST(XRayTracerConfigTest, XRayHttpTracerWithTypedConfig) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
 
   const std::string yaml_string = R"EOF(
   http:
@@ -41,12 +41,12 @@ TEST(XRayTracerConfigTest, XRayHttpTracerWithTypedConfig) {
   XRayTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr xray_tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr xray_tracer = factory.createHttpTracer(*message, context);
   ASSERT_NE(nullptr, xray_tracer);
 }
 
 TEST(XRayTracerConfigTest, XRayHttpTracerWithInvalidFileName) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
   NiceMock<Api::MockApi> api;
   NiceMock<Filesystem::MockInstance> file_system;
 
@@ -54,7 +54,7 @@ TEST(XRayTracerConfigTest, XRayHttpTracerWithInvalidFileName) {
   EXPECT_CALL(file_system, fileReadToEnd("rules.json"))
       .WillRepeatedly(Throw(EnvoyException("failed to open file.")));
   EXPECT_CALL(api, fileSystem()).WillRepeatedly(ReturnRef(file_system));
-  EXPECT_CALL(server, api()).WillRepeatedly(ReturnRef(api));
+  EXPECT_CALL(*context.server_factory_context_, api()).WillRepeatedly(ReturnRef(api));
 
   const std::string yaml_string = R"EOF(
   http:
@@ -76,12 +76,12 @@ TEST(XRayTracerConfigTest, XRayHttpTracerWithInvalidFileName) {
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
 
-  Tracing::HttpTracerPtr xray_tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr xray_tracer = factory.createHttpTracer(*message, context);
   ASSERT_NE(nullptr, xray_tracer);
 }
 
 TEST(XRayTracerConfigTest, ProtocolNotUDPThrows) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
   const std::string yaml_string = R"EOF(
   http:
     name: envoy.tracers.xray
@@ -102,11 +102,11 @@ TEST(XRayTracerConfigTest, ProtocolNotUDPThrows) {
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
 
-  ASSERT_THROW(factory.createHttpTracer(*message, server), EnvoyException);
+  ASSERT_THROW(factory.createHttpTracer(*message, context), EnvoyException);
 }
 
 TEST(XRayTracerConfigTest, UsingNamedPortThrows) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
   const std::string yaml_string = R"EOF(
   http:
     name: envoy.tracers.xray
@@ -127,7 +127,7 @@ TEST(XRayTracerConfigTest, UsingNamedPortThrows) {
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
 
-  ASSERT_THROW(factory.createHttpTracer(*message, server), EnvoyException);
+  ASSERT_THROW(factory.createHttpTracer(*message, context), EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -25,7 +25,7 @@ namespace {
 class XRayDriverTest : public ::testing::Test {
 public:
   const std::string operation_name_ = "test_operation_name";
-  NiceMock<Server::MockInstance> server_;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<Tracing::MockConfig> tracing_config_;
   Http::TestRequestHeaderMapImpl request_headers_{
@@ -36,7 +36,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
   request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;Sampled=0");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/};
-  Driver driver(config, server_);
+  Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
@@ -51,7 +51,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
   request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;Sampled=1");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/};
-  Driver driver(config, server_);
+  Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
@@ -64,7 +64,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
   request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/};
-  Driver driver(config, server_);
+  Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
@@ -79,7 +79,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
 
 TEST_F(XRayDriverTest, NoXRayTracerHeader) {
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/};
-  Driver driver(config, server_);
+  Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
@@ -94,9 +94,10 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
 
 TEST_F(XRayDriverTest, EmptySegmentNameDefaultToClusterName) {
   const std::string cluster_name = "FooBar";
-  EXPECT_CALL(server_.local_info_, clusterName()).WillRepeatedly(ReturnRef(cluster_name));
+  EXPECT_CALL(context_.server_factory_context_->local_info_, clusterName())
+      .WillRepeatedly(ReturnRef(cluster_name));
   XRayConfiguration config{"" /*daemon_endpoint*/, "", "" /*sampling_rules*/};
-  Driver driver(config, server_);
+  Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, true /*sampled*/};
   Envoy::SystemTime start_time;

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -94,7 +94,7 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
 
 TEST_F(XRayDriverTest, EmptySegmentNameDefaultToClusterName) {
   const std::string cluster_name = "FooBar";
-  EXPECT_CALL(context_.server_factory_context_->local_info_, clusterName())
+  EXPECT_CALL(context_.server_factory_context_.local_info_, clusterName())
       .WillRepeatedly(ReturnRef(cluster_name));
   XRayConfiguration config{"" /*daemon_endpoint*/, "", "" /*sampling_rules*/};
   Driver driver(config, context_);

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -18,10 +18,11 @@ namespace Zipkin {
 namespace {
 
 TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
 
-  EXPECT_CALL(server.cluster_manager_, get(Eq("fake_cluster")))
-      .WillRepeatedly(Return(&server.cluster_manager_.thread_local_cluster_));
+  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+      .WillRepeatedly(
+          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
 
   const std::string yaml_string = R"EOF(
   http:
@@ -38,15 +39,16 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
   ZipkinTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 
 TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithTypedConfig) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
 
-  EXPECT_CALL(server.cluster_manager_, get(Eq("fake_cluster")))
-      .WillRepeatedly(Return(&server.cluster_manager_.thread_local_cluster_));
+  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+      .WillRepeatedly(
+          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
 
   const std::string yaml_string = R"EOF(
   http:
@@ -64,7 +66,7 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithTypedConfig) {
   ZipkinTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, server);
+  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -20,9 +20,9 @@ namespace {
 TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
 
-  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+  EXPECT_CALL(context.server_factory_context_.cluster_manager_, get(Eq("fake_cluster")))
       .WillRepeatedly(
-          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
+          Return(&context.server_factory_context_.cluster_manager_.thread_local_cluster_));
 
   const std::string yaml_string = R"EOF(
   http:
@@ -46,9 +46,9 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
 TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithTypedConfig) {
   NiceMock<Server::Configuration::MockTracerFactoryContext> context;
 
-  EXPECT_CALL(context.server_factory_context_->cluster_manager_, get(Eq("fake_cluster")))
+  EXPECT_CALL(context.server_factory_context_.cluster_manager_, get(Eq("fake_cluster")))
       .WillRepeatedly(
-          Return(&context.server_factory_context_->cluster_manager_.thread_local_cluster_));
+          Return(&context.server_factory_context_.cluster_manager_.thread_local_cluster_));
 
   const std::string yaml_string = R"EOF(
   http:

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -23,6 +23,7 @@ envoy_cc_mock(
         "//include/envoy/server:instance_interface",
         "//include/envoy/server:options_interface",
         "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server:tracer_config_interface",
         "//include/envoy/server:worker_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/upstream:health_checker_interface",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -272,10 +272,8 @@ MockHealthCheckerFactoryContext::~MockHealthCheckerFactoryContext() = default;
 MockFilterChainFactoryContext::MockFilterChainFactoryContext() = default;
 MockFilterChainFactoryContext::~MockFilterChainFactoryContext() = default;
 
-MockTracerFactoryContext::MockTracerFactoryContext()
-    : server_factory_context_(
-          std::make_shared<NiceMock<Configuration::MockServerFactoryContext>>()) {
-  ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(*server_factory_context_));
+MockTracerFactoryContext::MockTracerFactoryContext() {
+  ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
 }

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -195,7 +195,8 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
 MockMain::~MockMain() = default;
 
 MockServerFactoryContext::MockServerFactoryContext()
-    : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())) {
+    : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
+      grpc_context_(scope_.symbolTable()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
@@ -270,6 +271,16 @@ MockHealthCheckerFactoryContext::~MockHealthCheckerFactoryContext() = default;
 
 MockFilterChainFactoryContext::MockFilterChainFactoryContext() = default;
 MockFilterChainFactoryContext::~MockFilterChainFactoryContext() = default;
+
+MockTracerFactoryContext::MockTracerFactoryContext()
+    : server_factory_context_(
+          std::make_shared<NiceMock<Configuration::MockServerFactoryContext>>()) {
+  ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(*server_factory_context_));
+  ON_CALL(*this, messageValidationVisitor())
+      .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
+}
+
+MockTracerFactoryContext::~MockTracerFactoryContext() = default;
 } // namespace Configuration
 } // namespace Server
 } // namespace Envoy

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -20,6 +20,7 @@
 #include "envoy/server/instance.h"
 #include "envoy/server/options.h"
 #include "envoy/server/overload_manager.h"
+#include "envoy/server/tracer_config.h"
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/server/worker.h"
 #include "envoy/ssl/context_manager.h"
@@ -488,6 +489,7 @@ public:
   Event::TestTimeSystem& timeSystem() { return time_system_; }
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
+  Grpc::Context& grpcContext() override { return grpc_context_; }
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
@@ -501,6 +503,7 @@ public:
   testing::NiceMock<MockAdmin> admin_;
   Event::GlobalTimeSystem time_system_;
   testing::NiceMock<Api::MockApi> api_;
+  Grpc::ContextImpl grpc_context_;
 };
 
 class MockFactoryContext : public virtual FactoryContext {
@@ -625,6 +628,18 @@ class MockFilterChainFactoryContext : public MockFactoryContext, public FilterCh
 public:
   MockFilterChainFactoryContext();
   ~MockFilterChainFactoryContext() override;
+};
+
+class MockTracerFactoryContext : public TracerFactoryContext {
+public:
+  MockTracerFactoryContext();
+  ~MockTracerFactoryContext() override;
+
+  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
+  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
+
+  std::shared_ptr<testing::NiceMock<Configuration::MockServerFactoryContext>>
+      server_factory_context_;
 };
 
 } // namespace Configuration

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -638,8 +638,7 @@ public:
   MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
 
-  std::shared_ptr<testing::NiceMock<Configuration::MockServerFactoryContext>>
-      server_factory_context_;
+  testing::NiceMock<Configuration::MockServerFactoryContext> server_factory_context_;
 };
 
 } // namespace Configuration


### PR DESCRIPTION
Description: introduce `TracerFactoryContext` abstraction to replace `Server::Instance` as an argument to `TracerFactory::createHttpTracer(config, context)`
Risk Level: Medium
Testing: unit test
Docs Changes: N/A
Release Notes: N/A

Context:
* This PR lays groundwork for implementing #9998
* Before this PR, `TracerFactory::createHttpTracer(config, context)` implementations worked directly with `Server::Instance`, which will not be possible once the responsibility to instantiate `HttpTracer`s is passed to `envoy.http_connection_manager` filter
* This PR introduces a `TracerFactoryContext` abstraction to replace `Server::Instance` as an argument to `TracerFactory::createHttpTracer(config, context)`
* At the moment, `TracerFactoryContext` is roughly an equivalent of `ServerFactoryContext`