### PR TITLE
Change the way of getting default build image

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -158,8 +158,8 @@ build:remote-msan --config=rbe-toolchain-clang-libc++
 build:remote-msan --config=rbe-toolchain-msan
 
 # Docker sandbox
-# NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L7
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu@sha256:3788a87461f2b3dc8048ad0ce5df40438a56e0a8f1a4ab0f61b4ef0d8c11ff1f
+# NOTE: The default building image uses the latest version of envoy-build-ubuntu in dockerhub for multi-arch supported.
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:e1146ed8c34b94073c1218c1f9d6f5493a1a325b
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,7 +4,7 @@ Two flavors of Envoy Docker images, based on Ubuntu and Alpine Linux, are built.
 
 ## Ubuntu Envoy image
 The Ubuntu based Envoy Docker image at [`envoyproxy/envoy-build:<hash>`](https://hub.docker.com/r/envoyproxy/envoy-build/) is used for CircleCI checks,
-where `<hash>` is specified in [`envoy_build_sha.sh`](https://github.com/envoyproxy/envoy/blob/master/ci/envoy_build_sha.sh). Developers
+where `<hash>` is specified in [`envoy_build_tag.sh`](https://github.com/envoyproxy/envoy/blob/master/ci/envoy_build_tag.sh). Developers
 may work with `envoyproxy/envoy-build:latest` to provide a self-contained environment for building Envoy binaries and
 running tests that reflects the latest built Ubuntu Envoy image. Moreover, the Docker image
 at [`envoyproxy/envoy:<hash>`](https://hub.docker.com/r/envoyproxy/envoy/) is an image that has an Envoy binary at `/usr/local/bin/envoy`. The `<hash>`

--- a/ci/do_coverity_local.sh
+++ b/ci/do_coverity_local.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-. ./ci/envoy_build_sha.sh
+. ./ci/envoy_build_tag.sh
 
 [[ -z "${ENVOY_DOCKER_BUILD_DIR}" ]] && ENVOY_DOCKER_BUILD_DIR=/tmp/envoy-docker-build
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
@@ -44,8 +44,8 @@ then
     --form token="${COVERITY_TOKEN}" \
     --form email="${COVERITY_USER_EMAIL}" \
     --form file=@"${COVERITY_OUTPUT_FILE}" \
-    --form version="${ENVOY_BUILD_SHA}" \
-    --form description="Envoy Proxy Build ${ENVOY_BUILD_SHA}" \
+    --form version="${ENVOY_BUILD_TAG}" \
+    --form description="Envoy Proxy Build ${ENVOY_BUILD_TAG}" \
     https://scan.coverity.com/projects/envoy-proxy
 else
   echo "Coverity Scan output file appears to be too small."

--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,2 +1,0 @@
-ENVOY_BUILD_SHA=$(grep envoyproxy/envoy-build-ubuntu@sha256 $(dirname $0)/../.bazelrc | sed -e 's#.*envoyproxy/envoy-build-ubuntu@sha256:\(.*\)#\1#' | uniq)
-[[ $(wc -l <<< "${ENVOY_BUILD_SHA}" | awk '{$1=$1};1') == 1 ]] || (echo ".bazelrc envoyproxy/envoy-build-ubuntu hashes are inconsistent!" && exit 1)

--- a/ci/envoy_build_tag.sh
+++ b/ci/envoy_build_tag.sh
@@ -1,0 +1,2 @@
+ENVOY_BUILD_TAG=$(grep envoyproxy/envoy-build-ubuntu $(dirname $0)/../.bazelrc | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#' | uniq)
+[[ $(wc -l <<< "${ENVOY_BUILD_TAG}" | awk '{$1=$1};1') == 1 ]] || (echo ".bazelrc envoyproxy/envoy-build-ubuntu hashes are inconsistent!" && exit 1)

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-. $(dirname $0)/envoy_build_sha.sh
+. $(dirname $0)/envoy_build_tag.sh
 
 # We run as root and later drop permissions. This is required to setup the USER
 # in useradd below, which is need for correct Python execution in the Docker
@@ -10,10 +10,10 @@ set -e
 USER=root
 USER_GROUP=root
 
-[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-ubuntu@sha256"
+[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-ubuntu"
 # The IMAGE_ID defaults to the CI hash but can be set to an arbitrary image ID (found with 'docker
 # images').
-[[ -z "${IMAGE_ID}" ]] && IMAGE_ID="${ENVOY_BUILD_SHA}"
+[[ -z "${IMAGE_ID}" ]] && IMAGE_ID="${ENVOY_BUILD_TAG}"
 [[ -z "${ENVOY_DOCKER_BUILD_DIR}" ]] && ENVOY_DOCKER_BUILD_DIR=/tmp/envoy-docker-build
 
 [[ -f .git ]] && [[ ! -d .git ]] && GIT_VOLUME_OPTION="-v $(git rev-parse --git-common-dir):$(git rev-parse --git-common-dir)"

--- a/tools/bazel-test-docker.sh
+++ b/tools/bazel-test-docker.sh
@@ -42,8 +42,8 @@ cat > "${DOCKER_ENV}" <<EOF
   export NO_PROXY="${NO_PROXY}"
 EOF
 
-. ./ci/envoy_build_sha.sh
-IMAGE=envoyproxy/envoy-build:${ENVOY_BUILD_SHA}
+. ./ci/envoy_build_tag.sh
+IMAGE=envoyproxy/envoy-build:${ENVOY_BUILD_TAG}
 
 # Note docker_wrapper.sh is tightly coupled to the order of arguments here due to where the test
 # name is passed in.


### PR DESCRIPTION
For supporting envoy build on different platform, it changes the
way of getting default build image from sha256 to xxx:tag. In
this way, it could be easier to adapt different platform.
1. Change the ENVOY_BUILD_SHA to ENVOY_BUILD_TAG
2. Change the name of "envoy_build_sha.sh" to "envoy_build_tag.sh"
3. Modify the bazel configuration file .bazelrc

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
