### PR TITLE
lua: timestamp in millis

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -343,6 +343,15 @@ the length of the signature. *data* is the content which will be hashed. *dataLe
 The function returns a pair. If the first element is *true*, the second element will be empty
 which means signature is verified; otherwise, the second element will store the error message.
 
+timestamp()
+^^^^^^^^^^^
+
+.. code-block:: lua
+
+  timestamp = timestamp()
+
+High resolution timestamp function. The function returns timestamp in milliseconds since epoch.
+
 .. _config_http_filters_lua_header_wrapper:
 
 Header object API

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -333,7 +333,7 @@ verifySignature()
 
 .. code-block:: lua
 
-  ok, error = verifySignature(hashFunction, pubkey, signature, signatureLength, data, dataLength)
+  ok, error = handle:verifySignature(hashFunction, pubkey, signature, signatureLength, data, dataLength)
 
 Verify signature using provided parameters. *hashFunction* is the variable for hash function which be used
 for verifying signature. *SHA1*, *SHA224*, *SHA256*, *SHA384* and *SHA512* are supported.
@@ -348,7 +348,7 @@ timestamp()
 
 .. code-block:: lua
 
-  timestamp = timestamp(format)
+  timestamp = handle:timestamp(format)
 
 High resolution timestamp function. *format* is an optional string parameter to indicate the format of the timestamp.
 *milliseconds_since_epoch* and *nanoseconds_since_epoch* are supported.

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -348,9 +348,11 @@ timestamp()
 
 .. code-block:: lua
 
-  timestamp = timestamp()
+  timestamp = timestamp(format)
 
-High resolution timestamp function. The function returns timestamp in milliseconds since epoch.
+High resolution timestamp function. *format* is an optional string parameter to indicate the format of the timestamp.
+*milliseconds_since_epoch* and *nanoseconds_since_epoch* are supported.
+The function returns timestamp in milliseconds since epoch by default if format is not set.
 
 .. _config_http_filters_lua_header_wrapper:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -24,6 +24,7 @@ Version history
   mapping of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * listeners: fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed by a client using only TLS 1.3.
 * lua: added a parameter to `httpCall` that makes it possible to have the call be asynchronous.
+* lua: added function `timestamp` to provide high resolution timestamps.
 * mongo: the stat emitted for queries without a max time set in the :ref:`MongoDB filter<config_network_filters_mongo_proxy>` was modified to emit correctly for Mongo v3.2+.
 * network filters: network filter extensions use the "envoy.filters.network" name space. A mapping
   of extension names is available in the :ref:`deprecated <deprecated>` documentation.

--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -20,7 +20,7 @@ void Coroutine::start(int function_ref, int num_args, const std::function<void()
 
   state_ = State::Yielded;
   lua_rawgeti(coroutine_state_.get(), LUA_REGISTRYINDEX, function_ref);
-  ASSERT(lua_isfunction(coroutine_state_.get(), -1));
+  ASSERT(lua_isfunction(coroutine_state_.get(), -1) == 1);
 
   // The function needs to come before the arguments but the arguments are already on the stack,
   // so we need to move it into position.
@@ -69,11 +69,15 @@ int ThreadLocalState::getGlobalRef(uint64_t slot) {
   return tls.global_slots_[slot];
 }
 
-uint64_t ThreadLocalState::registerGlobal(const std::string& global) {
-  tls_slot_->runOnAllThreads([this, global]() {
+uint64_t ThreadLocalState::registerGlobal(const std::string& global,
+                                          const InitializerList& initializers) {
+  tls_slot_->runOnAllThreads([this, global, initializers]() {
     LuaThreadLocal& tls = tls_slot_->getTyped<LuaThreadLocal>();
     lua_getglobal(tls.state_.get(), global.c_str());
     if (lua_isfunction(tls.state_.get(), -1)) {
+      for (const auto& initialize : initializers) {
+        initialize(tls.state_.get());
+      }
       tls.global_slots_.push_back(luaL_ref(tls.state_.get(), LUA_REGISTRYINDEX));
     } else {
       ENVOY_LOG(debug, "definition for '{}' not found in script", global);

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -62,6 +62,14 @@ namespace Lua {
 #define DECLARE_LUA_CLOSURE(Class, Name) DECLARE_LUA_FUNCTION_EX(Class, Name, lua_upvalueindex(1))
 
 /**
+ * Declare a Lua function in which values are added to a table to approximate an enum.
+ */
+#define LUA_ENUM(state, name, val)                                                                 \
+  lua_pushlstring(state, #name, sizeof(#name) - 1);                                                \
+  lua_pushnumber(state, val);                                                                      \
+  lua_settable(state, -3);
+
+/**
  * Calculate the maximum space needed to be aligned.
  */
 template <typename T> constexpr size_t maximumSpaceNeededToAlign() {
@@ -352,6 +360,8 @@ private:
 };
 
 using CoroutinePtr = std::unique_ptr<Coroutine>;
+using Initializer = std::function<void(lua_State*)>;
+using InitializerList = std::vector<const Initializer>;
 
 /**
  * This class wraps a Lua state that can be used safely across threads. The model is that every
@@ -377,9 +387,11 @@ public:
   /**
    * Register a global for later use.
    * @param global supplies the name of the global.
+   * @param initializers supplies a collection of initializers.
    * @return a slot/index for later use with getGlobalRef().
    */
-  uint64_t registerGlobal(const std::string& global);
+  uint64_t registerGlobal(const std::string& global,
+                          const std::vector<const Initializer>& initializers);
 
   /**
    * Register a type with the thread local state. After this call the type will be available on

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -23,7 +23,7 @@ namespace Lua {
  * Some general notes on everything in this file. Lua/C bindings are functional, but not the most
  * beautiful interfaces. For more general overview information see the following:
  * 1) https://www.lua.org/manual/5.1/manual.html#3
- * 2) https://doc.lagout.org/programmation/Lua/Programming%20in%20Lua%20Second%20Edition.pdf
+ * 2) https://doc.lagout.org/programmation/Lua/Programming%20in%20Lua.pdf
  * 3) http://luajit.org/extensions.html
  *
  * Instead of delving into crazy template metaprogramming in all cases, I've tried to use a mix

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -16,8 +16,9 @@ Http::FilterFactoryCb LuaFilterConfig::createFilterFactoryFromProtoTyped(
     Server::Configuration::FactoryContext& context) {
   FilterConfigConstSharedPtr filter_config(new FilterConfig{
       proto_config.inline_code(), context.threadLocal(), context.clusterManager()});
+  auto& time_source = context.dispatcher().timeSource();
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(filter_config));
+    callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, time_source));
   };
 }
 

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -17,7 +17,7 @@ Http::FilterFactoryCb LuaFilterConfig::createFilterFactoryFromProtoTyped(
   FilterConfigConstSharedPtr filter_config(new FilterConfig{
       proto_config.inline_code(), context.threadLocal(), context.clusterManager()});
   auto& time_source = context.dispatcher().timeSource();
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+  return [filter_config, &time_source](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, time_source));
   };
 }

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -503,12 +503,12 @@ int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
 int StreamHandleWrapper::luaTimestamp(lua_State* state) {
   auto now = time_source_.systemTime().time_since_epoch();
 
-  auto time_unit = luaL_optstring(state, 2, "");
-  if (strcmp(time_unit, "") == 0 || strcmp(time_unit, "milliseconds_since_epoch") == 0) {
+  absl::string_view unit_parameter = luaL_optstring(state, 2, "");
+  if (unit_parameter.empty() || unit_parameter.compare("milliseconds_since_epoch") == 0) {
     auto milliseconds_since_epoch =
         std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
     lua_pushnumber(state, milliseconds_since_epoch);
-  } else if (strcmp(time_unit, "nanoseconds_since_epoch") == 0) {
+  } else if (unit_parameter.compare("nanoseconds_since_epoch") == 0) {
     auto nanoseconds_since_epoch =
         std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
     lua_pushnumber(state, nanoseconds_since_epoch);

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -501,10 +501,22 @@ int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
 }
 
 int StreamHandleWrapper::luaTimestamp(lua_State* state) {
-  auto millis_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                time_source_.systemTime().time_since_epoch())
-                                .count();
-  lua_pushnumber(state, millis_since_epoch);
+  auto now = time_source_.systemTime().time_since_epoch();
+
+  auto time_unit = luaL_optstring(state, 2, "");
+  if (strcmp(time_unit, "") == 0 || strcmp(time_unit, "milliseconds_since_epoch") == 0) {
+    auto milliseconds_since_epoch =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+    lua_pushnumber(state, milliseconds_since_epoch);
+  } else if (strcmp(time_unit, "nanoseconds_since_epoch") == 0) {
+    auto nanoseconds_since_epoch =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+    lua_pushnumber(state, nanoseconds_since_epoch);
+  } else {
+    luaL_error(state,
+               "timestamp format must be milliseconds_since_epoch or nanoseconds_since_epoch.");
+  }
+
   return 1;
 }
 

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -248,7 +248,9 @@ private:
 
   /**
    * Timestamp.
-   * @return timestamp in millis
+   * @param1 (string) optional format (e.g. milliseconds_from_epoch, nanoseconds_from_epoch).
+   * Defaults to milliseconds_from_epoch.
+   * @return timestamp
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestamp);
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -224,6 +224,11 @@ private:
   Envoy::Common::Crypto::CryptoObjectPtr public_key_;
 };
 
+class Timestamp {
+public:
+    enum Resolution { Millisecond, Nanosecond };
+};
+
 } // namespace Lua
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -226,7 +226,7 @@ private:
 
 class Timestamp {
 public:
-    enum Resolution { Millisecond, Nanosecond };
+  enum Resolution { Millisecond, Nanosecond };
 };
 
 } // namespace Lua

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1883,8 +1883,8 @@ TEST_F(LuaHttpFilterTest, SignatureVerify) {
 TEST_F(LuaHttpFilterTest, Timestamp_ReturnsFormatSet) {
   const std::string SCRIPT{R"EOF(
       function envoy_on_request(request_handle)
-        request_handle:logTrace(request_handle:timestamp("milliseconds_since_epoch"))
-        request_handle:logTrace(request_handle:timestamp("nanoseconds_since_epoch"))
+        request_handle:logTrace(request_handle:timestamp(EnvoyTimestampResolution.MILLISECOND))
+        request_handle:logTrace(request_handle:timestamp(EnvoyTimestampResolution.NANOSECOND))
         request_handle:logTrace(request_handle:timestamp("invalid_format"))
       end
     )EOF"};
@@ -1898,9 +1898,9 @@ TEST_F(LuaHttpFilterTest, Timestamp_ReturnsFormatSet) {
   // Explicitly set to nanoseconds
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("1.583879145572e+18")));
   // Invalid format
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::err,
-                                  StrEq("[string \"...\"]:5: timestamp format must be "
-                                        "milliseconds_since_epoch or nanoseconds_since_epoch.")));
+  EXPECT_CALL(*filter_,
+              scriptLog(spdlog::level::err, StrEq("[string \"...\"]:5: timestamp format must be "
+                                                  "MILLISECOND or NANOSECOND.")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1904,7 +1904,7 @@ TEST_F(LuaHttpFilterTest, Timestamp_ReturnsFormatSet) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-TEST_F(LuaHttpFilterTest, Timestamp_DefaultsToMills_WhenNoFormatSet) {
+TEST_F(LuaHttpFilterTest, Timestamp_DefaultsToMilliseconds_WhenNoFormatSet) {
   const std::string SCRIPT{R"EOF(
       function envoy_on_request(request_handle)
         request_handle:logTrace(request_handle:timestamp())

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -636,6 +636,7 @@ inflight
 -ing
 init
 initializer
+initializers
 inlined
 inlining
 inobservability


### PR DESCRIPTION
Description: adds Lua function to get timestamp in higher resolution. Resolutions are: milliseconds since epoch and nanoseconds since epoch. Resolution defaults to milliseconds since epoch.

Risk Level: small-medium?
Testing: added unit test.
Docs Changes: added documentation for function in `lua_filter.rst`
Release Notes: added release note in `version_history.rst`

Fixes #10282