### PR TITLE
tracing: LightStep: do cleanup on tracer destruction in order to support dynamic (re-)configuration

### DIFF
--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -141,6 +141,8 @@ LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(
   enableTimer();
 }
 
+LightStepDriver::TlsLightStepTracer::~TlsLightStepTracer() { flush_timer_->disableTimer(); }
+
 lightstep::LightStepTracer& LightStepDriver::TlsLightStepTracer::tracer() { return *tracer_; }
 
 void LightStepDriver::TlsLightStepTracer::enableTimer() {

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -78,7 +78,6 @@ private:
   class LightStepTransporter : public lightstep::AsyncTransporter, Http::AsyncClient::Callbacks {
   public:
     explicit LightStepTransporter(LightStepDriver& driver);
-
     ~LightStepTransporter() override;
 
     // lightstep::AsyncTransporter
@@ -116,6 +115,7 @@ private:
   public:
     TlsLightStepTracer(const std::shared_ptr<lightstep::LightStepTracer>& tracer,
                        LightStepDriver& driver, Event::Dispatcher& dispatcher);
+    ~TlsLightStepTracer() override;
 
     lightstep::LightStepTracer& tracer();
 

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -450,6 +450,16 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
   driver_.reset();
 }
 
+TEST_F(LightStepDriverTest, DisableFlushTimerOnDestruction) {
+  setupValidDriver();
+
+  // Must disable flush timer on destruction.
+  EXPECT_CALL(*timer_, disableTimer());
+
+  // Trigger destruction.
+  driver_.reset();
+}
+
 TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
   for (Common::Ot::OpenTracingDriver::PropagationMode propagation_mode :
        {Common::Ot::OpenTracingDriver::PropagationMode::SingleHeader,


### PR DESCRIPTION
Description: do cleanup on tracer destruction in order to support dynamic (re-)configuration
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Context:
* part of #9998 
* in order to support complete removal of `HttpTracer` instances that are no longer in use, tracer implementations must do cleanup on destruction