### PR TITLE
[common] Fix integer overflow error in JitteredBackOffStrategy found by fuzzer.

### DIFF
--- a/source/common/common/backoff_strategy.h
+++ b/source/common/common/backoff_strategy.h
@@ -33,7 +33,7 @@ public:
 private:
   const uint64_t base_interval_;
   const uint64_t max_interval_{};
-  uint64_t current_retry_{1};
+  uint64_t next_interval_;
   Runtime::RandomGenerator& random_;
 };
 

--- a/test/common/common/backoff_strategy_test.cc
+++ b/test/common/common/backoff_strategy_test.cc
@@ -30,31 +30,52 @@ TEST(BackOffStrategyTest, JitteredBackOffBasicReset) {
   EXPECT_EQ(2, jittered_back_off.nextBackOffMs()); // Should start from start
 }
 
+TEST(BackOffStrategyTest, JitteredBackOffDoesntOverflow) {
+  NiceMock<Runtime::MockRandomGenerator> random;
+  ON_CALL(random, random()).WillByDefault(Return(std::numeric_limits<uint64_t>::max() - 1));
+
+  JitteredBackOffStrategy jittered_back_off(1, std::numeric_limits<uint64_t>::max(), random);
+  for (int iter = 0; iter < 100; ++iter) {
+    EXPECT_GE(std::numeric_limits<uint64_t>::max(), jittered_back_off.nextBackOffMs());
+  }
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max() - 1, jittered_back_off.nextBackOffMs());
+}
+
 TEST(BackOffStrategyTest, JitteredBackOffWithMaxInterval) {
   NiceMock<Runtime::MockRandomGenerator> random;
-  ON_CALL(random, random()).WillByDefault(Return(1024));
+  ON_CALL(random, random()).WillByDefault(Return(9999));
 
   JitteredBackOffStrategy jittered_back_off(5, 100, random);
   EXPECT_EQ(4, jittered_back_off.nextBackOffMs());
-  EXPECT_EQ(4, jittered_back_off.nextBackOffMs());
   EXPECT_EQ(9, jittered_back_off.nextBackOffMs());
-  EXPECT_EQ(49, jittered_back_off.nextBackOffMs());
-  EXPECT_EQ(94, jittered_back_off.nextBackOffMs());
-  EXPECT_EQ(94, jittered_back_off.nextBackOffMs()); // Should return Max here
+  EXPECT_EQ(19, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(39, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(79, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(99, jittered_back_off.nextBackOffMs()); // Should return Max here
+  EXPECT_EQ(99, jittered_back_off.nextBackOffMs());
 }
 
 TEST(BackOffStrategyTest, JitteredBackOffWithMaxIntervalReset) {
   NiceMock<Runtime::MockRandomGenerator> random;
-  ON_CALL(random, random()).WillByDefault(Return(1024));
+  ON_CALL(random, random()).WillByDefault(Return(9999));
 
   JitteredBackOffStrategy jittered_back_off(5, 100, random);
   EXPECT_EQ(4, jittered_back_off.nextBackOffMs());
-  EXPECT_EQ(4, jittered_back_off.nextBackOffMs());
   EXPECT_EQ(9, jittered_back_off.nextBackOffMs());
-  EXPECT_EQ(49, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(19, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(39, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(79, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(99, jittered_back_off.nextBackOffMs()); // Should return Max here
+  EXPECT_EQ(99, jittered_back_off.nextBackOffMs());
 
   jittered_back_off.reset();
-  EXPECT_EQ(4, jittered_back_off.nextBackOffMs()); // Should start from start
+  EXPECT_EQ(4, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(9, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(19, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(39, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(79, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(99, jittered_back_off.nextBackOffMs()); // Should return Max here
+  EXPECT_EQ(99, jittered_back_off.nextBackOffMs());
 }
 
 TEST(BackOffStrategyTest, FixedBackOffBasicReset) {

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -835,7 +835,7 @@ TEST_F(RouterRetryStateImplTest, Backoff) {
   EXPECT_TRUE(state_->enabled());
 
   EXPECT_CALL(random_, random()).WillOnce(Return(190));
-  retry_timer_ = new testing::StrictMock<Event::MockTimer>(&dispatcher_);
+  retry_timer_ = new Event::MockTimer(&dispatcher_);
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(15), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -834,21 +834,21 @@ TEST_F(RouterRetryStateImplTest, Backoff) {
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
 
-  EXPECT_CALL(random_, random()).WillOnce(Return(49));
-  retry_timer_ = new Event::MockTimer(&dispatcher_);
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(24), _));
+  EXPECT_CALL(random_, random()).WillOnce(Return(190));
+  retry_timer_ = new testing::StrictMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(15), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
 
-  EXPECT_CALL(random_, random()).WillOnce(Return(149));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(74), _));
+  EXPECT_CALL(random_, random()).WillOnce(Return(190));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(40), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
 
-  EXPECT_CALL(random_, random()).WillOnce(Return(349));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(174), _));
+  EXPECT_CALL(random_, random()).WillOnce(Return(190));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(90), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
@@ -879,19 +879,25 @@ TEST_F(RouterRetryStateImplTest, CustomBackOffInterval) {
   retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(350));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(50), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(150), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(751));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(51), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(351), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
 
-  EXPECT_CALL(random_, random()).WillOnce(Return(1499));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1200), _));
+  EXPECT_CALL(random_, random()).WillOnce(Return(2399));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(799), _));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->invokeCallback();
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(2399));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1199), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
@@ -914,19 +920,25 @@ TEST_F(RouterRetryStateImplTest, CustomBackOffIntervalDefaultMax) {
   retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(350));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(50), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(150), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
 
   EXPECT_CALL(random_, random()).WillOnce(Return(751));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(51), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(351), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();
 
-  EXPECT_CALL(random_, random()).WillOnce(Return(1499));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1000), _));
+  EXPECT_CALL(random_, random()).WillOnce(Return(2999));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(599), _));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->invokeCallback();
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(2999));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(999), _));
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->invokeCallback();

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -285,12 +285,12 @@ TEST_F(HdsTest, TestStreamConnectionFailure) {
       .WillOnce(Return(nullptr))
       .WillOnce(Return(&async_stream_));
 
-  EXPECT_CALL(random_, random()).WillOnce(Return(1000005)).WillRepeatedly(Return(1234567));
+  EXPECT_CALL(random_, random()).WillOnce(Return(1000005)).WillRepeatedly(Return(654321));
   EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(5), _));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1567), _));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(2567), _));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(4567), _));
-  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(25567), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(321), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(2321), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(6321), _));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(14321), _));
   EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
 
   // Test connection failure and retry


### PR DESCRIPTION
Description: Fix integer overflow in JitteredBackOffStrategy::nextBackOffMs found by fuzzing.  After 32 retries, multiplier becomes negative.  Of course, this is unlikely to ever happen in production, since it would take about 100 days before we'ld hit 32 retries with base_interval of 1ms and max_interval of uint64_t max.
Risk Level: n/a
Testing: unit
Docs Changes: n/a
Release Notes: n/a
