### PR TITLE
build: allow building envoy on s390x

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -273,6 +273,11 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_s390x",
+    values = {"cpu": "s390x"},
+)
+
+config_setting(
     name = "linux_mips64",
     values = {"cpu": "mips64"},
 )
@@ -360,6 +365,7 @@ alias(
             ":linux_x86_64": ":linux_x86_64",
             ":linux_aarch64": ":linux_aarch64",
             ":linux_ppc": ":linux_ppc",
+            ":linux_s390x": "linux_s390x",
             ":linux_mips64": ":linux_mips64",
             # If we're not on an linux platform return a value that will never match in the select() statement calling this
             # since it would have already been matched above.

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -2,11 +2,14 @@
 
 set -e
 
-# This works only on Linux-x86_64 and macOS-x86_64.
-if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || `uname -m` != "x86_64" ]]; then
-  echo "ERROR: wee8 is currently supported only on Linux-x86_64 and macOS-x86_64."
+# This works only on Linux-{x86_64,s390x} and macOS-x86_64.
+case "$$(uname -s)-$$(uname -m)" in
+Linux-x86_64|Linux-s390x|Darwin-x86_64)
+  ;;
+*)
+  echo "ERROR: wee8 is currently supported only on Linux-{x86_64,s390x} and macOS-x86_64." >&2
   exit 1
-fi
+esac
 
 # Bazel magic.
 ROOT=$$(dirname $(rootpath wee8/BUILD.gn))/..

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -784,5 +784,8 @@ def _is_arch(ctxt, arch):
 def _is_linux_ppc(ctxt):
     return _is_linux(ctxt) and _is_arch(ctxt, "ppc")
 
+def _is_linux_s390x(ctxt):
+    return _is_linux(ctxt) and _is_arch(ctxt, "s390x")
+
 def _is_linux_x86_64(ctxt):
     return _is_linux(ctxt) and _is_arch(ctxt, "x86_64")


### PR DESCRIPTION
Description:
This commit adds support for the new architecture -
s390x (aka [IBM Z](https://en.wikipedia.org/wiki/IBM_Z)).

Building envoy on s390x requires using openssl instead of
boringssl, moonjit instead of luajit, host gn and ninja
instead of bundled binaries, and endianness fixes in Utility
class.

The first requirement is covered by
https://github.com/envoyproxy/envoy-openssl

The other requirements will be addressed in separate commits.

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>

Risk Level: Low
Testing: Run the build on IBM Z
Docs Changes: None
Release Notes: None
