### PR TITLE
Fix doc build sed err 'extra char at the end of g cmd'

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -112,8 +112,8 @@ generate_api_rst v3
 
 # Fixup anchors and references in v3 so they form a distinct namespace.
 # TODO(htuch): Do this in protodoc generation in the future.
-find "${GENERATED_RST_DIR}"/api-v3 -name "*.rst" -print0 | xargs -0 sed -i "s#envoy_api_#envoy_v3_api_#g"
-find "${GENERATED_RST_DIR}"/api-v3 -name "*.rst" -print0 | xargs -0 sed -i "s#config_resource_monitors#v3_config_resource_monitors#g"
+find "${GENERATED_RST_DIR}"/api-v3 -name "*.rst" -print0 | xargs -0 sed -i -e "s#envoy_api_#envoy_v3_api_#g"
+find "${GENERATED_RST_DIR}"/api-v3 -name "*.rst" -print0 | xargs -0 sed -i -e "s#config_resource_monitors#v3_config_resource_monitors#g"
 
 mkdir -p ${GENERATED_RST_DIR}/api-docs
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: `./docs/build.sh` errors out to `Sed Error extra characters at the end of g command
`
Risk Level: Low
Testing:
Docs Changes: 
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
