### PR TITLE
async client: refactor `Http::AsyncClient::Callbacks` to pass in `Http::AsyncClient::Request*` for correlation between requests and responses

### DIFF
--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -53,51 +53,23 @@ public:
 
     /**
      * Called when the async HTTP request succeeds.
-     * @param request  request handle or nullptr if no request could be created.
+     * @param request  request handle.
      *                 NOTE: request handle is passed for correlation purposes only, e.g.
      *                 for client code to be able to exclude that handle from a list of
      *                 requests in progress.
      * @param response the HTTP response
      */
-    virtual void onRequestSuccess(const Request& request, ResponseMessagePtr&& response) PURE;
+    virtual void onSuccess(const Request& request, ResponseMessagePtr&& response) PURE;
 
     /**
      * Called when the async HTTP request fails.
-     * @param request request handle or nullptr if no request could be created.
+     * @param request request handle.
      *                NOTE: request handle is passed for correlation purposes only, e.g.
      *                for client code to be able to exclude that handle from a list of
      *                requests in progress.
      * @param reason  failure reason
      */
-    virtual void onRequestFailure(const Request& request, FailureReason reason) PURE;
-  };
-
-  /**
-   * Notifies caller of async HTTP request status.
-   */
-  class RequestCallbacks : public Callbacks {
-  public:
-    virtual ~RequestCallbacks() override = default;
-
-    /**
-     * Called when the async HTTP request succeeds.
-     * @param response the HTTP response
-     */
-    virtual void onSuccess(ResponseMessagePtr&& response) PURE;
-
-    /**
-     * Called when the async HTTP request fails.
-     * @param reason failure reason
-     */
-    virtual void onFailure(FailureReason reason) PURE;
-
-    // Callbacks
-
-    void onRequestSuccess(const Request&, ResponseMessagePtr&& response) override {
-      onSuccess(std::forward<ResponseMessagePtr>(response));
-    }
-
-    void onRequestFailure(const Request&, FailureReason reason) override { onFailure(reason); }
+    virtual void onFailure(const Request& request, FailureReason reason) PURE;
   };
 
   /**

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -43,6 +43,9 @@ public:
 
   /**
    * Notifies caller of async HTTP request status.
+   *
+   * To support a use case where a caller makes multiple requests in parallel,
+   * individual callback methods provide request context corresponding to that response.
    */
   class Callbacks {
   public:
@@ -56,7 +59,7 @@ public:
      *                 requests in progress.
      * @param response the HTTP response
      */
-    virtual void onSuccess(const Request* request, ResponseMessagePtr&& response) PURE;
+    virtual void onRequestSuccess(const Request* request, ResponseMessagePtr&& response) PURE;
 
     /**
      * Called when the async HTTP request fails.
@@ -66,7 +69,7 @@ public:
      *                requests in progress.
      * @param reason  failure reason
      */
-    virtual void onFailure(const Request* request, FailureReason reason) PURE;
+    virtual void onRequestFailure(const Request* request, FailureReason reason) PURE;
   };
 
   /**
@@ -90,11 +93,11 @@ public:
 
     // Callbacks
 
-    virtual void onSuccess(const Request*, ResponseMessagePtr&& response) override {
+    void onRequestSuccess(const Request*, ResponseMessagePtr&& response) override {
       onSuccess(std::forward<ResponseMessagePtr>(response));
     }
 
-    virtual void onFailure(const Request*, FailureReason reason) override { onFailure(reason); }
+    void onRequestFailure(const Request*, FailureReason reason) override { onFailure(reason); }
   };
 
   /**

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -59,7 +59,7 @@ public:
      *                 requests in progress.
      * @param response the HTTP response
      */
-    virtual void onRequestSuccess(const Request* request, ResponseMessagePtr&& response) PURE;
+    virtual void onRequestSuccess(const Request& request, ResponseMessagePtr&& response) PURE;
 
     /**
      * Called when the async HTTP request fails.
@@ -69,7 +69,7 @@ public:
      *                requests in progress.
      * @param reason  failure reason
      */
-    virtual void onRequestFailure(const Request* request, FailureReason reason) PURE;
+    virtual void onRequestFailure(const Request& request, FailureReason reason) PURE;
   };
 
   /**
@@ -93,11 +93,11 @@ public:
 
     // Callbacks
 
-    void onRequestSuccess(const Request*, ResponseMessagePtr&& response) override {
+    void onRequestSuccess(const Request&, ResponseMessagePtr&& response) override {
       onSuccess(std::forward<ResponseMessagePtr>(response));
     }
 
-    void onRequestFailure(const Request*, FailureReason reason) override { onFailure(reason); }
+    void onRequestFailure(const Request&, FailureReason reason) override { onFailure(reason); }
   };
 
   /**

--- a/source/common/config/remote_data_fetcher.cc
+++ b/source/common/config/remote_data_fetcher.cc
@@ -39,7 +39,8 @@ void RemoteDataFetcher::fetch() {
                            DurationUtil::durationToMilliseconds(uri_.timeout()))));
 }
 
-void RemoteDataFetcher::onSuccess(Http::ResponseMessagePtr&& response) {
+void RemoteDataFetcher::onSuccess(const Http::AsyncClient::Request&,
+                                  Http::ResponseMessagePtr&& response) {
   const uint64_t status_code = Http::Utility::getResponseStatus(response->headers());
   if (status_code == enumToInt(Http::Code::OK)) {
     ENVOY_LOG(debug, "fetch remote data [uri = {}]: success", uri_.uri());
@@ -66,7 +67,8 @@ void RemoteDataFetcher::onSuccess(Http::ResponseMessagePtr&& response) {
   request_ = nullptr;
 }
 
-void RemoteDataFetcher::onFailure(Http::AsyncClient::FailureReason reason) {
+void RemoteDataFetcher::onFailure(const Http::AsyncClient::Request&,
+                                  Http::AsyncClient::FailureReason reason) {
   ENVOY_LOG(debug, "fetch remote data [uri = {}]: network error {}", uri_.uri(), enumToInt(reason));
   request_ = nullptr;
   callback_.onFailure(FailureReason::Network);

--- a/source/common/config/remote_data_fetcher.h
+++ b/source/common/config/remote_data_fetcher.h
@@ -42,14 +42,14 @@ public:
  * Remote data fetcher.
  */
 class RemoteDataFetcher : public Logger::Loggable<Logger::Id::config>,
-                          public Http::AsyncClient::Callbacks {
+                          public Http::AsyncClient::RequestCallbacks {
 public:
   RemoteDataFetcher(Upstream::ClusterManager& cm, const envoy::config::core::v3::HttpUri& uri,
                     const std::string& content_hash, RemoteDataFetcherCallback& callback);
 
   ~RemoteDataFetcher() override;
 
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&& response) override;
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 

--- a/source/common/config/remote_data_fetcher.h
+++ b/source/common/config/remote_data_fetcher.h
@@ -42,16 +42,17 @@ public:
  * Remote data fetcher.
  */
 class RemoteDataFetcher : public Logger::Loggable<Logger::Id::config>,
-                          public Http::AsyncClient::RequestCallbacks {
+                          public Http::AsyncClient::Callbacks {
 public:
   RemoteDataFetcher(Upstream::ClusterManager& cm, const envoy::config::core::v3::HttpUri& uri,
                     const std::string& content_hash, RemoteDataFetcherCallback& callback);
 
   ~RemoteDataFetcher() override;
 
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&& response) override;
-  void onFailure(Http::AsyncClient::FailureReason reason) override;
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&& response) override;
+  void onFailure(const Http::AsyncClient::Request&,
+                 Http::AsyncClient::FailureReason reason) override;
 
   /**
    * Fetch data from remote.

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -267,7 +267,7 @@ void AsyncRequestImpl::onComplete() {
                                                    response_->trailers(), streamInfo(),
                                                    Tracing::EgressConfig::get());
 
-  callbacks_.onRequestSuccess(*this, std::move(response_));
+  callbacks_.onSuccess(*this, std::move(response_));
 }
 
 void AsyncRequestImpl::onHeaders(ResponseHeaderMapPtr&& headers, bool) {
@@ -302,7 +302,7 @@ void AsyncRequestImpl::onReset() {
 
   if (!cancelled_) {
     // In this case we don't have a valid response so we do need to raise a failure.
-    callbacks_.onRequestFailure(*this, AsyncClient::FailureReason::Reset);
+    callbacks_.onFailure(*this, AsyncClient::FailureReason::Reset);
   }
 }
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -267,7 +267,7 @@ void AsyncRequestImpl::onComplete() {
                                                    response_->trailers(), streamInfo(),
                                                    Tracing::EgressConfig::get());
 
-  callbacks_.onRequestSuccess(this, std::move(response_));
+  callbacks_.onRequestSuccess(*this, std::move(response_));
 }
 
 void AsyncRequestImpl::onHeaders(ResponseHeaderMapPtr&& headers, bool) {
@@ -302,7 +302,7 @@ void AsyncRequestImpl::onReset() {
 
   if (!cancelled_) {
     // In this case we don't have a valid response so we do need to raise a failure.
-    callbacks_.onRequestFailure(this, AsyncClient::FailureReason::Reset);
+    callbacks_.onRequestFailure(*this, AsyncClient::FailureReason::Reset);
   }
 }
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -267,7 +267,7 @@ void AsyncRequestImpl::onComplete() {
                                                    response_->trailers(), streamInfo(),
                                                    Tracing::EgressConfig::get());
 
-  callbacks_.onSuccess(std::move(response_));
+  callbacks_.onSuccess(this, std::move(response_));
 }
 
 void AsyncRequestImpl::onHeaders(ResponseHeaderMapPtr&& headers, bool) {
@@ -302,7 +302,7 @@ void AsyncRequestImpl::onReset() {
 
   if (!cancelled_) {
     // In this case we don't have a valid response so we do need to raise a failure.
-    callbacks_.onFailure(AsyncClient::FailureReason::Reset);
+    callbacks_.onFailure(this, AsyncClient::FailureReason::Reset);
   }
 }
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -267,7 +267,7 @@ void AsyncRequestImpl::onComplete() {
                                                    response_->trailers(), streamInfo(),
                                                    Tracing::EgressConfig::get());
 
-  callbacks_.onSuccess(this, std::move(response_));
+  callbacks_.onRequestSuccess(this, std::move(response_));
 }
 
 void AsyncRequestImpl::onHeaders(ResponseHeaderMapPtr&& headers, bool) {
@@ -302,7 +302,7 @@ void AsyncRequestImpl::onReset() {
 
   if (!cancelled_) {
     // In this case we don't have a valid response so we do need to raise a failure.
-    callbacks_.onFailure(this, AsyncClient::FailureReason::Reset);
+    callbacks_.onRequestFailure(this, AsyncClient::FailureReason::Reset);
   }
 }
 

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -28,13 +28,14 @@ RestApiFetcher::~RestApiFetcher() {
 
 void RestApiFetcher::initialize() { refresh(); }
 
-void RestApiFetcher::onSuccess(Http::ResponseMessagePtr&& response) {
+void RestApiFetcher::onSuccess(const Http::AsyncClient::Request& request,
+                               Http::ResponseMessagePtr&& response) {
   uint64_t response_code = Http::Utility::getResponseStatus(response->headers());
   if (response_code == enumToInt(Http::Code::NotModified)) {
     requestComplete();
     return;
   } else if (response_code != enumToInt(Http::Code::OK)) {
-    onFailure(Http::AsyncClient::FailureReason::Reset);
+    onFailure(request, Http::AsyncClient::FailureReason::Reset);
     return;
   }
 
@@ -47,7 +48,8 @@ void RestApiFetcher::onSuccess(Http::ResponseMessagePtr&& response) {
   requestComplete();
 }
 
-void RestApiFetcher::onFailure(Http::AsyncClient::FailureReason reason) {
+void RestApiFetcher::onFailure(const Http::AsyncClient::Request&,
+                               Http::AsyncClient::FailureReason reason) {
   // Currently Http::AsyncClient::FailureReason only has one value: "Reset".
   ASSERT(reason == Http::AsyncClient::FailureReason::Reset);
   onFetchFailure(Config::ConfigUpdateFailureReason::ConnectionFailure, nullptr);

--- a/source/common/http/rest_api_fetcher.h
+++ b/source/common/http/rest_api_fetcher.h
@@ -15,7 +15,7 @@ namespace Http {
  * A helper base class used to fetch a REST API at a jittered periodic interval. Once initialize()
  * is called, the API will be fetched and events raised.
  */
-class RestApiFetcher : public Http::AsyncClient::RequestCallbacks {
+class RestApiFetcher : public Http::AsyncClient::Callbacks {
 protected:
   RestApiFetcher(Upstream::ClusterManager& cm, const std::string& remote_cluster_name,
                  Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
@@ -61,9 +61,10 @@ private:
   void refresh();
   void requestComplete();
 
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&& response) override;
-  void onFailure(Http::AsyncClient::FailureReason reason) override;
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&& response) override;
+  void onFailure(const Http::AsyncClient::Request&,
+                 Http::AsyncClient::FailureReason reason) override;
 
   Runtime::RandomGenerator& random_;
   const std::chrono::milliseconds refresh_interval_;

--- a/source/common/http/rest_api_fetcher.h
+++ b/source/common/http/rest_api_fetcher.h
@@ -15,7 +15,7 @@ namespace Http {
  * A helper base class used to fetch a REST API at a jittered periodic interval. Once initialize()
  * is called, the API will be fetched and events raised.
  */
-class RestApiFetcher : public Http::AsyncClient::Callbacks {
+class RestApiFetcher : public Http::AsyncClient::RequestCallbacks {
 protected:
   RestApiFetcher(Upstream::ClusterManager& cm, const std::string& remote_cluster_name,
                  Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
@@ -61,7 +61,7 @@ private:
   void refresh();
   void requestComplete();
 
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&& response) override;
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 

--- a/source/common/router/shadow_writer_impl.h
+++ b/source/common/router/shadow_writer_impl.h
@@ -15,7 +15,7 @@ namespace Router {
  */
 class ShadowWriterImpl : Logger::Loggable<Logger::Id::router>,
                          public ShadowWriter,
-                         public Http::AsyncClient::Callbacks {
+                         public Http::AsyncClient::RequestCallbacks {
 public:
   ShadowWriterImpl(Upstream::ClusterManager& cm) : cm_(cm) {}
 
@@ -23,7 +23,7 @@ public:
   void shadow(const std::string& cluster, Http::RequestMessagePtr&& request,
               const Http::AsyncClient::RequestOptions& options) override;
 
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&&) override {}
   void onFailure(Http::AsyncClient::FailureReason) override {}
 

--- a/source/common/router/shadow_writer_impl.h
+++ b/source/common/router/shadow_writer_impl.h
@@ -15,7 +15,7 @@ namespace Router {
  */
 class ShadowWriterImpl : Logger::Loggable<Logger::Id::router>,
                          public ShadowWriter,
-                         public Http::AsyncClient::RequestCallbacks {
+                         public Http::AsyncClient::Callbacks {
 public:
   ShadowWriterImpl(Upstream::ClusterManager& cm) : cm_(cm) {}
 
@@ -23,9 +23,9 @@ public:
   void shadow(const std::string& cluster, Http::RequestMessagePtr&& request,
               const Http::AsyncClient::RequestOptions& options) override;
 
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&&) override {}
-  void onFailure(Http::AsyncClient::FailureReason) override {}
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override {}
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override {}
 
 private:
   Upstream::ClusterManager& cm_;

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -220,7 +220,7 @@ void RawHttpClientImpl::cancel() {
 }
 
 // Client
-void RawHttpClientImpl::check(Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+void RawHttpClientImpl::check(RequestCallbacks& callbacks,
                               const envoy::service::auth::v3::CheckRequest& request,
                               Tracing::Span& parent_span) {
   ASSERT(callbacks_ == nullptr);
@@ -286,14 +286,16 @@ void RawHttpClientImpl::check(Filters::Common::ExtAuthz::RequestCallbacks& callb
   }
 }
 
-void RawHttpClientImpl::onSuccess(Http::ResponseMessagePtr&& message) {
+void RawHttpClientImpl::onSuccess(const Http::AsyncClient::Request&,
+                                  Http::ResponseMessagePtr&& message) {
   callbacks_->onComplete(toResponse(std::move(message)));
   span_->finishSpan();
   callbacks_ = nullptr;
   span_ = nullptr;
 }
 
-void RawHttpClientImpl::onFailure(Http::AsyncClient::FailureReason reason) {
+void RawHttpClientImpl::onFailure(const Http::AsyncClient::Request&,
+                                  Http::AsyncClient::FailureReason reason) {
   ASSERT(reason == Http::AsyncClient::FailureReason::Reset);
   callbacks_->onComplete(std::make_unique<Response>(errorResponse()));
   span_->setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -220,7 +220,7 @@ void RawHttpClientImpl::cancel() {
 }
 
 // Client
-void RawHttpClientImpl::check(RequestCallbacks& callbacks,
+void RawHttpClientImpl::check(Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
                               const envoy::service::auth::v3::CheckRequest& request,
                               Tracing::Span& parent_span) {
   ASSERT(callbacks_ == nullptr);

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -142,7 +142,7 @@ using ClientConfigSharedPtr = std::shared_ptr<ClientConfig>;
  * setting a path prefix witch is not available for gRPC.
  */
 class RawHttpClientImpl : public Client,
-                          public Http::AsyncClient::RequestCallbacks,
+                          public Http::AsyncClient::Callbacks,
                           Logger::Loggable<Logger::Id::config> {
 public:
   explicit RawHttpClientImpl(Upstream::ClusterManager& cm, ClientConfigSharedPtr config,
@@ -151,19 +151,20 @@ public:
 
   // ExtAuthz::Client
   void cancel() override;
-  void check(Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
-             const envoy::service::auth::v3::CheckRequest& request, Tracing::Span&) override;
+  void check(RequestCallbacks& callbacks, const envoy::service::auth::v3::CheckRequest& request,
+             Tracing::Span&) override;
 
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&& message) override;
-  void onFailure(Http::AsyncClient::FailureReason reason) override;
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&& message) override;
+  void onFailure(const Http::AsyncClient::Request&,
+                 Http::AsyncClient::FailureReason reason) override;
 
 private:
   ResponsePtr toResponse(Http::ResponseMessagePtr message);
   Upstream::ClusterManager& cm_;
   ClientConfigSharedPtr config_;
   Http::AsyncClient::Request* request_{};
-  Filters::Common::ExtAuthz::RequestCallbacks* callbacks_{};
+  RequestCallbacks* callbacks_{};
   TimeSource& time_source_;
   Tracing::SpanPtr span_;
 };

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -142,7 +142,7 @@ using ClientConfigSharedPtr = std::shared_ptr<ClientConfig>;
  * setting a path prefix witch is not available for gRPC.
  */
 class RawHttpClientImpl : public Client,
-                          public Http::AsyncClient::Callbacks,
+                          public Http::AsyncClient::RequestCallbacks,
                           Logger::Loggable<Logger::Id::config> {
 public:
   explicit RawHttpClientImpl(Upstream::ClusterManager& cm, ClientConfigSharedPtr config,
@@ -151,10 +151,10 @@ public:
 
   // ExtAuthz::Client
   void cancel() override;
-  void check(RequestCallbacks& callbacks, const envoy::service::auth::v3::CheckRequest& request,
-             Tracing::Span&) override;
+  void check(Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+             const envoy::service::auth::v3::CheckRequest& request, Tracing::Span&) override;
 
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&& message) override;
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 
@@ -163,7 +163,7 @@ private:
   Upstream::ClusterManager& cm_;
   ClientConfigSharedPtr config_;
   Http::AsyncClient::Request* request_{};
-  RequestCallbacks* callbacks_{};
+  Filters::Common::ExtAuthz::RequestCallbacks* callbacks_{};
   TimeSource& time_source_;
   Tracing::SpanPtr span_;
 };

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -16,7 +16,7 @@ namespace {
 
 class JwksFetcherImpl : public JwksFetcher,
                         public Logger::Loggable<Logger::Id::filter>,
-                        public Http::AsyncClient::Callbacks {
+                        public Http::AsyncClient::RequestCallbacks {
 public:
   JwksFetcherImpl(Upstream::ClusterManager& cm) : cm_(cm) { ENVOY_LOG(trace, "{}", __func__); }
 

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -16,7 +16,7 @@ namespace {
 
 class JwksFetcherImpl : public JwksFetcher,
                         public Logger::Loggable<Logger::Id::filter>,
-                        public Http::AsyncClient::RequestCallbacks {
+                        public Http::AsyncClient::Callbacks {
 public:
   JwksFetcherImpl(Upstream::ClusterManager& cm) : cm_(cm) { ENVOY_LOG(trace, "{}", __func__); }
 
@@ -63,7 +63,7 @@ public:
   }
 
   // HTTP async receive methods
-  void onSuccess(Http::ResponseMessagePtr&& response) override {
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&& response) override {
     ENVOY_LOG(trace, "{}", __func__);
     complete_ = true;
     const uint64_t status_code = Http::Utility::getResponseStatus(response->headers());
@@ -93,7 +93,8 @@ public:
     reset();
   }
 
-  void onFailure(Http::AsyncClient::FailureReason reason) override {
+  void onFailure(const Http::AsyncClient::Request&,
+                 Http::AsyncClient::FailureReason reason) override {
     ENVOY_LOG(debug, "{}: fetch pubkey [uri = {}]: network error {}", __func__, uri_->uri(),
               enumToInt(reason));
     complete_ = true;

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -295,7 +295,8 @@ int StreamHandleWrapper::luaHttpCallAsynchronous(lua_State* state) {
   return 0;
 }
 
-void StreamHandleWrapper::onSuccess(Http::ResponseMessagePtr&& response) {
+void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
+                                    Http::ResponseMessagePtr&& response) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP response complete");
   http_request_ = nullptr;
@@ -341,7 +342,8 @@ void StreamHandleWrapper::onSuccess(Http::ResponseMessagePtr&& response) {
   }
 }
 
-void StreamHandleWrapper::onFailure(Http::AsyncClient::FailureReason) {
+void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
+                                    Http::AsyncClient::FailureReason) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP failure");
 
@@ -351,7 +353,7 @@ void StreamHandleWrapper::onFailure(Http::AsyncClient::FailureReason) {
           {{Http::Headers::get().Status,
             std::to_string(enumToInt(Http::Code::ServiceUnavailable))}})));
   response_message->body() = std::make_unique<Buffer::OwnedImpl>("upstream failure");
-  onSuccess(std::move(response_message));
+  onSuccess(request, std::move(response_message));
 }
 
 int StreamHandleWrapper::luaHeaders(lua_State* state) {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -78,7 +78,7 @@ class Filter;
  * The script interacts with Envoy entirely through this handle.
  */
 class StreamHandleWrapper : public Filters::Common::Lua::BaseLuaObject<StreamHandleWrapper>,
-                            public Http::AsyncClient::RequestCallbacks {
+                            public Http::AsyncClient::Callbacks {
 public:
   /**
    * The state machine for a stream handler. In the current implementation everything the filter
@@ -252,9 +252,9 @@ private:
     public_key_wrapper_.reset();
   }
 
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&&) override;
-  void onFailure(Http::AsyncClient::FailureReason) override;
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override;
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override;
 
   Filters::Common::Lua::Coroutine& coroutine_;
   Http::HeaderMap& headers_;
@@ -280,11 +280,11 @@ private:
 /**
  * An empty Callbacks client. It will ignore everything, including successes and failures.
  */
-class NoopCallbacks : public Http::AsyncClient::RequestCallbacks {
+class NoopCallbacks : public Http::AsyncClient::Callbacks {
 public:
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&&) override {}
-  void onFailure(Http::AsyncClient::FailureReason) override {}
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override {}
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override {}
 };
 
 /**

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -78,7 +78,7 @@ class Filter;
  * The script interacts with Envoy entirely through this handle.
  */
 class StreamHandleWrapper : public Filters::Common::Lua::BaseLuaObject<StreamHandleWrapper>,
-                            public Http::AsyncClient::Callbacks {
+                            public Http::AsyncClient::RequestCallbacks {
 public:
   /**
    * The state machine for a stream handler. In the current implementation everything the filter
@@ -252,7 +252,7 @@ private:
     public_key_wrapper_.reset();
   }
 
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&&) override;
   void onFailure(Http::AsyncClient::FailureReason) override;
 
@@ -280,9 +280,9 @@ private:
 /**
  * An empty Callbacks client. It will ignore everything, including successes and failures.
  */
-class NoopCallbacks : public Http::AsyncClient::Callbacks {
+class NoopCallbacks : public Http::AsyncClient::RequestCallbacks {
 public:
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&&) override {}
   void onFailure(Http::AsyncClient::FailureReason) override {}
 };

--- a/source/extensions/filters/http/squash/squash_filter.h
+++ b/source/extensions/filters/http/squash/squash_filter.h
@@ -56,16 +56,18 @@ private:
 
 using SquashFilterConfigSharedPtr = std::shared_ptr<SquashFilterConfig>;
 
-class AsyncClientCallbackShim : public Http::AsyncClient::RequestCallbacks {
+class AsyncClientCallbackShim : public Http::AsyncClient::Callbacks {
 public:
   AsyncClientCallbackShim(std::function<void(Http::ResponseMessagePtr&&)>&& on_success,
                           std::function<void(Http::AsyncClient::FailureReason)>&& on_fail)
       : on_success_(on_success), on_fail_(on_fail) {}
-  // Http::AsyncClient::RequestCallbacks
-  void onSuccess(Http::ResponseMessagePtr&& m) override {
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&& m) override {
     on_success_(std::forward<Http::ResponseMessagePtr>(m));
   }
-  void onFailure(Http::AsyncClient::FailureReason f) override { on_fail_(f); }
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason f) override {
+    on_fail_(f);
+  }
 
 private:
   const std::function<void(Http::ResponseMessagePtr&&)> on_success_;

--- a/source/extensions/filters/http/squash/squash_filter.h
+++ b/source/extensions/filters/http/squash/squash_filter.h
@@ -56,12 +56,12 @@ private:
 
 using SquashFilterConfigSharedPtr = std::shared_ptr<SquashFilterConfig>;
 
-class AsyncClientCallbackShim : public Http::AsyncClient::Callbacks {
+class AsyncClientCallbackShim : public Http::AsyncClient::RequestCallbacks {
 public:
   AsyncClientCallbackShim(std::function<void(Http::ResponseMessagePtr&&)>&& on_success,
                           std::function<void(Http::AsyncClient::FailureReason)>&& on_fail)
       : on_success_(on_success), on_fail_(on_fail) {}
-  // Http::AsyncClient::Callbacks
+  // Http::AsyncClient::RequestCallbacks
   void onSuccess(Http::ResponseMessagePtr&& m) override {
     on_success_(std::forward<Http::ResponseMessagePtr>(m));
   }

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -109,12 +109,13 @@ void TraceReporter::flushTraces() {
   }
 }
 
-void TraceReporter::onFailure(Http::AsyncClient::FailureReason) {
+void TraceReporter::onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) {
   ENVOY_LOG(debug, "failure submitting traces to datadog agent");
   driver_.tracerStats().reports_failed_.inc();
 }
 
-void TraceReporter::onSuccess(Http::ResponseMessagePtr&& http_response) {
+void TraceReporter::onSuccess(const Http::AsyncClient::Request&,
+                              Http::ResponseMessagePtr&& http_response) {
   uint64_t responseStatus = Http::Utility::getResponseStatus(http_response->headers());
   if (responseStatus != enumToInt(Http::Code::OK)) {
     // TODO: Consider adding retries for failed submissions.

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.h
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.h
@@ -94,7 +94,7 @@ private:
  * The timer interval can be controlled with the setting
  * tracing.datadog.flush_interval_ms, and defaults to 2000ms.
  */
-class TraceReporter : public Http::AsyncClient::Callbacks,
+class TraceReporter : public Http::AsyncClient::RequestCallbacks,
                       protected Logger::Loggable<Logger::Id::tracing> {
 public:
   /**
@@ -106,7 +106,7 @@ public:
    */
   TraceReporter(TraceEncoderSharedPtr encoder, Driver& driver, Event::Dispatcher& dispatcher);
 
-  // Http::AsyncClient::Callbacks.
+  // Http::AsyncClient::RequestCallbacks.
   void onSuccess(Http::ResponseMessagePtr&&) override;
   void onFailure(Http::AsyncClient::FailureReason) override;
 

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.h
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.h
@@ -94,7 +94,7 @@ private:
  * The timer interval can be controlled with the setting
  * tracing.datadog.flush_interval_ms, and defaults to 2000ms.
  */
-class TraceReporter : public Http::AsyncClient::RequestCallbacks,
+class TraceReporter : public Http::AsyncClient::Callbacks,
                       protected Logger::Loggable<Logger::Id::tracing> {
 public:
   /**
@@ -106,9 +106,9 @@ public:
    */
   TraceReporter(TraceEncoderSharedPtr encoder, Driver& driver, Event::Dispatcher& dispatcher);
 
-  // Http::AsyncClient::RequestCallbacks.
-  void onSuccess(Http::ResponseMessagePtr&&) override;
-  void onFailure(Http::AsyncClient::FailureReason) override;
+  // Http::AsyncClient::Callbacks.
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override;
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override;
 
 private:
   /**

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -68,14 +68,15 @@ LightStepDriver::LightStepTransporter::~LightStepTransporter() {
   }
 }
 
-void LightStepDriver::LightStepTransporter::onSuccess(Http::ResponseMessagePtr&& /*response*/) {
+void LightStepDriver::LightStepTransporter::onSuccess(const Http::AsyncClient::Request&,
+                                                      Http::ResponseMessagePtr&& /*response*/) {
   driver_.grpc_context_.chargeStat(*driver_.cluster(), driver_.request_names_, true);
   active_callback_->OnSuccess(*active_report_);
   reset();
 }
 
 void LightStepDriver::LightStepTransporter::onFailure(
-    Http::AsyncClient::FailureReason /*failure_reason*/) {
+    const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason /*failure_reason*/) {
   driver_.grpc_context_.chargeStat(*driver_.cluster(), driver_.request_names_, false);
   active_callback_->OnFailure(*active_report_);
   reset();

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -75,8 +75,7 @@ public:
   PropagationMode propagationMode() const override { return propagation_mode_; }
 
 private:
-  class LightStepTransporter : public lightstep::AsyncTransporter,
-                               Http::AsyncClient::RequestCallbacks {
+  class LightStepTransporter : public lightstep::AsyncTransporter, Http::AsyncClient::Callbacks {
   public:
     explicit LightStepTransporter(LightStepDriver& driver);
 
@@ -88,9 +87,10 @@ private:
     void Send(std::unique_ptr<lightstep::BufferChain>&& message,
               Callback& callback) noexcept override;
 
-    // Http::AsyncClient::RequestCallbacks
-    void onSuccess(Http::ResponseMessagePtr&& response) override;
-    void onFailure(Http::AsyncClient::FailureReason failure_reason) override;
+    // Http::AsyncClient::Callbacks
+    void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&& response) override;
+    void onFailure(const Http::AsyncClient::Request&,
+                   Http::AsyncClient::FailureReason failure_reason) override;
 
   private:
     std::unique_ptr<lightstep::BufferChain> active_report_;

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -75,7 +75,8 @@ public:
   PropagationMode propagationMode() const override { return propagation_mode_; }
 
 private:
-  class LightStepTransporter : public lightstep::AsyncTransporter, Http::AsyncClient::Callbacks {
+  class LightStepTransporter : public lightstep::AsyncTransporter,
+                               Http::AsyncClient::RequestCallbacks {
   public:
     explicit LightStepTransporter(LightStepDriver& driver);
 
@@ -87,7 +88,7 @@ private:
     void Send(std::unique_ptr<lightstep::BufferChain>&& message,
               Callback& callback) noexcept override;
 
-    // Http::AsyncClient::Callbacks
+    // Http::AsyncClient::RequestCallbacks
     void onSuccess(Http::ResponseMessagePtr&& response) override;
     void onFailure(Http::AsyncClient::FailureReason failure_reason) override;
 

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -197,11 +197,12 @@ void ReporterImpl::flushSpans() {
   }
 }
 
-void ReporterImpl::onFailure(Http::AsyncClient::FailureReason) {
+void ReporterImpl::onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) {
   driver_.tracerStats().reports_failed_.inc();
 }
 
-void ReporterImpl::onSuccess(Http::ResponseMessagePtr&& http_response) {
+void ReporterImpl::onSuccess(const Http::AsyncClient::Request&,
+                             Http::ResponseMessagePtr&& http_response) {
   if (Http::Utility::getResponseStatus(http_response->headers()) !=
       enumToInt(Http::Code::Accepted)) {
     driver_.tracerStats().reports_dropped_.inc();

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -170,7 +170,7 @@ struct CollectorInfo {
  *
  * The default values for the runtime parameters are 5 spans and 5000ms.
  */
-class ReporterImpl : public Reporter, Http::AsyncClient::RequestCallbacks {
+class ReporterImpl : public Reporter, Http::AsyncClient::Callbacks {
 public:
   /**
    * Constructor.
@@ -192,10 +192,10 @@ public:
    */
   void reportSpan(Span&& span) override;
 
-  // Http::AsyncClient::RequestCallbacks.
+  // Http::AsyncClient::Callbacks.
   // The callbacks below record Zipkin-span-related stats.
-  void onSuccess(Http::ResponseMessagePtr&&) override;
-  void onFailure(Http::AsyncClient::FailureReason) override;
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override;
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override;
 
   /**
    * Creates a heap-allocated ZipkinReporter.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -170,7 +170,7 @@ struct CollectorInfo {
  *
  * The default values for the runtime parameters are 5 spans and 5000ms.
  */
-class ReporterImpl : public Reporter, Http::AsyncClient::Callbacks {
+class ReporterImpl : public Reporter, Http::AsyncClient::RequestCallbacks {
 public:
   /**
    * Constructor.
@@ -192,7 +192,7 @@ public:
    */
   void reportSpan(Span&& span) override;
 
-  // Http::AsyncClient::Callbacks.
+  // Http::AsyncClient::RequestCallbacks.
   // The callbacks below record Zipkin-span-related stats.
   void onSuccess(Http::ResponseMessagePtr&&) override;
   void onFailure(Http::AsyncClient::FailureReason) override;

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -159,7 +159,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWith503) {
     callbacks.onSuccess(
         request_, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
-    return &request_;
+    return nullptr;
   });
 
   std::string async_data = "non-empty";
@@ -201,7 +201,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWithEmptyBody) {
     callbacks.onSuccess(
         request_, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "200"}}})});
-    return &request_;
+    return nullptr;
   });
 
   std::string async_data = "non-empty";
@@ -247,7 +247,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessIncorrectSha256) {
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
     callbacks.onSuccess(request_, std::move(response));
-    return &request_;
+    return nullptr;
   });
 
   std::string async_data = "non-empty";
@@ -292,7 +292,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccess) {
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
     callbacks.onSuccess(request_, std::move(response));
-    return &request_;
+    return nullptr;
   });
 
   std::string async_data = "non-empty";
@@ -331,7 +331,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceDoNotAllowEmpty) {
     callbacks.onSuccess(
         request_, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
-    return &request_;
+    return nullptr;
   });
 
   std::string async_data = "non-empty";
@@ -374,7 +374,7 @@ TEST_F(AsyncDataSourceTest, DatasourceReleasedBeforeFetchingData) {
       response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
       callbacks.onSuccess(request_, std::move(response));
-      return &request_;
+      return nullptr;
     });
 
     remote_data_provider_ = std::make_unique<Config::DataSource::RemoteAsyncDataProvider>(
@@ -421,7 +421,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
             request_,
             Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                 new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
-        return &request_;
+        return nullptr;
       },
       num_retries);
 
@@ -449,7 +449,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
                     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
                     callbacks.onSuccess(request_, std::move(response));
-                    return &request_;
+                    return nullptr;
                   }));
         }
 

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -116,7 +116,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceReturnFailure) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+    callbacks.onRequestFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
     return nullptr;
   });
 
@@ -156,7 +156,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWith503) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onSuccess(
+    callbacks.onRequestSuccess(
         &request_,
         Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
             Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
@@ -199,7 +199,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWithEmptyBody) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onSuccess(
+    callbacks.onRequestSuccess(
         &request_,
         Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
             Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}})});
@@ -248,7 +248,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessIncorrectSha256) {
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-    callbacks.onSuccess(&request_, std::move(response));
+    callbacks.onRequestSuccess(&request_, std::move(response));
     return &request_;
   });
 
@@ -293,7 +293,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccess) {
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-    callbacks.onSuccess(&request_, std::move(response));
+    callbacks.onRequestSuccess(&request_, std::move(response));
     return &request_;
   });
 
@@ -330,7 +330,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceDoNotAllowEmpty) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onSuccess(
+    callbacks.onRequestSuccess(
         &request_,
         Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
             Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
@@ -376,7 +376,7 @@ TEST_F(AsyncDataSourceTest, DatasourceReleasedBeforeFetchingData) {
           Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
       response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-      callbacks.onSuccess(&request_, std::move(response));
+      callbacks.onRequestSuccess(&request_, std::move(response));
       return &request_;
     });
 
@@ -420,7 +420,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
   initialize(
       [&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
           const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-        callbacks.onSuccess(
+        callbacks.onRequestSuccess(
             &request_,
             Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                 new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
@@ -451,7 +451,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
                             new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
                     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-                    callbacks.onSuccess(&request_, std::move(response));
+                    callbacks.onRequestSuccess(&request_, std::move(response));
                     return &request_;
                   }));
         }

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -116,7 +116,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceReturnFailure) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+    callbacks.onFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
     return nullptr;
   });
 
@@ -156,10 +156,9 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWith503) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onRequestSuccess(
-        request_,
-        Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
-            Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
+    callbacks.onSuccess(
+        request_, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
+                      new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
     return &request_;
   });
 
@@ -199,10 +198,9 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWithEmptyBody) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onRequestSuccess(
-        request_,
-        Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
-            Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}})});
+    callbacks.onSuccess(
+        request_, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
+                      new Http::TestResponseHeaderMapImpl{{":status", "200"}}})});
     return &request_;
   });
 
@@ -248,7 +246,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessIncorrectSha256) {
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-    callbacks.onRequestSuccess(request_, std::move(response));
+    callbacks.onSuccess(request_, std::move(response));
     return &request_;
   });
 
@@ -293,7 +291,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccess) {
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-    callbacks.onRequestSuccess(request_, std::move(response));
+    callbacks.onSuccess(request_, std::move(response));
     return &request_;
   });
 
@@ -330,10 +328,9 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceDoNotAllowEmpty) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onRequestSuccess(
-        request_,
-        Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
-            Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
+    callbacks.onSuccess(
+        request_, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
+                      new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
     return &request_;
   });
 
@@ -376,7 +373,7 @@ TEST_F(AsyncDataSourceTest, DatasourceReleasedBeforeFetchingData) {
           Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
       response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-      callbacks.onRequestSuccess(request_, std::move(response));
+      callbacks.onSuccess(request_, std::move(response));
       return &request_;
     });
 
@@ -420,7 +417,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
   initialize(
       [&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
           const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-        callbacks.onRequestSuccess(
+        callbacks.onSuccess(
             request_,
             Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                 new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
@@ -451,7 +448,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
                             new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
                     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-                    callbacks.onRequestSuccess(request_, std::move(response));
+                    callbacks.onSuccess(request_, std::move(response));
                     return &request_;
                   }));
         }

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -116,7 +116,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceReturnFailure) {
 
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-    callbacks.onRequestFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+    callbacks.onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
     return nullptr;
   });
 
@@ -157,7 +157,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWith503) {
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
     callbacks.onRequestSuccess(
-        &request_,
+        request_,
         Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
             Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
     return &request_;
@@ -200,7 +200,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessWithEmptyBody) {
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
     callbacks.onRequestSuccess(
-        &request_,
+        request_,
         Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
             Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}})});
     return &request_;
@@ -248,7 +248,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessIncorrectSha256) {
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-    callbacks.onRequestSuccess(&request_, std::move(response));
+    callbacks.onRequestSuccess(request_, std::move(response));
     return &request_;
   });
 
@@ -293,7 +293,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccess) {
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-    callbacks.onRequestSuccess(&request_, std::move(response));
+    callbacks.onRequestSuccess(request_, std::move(response));
     return &request_;
   });
 
@@ -331,7 +331,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceDoNotAllowEmpty) {
   initialize([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
     callbacks.onRequestSuccess(
-        &request_,
+        request_,
         Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
             Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
     return &request_;
@@ -376,7 +376,7 @@ TEST_F(AsyncDataSourceTest, DatasourceReleasedBeforeFetchingData) {
           Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
       response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-      callbacks.onRequestSuccess(&request_, std::move(response));
+      callbacks.onRequestSuccess(request_, std::move(response));
       return &request_;
     });
 
@@ -421,7 +421,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
       [&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
           const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
         callbacks.onRequestSuccess(
-            &request_,
+            request_,
             Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                 new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
         return &request_;
@@ -451,7 +451,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
                             new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
                     response->body() = std::make_unique<Buffer::OwnedImpl>(body);
 
-                    callbacks.onRequestSuccess(&request_, std::move(response));
+                    callbacks.onRequestSuccess(request_, std::move(response));
                     return &request_;
                   }));
         }

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -18,7 +18,7 @@ TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
       .Times(0);
-  http_callbacks_->onRequestFailure(http_request_, Http::AsyncClient::FailureReason::Reset);
+  http_callbacks_->onFailure(http_request_, Http::AsyncClient::FailureReason::Reset);
   EXPECT_TRUE(statsAre(1, 0, 0, 1, 0, 0, 0));
   timerTick();
   EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0));
@@ -37,7 +37,7 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   EXPECT_CALL(*timer_, enableTimer(_, _));
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, _));
-  http_callbacks_->onRequestSuccess(http_request_, std::move(message));
+  http_callbacks_->onSuccess(http_request_, std::move(message));
   EXPECT_TRUE(statsAre(1, 0, 1, 0, 0, 0, 0));
   request_in_progress_ = false;
   timerTick();

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -18,7 +18,7 @@ TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
       .Times(0);
-  http_callbacks_->onFailure(&http_request_, Http::AsyncClient::FailureReason::Reset);
+  http_callbacks_->onRequestFailure(&http_request_, Http::AsyncClient::FailureReason::Reset);
   EXPECT_TRUE(statsAre(1, 0, 0, 1, 0, 0, 0));
   timerTick();
   EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0));
@@ -37,7 +37,7 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   EXPECT_CALL(*timer_, enableTimer(_, _));
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, _));
-  http_callbacks_->onSuccess(&http_request_, std::move(message));
+  http_callbacks_->onRequestSuccess(&http_request_, std::move(message));
   EXPECT_TRUE(statsAre(1, 0, 1, 0, 0, 0, 0));
   request_in_progress_ = false;
   timerTick();

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -18,7 +18,7 @@ TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
       .Times(0);
-  http_callbacks_->onRequestFailure(&http_request_, Http::AsyncClient::FailureReason::Reset);
+  http_callbacks_->onRequestFailure(http_request_, Http::AsyncClient::FailureReason::Reset);
   EXPECT_TRUE(statsAre(1, 0, 0, 1, 0, 0, 0));
   timerTick();
   EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0));
@@ -37,7 +37,7 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   EXPECT_CALL(*timer_, enableTimer(_, _));
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, _));
-  http_callbacks_->onRequestSuccess(&http_request_, std::move(message));
+  http_callbacks_->onRequestSuccess(http_request_, std::move(message));
   EXPECT_TRUE(statsAre(1, 0, 1, 0, 0, 0, 0));
   request_in_progress_ = false;
   timerTick();

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -18,7 +18,7 @@ TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
       .Times(0);
-  http_callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
+  http_callbacks_->onFailure(&http_request_, Http::AsyncClient::FailureReason::Reset);
   EXPECT_TRUE(statsAre(1, 0, 0, 1, 0, 0, 0));
   timerTick();
   EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0));
@@ -37,7 +37,7 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   EXPECT_CALL(*timer_, enableTimer(_, _));
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, _));
-  http_callbacks_->onSuccess(std::move(message));
+  http_callbacks_->onSuccess(&http_request_, std::move(message));
   EXPECT_TRUE(statsAre(1, 0, 1, 0, 0, 0, 0));
   request_in_progress_ = false;
   timerTick();

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -151,7 +151,7 @@ public:
     }
     EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
     EXPECT_CALL(*timer_, enableTimer(_, _));
-    http_callbacks_->onRequestSuccess(&http_request_, std::move(message));
+    http_callbacks_->onRequestSuccess(http_request_, std::move(message));
     if (accept) {
       version_ = version;
     }

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -151,7 +151,7 @@ public:
     }
     EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
     EXPECT_CALL(*timer_, enableTimer(_, _));
-    http_callbacks_->onRequestSuccess(http_request_, std::move(message));
+    http_callbacks_->onSuccess(http_request_, std::move(message));
     if (accept) {
       version_ = version;
     }

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -151,7 +151,7 @@ public:
     }
     EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
     EXPECT_CALL(*timer_, enableTimer(_, _));
-    http_callbacks_->onSuccess(std::move(message));
+    http_callbacks_->onSuccess(&http_request_, std::move(message));
     if (accept) {
       version_ = version;
     }

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -151,7 +151,7 @@ public:
     }
     EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
     EXPECT_CALL(*timer_, enableTimer(_, _));
-    http_callbacks_->onSuccess(&http_request_, std::move(message));
+    http_callbacks_->onRequestSuccess(&http_request_, std::move(message));
     if (accept) {
       version_ = version;
     }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -53,7 +53,7 @@ public:
   }
 
   void expectSuccess(uint64_t code) {
-    EXPECT_CALL(callbacks_, onSuccess_(_, _))
+    EXPECT_CALL(callbacks_, onRequestSuccess_(_, _))
         .WillOnce(Invoke([code](const AsyncClient::Request*, ResponseMessage* response) -> void {
           EXPECT_EQ(code, Utility::getResponseStatus(response->headers()));
         }));
@@ -482,7 +482,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
   // Finish request 2.
   ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
-  EXPECT_CALL(callbacks2, onSuccess_(_, _));
+  EXPECT_CALL(callbacks2, onRequestSuccess_(_, _));
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
 
   // Finish request 1.
@@ -820,7 +820,7 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
       }));
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  EXPECT_CALL(callbacks_, onFailure(_, _));
+  EXPECT_CALL(callbacks_, onRequestFailure(_, _));
 
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
@@ -918,7 +918,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveRequest) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  EXPECT_CALL(callbacks_, onFailure(_, _));
+  EXPECT_CALL(callbacks_, onRequestFailure(_, _));
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 }
 
@@ -939,7 +939,7 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
   EXPECT_CALL(*child_span, injectContext(_));
   client_.send(std::move(message_), callbacks_, options);
 
-  EXPECT_CALL(callbacks_, onFailure(_, _));
+  EXPECT_CALL(callbacks_, onRequestFailure(_, _));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -52,9 +52,13 @@ public:
         .WillByDefault(ReturnRef(envoy::config::core::v3::Locality().default_instance()));
   }
 
-  void expectSuccess(uint64_t code) {
+  void expectSuccess(AsyncClient::Request* sent_request, uint64_t code) {
     EXPECT_CALL(callbacks_, onSuccess_(_, _))
-        .WillOnce(Invoke([code](const AsyncClient::Request&, ResponseMessage* response) -> void {
+        .WillOnce(Invoke([sent_request, code](const AsyncClient::Request& request,
+                                              ResponseMessage* response) -> void {
+          // Verify that callback is called with the same request handle as returned by
+          // AsyncClient::send().
+          EXPECT_EQ(sent_request, &request);
           EXPECT_EQ(code, Utility::getResponseStatus(response->headers()));
         }));
   }
@@ -152,9 +156,11 @@ TEST_F(AsyncClientImplTest, Basic) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&copy), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
-  expectSuccess(200);
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 200);
 
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
@@ -188,12 +194,15 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
 
   EXPECT_CALL(parent_span_, spawnChild_(_, "async fake_cluster egress", _))
       .WillOnce(Return(child_span));
-  expectSuccess(200);
 
   AsyncClient::RequestOptions options = AsyncClient::RequestOptions().setParentSpan(parent_span_);
   EXPECT_CALL(*child_span, setSampled(true));
   EXPECT_CALL(*child_span, injectContext(_));
-  client_.send(std::move(message_), callbacks_, options);
+
+  auto* request = client_.send(std::move(message_), callbacks_, options);
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 200);
 
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
@@ -228,7 +237,6 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   copy.addCopy(":scheme", "http");
 
   EXPECT_CALL(parent_span_, spawnChild_(_, child_span_name_, _)).WillOnce(Return(child_span));
-  expectSuccess(200);
 
   AsyncClient::RequestOptions options = AsyncClient::RequestOptions()
                                             .setParentSpan(parent_span_)
@@ -236,7 +244,11 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
                                             .setSampled(false);
   EXPECT_CALL(*child_span, setSampled(false));
   EXPECT_CALL(*child_span, injectContext(_));
-  client_.send(std::move(message_), callbacks_, options);
+
+  auto* request = client_.send(std::move(message_), callbacks_, options);
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 200);
 
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
@@ -279,13 +291,16 @@ TEST_F(AsyncClientImplTest, BasicHashPolicy) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&copy), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
-  expectSuccess(200);
 
   AsyncClient::RequestOptions options;
   Protobuf::RepeatedPtrField<envoy::config::route::v3::RouteAction::HashPolicy> hash_policy;
   hash_policy.Add()->mutable_header()->set_header_name(":path");
   options.setHashPolicy(hash_policy);
-  client_.send(std::move(message_), callbacks_, options);
+
+  auto* request = client_.send(std::move(message_), callbacks_, options);
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 200);
 
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
@@ -312,7 +327,9 @@ TEST_F(AsyncClientImplTest, Retry) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
 
   message_->headers().setReferenceEnvoyRetryOn(Headers::get().EnvoyRetryOnValues._5xx);
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
 
   // Expect retry and retry timer create.
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
@@ -333,7 +350,7 @@ TEST_F(AsyncClientImplTest, Retry) {
   timer_->invokeCallback();
 
   // Normal response.
-  expectSuccess(200);
+  expectSuccess(request, 200);
   ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers2), true);
 }
@@ -462,7 +479,8 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  auto* request1 = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request1, nullptr);
 
   // Send request 2.
   RequestMessagePtr message2{new RequestMessageImpl()};
@@ -478,18 +496,57 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
         return nullptr;
       }));
   EXPECT_CALL(stream_encoder2, encodeHeaders(HeaderMapEqualRef(&message2->headers()), true));
-  client_.send(std::move(message2), callbacks2, AsyncClient::RequestOptions());
+
+  auto* request2 = client_.send(std::move(message2), callbacks2, AsyncClient::RequestOptions());
+  EXPECT_NE(request2, nullptr);
+
+  // Send request 3.
+  RequestMessagePtr message3{new RequestMessageImpl()};
+  HttpTestUtility::addDefaultHeaders(message3->headers());
+  NiceMock<MockRequestEncoder> stream_encoder3;
+  ResponseDecoder* response_decoder3{};
+  MockAsyncClientCallbacks callbacks3;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseDecoder& decoder,
+                           ConnectionPool::Callbacks& callbacks) -> ConnectionPool::Cancellable* {
+        callbacks.onPoolReady(stream_encoder3, cm_.conn_pool_.host_, stream_info_);
+        response_decoder3 = &decoder;
+        return nullptr;
+      }));
+  EXPECT_CALL(stream_encoder3, encodeHeaders(HeaderMapEqualRef(&message3->headers()), true));
+
+  auto* request3 = client_.send(std::move(message3), callbacks3, AsyncClient::RequestOptions());
+  EXPECT_NE(request3, nullptr);
 
   // Finish request 2.
   ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
-  EXPECT_CALL(callbacks2, onSuccess_(_, _));
+  EXPECT_CALL(callbacks2, onSuccess_(_, _))
+      .WillOnce(Invoke(
+          [request2](const AsyncClient::Request& request, ResponseMessage* response) -> void {
+            // Verify that callback is called with the same request handle as returned by
+            // AsyncClient::send().
+            EXPECT_EQ(request2, &request);
+            EXPECT_EQ(503, Utility::getResponseStatus(response->headers()));
+          }));
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
 
   // Finish request 1.
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
-  expectSuccess(200);
+  expectSuccess(request1, 200);
   response_decoder_->decodeData(data, true);
+
+  // Finish request 3.
+  ResponseHeaderMapPtr response_headers3(new TestResponseHeaderMapImpl{{":status", "500"}});
+  EXPECT_CALL(callbacks3, onSuccess_(_, _))
+      .WillOnce(Invoke(
+          [request3](const AsyncClient::Request& request, ResponseMessage* response) -> void {
+            // Verify that callback is called with the same request handle as returned by
+            // AsyncClient::send().
+            EXPECT_EQ(request3, &request);
+            EXPECT_EQ(500, Utility::getResponseStatus(response->headers()));
+          }));
+  response_decoder3->decodeHeaders(std::move(response_headers3), true);
 }
 
 TEST_F(AsyncClientImplTest, StreamAndRequest) {
@@ -508,7 +565,8 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
 
   // Start stream
   Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
@@ -544,7 +602,7 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
   // Finish request.
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
-  expectSuccess(200);
+  expectSuccess(request, 200);
   response_decoder_->decodeData(data, true);
 }
 
@@ -598,9 +656,11 @@ TEST_F(AsyncClientImplTest, Trailers) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
-  expectSuccess(200);
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 200);
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, false);
@@ -617,9 +677,11 @@ TEST_F(AsyncClientImplTest, ImmediateReset) {
       }));
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  expectSuccess(503);
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 503);
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
 
   EXPECT_EQ(
@@ -818,11 +880,20 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
         response_decoder_ = &decoder;
         return nullptr;
       }));
-
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  EXPECT_CALL(callbacks_, onFailure(_, _));
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
+
+  EXPECT_CALL(callbacks_, onFailure(_, _))
+      .WillOnce(Invoke([sent_request = request](const AsyncClient::Request& request,
+                                                AsyncClient::FailureReason reason) {
+        // Verify that callback is called with the same request handle as returned by
+        // AsyncClient::send().
+        EXPECT_EQ(&request, sent_request);
+        EXPECT_EQ(reason, AsyncClient::FailureReason::Reset);
+      }));
+
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
@@ -915,11 +986,20 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveRequest) {
         callbacks.onPoolReady(stream_encoder_, cm_.conn_pool_.host_, stream_info_);
         return nullptr;
       }));
-
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
+
+  auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_NE(request, nullptr);
+
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  EXPECT_CALL(callbacks_, onFailure(_, _));
-  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
+  EXPECT_CALL(callbacks_, onFailure(_, _))
+      .WillOnce(Invoke([sent_request = request](const AsyncClient::Request& request,
+                                                AsyncClient::FailureReason reason) {
+        // Verify that callback is called with the same request handle as returned by
+        // AsyncClient::send().
+        EXPECT_EQ(&request, sent_request);
+        EXPECT_EQ(reason, AsyncClient::FailureReason::Reset);
+      }));
 }
 
 TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
@@ -937,9 +1017,18 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
   AsyncClient::RequestOptions options = AsyncClient::RequestOptions().setParentSpan(parent_span_);
   EXPECT_CALL(*child_span, setSampled(true));
   EXPECT_CALL(*child_span, injectContext(_));
-  client_.send(std::move(message_), callbacks_, options);
 
-  EXPECT_CALL(callbacks_, onFailure(_, _));
+  auto* request = client_.send(std::move(message_), callbacks_, options);
+  EXPECT_NE(request, nullptr);
+
+  EXPECT_CALL(callbacks_, onFailure(_, _))
+      .WillOnce(Invoke([sent_request = request](const AsyncClient::Request& request,
+                                                AsyncClient::FailureReason reason) {
+        // Verify that callback is called with the same request handle as returned by
+        // AsyncClient::send().
+        EXPECT_EQ(&request, sent_request);
+        EXPECT_EQ(reason, AsyncClient::FailureReason::Reset);
+      }));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
@@ -962,7 +1051,14 @@ TEST_F(AsyncClientImplTest, PoolFailure) {
         return nullptr;
       }));
 
-  expectSuccess(503);
+  EXPECT_CALL(callbacks_, onSuccess_(_, _))
+      .WillOnce(Invoke([](const AsyncClient::Request& request, ResponseMessage* response) -> void {
+        // Verify that callback is called with the same request handle as returned by
+        // AsyncClient::send().
+        EXPECT_NE(nullptr, &request);
+        EXPECT_EQ(503, Utility::getResponseStatus(response->headers()));
+      }));
+
   EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions()));
 
   EXPECT_EQ(
@@ -979,7 +1075,13 @@ TEST_F(AsyncClientImplTest, PoolFailureWithBody) {
         return nullptr;
       }));
 
-  expectSuccess(503);
+  EXPECT_CALL(callbacks_, onSuccess_(_, _))
+      .WillOnce(Invoke([](const AsyncClient::Request& request, ResponseMessage* response) -> void {
+        // Verify that callback is called with the same request handle as returned by
+        // AsyncClient::send().
+        EXPECT_NE(nullptr, &request);
+        EXPECT_EQ(503, Utility::getResponseStatus(response->headers()));
+      }));
   message_->body() = std::make_unique<Buffer::OwnedImpl>("hello");
   EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions()));
 
@@ -1056,12 +1158,16 @@ TEST_F(AsyncClientImplTest, RequestTimeout) {
       }));
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  expectSuccess(504);
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40), _));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  client_.send(std::move(message_), callbacks_,
-               AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(40)));
+
+  auto* request =
+      client_.send(std::move(message_), callbacks_,
+                   AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(40)));
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 504);
   timer_->invokeCallback();
 
   EXPECT_EQ(1UL,
@@ -1083,7 +1189,6 @@ TEST_F(AsyncClientImplTracingTest, RequestTimeout) {
       }));
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  expectSuccess(504);
 
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40), _));
@@ -1096,7 +1201,11 @@ TEST_F(AsyncClientImplTracingTest, RequestTimeout) {
                                             .setTimeout(std::chrono::milliseconds(40));
   EXPECT_CALL(*child_span, setSampled(true));
   EXPECT_CALL(*child_span, injectContext(_));
-  client_.send(std::move(message_), callbacks_, options);
+
+  auto* request = client_.send(std::move(message_), callbacks_, options);
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 504);
 
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -53,8 +53,8 @@ public:
   }
 
   void expectSuccess(uint64_t code) {
-    EXPECT_CALL(callbacks_, onSuccess_(_))
-        .WillOnce(Invoke([code](ResponseMessage* response) -> void {
+    EXPECT_CALL(callbacks_, onSuccess_(_, _))
+        .WillOnce(Invoke([code](const AsyncClient::Request*, ResponseMessage* response) -> void {
           EXPECT_EQ(code, Utility::getResponseStatus(response->headers()));
         }));
   }
@@ -482,7 +482,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
   // Finish request 2.
   ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
-  EXPECT_CALL(callbacks2, onSuccess_(_));
+  EXPECT_CALL(callbacks2, onSuccess_(_, _));
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
 
   // Finish request 1.
@@ -820,7 +820,7 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
       }));
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  EXPECT_CALL(callbacks_, onFailure(_));
+  EXPECT_CALL(callbacks_, onFailure(_, _));
 
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
@@ -918,7 +918,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveRequest) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  EXPECT_CALL(callbacks_, onFailure(_));
+  EXPECT_CALL(callbacks_, onFailure(_, _));
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 }
 
@@ -939,7 +939,7 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
   EXPECT_CALL(*child_span, injectContext(_));
   client_.send(std::move(message_), callbacks_, options);
 
-  EXPECT_CALL(callbacks_, onFailure(_));
+  EXPECT_CALL(callbacks_, onFailure(_, _));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -1053,8 +1053,8 @@ TEST_F(AsyncClientImplTest, PoolFailure) {
 
   EXPECT_CALL(callbacks_, onSuccess_(_, _))
       .WillOnce(Invoke([](const AsyncClient::Request& request, ResponseMessage* response) -> void {
-        // Verify that callback is called with the same request handle as returned by
-        // AsyncClient::send().
+        // The callback gets called before AsyncClient::send() completes, which means that we don't
+        // have a request handle to compare to.
         EXPECT_NE(nullptr, &request);
         EXPECT_EQ(503, Utility::getResponseStatus(response->headers()));
       }));
@@ -1077,8 +1077,8 @@ TEST_F(AsyncClientImplTest, PoolFailureWithBody) {
 
   EXPECT_CALL(callbacks_, onSuccess_(_, _))
       .WillOnce(Invoke([](const AsyncClient::Request& request, ResponseMessage* response) -> void {
-        // Verify that callback is called with the same request handle as returned by
-        // AsyncClient::send().
+        // The callback gets called before AsyncClient::send() completes, which means that we don't
+        // have a request handle to compare to.
         EXPECT_NE(nullptr, &request);
         EXPECT_EQ(503, Utility::getResponseStatus(response->headers()));
       }));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -53,7 +53,7 @@ public:
   }
 
   void expectSuccess(uint64_t code) {
-    EXPECT_CALL(callbacks_, onRequestSuccess_(_, _))
+    EXPECT_CALL(callbacks_, onSuccess_(_, _))
         .WillOnce(Invoke([code](const AsyncClient::Request&, ResponseMessage* response) -> void {
           EXPECT_EQ(code, Utility::getResponseStatus(response->headers()));
         }));
@@ -482,7 +482,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
   // Finish request 2.
   ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
-  EXPECT_CALL(callbacks2, onRequestSuccess_(_, _));
+  EXPECT_CALL(callbacks2, onSuccess_(_, _));
   response_decoder2->decodeHeaders(std::move(response_headers2), true);
 
   // Finish request 1.
@@ -820,7 +820,7 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
       }));
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
-  EXPECT_CALL(callbacks_, onRequestFailure(_, _));
+  EXPECT_CALL(callbacks_, onFailure(_, _));
 
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
@@ -918,7 +918,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveRequest) {
 
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  EXPECT_CALL(callbacks_, onRequestFailure(_, _));
+  EXPECT_CALL(callbacks_, onFailure(_, _));
   client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 }
 
@@ -939,7 +939,7 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
   EXPECT_CALL(*child_span, injectContext(_));
   client_.send(std::move(message_), callbacks_, options);
 
-  EXPECT_CALL(callbacks_, onRequestFailure(_, _));
+  EXPECT_CALL(callbacks_, onFailure(_, _));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -54,7 +54,7 @@ public:
 
   void expectSuccess(uint64_t code) {
     EXPECT_CALL(callbacks_, onRequestSuccess_(_, _))
-        .WillOnce(Invoke([code](const AsyncClient::Request*, ResponseMessage* response) -> void {
+        .WillOnce(Invoke([code](const AsyncClient::Request&, ResponseMessage* response) -> void {
           EXPECT_EQ(code, Utility::getResponseStatus(response->headers()));
         }));
   }

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -51,14 +51,14 @@ TEST_F(ShadowWriterImplTest, Success) {
 
   expectShadowWriter("cluster1", "cluster1-shadow");
   Http::ResponseMessagePtr response(new Http::ResponseMessageImpl());
-  callback_->onSuccess(&request_, std::move(response));
+  callback_->onRequestSuccess(&request_, std::move(response));
 }
 
 TEST_F(ShadowWriterImplTest, Failure) {
   InSequence s;
 
   expectShadowWriter("cluster1:8000", "cluster1-shadow:8000");
-  callback_->onFailure(&request_, Http::AsyncClient::FailureReason::Reset);
+  callback_->onRequestFailure(&request_, Http::AsyncClient::FailureReason::Reset);
 }
 
 TEST_F(ShadowWriterImplTest, NoCluster) {

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -51,14 +51,14 @@ TEST_F(ShadowWriterImplTest, Success) {
 
   expectShadowWriter("cluster1", "cluster1-shadow");
   Http::ResponseMessagePtr response(new Http::ResponseMessageImpl());
-  callback_->onRequestSuccess(request_, std::move(response));
+  callback_->onSuccess(request_, std::move(response));
 }
 
 TEST_F(ShadowWriterImplTest, Failure) {
   InSequence s;
 
   expectShadowWriter("cluster1:8000", "cluster1-shadow:8000");
-  callback_->onRequestFailure(request_, Http::AsyncClient::FailureReason::Reset);
+  callback_->onFailure(request_, Http::AsyncClient::FailureReason::Reset);
 }
 
 TEST_F(ShadowWriterImplTest, NoCluster) {

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -27,7 +27,6 @@ public:
     message->headers().setHost(host);
     EXPECT_CALL(cm_, get(Eq("foo")));
     EXPECT_CALL(cm_, httpAsyncClientForCluster("foo")).WillOnce(ReturnRef(cm_.async_client_));
-    Http::MockAsyncClientRequest request(&cm_.async_client_);
     auto options = Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(5));
     EXPECT_CALL(cm_.async_client_, send_(_, _, options))
         .WillOnce(Invoke(
@@ -36,13 +35,14 @@ public:
               EXPECT_EQ(message, inner_message);
               EXPECT_EQ(shadowed_host, message->headers().Host()->value().getStringView());
               callback_ = &callbacks;
-              return &request;
+              return &request_;
             }));
     writer_.shadow("foo", std::move(message), options);
   }
 
   Upstream::MockClusterManager cm_;
   ShadowWriterImpl writer_{cm_};
+  Http::MockAsyncClientRequest request_{&cm_.async_client_};
   Http::AsyncClient::Callbacks* callback_{};
 };
 
@@ -51,14 +51,14 @@ TEST_F(ShadowWriterImplTest, Success) {
 
   expectShadowWriter("cluster1", "cluster1-shadow");
   Http::ResponseMessagePtr response(new Http::ResponseMessageImpl());
-  callback_->onSuccess(std::move(response));
+  callback_->onSuccess(&request_, std::move(response));
 }
 
 TEST_F(ShadowWriterImplTest, Failure) {
   InSequence s;
 
   expectShadowWriter("cluster1:8000", "cluster1-shadow:8000");
-  callback_->onFailure(Http::AsyncClient::FailureReason::Reset);
+  callback_->onFailure(&request_, Http::AsyncClient::FailureReason::Reset);
 }
 
 TEST_F(ShadowWriterImplTest, NoCluster) {

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -51,14 +51,14 @@ TEST_F(ShadowWriterImplTest, Success) {
 
   expectShadowWriter("cluster1", "cluster1-shadow");
   Http::ResponseMessagePtr response(new Http::ResponseMessageImpl());
-  callback_->onRequestSuccess(&request_, std::move(response));
+  callback_->onRequestSuccess(request_, std::move(response));
 }
 
 TEST_F(ShadowWriterImplTest, Failure) {
   InSequence s;
 
   expectShadowWriter("cluster1:8000", "cluster1-shadow:8000");
-  callback_->onRequestFailure(&request_, Http::AsyncClient::FailureReason::Reset);
+  callback_->onRequestFailure(request_, Http::AsyncClient::FailureReason::Reset);
 }
 
 TEST_F(ShadowWriterImplTest, NoCluster) {

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -109,7 +109,7 @@ public:
             [&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
                 const Envoy::Http::AsyncClient::RequestOptions) -> Http::AsyncClient::Request* {
               message_ptr = std::move(message);
-              return nullptr;
+              return &async_request_;
             }));
 
     const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "200", false}});
@@ -119,7 +119,7 @@ public:
     client_->check(request_callbacks_, request, Tracing::NullSpan::instance());
     EXPECT_CALL(request_callbacks_,
                 onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzOkResponse(authz_response))));
-    client_->onSuccess(std::move(check_response));
+    client_->onSuccess(async_request_, std::move(check_response));
 
     return message_ptr;
   }
@@ -300,7 +300,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOk) {
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_http_status"), Eq("OK")));
   EXPECT_CALL(*child_span, finishSpan());
-  client_->onSuccess(std::move(check_response));
+  client_->onSuccess(async_request_, std::move(check_response));
 }
 
 // Verify client response headers when authorization_headers_to_add is configured.
@@ -329,7 +329,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeaders) {
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_http_status"), Eq("OK")));
   EXPECT_CALL(*child_span, finishSpan());
-  client_->onSuccess(std::move(check_response));
+  client_->onSuccess(async_request_, std::move(check_response));
 }
 
 // Verify client response headers when allow_upstream_headers is configured.
@@ -363,7 +363,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAllowHeader) {
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_http_status"), Eq("OK")));
   EXPECT_CALL(*child_span, finishSpan());
   auto message_response = TestCommon::makeMessageResponse(check_response_headers);
-  client_->onSuccess(std::move(message_response));
+  client_->onSuccess(async_request_, std::move(message_response));
 }
 
 // Test the client when a denied response is received.
@@ -385,7 +385,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDenied) {
   EXPECT_CALL(*child_span, finishSpan());
   EXPECT_CALL(request_callbacks_,
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzDeniedResponse(authz_response))));
-  client_->onSuccess(TestCommon::makeMessageResponse(expected_headers));
+  client_->onSuccess(async_request_, TestCommon::makeMessageResponse(expected_headers));
 }
 
 // Verify client response headers and body when the authorization server denies the request.
@@ -410,7 +410,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedWithAllAttributes) {
   EXPECT_CALL(*child_span, finishSpan());
   EXPECT_CALL(request_callbacks_,
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzDeniedResponse(authz_response))));
-  client_->onSuccess(TestCommon::makeMessageResponse(expected_headers, expected_body));
+  client_->onSuccess(async_request_,
+                     TestCommon::makeMessageResponse(expected_headers, expected_body));
 }
 
 // Verify client response headers when the authorization server denies the request and
@@ -439,7 +440,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
                                                                          {"x-foo", "bar", false},
                                                                          {":status", "401", false},
                                                                          {"foo", "bar", false}});
-  client_->onSuccess(TestCommon::makeMessageResponse(check_response_headers, expected_body));
+  client_->onSuccess(async_request_,
+                     TestCommon::makeMessageResponse(check_response_headers, expected_body));
 }
 
 // Test the client when an unknown error occurs.
@@ -458,7 +460,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
   EXPECT_CALL(*child_span, finishSpan());
-  client_->onFailure(Http::AsyncClient::FailureReason::Reset);
+  client_->onFailure(async_request_, Http::AsyncClient::FailureReason::Reset);
 }
 
 // Test the client when a call to authorization server returns a 5xx error status.
@@ -479,7 +481,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_http_status"), Eq("Service Unavailable")));
   EXPECT_CALL(*child_span, finishSpan());
-  client_->onSuccess(std::move(check_response));
+  client_->onSuccess(async_request_, std::move(check_response));
 }
 
 // Test the client when a call to authorization server returns a status code that cannot be
@@ -501,7 +503,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestErrorParsingStatusCode) {
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
   EXPECT_CALL(*child_span, finishSpan());
-  client_->onSuccess(std::move(check_response));
+  client_->onSuccess(async_request_, std::move(check_response));
 }
 
 // Test the client when the request is canceled.

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -109,7 +109,7 @@ public:
             [&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
                 const Envoy::Http::AsyncClient::RequestOptions) -> Http::AsyncClient::Request* {
               message_ptr = std::move(message);
-              return &async_request_;
+              return nullptr;
             }));
 
     const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "200", false}});

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -21,7 +21,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
             } else {
               response_message->body().reset(nullptr);
             }
-            cb.onSuccess(std::move(response_message));
+            cb.onSuccess(&request_, std::move(response_message));
             return &request_;
           }));
 }
@@ -33,7 +33,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm,
       .WillByDefault(testing::Invoke(
           [this, reason](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                          const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onFailure(reason);
+            cb.onFailure(&request_, reason);
             return &request_;
           }));
 }

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -21,7 +21,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
             } else {
               response_message->body().reset(nullptr);
             }
-            cb.onSuccess(&request_, std::move(response_message));
+            cb.onRequestSuccess(&request_, std::move(response_message));
             return &request_;
           }));
 }
@@ -33,7 +33,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm,
       .WillByDefault(testing::Invoke(
           [this, reason](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                          const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onFailure(&request_, reason);
+            cb.onRequestFailure(&request_, reason);
             return &request_;
           }));
 }

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -21,7 +21,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
             } else {
               response_message->body().reset(nullptr);
             }
-            cb.onRequestSuccess(&request_, std::move(response_message));
+            cb.onRequestSuccess(request_, std::move(response_message));
             return &request_;
           }));
 }
@@ -33,7 +33,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm,
       .WillByDefault(testing::Invoke(
           [this, reason](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                          const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onRequestFailure(&request_, reason);
+            cb.onRequestFailure(request_, reason);
             return &request_;
           }));
 }

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -21,7 +21,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
             } else {
               response_message->body().reset(nullptr);
             }
-            cb.onRequestSuccess(request_, std::move(response_message));
+            cb.onSuccess(request_, std::move(response_message));
             return &request_;
           }));
 }
@@ -33,7 +33,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm,
       .WillByDefault(testing::Invoke(
           [this, reason](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                          const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onRequestFailure(request_, reason);
+            cb.onFailure(request_, reason);
             return &request_;
           }));
 }

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -71,7 +71,7 @@ public:
                   new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
               response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
-              cb.onRequestSuccess(&request_, std::move(response_message));
+              cb.onRequestSuccess(request_, std::move(response_message));
               called_count_++;
               return &request_;
             }));

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -71,7 +71,7 @@ public:
                   new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
               response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
-              cb.onRequestSuccess(request_, std::move(response_message));
+              cb.onSuccess(request_, std::move(response_message));
               called_count_++;
               return &request_;
             }));

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -71,7 +71,7 @@ public:
                   new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
               response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
-              cb.onSuccess(std::move(response_message));
+              cb.onSuccess(&request_, std::move(response_message));
               called_count_++;
               return &request_;
             }));

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -71,7 +71,7 @@ public:
                   new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
               response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
-              cb.onSuccess(&request_, std::move(response_message));
+              cb.onRequestSuccess(&request_, std::move(response_message));
               called_count_++;
               return &request_;
             }));

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -797,7 +797,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 }
 
 // Basic HTTP request flow. Asynchronous flag set to false.
@@ -860,7 +860,7 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 }
 
 // Basic asynchronous, fire-and-forget HTTP request flow.
@@ -990,14 +990,14 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
             callbacks = &cb;
             return &request;
           }));
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 
   response_message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "403"}}});
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 403")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -1061,7 +1061,7 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 }
 
 // HTTP call followed by immediate response.
@@ -1114,7 +1114,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
                                            {"set-cookie", "flavor=chocolate; Path=/"},
                                            {"set-cookie", "variant=chewy; Path=/"}};
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 }
 
 // HTTP call with script error after resume.
@@ -1162,7 +1162,7 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
               scriptLog(spdlog::level::err,
                         StrEq("[string \"...\"]:14: attempt to index local 'foo' (a nil value)")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(&request, std::move(response_message));
 }
 
 // HTTP call failure.
@@ -1207,7 +1207,7 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 503")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("upstream failure")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onFailure(&request, Http::AsyncClient::FailureReason::Reset);
+  callbacks->onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
 }
 
 // HTTP call reset.
@@ -1283,7 +1283,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onFailure(&request, Http::AsyncClient::FailureReason::Reset);
+            cb.onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -797,7 +797,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 }
 
 // Basic HTTP request flow. Asynchronous flag set to false.
@@ -860,7 +860,7 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 }
 
 // Basic asynchronous, fire-and-forget HTTP request flow.
@@ -990,14 +990,14 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
             callbacks = &cb;
             return &request;
           }));
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 
   response_message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "403"}}});
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 403")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -1061,7 +1061,7 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 }
 
 // HTTP call followed by immediate response.
@@ -1114,7 +1114,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
                                            {"set-cookie", "flavor=chocolate; Path=/"},
                                            {"set-cookie", "variant=chewy; Path=/"}};
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 }
 
 // HTTP call with script error after resume.
@@ -1162,7 +1162,7 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
               scriptLog(spdlog::level::err,
                         StrEq("[string \"...\"]:14: attempt to index local 'foo' (a nil value)")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onSuccess(std::move(response_message));
+  callbacks->onSuccess(&request, std::move(response_message));
 }
 
 // HTTP call failure.
@@ -1207,7 +1207,7 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 503")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("upstream failure")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onFailure(Http::AsyncClient::FailureReason::Reset);
+  callbacks->onFailure(&request, Http::AsyncClient::FailureReason::Reset);
 }
 
 // HTTP call reset.
@@ -1283,7 +1283,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onFailure(Http::AsyncClient::FailureReason::Reset);
+            cb.onFailure(&request, Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -797,7 +797,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 }
 
 // Basic HTTP request flow. Asynchronous flag set to false.
@@ -860,7 +860,7 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 }
 
 // Basic asynchronous, fire-and-forget HTTP request flow.
@@ -990,14 +990,14 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
             callbacks = &cb;
             return &request;
           }));
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 
   response_message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "403"}}});
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 403")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -1061,7 +1061,7 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 }
 
 // HTTP call followed by immediate response.
@@ -1114,7 +1114,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
                                            {"set-cookie", "flavor=chocolate; Path=/"},
                                            {"set-cookie", "variant=chewy; Path=/"}};
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 }
 
 // HTTP call with script error after resume.
@@ -1162,7 +1162,7 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
               scriptLog(spdlog::level::err,
                         StrEq("[string \"...\"]:14: attempt to index local 'foo' (a nil value)")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(request, std::move(response_message));
+  callbacks->onSuccess(request, std::move(response_message));
 }
 
 // HTTP call failure.
@@ -1207,7 +1207,7 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 503")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("upstream failure")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
+  callbacks->onFailure(request, Http::AsyncClient::FailureReason::Reset);
 }
 
 // HTTP call reset.
@@ -1283,7 +1283,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
+            cb.onFailure(request, Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1284,6 +1284,8 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             cb.onFailure(request, Http::AsyncClient::FailureReason::Reset);
+            // Intentionally return nullptr (instead of request handle) to trigger a particular
+            // code path.
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -797,7 +797,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 }
 
 // Basic HTTP request flow. Asynchronous flag set to false.
@@ -860,7 +860,7 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 }
 
 // Basic asynchronous, fire-and-forget HTTP request flow.
@@ -990,14 +990,14 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
             callbacks = &cb;
             return &request;
           }));
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 
   response_message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "403"}}});
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 403")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -1061,7 +1061,7 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 }
 
 // HTTP call followed by immediate response.
@@ -1114,7 +1114,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
                                            {"set-cookie", "flavor=chocolate; Path=/"},
                                            {"set-cookie", "variant=chewy; Path=/"}};
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 }
 
 // HTTP call with script error after resume.
@@ -1162,7 +1162,7 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
               scriptLog(spdlog::level::err,
                         StrEq("[string \"...\"]:14: attempt to index local 'foo' (a nil value)")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestSuccess(&request, std::move(response_message));
+  callbacks->onRequestSuccess(request, std::move(response_message));
 }
 
 // HTTP call failure.
@@ -1207,7 +1207,7 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 503")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("upstream failure")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  callbacks->onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
+  callbacks->onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
 }
 
 // HTTP call reset.
@@ -1283,7 +1283,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            cb.onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
+            cb.onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -266,6 +266,8 @@ TEST_F(SquashFilterTest, DecodeHeaderContinuesOnClientFail) {
           [&](Envoy::Http::RequestMessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
               const Http::AsyncClient::RequestOptions&) -> Envoy::Http::AsyncClient::Request* {
             callbacks.onFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+            // Intentionally return nullptr (instead of request handle) to trigger a particular
+            // code path.
             return nullptr;
           }));
 

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -223,7 +223,7 @@ protected:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", status}}}));
     msg->body() = std::make_unique<Buffer::OwnedImpl>(body);
-    popPendingCallback()->onSuccess(std::move(msg));
+    popPendingCallback()->onSuccess(&request_, std::move(msg));
   }
 
   void completeCreateRequest() {
@@ -265,7 +265,7 @@ TEST_F(SquashFilterTest, DecodeHeaderContinuesOnClientFail) {
       .WillOnce(Invoke(
           [&](Envoy::Http::RequestMessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
               const Http::AsyncClient::RequestOptions&) -> Envoy::Http::AsyncClient::Request* {
-            callbacks.onFailure(Envoy::Http::AsyncClient::FailureReason::Reset);
+            callbacks.onFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 
@@ -286,7 +286,7 @@ TEST_F(SquashFilterTest, DecodeContinuesOnCreateAttachmentFail) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(*attachmentTimeout_timer_, disableTimer());
-  popPendingCallback()->onFailure(Envoy::Http::AsyncClient::FailureReason::Reset);
+  popPendingCallback()->onFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
 
   Envoy::Buffer::OwnedImpl data("nothing here");
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -365,7 +365,7 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachmentOnFailure) {
 
   auto retry_timer = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
   EXPECT_CALL(*retry_timer, enableTimer(config_->attachmentPollPeriod(), _));
-  popPendingCallback()->onFailure(Envoy::Http::AsyncClient::FailureReason::Reset);
+  popPendingCallback()->onFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
 
   // Expect the second get attachment request
   expectAsyncClientSend();

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -223,7 +223,7 @@ protected:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", status}}}));
     msg->body() = std::make_unique<Buffer::OwnedImpl>(body);
-    popPendingCallback()->onRequestSuccess(&request_, std::move(msg));
+    popPendingCallback()->onRequestSuccess(request_, std::move(msg));
   }
 
   void completeCreateRequest() {
@@ -265,7 +265,7 @@ TEST_F(SquashFilterTest, DecodeHeaderContinuesOnClientFail) {
       .WillOnce(Invoke(
           [&](Envoy::Http::RequestMessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
               const Http::AsyncClient::RequestOptions&) -> Envoy::Http::AsyncClient::Request* {
-            callbacks.onRequestFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+            callbacks.onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 
@@ -286,7 +286,7 @@ TEST_F(SquashFilterTest, DecodeContinuesOnCreateAttachmentFail) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(*attachmentTimeout_timer_, disableTimer());
-  popPendingCallback()->onRequestFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+  popPendingCallback()->onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
 
   Envoy::Buffer::OwnedImpl data("nothing here");
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -365,7 +365,7 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachmentOnFailure) {
 
   auto retry_timer = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
   EXPECT_CALL(*retry_timer, enableTimer(config_->attachmentPollPeriod(), _));
-  popPendingCallback()->onRequestFailure(&request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+  popPendingCallback()->onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
 
   // Expect the second get attachment request
   expectAsyncClientSend();

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -223,7 +223,7 @@ protected:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", status}}}));
     msg->body() = std::make_unique<Buffer::OwnedImpl>(body);
-    popPendingCallback()->onRequestSuccess(request_, std::move(msg));
+    popPendingCallback()->onSuccess(request_, std::move(msg));
   }
 
   void completeCreateRequest() {
@@ -265,7 +265,7 @@ TEST_F(SquashFilterTest, DecodeHeaderContinuesOnClientFail) {
       .WillOnce(Invoke(
           [&](Envoy::Http::RequestMessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
               const Http::AsyncClient::RequestOptions&) -> Envoy::Http::AsyncClient::Request* {
-            callbacks.onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+            callbacks.onFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));
 
@@ -286,7 +286,7 @@ TEST_F(SquashFilterTest, DecodeContinuesOnCreateAttachmentFail) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(*attachmentTimeout_timer_, disableTimer());
-  popPendingCallback()->onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+  popPendingCallback()->onFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
 
   Envoy::Buffer::OwnedImpl data("nothing here");
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -365,7 +365,7 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachmentOnFailure) {
 
   auto retry_timer = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
   EXPECT_CALL(*retry_timer, enableTimer(config_->attachmentPollPeriod(), _));
-  popPendingCallback()->onRequestFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
+  popPendingCallback()->onFailure(request_, Envoy::Http::AsyncClient::FailureReason::Reset);
 
   // Expect the second get attachment request
   expectAsyncClientSend();

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -258,6 +258,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
                 request_,
                 Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                     new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
+            // Intentionally return nullptr (instead of request handle) to trigger a particular
+            // code path.
             return nullptr;
           }));
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -173,7 +173,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message->body() = std::make_unique<Buffer::OwnedImpl>(
       api_->fileSystem().fileReadToEnd(TestEnvironment::runfilesPath(
           "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
-  callbacks_->onSuccess(std::move(message));
+  callbacks_->onSuccess(&request_, std::move(message));
   EXPECT_EQ(1U,
             stats_store_
                 .gauge("auth.clientssl.vpn.total_principals", Stats::Gauge::ImportMode::NeverImport)
@@ -227,7 +227,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}});
-  callbacks_->onSuccess(std::move(message));
+  callbacks_->onSuccess(&request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -238,7 +238,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}});
   message->body() = std::make_unique<Buffer::OwnedImpl>("bad_json");
-  callbacks_->onSuccess(std::move(message));
+  callbacks_->onSuccess(&request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -246,7 +246,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // No response failure.
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
-  callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
+  callbacks_->onFailure(&request_, Http::AsyncClient::FailureReason::Reset);
 
   // Interval timer fires, cannot obtain async client.
   EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
@@ -255,6 +255,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks.onSuccess(
+                nullptr,
                 Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                     new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
             return nullptr;

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -173,7 +173,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message->body() = std::make_unique<Buffer::OwnedImpl>(
       api_->fileSystem().fileReadToEnd(TestEnvironment::runfilesPath(
           "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
-  callbacks_->onSuccess(&request_, std::move(message));
+  callbacks_->onRequestSuccess(&request_, std::move(message));
   EXPECT_EQ(1U,
             stats_store_
                 .gauge("auth.clientssl.vpn.total_principals", Stats::Gauge::ImportMode::NeverImport)
@@ -227,7 +227,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}});
-  callbacks_->onSuccess(&request_, std::move(message));
+  callbacks_->onRequestSuccess(&request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -238,7 +238,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}});
   message->body() = std::make_unique<Buffer::OwnedImpl>("bad_json");
-  callbacks_->onSuccess(&request_, std::move(message));
+  callbacks_->onRequestSuccess(&request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -246,7 +246,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // No response failure.
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
-  callbacks_->onFailure(&request_, Http::AsyncClient::FailureReason::Reset);
+  callbacks_->onRequestFailure(&request_, Http::AsyncClient::FailureReason::Reset);
 
   // Interval timer fires, cannot obtain async client.
   EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
@@ -254,8 +254,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            callbacks.onSuccess(
-                nullptr,
+            callbacks.onRequestSuccess(
+                &request_,
                 Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                     new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
             return nullptr;

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -173,7 +173,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message->body() = std::make_unique<Buffer::OwnedImpl>(
       api_->fileSystem().fileReadToEnd(TestEnvironment::runfilesPath(
           "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
-  callbacks_->onRequestSuccess(&request_, std::move(message));
+  callbacks_->onRequestSuccess(request_, std::move(message));
   EXPECT_EQ(1U,
             stats_store_
                 .gauge("auth.clientssl.vpn.total_principals", Stats::Gauge::ImportMode::NeverImport)
@@ -227,7 +227,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}});
-  callbacks_->onRequestSuccess(&request_, std::move(message));
+  callbacks_->onRequestSuccess(request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -238,7 +238,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}});
   message->body() = std::make_unique<Buffer::OwnedImpl>("bad_json");
-  callbacks_->onRequestSuccess(&request_, std::move(message));
+  callbacks_->onRequestSuccess(request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -246,7 +246,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // No response failure.
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
-  callbacks_->onRequestFailure(&request_, Http::AsyncClient::FailureReason::Reset);
+  callbacks_->onRequestFailure(request_, Http::AsyncClient::FailureReason::Reset);
 
   // Interval timer fires, cannot obtain async client.
   EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
@@ -255,7 +255,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks.onRequestSuccess(
-                &request_,
+                request_,
                 Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                     new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
             return nullptr;

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -173,7 +173,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message->body() = std::make_unique<Buffer::OwnedImpl>(
       api_->fileSystem().fileReadToEnd(TestEnvironment::runfilesPath(
           "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
-  callbacks_->onRequestSuccess(request_, std::move(message));
+  callbacks_->onSuccess(request_, std::move(message));
   EXPECT_EQ(1U,
             stats_store_
                 .gauge("auth.clientssl.vpn.total_principals", Stats::Gauge::ImportMode::NeverImport)
@@ -227,7 +227,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}});
-  callbacks_->onRequestSuccess(request_, std::move(message));
+  callbacks_->onSuccess(request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -238,7 +238,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}});
   message->body() = std::make_unique<Buffer::OwnedImpl>("bad_json");
-  callbacks_->onRequestSuccess(request_, std::move(message));
+  callbacks_->onSuccess(request_, std::move(message));
 
   // Interval timer fires.
   setupRequest();
@@ -246,7 +246,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // No response failure.
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
-  callbacks_->onRequestFailure(request_, Http::AsyncClient::FailureReason::Reset);
+  callbacks_->onFailure(request_, Http::AsyncClient::FailureReason::Reset);
 
   // Interval timer fires, cannot obtain async client.
   EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
@@ -254,7 +254,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            callbacks.onRequestSuccess(
+            callbacks.onSuccess(
                 request_,
                 Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                     new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -158,7 +158,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   msg->body() = std::make_unique<Buffer::OwnedImpl>("");
 
-  callback->onRequestSuccess(request, std::move(msg));
+  callback->onSuccess(request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.datadog.reports_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.datadog.reports_dropped").value());

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -158,7 +158,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   msg->body() = std::make_unique<Buffer::OwnedImpl>("");
 
-  callback->onSuccess(std::move(msg));
+  callback->onSuccess(&request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.datadog.reports_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.datadog.reports_dropped").value());

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -158,7 +158,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   msg->body() = std::make_unique<Buffer::OwnedImpl>("");
 
-  callback->onRequestSuccess(&request, std::move(msg));
+  callback->onRequestSuccess(request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.datadog.reports_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.datadog.reports_dropped").value());

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -158,7 +158,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   msg->body() = std::make_unique<Buffer::OwnedImpl>("");
 
-  callback->onSuccess(&request, std::move(msg));
+  callback->onRequestSuccess(&request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.datadog.reports_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.datadog.reports_dropped").value());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -229,7 +229,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
                                                    start_time_, {Tracing::Reason::Sampling, true});
   third_span->finishSpan();
 
-  callback->onSuccess(&request, makeSuccessResponse());
+  callback->onRequestSuccess(&request, makeSuccessResponse());
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.success")
@@ -277,7 +277,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
   second_span->finishSpan();
 
-  callback->onFailure(&request, Http::AsyncClient::FailureReason::Reset);
+  callback->onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.failure")
@@ -411,7 +411,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
 
   timer_->invokeCallback();
 
-  callback->onSuccess(&request, makeSuccessResponse());
+  callback->onRequestSuccess(&request, makeSuccessResponse());
 
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.spans_sent").value());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -229,7 +229,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
                                                    start_time_, {Tracing::Reason::Sampling, true});
   third_span->finishSpan();
 
-  callback->onRequestSuccess(&request, makeSuccessResponse());
+  callback->onRequestSuccess(request, makeSuccessResponse());
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.success")
@@ -277,7 +277,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
   second_span->finishSpan();
 
-  callback->onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
+  callback->onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.failure")
@@ -411,7 +411,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
 
   timer_->invokeCallback();
 
-  callback->onRequestSuccess(&request, makeSuccessResponse());
+  callback->onRequestSuccess(request, makeSuccessResponse());
 
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.spans_sent").value());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -229,7 +229,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
                                                    start_time_, {Tracing::Reason::Sampling, true});
   third_span->finishSpan();
 
-  callback->onSuccess(makeSuccessResponse());
+  callback->onSuccess(&request, makeSuccessResponse());
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.success")
@@ -277,7 +277,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
   second_span->finishSpan();
 
-  callback->onFailure(Http::AsyncClient::FailureReason::Reset);
+  callback->onFailure(&request, Http::AsyncClient::FailureReason::Reset);
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.failure")
@@ -411,7 +411,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
 
   timer_->invokeCallback();
 
-  callback->onSuccess(makeSuccessResponse());
+  callback->onSuccess(&request, makeSuccessResponse());
 
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.spans_sent").value());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -229,7 +229,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
                                                    start_time_, {Tracing::Reason::Sampling, true});
   third_span->finishSpan();
 
-  callback->onRequestSuccess(request, makeSuccessResponse());
+  callback->onSuccess(request, makeSuccessResponse());
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.success")
@@ -277,7 +277,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
   second_span->finishSpan();
 
-  callback->onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
+  callback->onFailure(request, Http::AsyncClient::FailureReason::Reset);
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("grpc.lightstep.collector.CollectorService.Report.failure")
@@ -411,7 +411,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
 
   timer_->invokeCallback();
 
-  callback->onRequestSuccess(request, makeSuccessResponse());
+  callback->onSuccess(request, makeSuccessResponse());
 
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.timer_flushed").value());
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.spans_sent").value());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -111,14 +111,14 @@ public:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "202"}}}));
 
-    callback->onSuccess(std::move(msg));
+    callback->onSuccess(&request, std::move(msg));
 
     EXPECT_EQ(2U, stats_.counter("tracing.zipkin.spans_sent").value());
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_sent").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_dropped").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_failed").value());
 
-    callback->onFailure(Http::AsyncClient::FailureReason::Reset);
+    callback->onFailure(&request, Http::AsyncClient::FailureReason::Reset);
 
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_failed").value());
   }
@@ -236,7 +236,7 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "404"}}}));
 
   // AsyncClient can fail with valid HTTP headers
-  callback->onSuccess(std::move(msg));
+  callback->onSuccess(&request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.spans_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_sent").value());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -111,14 +111,14 @@ public:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "202"}}}));
 
-    callback->onSuccess(&request, std::move(msg));
+    callback->onRequestSuccess(&request, std::move(msg));
 
     EXPECT_EQ(2U, stats_.counter("tracing.zipkin.spans_sent").value());
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_sent").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_dropped").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_failed").value());
 
-    callback->onFailure(&request, Http::AsyncClient::FailureReason::Reset);
+    callback->onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
 
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_failed").value());
   }
@@ -236,7 +236,7 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "404"}}}));
 
   // AsyncClient can fail with valid HTTP headers
-  callback->onSuccess(&request, std::move(msg));
+  callback->onRequestSuccess(&request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.spans_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_sent").value());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -111,14 +111,14 @@ public:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "202"}}}));
 
-    callback->onRequestSuccess(request, std::move(msg));
+    callback->onSuccess(request, std::move(msg));
 
     EXPECT_EQ(2U, stats_.counter("tracing.zipkin.spans_sent").value());
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_sent").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_dropped").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_failed").value());
 
-    callback->onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
+    callback->onFailure(request, Http::AsyncClient::FailureReason::Reset);
 
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_failed").value());
   }
@@ -236,7 +236,7 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "404"}}}));
 
   // AsyncClient can fail with valid HTTP headers
-  callback->onRequestSuccess(request, std::move(msg));
+  callback->onSuccess(request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.spans_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_sent").value());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -111,14 +111,14 @@ public:
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "202"}}}));
 
-    callback->onRequestSuccess(&request, std::move(msg));
+    callback->onRequestSuccess(request, std::move(msg));
 
     EXPECT_EQ(2U, stats_.counter("tracing.zipkin.spans_sent").value());
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_sent").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_dropped").value());
     EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_failed").value());
 
-    callback->onRequestFailure(&request, Http::AsyncClient::FailureReason::Reset);
+    callback->onRequestFailure(request, Http::AsyncClient::FailureReason::Reset);
 
     EXPECT_EQ(1U, stats_.counter("tracing.zipkin.reports_failed").value());
   }
@@ -236,7 +236,7 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "404"}}}));
 
   // AsyncClient can fail with valid HTTP headers
-  callback->onRequestSuccess(&request, std::move(msg));
+  callback->onRequestSuccess(request, std::move(msg));
 
   EXPECT_EQ(1U, stats_.counter("tracing.zipkin.spans_sent").value());
   EXPECT_EQ(0U, stats_.counter("tracing.zipkin.reports_sent").value());

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -138,9 +138,6 @@ MockAsyncClient::~MockAsyncClient() = default;
 MockAsyncClientCallbacks::MockAsyncClientCallbacks() = default;
 MockAsyncClientCallbacks::~MockAsyncClientCallbacks() = default;
 
-MockAsyncClientRequestCallbacks::MockAsyncClientRequestCallbacks() = default;
-MockAsyncClientRequestCallbacks::~MockAsyncClientRequestCallbacks() = default;
-
 MockAsyncClientStreamCallbacks::MockAsyncClientStreamCallbacks() = default;
 MockAsyncClientStreamCallbacks::~MockAsyncClientStreamCallbacks() = default;
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -138,6 +138,9 @@ MockAsyncClient::~MockAsyncClient() = default;
 MockAsyncClientCallbacks::MockAsyncClientCallbacks() = default;
 MockAsyncClientCallbacks::~MockAsyncClientCallbacks() = default;
 
+MockAsyncClientRequestCallbacks::MockAsyncClientRequestCallbacks() = default;
+MockAsyncClientRequestCallbacks::~MockAsyncClientRequestCallbacks() = default;
+
 MockAsyncClientStreamCallbacks::MockAsyncClientStreamCallbacks() = default;
 MockAsyncClientStreamCallbacks::~MockAsyncClientStreamCallbacks() = default;
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -334,27 +334,15 @@ public:
   MockAsyncClientCallbacks();
   ~MockAsyncClientCallbacks() override;
 
-  void onRequestSuccess(const Http::AsyncClient::Request& request,
-                        ResponseMessagePtr&& response) override {
-    onRequestSuccess_(request, response.get());
+  void onSuccess(const Http::AsyncClient::Request& request,
+                 ResponseMessagePtr&& response) override {
+    onSuccess_(request, response.get());
   }
 
   // Http::AsyncClient::Callbacks
-  MOCK_METHOD(void, onRequestSuccess_, (const Http::AsyncClient::Request&, ResponseMessage*));
-  MOCK_METHOD(void, onRequestFailure,
+  MOCK_METHOD(void, onSuccess_, (const Http::AsyncClient::Request&, ResponseMessage*));
+  MOCK_METHOD(void, onFailure,
               (const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason));
-};
-
-class MockAsyncClientRequestCallbacks : public AsyncClient::RequestCallbacks {
-public:
-  MockAsyncClientRequestCallbacks();
-  ~MockAsyncClientRequestCallbacks() override;
-
-  void onSuccess(ResponseMessagePtr&& response) override { onSuccess_(response.get()); }
-
-  // Http::AsyncClient::RequestCallbacks
-  MOCK_METHOD(void, onSuccess_, (ResponseMessage * response));
-  MOCK_METHOD(void, onFailure, (Http::AsyncClient::FailureReason reason));
 };
 
 class MockAsyncClientStreamCallbacks : public AsyncClient::StreamCallbacks {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -334,9 +334,25 @@ public:
   MockAsyncClientCallbacks();
   ~MockAsyncClientCallbacks() override;
 
-  void onSuccess(ResponseMessagePtr&& response) override { onSuccess_(response.get()); }
+  void onSuccess(const Http::AsyncClient::Request* request,
+                 ResponseMessagePtr&& response) override {
+    onSuccess_(request, response.get());
+  }
 
   // Http::AsyncClient::Callbacks
+  MOCK_METHOD(void, onSuccess_, (const Http::AsyncClient::Request*, ResponseMessage*));
+  MOCK_METHOD(void, onFailure,
+              (const Http::AsyncClient::Request*, Http::AsyncClient::FailureReason));
+};
+
+class MockAsyncClientRequestCallbacks : public AsyncClient::RequestCallbacks {
+public:
+  MockAsyncClientRequestCallbacks();
+  ~MockAsyncClientRequestCallbacks() override;
+
+  void onSuccess(ResponseMessagePtr&& response) override { onSuccess_(response.get()); }
+
+  // Http::AsyncClient::RequestCallbacks
   MOCK_METHOD(void, onSuccess_, (ResponseMessage * response));
   MOCK_METHOD(void, onFailure, (Http::AsyncClient::FailureReason reason));
 };

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -334,14 +334,14 @@ public:
   MockAsyncClientCallbacks();
   ~MockAsyncClientCallbacks() override;
 
-  void onSuccess(const Http::AsyncClient::Request* request,
-                 ResponseMessagePtr&& response) override {
-    onSuccess_(request, response.get());
+  void onRequestSuccess(const Http::AsyncClient::Request* request,
+                        ResponseMessagePtr&& response) override {
+    onRequestSuccess_(request, response.get());
   }
 
   // Http::AsyncClient::Callbacks
-  MOCK_METHOD(void, onSuccess_, (const Http::AsyncClient::Request*, ResponseMessage*));
-  MOCK_METHOD(void, onFailure,
+  MOCK_METHOD(void, onRequestSuccess_, (const Http::AsyncClient::Request*, ResponseMessage*));
+  MOCK_METHOD(void, onRequestFailure,
               (const Http::AsyncClient::Request*, Http::AsyncClient::FailureReason));
 };
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -334,15 +334,15 @@ public:
   MockAsyncClientCallbacks();
   ~MockAsyncClientCallbacks() override;
 
-  void onRequestSuccess(const Http::AsyncClient::Request* request,
+  void onRequestSuccess(const Http::AsyncClient::Request& request,
                         ResponseMessagePtr&& response) override {
     onRequestSuccess_(request, response.get());
   }
 
   // Http::AsyncClient::Callbacks
-  MOCK_METHOD(void, onRequestSuccess_, (const Http::AsyncClient::Request*, ResponseMessage*));
+  MOCK_METHOD(void, onRequestSuccess_, (const Http::AsyncClient::Request&, ResponseMessage*));
   MOCK_METHOD(void, onRequestFailure,
-              (const Http::AsyncClient::Request*, Http::AsyncClient::FailureReason));
+              (const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason));
 };
 
 class MockAsyncClientRequestCallbacks : public AsyncClient::RequestCallbacks {


### PR DESCRIPTION
Description: refactor `Http::AsyncClient::Callbacks` to pass in `Http::AsyncClient::Request*` for correlation between requests and responses
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Context:
* related to #9998 

Motivation:
* let `Callbacks` implementations to be able to determine which of the multiple in-flight requests has changed it's status