### PR TITLE
Python virtualenv --no-site-packages arg is deprecated

### DIFF
--- a/tools/shell_utils.sh
+++ b/tools/shell_utils.sh
@@ -2,7 +2,7 @@ source_venv() {
   VENV_DIR=$1
   if [[ "${VIRTUAL_ENV}" == "" ]]; then
     if [[ ! -d "${VENV_DIR}"/venv ]]; then
-      virtualenv "${VENV_DIR}"/venv --no-site-packages --python=python3
+      virtualenv "${VENV_DIR}"/venv --python=python3
     fi
     source "${VENV_DIR}"/venv/bin/activate
   else


### PR DESCRIPTION
Signed-off-by: kathan24 <kshah@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Fix for failing git push due to deprecated virtualenv argument. My [another PR](https://github.com/envoyproxy/envoy/pull/9920) was failing due to this. I removed the argument locally and I was able to push my changes. 
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue] #10337 
[Optional Deprecated:]
