### PR TITLE
stats: clear the stats storage before asserting the symbol table is empty.

### DIFF
--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -163,7 +163,7 @@ public:
   }
 
 private:
-  bool save_use_fakes_{SymbolTableCreator::useFakeSymbolTables()};
+  const bool save_use_fakes_{SymbolTableCreator::useFakeSymbolTables()};
 };
 
 // Serializes a number into a uint8_t array, and check that it de-serializes to

--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -156,9 +156,14 @@ private:
 
 class SymbolTableCreatorTestPeer {
 public:
-  static void setUseFakeSymbolTables(bool use_fakes) {
+  ~SymbolTableCreatorTestPeer() { SymbolTableCreator::setUseFakeSymbolTables(save_use_fakes_); }
+
+  void setUseFakeSymbolTables(bool use_fakes) {
     SymbolTableCreator::setUseFakeSymbolTables(use_fakes);
   }
+
+private:
+  bool save_use_fakes_{SymbolTableCreator::useFakeSymbolTables()};
 };
 
 // Serializes a number into a uint8_t array, and check that it de-serializes to

--- a/test/common/stats/stat_test_utility_test.cc
+++ b/test/common/stats/stat_test_utility_test.cc
@@ -11,9 +11,12 @@ namespace {
 class StatTestUtilityTest : public testing::Test {
 protected:
   StatTestUtilityTest()
-      : symbol_table_(SymbolTableCreator::initAndMakeSymbolTable(false)),
-        test_store_(*symbol_table_), dynamic_(*symbol_table_), symbolic_(*symbol_table_) {}
+      : symbol_table_(SymbolTableCreator::makeSymbolTable()), test_store_(*symbol_table_),
+        dynamic_(*symbol_table_), symbolic_(*symbol_table_) {
+    symbol_table_creator_test_peer_.setUseFakeSymbolTables(false);
+  }
 
+  TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer_;
   SymbolTablePtr symbol_table_;
   TestUtil::TestStore test_store_;
   StatNameDynamicPool dynamic_;

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -908,10 +908,7 @@ TEST_F(StatsThreadLocalStoreTest, NonHotRestartNoTruncation) {
 
 class StatsThreadLocalStoreTestNoFixture : public testing::Test {
 protected:
-  StatsThreadLocalStoreTestNoFixture()
-      : save_use_fakes_(SymbolTableCreator::useFakeSymbolTables()) {}
   ~StatsThreadLocalStoreTestNoFixture() override {
-    TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(save_use_fakes_);
     if (threading_enabled_) {
       store_->shutdownThreading();
       tls_.shutdownThread();
@@ -919,7 +916,7 @@ protected:
   }
 
   void init(bool use_fakes) {
-    TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(use_fakes);
+    symbol_table_creator_test_peer_.setUseFakeSymbolTables(use_fakes);
     symbol_table_ = SymbolTableCreator::makeSymbolTable();
     alloc_ = std::make_unique<AllocatorImpl>(*symbol_table_);
     store_ = std::make_unique<ThreadLocalStoreImpl>(*alloc_);
@@ -943,7 +940,7 @@ protected:
   std::unique_ptr<ThreadLocalStoreImpl> store_;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
   NiceMock<ThreadLocal::MockInstance> tls_;
-  const bool save_use_fakes_;
+  TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer_;
   bool threading_enabled_{false};
 };
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -117,7 +117,8 @@ std::string ContentType(const BufferingStreamDecoderPtr& response) {
 } // namespace
 
 TEST_P(IntegrationAdminTest, Admin) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+  Stats::TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer;
+  symbol_table_creator_test_peer.setUseFakeSymbolTables(false);
   initialize();
 
   BufferingStreamDecoderPtr response;

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -205,7 +205,7 @@ private:
   }
 };
 class ClusterMemoryTestRunner : public testing::TestWithParam<Network::Address::IpVersion> {
-private:
+protected:
   Stats::TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer_;
 };
 

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -205,14 +205,8 @@ private:
   }
 };
 class ClusterMemoryTestRunner : public testing::TestWithParam<Network::Address::IpVersion> {
-protected:
-  ClusterMemoryTestRunner() : save_use_fakes_(Stats::SymbolTableCreator::useFakeSymbolTables()) {}
-  ~ClusterMemoryTestRunner() override {
-    Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(save_use_fakes_);
-  }
-
 private:
-  const bool save_use_fakes_;
+  Stats::TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClusterMemoryTestRunner,
@@ -220,7 +214,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ClusterMemoryTestRunner,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(true);
+  symbol_table_creator_test_peer_.setUseFakeSymbolTables(true);
 
   // A unique instance of ClusterMemoryTest allows for multiple runs of Envoy with
   // differing configuration. This is necessary for measuring the memory consumption
@@ -291,7 +285,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+  symbol_table_creator_test_peer_.setUseFakeSymbolTables(false);
 
   // A unique instance of ClusterMemoryTest allows for multiple runs of Envoy with
   // differing configuration. This is necessary for measuring the memory consumption
@@ -345,7 +339,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+  symbol_table_creator_test_peer_.setUseFakeSymbolTables(false);
 
   // A unique instance of ClusterMemoryTest allows for multiple runs of Envoy with
   // differing configuration. This is necessary for measuring the memory consumption

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1654,6 +1654,9 @@ protected:
 
   void clearStorage() {
     pool_.clear();
+    counters_.clear();
+    gauges_.clear();
+    histograms_.clear();
     EXPECT_EQ(0, symbol_table_->numSymbols());
   }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -469,8 +469,11 @@ TEST_P(ServerInstanceImplTest, Stats) {
 class TestWithSimTimeAndRealSymbolTables : public Event::TestUsingSimulatedTime {
 protected:
   TestWithSimTimeAndRealSymbolTables() {
-    Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+    symbol_table_creator_test_peer_.setUseFakeSymbolTables(false);
   }
+
+private:
+  Stats::TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer_;
 };
 
 class ServerStatsTest


### PR DESCRIPTION
Description: fixes a coverage-test issue related to keeping whether we use real/fake symbol tables in a static that is not cleared at the end of tests. Also reset that at the end of tests via RAII.
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a

