### PR TITLE
Enable Windows CI //source/exe:envoy-static build

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -78,6 +78,7 @@ def _envoy_linkopts():
 
 def _envoy_stamped_deps():
     return select({
+        "@envoy//bazel:windows_x86_64": [],
         "@envoy//bazel:apple": [
             "@envoy//bazel:raw_build_id.ldscript",
         ],

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -27,12 +27,13 @@ def envoy_copts(repository, test = False):
         "-Zc:__cplusplus",
         "-std:c++14",
         "-DWIN32",
-        "-D_WIN32_WINNT=0x0602",
-        "-DNTDDI_VERSION=0x06020000",
+        "-D_WIN32_WINNT=0x0A00",
+        "-DNTDDI_VERSION=0x0A000000",
         "-DWIN32_LEAN_AND_MEAN",
         "-DNOUSER",
         "-DNOMCX",
         "-DNOIME",
+        "-DNOCRYPT",
     ]
 
     return select({

--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -6,6 +6,9 @@ cc_library(
     name = "all_external",
     srcs = [":empty.cc"],
     defines = ["OPENTRACING_STATIC"],
+    # TODO: external/io_opentracing_cpp/BUILD.bazel:19:1: Executing genrule
+    # @io_opentracing_cpp//:generate_version_h failed - needs porting
+    tags = ["skip_on_windows"],
     deps = [
         "@com_github_datadog_dd_opentracing_cpp//:dd_opentracing_cpp",
         "@com_google_googletest//:gtest",

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -5,6 +5,8 @@ load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 envoy_package()
 
+# autotools packages are unusable on Windows as-is
+# TODO: Consider our own gperftools.BUILD file as we do with many other packages
 configure_make(
     name = "gperftools_build",
     configure_options = [
@@ -22,16 +24,20 @@ configure_make(
         "//bazel:debug_tcmalloc": ["libtcmalloc_debug.a"],
         "//conditions:default": ["libtcmalloc_and_profiler.a"],
     }),
+    tags = ["skip_on_windows"],
 )
 
 # Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/227
 cc_library(
     name = "gperftools",
+    tags = ["skip_on_windows"],
     deps = [
         "gperftools_build",
     ],
 )
 
+# autotools packages are unusable on Windows as-is
+# TODO: Consider our own luajit.BUILD file as we do with many other packages
 configure_make(
     name = "luajit",
     configure_command = "build.py",
@@ -47,6 +53,7 @@ configure_make(
     static_libraries = [
         "libluajit-5.1.a",
     ],
+    tags = ["skip_on_windows"],
 )
 
 envoy_cmake_external(

--- a/bazel/foreign_cc/cares-win32-nameser.patch
+++ b/bazel/foreign_cc/cares-win32-nameser.patch
@@ -1,0 +1,12 @@
+--- CMakeLists.txt.orig	2020-02-19 14:42:47.978299400 -0500
++++ CMakeLists.txt	2020-02-19 14:45:18.925903400 -0500
+@@ -652,6 +652,9 @@
+ # Headers installation target
+ IF (CARES_INSTALL)
+ 	SET (CARES_HEADERS ares.h ares_version.h ares_dns.h "${PROJECT_BINARY_DIR}/ares_build.h" ares_rules.h)
++	IF (WIN32)
++		SET (CARES_HEADERS ${CARES_HEADERS} nameser.h)
++	ENDIF()
+ 	INSTALL (FILES ${CARES_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ ENDIF ()
+ 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -206,6 +206,7 @@ def _com_github_c_ares_c_ares():
     location = REPOSITORY_LOCATIONS["com_github_c_ares_c_ares"]
     http_archive(
         name = "com_github_c_ares_c_ares",
+        patches = ["@envoy//bazel/foreign_cc:cares-win32-nameser.patch"],
         build_file_content = BUILD_ALL_CONTENT,
         **location
     )

--- a/ci/build_setup.ps1
+++ b/ci/build_setup.ps1
@@ -18,4 +18,4 @@ echo "ENVOY_BAZEL_ROOT: $env:ENVOY_BAZEL_ROOT"
 echo "ENVOY_SRCDIR: $env:ENVOY_SRCDIR"
 
 $env:BAZEL_BASE_OPTIONS="--noworkspace_rc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\.bazelrc"
-$env:BAZEL_BUILD_OPTIONS="--features=compiler_param_file --strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --jobs=$env:NUM_CPUS --show_task_finish --test_output=all $env:BAZEL_BUILD_EXTRA_OPTIONS $env:BAZEL_EXTRA_TEST_OPTIONS"
+$env:BAZEL_BUILD_OPTIONS="--config=msvc-cl --features=compiler_param_file --strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --jobs=$env:NUM_CPUS --show_task_finish --test_output=all $env:BAZEL_BUILD_EXTRA_OPTIONS $env:BAZEL_EXTRA_TEST_OPTIONS"

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -14,41 +14,53 @@ function bazel_binary_build($type) {
 }
 
 function bazel_test($type, $test) {
-  if ($test -ne "") {
-    bazel $env:BAZEL_BASE_OPTIONS.Split(" ") test $env:BAZEL_BUILD_OPTIONS.Split(" ") -c $type $test
+  if ($test) {
+    echo "running windows tests $test"
+    bazel $env:BAZEL_BASE_OPTIONS.Split(" ") test $env:BAZEL_BUILD_OPTIONS.Split(" ") -c $type --build_tests_only $test
   } else {
-    echo "running windows tests"
-    bazel $env:BAZEL_BASE_OPTIONS.Split(" ") test $env:BAZEL_BUILD_OPTIONS.Split(" ") -c $type "//test/..."
+    echo "running all windows tests"
+    bazel $env:BAZEL_BASE_OPTIONS.Split(" ") test $env:BAZEL_BUILD_OPTIONS.Split(" ") -c $type "//test/..." --test_tag_filters=-skip_on_windows --build_tests_only --test_summary=terse --test_output=errors
   }
   exit $LASTEXITCODE
 }
 
-$action = $args[0]
-$test = $args[1]
+$action, $test = $args
 
 switch ($action) {
   "bazel.release" {
     echo "bazel release build with tests..."
     bazel_binary_build "opt"
-    bazel_test "opt" "$test"
+    bazel_test "opt" $test
   }
   "bazel.release.server_only" {
     echo "bazel release build..."
     bazel_binary_build "opt"
   }
+  "bazel.release.test_only" {
+    echo "bazel release build with tests..."
+    bazel_test "opt" $test
+  }
   "bazel.debug" {
     echo "bazel debug build with tests..."
     bazel_binary_build "dbg"
-    bazel_test "dbg" "$test"
+    bazel_test "dbg" $test
   }
   "bazel.debug.server_only" {
     echo "bazel debug build..."
     bazel_binary_build "dbg"
   }
+  "bazel.debug.test_only" {
+    echo "bazel debug build with tests..."
+    bazel_test "dbg" $test
+  }
   "bazel.dev" {
     echo "bazel fastbuild build with tests..."
     bazel_binary_build "fastbuild"
-    bazel_test "fastbuild" "$test"
+    bazel_test "fastbuild" $test
+  }
+  "bazel.dev.test_only" {
+    echo "bazel fastbuild build with tests..."
+    bazel_test "fastbuild" $test
   }
   default {
     echo "unknown action: $action"

--- a/ci/windows_ci_steps.ps1
+++ b/ci/windows_ci_steps.ps1
@@ -1,0 +1,16 @@
+#powershell.exe -Command
+
+$BAZEL_STARTUP_OPTIONS = "--bazelrc=windows/.bazelrc --output_base=c:/_eb"
+$BAZEL_BUILD_OPTIONS = "--config=msvc-cl --show_task_finish --verbose_failures --test_output=all $BAZEL_BUILD_EXTRA_OPTIONS $BAZEL_EXTRA_TEST_OPTIONS"
+
+powershell -C bazel.exe $BAZEL_STARTUP_OPTIONS build $BAZEL_BUILD_OPTIONS //bazel/... --build_tag_filters=-skip_on_windows
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+powershell -C bazel.exe $BAZEL_STARTUP_OPTIONS build $BAZEL_BUILD_OPTIONS //source/exe:envoy-static
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+powershell -C bazel.exe $BAZEL_STARTUP_OPTIONS test $BAZEL_BUILD_OPTIONS //test/... --test_tag_filters=-manual --test_tag_filters=-skip_on_windows --build_tests_only --test_summary=terse --test_output=errors

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -1,4 +1,4 @@
-# No hashbang here because this script is intended for Windows
+#!/usr/bin/bash.exe
 
 set -e
 
@@ -13,13 +13,12 @@ df -h
 
 . "$(dirname "$0")"/setup_cache.sh
 
-# TODO(dio): Put in windows/.bazelrc.
-export PATH="/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64":$PATH
-
-BAZEL_STARTUP_OPTIONS="--bazelrc=windows/.bazelrc"
-BAZEL_BUILD_OPTIONS="--show_task_finish --verbose_failures \
+BAZEL_STARTUP_OPTIONS="--noworkspace_rc --bazelrc=windows/.bazelrc --output_base=c:/_eb"
+BAZEL_BUILD_OPTIONS="-c fastbuild --config=msvc-cl --show_task_finish --verbose_failures \
   --test_output=all ${BAZEL_BUILD_EXTRA_OPTIONS} ${BAZEL_EXTRA_TEST_OPTIONS}"
 
-bazel ${BAZEL_STARTUP_OPTIONS} build ${BAZEL_BUILD_OPTIONS} //bazel/foreign_cc:nghttp2 //bazel/foreign_cc:event //bazel/foreign_cc:yaml
+bazel ${BAZEL_STARTUP_OPTIONS} build ${BAZEL_BUILD_OPTIONS} //bazel/... --build_tag_filters=-skip_on_windows
 
-bazel ${BAZEL_STARTUP_OPTIONS} test ${BAZEL_BUILD_OPTIONS} @envoy_api_canonical//test/build/...
+bazel ${BAZEL_STARTUP_OPTIONS} build ${BAZEL_BUILD_OPTIONS} //source/exe:envoy-static
+
+# bazel ${BAZEL_STARTUP_OPTIONS} test ${BAZEL_BUILD_OPTIONS} //test/... --test_tag_filters=-skip_on_windows --build_tests_only --test_summary=terse --test_output=errors

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -18,6 +18,11 @@
 #include <mswsock.h>
 #include <ws2tcpip.h>
 
+// This is introduced in Windows SDK 10.0.17063.0 which is required
+// to build Envoy on Windows (we will reevaluate whether earlier builds
+// of Windows can be detected and PipeInstance marked unsupported at runtime.)
+#include <afunix.h>
+
 // <windows.h> defines some frequently used symbols, so we need to undef these
 // interfering symbols.
 #undef DELETE

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -163,7 +163,7 @@ InstanceConstSharedPtr peerAddressFromFd(os_fd_t fd) {
 }
 
 IoHandlePtr InstanceBase::socketFromSocketType(SocketType socket_type) const {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(WIN32)
   int flags = 0;
 #else
   int flags = SOCK_NONBLOCK;
@@ -195,7 +195,7 @@ IoHandlePtr InstanceBase::socketFromSocketType(SocketType socket_type) const {
                  fmt::format("socket(2) failed, got error: {}", strerror(result.errno_)));
   IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>(result.rc_);
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(WIN32)
   // Cannot set SOCK_NONBLOCK as a ::socket flag.
   const int rc = os_sys_calls.setsocketblocking(io_handle->fd(), false).rc_;
   RELEASE_ASSERT(!SOCKET_FAILURE(rc), "");

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -19,7 +19,7 @@ namespace Network {
 
 void ListenSocketImpl::doBind() {
   const Api::SysCallIntResult result = local_address_->bind(io_handle_->fd());
-  if (result.rc_ == -1) {
+  if (SOCKET_FAILURE(result.rc_)) {
     close();
     throw SocketBindException(
         fmt::format("cannot bind '{}': {}", local_address_->asString(), strerror(result.errno_)),

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -83,7 +83,7 @@ public:
   NetworkListenSocket(const Address::InstanceConstSharedPtr& address,
                       const Network::Socket::OptionsSharedPtr& options, bool bind_to_port)
       : ListenSocketImpl(address->socket(T::type), address) {
-    RELEASE_ASSERT(io_handle_->fd() != -1, "");
+    RELEASE_ASSERT(SOCKET_VALID(io_handle_->fd()), "");
 
     setPrebindSocketOptions();
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -193,9 +193,10 @@ void Utility::throwWithMalformedIp(absl::string_view ip_address) {
 // the default is to return a loopback address of type version. This function may
 // need to be updated in the future. Discussion can be found at Github issue #939.
 Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersion version) {
+  Address::InstanceConstSharedPtr ret;
+#ifndef WIN32
   struct ifaddrs* ifaddr;
   struct ifaddrs* ifa;
-  Address::InstanceConstSharedPtr ret;
 
   const int rc = getifaddrs(&ifaddr);
   RELEASE_ASSERT(!rc, "");
@@ -221,6 +222,7 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
   if (ifaddr) {
     freeifaddrs(ifaddr);
   }
+#endif
 
   // If the local address is not found above, then return the loopback address by default.
   if (ret == nullptr) {

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -70,7 +70,7 @@ EXTENSIONS = {
     # NOTE: The original_dst filter is implicitly loaded if original_dst functionality is
     #       configured on the listener. Do not remove it in that case or configs will fail to load.
     "envoy.filters.listener.original_dst":              "//source/extensions/filters/listener/original_dst:config",
-    "envoy.filters.listener.original_src":               "//source/extensions/filters/listener/original_src:config",
+    "envoy.filters.listener.original_src":              "//source/extensions/filters/listener/original_src:config",
     # NOTE: The proxy_protocol filter is implicitly loaded if proxy_protocol functionality is
     #       configured on the listener. Do not remove it in that case or configs will fail to load.
     "envoy.filters.listener.proxy_protocol":            "//source/extensions/filters/listener/proxy_protocol:config",
@@ -174,54 +174,75 @@ WINDOWS_EXTENSIONS = {
     #
 
     "envoy.access_loggers.file":                        "//source/extensions/access_loggers/file:config",
-    #"envoy.access_loggers.http_grpc":                   "//source/extensions/access_loggers/grpc:http_config",
+    "envoy.access_loggers.http_grpc":                   "//source/extensions/access_loggers/grpc:http_config",
+    "envoy.access_loggers.tcp_grpc":                    "//source/extensions/access_loggers/grpc:tcp_config",
+
+    #
+    # Clusters
+    #
+
+    "envoy.clusters.aggregate":                         "//source/extensions/clusters/aggregate:cluster",
+    "envoy.clusters.dynamic_forward_proxy":             "//source/extensions/clusters/dynamic_forward_proxy:cluster",
+    # "envoy.clusters.redis":                             "//source/extensions/clusters/redis:redis_cluster",
 
     #
     # gRPC Credentials Plugins
     #
 
-    #"envoy.grpc_credentials.file_based_metadata":      "//source/extensions/grpc_credentials/file_based_metadata:config",
+    "envoy.grpc_credentials.file_based_metadata":       "//source/extensions/grpc_credentials/file_based_metadata:config",
+    "envoy.grpc_credentials.aws_iam":                   "//source/extensions/grpc_credentials/aws_iam:config",
 
     #
     # Health checkers
     #
 
-    #"envoy.health_checkers.redis":                      "//source/extensions/health_checkers/redis:config",
+    # "envoy.health_checkers.redis":                      "//source/extensions/health_checkers/redis:config",
 
     #
     # HTTP filters
     #
 
-    #"envoy.filters.http.buffer":                        "//source/extensions/filters/http/buffer:config",
-    #"envoy.filters.http.cors":                          "//source/extensions/filters/http/cors:config",
-    #"envoy.filters.http.csrf":                          "//source/extensions/filters/http/csrf:config",
-    #"envoy.filters.http.dynamo":                        "//source/extensions/filters/http/dynamo:config",
-    #"envoy.filters.http.ext_authz":                     "//source/extensions/filters/http/ext_authz:config",
-    #"envoy.filters.http.fault":                         "//source/extensions/filters/http/fault:config",
-    #"envoy.filters.http.grpc_http1_bridge":             "//source/extensions/filters/http/grpc_http1_bridge:config",
-    #"envoy.filters.http.grpc_json_transcoder":          "//source/extensions/filters/http/grpc_json_transcoder:config",
-    #"envoy.filters.http.grpc_web":                      "//source/extensions/filters/http/grpc_web:config",
-    #"envoy.filters.http.gzip":                          "//source/extensions/filters/http/gzip:config",
-    #"envoy.filters.http.health_check":                  "//source/extensions/filters/http/health_check:config",
-    #"envoy.filters.http.ip_tagging":                    "//source/extensions/filters/http/ip_tagging:config",
-    #"envoy.filters.http.lua":                           "//source/extensions/filters/http/lua:config",
-    #"envoy.filters.http.ratelimit":                     "//source/extensions/filters/http/ratelimit:config",
-    #"envoy.filters.http.rbac":                          "//source/extensions/filters/http/rbac:config",
-    #"envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
-    #"envoy.filters.http.squash":                        "//source/extensions/filters/http/squash:config",
+    # "envoy.filters.http.adaptive_concurrency":          "//source/extensions/filters/http/adaptive_concurrency:config",
+    "envoy.filters.http.aws_request_signing":           "//source/extensions/filters/http/aws_request_signing:config",
+    "envoy.filters.http.buffer":                        "//source/extensions/filters/http/buffer:config",
+    "envoy.filters.http.cache":                         "//source/extensions/filters/http/cache:config",
+    "envoy.filters.http.cors":                          "//source/extensions/filters/http/cors:config",
+    "envoy.filters.http.csrf":                          "//source/extensions/filters/http/csrf:config",
+    "envoy.filters.http.dynamic_forward_proxy":         "//source/extensions/filters/http/dynamic_forward_proxy:config",
+    "envoy.filters.http.dynamo":                        "//source/extensions/filters/http/dynamo:config",
+    "envoy.filters.http.ext_authz":                     "//source/extensions/filters/http/ext_authz:config",
+    "envoy.filters.http.fault":                         "//source/extensions/filters/http/fault:config",
+    "envoy.filters.http.grpc_http1_bridge":             "//source/extensions/filters/http/grpc_http1_bridge:config",
+    "envoy.filters.http.grpc_http1_reverse_bridge":     "//source/extensions/filters/http/grpc_http1_reverse_bridge:config",
+    "envoy.filters.http.grpc_json_transcoder":          "//source/extensions/filters/http/grpc_json_transcoder:config",
+    "envoy.filters.http.grpc_stats":                    "//source/extensions/filters/http/grpc_stats:config",
+    "envoy.filters.http.grpc_web":                      "//source/extensions/filters/http/grpc_web:config",
+    "envoy.filters.http.gzip":                          "//source/extensions/filters/http/gzip:config",
+    "envoy.filters.http.header_to_metadata":            "//source/extensions/filters/http/header_to_metadata:config",
+    "envoy.filters.http.health_check":                  "//source/extensions/filters/http/health_check:config",
+    "envoy.filters.http.ip_tagging":                    "//source/extensions/filters/http/ip_tagging:config",
+    "envoy.filters.http.jwt_authn":                     "//source/extensions/filters/http/jwt_authn:config",
+    # "envoy.filters.http.lua":                           "//source/extensions/filters/http/lua:config",
+    "envoy.filters.http.on_demand":                     "//source/extensions/filters/http/on_demand:config",
+    "envoy.filters.http.original_src":                  "//source/extensions/filters/http/original_src:config",
+    "envoy.filters.http.ratelimit":                     "//source/extensions/filters/http/ratelimit:config",
+    "envoy.filters.http.rbac":                          "//source/extensions/filters/http/rbac:config",
+    "envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
+    "envoy.filters.http.squash":                        "//source/extensions/filters/http/squash:config",
+    "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
 
     #
     # Listener filters
     #
 
+    "envoy.filters.listener.http_inspector":            "//source/extensions/filters/listener/http_inspector:config",
+    # NOTE: The original_dst filter is implicitly loaded if original_dst functionality is
+    #       configured on the listener. Do not remove it in that case or configs will fail to load.
+    "envoy.filters.listener.original_dst":              "//source/extensions/filters/listener/original_dst:config",
+    "envoy.filters.listener.original_src":              "//source/extensions/filters/listener/original_src:config",
     # NOTE: The proxy_protocol filter is implicitly loaded if proxy_protocol functionality is
     #       configured on the listener. Do not remove it in that case or configs will fail to load.
     "envoy.filters.listener.proxy_protocol":            "//source/extensions/filters/listener/proxy_protocol:config",
-
-    # NOTE: The original_dst filter is implicitly loaded if original_dst functionality is
-    #       configured on the listener. Do not remove it in that case or configs will fail to load.
-    #"envoy.filters.listener.original_dst":              "//source/extensions/filters/listener/original_dst:config",
-
     "envoy.filters.listener.tls_inspector":             "//source/extensions/filters/listener/tls_inspector:config",
 
     #
@@ -229,37 +250,92 @@ WINDOWS_EXTENSIONS = {
     #
 
     "envoy.filters.network.client_ssl_auth":            "//source/extensions/filters/network/client_ssl_auth:config",
-    #"envoy.filters.network.echo":                       "//source/extensions/filters/network/echo:config",
-    #"envoy.filters.network.ext_authz":                  "//source/extensions/filters/network/ext_authz:config",
-    #"envoy.filters.network.http_connection_manager":    "//source/extensions/filters/network/http_connection_manager:config",
-    #"envoy.filters.network.mongo_proxy":                "//source/extensions/filters/network/mongo_proxy:config",
-    #"envoy.filters.network.mysql_proxy":                "//source/extensions/filters/network/mysql_proxy:config",
-    #"envoy.filters.network.redis_proxy":                "//source/extensions/filters/network/redis_proxy:config",
-    #"envoy.filters.network.ratelimit":                  "//source/extensions/filters/network/ratelimit:config",
+    "envoy.filters.network.dubbo_proxy":                "//source/extensions/filters/network/dubbo_proxy:config",
+    "envoy.filters.network.echo":                       "//source/extensions/filters/network/echo:config",
+    "envoy.filters.network.ext_authz":                  "//source/extensions/filters/network/ext_authz:config",
+    "envoy.filters.network.http_connection_manager":    "//source/extensions/filters/network/http_connection_manager:config",
+    # WiP
+    # "envoy.filters.network.kafka_broker":               "//source/extensions/filters/network/kafka:kafka_broker_config_lib",
+    "envoy.filters.network.local_ratelimit":            "//source/extensions/filters/network/local_ratelimit:config",
+    "envoy.filters.network.mongo_proxy":                "//source/extensions/filters/network/mongo_proxy:config",
+    # "envoy.filters.network.mysql_proxy":                "//source/extensions/filters/network/mysql_proxy:config",
+    "envoy.filters.network.ratelimit":                  "//source/extensions/filters/network/ratelimit:config",
+    "envoy.filters.network.rbac":                       "//source/extensions/filters/network/rbac:config",
+    # "envoy.filters.network.redis_proxy":                "//source/extensions/filters/network/redis_proxy:config",
     "envoy.filters.network.tcp_proxy":                  "//source/extensions/filters/network/tcp_proxy:config",
-    #"envoy.filters.network.thrift_proxy":               "//source/extensions/filters/network/thrift_proxy:config",
-    #"envoy.filters.network.sni_cluster":                "//source/extensions/filters/network/sni_cluster:config",
-    #"envoy.filters.network.zookeeper_proxy":            "//source/extensions/filters/network/zookeeper_proxy:config",
+    "envoy.filters.network.thrift_proxy":               "//source/extensions/filters/network/thrift_proxy:config",
+    "envoy.filters.network.sni_cluster":                "//source/extensions/filters/network/sni_cluster:config",
+    "envoy.filters.network.zookeeper_proxy":            "//source/extensions/filters/network/zookeeper_proxy:config",
+
+    #
+    # UDP filters
+    #
+
+    "envoy.filters.udp_listener.udp_proxy":             "//source/extensions/filters/udp/udp_proxy:config",
+
+    #
+    # Resource monitors
+    #
+
+    "envoy.resource_monitors.fixed_heap":               "//source/extensions/resource_monitors/fixed_heap:config",
+    "envoy.resource_monitors.injected_resource":        "//source/extensions/resource_monitors/injected_resource:config",
 
     #
     # Stat sinks
     #
 
-    #"envoy.stat_sinks.dog_statsd":                      "//source/extensions/stat_sinks/dog_statsd:config",
-    #"envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
-    #"envoy.stat_sinks.statsd":                          "//source/extensions/stat_sinks/statsd:config",
+    "envoy.stat_sinks.dog_statsd":                      "//source/extensions/stat_sinks/dog_statsd:config",
+    # "envoy.stat_sinks.hystrix":                         "//source/extensions/stat_sinks/hystrix:config",
+    "envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
+    # "envoy.stat_sinks.statsd":                          "//source/extensions/stat_sinks/statsd:config",
+
+    #
+    # Thrift filters
+    #
+
+    "envoy.filters.thrift.router":                      "//source/extensions/filters/network/thrift_proxy/router:config",
+    "envoy.filters.thrift.ratelimit":                   "//source/extensions/filters/network/thrift_proxy/filters/ratelimit:config",
 
     #
     # Tracers
     #
 
-    #"envoy.tracers.dynamic_ot":                         "//source/extensions/tracers/dynamic_ot:config",
-    #"envoy.tracers.lightstep":                          "//source/extensions/tracers/lightstep:config",
-    #"envoy.tracers.zipkin":                             "//source/extensions/tracers/zipkin:config",
+    # These first three require opentracing to build on windows, but it is
+    # a foreign_cc build based on a linux autotools build schema.
+    # "envoy.tracers.dynamic_ot":                         "//source/extensions/tracers/dynamic_ot:config",
+    # "envoy.tracers.lightstep":                          "//source/extensions/tracers/lightstep:config",
+    # "envoy.tracers.datadog":                            "//source/extensions/tracers/datadog:config",
+    "envoy.tracers.zipkin":                             "//source/extensions/tracers/zipkin:config",
+    # The opencensus tool needs windows porting (unistd.h isn't c++)
+    # "envoy.tracers.opencensus":                         "//source/extensions/tracers/opencensus:config",
+    # WiP
+    "envoy.tracers.xray":                               "//source/extensions/tracers/xray:config",
 
     #
     # Transport sockets
     #
 
-    #"envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
+    "envoy.transport_sockets.alts":                     "//source/extensions/transport_sockets/alts:config",
+    "envoy.transport_sockets.raw_buffer":               "//source/extensions/transport_sockets/raw_buffer:config",
+    "envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
+
+    #
+    # Retry host predicates
+    #
+
+    "envoy.retry_host_predicates.previous_hosts":       "//source/extensions/retry/host/previous_hosts:config",
+    "envoy.retry_host_predicates.omit_canary_hosts":    "//source/extensions/retry/host/omit_canary_hosts:config",
+    "envoy.retry_host_predicates.omit_host_metadata":   "//source/extensions/retry/host/omit_host_metadata:config",
+
+    #
+    # Retry priorities
+    #
+
+    "envoy.retry_priorities.previous_priorities":       "//source/extensions/retry/priority/previous_priorities:config",
+
+    #
+    # CacheFilter plugins
+    #
+
+    "envoy.filters.http.cache.simple_http_cache":       "//source/extensions/filters/http/cache/simple_http_cache:simple_http_cache_lib",
 }

--- a/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
@@ -146,6 +146,8 @@ private:
 
 class NullLogStream : public std::ostream {
 public:
+  NullLogStream() : std::ostream(NULL) {}
+
   NullLogStream& stream() { return *this; }
 };
 

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -184,10 +184,6 @@ Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(
   // For each listener config we share a single socket among all threaded listeners.
   // First we try to get the socket from our parent if applicable.
   if (address->type() == Network::Address::Type::Pipe) {
-// No such thing as AF_UNIX on Windows
-#ifdef WIN32
-    throw EnvoyException("network type pipe not supported on Windows");
-#else
     if (socket_type != Network::Address::SocketType::Stream) {
       // This could be implemented in the future, since Unix domain sockets
       // support SOCK_DGRAM, but there would need to be a way to specify it in
@@ -203,7 +199,6 @@ Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(
       return std::make_shared<Network::UdsListenSocket>(std::move(io_handle), address);
     }
     return std::make_shared<Network::UdsListenSocket>(address);
-#endif
   }
 
   const std::string scheme = (socket_type == Network::Address::SocketType::Stream)

--- a/windows/.bazelrc
+++ b/windows/.bazelrc
@@ -1,22 +1,48 @@
 # Windows/Envoy specific Bazel build/test options.
 
+build --action_env=PATH
+
+# see top-level .bazelrc for explanation
+startup --host_jvm_args=-Xmx2g
+
 build --define signal_trace=disabled
 build --define hot_restart=disabled
 build --define tcmalloc=disabled
-build --workspace_status_command="bash bazel/get_workspace_status"
+build --define manual_stamp=manual_stamp
 
-# Required to work around quiche build defect
-# Unguarded gcc pragmas are not recognized by MSVC
-build --copt="/wd4068"
+build --workspace_status_command="bash bazel/get_workspace_status"
+build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
+build --javabase=@bazel_tools//tools/jdk:remote_jdk11
+build --enable_platform_specific_config
+
+# Experimental: We already have absl in the build, define absl=1
+# to tell googletest to use absl for backtrace (this appears to be
+# broken on msvc-cl dbg builds)
+build --define absl=1
 
 # Should not be required after upstream fix, see issue;
 # https://github.com/bazelbuild/rules_foreign_cc/issues/301
-build --copt="-DCARES_STATICLIB"
 build --copt="-DNGHTTP2_STATICLIB"
-build --copt="-DCURL_STATICLIB"
+
+# Required to work around quiche build defect
+# Unguarded gcc pragmas are not recognized by MSVC
+build:msvc-cl --copt="/wd4068"
+# Allows 'nodiscard' function return values to be discarded
+build:msvc-cl --copt="/wd4834"
+# Allows inline functions to be undefined
+build:msvc-cl --copt="/wd4506"
+build:msvc-cl --copt="-D_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING"
+
+# Required to work around clang build defects
+# Conflicting definitions of _WIN32_WINNT
+# Overriding __TIME__ etc is problematic
+build:clang-cl --copt="-Wno-macro-redefined"
+build:clang-cl --copt="-Wno-builtin-macro-redefined"
+build:clang-cl --action_env=USE_CLANG_CL=1
 
 build --experimental_enable_runfiles
 build --features=compiler_param_file
 build --features=fully_static_link
 build --features=static_link_msvcrt
 build --dynamic_mode=off
+


### PR DESCRIPTION
Description:
 - Build and CI tooling to get windows compiling
   (Reintroduces an experimental ci/windows_build_steps.ps1)
 - Source changes required for Windows compilation on msvc
 - Pick up a flavor of nameser.h for Windows only from c-ares dependency

Risk Level: Low
Testing: local on linux/gcc windows/msvc
Docs Changes: n/a
Release Notes: n/a
