### PR TITLE
[test] Transition some benchmarks over to take advantage of envoy_cc_benchmark_binary and envoy_benchmark_test

### DIFF
--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -2,9 +2,10 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -209,7 +210,7 @@ envoy_cc_test(
     deps = ["//source/common/common:callback_impl_lib"],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "utility_speed_test",
     srcs = ["utility_speed_test.cc"],
     external_deps = [
@@ -220,6 +221,11 @@ envoy_cc_test_binary(
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "utility_speed_test_benchmark_test",
+    benchmark_binary = "utility_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -246,8 +246,8 @@ static void BM_IntervalSetInsert17(benchmark::State& state) {
     interval_set.insert(3, 6);
     interval_set.insert(3, 20);
     interval_set.insert(3, 22);
-    interval_set.insert(-2, 23);
-    interval_set.insert(-3, 24);
+    interval_set.insert(23, 9223372036854775806UL);
+    interval_set.insert(24, 9223372036854775805UL);
   }
 }
 BENCHMARK(BM_IntervalSetInsert17);
@@ -275,12 +275,3 @@ static void BM_IntervalSet50ToVector(benchmark::State& state) {
 }
 BENCHMARK(BM_IntervalSet50ToVector);
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -2,9 +2,10 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
@@ -106,7 +107,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "codes_speed_test",
     srcs = ["codes_speed_test.cc"],
     external_deps = [
@@ -117,6 +118,11 @@ envoy_cc_test_binary(
         "//source/common/stats:isolated_store_lib",
         "//source/common/stats:stats_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "codes_speed_test_benchmark_test",
+    benchmark_binary = "codes_speed_test",
 )
 
 envoy_cc_test_library(
@@ -259,7 +265,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "header_map_impl_speed_test",
     srcs = ["header_map_impl_speed_test.cc"],
     external_deps = [
@@ -268,6 +274,11 @@ envoy_cc_test_binary(
     deps = [
         "//source/common/http:header_map_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "header_map_impl_speed_test_benchmark_test",
+    benchmark_binary = "header_map_impl_speed_test",
 )
 
 envoy_proto_library(

--- a/test/common/http/codes_speed_test.cc
+++ b/test/common/http/codes_speed_test.cc
@@ -111,13 +111,3 @@ static void BM_ResponseTimingRealSymtab(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ResponseTimingRealSymtab);
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -222,13 +222,3 @@ BENCHMARK(HeaderMapImplPopulate);
 
 } // namespace Http
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -2,6 +2,8 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_test",
     "envoy_cc_test_binary",
     "envoy_cc_test_library",
@@ -42,7 +44,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "address_impl_speed_test",
     srcs = ["address_impl_speed_test.cc"],
     external_deps = [
@@ -51,6 +53,11 @@ envoy_cc_test_binary(
     deps = [
         "//source/common/network:address_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "address_impl_speed_test_benchmark_test",
+    benchmark_binary = "address_impl_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/network/address_impl_speed_test.cc
+++ b/test/common/network/address_impl_speed_test.cc
@@ -36,13 +36,3 @@ BENCHMARK(Ipv6InstanceCreate);
 } // namespace Address
 } // namespace Network
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/extensions_build_system.bzl
+++ b/test/extensions/extensions_build_system.bzl
@@ -1,4 +1,4 @@
-load("//bazel:envoy_build_system.bzl", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library")
+load("//bazel:envoy_build_system.bzl", "envoy_benchmark_test", "envoy_cc_benchmark_binary", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library")
 load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
 
 # All extension tests should use this version of envoy_cc_test(). It allows compiling out
@@ -39,3 +39,21 @@ def envoy_extension_cc_test_binary(
         return
 
     envoy_cc_test_binary(name, **kwargs)
+
+def envoy_extension_cc_benchmark_binary(
+        name,
+        extension_name,
+        **kwargs):
+    if not extension_name in EXTENSIONS:
+        return
+
+    envoy_cc_benchmark_binary(name, **kwargs)
+
+def envoy_extension_benchmark_test(
+        name,
+        extension_name,
+        **kwargs):
+    if not extension_name in EXTENSIONS:
+        return
+
+    envoy_benchmark_test(name, **kwargs)

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -4,8 +4,12 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_benchmark_test",
+    "envoy_extension_cc_benchmark_binary",
 )
 
 envoy_package()
@@ -24,9 +28,10 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_extension_cc_benchmark_binary(
     name = "tls_inspector_benchmark",
     srcs = ["tls_inspector_benchmark.cc"],
+    extension_name = "envoy.filters.listener.tls_inspector",
     external_deps = [
         "benchmark",
     ],
@@ -39,6 +44,12 @@ envoy_cc_test_binary(
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",
     ],
+)
+
+envoy_extension_benchmark_test(
+    name = "tls_inspector_benchmark_test",
+    benchmark_binary = "tls_inspector_benchmark",
+    extension_name = "envoy.filters.listener.tls_inspector",
 )
 
 envoy_cc_library(

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -81,7 +81,7 @@ static void BM_TlsInspector(benchmark::State& state) {
   for (auto _ : state) {
     Filter filter(cfg);
     filter.onAccept(cb);
-    dispatcher.file_event_callback_(Event::FileReadyType::Read);
+    RELEASE_ASSERT(dispatcher.file_event_callback_ == nullptr, "");
     RELEASE_ASSERT(socket.detectedTransportProtocol() == "tls", "");
     RELEASE_ASSERT(socket.requestedServerName() == "example.com", "");
     RELEASE_ASSERT(socket.requestedApplicationProtocols().size() == 2 &&
@@ -99,16 +99,3 @@ BENCHMARK(BM_TlsInspector)->Unit(benchmark::kMicrosecond);
 } // namespace ListenerFilters
 } // namespace Extensions
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_context(spdlog::level::warn,
-                                         Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
-
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -10,7 +10,6 @@ load(
     "envoy_extension_benchmark_test",
     "envoy_extension_cc_benchmark_binary",
     "envoy_extension_cc_test",
-    "envoy_extension_cc_test_binary",
 )
 
 envoy_package()
@@ -152,7 +151,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test_binary(
+envoy_extension_cc_benchmark_binary(
     name = "command_split_speed_test",
     srcs = ["command_split_speed_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
@@ -168,4 +167,10 @@ envoy_extension_cc_test_binary(
         "//test/test_common:printers_lib",
         "//test/test_common:simulated_time_system_lib",
     ],
+)
+
+envoy_extension_benchmark_test(
+    name = "command_split_speed_test_benchmark_test",
+    benchmark_binary = "command_split_speed_test",
+    extension_name = "envoy.filters.network.redis_proxy",
 )

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -7,6 +7,8 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_benchmark_test",
+    "envoy_extension_cc_benchmark_binary",
     "envoy_extension_cc_test",
     "envoy_extension_cc_test_binary",
 )
@@ -102,7 +104,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test_binary(
+envoy_extension_cc_benchmark_binary(
     name = "command_lookup_speed_test",
     srcs = ["command_lookup_speed_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
@@ -117,6 +119,12 @@ envoy_extension_cc_test_binary(
         "//test/test_common:printers_lib",
         "//test/test_common:simulated_time_system_lib",
     ],
+)
+
+envoy_extension_benchmark_test(
+    name = "command_lookup_speed_test_benchmark_test",
+    benchmark_binary = "command_lookup_speed_test",
+    extension_name = "envoy.filters.network.redis_proxy",
 )
 
 envoy_extension_cc_test(

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -85,13 +85,3 @@ static void BM_MakeRequests(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_MakeRequests);
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/filters/network/redis_proxy/command_split_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_split_speed_test.cc
@@ -49,7 +49,7 @@ public:
   void createShared(Common::Redis::RespValueSharedPtr request) {
     for (uint64_t i = 1; i < request->asArray().size(); i += 2) {
       auto single_set = std::make_shared<const Common::Redis::RespValue>(
-          request, Common::Redis::Utility::SetRequest::instance(), i, i + 2);
+          request, Common::Redis::Utility::SetRequest::instance(), i, i + 1);
     }
   }
 
@@ -130,13 +130,3 @@ static void BM_Split_CreateVariant(benchmark::State& state) {
   state.counters["use_count"] = request.use_count();
 }
 BENCHMARK(BM_Split_CreateVariant)->Ranges({{1, 100}, {64, 8 << 14}});
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}


### PR DESCRIPTION
Description: Transition some benchmarks over to take advantage of envoy_cc_benchmark_binary and envoy_benchmark_test.  This first round only covers benchmarks that do not require large refactors or code fixes in order to use the new framework.
Risk Level: n/a
Testing: test-only
Docs Changes: n/a
Release Notes: n/a
Fixes #9541 #9540 #9539