### PR TITLE
ci: force install/link bazelisk package in macos dependency setup

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -35,16 +35,10 @@ if [ -n "$CIRCLECI" ]; then
     mv ~/.gitconfig ~/.gitconfig_save
 fi
 
-# Required as bazel is installed in the latest macos vm image, we have to unlink it to
-# link the bazel command to bazelisk
-bazel_path=`which bazel`
-if is_installed "bazelbuild/tap/bazel" && ! brew unlink bazelbuild/tap/bazel; then
-    echo "Failed to unlink bazelbuild/tap/bazel"
+# Required as bazel and a foreign bazelisk are installed in the latest macos vm image, we have
+# to unlink/overwrite them to install bazelisk
+brew install --force bazelbuild/tap/bazelisk
+if ! brew link --overwrite bazelbuild/tap/bazelisk; then
+    echo "Failed to install and link bazelbuild/tap/bazelisk"
     exit 1
 fi
-bazelisk_path=`which bazel`
-if [ -z "$bazelisk_path" ]; then
-    echo "bazelisk not installed"
-    exit 1
-fi
-ln -s $bazelisk_path $bazel_path

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -37,6 +37,7 @@ fi
 
 # Required as bazel and a foreign bazelisk are installed in the latest macos vm image, we have
 # to unlink/overwrite them to install bazelisk
+echo "Installing bazelbuild/tap/bazelisk"
 brew install --force bazelbuild/tap/bazelisk
 if ! brew link --overwrite bazelbuild/tap/bazelisk; then
     echo "Failed to install and link bazelbuild/tap/bazelisk"

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -15,9 +15,9 @@ function is_installed {
 
 function install {
     echo "Installing $1"
-    if ! brew install "$1"
-    then
-        echo "Failed to install $1"
+    brew install "$1"
+    if ! brew link --overwrite "$1"; then
+        echo "Failed to install and link $1"
         exit 1
     fi
 }

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -27,13 +27,6 @@ if ! brew update; then
     exit 1
 fi
 
-# Required as bazel is installed in the latest macos vm image, we have to unlink it to
-# install bazelisk
-if is_installed "bazelbuild/tap/bazel" && ! brew unlink bazelbuild/tap/bazel; then
-    echo "Failed to unlink bazelbuild/tap/bazel"
-    exit 1
-fi
-
 DEPS="automake bazelbuild/tap/bazelisk cmake coreutils go libtool wget ninja"
 for DEP in ${DEPS}
 do

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -24,6 +24,13 @@ if ! brew update; then
     exit 1
 fi
 
+# Required as bazel is installed in the latest macos vm image, we have to unlink it to
+# install bazelisk
+if is_installed "bazelbuild/tap/bazel" && ! brew unlink bazelbuild/tap/bazel; then
+    echo "Failed to unlink bazelbuild/tap/bazel"
+    exit 1
+fi
+
 DEPS="automake bazelbuild/tap/bazelisk cmake coreutils go libtool wget ninja"
 for DEP in ${DEPS}
 do

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -23,7 +23,7 @@ if ! brew update; then
     exit 1
 fi
 
-DEPS="automake bazelisk cmake coreutils go libtool wget ninja"
+DEPS="automake cmake coreutils go libtool wget ninja"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"
@@ -42,4 +42,9 @@ if is_installed "bazelbuild/tap/bazel" && ! brew unlink bazelbuild/tap/bazel; th
     echo "Failed to unlink bazelbuild/tap/bazel"
     exit 1
 fi
-ln -s `which bazelisk` $bazel_path
+bazelisk_path=`which bazel`
+if [ -z "$bazelisk_path" ]; then
+    echo "bazelisk not installed"
+    exit 1
+fi
+ln -s $bazelisk_path $bazel_path

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -2,6 +2,9 @@
 
 # Installs the dependencies required for a macOS build via homebrew.
 # Tools are not upgraded to new versions.
+# See:
+# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md for
+# a list of pre-installed tools in the macOS image.
 
 # Setup bazelbuild tap
 brew tap bazelbuild/tap

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -15,7 +15,7 @@ function is_installed {
 
 function install {
     echo "Installing $1"
-    brew install "$1"
+    brew install --force "$1"
     if ! brew link --overwrite "$1"; then
         echo "Failed to install and link $1"
         exit 1


### PR DESCRIPTION
Description: Latest mac os images have bazel pre-installed so force install bazelisk and link with overwrite to allow install to succeed
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
