### PR TITLE
lua: allow using moonjit

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -44,6 +44,25 @@ configure_make(
     }),
     lib_source = "@com_github_luajit_luajit//:all",
     make_commands = [],
+    out_include_dir = "include/luajit-2.1",
+    static_libraries = [
+        "libluajit-5.1.a",
+    ],
+)
+
+configure_make(
+    name = "moonjit",
+    configure_command = "build.py",
+    configure_env_vars = select({
+        # This shouldn't be needed! See
+        # https://github.com/envoyproxy/envoy/issues/6084
+        # TODO(htuch): Remove when #6084 is fixed
+        "//bazel:asan_build": {"ENVOY_CONFIG_ASAN": "1"},
+        "//conditions:default": {},
+    }),
+    lib_source = "@com_github_moonjit_moonjit//:all",
+    make_commands = [],
+    out_include_dir = "include/moonjit-2.2",
     static_libraries = [
         "libluajit-5.1.a",
     ],

--- a/bazel/foreign_cc/moonjit.patch
+++ b/bazel/foreign_cc/moonjit.patch
@@ -1,0 +1,90 @@
+diff --git a/src/Makefile b/src/Makefile
+index f56465d..3f4f2fa 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -27,7 +27,7 @@ NODOTABIVER= 51
+ DEFAULT_CC = gcc
+ #
+ # LuaJIT builds as a native 32 or 64 bit binary by default.
+-CC= $(DEFAULT_CC)
++CC ?= $(DEFAULT_CC)
+ #
+ # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
+ #CC= $(DEFAULT_CC) -m32
+@@ -71,10 +71,10 @@ CCWARN= -Wall
+ # as dynamic mode.
+ #
+ # Mixed mode creates a static + dynamic library and a statically linked luajit.
+-BUILDMODE= mixed
++#BUILDMODE= mixed
+ #
+ # Static mode creates a static library and a statically linked luajit.
+-#BUILDMODE= static
++BUILDMODE= static
+ #
+ # Dynamic mode creates a dynamic library and a dynamically linked luajit.
+ # Note: this executable will only run when the library is installed!
+@@ -99,7 +99,7 @@ XCFLAGS=
+ # enabled by default. Some other features that *might* break some existing
+ # code (e.g. __pairs or os.execute() return values) can be enabled here.
+ # Note: this does not provide full compatibility with Lua 5.2 at this time.
+-#XCFLAGS+= -DLUAJIT_ENABLE_LUA52COMPAT
++XCFLAGS+= -DLUAJIT_ENABLE_LUA52COMPAT
+ #
+ # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
+ #XCFLAGS+= -DLUAJIT_DISABLE_JIT
+@@ -587,7 +587,7 @@ endif
+
+ Q= @
+ E= @echo
+-#Q=
++Q=
+ #E= @:
+
+ ##############################################################################
+EOF
+diff --git a/build.py b/build.py
+new file mode 100755
+index 0000000..9c71271
+--- /dev/null
++++ b/build.py
+@@ -0,0 +1,39 @@
++#!/usr/bin/env python
++
++import argparse
++import os
++import shutil
++
++def main():
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--prefix")
++    args = parser.parse_args()
++    src_dir = os.path.dirname(os.path.realpath(__file__))
++    shutil.copytree(src_dir, os.path.basename(src_dir))
++    os.chdir(os.path.basename(src_dir))
++
++    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
++    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
++    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["CFLAGS"] = ""
++    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
++    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't
++    # fail on it.
++    os.environ["LSAN_OPTIONS"] = "exitcode=0"
++
++    if "ENVOY_MSAN" in os.environ:
++      os.environ["HOST_CFLAGS"] = "-fno-sanitize=memory"
++      os.environ["HOST_LDFLAGS"] = "-fno-sanitize=memory"
++
++    # Blacklist LuaJIT from ASAN for now.
++    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.
++    if "ENVOY_CONFIG_ASAN" in os.environ:
++      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_moonjit_moonjit/clang-asan-blacklist.txt" % os.environ["PWD"]
++      with open("clang-asan-blacklist.txt", "w") as f:
++        f.write("fun:*\n")
++
++    os.system('make V=1 PREFIX="{}" install'.format(args.prefix))
++
++main()
++

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -131,6 +131,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_jbeder_yaml_cpp()
     _com_github_libevent_libevent()
     _com_github_luajit_luajit()
+    _com_github_moonjit_moonjit()
     _com_github_nghttp2_nghttp2()
     _com_github_nodejs_http_parser()
     _com_github_tencent_rapidjson()
@@ -718,6 +719,22 @@ def _com_github_luajit_luajit():
     native.bind(
         name = "luajit",
         actual = "@envoy//bazel/foreign_cc:luajit",
+    )
+
+def _com_github_moonjit_moonjit():
+    location = REPOSITORY_LOCATIONS["com_github_moonjit_moonjit"]
+    http_archive(
+        name = "com_github_moonjit_moonjit",
+        build_file_content = BUILD_ALL_CONTENT,
+        patches = ["@envoy//bazel/foreign_cc:moonjit.patch"],
+        patch_args = ["-p1"],
+        patch_cmds = ["chmod u+x build.py"],
+        **location
+    )
+
+    native.bind(
+        name = "moonjit",
+        actual = "@envoy//bazel/foreign_cc:moonjit",
     )
 
 def _com_github_gperftools_gperftools():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -120,6 +120,11 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "LuaJIT-2.1.0-beta3",
         urls = ["https://github.com/LuaJIT/LuaJIT/archive/v2.1.0-beta3.tar.gz"],
     ),
+    com_github_moonjit_moonjit = dict(
+        sha256 = "83deb2c880488dfe7dd8ebf09e3b1e7613ef4b8420de53de6f712f01aabca2b6",
+        strip_prefix = "moonjit-2.2.0",
+        urls = ["https://github.com/moonjit/moonjit/archive/2.2.0.tar.gz"],
+    ),
     com_github_nghttp2_nghttp2 = dict(
         sha256 = "eb9d9046495a49dd40c7ef5d6c9907b51e5a6b320ea6e2add11eb8b52c982c47",
         strip_prefix = "nghttp2-1.40.0",

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -17,6 +17,12 @@ and response flows. `LuaJIT <https://luajit.org/>`_ is used as the runtime. Beca
 supported Lua version is mostly 5.1 with some 5.2 features. See the `LuaJIT documentation
 <https://luajit.org/extensions.html>`_ for more details.
 
+.. note::
+
+  `moonjit <https://github.com/moonjit/moonjit/>`_ is a continuation of LuaJIT development, which
+  supports more 5.2 features and additional architectures. Envoy can be built with moonjit support
+  by using the following bazel option: ``--//source/extensions/filters/common/lua:moonjit=1``.
+
 The filter only supports loading Lua code in-line in the configuration. If local filesystem code
 is desired, a trivial in-line script can be used to load the rest of the code from the local
 environment.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -28,6 +28,7 @@ Version history
   mapping of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * listeners: fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed by a client using only TLS 1.3.
 * lua: added a parameter to `httpCall` that makes it possible to have the call be asynchronous.
+* lua: added moonjit support.
 * mongo: the stat emitted for queries without a max time set in the :ref:`MongoDB filter<config_network_filters_mongo_proxy>` was modified to emit correctly for Mongo v3.2+.
 * network filters: network filter extensions use the "envoy.filters.network" name space. A mapping
   of extension names is available in the :ref:`deprecated <deprecated>` documentation.

--- a/source/extensions/filters/common/lua/BUILD
+++ b/source/extensions/filters/common/lua/BUILD
@@ -5,22 +5,36 @@ load(
     "envoy_cc_library",
     "envoy_package",
 )
+load("//bazel:envoy_internal.bzl", "envoy_external_dep_path")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 envoy_package()
+
+bool_flag(
+    name = "moonjit",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "with_moonjit",
+    flag_values = {
+        ":moonjit": "True",
+    },
+)
 
 envoy_cc_library(
     name = "lua_lib",
     srcs = ["lua.cc"],
     hdrs = ["lua.h"],
-    external_deps = [
-        "luajit",
-    ],
     deps = [
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:c_smart_ptr_lib",
         "//source/common/protobuf",
-    ],
+    ] + select({
+        ":with_moonjit": [envoy_external_dep_path("moonjit")],
+        "//conditions:default": [envoy_external_dep_path("luajit")],
+    }),
 )
 
 envoy_cc_library(

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -11,7 +11,7 @@
 #include "common/common/c_smart_ptr.h"
 #include "common/common/logger.h"
 
-#include "luajit-2.1/lua.hpp"
+#include "lua.hpp"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Description:
moonjit (https://github.com/moonjit/moonjit) is a continuation of
LuaJIT development, which, as of late, has, unfortunately, come to
a stall.

In comparison to LuaJIT, moonjit, among other things, supports
s390x architecture as well as some of the Lua 5.2 language
features.

With this patch, moonjit can be enabled using

   --//source/extensions/filters/common/lua:moonjit=1

bazel flag.

Internally, moonjit integration is based on luajit integration.
Some of the fragments thereof (e.g. luajit.patch) were copy-pasted
with minimal modifications. While arguably ugly, this allows
updating LuaJIT and moonjit independently.

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>

Risk Level: Low
Testing: Run tests with `--//source/extensions/filters/common/lua:moonjit=1` flag
Docs Changes: None
Release Notes: None