### PR TITLE
gzip: make use of generalized compression filter

### DIFF
--- a/api/envoy/config/filter/http/gzip/v2/BUILD
+++ b/api/envoy/config/filter/http/gzip/v2/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@com_github_cncf_udpa//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/config/filter/http/compressor/v2:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
+    ],
 )

--- a/api/envoy/config/filter/http/gzip/v2/gzip.proto
+++ b/api/envoy/config/filter/http/gzip/v2/gzip.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.filter.http.gzip.v2;
 
+import "envoy/config/filter/http/compressor/v2/compressor.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/migrate.proto";
@@ -16,7 +18,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // Gzip :ref:`configuration overview <config_http_filters_gzip>`.
 // [#extension: envoy.filters.http.gzip]
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message Gzip {
   enum CompressionStrategy {
     DEFAULT = 0;
@@ -38,7 +40,10 @@ message Gzip {
   google.protobuf.UInt32Value memory_level = 1 [(validate.rules).uint32 = {lte: 9 gte: 1}];
 
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
-  google.protobuf.UInt32Value content_length = 2 [(validate.rules).uint32 = {gte: 30}];
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  google.protobuf.UInt32Value content_length = 2 [deprecated = true];
 
   // A value used for selecting the zlib compression level. This setting will affect speed and
   // amount of compression applied to the content. "BEST" provides higher compression at the cost of
@@ -59,19 +64,33 @@ message Gzip {
   // application/json, text/html, etc. When this field is not defined, compression will be applied
   // to the following mime-types: "application/javascript", "application/json",
   // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml".
-  repeated string content_type = 6 [(validate.rules).repeated = {max_items: 50}];
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  repeated string content_type = 6 [deprecated = true];
 
   // If true, disables compression when the response contains an etag header. When it is false, the
   // filter will preserve weak etags and remove the ones that require strong validation.
-  bool disable_on_etag_header = 7;
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  bool disable_on_etag_header = 7 [deprecated = true];
 
   // If true, removes accept-encoding from the request headers before dispatching it to the upstream
   // so that responses do not get compressed before reaching the filter.
-  bool remove_accept_encoding_header = 8;
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  bool remove_accept_encoding_header = 8 [deprecated = true];
 
   // Value from 9 to 15 that represents the base two logarithmic of the compressor's window size.
   // Larger window results in better compression at the expense of memory usage. The default is 12
   // which will produce a 4096 bytes window. For more details about this parameter, please refer to
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
+
+  // Set of configuration parameters common for all compression filters. If this field is set then
+  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
+  // `remove_accept_encoding_header` are ignored.
+  compressor.v2.Compressor compressor = 10;
 }

--- a/api/envoy/extensions/filters/http/gzip/v3/BUILD
+++ b/api/envoy/extensions/filters/http/gzip/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/filter/http/gzip/v2:pkg",
+        "//envoy/extensions/filters/http/compressor/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/gzip/v3/gzip.proto
+++ b/api/envoy/extensions/filters/http/gzip/v3/gzip.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.gzip.v3;
 
+import "envoy/extensions/filters/http/compressor/v3/compressor.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
@@ -16,7 +18,7 @@ option java_multiple_files = true;
 // Gzip :ref:`configuration overview <config_http_filters_gzip>`.
 // [#extension: envoy.filters.http.gzip]
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message Gzip {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.gzip.v2.Gzip";
@@ -39,12 +41,14 @@ message Gzip {
     }
   }
 
+  reserved 2, 6, 7, 8;
+
+  reserved "content_length", "content_type", "disable_on_etag_header",
+      "remove_accept_encoding_header";
+
   // Value from 1 to 9 that controls the amount of internal memory used by zlib. Higher values
   // use more memory, but are faster and produce better compression results. The default value is 5.
   google.protobuf.UInt32Value memory_level = 1 [(validate.rules).uint32 = {lte: 9 gte: 1}];
-
-  // Minimum response length, in bytes, which will trigger compression. The default value is 30.
-  google.protobuf.UInt32Value content_length = 2 [(validate.rules).uint32 = {gte: 30}];
 
   // A value used for selecting the zlib compression level. This setting will affect speed and
   // amount of compression applied to the content. "BEST" provides higher compression at the cost of
@@ -61,23 +65,14 @@ message Gzip {
   // refer to zlib manual.
   CompressionStrategy compression_strategy = 4 [(validate.rules).enum = {defined_only: true}];
 
-  // Set of strings that allows specifying which mime-types yield compression; e.g.,
-  // application/json, text/html, etc. When this field is not defined, compression will be applied
-  // to the following mime-types: "application/javascript", "application/json",
-  // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml".
-  repeated string content_type = 6 [(validate.rules).repeated = {max_items: 50}];
-
-  // If true, disables compression when the response contains an etag header. When it is false, the
-  // filter will preserve weak etags and remove the ones that require strong validation.
-  bool disable_on_etag_header = 7;
-
-  // If true, removes accept-encoding from the request headers before dispatching it to the upstream
-  // so that responses do not get compressed before reaching the filter.
-  bool remove_accept_encoding_header = 8;
-
   // Value from 9 to 15 that represents the base two logarithmic of the compressor's window size.
   // Larger window results in better compression at the expense of memory usage. The default is 12
   // which will produce a 4096 bytes window. For more details about this parameter, please refer to
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
+
+  // Set of configuration parameters common for all compression filters. If this field is set then
+  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
+  // `remove_accept_encoding_header` are ignored.
+  compressor.v3.Compressor compressor = 10;
 }

--- a/docs/root/configuration/http/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http/http_filters/gzip_filter.rst
@@ -45,7 +45,8 @@ By *default* compression will be *skipped* when:
   that the "gzip" will have a higher weight then "\*". For example, if *accept-encoding*
   is "gzip;q=0,\*;q=1", the filter will not compress. But if the header is set to
   "\*;q=0,gzip;q=1", the filter will compress.
-- A request whose *accept-encoding* header includes "identity".
+- A request whose *accept-encoding* header includes any encoding type with a higher
+  weight than "gzip"'s given the corresponding compression filter is present in the chain.
 - A response contains a *content-encoding* header.
 - A response contains a *cache-control* header whose value includes "no-transform".
 - A response contains a *transfer-encoding* header whose value includes "gzip".
@@ -80,7 +81,9 @@ Every configured Gzip filter has statistics rooted at <stat_prefix>.gzip.* with 
   not_compressed, Counter, Number of requests not compressed.
   no_accept_header, Counter, Number of requests with no accept header sent.
   header_identity, Counter, Number of requests sent with "identity" set as the *accept-encoding*.
-  header_gzip, Counter, Number of requests sent with "gzip" set as the *accept-encoding*.
+  header_gzip, Counter, Number of requests sent with "gzip" set as the *accept-encoding*. This counter is deprecated in favour of *header_compressor_used*.
+  header_compressor_used, Counter, Number of requests sent with "gzip" set as the *accept-encoding*.
+  header_compressor_overshadowed, Counter, Number of requests skipped by this filter instance because they were handled by another filter in the same filter chain.
   header_wildcard, Counter, Number of requests sent with "\*" set as the *accept-encoding*.
   header_not_valid, Counter, Number of requests sent with a not valid *accept-encoding* header (aka "q=0" or an unsupported encoding type).
   total_uncompressed_bytes, Counter, The total uncompressed bytes of all the requests that were marked for compression.

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -87,7 +87,11 @@ Deprecated items below are listed in chronological order.
 * The `header_fields`, `custom_header_fields`, and `additional_headers` fields for the route checker
   tool have been deprecated in favor of `request_header_fields`, `response_header_fields`,
   `additional_request_headers`, and `additional_response_headers`.
-
+* The `content_length`, `content_type`, `disable_on_etag_header` and `remove_accept_encoding_header`
+  fields in :ref:`HTTP Gzip filter config <envoy_api_msg_config.filter.http.gzip.v2.Gzip>` have
+  been deprecated in favor of `compressor`.
+* The statistics counter `header_gzip` in :ref:`HTTP Gzip filter <config_http_filters_gzip>`
+  has been deprecated in favor of `header_compressor_used`.
 
 1.13.0 (January 20, 2020)
 =========================

--- a/generated_api_shadow/envoy/config/filter/http/gzip/v2/BUILD
+++ b/generated_api_shadow/envoy/config/filter/http/gzip/v2/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@com_github_cncf_udpa//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/config/filter/http/compressor/v2:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
+    ],
 )

--- a/generated_api_shadow/envoy/config/filter/http/gzip/v2/gzip.proto
+++ b/generated_api_shadow/envoy/config/filter/http/gzip/v2/gzip.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.filter.http.gzip.v2;
 
+import "envoy/config/filter/http/compressor/v2/compressor.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/migrate.proto";
@@ -16,7 +18,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.filte
 // Gzip :ref:`configuration overview <config_http_filters_gzip>`.
 // [#extension: envoy.filters.http.gzip]
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message Gzip {
   enum CompressionStrategy {
     DEFAULT = 0;
@@ -38,7 +40,10 @@ message Gzip {
   google.protobuf.UInt32Value memory_level = 1 [(validate.rules).uint32 = {lte: 9 gte: 1}];
 
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
-  google.protobuf.UInt32Value content_length = 2 [(validate.rules).uint32 = {gte: 30}];
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  google.protobuf.UInt32Value content_length = 2 [deprecated = true];
 
   // A value used for selecting the zlib compression level. This setting will affect speed and
   // amount of compression applied to the content. "BEST" provides higher compression at the cost of
@@ -59,19 +64,33 @@ message Gzip {
   // application/json, text/html, etc. When this field is not defined, compression will be applied
   // to the following mime-types: "application/javascript", "application/json",
   // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml".
-  repeated string content_type = 6 [(validate.rules).repeated = {max_items: 50}];
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  repeated string content_type = 6 [deprecated = true];
 
   // If true, disables compression when the response contains an etag header. When it is false, the
   // filter will preserve weak etags and remove the ones that require strong validation.
-  bool disable_on_etag_header = 7;
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  bool disable_on_etag_header = 7 [deprecated = true];
 
   // If true, removes accept-encoding from the request headers before dispatching it to the upstream
   // so that responses do not get compressed before reaching the filter.
-  bool remove_accept_encoding_header = 8;
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  bool remove_accept_encoding_header = 8 [deprecated = true];
 
   // Value from 9 to 15 that represents the base two logarithmic of the compressor's window size.
   // Larger window results in better compression at the expense of memory usage. The default is 12
   // which will produce a 4096 bytes window. For more details about this parameter, please refer to
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
+
+  // Set of configuration parameters common for all compression filters. If this field is set then
+  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
+  // `remove_accept_encoding_header` are ignored.
+  compressor.v2.Compressor compressor = 10;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/gzip/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/gzip/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/filter/http/gzip/v2:pkg",
+        "//envoy/extensions/filters/http/compressor/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/http/gzip/v3/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/gzip/v3/gzip.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.gzip.v3;
 
+import "envoy/extensions/filters/http/compressor/v3/compressor.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/versioning.proto";
@@ -16,7 +18,7 @@ option java_multiple_files = true;
 // Gzip :ref:`configuration overview <config_http_filters_gzip>`.
 // [#extension: envoy.filters.http.gzip]
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message Gzip {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.gzip.v2.Gzip";
@@ -44,7 +46,10 @@ message Gzip {
   google.protobuf.UInt32Value memory_level = 1 [(validate.rules).uint32 = {lte: 9 gte: 1}];
 
   // Minimum response length, in bytes, which will trigger compression. The default value is 30.
-  google.protobuf.UInt32Value content_length = 2 [(validate.rules).uint32 = {gte: 30}];
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  google.protobuf.UInt32Value hidden_envoy_deprecated_content_length = 2 [deprecated = true];
 
   // A value used for selecting the zlib compression level. This setting will affect speed and
   // amount of compression applied to the content. "BEST" provides higher compression at the cost of
@@ -65,19 +70,33 @@ message Gzip {
   // application/json, text/html, etc. When this field is not defined, compression will be applied
   // to the following mime-types: "application/javascript", "application/json",
   // "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml".
-  repeated string content_type = 6 [(validate.rules).repeated = {max_items: 50}];
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  repeated string hidden_envoy_deprecated_content_type = 6 [deprecated = true];
 
   // If true, disables compression when the response contains an etag header. When it is false, the
   // filter will preserve weak etags and remove the ones that require strong validation.
-  bool disable_on_etag_header = 7;
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  bool hidden_envoy_deprecated_disable_on_etag_header = 7 [deprecated = true];
 
   // If true, removes accept-encoding from the request headers before dispatching it to the upstream
   // so that responses do not get compressed before reaching the filter.
-  bool remove_accept_encoding_header = 8;
+  // .. attention:
+  //
+  //    **This field is deprecated**. Set the `compressor` field instead.
+  bool hidden_envoy_deprecated_remove_accept_encoding_header = 8 [deprecated = true];
 
   // Value from 9 to 15 that represents the base two logarithmic of the compressor's window size.
   // Larger window results in better compression at the expense of memory usage. The default is 12
   // which will produce a 4096 bytes window. For more details about this parameter, please refer to
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
+
+  // Set of configuration parameters common for all compression filters. If this field is set then
+  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
+  // `remove_accept_encoding_header` are ignored.
+  compressor.v3.Compressor compressor = 10;
 }

--- a/source/extensions/filters/http/gzip/BUILD
+++ b/source/extensions/filters/http/gzip/BUILD
@@ -17,14 +17,10 @@ envoy_cc_library(
     srcs = ["gzip_filter.cc"],
     hdrs = ["gzip_filter.h"],
     deps = [
-        "//include/envoy/http:filter_interface",
-        "//include/envoy/json:json_object_interface",
-        "//include/envoy/runtime:runtime_interface",
-        "//source/common/buffer:buffer_lib",
         "//source/common/compressor:compressor_lib",
-        "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/common/protobuf",
+        "//source/extensions/filters/http/common/compressor:compressor_lib",
         "@envoy_api//envoy/extensions/filters/http/gzip/v3:pkg_cc_proto",
     ],
 )
@@ -35,7 +31,6 @@ envoy_cc_extension(
     hdrs = ["config.h"],
     security_posture = "robust_to_untrusted_downstream",
     deps = [
-        "//include/envoy/registry",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:factory_base_lib",
         "//source/extensions/filters/http/gzip:gzip_filter_lib",

--- a/source/extensions/filters/http/gzip/config.cc
+++ b/source/extensions/filters/http/gzip/config.cc
@@ -1,9 +1,5 @@
 #include "extensions/filters/http/gzip/config.h"
 
-#include "envoy/extensions/filters/http/gzip/v3/gzip.pb.h"
-#include "envoy/extensions/filters/http/gzip/v3/gzip.pb.validate.h"
-#include "envoy/registry/registry.h"
-
 #include "extensions/filters/http/gzip/gzip_filter.h"
 
 namespace Envoy {
@@ -14,10 +10,10 @@ namespace Gzip {
 Http::FilterFactoryCb GzipFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::gzip::v3::Gzip& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  GzipFilterConfigSharedPtr config = std::make_shared<GzipFilterConfig>(
+  Common::Compressors::CompressorFilterConfigSharedPtr config = std::make_shared<GzipFilterConfig>(
       proto_config, stats_prefix, context.scope(), context.runtime());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<GzipFilter>(config));
+    callbacks.addStreamFilter(std::make_shared<Common::Compressors::CompressorFilter>(config));
   };
 }
 

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -1,13 +1,7 @@
 #include "extensions/filters/http/gzip/gzip_filter.h"
 
-#include "envoy/extensions/filters/http/gzip/v3/gzip.pb.h"
-#include "envoy/stats/scope.h"
-
-#include "common/common/macros.h"
-
-#include "absl/strings/str_cat.h"
-#include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include "common/http/headers.h"
+#include "common/protobuf/protobuf.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -21,37 +15,26 @@ const uint64_t DefaultMemoryLevel = 5;
 // Default and maximum compression window size.
 const uint64_t DefaultWindowBits = 12;
 
-// Minimum length of an upstream response that allows compression.
-const uint64_t MinimumContentLength = 30;
-
 // When summed to window bits, this sets a gzip header and trailer around the compressed data.
 const uint64_t GzipHeaderValue = 16;
-
-// Used for verifying accept-encoding values.
-const char ZeroQvalueString[] = "q=0";
-
-// Default content types will be used if any is provided by the user.
-const std::vector<std::string>& defaultContentEncoding() {
-  CONSTRUCT_ON_FIRST_USE(std::vector<std::string>,
-                         {"text/html", "text/plain", "text/css", "application/javascript",
-                          "application/json", "image/svg+xml", "text/xml",
-                          "application/xhtml+xml"});
-}
 
 } // namespace
 
 GzipFilterConfig::GzipFilterConfig(const envoy::extensions::filters::http::gzip::v3::Gzip& gzip,
                                    const std::string& stats_prefix, Stats::Scope& scope,
                                    Runtime::Loader& runtime)
-    : compression_level_(compressionLevelEnum(gzip.compression_level())),
+    : CompressorFilterConfig(compressorConfig(gzip), stats_prefix + "gzip.", scope, runtime,
+                             Http::Headers::get().ContentEncodingValues.Gzip),
+      compression_level_(compressionLevelEnum(gzip.compression_level())),
       compression_strategy_(compressionStrategyEnum(gzip.compression_strategy())),
-      content_length_(contentLengthUint(gzip.content_length().value())),
       memory_level_(memoryLevelUint(gzip.memory_level().value())),
-      window_bits_(windowBitsUint(gzip.window_bits().value())),
-      content_type_values_(contentTypeSet(gzip.content_type())),
-      disable_on_etag_header_(gzip.disable_on_etag_header()),
-      remove_accept_encoding_header_(gzip.remove_accept_encoding_header()),
-      stats_(generateStats(stats_prefix + "gzip.", scope)), runtime_(runtime) {}
+      window_bits_(windowBitsUint(gzip.window_bits().value())) {}
+
+std::unique_ptr<Compressor::Compressor> GzipFilterConfig::makeCompressor() {
+  auto compressor = std::make_unique<Compressor::ZlibCompressorImpl>();
+  compressor->init(compressionLevel(), compressionStrategy(), windowBits(), memoryLevel());
+  return compressor;
+}
 
 Compressor::ZlibCompressorImpl::CompressionLevel GzipFilterConfig::compressionLevelEnum(
     envoy::extensions::filters::http::gzip::v3::Gzip::CompressionLevel::Enum compression_level) {
@@ -79,17 +62,6 @@ Compressor::ZlibCompressorImpl::CompressionStrategy GzipFilterConfig::compressio
   }
 }
 
-StringUtil::CaseUnorderedSet
-GzipFilterConfig::contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types) {
-  return types.empty() ? StringUtil::CaseUnorderedSet(defaultContentEncoding().begin(),
-                                                      defaultContentEncoding().end())
-                       : StringUtil::CaseUnorderedSet(types.cbegin(), types.cend());
-}
-
-uint64_t GzipFilterConfig::contentLengthUint(Protobuf::uint32 length) {
-  return length >= MinimumContentLength ? length : MinimumContentLength;
-}
-
 uint64_t GzipFilterConfig::memoryLevelUint(Protobuf::uint32 level) {
   return level > 0 ? level : DefaultMemoryLevel;
 }
@@ -98,208 +70,23 @@ uint64_t GzipFilterConfig::windowBitsUint(Protobuf::uint32 window_bits) {
   return (window_bits > 0 ? window_bits : DefaultWindowBits) | GzipHeaderValue;
 }
 
-GzipFilter::GzipFilter(const GzipFilterConfigSharedPtr& config)
-    : skip_compression_{true}, config_(config) {}
-
-Http::FilterHeadersStatus GzipFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
-  if (config_->runtime().snapshot().featureEnabled("gzip.filter_enabled", 100) &&
-      isAcceptEncodingAllowed(headers)) {
-    skip_compression_ = false;
-    if (config_->removeAcceptEncodingHeader()) {
-      headers.removeAcceptEncoding();
-    }
-  } else {
-    config_->stats().not_compressed_.inc();
+const envoy::extensions::filters::http::compressor::v3::Compressor
+GzipFilterConfig::compressorConfig(const envoy::extensions::filters::http::gzip::v3::Gzip& gzip) {
+  if (gzip.has_compressor()) {
+    return gzip.compressor();
   }
-
-  return Http::FilterHeadersStatus::Continue;
-}
-
-Http::FilterHeadersStatus GzipFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
-                                                    bool end_stream) {
-  if (!end_stream && !skip_compression_ && isMinimumContentLength(headers) &&
-      isContentTypeAllowed(headers) && !hasCacheControlNoTransform(headers) &&
-      isEtagAllowed(headers) && isTransferEncodingAllowed(headers) && !headers.ContentEncoding()) {
-    sanitizeEtagHeader(headers);
-    insertVaryHeader(headers);
-    headers.removeContentLength();
-    headers.setReferenceContentEncoding(Http::Headers::get().ContentEncodingValues.Gzip);
-    compressor_.init(config_->compressionLevel(), config_->compressionStrategy(),
-                     config_->windowBits(), config_->memoryLevel());
-    config_->stats().compressed_.inc();
-  } else if (!skip_compression_) {
-    skip_compression_ = true;
-    config_->stats().not_compressed_.inc();
+  envoy::extensions::filters::http::compressor::v3::Compressor compressor = {};
+  if (gzip.has_hidden_envoy_deprecated_content_length()) {
+    compressor.set_allocated_content_length(
+        new Protobuf::UInt32Value(gzip.hidden_envoy_deprecated_content_length()));
   }
-  return Http::FilterHeadersStatus::Continue;
-}
-
-Http::FilterDataStatus GzipFilter::encodeData(Buffer::Instance& data, bool end_stream) {
-  if (!skip_compression_) {
-    config_->stats().total_uncompressed_bytes_.add(data.length());
-    compressor_.compress(data, end_stream ? Compressor::State::Finish : Compressor::State::Flush);
-    config_->stats().total_compressed_bytes_.add(data.length());
+  for (const std::string& ctype : gzip.hidden_envoy_deprecated_content_type()) {
+    compressor.add_content_type(ctype);
   }
-  return Http::FilterDataStatus::Continue;
-}
-
-Http::FilterTrailersStatus GzipFilter::encodeTrailers(Http::ResponseTrailerMap&) {
-  if (!skip_compression_) {
-    Buffer::OwnedImpl empty_buffer;
-    compressor_.compress(empty_buffer, Compressor::State::Finish);
-    config_->stats().total_compressed_bytes_.add(empty_buffer.length());
-    encoder_callbacks_->addEncodedData(empty_buffer, true);
-  }
-  return Http::FilterTrailersStatus::Continue;
-}
-
-bool GzipFilter::hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) const {
-  const Http::HeaderEntry* cache_control = headers.CacheControl();
-  if (cache_control) {
-    return StringUtil::caseFindToken(cache_control->value().getStringView(), ",",
-                                     Http::Headers::get().CacheControlValues.NoTransform);
-  }
-
-  return false;
-}
-
-// TODO(gsagula): Since gzip is the only available content-encoding in Envoy at the moment,
-// order/priority of preferred server encodings is disregarded (RFC2616-14.3). Replace this
-// with a data structure that parses Accept-Encoding values and allows fast lookup of
-// key/priority. Also, this should be part of some utility library.
-// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-bool GzipFilter::isAcceptEncodingAllowed(Http::RequestHeaderMap& headers) const {
-  const Http::HeaderEntry* accept_encoding = headers.AcceptEncoding();
-
-  if (accept_encoding) {
-    bool is_wildcard = false; // true if found and not followed by `q=0`.
-    for (const auto token : StringUtil::splitToken(
-             headers.AcceptEncoding()->value().getStringView(), ",", false /* keep_empty */)) {
-      const auto value = StringUtil::trim(StringUtil::cropRight(token, ";"));
-      const auto q_value = StringUtil::trim(StringUtil::cropLeft(token, ";"));
-      // If value is the gzip coding, check the qvalue and return.
-      if (value == Http::Headers::get().AcceptEncodingValues.Gzip) {
-        const bool is_gzip = !absl::EqualsIgnoreCase(q_value, ZeroQvalueString);
-        if (is_gzip) {
-          config_->stats().header_gzip_.inc();
-          return true;
-        }
-        config_->stats().header_not_valid_.inc();
-        return false;
-      }
-      // If value is the identity coding, return false. The data should
-      // not be transformed in this case.
-      // https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.5.
-      if (value == Http::Headers::get().AcceptEncodingValues.Identity) {
-        config_->stats().header_identity_.inc();
-        return false;
-      }
-      // Otherwise, check if the header contains the wildcard. If so,
-      // mark as true. Use this as the very last resort, as gzip or
-      // identity is weighted higher. Note that this filter disregards
-      // order/priority at this time.
-      if (value == Http::Headers::get().AcceptEncodingValues.Wildcard) {
-        is_wildcard = !absl::EqualsIgnoreCase(q_value, ZeroQvalueString);
-      }
-    }
-    // If neither identity nor gzip codings are present, return the result of the wildcard.
-    if (is_wildcard) {
-      config_->stats().header_wildcard_.inc();
-      return true;
-    }
-    config_->stats().header_not_valid_.inc();
-    return false;
-  }
-  config_->stats().no_accept_header_.inc();
-  // If no accept-encoding header is present, return false.
-  return false;
-}
-
-bool GzipFilter::isContentTypeAllowed(Http::ResponseHeaderMap& headers) const {
-  const Http::HeaderEntry* content_type = headers.ContentType();
-  if (content_type && !config_->contentTypeValues().empty()) {
-    const absl::string_view value =
-        StringUtil::trim(StringUtil::cropRight(content_type->value().getStringView(), ";"));
-    return config_->contentTypeValues().find(value) != config_->contentTypeValues().end();
-  }
-
-  return true;
-}
-
-bool GzipFilter::isEtagAllowed(Http::ResponseHeaderMap& headers) const {
-  const bool is_etag_allowed = !(config_->disableOnEtagHeader() && headers.Etag());
-  if (!is_etag_allowed) {
-    config_->stats().not_compressed_etag_.inc();
-  }
-  return is_etag_allowed;
-}
-
-bool GzipFilter::isMinimumContentLength(Http::ResponseHeaderMap& headers) const {
-  const Http::HeaderEntry* content_length = headers.ContentLength();
-  if (content_length) {
-    uint64_t length;
-    const bool is_minimum_content_length =
-        absl::SimpleAtoi(content_length->value().getStringView(), &length) &&
-        length >= config_->minimumLength();
-    if (!is_minimum_content_length) {
-      config_->stats().content_length_too_small_.inc();
-    }
-    return is_minimum_content_length;
-  }
-
-  const Http::HeaderEntry* transfer_encoding = headers.TransferEncoding();
-  return (transfer_encoding &&
-          StringUtil::caseFindToken(transfer_encoding->value().getStringView(), ",",
-                                    Http::Headers::get().TransferEncodingValues.Chunked));
-}
-
-bool GzipFilter::isTransferEncodingAllowed(Http::ResponseHeaderMap& headers) const {
-  const Http::HeaderEntry* transfer_encoding = headers.TransferEncoding();
-  if (transfer_encoding) {
-    for (auto header_value :
-         // TODO(gsagula): add Http::HeaderMap::string_view() so string length doesn't need to be
-         // computed twice. Find all other sites where this can be improved.
-         StringUtil::splitToken(transfer_encoding->value().getStringView(), ",", true)) {
-      const auto trimmed_value = StringUtil::trim(header_value);
-      if (absl::EqualsIgnoreCase(trimmed_value, Http::Headers::get().TransferEncodingValues.Gzip) ||
-          absl::EqualsIgnoreCase(trimmed_value,
-                                 Http::Headers::get().TransferEncodingValues.Deflate)) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-void GzipFilter::insertVaryHeader(Http::ResponseHeaderMap& headers) {
-  const Http::HeaderEntry* vary = headers.Vary();
-  if (vary) {
-    if (!StringUtil::findToken(vary->value().getStringView(), ",",
-                               Http::Headers::get().VaryValues.AcceptEncoding, true)) {
-      std::string new_header;
-      absl::StrAppend(&new_header, vary->value().getStringView(), ", ",
-                      Http::Headers::get().VaryValues.AcceptEncoding);
-      headers.setVary(new_header);
-    }
-  } else {
-    headers.setReferenceVary(Http::Headers::get().VaryValues.AcceptEncoding);
-  }
-}
-
-// TODO(gsagula): It seems that every proxy has a different opinion how to handle Etag. Some
-// discussions around this topic have been going on for over a decade, e.g.,
-// https://bz.apache.org/bugzilla/show_bug.cgi?id=45023
-// This design attempts to stay more on the safe side by preserving weak etags and removing
-// the strong ones when disable_on_etag_header is false. Envoy does NOT re-write entity tags.
-void GzipFilter::sanitizeEtagHeader(Http::ResponseHeaderMap& headers) {
-  const Http::HeaderEntry* etag = headers.Etag();
-  if (etag) {
-    absl::string_view value(etag->value().getStringView());
-    if (value.length() > 2 && !((value[0] == 'w' || value[0] == 'W') && value[1] == '/')) {
-      headers.removeEtag();
-    }
-  }
+  compressor.set_disable_on_etag_header(gzip.hidden_envoy_deprecated_disable_on_etag_header());
+  compressor.set_remove_accept_encoding_header(
+      gzip.hidden_envoy_deprecated_remove_accept_encoding_header());
+  return compressor;
 }
 
 } // namespace Gzip

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -1,17 +1,10 @@
 #pragma once
 
 #include "envoy/extensions/filters/http/gzip/v3/gzip.pb.h"
-#include "envoy/http/filter.h"
-#include "envoy/http/header_map.h"
-#include "envoy/json/json_object.h"
-#include "envoy/runtime/runtime.h"
-#include "envoy/stats/scope.h"
-#include "envoy/stats/stats_macros.h"
 
-#include "common/buffer/buffer_impl.h"
 #include "common/compressor/zlib_compressor_impl.h"
-#include "common/http/header_map_impl.h"
-#include "common/protobuf/protobuf.h"
+
+#include "extensions/filters/http/common/compressor/compressor.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -19,43 +12,15 @@ namespace HttpFilters {
 namespace Gzip {
 
 /**
- * All gzip filter stats. @see stats_macros.h
- * "total_uncompressed_bytes" only includes bytes
- * from requests that were marked for compression.
- * If the request was not marked for compression,
- * the filter increments "not_compressed", but does
- * not add to "total_uncompressed_bytes". This way,
- * the user can measure the memory performance of the
- * compression.
- */
-#define ALL_GZIP_STATS(COUNTER)                                                                    \
-  COUNTER(compressed)                                                                              \
-  COUNTER(not_compressed)                                                                          \
-  COUNTER(no_accept_header)                                                                        \
-  COUNTER(header_identity)                                                                         \
-  COUNTER(header_gzip)                                                                             \
-  COUNTER(header_wildcard)                                                                         \
-  COUNTER(header_not_valid)                                                                        \
-  COUNTER(total_uncompressed_bytes)                                                                \
-  COUNTER(total_compressed_bytes)                                                                  \
-  COUNTER(content_length_too_small)                                                                \
-  COUNTER(not_compressed_etag)
-
-/**
- * Struct definition for gzip stats. @see stats_macros.h
- */
-struct GzipStats {
-  ALL_GZIP_STATS(GENERATE_COUNTER_STRUCT)
-};
-
-/**
  * Configuration for the gzip filter.
  */
-class GzipFilterConfig {
+class GzipFilterConfig : public Common::Compressors::CompressorFilterConfig {
 
 public:
   GzipFilterConfig(const envoy::extensions::filters::http::gzip::v3::Gzip& gzip,
                    const std::string& stats_prefix, Stats::Scope& scope, Runtime::Loader& runtime);
+
+  std::unique_ptr<Compressor::Compressor> makeCompressor() override;
 
   Compressor::ZlibCompressorImpl::CompressionLevel compressionLevel() const {
     return compression_level_;
@@ -64,13 +29,7 @@ public:
     return compression_strategy_;
   }
 
-  Runtime::Loader& runtime() { return runtime_; }
-  GzipStats& stats() { return stats_; }
-  const StringUtil::CaseUnorderedSet& contentTypeValues() const { return content_type_values_; }
-  bool disableOnEtagHeader() const { return disable_on_etag_header_; }
-  bool removeAcceptEncodingHeader() const { return remove_accept_encoding_header_; }
   uint64_t memoryLevel() const { return memory_level_; }
-  uint64_t minimumLength() const { return content_length_; }
   uint64_t windowBits() const { return window_bits_; }
 
 private:
@@ -78,92 +37,19 @@ private:
       envoy::extensions::filters::http::gzip::v3::Gzip::CompressionLevel::Enum compression_level);
   static Compressor::ZlibCompressorImpl::CompressionStrategy compressionStrategyEnum(
       envoy::extensions::filters::http::gzip::v3::Gzip::CompressionStrategy compression_strategy);
-  static StringUtil::CaseUnorderedSet
-  contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types);
 
-  static uint64_t contentLengthUint(Protobuf::uint32 length);
   static uint64_t memoryLevelUint(Protobuf::uint32 level);
   static uint64_t windowBitsUint(Protobuf::uint32 window_bits);
 
-  static GzipStats generateStats(const std::string& prefix, Stats::Scope& scope) {
-    return GzipStats{ALL_GZIP_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
-  }
+  // TODO(rojkov): this is going to be deprecated when the old configuration fields are dropped.
+  static const envoy::extensions::filters::http::compressor::v3::Compressor
+  compressorConfig(const envoy::extensions::filters::http::gzip::v3::Gzip& gzip);
 
   Compressor::ZlibCompressorImpl::CompressionLevel compression_level_;
   Compressor::ZlibCompressorImpl::CompressionStrategy compression_strategy_;
 
-  int32_t content_length_;
   int32_t memory_level_;
   int32_t window_bits_;
-
-  StringUtil::CaseUnorderedSet content_type_values_;
-  bool disable_on_etag_header_;
-  bool remove_accept_encoding_header_;
-  GzipStats stats_;
-  Runtime::Loader& runtime_;
-};
-using GzipFilterConfigSharedPtr = std::shared_ptr<GzipFilterConfig>;
-
-/**
- * A filter that compresses data dispatched from the upstream upon client request.
- */
-class GzipFilter : public Http::StreamFilter {
-public:
-  GzipFilter(const GzipFilterConfigSharedPtr& config);
-
-  // Http::StreamFilterBase
-  void onDestroy() override{};
-
-  // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
-                                          bool end_stream) override;
-  Http::FilterDataStatus decodeData(Buffer::Instance&, bool) override {
-    return Http::FilterDataStatus::Continue;
-  }
-  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
-    return Http::FilterTrailersStatus::Continue;
-  }
-  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
-    decoder_callbacks_ = &callbacks;
-  };
-
-  // Http::StreamEncoderFilter
-  Http::FilterHeadersStatus encode100ContinueHeaders(Http::ResponseHeaderMap&) override {
-    return Http::FilterHeadersStatus::Continue;
-  }
-  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
-                                          bool end_stream) override;
-  Http::FilterDataStatus encodeData(Buffer::Instance& buffer, bool end_stream) override;
-  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap&) override;
-  Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap&) override {
-    return Http::FilterMetadataStatus::Continue;
-  }
-  void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override {
-    encoder_callbacks_ = &callbacks;
-  }
-
-private:
-  // TODO(gsagula): This is here temporarily and just to facilitate testing. Ideally all
-  // the logic in these private member functions would be available in another class.
-  friend class GzipFilterTest;
-
-  bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) const;
-  bool isAcceptEncodingAllowed(Http::RequestHeaderMap& headers) const;
-  bool isContentTypeAllowed(Http::ResponseHeaderMap& headers) const;
-  bool isEtagAllowed(Http::ResponseHeaderMap& headers) const;
-  bool isMinimumContentLength(Http::ResponseHeaderMap& headers) const;
-  bool isTransferEncodingAllowed(Http::ResponseHeaderMap& headers) const;
-
-  void sanitizeEtagHeader(Http::ResponseHeaderMap& headers);
-  void insertVaryHeader(Http::ResponseHeaderMap& headers);
-
-  bool skip_compression_;
-  Buffer::OwnedImpl compressed_data_;
-  Compressor::ZlibCompressorImpl compressor_;
-  GzipFilterConfigSharedPtr config_;
-
-  Http::StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};
-  Http::StreamEncoderFilterCallbacks* encoder_callbacks_{nullptr};
 };
 
 } // namespace Gzip

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -73,11 +73,12 @@ public:
         window_bits: 10
         compression_level: best
         compression_strategy: rle
-        content_length: 100
-        content_type:
-          - text/html
-          - application/json
-        disable_on_etag_header: true
+        compressor:
+          disable_on_etag_header: true
+          content_length: 100
+          content_type:
+            - text/html
+            - application/json
     )EOF"};
 
   const std::string default_config{"name: envoy.filters.http.gzip"};

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -65,6 +65,21 @@ public:
     EXPECT_EQ(response->body(), std::string(content_length, 'a'));
   }
 
+  const std::string deprecated_full_config{R"EOF(
+      name: gzip
+      typed_config:
+        "@type": type.googleapis.com/envoy.config.filter.http.gzip.v2.Gzip
+        memory_level: 3
+        window_bits: 10
+        compression_level: best
+        compression_strategy: rle
+        disable_on_etag_header: true
+        content_length: 100
+        content_type:
+          - text/html
+          - application/json
+    )EOF"};
+
   const std::string full_config{R"EOF(
       name: gzip
       typed_config:
@@ -105,6 +120,21 @@ TEST_P(GzipIntegrationTest, AcceptanceDefaultConfigTest) {
                           Http::TestResponseHeaderMapImpl{{":status", "200"},
                                                           {"content-length", "4400"},
                                                           {"content-type", "text/xml"}});
+}
+
+/**
+ * Exercises gzip compression with deprecated full configuration.
+ */
+TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(AcceptanceDeprecatedFullConfigTest)) {
+  initializeFilter(deprecated_full_config);
+  doRequestAndCompression(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                         {":path", "/test/long/url"},
+                                                         {":scheme", "http"},
+                                                         {":authority", "host"},
+                                                         {"accept-encoding", "deflate, gzip"}},
+                          Http::TestResponseHeaderMapImpl{{":status", "200"},
+                                                          {"content-length", "4400"},
+                                                          {"content-type", "application/json"}});
 }
 
 /**

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -36,43 +36,15 @@ protected:
     decompressor_.init(31);
   }
 
-  // GzipFilter private member functions
-  void sanitizeEtagHeader(Http::ResponseHeaderMap& headers) {
-    filter_->sanitizeEtagHeader(headers);
-  }
-
-  void insertVaryHeader(Http::ResponseHeaderMap& headers) { filter_->insertVaryHeader(headers); }
-
-  bool isContentTypeAllowed(Http::ResponseHeaderMap& headers) {
-    return filter_->isContentTypeAllowed(headers);
-  }
-
-  bool isEtagAllowed(Http::ResponseHeaderMap& headers) { return filter_->isEtagAllowed(headers); }
-
-  bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) {
-    return filter_->hasCacheControlNoTransform(headers);
-  }
-
-  bool isAcceptEncodingAllowed(Http::RequestHeaderMap& headers) {
-    return filter_->isAcceptEncodingAllowed(headers);
-  }
-
-  bool isMinimumContentLength(Http::ResponseHeaderMap& headers) {
-    return filter_->isMinimumContentLength(headers);
-  }
-
-  bool isTransferEncodingAllowed(Http::ResponseHeaderMap& headers) {
-    return filter_->isTransferEncodingAllowed(headers);
-  }
-
   // GzipFilterTest Helpers
   void setUpFilter(std::string&& json) {
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
     envoy::extensions::filters::http::gzip::v3::Gzip gzip;
     TestUtility::loadFromJson(json, gzip);
     config_.reset(new GzipFilterConfig(gzip, "test.", stats_, runtime_));
-    filter_ = std::make_unique<GzipFilter>(config_);
+    filter_ = std::make_unique<Common::Compressors::CompressorFilter>(config_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   }
 
   void verifyCompressedData(const uint32_t content_length) {
@@ -160,7 +132,7 @@ protected:
     EXPECT_EQ(28, config_->windowBits());
     EXPECT_EQ(false, config_->disableOnEtagHeader());
     EXPECT_EQ(false, config_->removeAcceptEncodingHeader());
-    EXPECT_EQ(8, config_->contentTypeValues().size());
+    EXPECT_EQ(18, config_->contentTypeValues().size());
   }
 
   void doResponseNoCompression(Http::TestResponseHeaderMapImpl&& headers) {
@@ -180,8 +152,8 @@ protected:
     EXPECT_EQ(1, stats_.counter("test.gzip.not_compressed").value());
   }
 
-  GzipFilterConfigSharedPtr config_;
-  std::unique_ptr<GzipFilter> filter_;
+  std::shared_ptr<GzipFilterConfig> config_;
+  std::unique_ptr<Common::Compressors::CompressorFilter> filter_;
   Buffer::OwnedImpl data_;
   Decompressor::ZlibDecompressorImpl decompressor_;
   Buffer::OwnedImpl decompressed_data_;
@@ -189,13 +161,23 @@ protected:
   Stats::IsolatedStoreImpl stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
 };
 
 // Test if Runtime Feature is Disabled
 TEST_F(GzipFilterTest, RuntimeDisabled) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("gzip.filter_enabled", 100))
-      .WillOnce(Return(false));
-  doRequest({{":method", "get"}, {"accept-encoding", "deflate, gzip"}}, false);
+  setUpFilter(R"EOF(
+{
+  "compressor": {
+    "runtime_enabled": {
+      "default_value": true,
+      "runtime_key": "foo_key"
+    }
+  }
+}
+)EOF");
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillOnce(Return(false));
+  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
   doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
 }
 
@@ -210,7 +192,7 @@ TEST_F(GzipFilterTest, DefaultConfigValues) {
             config_->compressionStrategy());
   EXPECT_EQ(Compressor::ZlibCompressorImpl::CompressionLevel::Standard,
             config_->compressionLevel());
-  EXPECT_EQ(8, config_->contentTypeValues().size());
+  EXPECT_EQ(18, config_->contentTypeValues().size());
 }
 
 TEST_F(GzipFilterTest, AvailableCombinationCompressionStrategyAndLevelConfig) {
@@ -249,22 +231,6 @@ TEST_F(GzipFilterTest, AcceptanceGzipEncodingWithTrailers) {
   doResponseCompression({{":method", "get"}, {"content-length", "256"}}, true);
 }
 
-// Verifies isAcceptEncodingAllowed function.
-TEST_F(GzipFilterTest, HasCacheControlNoTransform) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "no-cache"}};
-    EXPECT_FALSE(hasCacheControlNoTransform(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "no-transform"}};
-    EXPECT_TRUE(hasCacheControlNoTransform(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "No-Transform"}};
-    EXPECT_TRUE(hasCacheControlNoTransform(headers));
-  }
-}
-
 // Verifies that compression is skipped when cache-control header has no-transform value.
 TEST_F(GzipFilterTest, HasCacheControlNoTransformNoCompression) {
   doRequest({{":method", "get"}, {"accept-encoding", "gzip;q=0, deflate"}}, true);
@@ -280,121 +246,6 @@ TEST_F(GzipFilterTest, HasCacheControlNoTransformCompression) {
       {{":method", "get"}, {"content-length", "256"}, {"cache-control", "no-cache"}}, false);
 }
 
-// Verifies isAcceptEncodingAllowed function.
-TEST_F(GzipFilterTest, IsAcceptEncodingAllowed) {
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip, br"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(1, stats_.counter("test.gzip.header_gzip").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip;q=1.0, *;q=0.5"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.gzip.header_gzip").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {
-        {"accept-encoding", "\tdeflate\t, gzip\t ; q\t =\t 1.0,\t * ;q=0.5"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(3, stats_.counter("test.gzip.header_gzip").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "deflate,gzip;q=1.0,*;q=0"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(4, stats_.counter("test.gzip.header_gzip").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip;q=0.2, br;q=1"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(5, stats_.counter("test.gzip.header_gzip").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "*"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(1, stats_.counter("test.gzip.header_wildcard").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "*;q=1"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.gzip.header_wildcard").value());
-  }
-  {
-    // gzip header is not valid due to q=0.
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "gzip;q=0,*;q=1"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(5, stats_.counter("test.gzip.header_gzip").value());
-    EXPECT_EQ(1, stats_.counter("test.gzip.header_not_valid").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(1, stats_.counter("test.gzip.no_accept_header").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity, *;q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(1, stats_.counter("test.gzip.header_identity").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity;q=0.5, *;q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.gzip.header_identity").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity;q=0, *;q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(3, stats_.counter("test.gzip.header_identity").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "xyz;q=1, br;q=0.2, *"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(3, stats_.counter("test.gzip.header_wildcard").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "xyz;q=1, br;q=0.2, *;q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(3, stats_.counter("test.gzip.header_wildcard").value());
-    EXPECT_EQ(2, stats_.counter("test.gzip.header_not_valid").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "xyz;q=1, br;q=0.2"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(3, stats_.counter("test.gzip.header_not_valid").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(4, stats_.counter("test.gzip.header_identity").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity;q=1"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(5, stats_.counter("test.gzip.header_identity").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity;q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(6, stats_.counter("test.gzip.header_identity").value());
-  }
-  {
-    // Test that we return identity and ignore the invalid wildcard.
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity, *;q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(7, stats_.counter("test.gzip.header_identity").value());
-    EXPECT_EQ(3, stats_.counter("test.gzip.header_not_valid").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip;Q=.5, br"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(6, stats_.counter("test.gzip.header_gzip").value());
-  }
-  {
-    Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "identity;Q=0"}};
-    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
-    EXPECT_EQ(8, stats_.counter("test.gzip.header_identity").value());
-  }
-}
-
 // Verifies that compression is skipped when accept-encoding header is not allowed.
 TEST_F(GzipFilterTest, AcceptEncodingNoCompression) {
   doRequest({{":method", "get"}, {"accept-encoding", "gzip;q=0, deflate"}}, true);
@@ -405,40 +256,6 @@ TEST_F(GzipFilterTest, AcceptEncodingNoCompression) {
 TEST_F(GzipFilterTest, AcceptEncodingCompression) {
   doRequest({{":method", "get"}, {"accept-encoding", "gzip, deflate"}}, true);
   doResponseCompression({{":method", "get"}, {"content-length", "256"}}, false);
-}
-
-// Verifies isMinimumContentLength function.
-TEST_F(GzipFilterTest, IsMinimumContentLength) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "31"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "29"}};
-    EXPECT_FALSE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-
-  setUpFilter(R"EOF({"content_length": 500})EOF");
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "501"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "499"}};
-    EXPECT_FALSE(isMinimumContentLength(headers));
-  }
 }
 
 // Verifies that compression is skipped when content-length header is NOT allowed.
@@ -452,90 +269,6 @@ TEST_F(GzipFilterTest, ContentLengthCompression) {
   setUpFilter(R"EOF({"content_length": 500})EOF");
   doRequest({{":method", "get"}, {"accept-encoding", "gzip"}}, true);
   doResponseCompression({{":method", "get"}, {"content-length", "1000"}}, false);
-}
-
-// Verifies isContentTypeAllowed function.
-TEST_F(GzipFilterTest, IsContentTypeAllowed) {
-
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/html"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/plain"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/javascript"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/svg+xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/json;charset=utf-8"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/json"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/xhtml+xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "Application/XHTML+XML"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
-    EXPECT_FALSE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "\ttext/html\t"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-
-  setUpFilter(R"EOF(
-    {
-      "content_type": [
-        "text/html",
-        "xyz/svg+xml",
-        "Test/INSENSITIVE"
-      ]
-    }
-  )EOF");
-
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "xyz/svg+xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "xyz/false"}};
-    EXPECT_FALSE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
-    EXPECT_FALSE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "test/insensitive"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
 }
 
 // Verifies that compression is skipped when content-encoding header is NOT allowed.
@@ -567,63 +300,6 @@ TEST_F(GzipFilterTest, ContentTypeCompression) {
                         false);
 }
 
-// Verifies sanitizeEtagHeader function.
-TEST_F(GzipFilterTest, SanitizeEtagHeader) {
-  {
-    std::string etag_header{R"EOF(W/"686897696a7c876b7e")EOF"};
-    Http::TestResponseHeaderMapImpl headers = {{"etag", etag_header}};
-    sanitizeEtagHeader(headers);
-    EXPECT_EQ(etag_header, headers.get_("etag"));
-  }
-  {
-    std::string etag_header{R"EOF(w/"686897696a7c876b7e")EOF"};
-    Http::TestResponseHeaderMapImpl headers = {{"etag", etag_header}};
-    sanitizeEtagHeader(headers);
-    EXPECT_EQ(etag_header, headers.get_("etag"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
-    sanitizeEtagHeader(headers);
-    EXPECT_FALSE(headers.has("etag"));
-  }
-}
-
-// Verifies isEtagAllowed function.
-TEST_F(GzipFilterTest, IsEtagAllowed) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(0, stats_.counter("test.gzip.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(0, stats_.counter("test.gzip.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(0, stats_.counter("test.gzip.not_compressed_etag").value());
-  }
-
-  setUpFilter(R"EOF({ "disable_on_etag_header": true })EOF");
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
-    EXPECT_FALSE(isEtagAllowed(headers));
-    EXPECT_EQ(1, stats_.counter("test.gzip.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
-    EXPECT_FALSE(isEtagAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.gzip.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.gzip.not_compressed_etag").value());
-  }
-}
-
 // Verifies that compression is skipped when etag header is NOT allowed.
 TEST_F(GzipFilterTest, EtagNoCompression) {
   setUpFilter(R"EOF({ "disable_on_etag_header": true })EOF");
@@ -642,42 +318,6 @@ TEST_F(GzipFilterTest, EtagCompression) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
   EXPECT_FALSE(headers.has("etag"));
   EXPECT_EQ("gzip", headers.get_("content-encoding"));
-}
-
-// Verifies isTransferEncodingAllowed function.
-TEST_F(GzipFilterTest, IsTransferEncodingAllowed) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
-    EXPECT_TRUE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
-    EXPECT_TRUE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "deflate"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Deflate"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "gzip"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "gzip, chunked"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", " gzip\t,  chunked\t"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
 }
 
 // Tests compression when Transfer-Encoding header exists.
@@ -715,35 +355,6 @@ TEST_F(GzipFilterTest, EmptyResponse) {
   EXPECT_EQ("", headers.get_("content-length"));
   EXPECT_EQ("", headers.get_("content-encoding"));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, true));
-}
-
-// Verifies insertVaryHeader function.
-TEST_F(GzipFilterTest, InsertVaryHeader) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "Cookie"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Cookie, Accept-Encoding", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "accept-encoding"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("accept-encoding, Accept-Encoding", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "Accept-Encoding, Cookie"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Accept-Encoding, Cookie", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "Accept-Encoding"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
-  }
 }
 
 // Filter should set Vary header value with `accept-encoding`.

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -177,7 +177,7 @@ TEST_F(GzipFilterTest, RuntimeDisabled) {
 }
 )EOF");
   EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillOnce(Return(false));
-  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
+  doRequest({{":method", "get"}, {"accept-encoding", "deflate, gzip"}}, false);
   doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
 }
 


### PR DESCRIPTION
Description:
This is the second part of the refactoring started in #7057. The `GzipFilter` class is removed completely and generalized `CompressionFilter` is instantiated instead by `GzipFilterFactory`. Instances of `CompressionFilter are configured to use "gzip" compressors to deflate HTTP streams.

Risk Level: Medium
Testing: unit tests, manual tests
Docs Changes: `updated docs/root/configuration/http_filters/gzip_filter.rst`
Release Notes: N/A

Deprecated: the statistics counter `<stat_prefix>.gzip.header_gzip` is deprecated in favor of `<stat_prefix>.gzip.header_compressor_used` provided by the generalized compression filter (the meaning stays the same). Also a new counter `<stat_prefix>.gzip.header_compressor_overshadowed` is added which contains a number of requests skipped by this filter instance because they were handled by another compression filter in the same filter chain.