### PR TITLE
test: Add bazel build extensions for benchmark targets

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -11,6 +11,7 @@ load("//bazel:envoy_internal.bzl", "envoy_select_force_libcpp")
 exports_files([
     "gen_sh_test_runner.sh",
     "sh_test_wrapper.sh",
+    "test_for_benchmark_wrapper.sh",
 ])
 
 genrule(

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -21,6 +21,8 @@ load(
 )
 load(
     ":envoy_test.bzl",
+    _envoy_benchmark_test = "envoy_benchmark_test",
+    _envoy_cc_benchmark_binary = "envoy_cc_benchmark_binary",
     _envoy_cc_fuzz_test = "envoy_cc_fuzz_test",
     _envoy_cc_mock = "envoy_cc_mock",
     _envoy_cc_test = "envoy_cc_test",
@@ -185,5 +187,7 @@ envoy_cc_mock = _envoy_cc_mock
 envoy_cc_test = _envoy_cc_test
 envoy_cc_test_binary = _envoy_cc_test_binary
 envoy_cc_test_library = _envoy_cc_test_library
+envoy_cc_benchmark_binary = _envoy_cc_benchmark_binary
+envoy_benchmark_test = _envoy_benchmark_test
 envoy_py_test_binary = _envoy_py_test_binary
 envoy_sh_test = _envoy_sh_test

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -248,6 +248,29 @@ def envoy_cc_test_binary(
         **kargs
     )
 
+# Envoy benchmark binaries should be specified with this function.
+def envoy_cc_benchmark_binary(
+        name,
+        deps = [],
+        **kargs):
+    envoy_cc_test_binary(
+        name,
+        deps = deps + ["//test/benchmark:main"],
+        **kargs
+    )
+
+# Tests to validate that Envoy benchmarks run successfully should be specified with this function.
+def envoy_benchmark_test(
+        name,
+        benchmark_binary,
+        data = []):
+    native.sh_test(
+        name = name,
+        srcs = ["//bazel:test_for_benchmark_wrapper.sh"],
+        data = [":" + benchmark_binary] + data,
+        args = ["%s/%s" % (native.package_name(), benchmark_binary)],
+    )
+
 # Envoy Python test binaries should be specified with this function.
 def envoy_py_test_binary(
         name,

--- a/bazel/test_for_benchmark_wrapper.sh
+++ b/bazel/test_for_benchmark_wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Set the benchmark time to 0 to just verify that the benchmark runs to completion.
+"${TEST_SRCDIR}/envoy/$@" --benchmark_min_time=0

--- a/test/benchmark/BUILD
+++ b/test/benchmark/BUILD
@@ -1,0 +1,22 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_test_library(
+    name = "main",
+    srcs = ["main.cc"],
+    external_deps = [
+        "abseil_symbolize",
+        "benchmark",
+    ],
+    deps = select({
+        "//bazel:disable_signal_trace": [],
+        "//conditions:default": ["//source/common/signal:sigaction_lib"],
+    }),
+)

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -1,0 +1,27 @@
+// NOLINT(namespace-envoy)
+// This is an Envoy driver for benchmarks.
+
+#include "benchmark/benchmark.h"
+
+#ifdef ENVOY_HANDLE_SIGNALS
+#include "common/signal/signal_action.h"
+#endif
+
+#include "absl/debugging/symbolize.h"
+
+// Boilerplate main(), which discovers benchmarks and runs them.
+int main(int argc, char** argv) {
+#ifndef __APPLE__
+  absl::InitializeSymbolizer(argv[0]);
+#endif
+#ifdef ENVOY_HANDLE_SIGNALS
+  // Enabled by default. Control with "bazel --define=signal_trace=disabled"
+  Envoy::SignalAction handle_sigs;
+#endif
+
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
Description: Add bazel build extensions for benchmarks targets and tests for benchmark targets that expands to a benchmark binary with an implicit dependency on //test/benchmark:main.   Followup PRs will refactor existing benchmarks so they can take advantage of this new framework.
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
