### PR TITLE
test: remove descriptor file during test shutdown for transcoder test

### DIFF
--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -44,7 +44,7 @@ class GrpcJsonTranscoderFilterTestBase {
 protected:
   GrpcJsonTranscoderFilterTestBase() : api_(Api::createApiForTest()) {}
   ~GrpcJsonTranscoderFilterTestBase() {
-    TestEnvironment::removePath("envoy_test/proto.descriptor");
+    TestEnvironment::removePath(TestEnvironment::temporaryPath("envoy_test/proto.descriptor"));
   }
 
   Api::ApiPtr api_;

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -43,7 +43,9 @@ namespace {
 class GrpcJsonTranscoderFilterTestBase {
 protected:
   GrpcJsonTranscoderFilterTestBase() : api_(Api::createApiForTest()) {}
-  ~GrpcJsonTranscoderFilterTestBase() { TestEnvironment::removePath("envoy_test/proto.descriptor"); }
+  ~GrpcJsonTranscoderFilterTestBase() {
+    TestEnvironment::removePath("envoy_test/proto.descriptor");
+  }
 
   Api::ApiPtr api_;
 };

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -49,6 +49,8 @@ protected:
 
 class GrpcJsonTranscoderConfigTest : public testing::Test, public GrpcJsonTranscoderFilterTestBase {
 protected:
+  ~GrpcJsonTranscoderConfigTest() { TestEnvironment::removePath("envoy_test/proto.descriptor"); }
+
   const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
   getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
                  bool match_incoming_request_route = false,

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -43,14 +43,13 @@ namespace {
 class GrpcJsonTranscoderFilterTestBase {
 protected:
   GrpcJsonTranscoderFilterTestBase() : api_(Api::createApiForTest()) {}
+  ~GrpcJsonTranscoderFilterTestBase() { TestEnvironment::removePath("envoy_test/proto.descriptor"); }
 
   Api::ApiPtr api_;
 };
 
 class GrpcJsonTranscoderConfigTest : public testing::Test, public GrpcJsonTranscoderFilterTestBase {
 protected:
-  ~GrpcJsonTranscoderConfigTest() { TestEnvironment::removePath("envoy_test/proto.descriptor"); }
-
   const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
   getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
                  bool match_incoming_request_route = false,


### PR DESCRIPTION
During coverage the temp folder is shared between tests, so this file
ends up leaking between tests. This ensures that we clean it up during
test shut down.

Signed-off-by: Snow Pettersen <kpettersen@netflix.com>