### PR TITLE
stats: pass tags by const ref

### DIFF
--- a/include/envoy/stats/scope.h
+++ b/include/envoy/stats/scope.h
@@ -63,7 +63,7 @@ public:
    * @return a counter within the scope's namespace.
    */
   virtual Counter& counterFromStatNameWithTags(const StatName& name,
-                                               StatNameTagVectorOptRef tags) PURE;
+                                               StatNameTagVectorOptConstRef tags) PURE;
 
   /**
    * TODO(#6667): this variant is deprecated: use counterFromStatName.
@@ -90,7 +90,7 @@ public:
    * @param import_mode Whether hot-restart should accumulate this value.
    * @return a gauge within the scope's namespace.
    */
-  virtual Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  virtual Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Gauge::ImportMode import_mode) PURE;
 
   /**
@@ -125,7 +125,7 @@ public:
    * @return a histogram within the scope's namespace with a particular value type.
    */
   virtual Histogram& histogramFromStatNameWithTags(const StatName& name,
-                                                   StatNameTagVectorOptRef tags,
+                                                   StatNameTagVectorOptConstRef tags,
                                                    Histogram::Unit unit) PURE;
 
   /**

--- a/include/envoy/stats/tag.h
+++ b/include/envoy/stats/tag.h
@@ -25,7 +25,8 @@ using TagVector = std::vector<Tag>;
 
 using StatNameTag = std::pair<StatName, StatName>;
 using StatNameTagVector = std::vector<StatNameTag>;
-using StatNameTagVectorOptRef = absl::optional<std::reference_wrapper<StatNameTagVector>>;
+using StatNameTagVectorOptConstRef =
+    absl::optional<std::reference_wrapper<const StatNameTagVector>>;
 
 } // namespace Stats
 } // namespace Envoy

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -102,14 +102,14 @@ public:
 
   // Stats::Scope
   Counter& counterFromStatNameWithTags(const StatName& name,
-                                       StatNameTagVectorOptRef tags) override {
+                                       StatNameTagVectorOptConstRef tags) override {
     TagUtility::TagStatNameJoiner joiner(name, tags, symbolTable());
     Counter& counter = counters_.get(joiner.nameWithTags());
     return counter;
   }
   ScopePtr createScope(const std::string& name) override;
   void deliverHistogramToSinks(const Histogram&, uint64_t) override {}
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
     TagUtility::TagStatNameJoiner joiner(name, tags, symbolTable());
     Gauge& gauge = gauges_.get(joiner.nameWithTags(), import_mode);
@@ -118,7 +118,7 @@ public:
   }
   NullCounterImpl& nullCounter() { return *null_counter_; }
   NullGaugeImpl& nullGauge(const std::string&) override { return *null_gauge_; }
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
     TagUtility::TagStatNameJoiner joiner(name, tags, symbolTable());
     Histogram& histogram = histograms_.get(joiner.nameWithTags(), unit);

--- a/source/common/stats/scope_prefixer.cc
+++ b/source/common/stats/scope_prefixer.cc
@@ -27,13 +27,14 @@ ScopePtr ScopePrefixer::createScope(const std::string& name) {
 }
 
 Counter& ScopePrefixer::counterFromStatNameWithTags(const StatName& name,
-                                                    StatNameTagVectorOptRef tags) {
+                                                    StatNameTagVectorOptConstRef tags) {
   Stats::SymbolTable::StoragePtr stat_name_storage =
       scope_.symbolTable().join({prefix_.statName(), name});
   return scope_.counterFromStatNameWithTags(StatName(stat_name_storage.get()), tags);
 }
 
-Gauge& ScopePrefixer::gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+Gauge& ScopePrefixer::gaugeFromStatNameWithTags(const StatName& name,
+                                                StatNameTagVectorOptConstRef tags,
                                                 Gauge::ImportMode import_mode) {
   Stats::SymbolTable::StoragePtr stat_name_storage =
       scope_.symbolTable().join({prefix_.statName(), name});
@@ -41,7 +42,7 @@ Gauge& ScopePrefixer::gaugeFromStatNameWithTags(const StatName& name, StatNameTa
 }
 
 Histogram& ScopePrefixer::histogramFromStatNameWithTags(const StatName& name,
-                                                        StatNameTagVectorOptRef tags,
+                                                        StatNameTagVectorOptConstRef tags,
                                                         Histogram::Unit unit) {
   Stats::SymbolTable::StoragePtr stat_name_storage =
       scope_.symbolTable().join({prefix_.statName(), name});

--- a/source/common/stats/scope_prefixer.h
+++ b/source/common/stats/scope_prefixer.h
@@ -17,10 +17,11 @@ public:
 
   // Scope
   ScopePtr createScope(const std::string& name) override;
-  Counter& counterFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags) override;
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Counter& counterFromStatNameWithTags(const StatName& name,
+                                       StatNameTagVectorOptConstRef tags) override;
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override;
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override;
   void deliverHistogramToSinks(const Histogram& histograms, uint64_t val) override;
 

--- a/source/common/stats/tag_utility.cc
+++ b/source/common/stats/tag_utility.cc
@@ -7,7 +7,7 @@ namespace Stats {
 namespace TagUtility {
 
 TagStatNameJoiner::TagStatNameJoiner(StatName prefix, StatName stat_name,
-                                     StatNameTagVectorOptRef stat_name_tags,
+                                     StatNameTagVectorOptConstRef stat_name_tags,
                                      SymbolTable& symbol_table) {
   prefix_storage_ = symbol_table.join({prefix, stat_name});
   tag_extracted_name_ = StatName(prefix_storage_.get());
@@ -21,7 +21,8 @@ TagStatNameJoiner::TagStatNameJoiner(StatName prefix, StatName stat_name,
   }
 }
 
-TagStatNameJoiner::TagStatNameJoiner(StatName stat_name, StatNameTagVectorOptRef stat_name_tags,
+TagStatNameJoiner::TagStatNameJoiner(StatName stat_name,
+                                     StatNameTagVectorOptConstRef stat_name_tags,
                                      SymbolTable& symbol_table) {
   tag_extracted_name_ = stat_name;
 

--- a/source/common/stats/tag_utility.h
+++ b/source/common/stats/tag_utility.h
@@ -22,15 +22,15 @@ public:
    * @param name StaName the stat name to use.
    * @param stat_name_tags optionally StatNameTagVector the stat name tags to add to the stat name.
    */
-  TagStatNameJoiner(StatName prefix, StatName stat_name, StatNameTagVectorOptRef stat_name_tags,
-                    SymbolTable& symbol_table);
+  TagStatNameJoiner(StatName prefix, StatName stat_name,
+                    StatNameTagVectorOptConstRef stat_name_tags, SymbolTable& symbol_table);
 
   /**
    * Combines a stat name and tags into a single stat name.
    * @param name StaName the stat name to use.
    * @param stat_name_tags StatNameTagVector the stat name tags to optionally add to the stat name.
    */
-  TagStatNameJoiner(StatName stat_name, StatNameTagVectorOptRef stat_name_tags,
+  TagStatNameJoiner(StatName stat_name, StatNameTagVectorOptConstRef stat_name_tags,
                     SymbolTable& symbol_table);
 
   /**

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -390,7 +390,7 @@ ThreadLocalStoreImpl::ScopeImpl::findStatLockHeld(
 }
 
 Counter& ThreadLocalStoreImpl::ScopeImpl::counterFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptRef stat_name_tags) {
+    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags) {
   if (parent_.rejectsAll()) {
     return parent_.null_counter_;
   }
@@ -444,7 +444,8 @@ void ThreadLocalStoreImpl::ScopeImpl::deliverHistogramToSinks(const Histogram& h
 }
 
 Gauge& ThreadLocalStoreImpl::ScopeImpl::gaugeFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptRef stat_name_tags, Gauge::ImportMode import_mode) {
+    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags,
+    Gauge::ImportMode import_mode) {
   if (parent_.rejectsAll()) {
     return parent_.null_gauge_;
   }
@@ -481,7 +482,7 @@ Gauge& ThreadLocalStoreImpl::ScopeImpl::gaugeFromStatNameWithTags(
 }
 
 Histogram& ThreadLocalStoreImpl::ScopeImpl::histogramFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptRef stat_name_tags, Histogram::Unit unit) {
+    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags, Histogram::Unit unit) {
   if (parent_.rejectsAll()) {
     return parent_.null_histogram_;
   }

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -162,7 +162,7 @@ public:
 
   // Stats::Scope
   Counter& counterFromStatNameWithTags(const StatName& name,
-                                       StatNameTagVectorOptRef tags) override {
+                                       StatNameTagVectorOptConstRef tags) override {
     return default_scope_->counterFromStatNameWithTags(name, tags);
   }
   Counter& counter(const std::string& name) override { return default_scope_->counter(name); }
@@ -170,14 +170,14 @@ public:
   void deliverHistogramToSinks(const Histogram& histogram, uint64_t value) override {
     return default_scope_->deliverHistogramToSinks(histogram, value);
   }
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
     return default_scope_->gaugeFromStatNameWithTags(name, tags, import_mode);
   }
   Gauge& gauge(const std::string& name, Gauge::ImportMode import_mode) override {
     return default_scope_->gauge(name, import_mode);
   }
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
     return default_scope_->histogramFromStatNameWithTags(name, tags, unit);
   }
@@ -285,11 +285,12 @@ private:
 
     // Stats::Scope
     Counter& counterFromStatNameWithTags(const StatName& name,
-                                         StatNameTagVectorOptRef tags) override;
+                                         StatNameTagVectorOptConstRef tags) override;
     void deliverHistogramToSinks(const Histogram& histogram, uint64_t value) override;
-    Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+    Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                      Gauge::ImportMode import_mode) override;
-    Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+    Histogram& histogramFromStatNameWithTags(const StatName& name,
+                                             StatNameTagVectorOptConstRef tags,
                                              Histogram::Unit unit) override;
     Histogram& tlsHistogram(StatName name, ParentHistogramImpl& parent) override;
     ScopePtr createScope(const std::string& name) override {

--- a/test/common/stats/stat_test_utility.cc
+++ b/test/common/stats/stat_test_utility.cc
@@ -144,7 +144,7 @@ Counter& TestStore::counter(const std::string& name) {
 }
 
 Counter& TestStore::counterFromStatNameWithTags(const StatName& stat_name,
-                                                StatNameTagVectorOptRef tags) {
+                                                StatNameTagVectorOptConstRef tags) {
   std::string name = symbolTable().toString(stat_name);
   Counter*& counter_ref = counter_map_[name];
   if (counter_ref == nullptr) {
@@ -165,7 +165,8 @@ Gauge& TestStore::gauge(const std::string& name, Gauge::ImportMode mode) {
   return *gauge_ref;
 }
 
-Gauge& TestStore::gaugeFromStatNameWithTags(const StatName& stat_name, StatNameTagVectorOptRef tags,
+Gauge& TestStore::gaugeFromStatNameWithTags(const StatName& stat_name,
+                                            StatNameTagVectorOptConstRef tags,
                                             Gauge::ImportMode mode) {
   std::string name = symbolTable().toString(stat_name);
   Gauge*& gauge_ref = gauge_map_[name];
@@ -186,7 +187,7 @@ Histogram& TestStore::histogram(const std::string& name, Histogram::Unit unit) {
 }
 
 Histogram& TestStore::histogramFromStatNameWithTags(const StatName& stat_name,
-                                                    StatNameTagVectorOptRef tags,
+                                                    StatNameTagVectorOptConstRef tags,
                                                     Histogram::Unit unit) {
   std::string name = symbolTable().toString(stat_name);
   Histogram*& histogram_ref = histogram_map_[name];

--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -104,10 +104,11 @@ public:
   Counter& counter(const std::string& name) override;
   Gauge& gauge(const std::string& name, Gauge::ImportMode import_mode) override;
   Histogram& histogram(const std::string& name, Histogram::Unit unit) override;
-  Counter& counterFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags) override;
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Counter& counterFromStatNameWithTags(const StatName& name,
+                                       StatNameTagVectorOptConstRef tags) override;
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override;
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override;
 
   // New APIs available for tests.

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -82,18 +82,18 @@ public:
   }
 
   Counter& counterFromStatNameWithTags(const StatName& name,
-                                       StatNameTagVectorOptRef tags) override {
+                                       StatNameTagVectorOptConstRef tags) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->counterFromStatNameWithTags(name, tags);
   }
 
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->gaugeFromStatNameWithTags(name, tags, import_mode);
   }
 
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->histogramFromStatNameWithTags(name, tags, unit);
@@ -146,7 +146,7 @@ class TestIsolatedStoreImpl : public StoreRoot {
 public:
   // Stats::Scope
   Counter& counterFromStatNameWithTags(const StatName& name,
-                                       StatNameTagVectorOptRef tags) override {
+                                       StatNameTagVectorOptConstRef tags) override {
     Thread::LockGuard lock(lock_);
     return store_.counterFromStatNameWithTags(name, tags);
   }
@@ -159,7 +159,7 @@ public:
     return ScopePtr{new TestScopeWrapper(lock_, store_.createScope(name))};
   }
   void deliverHistogramToSinks(const Histogram&, uint64_t) override {}
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
     return store_.gaugeFromStatNameWithTags(name, tags, import_mode);
@@ -168,7 +168,7 @@ public:
     Thread::LockGuard lock(lock_);
     return store_.gauge(name, import_mode);
   }
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef tags,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
     Thread::LockGuard lock(lock_);
     return store_.histogramFromStatNameWithTags(name, tags, unit);

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -294,16 +294,17 @@ public:
   MOCK_METHOD(GaugeOptConstRef, findGauge, (StatName), (const));
   MOCK_METHOD(HistogramOptConstRef, findHistogram, (StatName), (const));
 
-  Counter& counterFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef) override {
+  Counter& counterFromStatNameWithTags(const StatName& name,
+                                       StatNameTagVectorOptConstRef) override {
     // We always just respond with the mocked counter, so the tags don't matter.
     return counter(symbol_table_->toString(name));
   }
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef,
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef,
                                    Gauge::ImportMode import_mode) override {
     // We always just respond with the mocked gauge, so the tags don't matter.
     return gauge(symbol_table_->toString(name), import_mode);
   }
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptRef,
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef,
                                            Histogram::Unit unit) override {
     return histogram(symbol_table_->toString(name), unit);
   }


### PR DESCRIPTION
These don't need to be mutable, so pass them by const reference.

Signed-off-by: Snow Pettersen <kpettersen@netflix.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a