### PR TITLE
common: add big-endian support to Ip6ntohl and Ip6htonl

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -424,17 +424,19 @@ bool Utility::portInRangeList(const Address::Instance& address, const std::list<
 }
 
 absl::uint128 Utility::Ip6ntohl(const absl::uint128& address) {
-  // TODO(ccaraman): Support Ip6ntohl for big-endian.
-  static_assert(ABSL_IS_LITTLE_ENDIAN,
-                "Machines using big-endian byte order is not supported for IPv6.");
+#ifdef ABSL_IS_LITTLE_ENDIAN
   return flipOrder(address);
+#else
+  return address;
+#endif
 }
 
 absl::uint128 Utility::Ip6htonl(const absl::uint128& address) {
-  // TODO(ccaraman): Support Ip6ntohl for big-endian.
-  static_assert(ABSL_IS_LITTLE_ENDIAN,
-                "Machines using big-endian byte order is not supported for IPv6.");
+#ifdef ABSL_IS_LITTLE_ENDIAN
   return flipOrder(address);
+#else
+  return address;
+#endif
 }
 
 absl::uint128 Utility::flipOrder(const absl::uint128& input) {


### PR DESCRIPTION
Description:
This patch resolves the TODO from
https://github.com/envoyproxy/envoy/pull/2431.
Tests pass on a big-endian machine (IBM Z).

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>

Risk Level: Low
Testing: run tests on a big-endian machine (e.g. IBM Z)
Docs Changes: None
Release Notes: None