### PR TITLE
api: embed tracing provider config into `http_connection_manager`

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -10,6 +10,7 @@ api_proto_package(
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/core:pkg",
         "//envoy/config/filter/accesslog/v2:pkg",
+        "//envoy/config/trace/v2:pkg",
         "//envoy/type:pkg",
         "//envoy/type/tracing/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -7,6 +7,7 @@ import "envoy/api/v2/core/protocol.proto";
 import "envoy/api/v2/route.proto";
 import "envoy/api/v2/scoped_route.proto";
 import "envoy/config/filter/accesslog/v2/accesslog.proto";
+import "envoy/config/trace/v2/trace.proto";
 import "envoy/type/percent.proto";
 import "envoy/type/tracing/v2/custom_tag.proto";
 
@@ -89,7 +90,7 @@ message HttpConnectionManager {
     ALWAYS_FORWARD_ONLY = 4;
   }
 
-  // [#next-free-field: 9]
+  // [#next-free-field: 10]
   message Tracing {
     enum OperationName {
       // The HTTP listener is used for ingress/incoming requests.
@@ -156,6 +157,12 @@ message HttpConnectionManager {
 
     // A list of custom tags with unique tag name to create tags for the active span.
     repeated type.tracing.v2.CustomTag custom_tags = 8;
+
+    // Configuration for an external tracing provider.
+    // If not specified, Envoy will fall back to using tracing provider configuration
+    // from the bootstrap config.
+    // [#not-implemented-hide:]
+    trace.v2.Tracing.Http provider = 9;
   }
 
   message InternalAddressConfig {

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -11,6 +11,7 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",
         "//envoy/config/route/v3:pkg",
+        "//envoy/config/trace/v3:pkg",
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/protocol.proto";
 import "envoy/config/route/v3/route.proto";
 import "envoy/config/route/v3/scoped_route.proto";
+import "envoy/config/trace/v3/trace.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 
@@ -91,7 +92,7 @@ message HttpConnectionManager {
     ALWAYS_FORWARD_ONLY = 4;
   }
 
-  // [#next-free-field: 9]
+  // [#next-free-field: 10]
   message Tracing {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing";
@@ -144,6 +145,12 @@ message HttpConnectionManager {
 
     // A list of custom tags with unique tag name to create tags for the active span.
     repeated type.tracing.v3.CustomTag custom_tags = 8;
+
+    // Configuration for an external tracing provider.
+    // If not specified, Envoy will fall back to using tracing provider configuration
+    // from the bootstrap config.
+    // [#not-implemented-hide:]
+    config.trace.v3.Tracing.Http provider = 9;
   }
 
   message InternalAddressConfig {

--- a/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -10,6 +10,7 @@ api_proto_package(
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/core:pkg",
         "//envoy/config/filter/accesslog/v2:pkg",
+        "//envoy/config/trace/v2:pkg",
         "//envoy/type:pkg",
         "//envoy/type/tracing/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -7,6 +7,7 @@ import "envoy/api/v2/core/protocol.proto";
 import "envoy/api/v2/route.proto";
 import "envoy/api/v2/scoped_route.proto";
 import "envoy/config/filter/accesslog/v2/accesslog.proto";
+import "envoy/config/trace/v2/trace.proto";
 import "envoy/type/percent.proto";
 import "envoy/type/tracing/v2/custom_tag.proto";
 
@@ -89,7 +90,7 @@ message HttpConnectionManager {
     ALWAYS_FORWARD_ONLY = 4;
   }
 
-  // [#next-free-field: 9]
+  // [#next-free-field: 10]
   message Tracing {
     enum OperationName {
       // The HTTP listener is used for ingress/incoming requests.
@@ -156,6 +157,12 @@ message HttpConnectionManager {
 
     // A list of custom tags with unique tag name to create tags for the active span.
     repeated type.tracing.v2.CustomTag custom_tags = 8;
+
+    // Configuration for an external tracing provider.
+    // If not specified, Envoy will fall back to using tracing provider configuration
+    // from the bootstrap config.
+    // [#not-implemented-hide:]
+    trace.v2.Tracing.Http provider = 9;
   }
 
   message InternalAddressConfig {

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -11,6 +11,7 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",
         "//envoy/config/route/v3:pkg",
+        "//envoy/config/trace/v3:pkg",
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/protocol.proto";
 import "envoy/config/route/v3/route.proto";
 import "envoy/config/route/v3/scoped_route.proto";
+import "envoy/config/trace/v3/trace.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 
@@ -91,7 +92,7 @@ message HttpConnectionManager {
     ALWAYS_FORWARD_ONLY = 4;
   }
 
-  // [#next-free-field: 9]
+  // [#next-free-field: 10]
   message Tracing {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing";
@@ -161,6 +162,12 @@ message HttpConnectionManager {
 
     // A list of custom tags with unique tag name to create tags for the active span.
     repeated type.tracing.v3.CustomTag custom_tags = 8;
+
+    // Configuration for an external tracing provider.
+    // If not specified, Envoy will fall back to using tracing provider configuration
+    // from the bootstrap config.
+    // [#not-implemented-hide:]
+    config.trace.v3.Tracing.Http provider = 9;
   }
 
   message InternalAddressConfig {

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -178,6 +178,41 @@ http_filters:
   EXPECT_EQ(5 * 60 * 1000, config.streamIdleTimeout().count());
 }
 
+TEST_F(HttpConnectionManagerConfigTest, TracingConfigurationWithInlinedTracerProvider) {
+  const std::string yaml_string = R"EOF(
+codec_type: http1
+server_name: foo
+stat_prefix: router
+route_config:
+  virtual_hosts:
+  - name: service
+    domains:
+    - "*"
+    routes:
+    - match:
+        prefix: "/"
+      route:
+        cluster: cluster
+tracing:
+  operation_name: ingress
+  max_path_tag_length: 128
+  provider:                # notice inlined tracing provider configuration
+    name: zipkin
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+      collector_cluster: zipkin
+      collector_endpoint: "/api/v1/spans"
+      collector_endpoint_version: HTTP_JSON
+http_filters:
+- name: envoy.filters.http.router
+  )EOF";
+
+  auto config = parseHttpConnectionManagerFromV2Yaml(yaml_string);
+
+  // Verify that inlined tracing provider configuration is actually parsed.
+  EXPECT_EQ("zipkin", config.tracing().provider().name());
+}
+
 TEST_F(HttpConnectionManagerConfigTest, TracingNotEnabledAndNoTracingConfigInBootstrap) {
   const std::string yaml_string = R"EOF(
 codec_type: http1


### PR DESCRIPTION
Description: embed tracing provider config into `http_connection_manager`
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Context:
* part of #9998

Example configuration (notice new `provider` field):
```yaml
codec_type: http1
server_name: foo
stat_prefix: router
route_config:
  ...
tracing:
  operation_name: ingress
  max_path_tag_length: 128
  provider:                # notice inlined tracing provider configuration
    name: zipkin
    typed_config:
      "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
      collector_cluster: zipkin
      collector_endpoint: "/api/v1/spans"
      collector_endpoint_version: HTTP_JSON
http_filters:
- name: envoy.filters.http.router
```