### PR TITLE
async client: introduce `AsyncClientRequestTracker` to keep track of inflight requests and cancel them on destruction

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -36,6 +36,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "async_client_utility_lib",
+    srcs = ["async_client_utility.cc"],
+    hdrs = ["async_client_utility.h"],
+    deps = [
+        "//include/envoy/http:async_client_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "codec_client_lib",
     srcs = ["codec_client.cc"],
     hdrs = ["codec_client.h"],

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -9,7 +9,7 @@ AsyncClientRequestTracker::~AsyncClientRequestTracker() {
   }
 }
 
-AsyncClientRequestTracker& AsyncClientRequestTracker::operator+=(AsyncClient::Request* request) {
+AsyncClientRequestTracker& AsyncClientRequestTracker::add(AsyncClient::Request* request) {
   // Let client code to avoid conditionals.
   if (request) {
     ASSERT(active_requests_.find(request) == active_requests_.end());
@@ -18,8 +18,7 @@ AsyncClientRequestTracker& AsyncClientRequestTracker::operator+=(AsyncClient::Re
   return *this;
 }
 
-AsyncClientRequestTracker&
-AsyncClientRequestTracker::operator-=(const AsyncClient::Request* request) {
+AsyncClientRequestTracker& AsyncClientRequestTracker::remove(const AsyncClient::Request* request) {
   // Let client code to avoid conditionals.
   if (request) {
     auto it = active_requests_.find(const_cast<AsyncClient::Request*>(request));

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -10,7 +10,7 @@ AsyncClientRequestTracker::~AsyncClientRequestTracker() {
 }
 
 void AsyncClientRequestTracker::add(AsyncClient::Request& request) {
-  ASSERT(active_requests_.find(&request) == active_requests_.end());
+  ASSERT(active_requests_.find(&request) == active_requests_.end(), "request is already tracked.");
   active_requests_.insert(&request);
 }
 

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -9,23 +9,17 @@ AsyncClientRequestTracker::~AsyncClientRequestTracker() {
   }
 }
 
-void AsyncClientRequestTracker::add(AsyncClient::Request* request) {
-  // Let client code to avoid conditionals.
-  if (request) {
-    ASSERT(active_requests_.find(request) == active_requests_.end());
-    active_requests_.insert(request);
-  }
+void AsyncClientRequestTracker::add(AsyncClient::Request& request) {
+  ASSERT(active_requests_.find(&request) == active_requests_.end());
+  active_requests_.insert(&request);
 }
 
-void AsyncClientRequestTracker::remove(const AsyncClient::Request* request) {
-  // Let client code to avoid conditionals.
-  if (request) {
-    auto it = active_requests_.find(const_cast<AsyncClient::Request*>(request));
-    // Support a use case where request callbacks might get called prior to a request handle
-    // is returned from AsyncClient::send().
-    if (it != active_requests_.end()) {
-      active_requests_.erase(it);
-    }
+void AsyncClientRequestTracker::remove(const AsyncClient::Request& request) {
+  auto it = active_requests_.find(const_cast<AsyncClient::Request*>(&request));
+  // Support a use case where request callbacks might get called prior to a request handle
+  // is returned from AsyncClient::send().
+  if (it != active_requests_.end()) {
+    active_requests_.erase(it);
   }
 }
 

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -9,16 +9,15 @@ AsyncClientRequestTracker::~AsyncClientRequestTracker() {
   }
 }
 
-AsyncClientRequestTracker& AsyncClientRequestTracker::add(AsyncClient::Request* request) {
+void AsyncClientRequestTracker::add(AsyncClient::Request* request) {
   // Let client code to avoid conditionals.
   if (request) {
     ASSERT(active_requests_.find(request) == active_requests_.end());
     active_requests_.insert(request);
   }
-  return *this;
 }
 
-AsyncClientRequestTracker& AsyncClientRequestTracker::remove(const AsyncClient::Request* request) {
+void AsyncClientRequestTracker::remove(const AsyncClient::Request* request) {
   // Let client code to avoid conditionals.
   if (request) {
     auto it = active_requests_.find(const_cast<AsyncClient::Request*>(request));
@@ -28,7 +27,6 @@ AsyncClientRequestTracker& AsyncClientRequestTracker::remove(const AsyncClient::
       active_requests_.erase(it);
     }
   }
-  return *this;
 }
 
 } // namespace Http

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -1,0 +1,36 @@
+#include "common/http/async_client_utility.h"
+
+namespace Envoy {
+namespace Http {
+
+AsyncClientRequestTracker::~AsyncClientRequestTracker() {
+  for (auto* active_request : active_requests_) {
+    active_request->cancel();
+  }
+}
+
+AsyncClientRequestTracker& AsyncClientRequestTracker::operator+=(AsyncClient::Request* request) {
+  // Let client code to avoid conditionals.
+  if (request) {
+    ASSERT(active_requests_.find(request) == active_requests_.end());
+    active_requests_.insert(request);
+  }
+  return *this;
+}
+
+AsyncClientRequestTracker&
+AsyncClientRequestTracker::operator-=(const AsyncClient::Request* request) {
+  // Let client code to avoid conditionals.
+  if (request) {
+    auto it = active_requests_.find(const_cast<AsyncClient::Request*>(request));
+    // Support a use case where request callbacks might get called prior to a request handle
+    // is returned from AsyncClient::send().
+    if (it != active_requests_.end()) {
+      active_requests_.erase(it);
+    }
+  }
+  return *this;
+}
+
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -15,6 +15,9 @@ void AsyncClientRequestTracker::add(AsyncClient::Request& request) {
 }
 
 void AsyncClientRequestTracker::remove(const AsyncClient::Request& request) {
+  // Notice that use of "const_cast" here is motivated by keeping API convenient for client code.
+  // In the context where remove() will be typically called, request.cancel() is no longer
+  // desirable and therefore get prevented by means of "const" modifier.
   auto it = active_requests_.find(const_cast<AsyncClient::Request*>(&request));
   // Support a use case where request callbacks might get called prior to a request handle
   // is returned from AsyncClient::send().

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -21,6 +21,15 @@ public:
   void add(AsyncClient::Request& request);
   /**
    * Excludes a given async HTTP request from a set of known active requests.
+   *
+   * NOTE: Asymmetry between signatures of add() and remove() is caused by the difference
+   *       between contexts in which these methods will be used.
+   *       add() will be called right after AsyncClient::send() when request.cancel() is
+   *       perfectly valid and desirable.
+   *       However, remove() will be called in the context of
+   *       AsyncClient::Callbacks::[onSuccess | onFailure] where request.cancel() is no longer
+   *       expected and therefore get prevented by means of "const" modifier.
+   *
    * @param request request handle
    */
   void remove(const AsyncClient::Request& request);

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "envoy/http/async_client.h"
+
+namespace Envoy {
+namespace Http {
+
+/**
+ * Keeps track of active async HTTP requests to be able to cancel them on destruction.
+ */
+class AsyncClientRequestTracker {
+public:
+  /**
+   * Cancels all known active async HTTP requests.
+   */
+  ~AsyncClientRequestTracker();
+  /**
+   * Includes a given async HTTP request into a set of known active requests.
+   */
+  AsyncClientRequestTracker& operator+=(AsyncClient::Request* request);
+  /**
+   * Excludes a given async HTTP request from a set of known active requests.
+   */
+  AsyncClientRequestTracker& operator-=(const AsyncClient::Request* request);
+
+private:
+  // Track active async HTTP requests to be able to cancel them on destruction.
+  std::unordered_set<AsyncClient::Request*> active_requests_;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -17,11 +17,11 @@ public:
   /**
    * Includes a given async HTTP request into a set of known active requests.
    */
-  void add(AsyncClient::Request* request);
+  void add(AsyncClient::Request& request);
   /**
    * Excludes a given async HTTP request from a set of known active requests.
    */
-  void remove(const AsyncClient::Request* request);
+  void remove(const AsyncClient::Request& request);
 
 private:
   // Track active async HTTP requests to be able to cancel them on destruction.

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -25,7 +25,7 @@ public:
 
 private:
   // Track active async HTTP requests to be able to cancel them on destruction.
-  std::unordered_set<AsyncClient::Request*> active_requests_;
+  absl::flat_hash_set<AsyncClient::Request*> active_requests_;
 };
 
 } // namespace Http

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -17,11 +17,11 @@ public:
   /**
    * Includes a given async HTTP request into a set of known active requests.
    */
-  AsyncClientRequestTracker& operator+=(AsyncClient::Request* request);
+  AsyncClientRequestTracker& add(AsyncClient::Request* request);
   /**
    * Excludes a given async HTTP request from a set of known active requests.
    */
-  AsyncClientRequestTracker& operator-=(const AsyncClient::Request* request);
+  AsyncClientRequestTracker& remove(const AsyncClient::Request* request);
 
 private:
   // Track active async HTTP requests to be able to cancel them on destruction.

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -16,10 +16,12 @@ public:
   ~AsyncClientRequestTracker();
   /**
    * Includes a given async HTTP request into a set of known active requests.
+   * @param request request handle
    */
   void add(AsyncClient::Request& request);
   /**
    * Excludes a given async HTTP request from a set of known active requests.
+   * @param request request handle
    */
   void remove(const AsyncClient::Request& request);
 

--- a/source/common/http/async_client_utility.h
+++ b/source/common/http/async_client_utility.h
@@ -17,11 +17,11 @@ public:
   /**
    * Includes a given async HTTP request into a set of known active requests.
    */
-  AsyncClientRequestTracker& add(AsyncClient::Request* request);
+  void add(AsyncClient::Request* request);
   /**
    * Excludes a given async HTTP request from a set of known active requests.
    */
-  AsyncClientRequestTracker& remove(const AsyncClient::Request* request);
+  void remove(const AsyncClient::Request* request);
 
 private:
   // Track active async HTTP requests to be able to cancel them on destruction.

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -37,6 +37,15 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "async_client_utility_test",
+    srcs = ["async_client_utility_test.cc"],
+    deps = [
+        "//source/common/http:async_client_utility_lib",
+        "//test/mocks/http:http_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "codec_client_test",
     srcs = ["codec_client_test.cc"],
     deps = [

--- a/test/common/http/async_client_utility_test.cc
+++ b/test/common/http/async_client_utility_test.cc
@@ -23,6 +23,11 @@ public:
   StrictMock<MockAsyncClientRequest> request3_{&async_client_};
 };
 
+TEST_F(AsyncClientRequestTrackerTest, ShouldSupportRemoveWithoutAdd) {
+  // Should not fail.
+  active_requests_->remove(request1_);
+}
+
 TEST_F(AsyncClientRequestTrackerTest, OnDestructDoNothingIfThereAreNoActiveRequests) {
   // Trigger destruction.
   active_requests_.reset();

--- a/test/common/http/async_client_utility_test.cc
+++ b/test/common/http/async_client_utility_test.cc
@@ -30,11 +30,11 @@ TEST_F(AsyncClientRequestTrackerTest, OnDestructDoNothingIfThereAreNoActiveReque
 
 TEST_F(AsyncClientRequestTrackerTest, OnDestructCancelActiveRequests) {
   // Include active requests.
-  *active_requests_ += &request1_;
-  *active_requests_ += &request2_;
-  *active_requests_ += &request3_;
+  active_requests_->add(&request1_);
+  active_requests_->add(&request2_);
+  active_requests_->add(&request3_);
   // Exclude active requests.
-  *active_requests_ -= &request2_;
+  active_requests_->remove(&request2_);
 
   // Must cancel active requests on destruction.
   EXPECT_CALL(request1_, cancel());

--- a/test/common/http/async_client_utility_test.cc
+++ b/test/common/http/async_client_utility_test.cc
@@ -1,0 +1,49 @@
+#include "common/http/async_client_utility.h"
+
+#include "test/mocks/http/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+using testing::StrictMock;
+
+namespace Envoy {
+namespace Http {
+namespace {
+
+class AsyncClientRequestTrackerTest : public testing::Test {
+public:
+  std::unique_ptr<AsyncClientRequestTracker> active_requests_{
+      std::make_unique<AsyncClientRequestTracker>()};
+
+  NiceMock<MockAsyncClient> async_client_;
+  StrictMock<MockAsyncClientRequest> request1_{&async_client_};
+  StrictMock<MockAsyncClientRequest> request2_{&async_client_};
+  StrictMock<MockAsyncClientRequest> request3_{&async_client_};
+};
+
+TEST_F(AsyncClientRequestTrackerTest, OnDestructDoNothingIfThereAreNoActiveRequests) {
+  // Trigger destruction.
+  active_requests_.reset();
+}
+
+TEST_F(AsyncClientRequestTrackerTest, OnDestructCancelActiveRequests) {
+  // Include active requests.
+  *active_requests_ += &request1_;
+  *active_requests_ += &request2_;
+  *active_requests_ += &request3_;
+  // Exclude active requests.
+  *active_requests_ -= &request2_;
+
+  // Must cancel active requests on destruction.
+  EXPECT_CALL(request1_, cancel());
+  EXPECT_CALL(request3_, cancel());
+
+  // Trigger destruction.
+  active_requests_.reset();
+}
+
+} // namespace
+} // namespace Http
+} // namespace Envoy

--- a/test/common/http/async_client_utility_test.cc
+++ b/test/common/http/async_client_utility_test.cc
@@ -30,11 +30,11 @@ TEST_F(AsyncClientRequestTrackerTest, OnDestructDoNothingIfThereAreNoActiveReque
 
 TEST_F(AsyncClientRequestTrackerTest, OnDestructCancelActiveRequests) {
   // Include active requests.
-  active_requests_->add(&request1_);
-  active_requests_->add(&request2_);
-  active_requests_->add(&request3_);
+  active_requests_->add(request1_);
+  active_requests_->add(request2_);
+  active_requests_->add(request3_);
   // Exclude active requests.
-  active_requests_->remove(&request2_);
+  active_requests_->remove(request2_);
 
   // Must cancel active requests on destruction.
   EXPECT_CALL(request1_, cancel());


### PR DESCRIPTION
Description: introduce `AsyncClientRequestTracker` to keep track of inflight requests and cancel them on destruction
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Context:
* related to #9998 

Motivation:
* some tracers implementations, e.g. `zipkin` and `datadog`, allow concurrent inflight requests to trace collector
* it's important to track those requests  and cancel them in case tracer gets removed
* `AsyncClientRequestTracker` is meant to be reusable in such cases