### PR TITLE
protobuf: refactor proto visitor pattern.

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -342,6 +342,7 @@ envoy_cc_library(
         ":api_type_oracle_lib",
         "//source/common/common:assert_lib",
         "//source/common/protobuf",
+        "//source/common/protobuf:visitor_lib",
         "//source/common/protobuf:well_known_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/source/common/config/version_converter.cc
+++ b/source/common/config/version_converter.cc
@@ -4,6 +4,7 @@
 
 #include "common/common/assert.h"
 #include "common/config/api_type_oracle.h"
+#include "common/protobuf/visitor.h"
 #include "common/protobuf/well_known.h"
 
 #include "absl/strings/match.h"
@@ -30,30 +31,6 @@ public:
   // Invoked when a message is visited, with the message and a context.
   virtual void onMessage(Protobuf::Message&, const void*){};
 };
-
-// TODO(htuch): refactor these message visitor patterns into utility.cc and share with
-// MessageUtil::checkForUnexpectedFields.
-void traverseMutableMessage(ProtoVisitor& visitor, Protobuf::Message& message, const void* ctxt) {
-  visitor.onMessage(message, ctxt);
-  const Protobuf::Descriptor* descriptor = message.GetDescriptor();
-  const Protobuf::Reflection* reflection = message.GetReflection();
-  for (int i = 0; i < descriptor->field_count(); ++i) {
-    const Protobuf::FieldDescriptor* field = descriptor->field(i);
-    const void* field_ctxt = visitor.onField(message, *field, ctxt);
-    // If this is a message, recurse to scrub deprecated fields in the sub-message.
-    if (field->cpp_type() == Protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
-      if (field->is_repeated()) {
-        const int size = reflection->FieldSize(message, field);
-        for (int j = 0; j < size; ++j) {
-          traverseMutableMessage(visitor, *reflection->MutableRepeatedMessage(&message, field, j),
-                                 field_ctxt);
-        }
-      } else if (reflection->HasField(message, field)) {
-        traverseMutableMessage(visitor, *reflection->MutableMessage(&message, field), field_ctxt);
-      }
-    }
-  }
-}
 
 // Reinterpret a Protobuf message as another Protobuf message by converting to wire format and back.
 // This only works for messages that can be effectively duck typed this way, e.g. with a subtype
@@ -88,7 +65,7 @@ DynamicMessagePtr createForDescriptorWithCast(const Protobuf::Message& message,
 // internally, we later want to recover their original types.
 void annotateWithOriginalType(const Protobuf::Descriptor& prev_descriptor,
                               Protobuf::Message& next_message) {
-  class TypeAnnotatingProtoVisitor : public ProtoVisitor {
+  class TypeAnnotatingProtoVisitor : public ProtobufMessage::ProtoVisitor {
   public:
     void onMessage(Protobuf::Message& message, const void* ctxt) override {
       const Protobuf::Descriptor* descriptor = message.GetDescriptor();
@@ -127,7 +104,7 @@ void annotateWithOriginalType(const Protobuf::Descriptor& prev_descriptor,
     }
   };
   TypeAnnotatingProtoVisitor proto_visitor;
-  traverseMutableMessage(proto_visitor, next_message, &prev_descriptor);
+  ProtobufMessage::traverseMutableMessage(proto_visitor, next_message, &prev_descriptor);
 }
 
 } // namespace
@@ -140,7 +117,7 @@ void VersionConverter::upgrade(const Protobuf::Message& prev_message,
 }
 
 void VersionConverter::eraseOriginalTypeInformation(Protobuf::Message& message) {
-  class TypeErasingProtoVisitor : public ProtoVisitor {
+  class TypeErasingProtoVisitor : public ProtobufMessage::ProtoVisitor {
   public:
     void onMessage(Protobuf::Message& message, const void*) override {
       const Protobuf::Reflection* reflection = message.GetReflection();
@@ -149,7 +126,7 @@ void VersionConverter::eraseOriginalTypeInformation(Protobuf::Message& message) 
     }
   };
   TypeErasingProtoVisitor proto_visitor;
-  traverseMutableMessage(proto_visitor, message, nullptr);
+  ProtobufMessage::traverseMutableMessage(proto_visitor, message, nullptr);
 }
 
 DynamicMessagePtr VersionConverter::recoverOriginal(const Protobuf::Message& upgraded_message) {
@@ -226,7 +203,7 @@ void VersionConverter::prepareMessageForGrpcWire(Protobuf::Message& message,
 }
 
 void VersionUtil::scrubHiddenEnvoyDeprecated(Protobuf::Message& message) {
-  class HiddenFieldScrubbingProtoVisitor : public ProtoVisitor {
+  class HiddenFieldScrubbingProtoVisitor : public ProtobufMessage::ProtoVisitor {
   public:
     const void* onField(Protobuf::Message& message, const Protobuf::FieldDescriptor& field,
                         const void*) override {
@@ -238,7 +215,7 @@ void VersionUtil::scrubHiddenEnvoyDeprecated(Protobuf::Message& message) {
     }
   };
   HiddenFieldScrubbingProtoVisitor proto_visitor;
-  traverseMutableMessage(proto_visitor, message, nullptr);
+  ProtobufMessage::traverseMutableMessage(proto_visitor, message, nullptr);
 }
 
 } // namespace Config

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -68,10 +68,18 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/config:api_type_oracle_lib",
         "//source/common/config:version_converter_lib",
+        "//source/common/protobuf:visitor_lib",
         "@com_github_cncf_udpa//udpa/annotations:pkg_cc_proto",
         "@envoy_api//envoy/annotations:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],
+)
+
+envoy_cc_library(
+    name = "visitor_lib",
+    srcs = ["visitor.cc"],
+    hdrs = ["visitor.h"],
+    deps = [":protobuf"],
 )
 
 envoy_cc_library(

--- a/source/common/protobuf/visitor.cc
+++ b/source/common/protobuf/visitor.cc
@@ -1,0 +1,50 @@
+#include "common/protobuf/visitor.h"
+
+namespace Envoy {
+namespace ProtobufMessage {
+
+void traverseMutableMessage(ProtoVisitor& visitor, Protobuf::Message& message, const void* ctxt) {
+  visitor.onMessage(message, ctxt);
+  const Protobuf::Descriptor* descriptor = message.GetDescriptor();
+  const Protobuf::Reflection* reflection = message.GetReflection();
+  for (int i = 0; i < descriptor->field_count(); ++i) {
+    const Protobuf::FieldDescriptor* field = descriptor->field(i);
+    const void* field_ctxt = visitor.onField(message, *field, ctxt);
+    // If this is a message, recurse to visit fields in the sub-message.
+    if (field->cpp_type() == Protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+      if (field->is_repeated()) {
+        const int size = reflection->FieldSize(message, field);
+        for (int j = 0; j < size; ++j) {
+          traverseMutableMessage(visitor, *reflection->MutableRepeatedMessage(&message, field, j),
+                                 field_ctxt);
+        }
+      } else if (reflection->HasField(message, field)) {
+        traverseMutableMessage(visitor, *reflection->MutableMessage(&message, field), field_ctxt);
+      }
+    }
+  }
+}
+void traverseMessage(ConstProtoVisitor& visitor, const Protobuf::Message& message,
+                     const void* ctxt) {
+  visitor.onMessage(message, ctxt);
+  const Protobuf::Descriptor* descriptor = message.GetDescriptor();
+  const Protobuf::Reflection* reflection = message.GetReflection();
+  for (int i = 0; i < descriptor->field_count(); ++i) {
+    const Protobuf::FieldDescriptor* field = descriptor->field(i);
+    const void* field_ctxt = visitor.onField(message, *field, ctxt);
+    // If this is a message, recurse to scrub deprecated fields in the sub-message.
+    if (field->cpp_type() == Protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+      if (field->is_repeated()) {
+        const int size = reflection->FieldSize(message, field);
+        for (int j = 0; j < size; ++j) {
+          traverseMessage(visitor, reflection->GetRepeatedMessage(message, field, j), field_ctxt);
+        }
+      } else if (reflection->HasField(message, field)) {
+        traverseMessage(visitor, reflection->GetMessage(message, field), field_ctxt);
+      }
+    }
+  }
+}
+
+} // namespace ProtobufMessage
+} // namespace Envoy

--- a/source/common/protobuf/visitor.h
+++ b/source/common/protobuf/visitor.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace ProtobufMessage {
+
+class ProtoVisitor {
+public:
+  virtual ~ProtoVisitor() = default;
+
+  // Invoked when a field is visited, with the message, field descriptor and context. Returns a new
+  // context for use when traversing the sub-message in a field.
+  virtual const void* onField(Protobuf::Message&, const Protobuf::FieldDescriptor&,
+                              const void* ctxt) {
+    return ctxt;
+  }
+
+  // Invoked when a message is visited, with the message and a context.
+  virtual void onMessage(Protobuf::Message&, const void*){};
+};
+
+class ConstProtoVisitor {
+public:
+  virtual ~ConstProtoVisitor() = default;
+
+  // Invoked when a field is visited, with the message, field descriptor and context. Returns a new
+  // context for use when traversing the sub-message in a field.
+  virtual const void* onField(const Protobuf::Message&, const Protobuf::FieldDescriptor&,
+                              const void* ctxt) {
+    return ctxt;
+  }
+
+  // Invoked when a message is visited, with the message and a context.
+  virtual void onMessage(const Protobuf::Message&, const void*){};
+};
+
+void traverseMutableMessage(ProtoVisitor& visitor, Protobuf::Message& message, const void* ctxt);
+void traverseMessage(ConstProtoVisitor& visitor, const Protobuf::Message& message,
+                     const void* ctxt);
+
+} // namespace ProtobufMessage
+} // namespace Envoy


### PR DESCRIPTION
Move the proto traversal handling in version_converter.cc to a
standalone library. This lets us replace existing proto visitor patterns in
common/protobuf/utility.cc for unexpected field checks.

The redaction code is actually a bit more involved, so I'm not
refactoring this; it needs to recurse through Any/TypedStruct.
Ultimately we might want something like this, but it doesn't seem super
helpful given we only have a the single instance of this right now.

Risk level: Low
Testing: Existing tests continue to pass.

Signed-off-by: Harvey Tuch <htuch@google.com>