### PR TITLE
[build] fix fuzz build mode macro and test runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -188,7 +188,6 @@ build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 # Fuzz builds
 build:asan-fuzzer --config=clang-asan
 build:asan-fuzzer --define=FUZZING_ENGINE=libfuzzer
-build:asan-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 build:asan-fuzzer --copt=-fsanitize=fuzzer-no-link
 build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -93,6 +93,7 @@ def envoy_cc_fuzz_test(
         srcs = tar_src,
         testonly = 1,
     )
+    fuzz_copts = ["-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"]
     test_lib_name = name + "_lib"
     envoy_cc_test_library(
         name = test_lib_name,
@@ -105,7 +106,7 @@ def envoy_cc_fuzz_test(
     )
     native.cc_test(
         name = name,
-        copts = envoy_copts("@envoy", test = True),
+        copts = fuzz_copts + envoy_copts("@envoy", test = True),
         linkopts = _envoy_test_linkopts(),
         linkstatic = 1,
         args = ["$(locations %s)" % corpus_name],
@@ -129,7 +130,7 @@ def envoy_cc_fuzz_test(
     # provide a path to FuzzingEngine.
     native.cc_binary(
         name = name + "_driverless",
-        copts = envoy_copts("@envoy", test = True),
+        copts = fuzz_copts + envoy_copts("@envoy", test = True),
         linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
         linkstatic = 1,
         testonly = 1,
@@ -139,7 +140,7 @@ def envoy_cc_fuzz_test(
 
     native.cc_test(
         name = name + "_with_libfuzzer",
-        copts = envoy_copts("@envoy", test = True),
+        copts = fuzz_copts + envoy_copts("@envoy", test = True),
         linkopts = ["-fsanitize=fuzzer"] + _envoy_test_linkopts(),
         linkstatic = 1,
         testonly = 1,

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -15,6 +15,7 @@ envoy_package()
 
 envoy_cc_test(
     name = "config_impl_test",
+    copts = ["-UFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"],
     deps = [":config_impl_test_lib"],
 )
 

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -15,7 +15,6 @@ envoy_package()
 
 envoy_cc_test(
     name = "config_impl_test",
-    copts = ["-UFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"],
     deps = [":config_impl_test_lib"],
 )
 


### PR DESCRIPTION
I'm seeing a failure in OSS-Fuzz build, as well as fuzz CI tool https://github.com/envoyproxy/envoy/pull/10289 due to fuzzing build macro `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`.

Basically, PR https://github.com/envoyproxy/envoy/pull/10050 introduced regex rewrites that are tested in `config_impl_test`, which is executed to create the corpus for `route_fuzz_test`. Fuzz builds are built with the `FUZZING_BUILD_MODE...` macro, and the RE2 library that does the regex rewrites in the test only does single replacements in fuzzing mode rather than the global replacement in the tests, so the test fails, and the fuzz build fails.

This change defined `FUZZING_BUILD_MODE...` only for fuzzing build rules, and explicitly undefines them for the `config_impl_test`. 

RE OSS-Fuzz builds, this is odd. Bazel CLI flags take precedence, so I'm not sure what to do when we build in that environment. I can't seem to `#undef` in the tests, but I need to come up with some solution.I don't like manually removing the CLI flag in our build script, but maybe? https://github.com/google/oss-fuzz/blob/66e0e379395d3a3ee741b08f4d306e1ed71c4003/infra/base-images/base-clang/Dockerfile

Testing:
`bazel build //test/common/router:route_fuzz_test_with_libfuzzer --config=asan-fuzzer`

Signed-off-by: Asra Ali <asraa@google.com>
