### PR TITLE
Expose fault.http.abort.http_status setting via HTTTP header

### DIFF
--- a/api/envoy/config/filter/fault/v2/fault.proto
+++ b/api/envoy/config/filter/fault/v2/fault.proto
@@ -27,7 +27,7 @@ message FaultDelay {
   }
 
   // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderDelay {
   }
@@ -65,7 +65,7 @@ message FaultRateLimit {
   }
 
   // Rate limits are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderLimit {
   }

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -21,10 +21,10 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
-  reserved 1;
-
   message HeaderAbort {
   }
+
+  reserved 1;
 
   oneof error_type {
     option (validate.required) = true;

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -21,6 +21,9 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
+  // Fault delays are controlled via an HTTP header (if applicable). See the
+  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // more information.
   message HeaderAbort {
   }
 
@@ -32,6 +35,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
+    // Fault delays are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -23,11 +23,16 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 message FaultAbort {
   reserved 1;
 
+  message HeaderAbort {
+  }
+
   oneof error_type {
     option (validate.required) = true;
 
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+
+    HeaderAbort header_abort = 3;
   }
 
   // The percentage of requests/operations/connections that will be aborted with the error code

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -21,8 +21,8 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
-  // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // Fault aborts are controlled via an HTTP header (if applicable). See the
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderAbort {
   }
@@ -35,7 +35,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
-    // Fault delays are controlled via an HTTP header (if applicable).
+    // Fault aborts are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -32,7 +32,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
-    HeaderAbort header_abort = 3;
+    HeaderAbort header_abort = 4;
   }
 
   // The percentage of requests/operations/connections that will be aborted with the error code

--- a/api/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -30,7 +30,7 @@ message FaultDelay {
   }
 
   // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderDelay {
     option (udpa.annotations.versioning).previous_message_type =
@@ -75,7 +75,7 @@ message FaultRateLimit {
   }
 
   // Rate limits are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderLimit {
     option (udpa.annotations.versioning).previous_message_type =

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -24,6 +24,9 @@ message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
 
+  // Fault delays are controlled via an HTTP header (if applicable). See the
+  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // more information.
   message HeaderAbort {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.fault.v2.FaultAbort.HeaderAbort";
@@ -37,6 +40,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
+    // Fault delays are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -21,6 +21,9 @@ option java_multiple_files = true;
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
+  message HeaderAbort {
+  }
+
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
 
@@ -31,6 +34,8 @@ message FaultAbort {
 
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+
+    HeaderAbort header_abort = 4;
   }
 
   // The percentage of requests/operations/connections that will be aborted with the error code

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -24,8 +24,8 @@ message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
 
-  // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // Fault aborts are controlled via an HTTP header (if applicable). See the
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderAbort {
     option (udpa.annotations.versioning).previous_message_type =
@@ -40,7 +40,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
-    // Fault delays are controlled via an HTTP header (if applicable).
+    // Fault aborts are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -21,11 +21,13 @@ option java_multiple_files = true;
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
-  message HeaderAbort {
-  }
-
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
+
+  message HeaderAbort {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.filter.http.fault.v2.FaultAbort.HeaderAbort";
+  }
 
   reserved 1;
 

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -36,6 +36,9 @@ The fault filter has the capability to allow fault configuration to be specified
 This is useful in certain scenarios in which it is desired to allow the client to specify its own
 fault configuration. The currently supported header controls are:
 
+* Request abort configuration via the *x-envoy-fault-abort-request* header. The header value
+  should be an integer that specifies the HTTP status code to return in response to a request
+  and must be in the range [100, 600).
 * Request delay configuration via the *x-envoy-fault-delay-request* header. The header value
   should be an integer that specifies the number of milliseconds to throttle the latency for.
 * Response rate limit configuration via the *x-envoy-fault-throughput-response* header. The
@@ -57,6 +60,10 @@ options:
   typed_config:
     "@type": type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault
     max_active_faults: 100
+    abort:
+      header_abort: {}
+      percentage:
+        numerator: 100
     delay:
       header_delay: {}
       percentage:

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -43,11 +43,11 @@ fault configuration. The currently supported header controls are:
 * Request delay configuration via the *x-envoy-fault-delay-request* header. The header value
   should be an integer that specifies the number of milliseconds to throttle the latency for.
   In order for the header to work, :ref:`header_delay
-  <envoy_api_field_config.filter.common.fault.v2.FaultDelay.header_delay>` needs to be set.
+  <envoy_api_field_config.filter.http.fault.v2.FaultDelay.header_delay>` needs to be set.
 * Response rate limit configuration via the *x-envoy-fault-throughput-response* header. The
   header value should be an integer that specified the limit in KiB/s and must be > 0. In order
   for the header to work, :ref:`header_limit
-  <envoy_api_field_config.filter.common.fault.v2.FaultRateLimit.header_limit>` needs to be set.
+  <envoy_api_field_config.filter.http.fault.v2.FaultRateLimit.header_limit>` needs to be set.
 
 .. attention::
 

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -43,11 +43,11 @@ fault configuration. The currently supported header controls are:
 * Request delay configuration via the *x-envoy-fault-delay-request* header. The header value
   should be an integer that specifies the number of milliseconds to throttle the latency for.
   In order for the header to work, :ref:`header_delay
-  <envoy_api_field_config.filter.http.fault.v2.FaultDelay.header_delay>` needs to be set.
+  <envoy_api_field_config.filter.fault.v2.FaultDelay.header_delay>` needs to be set.
 * Response rate limit configuration via the *x-envoy-fault-throughput-response* header. The
   header value should be an integer that specified the limit in KiB/s and must be > 0. In order
   for the header to work, :ref:`header_limit
-  <envoy_api_field_config.filter.http.fault.v2.FaultRateLimit.header_limit>` needs to be set.
+  <envoy_api_field_config.filter.fault.v2.FaultRateLimit.header_limit>` needs to be set.
 
 .. attention::
 

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -43,11 +43,11 @@ fault configuration. The currently supported header controls are:
 * Request delay configuration via the *x-envoy-fault-delay-request* header. The header value
   should be an integer that specifies the number of milliseconds to throttle the latency for.
   In order for the header to work, :ref:`header_delay
-  <envoy_api_field_config.filter.http.fault.v2.FaultDelay.header_delay>` needs to be set.
+  <envoy_api_field_config.filter.common.fault.v2.FaultDelay.header_delay>` needs to be set.
 * Response rate limit configuration via the *x-envoy-fault-throughput-response* header. The
   header value should be an integer that specified the limit in KiB/s and must be > 0. In order
   for the header to work, :ref:`header_limit
-  <envoy_api_field_config.filter.http.fault.v2.FaultRateLimit.header_limit>` needs to be set.
+  <envoy_api_field_config.filter.common.fault.v2.FaultRateLimit.header_limit>` needs to be set.
 
 .. attention::
 

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -38,7 +38,7 @@ fault configuration. The currently supported header controls are:
 
 * Request abort configuration via the *x-envoy-fault-abort-request* header. The header value
   should be an integer that specifies the HTTP status code to return in response to a request
-  and must be in the range [100, 600).
+  and must be in the range [200, 600).
 * Request delay configuration via the *x-envoy-fault-delay-request* header. The header value
   should be an integer that specifies the number of milliseconds to throttle the latency for.
 * Response rate limit configuration via the *x-envoy-fault-throughput-response* header. The

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -38,11 +38,16 @@ fault configuration. The currently supported header controls are:
 
 * Request abort configuration via the *x-envoy-fault-abort-request* header. The header value
   should be an integer that specifies the HTTP status code to return in response to a request
-  and must be in the range [200, 600).
+  and must be in the range [200, 600). In order for the header to work, :ref:`header_abort
+  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set.
 * Request delay configuration via the *x-envoy-fault-delay-request* header. The header value
   should be an integer that specifies the number of milliseconds to throttle the latency for.
+  In order for the header to work, :ref:`header_delay
+  <envoy_api_field_config.filter.http.fault.v2.FaultDelay.header_delay>` needs to be set.
 * Response rate limit configuration via the *x-envoy-fault-throughput-response* header. The
-  header value should be an integer that specified the limit in KiB/s and must be > 0.
+  header value should be an integer that specified the limit in KiB/s and must be > 0. In order
+  for the header to work, :ref:`header_limit
+  <envoy_api_field_config.filter.http.fault.v2.FaultRateLimit.header_limit>` needs to be set.
 
 .. attention::
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,6 +16,7 @@ Version history
   of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * ext_authz: disabled the use of lowercase string matcher for headers matching in HTTP-based `ext_authz`.
   Can be reverted temporarily by setting runtime feature `envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher` to false.
+* fault: added support for controlling abort faults with :ref:`HTTP header fault configuration <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 * http: added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature `envoy.reloadable_features.http1_flood_protection`
 * http: fixing a bug in HTTP/1.0 responses where Connection: keep-alive was not appended for connections which were kept alive.
 * http: fixed a bug that could send extra METADATA frames and underflow memory when encoding METADATA frames on a connection that was dispatching data.

--- a/generated_api_shadow/envoy/config/filter/fault/v2/fault.proto
+++ b/generated_api_shadow/envoy/config/filter/fault/v2/fault.proto
@@ -27,7 +27,7 @@ message FaultDelay {
   }
 
   // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderDelay {
   }
@@ -65,7 +65,7 @@ message FaultRateLimit {
   }
 
   // Rate limits are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderLimit {
   }

--- a/generated_api_shadow/envoy/config/filter/http/fault/v2/fault.proto
+++ b/generated_api_shadow/envoy/config/filter/http/fault/v2/fault.proto
@@ -21,6 +21,9 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
+  message HeaderAbort {
+  }
+
   reserved 1;
 
   oneof error_type {
@@ -28,6 +31,8 @@ message FaultAbort {
 
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+
+    HeaderAbort header_abort = 4;
   }
 
   // The percentage of requests/operations/connections that will be aborted with the error code

--- a/generated_api_shadow/envoy/config/filter/http/fault/v2/fault.proto
+++ b/generated_api_shadow/envoy/config/filter/http/fault/v2/fault.proto
@@ -21,6 +21,9 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
+  // Fault delays are controlled via an HTTP header (if applicable). See the
+  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // more information.
   message HeaderAbort {
   }
 
@@ -32,6 +35,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
+    // Fault delays are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/generated_api_shadow/envoy/config/filter/http/fault/v2/fault.proto
+++ b/generated_api_shadow/envoy/config/filter/http/fault/v2/fault.proto
@@ -21,8 +21,8 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // [#extension: envoy.filters.http.fault]
 
 message FaultAbort {
-  // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // Fault aborts are controlled via an HTTP header (if applicable). See the
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderAbort {
   }
@@ -35,7 +35,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
-    // Fault delays are controlled via an HTTP header (if applicable).
+    // Fault aborts are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -30,7 +30,7 @@ message FaultDelay {
   }
 
   // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderDelay {
     option (udpa.annotations.versioning).previous_message_type =
@@ -77,7 +77,7 @@ message FaultRateLimit {
   }
 
   // Rate limits are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderLimit {
     option (udpa.annotations.versioning).previous_message_type =

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -24,6 +24,9 @@ message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
 
+  // Fault delays are controlled via an HTTP header (if applicable). See the
+  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // more information.
   message HeaderAbort {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.fault.v2.FaultAbort.HeaderAbort";
@@ -37,6 +40,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
+    // Fault delays are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -24,6 +24,11 @@ message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
 
+  message HeaderAbort {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.filter.http.fault.v2.FaultAbort.HeaderAbort";
+  }
+
   reserved 1;
 
   oneof error_type {
@@ -31,6 +36,8 @@ message FaultAbort {
 
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+
+    HeaderAbort header_abort = 4;
   }
 
   // The percentage of requests/operations/connections that will be aborted with the error code

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -24,8 +24,8 @@ message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
 
-  // Fault delays are controlled via an HTTP header (if applicable). See the
-  // :ref:`http fault filter <config_http_filters_fault_injection_http_header>` documentation for
+  // Fault aborts are controlled via an HTTP header (if applicable). See the
+  // :ref:`HTTP fault filter <config_http_filters_fault_injection_http_header>` documentation for
   // more information.
   message HeaderAbort {
     option (udpa.annotations.versioning).previous_message_type =
@@ -40,7 +40,7 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
-    // Fault delays are controlled via an HTTP header (if applicable).
+    // Fault aborts are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
 

--- a/source/extensions/filters/common/fault/BUILD
+++ b/source/extensions/filters/common/fault/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["fault_config.h"],
     deps = [
         "//include/envoy/http:header_map_interface",
+        "//source/common/http:codes_lib",
         "//source/common/http:headers_lib",
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/extensions/filters/common/fault/v3:pkg_cc_proto",

--- a/source/extensions/filters/common/fault/BUILD
+++ b/source/extensions/filters/common/fault/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/extensions/filters/common/fault/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/fault/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -11,16 +11,18 @@ namespace Filters {
 namespace Common {
 namespace Fault {
 
-FaultAbortConfig:: FaultAbortConfig(
-  const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config)
-     : percentage_(abort_config.percentage()) {
+FaultAbortConfig::FaultAbortConfig(
+    const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config)
+    : percentage_(abort_config.percentage()) {
   switch (abort_config.error_type_case()) {
-    case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::kHttpStatus:
-      provider_ = std::make_unique<FixedAbortProvider>(abort_config.http_status());
-    case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::kHeaderAbort:
-      provider_ = std::make_unique<HeaderAbortProvider>();
-    case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::ERROR_TYPE_NOT_SET:
-      NOT_REACHED_GCOVR_EXCL_LINE;
+  case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::kHttpStatus:
+    provider_ = std::make_unique<FixedAbortProvider>(abort_config.http_status());
+    break;
+  case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::kHeaderAbort:
+    provider_ = std::make_unique<HeaderAbortProvider>();
+    break;
+  case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::ERROR_TYPE_NOT_SET:
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -27,17 +27,22 @@ FaultAbortConfig::FaultAbortConfig(
 }
 
 absl::optional<Http::Code>
-FaultAbortConfig::HeaderAbortProvider::status_code(const Http::HeaderEntry* header) const {
+FaultAbortConfig::HeaderAbortProvider::statusCode(const Http::HeaderEntry* header) const {
+  absl::optional<Http::Code> ret;
   if (header == nullptr) {
-    return absl::nullopt;
+    return ret;
   }
 
-  uint64_t value;
-  if (!absl::SimpleAtoi(header->value().getStringView(), &value)) {
-    return absl::nullopt;
+  uint64_t code;
+  if (!absl::SimpleAtoi(header->value().getStringView(), &code)) {
+    return ret;
   }
 
-  return static_cast<Http::Code>(value);
+  if (code >= 200 and code < 600) {
+    ret = static_cast<Http::Code>(code);
+  }
+
+  return ret;
 }
 
 FaultDelayConfig::FaultDelayConfig(

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -1,6 +1,7 @@
 #include "extensions/filters/common/fault/fault_config.h"
 
 #include "envoy/extensions/filters/common/fault/v3/fault.pb.h"
+#include "envoy/extensions/filters/http/fault/v3/fault.pb.h"
 
 #include "common/protobuf/utility.h"
 
@@ -9,6 +10,18 @@ namespace Extensions {
 namespace Filters {
 namespace Common {
 namespace Fault {
+
+FaultAbortConfig:: FaultAbortConfig(
+  const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config)
+     : percentage_(abort_config.percentage()) {
+  switch (abort_config.error_type_case()) {
+    case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::kHttpStatus:
+      provider_ = std::make_unique<FixedAbortProvider>(abort_config.http_status());
+    case envoy::extensions::filters::http::fault::v3::FaultAbort::ErrorTypeCase::ERROR_TYPE_NOT_SET:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+  }
+}
+
 
 FaultDelayConfig::FaultDelayConfig(
     const envoy::extensions::filters::common::fault::v3::FaultDelay& delay_config)

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -26,7 +26,7 @@ FaultAbortConfig::FaultAbortConfig(
   }
 }
 
-absl::optional<uint64_t>
+absl::optional<Http::Code>
 FaultAbortConfig::HeaderAbortProvider::status_code(const Http::HeaderEntry* header) const {
   if (header == nullptr) {
     return absl::nullopt;
@@ -37,7 +37,7 @@ FaultAbortConfig::HeaderAbortProvider::status_code(const Http::HeaderEntry* head
     return absl::nullopt;
   }
 
-  return value;
+  return static_cast<Http::Code>(value);
 }
 
 FaultDelayConfig::FaultDelayConfig(

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -27,7 +27,7 @@ FaultAbortConfig::FaultAbortConfig(
 }
 
 absl::optional<uint64_t>
-FaultAbortConfig::HeaderAbortProvider::statusCode(const Http::HeaderEntry* header) const {
+FaultAbortConfig::HeaderAbortProvider::status_code(const Http::HeaderEntry* header) const {
   if (header == nullptr) {
     return absl::nullopt;
   }

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -38,7 +38,7 @@ FaultAbortConfig::HeaderAbortProvider::statusCode(const Http::HeaderEntry* heade
     return ret;
   }
 
-  if (code >= 200 and code < 600) {
+  if (code >= 200 && code < 600) {
     ret = static_cast<Http::Code>(code);
   }
 

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -21,7 +21,7 @@ public:
   const Http::LowerCaseString DelayRequest{absl::StrCat(prefix(), "-fault-delay-request")};
   const Http::LowerCaseString ThroughputResponse{
       absl::StrCat(prefix(), "-fault-throughput-response")};
-  const Http::LowerCaseString AbortRequest{absl::StrCat(prefix(), "-fault-abort-http-status")};
+  const Http::LowerCaseString AbortRequest{absl::StrCat(prefix(), "-fault-abort")};
 };
 
 using HeaderNames = ConstSingleton<HeaderNameValues>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -21,6 +21,7 @@ public:
   const Http::LowerCaseString DelayRequest{absl::StrCat(prefix(), "-fault-delay-request")};
   const Http::LowerCaseString ThroughputResponse{
       absl::StrCat(prefix(), "-fault-throughput-response")};
+  const Http::LowerCaseString AbortCodeRequest{absl::StrCat(prefix(), "-fault-abort-http-status")};
 };
 
 using HeaderNames = ConstSingleton<HeaderNameValues>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -21,7 +21,7 @@ public:
   const Http::LowerCaseString DelayRequest{absl::StrCat(prefix(), "-fault-delay-request")};
   const Http::LowerCaseString ThroughputResponse{
       absl::StrCat(prefix(), "-fault-throughput-response")};
-  const Http::LowerCaseString AbortRequest{absl::StrCat(prefix(), "-fault-abort")};
+  const Http::LowerCaseString AbortRequest{absl::StrCat(prefix(), "-fault-abort-request")};
 };
 
 using HeaderNames = ConstSingleton<HeaderNameValues>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -31,8 +31,8 @@ public:
   FaultAbortConfig(const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config);
 
   const envoy::type::v3::FractionalPercent& percentage() const { return percentage_; }
-  absl::optional<uint64_t> statusCode(const Http::HeaderEntry* header) const {
-    return provider_->statusCode(header);
+  absl::optional<uint64_t> status_code(const Http::HeaderEntry* header) const {
+    return provider_->status_code(header);
   }
 
 private:
@@ -43,28 +43,28 @@ private:
 
     // Return the HTTP status code to use. Optionally passed an HTTP header that may contain the
     // HTTP status code depending on the provider implementation.
-    virtual absl::optional<uint64_t> statusCode(const Http::HeaderEntry* header) const PURE;
+    virtual absl::optional<uint64_t> status_code(const Http::HeaderEntry* header) const PURE;
   };
 
   // Delay provider that uses a fixed delay.
   class FixedAbortProvider : public AbortProvider {
   public:
-    FixedAbortProvider(uint64_t statusCode) : statusCode_(statusCode) {}
+    FixedAbortProvider(uint64_t status_code) : status_code_(status_code) {}
 
     // DelayProvider
-    absl::optional<uint64_t> statusCode(const Http::HeaderEntry*) const override {
-      return statusCode_;
+    absl::optional<uint64_t> status_code(const Http::HeaderEntry*) const override {
+      return status_code_;
     }
 
   private:
-    const uint64_t statusCode_;
+    const uint64_t status_code_;
   };
 
   // Abort provider the reads a delay from an HTTP header.
   class HeaderAbortProvider : public AbortProvider {
   public:
     // AbortProvider
-    absl::optional<uint64_t> statusCode(const Http::HeaderEntry* header) const override;
+    absl::optional<uint64_t> status_code(const Http::HeaderEntry* header) const override;
   };
 
   using AbortProviderPtr = std::unique_ptr<AbortProvider>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -5,6 +5,7 @@
 #include "envoy/http/header_map.h"
 #include "envoy/type/v3/percent.pb.h"
 
+#include "common/http/codes.h"
 #include "common/http/headers.h"
 #include "common/singleton/const_singleton.h"
 
@@ -31,7 +32,7 @@ public:
   FaultAbortConfig(const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config);
 
   const envoy::type::v3::FractionalPercent& percentage() const { return percentage_; }
-  absl::optional<uint64_t> status_code(const Http::HeaderEntry* header) const {
+  absl::optional<Http::Code> status_code(const Http::HeaderEntry* header) const {
     return provider_->status_code(header);
   }
 
@@ -43,7 +44,7 @@ private:
 
     // Return the HTTP status code to use. Optionally passed an HTTP header that may contain the
     // HTTP status code depending on the provider implementation.
-    virtual absl::optional<uint64_t> status_code(const Http::HeaderEntry* header) const PURE;
+    virtual absl::optional<Http::Code> status_code(const Http::HeaderEntry* header) const PURE;
   };
 
   // Delay provider that uses a fixed delay.
@@ -52,8 +53,8 @@ private:
     FixedAbortProvider(uint64_t status_code) : status_code_(status_code) {}
 
     // DelayProvider
-    absl::optional<uint64_t> status_code(const Http::HeaderEntry*) const override {
-      return status_code_;
+    absl::optional<Http::Code> status_code(const Http::HeaderEntry*) const override {
+      return static_cast<Http::Code>(status_code_);
     }
 
   private:
@@ -64,7 +65,7 @@ private:
   class HeaderAbortProvider : public AbortProvider {
   public:
     // AbortProvider
-    absl::optional<uint64_t> status_code(const Http::HeaderEntry* header) const override;
+    absl::optional<Http::Code> status_code(const Http::HeaderEntry* header) const override;
   };
 
   using AbortProviderPtr = std::unique_ptr<AbortProvider>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -21,7 +21,7 @@ public:
   const Http::LowerCaseString DelayRequest{absl::StrCat(prefix(), "-fault-delay-request")};
   const Http::LowerCaseString ThroughputResponse{
       absl::StrCat(prefix(), "-fault-throughput-response")};
-  const Http::LowerCaseString AbortCodeRequest{absl::StrCat(prefix(), "-fault-abort-http-status")};
+  const Http::LowerCaseString AbortRequest{absl::StrCat(prefix(), "-fault-abort-http-status")};
 };
 
 using HeaderNames = ConstSingleton<HeaderNameValues>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -32,8 +32,8 @@ public:
   FaultAbortConfig(const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config);
 
   const envoy::type::v3::FractionalPercent& percentage() const { return percentage_; }
-  absl::optional<Http::Code> status_code(const Http::HeaderEntry* header) const {
-    return provider_->status_code(header);
+  absl::optional<Http::Code> statusCode(const Http::HeaderEntry* header) const {
+    return provider_->statusCode(header);
   }
 
 private:
@@ -44,16 +44,16 @@ private:
 
     // Return the HTTP status code to use. Optionally passed an HTTP header that may contain the
     // HTTP status code depending on the provider implementation.
-    virtual absl::optional<Http::Code> status_code(const Http::HeaderEntry* header) const PURE;
+    virtual absl::optional<Http::Code> statusCode(const Http::HeaderEntry* header) const PURE;
   };
 
-  // Delay provider that uses a fixed delay.
+  // Delay provider that uses a fixed abort status code.
   class FixedAbortProvider : public AbortProvider {
   public:
     FixedAbortProvider(uint64_t status_code) : status_code_(status_code) {}
 
-    // DelayProvider
-    absl::optional<Http::Code> status_code(const Http::HeaderEntry*) const override {
+    // AbortProvider
+    absl::optional<Http::Code> statusCode(const Http::HeaderEntry*) const override {
       return static_cast<Http::Code>(status_code_);
     }
 
@@ -61,11 +61,11 @@ private:
     const uint64_t status_code_;
   };
 
-  // Abort provider the reads a delay from an HTTP header.
+  // Abort provider the reads a status code from an HTTP header.
   class HeaderAbortProvider : public AbortProvider {
   public:
     // AbortProvider
-    absl::optional<Http::Code> status_code(const Http::HeaderEntry* header) const override;
+    absl::optional<Http::Code> statusCode(const Http::HeaderEntry* header) const override;
   };
 
   using AbortProviderPtr = std::unique_ptr<AbortProvider>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -40,10 +40,9 @@ private:
   public:
     virtual ~AbortProvider() = default;
 
-    // Return the HTTP status code to use. Optionally passed an HTTP header that may contain the HTTP status code
-    // depending on the provider implementation.
-    virtual absl::optional<uint64_t>
-    statusCode(const Http::HeaderEntry* header) const PURE;
+    // Return the HTTP status code to use. Optionally passed an HTTP header that may contain the
+    // HTTP status code depending on the provider implementation.
+    virtual absl::optional<uint64_t> statusCode(const Http::HeaderEntry* header) const PURE;
   };
 
   // Delay provider that uses a fixed delay.
@@ -64,8 +63,7 @@ private:
   class HeaderAbortProvider : public AbortProvider {
   public:
     // AbortProvider
-    absl::optional<uint64_t>
-    statusCode(const Http::HeaderEntry* header) const override;
+    absl::optional<uint64_t> statusCode(const Http::HeaderEntry* header) const override;
   };
 
   using AbortProviderPtr = std::unique_ptr<AbortProvider>;

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -287,9 +287,8 @@ FaultFilter::abortHttpStatus(const Http::RequestHeaderMap& request_headers) {
     return ret;
   }
 
-
-  // See if the configured abort provider has a default status code, if not there is no abort status code (e.g.,
-  // header configuration and no/invalid header).
+  // See if the configured abort provider has a default status code, if not there is no abort status
+  // code (e.g., header configuration and no/invalid header).
   auto config_abort = fault_settings_->requestAbort()->status_code(
       request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortRequest));
   if (!config_abort.has_value()) {

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -287,6 +287,9 @@ FaultFilter::abortHttpStatus(const Http::RequestHeaderMap& request_headers) {
     return ret;
   }
 
+
+  // See if the configured abort provider has a default status code, if not there is no abort status code (e.g.,
+  // header configuration and no/invalid header).
   auto config_abort = fault_settings_->requestAbort()->status_code(
       request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortRequest));
   if (!config_abort.has_value()) {

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -287,15 +287,15 @@ FaultFilter::abortHttpStatus(const Http::RequestHeaderMap& request_headers) {
     return ret;
   }
 
-  auto config_abort_code = fault_settings_->requestAbort()->status_code(
+  auto config_abort = fault_settings_->requestAbort()->status_code(
       request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortCodeRequest));
-  if (!config_abort_code.has_value()) {
+  if (!config_abort.has_value()) {
     return ret;
   }
 
   // TODO(mattklein123): check http status codes obtained from runtime.
   uint64_t http_status = config_->runtime().snapshot().getInteger(
-      fault_settings_->abortHttpStatusRuntime(), config_abort_code.value());
+      fault_settings_->abortHttpStatusRuntime(), config_abort.value());
 
   if (!downstream_cluster_abort_http_status_key_.empty()) {
     http_status = config_->runtime().snapshot().getInteger(

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -291,7 +291,6 @@ FaultFilter::abortHttpStatus(const Http::RequestHeaderMap& request_headers) {
       request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortRequest));
   if (!config_abort.has_value()) {
     return absl::nullopt;
-    ;
   }
 
   auto status_code = static_cast<uint64_t>(config_abort.value());

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -288,7 +288,7 @@ FaultFilter::abortHttpStatus(const Http::RequestHeaderMap& request_headers) {
   }
 
   auto config_abort = fault_settings_->requestAbort()->status_code(
-      request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortCodeRequest));
+      request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortRequest));
   if (!config_abort.has_value()) {
     return ret;
   }

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -287,7 +287,7 @@ FaultFilter::abortHttpStatus(const Http::RequestHeaderMap& request_headers) {
     return ret;
   }
 
-  auto config_abort_code = fault_settings_->requestAbort()->statusCode(
+  auto config_abort_code = fault_settings_->requestAbort()->status_code(
       request_headers.get(Filters::Common::Fault::HeaderNames::get().AbortCodeRequest));
   if (!config_abort_code.has_value()) {
     return ret;

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -373,7 +373,7 @@ void FaultFilter::postDelayInjection(const Http::RequestHeaderMap& request_heade
   resetTimerState();
 
   // Delays can be followed by aborts
-  auto abort_code = abortHttpStatus(request_headers);
+  const auto abort_code = abortHttpStatus(request_headers);
   if (abort_code.has_value()) {
     abortWithHTTPStatus(abort_code.value());
   } else {

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -155,8 +155,8 @@ Http::FilterHeadersStatus FaultFilter::decodeHeaders(Http::RequestHeaderMap& hea
 
   absl::optional<std::chrono::milliseconds> duration = delayDuration(headers);
   if (duration.has_value()) {
-    delay_timer_ =
-        decoder_callbacks_->dispatcher().createTimer([this, &headers]() -> void { postDelayInjection(headers); });
+    delay_timer_ = decoder_callbacks_->dispatcher().createTimer(
+        [this, &headers]() -> void { postDelayInjection(headers); });
     ENVOY_LOG(debug, "fault: delaying request {}ms", duration.value().count());
     delay_timer_->enableTimer(duration.value(), &decoder_callbacks_->scope());
     recordDelaysInjectedStats();
@@ -240,11 +240,11 @@ bool FaultFilter::isAbortEnabled() {
   }
 
   if (!downstream_cluster_abort_percent_key_.empty()) {
-    return config_->runtime().snapshot().featureEnabled(downstream_cluster_abort_percent_key_,
-                                                        fault_settings_->requestAbort()->percentage());
+    return config_->runtime().snapshot().featureEnabled(
+        downstream_cluster_abort_percent_key_, fault_settings_->requestAbort()->percentage());
   }
-  return config_->runtime().snapshot().featureEnabled(fault_settings_->abortPercentRuntime(),
-                                                      fault_settings_->requestAbort()->percentage());
+  return config_->runtime().snapshot().featureEnabled(
+      fault_settings_->abortPercentRuntime(), fault_settings_->requestAbort()->percentage());
 }
 
 absl::optional<std::chrono::milliseconds>
@@ -382,9 +382,8 @@ void FaultFilter::postDelayInjection(const Http::RequestHeaderMap& request_heade
 
 void FaultFilter::abortWithHTTPStatus(uint64_t abort_code) {
   decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FaultInjected);
-  decoder_callbacks_->sendLocalReply(static_cast<Http::Code>(abort_code),
-                                     "fault filter abort", nullptr, absl::nullopt,
-                                     RcDetails::get().FaultAbort);
+  decoder_callbacks_->sendLocalReply(static_cast<Http::Code>(abort_code), "fault filter abort",
+                                     nullptr, absl::nullopt, RcDetails::get().FaultAbort);
   recordAbortsInjectedStats();
 }
 

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -52,8 +52,9 @@ public:
   const std::vector<Http::HeaderUtility::HeaderDataPtr>& filterHeaders() const {
     return fault_filter_headers_;
   }
-  envoy::type::v3::FractionalPercent abortPercentage() const { return abort_percentage_; }
-  uint64_t abortCode() const { return http_status_; }
+  const Filters::Common::Fault::FaultAbortConfig* requestAbort() const {
+    return request_abort_config_.get();
+  }
   const Filters::Common::Fault::FaultDelayConfig* requestDelay() const {
     return request_delay_config_.get();
   }
@@ -86,8 +87,8 @@ private:
   using RuntimeKeys = ConstSingleton<RuntimeKeyValues>;
 
   envoy::type::v3::FractionalPercent abort_percentage_;
-  uint64_t http_status_{}; // HTTP or gRPC return codes
   Filters::Common::Fault::FaultDelayConfigPtr request_delay_config_;
+  Filters::Common::Fault::FaultAbortConfigPtr request_abort_config_;
   std::string upstream_cluster_; // restrict faults to specific upstream cluster
   const std::vector<Http::HeaderUtility::HeaderDataPtr> fault_filter_headers_;
   absl::flat_hash_set<std::string> downstream_nodes_{}; // Inject failures for specific downstream
@@ -243,15 +244,15 @@ private:
   void recordAbortsInjectedStats();
   void recordDelaysInjectedStats();
   void resetTimerState();
-  void postDelayInjection();
-  void abortWithHTTPStatus();
+  void postDelayInjection(const Http::RequestHeaderMap& request_headers);
+  void abortWithHTTPStatus(uint64_t abort_code);
   bool matchesTargetUpstreamCluster();
   bool matchesDownstreamNodes(const Http::RequestHeaderMap& headers);
   bool isAbortEnabled();
   bool isDelayEnabled();
   absl::optional<std::chrono::milliseconds>
   delayDuration(const Http::RequestHeaderMap& request_headers);
-  uint64_t abortHttpStatus();
+  absl::optional<uint64_t> abortHttpStatus(const Http::RequestHeaderMap& request_headers);
   void maybeIncActiveFaults();
   void maybeSetupResponseRateLimit(const Http::RequestHeaderMap& request_headers);
 

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -245,14 +245,14 @@ private:
   void recordDelaysInjectedStats();
   void resetTimerState();
   void postDelayInjection(const Http::RequestHeaderMap& request_headers);
-  void abortWithHTTPStatus(uint64_t abort_code);
+  void abortWithHTTPStatus(Http::Code abort_code);
   bool matchesTargetUpstreamCluster();
   bool matchesDownstreamNodes(const Http::RequestHeaderMap& headers);
   bool isAbortEnabled();
   bool isDelayEnabled();
   absl::optional<std::chrono::milliseconds>
   delayDuration(const Http::RequestHeaderMap& request_headers);
-  absl::optional<uint64_t> abortHttpStatus(const Http::RequestHeaderMap& request_headers);
+  absl::optional<Http::Code> abortHttpStatus(const Http::RequestHeaderMap& request_headers);
   void maybeIncActiveFaults();
   void maybeSetupResponseRateLimit(const Http::RequestHeaderMap& request_headers);
 

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -27,7 +27,8 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
 
   // Valid header.
   Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"}};
-  EXPECT_EQ(401, config.status_code(good_headers.get(HeaderNames::get().AbortRequest)).value());
+  EXPECT_EQ(Http::Code::Unauthorized,
+            config.status_code(good_headers.get(HeaderNames::get().AbortRequest)).value());
 }
 
 TEST(FaultConfigTest, FaultDelayHeaderConfig) {

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -25,11 +25,11 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-abort-request", "abc"}};
   EXPECT_EQ(absl::nullopt, config.statusCode(bad_headers.get(HeaderNames::get().AbortRequest)));
 
-  // Out of range header.
+  // Out of range header - value too low.
   Http::TestHeaderMapImpl too_low_headers{{"x-envoy-fault-abort-request", "199"}};
   EXPECT_EQ(absl::nullopt, config.statusCode(too_low_headers.get(HeaderNames::get().AbortRequest)));
 
-  // Out of range header.
+  // Out of range header - value too high.
   Http::TestHeaderMapImpl too_high_headers{{"x-envoy-fault-abort-request", "600"}};
   EXPECT_EQ(absl::nullopt,
             config.statusCode(too_high_headers.get(HeaderNames::get().AbortRequest)));

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -25,11 +25,6 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-abort-request", "abc"}};
   EXPECT_EQ(absl::nullopt, config.statusCode(bad_headers.get(HeaderNames::get().AbortRequest)));
 
-  // Valid header.
-  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"}};
-  EXPECT_EQ(Http::Code::Unauthorized,
-            config.statusCode(good_headers.get(HeaderNames::get().AbortRequest)).value());
-
   // Out of range header.
   Http::TestHeaderMapImpl too_low_headers{{"x-envoy-fault-abort-request", "199"}};
   EXPECT_EQ(absl::nullopt, config.statusCode(too_low_headers.get(HeaderNames::get().AbortRequest)));
@@ -38,6 +33,11 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   Http::TestHeaderMapImpl too_high_headers{{"x-envoy-fault-abort-request", "600"}};
   EXPECT_EQ(absl::nullopt,
             config.statusCode(too_high_headers.get(HeaderNames::get().AbortRequest)));
+
+  // Valid header.
+  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"}};
+  EXPECT_EQ(Http::Code::Unauthorized,
+            config.statusCode(good_headers.get(HeaderNames::get().AbortRequest)).value());
 }
 
 TEST(FaultConfigTest, FaultDelayHeaderConfig) {

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -13,6 +13,23 @@ namespace Common {
 namespace Fault {
 namespace {
 
+TEST(FaultConfigTest, FaultAbortHeaderConfig) {
+  envoy::extensions::filters::http::fault::v3::FaultAbort proto_config;
+  proto_config.mutable_header_abort();
+  FaultAbortConfig config(proto_config);
+
+  // No header.
+  EXPECT_EQ(absl::nullopt, config.status_code(nullptr));
+
+  // Header with bad data.
+  Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-delay-request", "abc"}};
+  EXPECT_EQ(absl::nullopt, config.status_code(bad_headers.get(HeaderNames::get().AbortCodeRequest)));
+
+  // Valid header.
+  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-http-status", "401"}};
+  EXPECT_EQ(401, config.status_code(good_headers.get(HeaderNames::get().AbortCodeRequest)).value());
+}
+
 TEST(FaultConfigTest, FaultDelayHeaderConfig) {
   envoy::extensions::filters::common::fault::v3::FaultDelay proto_config;
   proto_config.mutable_header_delay();

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -23,11 +23,11 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
 
   // Header with bad data.
   Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-delay-request", "abc"}};
-  EXPECT_EQ(absl::nullopt, config.status_code(bad_headers.get(HeaderNames::get().AbortCodeRequest)));
+  EXPECT_EQ(absl::nullopt, config.status_code(bad_headers.get(HeaderNames::get().AbortRequest)));
 
   // Valid header.
   Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-http-status", "401"}};
-  EXPECT_EQ(401, config.status_code(good_headers.get(HeaderNames::get().AbortCodeRequest)).value());
+  EXPECT_EQ(401, config.status_code(good_headers.get(HeaderNames::get().AbortRequest)).value());
 }
 
 TEST(FaultConfigTest, FaultDelayHeaderConfig) {

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -26,7 +26,7 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   EXPECT_EQ(absl::nullopt, config.status_code(bad_headers.get(HeaderNames::get().AbortRequest)));
 
   // Valid header.
-  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-http-status", "401"}};
+  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort", "401"}};
   EXPECT_EQ(401, config.status_code(good_headers.get(HeaderNames::get().AbortRequest)).value());
 }
 

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -29,6 +29,15 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"}};
   EXPECT_EQ(Http::Code::Unauthorized,
             config.statusCode(good_headers.get(HeaderNames::get().AbortRequest)).value());
+
+  // Out of range header.
+  Http::TestHeaderMapImpl too_low_headers{{"x-envoy-fault-abort-request", "199"}};
+  EXPECT_EQ(absl::nullopt, config.statusCode(too_low_headers.get(HeaderNames::get().AbortRequest)));
+
+  // Out of range header.
+  Http::TestHeaderMapImpl too_high_headers{{"x-envoy-fault-abort-request", "600"}};
+  EXPECT_EQ(absl::nullopt,
+            config.statusCode(too_high_headers.get(HeaderNames::get().AbortRequest)));
 }
 
 TEST(FaultConfigTest, FaultDelayHeaderConfig) {

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -19,16 +19,16 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   FaultAbortConfig config(proto_config);
 
   // No header.
-  EXPECT_EQ(absl::nullopt, config.status_code(nullptr));
+  EXPECT_EQ(absl::nullopt, config.statusCode(nullptr));
 
   // Header with bad data.
   Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-abort-request", "abc"}};
-  EXPECT_EQ(absl::nullopt, config.status_code(bad_headers.get(HeaderNames::get().AbortRequest)));
+  EXPECT_EQ(absl::nullopt, config.statusCode(bad_headers.get(HeaderNames::get().AbortRequest)));
 
   // Valid header.
   Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"}};
   EXPECT_EQ(Http::Code::Unauthorized,
-            config.status_code(good_headers.get(HeaderNames::get().AbortRequest)).value());
+            config.statusCode(good_headers.get(HeaderNames::get().AbortRequest)).value());
 }
 
 TEST(FaultConfigTest, FaultDelayHeaderConfig) {

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -22,11 +22,11 @@ TEST(FaultConfigTest, FaultAbortHeaderConfig) {
   EXPECT_EQ(absl::nullopt, config.status_code(nullptr));
 
   // Header with bad data.
-  Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-delay-request", "abc"}};
+  Http::TestHeaderMapImpl bad_headers{{"x-envoy-fault-abort-request", "abc"}};
   EXPECT_EQ(absl::nullopt, config.status_code(bad_headers.get(HeaderNames::get().AbortRequest)));
 
   // Valid header.
-  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort", "401"}};
+  Http::TestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"}};
   EXPECT_EQ(401, config.status_code(good_headers.get(HeaderNames::get().AbortRequest)).value());
 }
 

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -106,7 +106,7 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultConfig) {
                                                  {":authority", "host"},
                                                  {"x-envoy-fault-delay-request", "200"},
                                                  {"x-envoy-fault-throughput-response", "1"},
-                                                 {"x-envoy-fault-abort-http-status", "429"}};
+                                                 {"x-envoy-fault-abort-request", "429"}};
   const auto current_time = simTime().monotonicTime();
   IntegrationStreamDecoderPtr decoder = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest();

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -69,6 +69,7 @@ typed_config:
   auto response =
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 1024);
 
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }
@@ -92,6 +93,7 @@ TEST_P(FaultIntegrationTestAllProtocols, ResponseRateLimitNoTrailers) {
   decoder->waitForBodyData(127);
   decoder->waitForEndStream();
 
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }
@@ -105,8 +107,7 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultConfig) {
                                                  {":scheme", "http"},
                                                  {":authority", "host"},
                                                  {"x-envoy-fault-delay-request", "200"},
-                                                 {"x-envoy-fault-throughput-response", "1"},
-                                                 {"x-envoy-fault-abort-request", "429"}};
+                                                 {"x-envoy-fault-throughput-response", "1"}};
   const auto current_time = simTime().monotonicTime();
   IntegrationStreamDecoderPtr decoder = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest();
@@ -127,11 +128,8 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultConfig) {
   decoder->waitForBodyData(128);
   decoder->waitForEndStream();
 
-  // Verify abort
-  EXPECT_EQ(429, Http::Utility::getResponseStatus(decoder->headers()));
-
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
-  EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }
 
@@ -142,6 +140,7 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultConfigNoHeaders) {
   auto response =
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 1024);
 
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }
@@ -177,6 +176,7 @@ TEST_P(FaultIntegrationTestHttp2, ResponseRateLimitTrailersBodyFlushed) {
   decoder->waitForEndStream();
   EXPECT_NE(nullptr, decoder->trailers());
 
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }
@@ -203,6 +203,7 @@ TEST_P(FaultIntegrationTestHttp2, ResponseRateLimitTrailersBodyNotFlushed) {
   decoder->waitForEndStream();
   EXPECT_NE(nullptr, decoder->trailers());
 
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -282,7 +282,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
 TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
   SetUpTest(header_abort_only_yaml);
 
-  request_headers_.addCopy("x-envoy-fault-abort-http-status", "429");
+  request_headers_.addCopy("x-envoy-fault-abort-request", "429");
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -90,6 +90,13 @@ public:
     http_status: 503
   )EOF";
 
+  const std::string header_abort_only_yaml = R"EOF(
+  abort:
+    header_abort: {}
+    percentage:
+      numerator: 100
+  )EOF";
+
   const std::string fixed_delay_and_abort_match_headers_yaml = R"EOF(
   delay:
     type: fixed
@@ -229,6 +236,53 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
       envoy::type::v3::FractionalPercent::HUNDRED);
   fault.mutable_abort()->set_http_status(429);
   SetUpTest(fault);
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+      .Times(0);
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("fault.http.abort.abort_percent",
+                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
+      .WillOnce(Return(429));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
+  EXPECT_CALL(decoder_filter_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
+  EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
+
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+  Http::MetadataMap metadata_map{{"metadata", "metadata"}};
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
+  EXPECT_EQ(1UL, config_->stats().active_faults_.value());
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+  filter_->onDestroy();
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().active_faults_.value());
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+}
+
+TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
+  SetUpTest(header_abort_only_yaml);
+
+  request_headers_.addCopy("x-envoy-fault-abort-http-status", "429");
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -293,7 +293,7 @@ TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
   EXPECT_CALL(runtime_.snapshot_,
               featureEnabled("fault.http.abort.abort_percent",
                              Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .WillOnce(Return(false));
+      .Times(0);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
@@ -355,7 +355,7 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
   EXPECT_CALL(runtime_.snapshot_,
               featureEnabled("fault.http.abort.abort_percent",
                              Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .WillOnce(Return(false));
+      .Times(0);
 
   // Delay only case
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
@@ -400,12 +400,6 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
-
-  // Abort related calls.
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.cluster.abort.abort_percent",
-                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .WillOnce(Return(false));
 
   // Delay only case, no aborts.
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.cluster.abort.http_status", _)).Times(0);
@@ -773,12 +767,6 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchSuccess) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
-  // Abort related calls
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.abort.abort_percent",
-                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .WillOnce(Return(false));
-
   // Delay only case
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
@@ -893,12 +881,6 @@ void FaultFilterTest::TestPerFilterConfigFault(
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
-  // Abort related calls
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.abort.abort_percent",
-                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .WillOnce(Return(false));
-
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   timer_->invokeCallback();
 
@@ -949,10 +931,6 @@ public:
                 featureEnabled("fault.http.rate_limit.response_percent",
                                Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
         .WillOnce(Return(enable_runtime));
-    EXPECT_CALL(runtime_.snapshot_,
-                featureEnabled("fault.http.abort.abort_percent",
-                               Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-        .WillOnce(Return(false));
   }
 };
 

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -343,12 +343,6 @@ TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", 5000))
       .WillOnce(Return(0));
 
-  // Abort related calls
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.abort.abort_percent",
-                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .Times(0);
-
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_, setResponseFlag(_)).Times(0);
@@ -404,12 +398,6 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
               setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
-
-  // Abort related calls
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("fault.http.abort.abort_percent",
-                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0))))
-      .Times(0);
 
   // Delay only case
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);


### PR DESCRIPTION
Description: The partial implementation of https://github.com/envoyproxy/envoy/issues/10254. Adding a support for http header responsible for injecting faults - aborting requests with `x-envoy-fault-abort-request` HTTP header set.
Risk Level: low, new feature. 
Testing: Added
Docs Changes: Added
Release Notes: Added

