### PR TITLE
tracing: Zipkin: do cleanup on tracer destruction in order to support dynamic (re-)configuration

### DIFF
--- a/source/extensions/tracers/zipkin/BUILD
+++ b/source/extensions/tracers/zipkin/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
         "//source/common/common:hex_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:utility_lib",
+        "//source/common/http:async_client_utility_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:message_lib",
         "//source/common/http:utility_lib",

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -188,21 +188,28 @@ void ReporterImpl::flushSpans() {
 
     const uint64_t timeout =
         driver_.runtime().snapshot().getInteger("tracing.zipkin.request_timeout", 5000U);
-    driver_.clusterManager()
-        .httpAsyncClientForCluster(driver_.cluster()->name())
-        .send(std::move(message), *this,
-              Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(timeout)));
+    auto* request = driver_.clusterManager()
+                        .httpAsyncClientForCluster(driver_.cluster()->name())
+                        .send(std::move(message), *this,
+                              Http::AsyncClient::RequestOptions().setTimeout(
+                                  std::chrono::milliseconds(timeout)));
+    if (request) {
+      active_requests_.add(*request);
+    }
 
     span_buffer_->clear();
   }
 }
 
-void ReporterImpl::onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) {
+void ReporterImpl::onFailure(const Http::AsyncClient::Request& request,
+                             Http::AsyncClient::FailureReason) {
+  active_requests_.remove(request);
   driver_.tracerStats().reports_failed_.inc();
 }
 
-void ReporterImpl::onSuccess(const Http::AsyncClient::Request&,
+void ReporterImpl::onSuccess(const Http::AsyncClient::Request& request,
                              Http::ResponseMessagePtr&& http_response) {
+  active_requests_.remove(request);
   if (Http::Utility::getResponseStatus(http_response->headers()) !=
       enumToInt(Http::Code::Accepted)) {
     driver_.tracerStats().reports_dropped_.inc();

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -188,11 +188,11 @@ void ReporterImpl::flushSpans() {
 
     const uint64_t timeout =
         driver_.runtime().snapshot().getInteger("tracing.zipkin.request_timeout", 5000U);
-    auto* request = driver_.clusterManager()
-                        .httpAsyncClientForCluster(driver_.cluster()->name())
-                        .send(std::move(message), *this,
-                              Http::AsyncClient::RequestOptions().setTimeout(
-                                  std::chrono::milliseconds(timeout)));
+    Http::AsyncClient::Request* request = driver_.clusterManager()
+                                              .httpAsyncClientForCluster(driver_.cluster()->name())
+                                              .send(std::move(message), *this,
+                                                    Http::AsyncClient::RequestOptions().setTimeout(
+                                                        std::chrono::milliseconds(timeout)));
     if (request) {
       active_requests_.add(*request);
     }

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -7,6 +7,7 @@
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/http/async_client_utility.h"
 #include "common/http/header_map_impl.h"
 #include "common/json/json_loader.h"
 
@@ -226,6 +227,8 @@ private:
   Event::TimerPtr flush_timer_;
   const CollectorInfo collector_;
   SpanBufferPtr span_buffer_;
+  // Track active HTTP requests to be able to cancel them on destruction.
+  Http::AsyncClientRequestTracker active_requests_;
 };
 } // namespace Zipkin
 } // namespace Tracers

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -29,11 +29,14 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::DoAll;
 using testing::Eq;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
+using testing::StrictMock;
+using testing::WithArg;
 
 namespace Envoy {
 namespace Extensions {
@@ -242,6 +245,66 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
   EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_sent").value());
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_dropped").value());
   EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_failed").value());
+}
+
+TEST_F(ZipkinDriverTest, CancelInflightRequestsOnDestruction) {
+  setupValidDriver("HTTP_JSON_V1");
+
+  StrictMock<Http::MockAsyncClientRequest> request1(&cm_.async_client_),
+      request2(&cm_.async_client_), request3(&cm_.async_client_), request4(&cm_.async_client_);
+  Http::AsyncClient::Callbacks* callback{};
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+
+  // Expect 4 separate report requests to be made.
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
+      .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callback)), Return(&request1)))
+      .WillOnce(Return(&request2))
+      .WillOnce(Return(&request3))
+      .WillOnce(Return(&request4));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.zipkin.min_flush_spans", 5))
+      .Times(4)
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.zipkin.request_timeout", 5000U))
+      .Times(4)
+      .WillRepeatedly(Return(5000U));
+
+  // Trigger 1st report request.
+  driver_
+      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+                  {Tracing::Reason::Sampling, true})
+      ->finishSpan();
+  // Trigger 2nd report request.
+  driver_
+      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+                  {Tracing::Reason::Sampling, true})
+      ->finishSpan();
+  // Trigger 3rd report request.
+  driver_
+      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+                  {Tracing::Reason::Sampling, true})
+      ->finishSpan();
+  // Trigger 4th report request.
+  driver_
+      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+                  {Tracing::Reason::Sampling, true})
+      ->finishSpan();
+
+  Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "404"}}}));
+
+  // Simulate completion of the 2nd report request.
+  callback->onSuccess(request2, std::move(msg));
+
+  // Simulate failure of the 3rd report request.
+  callback->onFailure(request3, Http::AsyncClient::FailureReason::Reset);
+
+  // Expect 1st and 4th requests to be cancelled on destruction.
+  EXPECT_CALL(request1, cancel());
+  EXPECT_CALL(request4, cancel());
+
+  // Trigger destruction.
+  driver_.reset();
 }
 
 TEST_F(ZipkinDriverTest, FlushSpansTimer) {


### PR DESCRIPTION
Description: do cleanup on tracer destruction in order to support dynamic (re-)configuration
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Context:
* part of #9998
* ~~depends on #10358 and #10359~~

Motivation:
* since Zipkin tracer allows multiple concurrent in-flight requests to the collector, we need to keep track of all of them and cancel them if tracer gets removed
