### PR TITLE
[buffer] Change Buffer::getRawSlices API to improve performance and usability.

### DIFF
--- a/include/envoy/buffer/BUILD
+++ b/include/envoy/buffer/BUILD
@@ -11,6 +11,9 @@ envoy_package()
 envoy_cc_library(
     name = "buffer_interface",
     hdrs = ["buffer.h"],
+    external_deps = [
+        "abseil_inlined_vector",
+    ],
     deps = [
         "//include/envoy/api:os_sys_calls_interface",
         "//include/envoy/network:io_handle_interface",

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -125,13 +125,17 @@ public:
 
   /**
    * Fetch the raw buffer slices. This routine is optimized for performance.
-   * @param out supplies an array of RawSlice objects to fill.
-   * @param out_size supplies the size of out.
-   * @return the actual number of slices needed, which may be greater than out_size. Passing
-   *         nullptr for out and 0 for out_size will just return the size of the array needed
-   *         to capture all of the slice data.
+   * @param out supplies an array of RawSlice objects to fill. Must not be nullptr.
+   * @param out_size supplies the size of out. Must be greater than 0.
+   * @return the number of slices written to |out|.
    */
-  virtual uint64_t getRawSlices(RawSlice* out, uint64_t out_size) const PURE;
+  virtual uint64_t getAtMostNRawSlices(RawSlice* out, uint64_t out_size) const PURE;
+
+  /**
+   * Get the contents of the buffer as a vector of raw buffer slices.
+   * @return std::vector with RawSlice for every non-empty slice in the buffer.
+   */
+  virtual std::vector<RawSlice> getRawSlices() const PURE;
 
   /**
    * @return uint64_t the total length of the buffer (not necessarily contiguous in memory).

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "envoy/api/os_sys_calls.h"
 #include "envoy/common/exception.h"

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -4,7 +4,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "envoy/api/os_sys_calls.h"
 #include "envoy/common/exception.h"
@@ -16,6 +15,7 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Buffer {
@@ -128,32 +128,17 @@ public:
   virtual void drain(uint64_t size) PURE;
 
   /**
-   * Fetch the raw buffer slices. This routine is optimized for performance.
-   * @param out supplies an array of RawSlice objects to fill. Must not be nullptr.
-   * @param out_size supplies the size of out. Must be greater than 0.
-   * @return the number of slices written to |out|.
-   */
-  virtual uint64_t getAtMostNRawSlices(RawSlice* out, uint64_t out_size) const PURE;
-
-  /**
    * Fetch the raw buffer slices.
-   * @param raw_slices supplies the inline vector of RawSlice objects to fill.
+   * @param max_slices supplies an optional limit on the number of slices to fetch, for performance.
+   * @return RawSliceVector with non-empty slices in the buffer.
    */
-  virtual void getRawSlices(RawSliceVector& raw_slices) const PURE;
+  virtual RawSliceVector
+  getRawSlices(absl::optional<uint64_t> max_slices = absl::nullopt) const PURE;
 
   /**
    * @return uint64_t the total length of the buffer (not necessarily contiguous in memory).
    */
   virtual uint64_t length() const PURE;
-
-  /**
-   * Computes the number of non-empty slices in the buffer representation by iterating through the
-   * list of raw slices and counting the number of non-empty ones. This utility method exists for
-   * the purpose of UDP processing code which needs to make stronger checks on the number of slices
-   * used by the buffer representations, and some tests.
-   * @return the number of non-empty slices in the buffer representation, computed slowly.
-   */
-  virtual uint64_t numSlicesComputedSlowly() const PURE;
 
   /**
    * @return a pointer to the first byte of data that has been linearized out to size bytes.

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -95,8 +95,7 @@ AccessLogFileImpl::~AccessLogFileImpl() {
 }
 
 void AccessLogFileImpl::doWrite(Buffer::Instance& buffer) {
-  Buffer::RawSliceVector slices;
-  buffer.getRawSlices(slices);
+  Buffer::RawSliceVector slices = buffer.getRawSlices();
 
   // We must do the actual writes to disk under lock, so that we don't intermix chunks from
   // different AccessLogFileImpl pointing to the same underlying file. This can happen either via

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -95,7 +95,8 @@ AccessLogFileImpl::~AccessLogFileImpl() {
 }
 
 void AccessLogFileImpl::doWrite(Buffer::Instance& buffer) {
-  std::vector<Buffer::RawSlice> slices = buffer.getRawSlices();
+  Buffer::RawSliceVector slices;
+  buffer.getRawSlices(slices);
 
   // We must do the actual writes to disk under lock, so that we don't intermix chunks from
   // different AccessLogFileImpl pointing to the same underlying file. This can happen either via

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -95,9 +95,7 @@ AccessLogFileImpl::~AccessLogFileImpl() {
 }
 
 void AccessLogFileImpl::doWrite(Buffer::Instance& buffer) {
-  uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
+  std::vector<Buffer::RawSlice> slices = buffer.getRawSlices();
 
   // We must do the actual writes to disk under lock, so that we don't intermix chunks from
   // different AccessLogFileImpl pointing to the same underlying file. This can happen either via

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -519,7 +519,8 @@ public:
   void commit(RawSlice* iovecs, uint64_t num_iovecs) override;
   void copyOut(size_t start, uint64_t size, void* data) const override;
   void drain(uint64_t size) override;
-  uint64_t getRawSlices(RawSlice* out, uint64_t out_size) const override;
+  uint64_t getAtMostNRawSlices(RawSlice* out, uint64_t out_size) const override;
+  std::vector<RawSlice> getRawSlices() const override;
   uint64_t length() const override;
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -520,8 +520,9 @@ public:
   void copyOut(size_t start, uint64_t size, void* data) const override;
   void drain(uint64_t size) override;
   uint64_t getAtMostNRawSlices(RawSlice* out, uint64_t out_size) const override;
-  std::vector<RawSlice> getRawSlices() const override;
+  void getRawSlices(RawSliceVector& raw_slices) const override;
   uint64_t length() const override;
+  uint64_t numSlicesComputedSlowly() const override;
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -519,10 +519,8 @@ public:
   void commit(RawSlice* iovecs, uint64_t num_iovecs) override;
   void copyOut(size_t start, uint64_t size, void* data) const override;
   void drain(uint64_t size) override;
-  uint64_t getAtMostNRawSlices(RawSlice* out, uint64_t out_size) const override;
-  void getRawSlices(RawSliceVector& raw_slices) const override;
+  RawSliceVector getRawSlices(absl::optional<uint64_t> max_slices = absl::nullopt) const override;
   uint64_t length() const override;
-  uint64_t numSlicesComputedSlowly() const override;
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;

--- a/source/common/buffer/zero_copy_input_stream_impl.cc
+++ b/source/common/buffer/zero_copy_input_stream_impl.cc
@@ -26,7 +26,7 @@ bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
   }
 
   Buffer::RawSlice slice;
-  const uint64_t num_slices = buffer_->getRawSlices(&slice, 1);
+  const uint64_t num_slices = buffer_->getAtMostNRawSlices(&slice, 1);
 
   if (num_slices > 0 && slice.len_ > 0) {
     *data = slice.mem_;

--- a/source/common/buffer/zero_copy_input_stream_impl.cc
+++ b/source/common/buffer/zero_copy_input_stream_impl.cc
@@ -25,10 +25,10 @@ bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
     position_ = 0;
   }
 
-  Buffer::RawSlice slice;
-  const uint64_t num_slices = buffer_->getAtMostNRawSlices(&slice, 1);
+  Buffer::RawSliceVector slices = buffer_->getRawSlices(1);
 
-  if (num_slices > 0 && slice.len_ > 0) {
+  if (slices.size() > 0 && slices[0].len_ > 0) {
+    auto& slice = slices[0];
     *data = slice.mem_;
     *size = slice.len_;
     position_ = slice.len_;

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -194,13 +194,9 @@ std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
   std::string ret;
   ret.reserve(output_length);
 
-  uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
-
   uint64_t j = 0;
   uint8_t next_c = 0;
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : buffer.getRawSlices()) {
     const uint8_t* slice_mem = static_cast<const uint8_t*>(slice.mem_);
 
     for (uint64_t i = 0; i < slice.len_ && j < length; ++i, ++j) {

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -196,9 +196,7 @@ std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
 
   uint64_t j = 0;
   uint8_t next_c = 0;
-  Buffer::RawSliceVector slices;
-  buffer.getRawSlices(slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : buffer.getRawSlices()) {
     const uint8_t* slice_mem = static_cast<const uint8_t*>(slice.mem_);
 
     for (uint64_t i = 0; i < slice.len_ && j < length; ++i, ++j) {

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -196,7 +196,9 @@ std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
 
   uint64_t j = 0;
   uint8_t next_c = 0;
-  for (const Buffer::RawSlice& slice : buffer.getRawSlices()) {
+  Buffer::RawSliceVector slices;
+  buffer.getRawSlices(slices);
+  for (const Buffer::RawSlice& slice : slices) {
     const uint8_t* slice_mem = static_cast<const uint8_t*>(slice.mem_);
 
     for (uint64_t i = 0; i < slice.len_ && j < length; ++i, ++j) {

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -38,11 +38,7 @@ void ZlibCompressorImpl::init(CompressionLevel comp_level, CompressionStrategy c
 uint64_t ZlibCompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibCompressorImpl::compress(Buffer::Instance& buffer, State state) {
-  const uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
-
-  for (const Buffer::RawSlice& input_slice : slices) {
+  for (const Buffer::RawSlice& input_slice : buffer.getRawSlices()) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     // Z_NO_FLUSH tells the compressor to take the data in and compresses it as much as possible

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -38,9 +38,7 @@ void ZlibCompressorImpl::init(CompressionLevel comp_level, CompressionStrategy c
 uint64_t ZlibCompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibCompressorImpl::compress(Buffer::Instance& buffer, State state) {
-  Buffer::RawSliceVector input_slices;
-  buffer.getRawSlices(input_slices);
-  for (const Buffer::RawSlice& input_slice : input_slices) {
+  for (const Buffer::RawSlice& input_slice : buffer.getRawSlices()) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     // Z_NO_FLUSH tells the compressor to take the data in and compresses it as much as possible

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -38,7 +38,9 @@ void ZlibCompressorImpl::init(CompressionLevel comp_level, CompressionStrategy c
 uint64_t ZlibCompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibCompressorImpl::compress(Buffer::Instance& buffer, State state) {
-  for (const Buffer::RawSlice& input_slice : buffer.getRawSlices()) {
+  Buffer::RawSliceVector input_slices;
+  buffer.getRawSlices(input_slices);
+  for (const Buffer::RawSlice& input_slice : input_slices) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     // Z_NO_FLUSH tells the compressor to take the data in and compresses it as much as possible

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -37,11 +37,7 @@ uint64_t ZlibDecompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
                                       Buffer::Instance& output_buffer) {
-  const uint64_t num_slices = input_buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  input_buffer.getRawSlices(slices.begin(), num_slices);
-
-  for (const Buffer::RawSlice& input_slice : slices) {
+  for (const Buffer::RawSlice& input_slice : input_buffer.getRawSlices()) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     while (inflateNext()) {

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -37,7 +37,9 @@ uint64_t ZlibDecompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
                                       Buffer::Instance& output_buffer) {
-  for (const Buffer::RawSlice& input_slice : input_buffer.getRawSlices()) {
+  Buffer::RawSliceVector input_slices;
+  input_buffer.getRawSlices(input_slices);
+  for (const Buffer::RawSlice& input_slice : input_slices) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     while (inflateNext()) {

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -37,9 +37,7 @@ uint64_t ZlibDecompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
                                       Buffer::Instance& output_buffer) {
-  Buffer::RawSliceVector input_slices;
-  input_buffer.getRawSlices(input_slices);
-  for (const Buffer::RawSlice& input_slice : input_slices) {
+  for (const Buffer::RawSlice& input_slice : input_buffer.getRawSlices()) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     while (inflateNext()) {

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -60,7 +60,9 @@ void Decoder::frameDataEnd() {
 
 uint64_t FrameInspector::inspect(const Buffer::Instance& data) {
   uint64_t delta = 0;
-  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
+  Buffer::RawSliceVector slices;
+  data.getRawSlices(slices);
+  for (const Buffer::RawSlice& slice : slices) {
     uint8_t* mem = reinterpret_cast<uint8_t*>(slice.mem_);
     for (uint64_t j = 0; j < slice.len_;) {
       uint8_t c = *mem;

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -59,11 +59,8 @@ void Decoder::frameDataEnd() {
 }
 
 uint64_t FrameInspector::inspect(const Buffer::Instance& data) {
-  uint64_t count = data.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(count);
-  data.getRawSlices(slices.begin(), count);
   uint64_t delta = 0;
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     uint8_t* mem = reinterpret_cast<uint8_t*>(slice.mem_);
     for (uint64_t j = 0; j < slice.len_;) {
       uint8_t c = *mem;

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -60,9 +60,7 @@ void Decoder::frameDataEnd() {
 
 uint64_t FrameInspector::inspect(const Buffer::Instance& data) {
   uint64_t delta = 0;
-  Buffer::RawSliceVector slices;
-  data.getRawSlices(slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     uint8_t* mem = reinterpret_cast<uint8_t*>(slice.mem_);
     for (uint64_t j = 0; j < slice.len_;) {
       uint8_t c = *mem;

--- a/source/common/grpc/google_grpc_utils.cc
+++ b/source/common/grpc/google_grpc_utils.cc
@@ -66,7 +66,8 @@ grpc::ByteBuffer GoogleGrpcUtils::makeByteBuffer(Buffer::InstancePtr&& buffer_in
   if (!buffer_instance) {
     return {};
   }
-  std::vector<Buffer::RawSlice> raw_slices = buffer_instance->getRawSlices();
+  Buffer::RawSliceVector raw_slices;
+  buffer_instance->getRawSlices(raw_slices);
   if (raw_slices.empty()) {
     return {};
   }

--- a/source/common/grpc/google_grpc_utils.cc
+++ b/source/common/grpc/google_grpc_utils.cc
@@ -66,8 +66,7 @@ grpc::ByteBuffer GoogleGrpcUtils::makeByteBuffer(Buffer::InstancePtr&& buffer_in
   if (!buffer_instance) {
     return {};
   }
-  Buffer::RawSliceVector raw_slices;
-  buffer_instance->getRawSlices(raw_slices);
+  Buffer::RawSliceVector raw_slices = buffer_instance->getRawSlices();
   if (raw_slices.empty()) {
     return {};
   }

--- a/source/common/grpc/google_grpc_utils.cc
+++ b/source/common/grpc/google_grpc_utils.cc
@@ -66,24 +66,17 @@ grpc::ByteBuffer GoogleGrpcUtils::makeByteBuffer(Buffer::InstancePtr&& buffer_in
   if (!buffer_instance) {
     return {};
   }
-  Buffer::RawSlice on_raw_slice;
-  // NB: we need to pass in >= 1 in order to get the real "n" (see Buffer::Instance for details).
-  const int n_slices = buffer_instance->getRawSlices(&on_raw_slice, 1);
-  if (n_slices <= 0) {
+  std::vector<Buffer::RawSlice> raw_slices = buffer_instance->getRawSlices();
+  if (raw_slices.empty()) {
     return {};
   }
-  auto* container = new BufferInstanceContainer{n_slices, std::move(buffer_instance)};
-  if (n_slices == 1) {
-    grpc::Slice one_slice(on_raw_slice.mem_, on_raw_slice.len_,
-                          &BufferInstanceContainer::derefBufferInstanceContainer, container);
-    return {&one_slice, 1};
-  }
-  absl::FixedArray<Buffer::RawSlice> many_raw_slices(n_slices);
-  container->buffer_->getRawSlices(many_raw_slices.begin(), n_slices);
+
+  auto* container =
+      new BufferInstanceContainer{static_cast<int>(raw_slices.size()), std::move(buffer_instance)};
   std::vector<grpc::Slice> slices;
-  slices.reserve(n_slices);
-  for (int i = 0; i < n_slices; i++) {
-    slices.emplace_back(many_raw_slices[i].mem_, many_raw_slices[i].len_,
+  slices.reserve(raw_slices.size());
+  for (Buffer::RawSlice& raw_slice : raw_slices) {
+    slices.emplace_back(raw_slice.mem_, raw_slice.len_,
                         &BufferInstanceContainer::derefBufferInstanceContainer, container);
   }
   return {&slices[0], slices.size()};

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -451,10 +451,7 @@ bool ConnectionImpl::maybeDirectDispatch(Buffer::Instance& data) {
   }
 
   ssize_t total_parsed = 0;
-  uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  data.getRawSlices(slices.begin(), num_slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     total_parsed += slice.len_;
     onBody(static_cast<const char*>(slice.mem_), slice.len_);
   }
@@ -475,10 +472,7 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
 
   ssize_t total_parsed = 0;
   if (data.length() > 0) {
-    uint64_t num_slices = data.getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-    data.getRawSlices(slices.begin(), num_slices);
-    for (const Buffer::RawSlice& slice : slices) {
+    for (const Buffer::RawSlice& slice : data.getRawSlices()) {
       total_parsed += dispatchSlice(static_cast<const char*>(slice.mem_), slice.len_);
     }
   } else {

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -450,8 +450,10 @@ bool ConnectionImpl::maybeDirectDispatch(Buffer::Instance& data) {
     return false;
   }
 
+  Buffer::RawSliceVector slices;
+  data.getRawSlices(slices);
   ssize_t total_parsed = 0;
-  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
+  for (const Buffer::RawSlice& slice : slices) {
     total_parsed += slice.len_;
     onBody(static_cast<const char*>(slice.mem_), slice.len_);
   }
@@ -472,7 +474,9 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
 
   ssize_t total_parsed = 0;
   if (data.length() > 0) {
-    for (const Buffer::RawSlice& slice : data.getRawSlices()) {
+    Buffer::RawSliceVector slices;
+    data.getRawSlices(slices);
+    for (const Buffer::RawSlice& slice : slices) {
       total_parsed += dispatchSlice(static_cast<const char*>(slice.mem_), slice.len_);
     }
   } else {

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -450,10 +450,8 @@ bool ConnectionImpl::maybeDirectDispatch(Buffer::Instance& data) {
     return false;
   }
 
-  Buffer::RawSliceVector slices;
-  data.getRawSlices(slices);
   ssize_t total_parsed = 0;
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     total_parsed += slice.len_;
     onBody(static_cast<const char*>(slice.mem_), slice.len_);
   }
@@ -474,9 +472,7 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
 
   ssize_t total_parsed = 0;
   if (data.length() > 0) {
-    Buffer::RawSliceVector slices;
-    data.getRawSlices(slices);
-    for (const Buffer::RawSlice& slice : slices) {
+    for (const Buffer::RawSlice& slice : data.getRawSlices()) {
       total_parsed += dispatchSlice(static_cast<const char*>(slice.mem_), slice.len_);
     }
   } else {

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -450,9 +450,7 @@ ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {
   ENVOY_CONN_LOG(trace, "dispatching {} bytes", connection_, data.length());
-  Buffer::RawSliceVector slices;
-  data.getRawSlices(slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     dispatching_ = true;
     ssize_t rc =
         nghttp2_session_mem_recv(session_, static_cast<const uint8_t*>(slice.mem_), slice.len_);

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -450,7 +450,9 @@ ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {
   ENVOY_CONN_LOG(trace, "dispatching {} bytes", connection_, data.length());
-  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
+  Buffer::RawSliceVector slices;
+  data.getRawSlices(slices);
+  for (const Buffer::RawSlice& slice : slices) {
     dispatching_ = true;
     ssize_t rc =
         nghttp2_session_mem_recv(session_, static_cast<const uint8_t*>(slice.mem_), slice.len_);

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -450,10 +450,7 @@ ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {
   ENVOY_CONN_LOG(trace, "dispatching {} bytes", connection_, data.length());
-  uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  data.getRawSlices(slices.begin(), num_slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     dispatching_ = true;
     ssize_t rc =
         nghttp2_session_mem_recv(session_, static_cast<const uint8_t*>(slice.mem_), slice.len_);

--- a/source/common/http/http2/metadata_decoder.cc
+++ b/source/common/http/http2/metadata_decoder.cc
@@ -40,10 +40,8 @@ bool MetadataDecoder::onMetadataFrameComplete(bool end_metadata) {
 }
 
 bool MetadataDecoder::decodeMetadataPayloadUsingNghttp2(bool end_metadata) {
-  // Computes how many slices are needed to get all the data out.
-  const int num_slices = payload_.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  payload_.getRawSlices(slices.begin(), num_slices);
+  std::vector<Buffer::RawSlice> slices = payload_.getRawSlices();
+  const int num_slices = slices.size();
 
   // Data consumed by nghttp2 so far.
   ssize_t payload_size_consumed = 0;

--- a/source/common/http/http2/metadata_decoder.cc
+++ b/source/common/http/http2/metadata_decoder.cc
@@ -40,7 +40,8 @@ bool MetadataDecoder::onMetadataFrameComplete(bool end_metadata) {
 }
 
 bool MetadataDecoder::decodeMetadataPayloadUsingNghttp2(bool end_metadata) {
-  std::vector<Buffer::RawSlice> slices = payload_.getRawSlices();
+  Buffer::RawSliceVector slices;
+  payload_.getRawSlices(slices);
   const int num_slices = slices.size();
 
   // Data consumed by nghttp2 so far.

--- a/source/common/http/http2/metadata_decoder.cc
+++ b/source/common/http/http2/metadata_decoder.cc
@@ -40,8 +40,7 @@ bool MetadataDecoder::onMetadataFrameComplete(bool end_metadata) {
 }
 
 bool MetadataDecoder::decodeMetadataPayloadUsingNghttp2(bool end_metadata) {
-  Buffer::RawSliceVector slices;
-  payload_.getRawSlices(slices);
+  Buffer::RawSliceVector slices = payload_.getRawSlices();
   const int num_slices = slices.size();
 
   // Data consumed by nghttp2 so far.

--- a/source/common/http/message_impl.h
+++ b/source/common/http/message_impl.h
@@ -30,16 +30,11 @@ public:
     trailers_ = std::move(trailers);
   }
   std::string bodyAsString() const override {
-    std::string ret;
     if (body_) {
-      uint64_t num_slices = body_->getRawSlices(nullptr, 0);
-      absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-      body_->getRawSlices(slices.begin(), num_slices);
-      for (const Buffer::RawSlice& slice : slices) {
-        ret.append(reinterpret_cast<const char*>(slice.mem_), slice.len_);
-      }
+      return body_->toString();
+    } else {
+      return "";
     }
-    return ret;
   }
 
 private:

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -501,10 +501,9 @@ Utility::protobufAddressSocketType(const envoy::config::core::v3::Address& proto
 Api::IoCallUint64Result Utility::writeToSocket(IoHandle& handle, const Buffer::Instance& buffer,
                                                const Address::Ip* local_ip,
                                                const Address::Instance& peer_address) {
-  const uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
-  return writeToSocket(handle, slices.begin(), num_slices, local_ip, peer_address);
+  std::vector<Buffer::RawSlice> slices = buffer.getRawSlices();
+  return writeToSocket(handle, !slices.empty() ? &slices[0] : nullptr, slices.size(), local_ip,
+                       peer_address);
 }
 
 Api::IoCallUint64Result Utility::writeToSocket(IoHandle& handle, Buffer::RawSlice* slices,

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -501,8 +501,7 @@ Utility::protobufAddressSocketType(const envoy::config::core::v3::Address& proto
 Api::IoCallUint64Result Utility::writeToSocket(IoHandle& handle, const Buffer::Instance& buffer,
                                                const Address::Ip* local_ip,
                                                const Address::Instance& peer_address) {
-  Buffer::RawSliceVector slices;
-  buffer.getRawSlices(slices);
+  Buffer::RawSliceVector slices = buffer.getRawSlices();
   return writeToSocket(handle, !slices.empty() ? &slices[0] : nullptr, slices.size(), local_ip,
                        peer_address);
 }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -501,7 +501,8 @@ Utility::protobufAddressSocketType(const envoy::config::core::v3::Address& proto
 Api::IoCallUint64Result Utility::writeToSocket(IoHandle& handle, const Buffer::Instance& buffer,
                                                const Address::Ip* local_ip,
                                                const Address::Instance& peer_address) {
-  std::vector<Buffer::RawSlice> slices = buffer.getRawSlices();
+  Buffer::RawSliceVector slices;
+  buffer.getRawSlices(slices);
   return writeToSocket(handle, !slices.empty() ? &slices[0] : nullptr, slices.size(), local_ip,
                        peer_address);
 }

--- a/source/extensions/common/crypto/utility_impl.cc
+++ b/source/extensions/common/crypto/utility_impl.cc
@@ -17,10 +17,7 @@ std::vector<uint8_t> UtilityImpl::getSha256Digest(const Buffer::Instance& buffer
   bssl::ScopedEVP_MD_CTX ctx;
   auto rc = EVP_DigestInit(ctx.get(), EVP_sha256());
   RELEASE_ASSERT(rc == 1, "Failed to init digest context");
-  const auto num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
-  for (const auto& slice : slices) {
+  for (const auto& slice : buffer.getRawSlices()) {
     rc = EVP_DigestUpdate(ctx.get(), slice.mem_, slice.len_);
     RELEASE_ASSERT(rc == 1, "Failed to update digest");
   }

--- a/source/extensions/common/crypto/utility_impl.cc
+++ b/source/extensions/common/crypto/utility_impl.cc
@@ -17,9 +17,7 @@ std::vector<uint8_t> UtilityImpl::getSha256Digest(const Buffer::Instance& buffer
   bssl::ScopedEVP_MD_CTX ctx;
   auto rc = EVP_DigestInit(ctx.get(), EVP_sha256());
   RELEASE_ASSERT(rc == 1, "Failed to init digest context");
-  Buffer::RawSliceVector slices;
-  buffer.getRawSlices(slices);
-  for (const auto& slice : slices) {
+  for (const auto& slice : buffer.getRawSlices()) {
     rc = EVP_DigestUpdate(ctx.get(), slice.mem_, slice.len_);
     RELEASE_ASSERT(rc == 1, "Failed to update digest");
   }

--- a/source/extensions/common/crypto/utility_impl.cc
+++ b/source/extensions/common/crypto/utility_impl.cc
@@ -17,7 +17,9 @@ std::vector<uint8_t> UtilityImpl::getSha256Digest(const Buffer::Instance& buffer
   bssl::ScopedEVP_MD_CTX ctx;
   auto rc = EVP_DigestInit(ctx.get(), EVP_sha256());
   RELEASE_ASSERT(rc == 1, "Failed to init digest context");
-  for (const auto& slice : buffer.getRawSlices()) {
+  Buffer::RawSliceVector slices;
+  buffer.getRawSlices(slices);
+  for (const auto& slice : slices) {
     rc = EVP_DigestUpdate(ctx.get(), slice.mem_, slice.len_);
     RELEASE_ASSERT(rc == 1, "Failed to update digest");
   }

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -28,9 +28,7 @@ bool Utility::addBufferToProtoBytes(envoy::data::tap::v3::Body& output_body,
   ASSERT(buffer_start_offset + buffer_length_to_copy <= data.length());
   const uint32_t final_bytes_to_copy = std::min(max_buffered_bytes, buffer_length_to_copy);
 
-  const uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  data.getRawSlices(slices.begin(), num_slices);
+  std::vector<Buffer::RawSlice> slices = data.getRawSlices();
   trimSlices(slices, buffer_start_offset, final_bytes_to_copy);
   for (const Buffer::RawSlice& slice : slices) {
     output_body.mutable_as_bytes()->append(static_cast<const char*>(slice.mem_), slice.len_);

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -28,8 +28,7 @@ bool Utility::addBufferToProtoBytes(envoy::data::tap::v3::Body& output_body,
   ASSERT(buffer_start_offset + buffer_length_to_copy <= data.length());
   const uint32_t final_bytes_to_copy = std::min(max_buffered_bytes, buffer_length_to_copy);
 
-  Buffer::RawSliceVector slices;
-  data.getRawSlices(slices);
+  Buffer::RawSliceVector slices = data.getRawSlices();
   trimSlices(slices, buffer_start_offset, final_bytes_to_copy);
   for (const Buffer::RawSlice& slice : slices) {
     output_body.mutable_as_bytes()->append(static_cast<const char*>(slice.mem_), slice.len_);

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -28,7 +28,8 @@ bool Utility::addBufferToProtoBytes(envoy::data::tap::v3::Body& output_body,
   ASSERT(buffer_start_offset + buffer_length_to_copy <= data.length());
   const uint32_t final_bytes_to_copy = std::min(max_buffered_bytes, buffer_length_to_copy);
 
-  std::vector<Buffer::RawSlice> slices = data.getRawSlices();
+  Buffer::RawSliceVector slices;
+  data.getRawSlices(slices);
   trimSlices(slices, buffer_start_offset, final_bytes_to_copy);
   for (const Buffer::RawSlice& slice : slices) {
     output_body.mutable_as_bytes()->append(static_cast<const char*>(slice.mem_), slice.len_);

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -137,13 +137,18 @@ Http::FilterTrailersStatus DynamoFilter::encodeTrailers(Http::ResponseTrailerMap
 std::string DynamoFilter::buildBody(const Buffer::Instance* buffered,
                                     const Buffer::Instance& last) {
   std::string body;
+  body.reserve((buffered ? buffered->length() : 0) + last.length());
   if (buffered) {
-    for (const Buffer::RawSlice& slice : buffered->getRawSlices()) {
+    Buffer::RawSliceVector slices;
+    buffered->getRawSlices(slices);
+    for (const Buffer::RawSlice& slice : slices) {
       body.append(static_cast<const char*>(slice.mem_), slice.len_);
     }
   }
 
-  for (const Buffer::RawSlice& slice : last.getRawSlices()) {
+  Buffer::RawSliceVector slices;
+  last.getRawSlices(slices);
+  for (const Buffer::RawSlice& slice : slices) {
     body.append(static_cast<const char*>(slice.mem_), slice.len_);
   }
 

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -138,18 +138,12 @@ std::string DynamoFilter::buildBody(const Buffer::Instance* buffered,
                                     const Buffer::Instance& last) {
   std::string body;
   if (buffered) {
-    uint64_t num_slices = buffered->getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-    buffered->getRawSlices(slices.begin(), num_slices);
-    for (const Buffer::RawSlice& slice : slices) {
+    for (const Buffer::RawSlice& slice : buffered->getRawSlices()) {
       body.append(static_cast<const char*>(slice.mem_), slice.len_);
     }
   }
 
-  uint64_t num_slices = last.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  last.getRawSlices(slices.begin(), num_slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : last.getRawSlices()) {
     body.append(static_cast<const char*>(slice.mem_), slice.len_);
   }
 

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -139,16 +139,12 @@ std::string DynamoFilter::buildBody(const Buffer::Instance* buffered,
   std::string body;
   body.reserve((buffered ? buffered->length() : 0) + last.length());
   if (buffered) {
-    Buffer::RawSliceVector slices;
-    buffered->getRawSlices(slices);
-    for (const Buffer::RawSlice& slice : slices) {
+    for (const Buffer::RawSlice& slice : buffered->getRawSlices()) {
       body.append(static_cast<const char*>(slice.mem_), slice.len_);
     }
   }
 
-  Buffer::RawSliceVector slices;
-  last.getRawSlices(slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : last.getRawSlices()) {
     body.append(static_cast<const char*>(slice.mem_), slice.len_);
   }
 

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -309,14 +309,7 @@ void SquashFilter::cleanup() {
 
 Json::ObjectSharedPtr SquashFilter::getJsonBody(Http::ResponseMessagePtr&& m) {
   Buffer::InstancePtr& data = m->body();
-  uint64_t num_slices = data->getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  data->getRawSlices(slices.begin(), num_slices);
-  std::string jsonbody;
-  for (const Buffer::RawSlice& slice : slices) {
-    jsonbody += std::string(static_cast<const char*>(slice.mem_), slice.len_);
-  }
-
+  std::string jsonbody = data->toString();
   return Json::Factory::loadFromString(jsonbody);
 }
 

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -330,10 +330,7 @@ RespValue::CompositeArray::CompositeArrayConstIterator::empty() {
 }
 
 void DecoderImpl::decode(Buffer::Instance& data) {
-  uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  data.getRawSlices(slices.begin(), num_slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     parseSlice(slice);
   }
 

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -330,9 +330,7 @@ RespValue::CompositeArray::CompositeArrayConstIterator::empty() {
 }
 
 void DecoderImpl::decode(Buffer::Instance& data) {
-  Buffer::RawSliceVector slices;
-  data.getRawSlices(slices);
-  for (const Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     parseSlice(slice);
   }
 

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -330,7 +330,9 @@ RespValue::CompositeArray::CompositeArrayConstIterator::empty() {
 }
 
 void DecoderImpl::decode(Buffer::Instance& data) {
-  for (const Buffer::RawSlice& slice : data.getRawSlices()) {
+  Buffer::RawSliceVector slices;
+  data.getRawSlices(slices);
+  for (const Buffer::RawSlice& slice : slices) {
     parseSlice(slice);
   }
 

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -66,11 +66,8 @@ public:
    * Impl note: similar to redis codec, which also keeps state.
    */
   void onData(Buffer::Instance& data) override {
-    // Convert buffer to slices and pass them to `doParse`.
-    uint64_t num_slices = data.getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-    data.getRawSlices(slices.begin(), num_slices);
-    for (const Buffer::RawSlice& slice : slices) {
+    // Pass slices to `doParse`.
+    for (const Buffer::RawSlice& slice : data.getRawSlices()) {
       doParse(slice);
     }
   }

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -67,9 +67,7 @@ public:
    */
   void onData(Buffer::Instance& data) override {
     // Pass slices to `doParse`.
-    Buffer::RawSliceVector slices;
-    data.getRawSlices(slices);
-    for (const Buffer::RawSlice& slice : slices) {
+    for (const Buffer::RawSlice& slice : data.getRawSlices()) {
       doParse(slice);
     }
   }

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -67,7 +67,9 @@ public:
    */
   void onData(Buffer::Instance& data) override {
     // Pass slices to `doParse`.
-    for (const Buffer::RawSlice& slice : data.getRawSlices()) {
+    Buffer::RawSliceVector slices;
+    data.getRawSlices(slices);
+    for (const Buffer::RawSlice& slice : slices) {
       doParse(slice);
     }
   }

--- a/source/extensions/quic_listeners/quiche/active_quic_listener.cc
+++ b/source/extensions/quic_listeners/quiche/active_quic_listener.cc
@@ -81,7 +81,7 @@ void ActiveQuicListener::onData(Network::UdpRecvData& data) {
       quic::QuicTime::Delta::FromMicroseconds(std::chrono::duration_cast<std::chrono::microseconds>(
                                                   data.receive_time_.time_since_epoch())
                                                   .count());
-  ASSERT(data.buffer_->getRawSlices().size() == 1);
+  ASSERT(data.buffer_->numSlicesComputedSlowly() == 1);
   Buffer::RawSlice slice;
   data.buffer_->getAtMostNRawSlices(&slice, 1);
   // TODO(danzh): pass in TTL and UDP header.

--- a/source/extensions/quic_listeners/quiche/active_quic_listener.cc
+++ b/source/extensions/quic_listeners/quiche/active_quic_listener.cc
@@ -81,10 +81,9 @@ void ActiveQuicListener::onData(Network::UdpRecvData& data) {
       quic::QuicTime::Delta::FromMicroseconds(std::chrono::duration_cast<std::chrono::microseconds>(
                                                   data.receive_time_.time_since_epoch())
                                                   .count());
-  uint64_t num_slice = data.buffer_->getRawSlices(nullptr, 0);
-  ASSERT(num_slice == 1);
+  ASSERT(data.buffer_->getRawSlices().size() == 1);
   Buffer::RawSlice slice;
-  data.buffer_->getRawSlices(&slice, 1);
+  data.buffer_->getAtMostNRawSlices(&slice, 1);
   // TODO(danzh): pass in TTL and UDP header.
   quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,
                                   /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,

--- a/source/extensions/quic_listeners/quiche/active_quic_listener.cc
+++ b/source/extensions/quic_listeners/quiche/active_quic_listener.cc
@@ -81,12 +81,11 @@ void ActiveQuicListener::onData(Network::UdpRecvData& data) {
       quic::QuicTime::Delta::FromMicroseconds(std::chrono::duration_cast<std::chrono::microseconds>(
                                                   data.receive_time_.time_since_epoch())
                                                   .count());
-  ASSERT(data.buffer_->numSlicesComputedSlowly() == 1);
-  Buffer::RawSlice slice;
-  data.buffer_->getAtMostNRawSlices(&slice, 1);
+  ASSERT(data.buffer_->getRawSlices().size() == 1);
+  Buffer::RawSliceVector slices = data.buffer_->getRawSlices(/*max_slices=*/1);
   // TODO(danzh): pass in TTL and UDP header.
-  quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,
-                                  /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
+  quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slices[0].mem_), slices[0].len_,
+                                  timestamp, /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
                                   /*packet_headers=*/nullptr, /*headers_length=*/0,
                                   /*owns_header_buffer*/ false);
   quic_dispatcher_->ProcessPacket(self_address, peer_address, packet);

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
@@ -58,10 +58,9 @@ void EnvoyQuicClientConnection::processPacket(
       quic::QuicTime::Delta::FromMicroseconds(
           std::chrono::duration_cast<std::chrono::microseconds>(receive_time.time_since_epoch())
               .count());
-  uint64_t num_slice = buffer->getRawSlices(nullptr, 0);
-  ASSERT(num_slice == 1);
+  ASSERT(buffer->getRawSlices().size() == 1);
   Buffer::RawSlice slice;
-  buffer->getRawSlices(&slice, 1);
+  buffer->getAtMostNRawSlices(&slice, 1);
   quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,
                                   /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
                                   /*packet_headers=*/nullptr, /*headers_length=*/0,

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
@@ -58,7 +58,7 @@ void EnvoyQuicClientConnection::processPacket(
       quic::QuicTime::Delta::FromMicroseconds(
           std::chrono::duration_cast<std::chrono::microseconds>(receive_time.time_since_epoch())
               .count());
-  ASSERT(buffer->getRawSlices().size() == 1);
+  ASSERT(buffer->numSlicesComputedSlowly() == 1);
   Buffer::RawSlice slice;
   buffer->getAtMostNRawSlices(&slice, 1);
   quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
@@ -58,11 +58,10 @@ void EnvoyQuicClientConnection::processPacket(
       quic::QuicTime::Delta::FromMicroseconds(
           std::chrono::duration_cast<std::chrono::microseconds>(receive_time.time_since_epoch())
               .count());
-  ASSERT(buffer->numSlicesComputedSlowly() == 1);
-  Buffer::RawSlice slice;
-  buffer->getAtMostNRawSlices(&slice, 1);
-  quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slice.mem_), slice.len_, timestamp,
-                                  /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
+  ASSERT(buffer->getRawSlices().size() == 1);
+  Buffer::RawSliceVector slices = buffer->getRawSlices(/*max_slices=*/1);
+  quic::QuicReceivedPacket packet(reinterpret_cast<char*>(slices[0].mem_), slices[0].len_,
+                                  timestamp, /*owns_buffer=*/false, /*ttl=*/0, /*ttl_valid=*/false,
                                   /*packet_headers=*/nullptr, /*headers_length=*/0,
                                   /*owns_header_buffer*/ false);
   ProcessUdpPacket(envoyAddressInstanceToQuicSocketAddress(local_address),

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
@@ -25,19 +25,19 @@ QuicMemSliceImpl::QuicMemSliceImpl(QuicUniqueBufferPtr buffer, size_t length)
 QuicMemSliceImpl::QuicMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t length) {
   ASSERT(firstSliceLength(buffer) == length);
   single_slice_buffer_.move(buffer, length);
-  ASSERT(single_slice_buffer_.getRawSlices(nullptr, 0) == 1);
+  ASSERT(single_slice_buffer_.getRawSlices().size() == 1);
 }
 
 const char* QuicMemSliceImpl::data() const {
   Envoy::Buffer::RawSlice out;
-  uint64_t num_slices = single_slice_buffer_.getRawSlices(&out, 1);
+  uint64_t num_slices = single_slice_buffer_.getAtMostNRawSlices(&out, 1);
   ASSERT(num_slices <= 1);
   return static_cast<const char*>(out.mem_);
 }
 
 size_t QuicMemSliceImpl::firstSliceLength(Envoy::Buffer::Instance& buffer) {
   Envoy::Buffer::RawSlice slice;
-  uint64_t total_num = buffer.getRawSlices(&slice, 1);
+  uint64_t total_num = buffer.getAtMostNRawSlices(&slice, 1);
   ASSERT(total_num != 0);
   return slice.len_;
 }

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
@@ -25,7 +25,7 @@ QuicMemSliceImpl::QuicMemSliceImpl(QuicUniqueBufferPtr buffer, size_t length)
 QuicMemSliceImpl::QuicMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t length) {
   ASSERT(firstSliceLength(buffer) == length);
   single_slice_buffer_.move(buffer, length);
-  ASSERT(single_slice_buffer_.getRawSlices().size() == 1);
+  ASSERT(single_slice_buffer_.numSlicesComputedSlowly() == 1);
 }
 
 const char* QuicMemSliceImpl::data() const {

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
@@ -25,21 +25,19 @@ QuicMemSliceImpl::QuicMemSliceImpl(QuicUniqueBufferPtr buffer, size_t length)
 QuicMemSliceImpl::QuicMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t length) {
   ASSERT(firstSliceLength(buffer) == length);
   single_slice_buffer_.move(buffer, length);
-  ASSERT(single_slice_buffer_.numSlicesComputedSlowly() == 1);
+  ASSERT(single_slice_buffer_.getRawSlices().size() == 1);
 }
 
 const char* QuicMemSliceImpl::data() const {
-  Envoy::Buffer::RawSlice out;
-  uint64_t num_slices = single_slice_buffer_.getAtMostNRawSlices(&out, 1);
-  ASSERT(num_slices <= 1);
-  return static_cast<const char*>(out.mem_);
+  Envoy::Buffer::RawSliceVector slices = single_slice_buffer_.getRawSlices(/*max_slices=*/1);
+  ASSERT(slices.size() <= 1);
+  return !slices.empty() ? static_cast<const char*>(slices[0].mem_) : nullptr;
 }
 
 size_t QuicMemSliceImpl::firstSliceLength(Envoy::Buffer::Instance& buffer) {
-  Envoy::Buffer::RawSlice slice;
-  uint64_t total_num = buffer.getAtMostNRawSlices(&slice, 1);
-  ASSERT(total_num != 0);
-  return slice.len_;
+  Envoy::Buffer::RawSliceVector slices = buffer.getRawSlices(/*max_slices=*/1);
+  ASSERT(slices.size() == 1);
+  return slices[0].len_;
 }
 
 } // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
@@ -11,9 +11,8 @@
 namespace quic {
 
 quiche::QuicheStringPiece QuicMemSliceSpanImpl::GetData(size_t index) {
-  absl::FixedArray<Envoy::Buffer::RawSlice> slices(index + 1);
-  uint64_t num_slices = buffer_->getAtMostNRawSlices(slices.begin(), index + 1);
-  ASSERT(num_slices > index);
+  Envoy::Buffer::RawSliceVector slices = buffer_->getRawSlices(/*max_slices=*/index + 1);
+  ASSERT(slices.size() > index);
   return {reinterpret_cast<char*>(slices[index].mem_), slices[index].len_};
 }
 

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
@@ -11,10 +11,9 @@
 namespace quic {
 
 quiche::QuicheStringPiece QuicMemSliceSpanImpl::GetData(size_t index) {
-  uint64_t num_slices = buffer_->getRawSlices(nullptr, 0);
+  absl::FixedArray<Envoy::Buffer::RawSlice> slices(index + 1);
+  uint64_t num_slices = buffer_->getAtMostNRawSlices(slices.begin(), index + 1);
   ASSERT(num_slices > index);
-  absl::FixedArray<Envoy::Buffer::RawSlice> slices(num_slices);
-  buffer_->getRawSlices(slices.begin(), num_slices);
   return {reinterpret_cast<char*>(slices[index].mem_), slices[index].len_};
 }
 

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
@@ -45,7 +45,7 @@ public:
   // QuicMemSliceSpan
   quiche::QuicheStringPiece GetData(size_t index);
   QuicByteCount total_length() { return buffer_->length(); };
-  size_t NumSlices() { return buffer_->getRawSlices(nullptr, 0); }
+  size_t NumSlices() { return buffer_->getRawSlices().size(); }
   template <typename ConsumeFunction> QuicByteCount ConsumeAll(ConsumeFunction consume);
   bool empty() const { return buffer_->length() == 0; }
 
@@ -55,11 +55,8 @@ private:
 
 template <typename ConsumeFunction>
 QuicByteCount QuicMemSliceSpanImpl::ConsumeAll(ConsumeFunction consume) {
-  uint64_t num_slices = buffer_->getRawSlices(nullptr, 0);
-  absl::FixedArray<Envoy::Buffer::RawSlice> slices(num_slices);
-  buffer_->getRawSlices(slices.begin(), num_slices);
   size_t saved_length = 0;
-  for (auto& slice : slices) {
+  for (auto& slice : buffer_->getRawSlices()) {
     if (slice.len_ == 0) {
       continue;
     }

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
@@ -45,7 +45,7 @@ public:
   // QuicMemSliceSpan
   quiche::QuicheStringPiece GetData(size_t index);
   QuicByteCount total_length() { return buffer_->length(); };
-  size_t NumSlices() { return buffer_->getRawSlices().size(); }
+  size_t NumSlices() { return buffer_->numSlicesComputedSlowly(); }
   template <typename ConsumeFunction> QuicByteCount ConsumeAll(ConsumeFunction consume);
   bool empty() const { return buffer_->length() == 0; }
 
@@ -56,7 +56,9 @@ private:
 template <typename ConsumeFunction>
 QuicByteCount QuicMemSliceSpanImpl::ConsumeAll(ConsumeFunction consume) {
   size_t saved_length = 0;
-  for (auto& slice : buffer_->getRawSlices()) {
+  Envoy::Buffer::RawSliceVector slices;
+  buffer_->getRawSlices(slices);
+  for (auto& slice : slices) {
     if (slice.len_ == 0) {
       continue;
     }

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
@@ -45,7 +45,7 @@ public:
   // QuicMemSliceSpan
   quiche::QuicheStringPiece GetData(size_t index);
   QuicByteCount total_length() { return buffer_->length(); };
-  size_t NumSlices() { return buffer_->numSlicesComputedSlowly(); }
+  size_t NumSlices() { return buffer_->getRawSlices().size(); }
   template <typename ConsumeFunction> QuicByteCount ConsumeAll(ConsumeFunction consume);
   bool empty() const { return buffer_->length() == 0; }
 
@@ -56,9 +56,7 @@ private:
 template <typename ConsumeFunction>
 QuicByteCount QuicMemSliceSpanImpl::ConsumeAll(ConsumeFunction consume) {
   size_t saved_length = 0;
-  Envoy::Buffer::RawSliceVector slices;
-  buffer_->getRawSlices(slices);
-  for (auto& slice : slices) {
+  for (auto& slice : buffer_->getRawSlices()) {
     if (slice.len_ == 0) {
       continue;
     }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -152,8 +152,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
     }
   }
 
-  ENVOY_CONN_LOG(trace, "ssl read {} bytes into {} slices", callbacks_->connection(), bytes_read,
-                 read_buffer.getRawSlices().size());
+  ENVOY_CONN_LOG(trace, "ssl read {} bytes", callbacks_->connection(), bytes_read);
 
   return {action, bytes_read, end_stream};
 }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -153,7 +153,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
   }
 
   ENVOY_CONN_LOG(trace, "ssl read {} bytes into {} slices", callbacks_->connection(), bytes_read,
-                 read_buffer.getRawSlices(nullptr, 0));
+                 read_buffer.getRawSlices().size());
 
   return {action, bytes_read, end_stream};
 }

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -123,11 +123,13 @@ public:
     return 1;
   }
 
-  std::vector<Buffer::RawSlice> getRawSlices() const override {
-    return {{const_cast<char*>(start()), size_}};
+  void getRawSlices(Buffer::RawSliceVector& raw_slices) const override {
+    raw_slices.emplace_back(Buffer::RawSlice{const_cast<char*>(start()), size_});
   }
 
   uint64_t length() const override { return size_; }
+
+  uint64_t numSlicesComputedSlowly() const override { return 1; }
 
   void* linearize(uint32_t /*size*/) override {
     // Sketchy, but probably will work for test purposes.
@@ -385,7 +387,9 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     break;
   }
   case test::common::buffer::Action::kGetRawSlices: {
-    const uint64_t slices_needed = target_buffer.getRawSlices().size();
+    Buffer::RawSliceVector all_slices;
+    target_buffer.getRawSlices(all_slices);
+    const uint64_t slices_needed = all_slices.size();
     const uint64_t slices_tested =
         std::min(slices_needed, static_cast<uint64_t>(action.get_raw_slices()));
     if (slices_tested == 0) {

--- a/test/common/buffer/watermark_buffer_test.cc
+++ b/test/common/buffer/watermark_buffer_test.cc
@@ -264,11 +264,11 @@ TEST_F(WatermarkBufferTest, MoveWatermarks) {
   EXPECT_EQ(0, buffer_.length());
 }
 
-TEST_F(WatermarkBufferTest, GetAtMostNRawSlices) {
+TEST_F(WatermarkBufferTest, GetRawSlices) {
   buffer_.add(TEN_BYTES, 10);
 
-  RawSlice slices[2];
-  ASSERT_EQ(1, buffer_.getAtMostNRawSlices(&slices[0], 2));
+  RawSliceVector slices = buffer_.getRawSlices(/*max_slices=*/2);
+  ASSERT_EQ(1, slices.size());
   EXPECT_EQ(10, slices[0].len_);
   EXPECT_EQ(0, memcmp(slices[0].mem_, &TEN_BYTES[0], 10));
 

--- a/test/common/buffer/watermark_buffer_test.cc
+++ b/test/common/buffer/watermark_buffer_test.cc
@@ -264,11 +264,11 @@ TEST_F(WatermarkBufferTest, MoveWatermarks) {
   EXPECT_EQ(0, buffer_.length());
 }
 
-TEST_F(WatermarkBufferTest, GetRawSlices) {
+TEST_F(WatermarkBufferTest, GetAtMostNRawSlices) {
   buffer_.add(TEN_BYTES, 10);
 
   RawSlice slices[2];
-  ASSERT_EQ(1, buffer_.getRawSlices(&slices[0], 2));
+  ASSERT_EQ(1, buffer_.getAtMostNRawSlices(&slices[0], 2));
   EXPECT_EQ(10, slices[0].len_);
   EXPECT_EQ(0, memcmp(slices[0].mem_, &TEN_BYTES[0], 10));
 

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -14,9 +14,8 @@ namespace {
 class ZlibCompressorImplTest : public testing::Test {
 protected:
   void expectValidFlushedBuffer(const Buffer::OwnedImpl& output_buffer) {
-    uint64_t num_comp_slices = output_buffer.getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> compressed_slices(num_comp_slices);
-    output_buffer.getRawSlices(compressed_slices.begin(), num_comp_slices);
+    std::vector<Buffer::RawSlice> compressed_slices = output_buffer.getRawSlices();
+    const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(
         reinterpret_cast<unsigned char*>(compressed_slices[0].mem_), compressed_slices[0].len_);
@@ -35,9 +34,8 @@ protected:
 
   void expectValidFinishedBuffer(const Buffer::OwnedImpl& output_buffer,
                                  const uint32_t input_size) {
-    uint64_t num_comp_slices = output_buffer.getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> compressed_slices(num_comp_slices);
-    output_buffer.getRawSlices(compressed_slices.begin(), num_comp_slices);
+    std::vector<Buffer::RawSlice> compressed_slices = output_buffer.getRawSlices();
+    const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(
         reinterpret_cast<unsigned char*>(compressed_slices[0].mem_), compressed_slices[0].len_);

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -14,7 +14,8 @@ namespace {
 class ZlibCompressorImplTest : public testing::Test {
 protected:
   void expectValidFlushedBuffer(const Buffer::OwnedImpl& output_buffer) {
-    std::vector<Buffer::RawSlice> compressed_slices = output_buffer.getRawSlices();
+    Buffer::RawSliceVector compressed_slices;
+    output_buffer.getRawSlices(compressed_slices);
     const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(
@@ -34,7 +35,8 @@ protected:
 
   void expectValidFinishedBuffer(const Buffer::OwnedImpl& output_buffer,
                                  const uint32_t input_size) {
-    std::vector<Buffer::RawSlice> compressed_slices = output_buffer.getRawSlices();
+    Buffer::RawSliceVector compressed_slices;
+    output_buffer.getRawSlices(compressed_slices);
     const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -14,8 +14,7 @@ namespace {
 class ZlibCompressorImplTest : public testing::Test {
 protected:
   void expectValidFlushedBuffer(const Buffer::OwnedImpl& output_buffer) {
-    Buffer::RawSliceVector compressed_slices;
-    output_buffer.getRawSlices(compressed_slices);
+    Buffer::RawSliceVector compressed_slices = output_buffer.getRawSlices();
     const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(
@@ -35,8 +34,7 @@ protected:
 
   void expectValidFinishedBuffer(const Buffer::OwnedImpl& output_buffer,
                                  const uint32_t input_size) {
-    Buffer::RawSliceVector compressed_slices;
-    output_buffer.getRawSlices(compressed_slices);
+    Buffer::RawSliceVector compressed_slices = output_buffer.getRawSlices();
     const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -259,7 +259,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressOfMultipleSlices) {
     original_text.append(sample);
   }
 
-  const uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
+  const uint64_t num_slices = buffer.getRawSlices().size();
   EXPECT_EQ(num_slices, 20);
 
   Envoy::Compressor::ZlibCompressorImpl compressor;

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -259,9 +259,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressOfMultipleSlices) {
     original_text.append(sample);
   }
 
-  Buffer::RawSliceVector slices;
-  buffer.getRawSlices(slices);
-  const uint64_t num_slices = slices.size();
+  const uint64_t num_slices = buffer.getRawSlices().size();
   EXPECT_EQ(num_slices, 20);
 
   Envoy::Compressor::ZlibCompressorImpl compressor;

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -259,7 +259,9 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressOfMultipleSlices) {
     original_text.append(sample);
   }
 
-  const uint64_t num_slices = buffer.getRawSlices().size();
+  Buffer::RawSliceVector slices;
+  buffer.getRawSlices(slices);
+  const uint64_t num_slices = slices.size();
   EXPECT_EQ(num_slices, 20);
 
   Envoy::Compressor::ZlibCompressorImpl compressor;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1069,7 +1069,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedResponse) {
   ON_CALL(connection_, write(_, _)).WillByDefault(Invoke([&output](Buffer::Instance& data, bool) {
     // Verify that individual writes into the codec's output buffer were coalesced into a single
     // slice
-    ASSERT_EQ(1, data.getRawSlices(nullptr, 0));
+    ASSERT_EQ(1, data.getRawSlices().size());
     output.append(data.toString());
     data.drain(data.length());
   }));

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1069,7 +1069,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedResponse) {
   ON_CALL(connection_, write(_, _)).WillByDefault(Invoke([&output](Buffer::Instance& data, bool) {
     // Verify that individual writes into the codec's output buffer were coalesced into a single
     // slice
-    ASSERT_EQ(1, data.getRawSlices().size());
+    ASSERT_EQ(1, data.numSlicesComputedSlowly());
     output.append(data.toString());
     data.drain(data.length());
   }));

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1069,7 +1069,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedResponse) {
   ON_CALL(connection_, write(_, _)).WillByDefault(Invoke([&output](Buffer::Instance& data, bool) {
     // Verify that individual writes into the codec's output buffer were coalesced into a single
     // slice
-    ASSERT_EQ(1, data.numSlicesComputedSlowly());
+    ASSERT_EQ(1, data.getRawSlices().size());
     output.append(data.toString());
     data.drain(data.length());
   }));

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -93,8 +93,7 @@ protected:
   }
 
   void expectValidFinishedBuffer(const uint32_t content_length) {
-    Buffer::RawSliceVector compressed_slices;
-    data_.getRawSlices(compressed_slices);
+    Buffer::RawSliceVector compressed_slices = data_.getRawSlices();
     const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -93,9 +93,8 @@ protected:
   }
 
   void expectValidFinishedBuffer(const uint32_t content_length) {
-    uint64_t num_comp_slices = data_.getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> compressed_slices(num_comp_slices);
-    data_.getRawSlices(compressed_slices.begin(), num_comp_slices);
+    std::vector<Buffer::RawSlice> compressed_slices = data_.getRawSlices();
+    const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(
         reinterpret_cast<unsigned char*>(compressed_slices[0].mem_), compressed_slices[0].len_);

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -93,7 +93,8 @@ protected:
   }
 
   void expectValidFinishedBuffer(const uint32_t content_length) {
-    std::vector<Buffer::RawSlice> compressed_slices = data_.getRawSlices();
+    Buffer::RawSliceVector compressed_slices;
+    data_.getRawSlices(compressed_slices);
     const uint64_t num_comp_slices = compressed_slices.size();
 
     const std::string header_hex_str = Hex::encode(

--- a/test/extensions/filters/network/kafka/buffer_based_test.h
+++ b/test/extensions/filters/network/kafka/buffer_based_test.h
@@ -20,9 +20,8 @@ namespace Kafka {
 class BufferBasedTest {
 protected:
   const char* getBytes() {
-    absl::FixedArray<Envoy::Buffer::RawSlice> slices(1);
-    uint64_t num_slices = buffer_.getAtMostNRawSlices(slices.begin(), 1);
-    ASSERT(num_slices == 1);
+    Buffer::RawSliceVector slices = buffer_.getRawSlices(1);
+    ASSERT(slices.size() == 1);
     return reinterpret_cast<const char*>((slices[0]).mem_);
   }
 

--- a/test/extensions/filters/network/kafka/buffer_based_test.h
+++ b/test/extensions/filters/network/kafka/buffer_based_test.h
@@ -20,9 +20,9 @@ namespace Kafka {
 class BufferBasedTest {
 protected:
   const char* getBytes() {
-    uint64_t num_slices = buffer_.getRawSlices(nullptr, 0);
-    absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-    buffer_.getRawSlices(slices.begin(), num_slices);
+    absl::FixedArray<Envoy::Buffer::RawSlice> slices(1);
+    uint64_t num_slices = buffer_.getAtMostNRawSlices(slices.begin(), 1);
+    ASSERT(num_slices == 1);
     return reinterpret_cast<const char*>((slices[0]).mem_);
   }
 

--- a/test/extensions/filters/network/kafka/serialization_utilities.cc
+++ b/test/extensions/filters/network/kafka/serialization_utilities.cc
@@ -13,9 +13,9 @@ void assertStringViewIncrement(const absl::string_view incremented,
 }
 
 const char* getRawData(const Buffer::OwnedImpl& buffer) {
-  uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
+  absl::FixedArray<Buffer::RawSlice> slices(1);
+  uint64_t num_slices = buffer.getAtMostNRawSlices(slices.begin(), 1);
+  ASSERT(num_slices == 1);
   return reinterpret_cast<const char*>((slices[0]).mem_);
 }
 

--- a/test/extensions/filters/network/kafka/serialization_utilities.cc
+++ b/test/extensions/filters/network/kafka/serialization_utilities.cc
@@ -13,9 +13,8 @@ void assertStringViewIncrement(const absl::string_view incremented,
 }
 
 const char* getRawData(const Buffer::OwnedImpl& buffer) {
-  absl::FixedArray<Buffer::RawSlice> slices(1);
-  uint64_t num_slices = buffer.getAtMostNRawSlices(slices.begin(), 1);
-  ASSERT(num_slices == 1);
+  Buffer::RawSliceVector slices = buffer.getRawSlices(1);
+  ASSERT(slices.size() == 1);
   return reinterpret_cast<const char*>((slices[0]).mem_);
 }
 

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -730,7 +730,7 @@ TEST(EnvoyQuicMemSliceTest, ConstructMemSliceFromBuffer) {
   std::string str2(1024, 'a');
   // str2 is copied.
   buffer.add(str2);
-  EXPECT_EQ(1u, buffer.getRawSlices(nullptr, 0));
+  EXPECT_EQ(1u, buffer.getRawSlices().size());
   buffer.addBufferFragment(fragment);
 
   quic::QuicMemSlice slice1{quic::QuicMemSliceImpl(buffer, str2.length())};

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -730,7 +730,7 @@ TEST(EnvoyQuicMemSliceTest, ConstructMemSliceFromBuffer) {
   std::string str2(1024, 'a');
   // str2 is copied.
   buffer.add(str2);
-  EXPECT_EQ(1u, buffer.numSlicesComputedSlowly());
+  EXPECT_EQ(1u, buffer.getRawSlices().size());
   buffer.addBufferFragment(fragment);
 
   quic::QuicMemSlice slice1{quic::QuicMemSliceImpl(buffer, str2.length())};

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -730,7 +730,7 @@ TEST(EnvoyQuicMemSliceTest, ConstructMemSliceFromBuffer) {
   std::string str2(1024, 'a');
   // str2 is copied.
   buffer.add(str2);
-  EXPECT_EQ(1u, buffer.getRawSlices().size());
+  EXPECT_EQ(1u, buffer.numSlicesComputedSlowly());
   buffer.addBufferFragment(fragment);
 
   quic::QuicMemSlice slice1{quic::QuicMemSliceImpl(buffer, str2.length())};

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4409,7 +4409,9 @@ TEST_P(SslReadBufferLimitTest, SmallReadsIntoSameSlice) {
   EXPECT_CALL(*read_filter_, onData(_, _))
       .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> Network::FilterStatus {
         EXPECT_GE(expected_chunk_size, data.length());
-        EXPECT_EQ(1, data.getRawSlices().size());
+        Buffer::RawSliceVector slices;
+        data.getRawSlices(slices);
+        EXPECT_EQ(1, slices.size());
         filter_seen += data.length();
         data.drain(data.length());
         if (filter_seen == (write_size * num_writes)) {

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4409,7 +4409,7 @@ TEST_P(SslReadBufferLimitTest, SmallReadsIntoSameSlice) {
   EXPECT_CALL(*read_filter_, onData(_, _))
       .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> Network::FilterStatus {
         EXPECT_GE(expected_chunk_size, data.length());
-        EXPECT_EQ(1, data.getRawSlices(nullptr, 0));
+        EXPECT_EQ(1, data.getRawSlices().size());
         filter_seen += data.length();
         data.drain(data.length());
         if (filter_seen == (write_size * num_writes)) {

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4409,9 +4409,7 @@ TEST_P(SslReadBufferLimitTest, SmallReadsIntoSameSlice) {
   EXPECT_CALL(*read_filter_, onData(_, _))
       .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> Network::FilterStatus {
         EXPECT_GE(expected_chunk_size, data.length());
-        Buffer::RawSliceVector slices;
-        data.getRawSlices(slices);
-        EXPECT_EQ(1, slices.size());
+        EXPECT_EQ(1, data.getRawSlices().size());
         filter_seen += data.length();
         data.drain(data.length());
         if (filter_seen == (write_size * num_writes)) {

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -97,10 +97,8 @@ bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instan
   // Check whether the two buffers contain the same content. It is valid for the content
   // to be arranged differently in the buffers. For example, lhs could have one slice
   // containing 10 bytes while rhs has ten slices containing one byte each.
-  Buffer::RawSliceVector lhs_slices;
-  lhs.getRawSlices(lhs_slices);
-  Buffer::RawSliceVector rhs_slices;
-  rhs.getRawSlices(rhs_slices);
+  Buffer::RawSliceVector lhs_slices = lhs.getRawSlices();
+  Buffer::RawSliceVector rhs_slices = rhs.getRawSlices();
 
   size_t rhs_slice = 0;
   size_t rhs_offset = 0;

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -97,19 +97,16 @@ bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instan
   // Check whether the two buffers contain the same content. It is valid for the content
   // to be arranged differently in the buffers. For example, lhs could have one slice
   // containing 10 bytes while rhs has ten slices containing one byte each.
-  uint64_t lhs_num_slices = lhs.getRawSlices(nullptr, 0);
-  uint64_t rhs_num_slices = rhs.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> lhs_slices(lhs_num_slices);
-  lhs.getRawSlices(lhs_slices.begin(), lhs_num_slices);
-  absl::FixedArray<Buffer::RawSlice> rhs_slices(rhs_num_slices);
-  rhs.getRawSlices(rhs_slices.begin(), rhs_num_slices);
+  std::vector<Buffer::RawSlice> lhs_slices = lhs.getRawSlices();
+  std::vector<Buffer::RawSlice> rhs_slices = rhs.getRawSlices();
+
   size_t rhs_slice = 0;
   size_t rhs_offset = 0;
-  for (size_t lhs_slice = 0; lhs_slice < lhs_num_slices; lhs_slice++) {
+  for (size_t lhs_slice = 0; lhs_slice < lhs_slices.size(); lhs_slice++) {
     for (size_t lhs_offset = 0; lhs_offset < lhs_slices[lhs_slice].len_; lhs_offset++) {
       while (rhs_offset >= rhs_slices[rhs_slice].len_) {
         rhs_slice++;
-        ASSERT(rhs_slice < rhs_num_slices);
+        ASSERT(rhs_slice < rhs_slices.size());
         rhs_offset = 0;
       }
       auto lhs_str = static_cast<const uint8_t*>(lhs_slices[lhs_slice].mem_);

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -97,8 +97,10 @@ bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instan
   // Check whether the two buffers contain the same content. It is valid for the content
   // to be arranged differently in the buffers. For example, lhs could have one slice
   // containing 10 bytes while rhs has ten slices containing one byte each.
-  std::vector<Buffer::RawSlice> lhs_slices = lhs.getRawSlices();
-  std::vector<Buffer::RawSlice> rhs_slices = rhs.getRawSlices();
+  Buffer::RawSliceVector lhs_slices;
+  lhs.getRawSlices(lhs_slices);
+  Buffer::RawSliceVector rhs_slices;
+  rhs.getRawSlices(rhs_slices);
 
   size_t rhs_slice = 0;
   size_t rhs_offset = 0;


### PR DESCRIPTION
Description: Replace the Buffer::getRawSlices API with methods that have similar contract but better performance characteristics.

Buffer::getRawSlices now returns a RawSliceVector with all nonempty slices in the buffer.  It provides an optional max_slicer argument for cases where only a subset of the slices are needed. 
 This new API avoids the need to iterate through the whole slicer list to compute the size in cases where a subset of the slices are needed or a separate call to getRawSlices(nullptr, 0) to determine the number of nonempty slices and use of FixedArray in cases where iterating through the full contents of the buffer is required.  

Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a