### PR TITLE
docs: Add example circuit breaker configuration

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cluster_circuit_breakers.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_circuit_breakers.rst
@@ -6,6 +6,19 @@ Circuit breaking
 * Circuit Breaking :ref:`architecture overview <arch_overview_circuit_break>`.
 * :ref:`v2 API documentation <envoy_api_msg_cluster.CircuitBreakers>`.
 
+The following is an example circuit breaker configuration:
+
+.. code-block:: yaml
+
+  circuit_breakers:
+  thresholds:
+    - priority: "DEFAULT"
+      max_requests: 75
+      max_pending_requests: 35
+      retry_budget:
+        budget_percent: 25.0
+        min_retry_concurrency: 10
+
 Runtime
 -------
 

--- a/docs/root/configuration/upstream/cluster_manager/cluster_circuit_breakers.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_circuit_breakers.rst
@@ -16,7 +16,8 @@ The following is an example circuit breaker configuration:
       max_requests: 75
       max_pending_requests: 35
       retry_budget:
-        budget_percent: 25.0
+        budget_percent:
+          value: 25.0
         min_retry_concurrency: 10
 
 Runtime


### PR DESCRIPTION
This patch adds an example configuration to the circuit breaker docs.

Addresses https://github.com/envoyproxy/envoy/issues/10277.