### PR TITLE
Fix MetadataEncoderDecoderDeathTest in coverage build.

### DIFF
--- a/test/common/http/http2/metadata_encoder_decoder_test.cc
+++ b/test/common/http/http2/metadata_encoder_decoder_test.cc
@@ -333,6 +333,7 @@ using MetadataEncoderDecoderDeathTest = MetadataEncoderDecoderTest;
 
 // Crash if a caller tries to pack more frames than the encoder has data for.
 TEST_F(MetadataEncoderDecoderDeathTest, PackTooManyFrames) {
+  Logger::StderrSinkDelegate stderr_sink(Logger::Registry::getSink()); // For coverage build.
   MetadataMap metadata_map = {
       {"header_key1", std::string(5, 'a')},
       {"header_key2", std::string(5, 'b')},


### PR DESCRIPTION
Description: This test failed in the coverage build because death tests need a StderrSinkDelegate in order to recognize RELEASE_ASSERT failure messages. Add that delegate.
Risk Level: Low (test only)
Testing: VALIDATE_COVERAGE=false test/run_envoy_bazel_coverage.sh "//test/common/http/http2/..."
Docs Changes: n/a
Release Notes: n/a