### PR TITLE
utility: convert typed_config to factory config

### DIFF
--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -242,7 +242,6 @@ public:
 
   /**
    * Translate a nested config into a proto message provided by the implementation factory.
-   * @param extension_name name of extension corresponding to config.
    * @param enclosing_message proto that contains a field 'config'. Note: the enclosing proto is
    * provided because for statically registered implementations, a custom config is generally
    * optional, which means the conversion must be done conditionally.
@@ -266,6 +265,30 @@ public:
     translateOpaqueConfig(enclosing_message.typed_config(),
                           enclosing_message.hidden_envoy_deprecated_config(), validation_visitor,
                           *config);
+    return config;
+  }
+
+  /**
+   * Translate the typed any field into a proto message provided by the implementation factory.
+   * @param typed_config typed configuration.
+   * @param validation_visitor message validation visitor instance.
+   * @param factory implementation factory with the method 'createEmptyConfigProto' to produce a
+   * proto to be filled with the translated configuration.
+   */
+  template <class Factory>
+  static ProtobufTypes::MessagePtr
+  translateAnyToFactoryConfig(const ProtobufWkt::Any& typed_config,
+                              ProtobufMessage::ValidationVisitor& validation_visitor,
+                              Factory& factory) {
+    ProtobufTypes::MessagePtr config = factory.createEmptyConfigProto();
+
+    // Fail in an obvious way if a plugin does not return a proto.
+    RELEASE_ASSERT(config != nullptr, "");
+
+    // Check that the config type is not google.protobuf.Empty
+    RELEASE_ASSERT(config->GetDescriptor()->full_name() != "google.protobuf.Empty", "");
+
+    translateOpaqueConfig(typed_config, ProtobufWkt::Struct(), validation_visitor, *config);
     return config;
   }
 

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -317,11 +317,10 @@ TEST(UtilityTest, TranslateAnyToFactoryConfig) {
     return ProtobufTypes::MessagePtr{new ProtobufWkt::Duration()};
   }));
 
-  const auto& config =
-      dynamic_cast<const ProtobufWkt::Duration&>(*Utility::translateAnyToFactoryConfig(
-          typed_config, ProtobufMessage::getStrictValidationVisitor(), factory));
+  auto config = Utility::translateAnyToFactoryConfig(
+      typed_config, ProtobufMessage::getStrictValidationVisitor(), factory);
 
-  EXPECT_EQ(config.seconds(), 42);
+  EXPECT_THAT(*config, ProtoEq(source_duration));
 }
 
 void packTypedStructIntoAny(ProtobufWkt::Any& typed_config, const Protobuf::Message& inner) {

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -12,6 +12,7 @@
 #include "common/config/well_known_names.h"
 #include "common/protobuf/protobuf.h"
 
+#include "test/mocks/config/mocks.h"
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/stats/mocks.h"
@@ -285,6 +286,42 @@ TEST(UtilityTest, AnyWrongType) {
                                      ProtobufMessage::getStrictValidationVisitor(), out),
       EnvoyException,
       R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\] .*)");
+}
+
+TEST(UtilityTest, TranslateAnyWrongToFactoryConfig) {
+  ProtobufWkt::Duration source_duration;
+  source_duration.set_seconds(42);
+  ProtobufWkt::Any typed_config;
+  typed_config.PackFrom(source_duration);
+
+  MockTypedFactory factory;
+  EXPECT_CALL(factory, createEmptyConfigProto()).WillOnce(Invoke([]() -> ProtobufTypes::MessagePtr {
+    return ProtobufTypes::MessagePtr{new ProtobufWkt::Timestamp()};
+  }));
+
+  EXPECT_THROW_WITH_REGEX(
+      Utility::translateAnyToFactoryConfig(typed_config,
+                                           ProtobufMessage::getStrictValidationVisitor(), factory),
+      EnvoyException,
+      R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\] .*)");
+}
+
+TEST(UtilityTest, TranslateAnyToFactoryConfig) {
+  ProtobufWkt::Duration source_duration;
+  source_duration.set_seconds(42);
+  ProtobufWkt::Any typed_config;
+  typed_config.PackFrom(source_duration);
+
+  MockTypedFactory factory;
+  EXPECT_CALL(factory, createEmptyConfigProto()).WillOnce(Invoke([]() -> ProtobufTypes::MessagePtr {
+    return ProtobufTypes::MessagePtr{new ProtobufWkt::Duration()};
+  }));
+
+  const auto& config =
+      dynamic_cast<const ProtobufWkt::Duration&>(*Utility::translateAnyToFactoryConfig(
+          typed_config, ProtobufMessage::getStrictValidationVisitor(), factory));
+
+  EXPECT_EQ(config.seconds(), 42);
 }
 
 void packTypedStructIntoAny(ProtobufWkt::Any& typed_config, const Protobuf::Message& inner) {

--- a/test/mocks/config/mocks.cc
+++ b/test/mocks/config/mocks.cc
@@ -39,5 +39,6 @@ MockSubscriptionCallbacks::MockSubscriptionCallbacks() {
 
 MockSubscriptionCallbacks::~MockSubscriptionCallbacks() = default;
 
+MockTypedFactory::~MockTypedFactory() = default;
 } // namespace Config
 } // namespace Envoy

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -5,6 +5,7 @@
 #include "envoy/config/endpoint/v3/endpoint.pb.h"
 #include "envoy/config/grpc_mux.h"
 #include "envoy/config/subscription.h"
+#include "envoy/config/typed_config.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 
 #include "common/config/config_provider_impl.h"
@@ -117,6 +118,16 @@ public:
               (std::vector<std::unique_ptr<const Protobuf::Message>> && config_protos,
                Server::Configuration::ServerFactoryContext& factory_context,
                const Envoy::Config::ConfigProviderManager::OptionalArg& optarg));
+};
+
+class MockTypedFactory : public TypedFactory {
+public:
+  ~MockTypedFactory() override;
+
+  MOCK_METHOD(ProtobufTypes::MessagePtr, createEmptyConfigProto, ());
+  MOCK_METHOD(std::string, configType, ());
+  MOCK_METHOD(std::string, name, (), (const));
+  MOCK_METHOD(std::string, category, (), (const));
 };
 
 } // namespace Config


### PR DESCRIPTION
Signed-off-by: Yan Xue <yxyan@google.com>

Description: convert typed_config to factory config
Risk Level: Low
Testing: Unit test
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
