### PR TITLE
WiP coverage: attempt to fix coverage by resolving a potential overload of UtilityTest, by adding an anon namespace

### DIFF
--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -31,7 +31,6 @@ namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace HttpConnectionManager {
-namespace {
 
 envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
 parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
@@ -1387,7 +1386,6 @@ TEST_F(UtilityTest, EnsureCreateSingletonsActuallyReturnsTheSameInstances) {
   EXPECT_EQ(singletons_two.http_tracer_manager_, singletons_one.http_tracer_manager_);
 }
 
-} // namespace
 } // namespace HttpConnectionManager
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -31,6 +31,7 @@ namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace HttpConnectionManager {
+namespace {
 
 envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
 parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
@@ -1386,6 +1387,7 @@ TEST_F(UtilityTest, EnsureCreateSingletonsActuallyReturnsTheSameInstances) {
   EXPECT_EQ(singletons_two.http_tracer_manager_, singletons_one.http_tracer_manager_);
 }
 
+} // namespace
 } // namespace HttpConnectionManager
 } // namespace NetworkFilters
 } // namespace Extensions


### PR DESCRIPTION
Description: will add as PR if coverage passes. A coverage test in another PR failed with:
```
[ RUN      ] UtilityTest.EnsureCreateSingletonsActuallyReturnsTheSameInstances
external/com_google_googletest/googletest/src/gtest.cc:2332: Failure
Failed
All tests in the same test suite must use the same test fixture
class, so mixing TEST_F and TEST in the same test suite is
illegal.  In test suite UtilityTest,
test EnsureCreateSingletonsActuallyReturnsTheSameInstances is defined using TEST_F but
test ComputeHashedVersion is defined using TEST.  You probably
want to change the TEST to TEST_F or move it to another test
case.
Stack trace:
  0x10f71fb5: testing::Test::HasSameFixtureClass()
  0x10f724de: testing::Test::Run()
  0x10f730c8: testing::TestInfo::Run()
  0x10f73839: testing::TestSuite::Run()
... Google Test internal frames ...
```
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
