### PR TITLE
[config] Add basic config validators for path rewrite, host rewrite and redirect actions

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -786,7 +786,8 @@ message RouteAction {
   //
   //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
   //   requests to */prefix/etc* will be stripped to */etc*.
-  string prefix_rewrite = 5;
+  string prefix_rewrite = 5
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Indicates that during forwarding, portions of the path that match the
   // pattern should be rewritten, even allowing the substitution of capture
@@ -821,7 +822,10 @@ message RouteAction {
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
     // this value.
-    string host_rewrite = 6 [(udpa.annotations.field_migrate).rename = "host_rewrite_literal"];
+    string host_rewrite = 6 [
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false},
+      (udpa.annotations.field_migrate).rename = "host_rewrite_literal"
+    ];
 
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
@@ -838,8 +842,10 @@ message RouteAction {
     //
     //   Pay attention to the potential security implications of using this option. Provided header
     //   must come from trusted source.
-    string auto_host_rewrite_header = 29
-        [(udpa.annotations.field_migrate).rename = "host_rewrite_header"];
+    string auto_host_rewrite_header = 29 [
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).rename = "host_rewrite_header"
+    ];
   }
 
   // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
@@ -1132,14 +1138,16 @@ message RedirectAction {
   }
 
   // The host portion of the URL will be swapped with this value.
-  string host_redirect = 1;
+  string host_redirect = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // The port value of the URL will be swapped with this value.
   uint32 port_redirect = 8;
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
-    string path_redirect = 2;
+    string path_redirect = 2
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during redirection, the matched prefix (or path)
     // should be swapped with this value. This option allows redirect URLs be dynamically created
@@ -1149,7 +1157,8 @@ message RedirectAction {
     //
     //   Pay attention to the use of trailing slashes as mentioned in
     //   :ref:`RouteAction's prefix_rewrite <envoy_api_field_route.RouteAction.prefix_rewrite>`.
-    string prefix_rewrite = 5;
+    string prefix_rewrite = 5
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
   }
 
   // The HTTP status code to use in the redirect response. The default response

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -762,7 +762,8 @@ message RouteAction {
   //
   //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
   //   requests to */prefix/etc* will be stripped to */etc*.
-  string prefix_rewrite = 5;
+  string prefix_rewrite = 5
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Indicates that during forwarding, portions of the path that match the
   // pattern should be rewritten, even allowing the substitution of capture
@@ -797,7 +798,8 @@ message RouteAction {
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
     // this value.
-    string host_rewrite_literal = 6;
+    string host_rewrite_literal = 6
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
@@ -814,7 +816,8 @@ message RouteAction {
     //
     //   Pay attention to the potential security implications of using this option. Provided header
     //   must come from trusted source.
-    string host_rewrite_header = 29;
+    string host_rewrite_header = 29
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
   }
 
   // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
@@ -1119,14 +1122,16 @@ message RedirectAction {
   }
 
   // The host portion of the URL will be swapped with this value.
-  string host_redirect = 1;
+  string host_redirect = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // The port value of the URL will be swapped with this value.
   uint32 port_redirect = 8;
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
-    string path_redirect = 2;
+    string path_redirect = 2
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during redirection, the matched prefix (or path)
     // should be swapped with this value. This option allows redirect URLs be dynamically created
@@ -1136,7 +1141,8 @@ message RedirectAction {
     //
     //   Pay attention to the use of trailing slashes as mentioned in
     //   :ref:`RouteAction's prefix_rewrite <envoy_api_field_config.route.v3.RouteAction.prefix_rewrite>`.
-    string prefix_rewrite = 5;
+    string prefix_rewrite = 5
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
   }
 
   // The HTTP status code to use in the redirect response. The default response

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -786,7 +786,8 @@ message RouteAction {
   //
   //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
   //   requests to */prefix/etc* will be stripped to */etc*.
-  string prefix_rewrite = 5;
+  string prefix_rewrite = 5
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Indicates that during forwarding, portions of the path that match the
   // pattern should be rewritten, even allowing the substitution of capture
@@ -821,7 +822,10 @@ message RouteAction {
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
     // this value.
-    string host_rewrite = 6 [(udpa.annotations.field_migrate).rename = "host_rewrite_literal"];
+    string host_rewrite = 6 [
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false},
+      (udpa.annotations.field_migrate).rename = "host_rewrite_literal"
+    ];
 
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
@@ -838,8 +842,10 @@ message RouteAction {
     //
     //   Pay attention to the potential security implications of using this option. Provided header
     //   must come from trusted source.
-    string auto_host_rewrite_header = 29
-        [(udpa.annotations.field_migrate).rename = "host_rewrite_header"];
+    string auto_host_rewrite_header = 29 [
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).rename = "host_rewrite_header"
+    ];
   }
 
   // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
@@ -1132,14 +1138,16 @@ message RedirectAction {
   }
 
   // The host portion of the URL will be swapped with this value.
-  string host_redirect = 1;
+  string host_redirect = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // The port value of the URL will be swapped with this value.
   uint32 port_redirect = 8;
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
-    string path_redirect = 2;
+    string path_redirect = 2
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during redirection, the matched prefix (or path)
     // should be swapped with this value. This option allows redirect URLs be dynamically created
@@ -1149,7 +1157,8 @@ message RedirectAction {
     //
     //   Pay attention to the use of trailing slashes as mentioned in
     //   :ref:`RouteAction's prefix_rewrite <envoy_api_field_route.RouteAction.prefix_rewrite>`.
-    string prefix_rewrite = 5;
+    string prefix_rewrite = 5
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
   }
 
   // The HTTP status code to use in the redirect response. The default response

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -836,7 +836,8 @@ message RouteAction {
   //
   //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
   //   requests to */prefix/etc* will be stripped to */etc*.
-  string prefix_rewrite = 5;
+  string prefix_rewrite = 5
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Indicates that during forwarding, portions of the path that match the
   // pattern should be rewritten, even allowing the substitution of capture
@@ -871,7 +872,8 @@ message RouteAction {
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
     // this value.
-    string host_rewrite_literal = 6;
+    string host_rewrite_literal = 6
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
@@ -888,7 +890,8 @@ message RouteAction {
     //
     //   Pay attention to the potential security implications of using this option. Provided header
     //   must come from trusted source.
-    string host_rewrite_header = 29;
+    string host_rewrite_header = 29
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
   }
 
   // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
@@ -1196,14 +1199,16 @@ message RedirectAction {
   }
 
   // The host portion of the URL will be swapped with this value.
-  string host_redirect = 1;
+  string host_redirect = 1
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // The port value of the URL will be swapped with this value.
   uint32 port_redirect = 8;
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
-    string path_redirect = 2;
+    string path_redirect = 2
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during redirection, the matched prefix (or path)
     // should be swapped with this value. This option allows redirect URLs be dynamically created
@@ -1213,7 +1218,8 @@ message RedirectAction {
     //
     //   Pay attention to the use of trailing slashes as mentioned in
     //   :ref:`RouteAction's prefix_rewrite <envoy_api_field_config.route.v3.RouteAction.prefix_rewrite>`.
-    string prefix_rewrite = 5;
+    string prefix_rewrite = 5
+        [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
   }
 
   // The HTTP status code to use in the redirect response. The default response

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3653,6 +3653,108 @@ virtual_hosts:
       "Only unique values for domains are permitted. Duplicate entry of domain bar.*");
 }
 
+TEST_F(RouteMatcherTest, TestInvalidCharactersInPrefixRewrites) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: www
+  domains: ["*"]
+  routes:
+  - match: { prefix: "/foo" }
+    route:
+      prefix_rewrite: "/\ndroptable"
+      cluster: www
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "RouteActionValidationError.PrefixRewrite:.*value does not match regex pattern");
+}
+
+TEST_F(RouteMatcherTest, TestInvalidCharactersInHostRewrites) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: www
+  domains: ["*"]
+  routes:
+  - match: { prefix: "/foo" }
+    route:
+      host_rewrite: "new_host\ndroptable"
+      cluster: www
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "RouteActionValidationError.HostRewriteLiteral:.*value does not match regex pattern");
+}
+
+TEST_F(RouteMatcherTest, TestInvalidCharactersInAutoHostRewrites) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: www
+  domains: ["*"]
+  routes:
+  - match: { prefix: "/foo" }
+    route:
+      auto_host_rewrite_header: "x-host\ndroptable"
+      cluster: www
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "RouteActionValidationError.HostRewriteHeader:.*value does not match regex pattern");
+}
+
+TEST_F(RouteMatcherTest, TestInvalidCharactersInHostRedirect) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: www
+  domains: ["*"]
+  routes:
+  - match: { prefix: "/foo" }
+    redirect: { host_redirect: "new.host\ndroptable" }
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "RedirectActionValidationError.HostRedirect:.*value does not match regex pattern");
+}
+
+TEST_F(RouteMatcherTest, TestInvalidCharactersInPathRedirect) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: www
+  domains: ["*"]
+  routes:
+  - match: { prefix: "/foo" }
+    redirect: { path_redirect: "/new_path\ndroptable" }
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "RedirectActionValidationError.PathRedirect:.*value does not match regex pattern");
+}
+
+TEST_F(RouteMatcherTest, TestInvalidCharactersInPrefixRewriteRedirect) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: www
+  domains: ["*"]
+  routes:
+  - match: { prefix: "/foo" }
+    redirect: { prefix_rewrite: "/new/prefix\ndroptable"}
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), factory_context_, true),
+      EnvoyException,
+      "RedirectActionValidationError.PrefixRewrite:.*value does not match regex pattern");
+}
+
 TEST_F(RouteMatcherTest, TestPrefixAndRegexRewrites) {
   const std::string yaml = R"EOF(
 virtual_hosts:


### PR DESCRIPTION
Description: Reject path rewrite, host rewrite and redirect config fields that contain \0, \r or \n characters.  This provides some basic protection against config errors that could result in problems due to the proxy, upstream and downstream disagreeing about the contents of headers.
Risk Level: medium
Testing: Added config tests that trigger on the new validations
Docs Changes: n/a
Release Notes: TBD
Fixes #10332
