### PR TITLE
coverage: disambiguate HCM UtilityTest from other UtilityTests.

### DIFF
--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1315,9 +1315,9 @@ TEST_F(FilterChainTest, InvalidConfig) {
       EnvoyException, "Error: multiple upgrade configs with the same name: 'websocket'");
 }
 
-class UtilityTest : public testing::Test {
+class HcmUtilityTest : public testing::Test {
 public:
-  UtilityTest() {
+  HcmUtilityTest() {
     // Although different Listeners will have separate FactoryContexts,
     // those contexts must share the same SingletonManager.
     ON_CALL(context_two_, singletonManager()).WillByDefault([&]() -> Singleton::Manager& {
@@ -1328,7 +1328,7 @@ public:
   NiceMock<Server::Configuration::MockFactoryContext> context_two_;
 };
 
-TEST_F(UtilityTest, EnsureCreateSingletonsActuallyReturnsTheSameInstances) {
+TEST_F(HcmUtilityTest, EnsureCreateSingletonsActuallyReturnsTheSameInstances) {
   // Simulate `HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoTyped()`
   // call for filter instance "one".
   auto singletons_one = Utility::createSingletons(context_one_);


### PR DESCRIPTION
Needed in a single coverage binary.

Risk level: Low
Testing: coverage run.

Signed-off-by: Harvey Tuch <htuch@google.com>