### PR TITLE
router: refactor RetryPolicy

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -15,11 +15,11 @@
 namespace Envoy {
 namespace Http {
 
+AsyncStreamImpl::NullRetryPolicy AsyncStreamImpl::RouteEntryImpl::retry_policy_;
 const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>
     AsyncStreamImpl::NullRateLimitPolicy::rate_limit_policy_entry_;
 const AsyncStreamImpl::NullHedgePolicy AsyncStreamImpl::RouteEntryImpl::hedge_policy_;
 const AsyncStreamImpl::NullRateLimitPolicy AsyncStreamImpl::RouteEntryImpl::rate_limit_policy_;
-const AsyncStreamImpl::NullRetryPolicy AsyncStreamImpl::RouteEntryImpl::retry_policy_;
 const std::vector<Router::ShadowPolicyPtr> AsyncStreamImpl::RouteEntryImpl::shadow_policies_;
 const AsyncStreamImpl::NullVirtualHost AsyncStreamImpl::RouteEntryImpl::virtual_host_;
 const AsyncStreamImpl::NullRateLimitPolicy AsyncStreamImpl::NullVirtualHost::rate_limit_policy_;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -126,18 +126,8 @@ private:
         rate_limit_policy_entry_;
   };
 
-  struct NullRetryPolicy : public Router::RetryPolicy {
-    // Router::RetryPolicy
-    std::chrono::milliseconds perTryTimeout() const override {
-      return std::chrono::milliseconds(0);
-    }
-    std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override {
-      return {};
-    }
-    Upstream::RetryPrioritySharedPtr retryPriority() const override { return {}; }
-
-    uint32_t hostSelectionMaxAttempts() const override { return 1; }
-    uint32_t numRetries() const override { return 1; }
+  struct NullRetryPolicy : public Router::CoreRetryPolicy {
+    // Router::CoreRetryPolicy
     uint32_t retryOn() const override { return 0; }
     const std::vector<uint32_t>& retriableStatusCodes() const override {
       return retriable_status_codes_;
@@ -148,11 +138,31 @@ private:
     const std::vector<Http::HeaderMatcherSharedPtr>& retriableRequestHeaders() const override {
       return retriable_request_headers_;
     }
+
+    // Router::RetryPolicy
+    bool enabled() const override { return true; }
+    void recordRequestHeader(Http::RequestHeaderMap&) override {}
+    void recordResponseHeaders(const Http::ResponseHeaderMap&) override {}
+    void recordReset(Http::StreamResetReason) override {}
+    bool wouldRetryFromHeaders(const Http::ResponseHeaderMap&) const override { return false; }
+    bool wouldRetryFromReset(Http::StreamResetReason) const override { return false; }
+    std::chrono::milliseconds perTryTimeout() const override {
+      return std::chrono::milliseconds(0);
+    }
+    std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override {
+      return {};
+    }
+    Upstream::RetryPrioritySharedPtr retryPriority() const override { return {}; }
+    uint32_t hostSelectionMaxAttempts() const override { return 1; }
+    uint32_t numRetries() const override { return 1; }
+    uint32_t& remainingRetries() override { return remaining_retries_; }
+
     absl::optional<std::chrono::milliseconds> baseInterval() const override {
       return absl::nullopt;
     }
     absl::optional<std::chrono::milliseconds> maxInterval() const override { return absl::nullopt; }
 
+    uint32_t remaining_retries_{1};
     const std::vector<uint32_t> retriable_status_codes_{};
     const std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_{};
     const std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_{};
@@ -226,7 +236,7 @@ private:
       return Upstream::ResourcePriority::Default;
     }
     const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
-    const Router::RetryPolicy& retryPolicy() const override { return retry_policy_; }
+    Router::RetryPolicy& retryPolicy() const override { return retry_policy_; }
     uint32_t retryShadowBufferLimit() const override {
       return std::numeric_limits<uint32_t>::max();
     }
@@ -278,9 +288,9 @@ private:
     uint32_t maxInternalRedirects() const override { return 1; }
     const std::string& routeName() const override { return route_name_; }
     std::unique_ptr<const HashPolicyImpl> hash_policy_;
+    static NullRetryPolicy retry_policy_;
     static const NullHedgePolicy hedge_policy_;
     static const NullRateLimitPolicy rate_limit_policy_;
-    static const NullRetryPolicy retry_policy_;
     static const std::vector<Router::ShadowPolicyPtr> shadow_policies_;
     static const NullVirtualHost virtual_host_;
     static const std::multimap<std::string, std::string> opaque_config_;

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -37,6 +37,7 @@ envoy_cc_library(
         ":header_formatter_lib",
         ":header_parser_lib",
         ":metadatamatchcriteria_lib",
+        ":retry_policy_lib",
         ":retry_state_lib",
         ":router_ratelimit_lib",
         ":tls_context_match_criteria_lib",
@@ -68,6 +69,26 @@ envoy_cc_library(
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "retry_policy_lib",
+    srcs = ["retry_policy_impl.cc"],
+    hdrs = ["retry_policy_impl.h"],
+    deps = [
+        ":retry_state_lib",
+        "//include/envoy/http:header_map_interface",
+        "//include/envoy/router:router_interface",
+        "//include/envoy/upstream:upstream_interface",
+        "//source/common/common:utility_lib",
+        "//source/common/config:utility_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_utility_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -27,6 +27,7 @@
 #include "common/router/header_formatter.h"
 #include "common/router/header_parser.h"
 #include "common/router/metadatamatchcriteria_impl.h"
+#include "common/router/retry_policy_impl.h"
 #include "common/router/router_ratelimit.h"
 #include "common/router/tls_context_match_criteria_impl.h"
 #include "common/stats/symbol_table_impl.h"
@@ -234,59 +235,6 @@ private:
 using VirtualHostSharedPtr = std::shared_ptr<VirtualHostImpl>;
 
 /**
- * Implementation of RetryPolicy that reads from the proto route or virtual host config.
- */
-class RetryPolicyImpl : public RetryPolicy {
-
-public:
-  RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
-                  ProtobufMessage::ValidationVisitor& validation_visitor);
-  RetryPolicyImpl() = default;
-
-  // Router::RetryPolicy
-  std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
-  uint32_t numRetries() const override { return num_retries_; }
-  uint32_t retryOn() const override { return retry_on_; }
-  std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override;
-  Upstream::RetryPrioritySharedPtr retryPriority() const override;
-  uint32_t hostSelectionMaxAttempts() const override { return host_selection_attempts_; }
-  const std::vector<uint32_t>& retriableStatusCodes() const override {
-    return retriable_status_codes_;
-  }
-  const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
-    return retriable_headers_;
-  }
-  const std::vector<Http::HeaderMatcherSharedPtr>& retriableRequestHeaders() const override {
-    return retriable_request_headers_;
-  }
-  absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
-  absl::optional<std::chrono::milliseconds> maxInterval() const override { return max_interval_; }
-
-private:
-  std::chrono::milliseconds per_try_timeout_{0};
-  // We set the number of retries to 1 by default (i.e. when no route or vhost level retry policy is
-  // set) so that when retries get enabled through the x-envoy-retry-on header we default to 1
-  // retry.
-  uint32_t num_retries_{1};
-  uint32_t retry_on_{};
-  // Each pair contains the name and config proto to be used to create the RetryHostPredicates
-  // that should be used when with this policy.
-  std::vector<std::pair<Upstream::RetryHostPredicateFactory&, ProtobufTypes::MessagePtr>>
-      retry_host_predicate_configs_;
-  Upstream::RetryPrioritySharedPtr retry_priority_;
-  // Name and config proto to use to create the RetryPriority to use with this policy. Default
-  // initialized when no RetryPriority should be used.
-  std::pair<Upstream::RetryPriorityFactory*, ProtobufTypes::MessagePtr> retry_priority_config_;
-  uint32_t host_selection_attempts_{1};
-  std::vector<uint32_t> retriable_status_codes_;
-  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
-  std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
-  absl::optional<std::chrono::milliseconds> base_interval_;
-  absl::optional<std::chrono::milliseconds> max_interval_;
-  ProtobufMessage::ValidationVisitor* validation_visitor_{};
-};
-
-/**
  * Implementation of ShadowPolicy that reads from the proto route config.
  */
 class ShadowPolicyImpl : public ShadowPolicy {
@@ -430,7 +378,7 @@ public:
   }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
-  const RetryPolicy& retryPolicy() const override { return retry_policy_; }
+  RetryPolicy& retryPolicy() const override { return *retry_policy_; }
   uint32_t retryShadowBufferLimit() const override { return retry_shadow_buffer_limit_; }
   const std::vector<ShadowPolicyPtr>& shadowPolicies() const override { return shadow_policies_; }
   const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
@@ -534,7 +482,7 @@ private:
     const HedgePolicy& hedgePolicy() const override { return parent_->hedgePolicy(); }
     Upstream::ResourcePriority priority() const override { return parent_->priority(); }
     const RateLimitPolicy& rateLimitPolicy() const override { return parent_->rateLimitPolicy(); }
-    const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
+    RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
     uint32_t retryShadowBufferLimit() const override { return parent_->retryShadowBufferLimit(); }
     const std::vector<ShadowPolicyPtr>& shadowPolicies() const override {
       return parent_->shadowPolicies();
@@ -673,7 +621,7 @@ private:
   buildHedgePolicy(const absl::optional<envoy::config::route::v3::HedgePolicy>& vhost_hedge_policy,
                    const envoy::config::route::v3::RouteAction& route_config) const;
 
-  RetryPolicyImpl
+  RetryPolicySharedPtr
   buildRetryPolicy(const absl::optional<envoy::config::route::v3::RetryPolicy>& vhost_retry_policy,
                    const envoy::config::route::v3::RouteAction& route_config,
                    ProtobufMessage::ValidationVisitor& validation_visitor) const;
@@ -703,7 +651,7 @@ private:
   const std::string prefix_rewrite_redirect_;
   const bool strip_query_;
   const HedgePolicyImpl hedge_policy_;
-  const RetryPolicyImpl retry_policy_;
+  RetryPolicySharedPtr retry_policy_;
   const RateLimitPolicyImpl rate_limit_policy_;
   std::vector<ShadowPolicyPtr> shadow_policies_;
   const Upstream::ResourcePriority priority_;

--- a/source/common/router/retry_policy_impl.cc
+++ b/source/common/router/retry_policy_impl.cc
@@ -1,0 +1,261 @@
+#include "common/router/retry_policy_impl.h"
+
+#include "envoy/http/header_map.h"
+
+#include "common/config/utility.h"
+#include "common/grpc/common.h"
+#include "common/http/codes.h"
+#include "common/http/header_utility.h"
+#include "common/http/headers.h"
+#include "common/http/utility.h"
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+#include "common/router/retry_state_impl.h"
+
+namespace Envoy {
+namespace Router {
+
+RetryPolicyImpl::RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
+                                 ProtobufMessage::ValidationVisitor& validation_visitor)
+    : per_try_timeout_(
+          std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(retry_policy, per_try_timeout, 0))),
+      num_retries_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(retry_policy, num_retries, 1)),
+      remaining_retries_(num_retries_),
+      retriable_status_codes_(retry_policy.retriable_status_codes().begin(),
+                              retry_policy.retriable_status_codes().end()),
+      retriable_headers_(
+          Http::HeaderUtility::buildHeaderMatcherVector(retry_policy.retriable_headers())),
+      retriable_request_headers_(
+          Http::HeaderUtility::buildHeaderMatcherVector(retry_policy.retriable_request_headers())),
+      validation_visitor_(&validation_visitor) {
+  retry_on_ = RetryStateImpl::parseRetryOn(retry_policy.retry_on()).first;
+  retry_on_ |= RetryStateImpl::parseRetryGrpcOn(retry_policy.retry_on()).first;
+
+  for (const auto& host_predicate : retry_policy.retry_host_predicate()) {
+    auto& factory = Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryHostPredicateFactory>(
+        host_predicate);
+    auto config = Envoy::Config::Utility::translateToFactoryConfig(host_predicate,
+                                                                   validation_visitor, factory);
+    retry_host_predicate_configs_.emplace_back(factory, std::move(config));
+  }
+
+  const auto& retry_priority = retry_policy.retry_priority();
+  if (!retry_priority.name().empty()) {
+    auto& factory =
+        Envoy::Config::Utility::getAndCheckFactory<Upstream::RetryPriorityFactory>(retry_priority);
+    retry_priority_config_ =
+        std::make_pair(&factory, Envoy::Config::Utility::translateToFactoryConfig(
+                                     retry_priority, validation_visitor, factory));
+  }
+
+  auto host_selection_attempts = retry_policy.host_selection_retry_max_attempts();
+  if (host_selection_attempts) {
+    host_selection_attempts_ = host_selection_attempts;
+  }
+
+  if (retry_policy.has_retry_back_off()) {
+    base_interval_ = std::chrono::milliseconds(
+        PROTOBUF_GET_MS_REQUIRED(retry_policy.retry_back_off(), base_interval));
+    if ((*base_interval_).count() < 1) {
+      base_interval_ = std::chrono::milliseconds(1);
+    }
+
+    max_interval_ = PROTOBUF_GET_OPTIONAL_MS(retry_policy.retry_back_off(), max_interval);
+    if (max_interval_) {
+      // Apply the same rounding to max interval in case both are set to sub-millisecond values.
+      if ((*max_interval_).count() < 1) {
+        max_interval_ = std::chrono::milliseconds(1);
+      }
+
+      if ((*max_interval_).count() < (*base_interval_).count()) {
+        throw EnvoyException(
+            "retry_policy.max_interval must greater than or equal to the base_interval");
+      }
+    }
+  }
+}
+
+void RetryPolicyImpl::recordRequestHeader(Http::RequestHeaderMap& request_headers) {
+  // Merge in the headers.
+  if (request_headers.EnvoyRetryOn()) {
+    retry_on_ |=
+        RetryStateImpl::parseRetryOn(request_headers.EnvoyRetryOn()->value().getStringView()).first;
+  }
+  if (request_headers.EnvoyRetryGrpcOn()) {
+    retry_on_ |= RetryStateImpl::parseRetryGrpcOn(
+                     request_headers.EnvoyRetryGrpcOn()->value().getStringView())
+                     .first;
+  }
+
+  if (!retriable_request_headers_.empty()) {
+    // If this route limits retries by request headers, make sure there is a match.
+    bool request_header_match = false;
+    for (const auto& retriable_header : retriable_request_headers_) {
+      if (retriable_header->matchesHeaders(request_headers)) {
+        request_header_match = true;
+        break;
+      }
+    }
+
+    if (!request_header_match) {
+      retry_on_ = 0;
+    }
+  }
+  if (retry_on_ != 0 && request_headers.EnvoyMaxRetries()) {
+    uint64_t temp;
+    if (absl::SimpleAtoi(request_headers.EnvoyMaxRetries()->value().getStringView(), &temp)) {
+      // The max retries header takes precedence if set.
+      num_retries_ = remaining_retries_ = temp;
+    }
+  }
+
+  if (request_headers.EnvoyRetriableStatusCodes()) {
+    for (const auto code : StringUtil::splitToken(
+             request_headers.EnvoyRetriableStatusCodes()->value().getStringView(), ",")) {
+      unsigned int out;
+      if (absl::SimpleAtoi(code, &out)) {
+        retriable_status_codes_.emplace_back(out);
+      }
+    }
+  }
+
+  if (request_headers.EnvoyRetriableHeaderNames()) {
+    // Retriable headers in the configuration are specified via HeaderMatcher.
+    // Giving the same flexibility via request header would require the user
+    // to provide HeaderMatcher serialized into a string. To avoid this extra
+    // complexity we only support name-only header matchers via request
+    // header. Anything more sophisticated needs to be provided via config.
+    for (const auto header_name : StringUtil::splitToken(
+             request_headers.EnvoyRetriableHeaderNames()->value().getStringView(), ",")) {
+      envoy::config::route::v3::HeaderMatcher header_matcher;
+      header_matcher.set_name(std::string(absl::StripAsciiWhitespace(header_name)));
+      retriable_headers_.emplace_back(
+          std::make_shared<Http::HeaderUtility::HeaderData>(header_matcher));
+    }
+  }
+
+  request_headers.removeEnvoyRetryOn();
+  request_headers.removeEnvoyRetryGrpcOn();
+  request_headers.removeEnvoyMaxRetries();
+}
+
+bool RetryPolicyImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_headers) const {
+  if (response_headers.EnvoyOverloaded() != nullptr) {
+    return false;
+  }
+
+  // We never retry if the request is rate limited.
+  if (response_headers.EnvoyRateLimited() != nullptr) {
+    return false;
+  }
+
+  if (retry_on_ & CoreRetryPolicy::RETRY_ON_5XX) {
+    if (Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(response_headers))) {
+      return true;
+    }
+  }
+
+  if (retry_on_ & CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR) {
+    if (Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(response_headers))) {
+      return true;
+    }
+  }
+
+  if ((retry_on_ & CoreRetryPolicy::RETRY_ON_RETRIABLE_4XX)) {
+    Http::Code code = static_cast<Http::Code>(Http::Utility::getResponseStatus(response_headers));
+    if (code == Http::Code::Conflict) {
+      return true;
+    }
+  }
+
+  if ((retry_on_ & CoreRetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES)) {
+    for (auto code : retriable_status_codes_) {
+      if (Http::Utility::getResponseStatus(response_headers) == code) {
+        return true;
+      }
+    }
+  }
+
+  if (retry_on_ & CoreRetryPolicy::RETRY_ON_RETRIABLE_HEADERS) {
+    for (const auto& retriable_header : retriable_headers_) {
+      if (retriable_header->matchesHeaders(response_headers)) {
+        return true;
+      }
+    }
+  }
+
+  if (retry_on_ &
+      (CoreRetryPolicy::RETRY_ON_GRPC_CANCELLED | CoreRetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
+       CoreRetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED |
+       CoreRetryPolicy::RETRY_ON_GRPC_UNAVAILABLE | CoreRetryPolicy::RETRY_ON_GRPC_INTERNAL)) {
+    absl::optional<Grpc::Status::GrpcStatus> status = Grpc::Common::getGrpcStatus(response_headers);
+    if (status) {
+      if ((status.value() == Grpc::Status::Canceled &&
+           (retry_on_ & CoreRetryPolicy::RETRY_ON_GRPC_CANCELLED)) ||
+          (status.value() == Grpc::Status::DeadlineExceeded &&
+           (retry_on_ & CoreRetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED)) ||
+          (status.value() == Grpc::Status::ResourceExhausted &&
+           (retry_on_ & CoreRetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED)) ||
+          (status.value() == Grpc::Status::Unavailable &&
+           (retry_on_ & CoreRetryPolicy::RETRY_ON_GRPC_UNAVAILABLE)) ||
+          (status.value() == Grpc::Status::Internal &&
+           (retry_on_ & CoreRetryPolicy::RETRY_ON_GRPC_INTERNAL))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+bool RetryPolicyImpl::wouldRetryFromReset(Http::StreamResetReason reset_reason) const {
+  // First check "never retry" conditions so we can short circuit (we never
+  // retry if the reset reason is overflow).
+  if (reset_reason == Http::StreamResetReason::Overflow) {
+    return false;
+  }
+
+  if (retry_on_ & CoreRetryPolicy::RETRY_ON_RESET) {
+    return true;
+  }
+
+  if (retry_on_ & (CoreRetryPolicy::RETRY_ON_5XX | CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR)) {
+    // Currently we count an upstream reset as a "5xx" (since it will result in
+    // one). With RETRY_ON_RESET we may eventually remove these policies.
+    return true;
+  }
+
+  if ((retry_on_ & CoreRetryPolicy::RETRY_ON_REFUSED_STREAM) &&
+      reset_reason == Http::StreamResetReason::RemoteRefusedStreamReset) {
+    return true;
+  }
+
+  if ((retry_on_ & CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE) &&
+      reset_reason == Http::StreamResetReason::ConnectionFailure) {
+    return true;
+  }
+
+  return false;
+}
+
+std::vector<Upstream::RetryHostPredicateSharedPtr> RetryPolicyImpl::retryHostPredicates() const {
+  std::vector<Upstream::RetryHostPredicateSharedPtr> predicates;
+
+  for (const auto& config : retry_host_predicate_configs_) {
+    predicates.emplace_back(config.first.createHostPredicate(*config.second, num_retries_));
+  }
+
+  return predicates;
+}
+
+Upstream::RetryPrioritySharedPtr RetryPolicyImpl::retryPriority() const {
+  if (retry_priority_config_.first == nullptr) {
+    return nullptr;
+  }
+
+  return retry_priority_config_.first->createRetryPriority(*retry_priority_config_.second,
+                                                           *validation_visitor_, num_retries_);
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/retry_policy_impl.h
+++ b/source/common/router/retry_policy_impl.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "envoy/config/route/v3/route_components.pb.h"
+#include "envoy/router/router.h"
+
+namespace Envoy {
+namespace Router {
+class RetryPolicyImpl : public CoreRetryPolicy {
+public:
+  RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& retry_policy,
+                  ProtobufMessage::ValidationVisitor& validation_visitor);
+  RetryPolicyImpl() = default;
+
+  // Router::CoreRetryPolicy
+  uint32_t retryOn() const override { return retry_on_; }
+  const std::vector<uint32_t>& retriableStatusCodes() const override {
+    return retriable_status_codes_;
+  }
+  const std::vector<Http::HeaderMatcherSharedPtr>& retriableHeaders() const override {
+    return retriable_headers_;
+  }
+  const std::vector<Http::HeaderMatcherSharedPtr>& retriableRequestHeaders() const override {
+    return retriable_request_headers_;
+  }
+
+  // Router::RetryPolicy
+  bool enabled() const override { return retry_on_ != 0; }
+  void recordRequestHeader(Http::RequestHeaderMap& request_header) override;
+  void recordResponseHeaders(const Http::ResponseHeaderMap&) override{};
+  void recordReset(Http::StreamResetReason) override{};
+  bool wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_header) const override;
+  bool wouldRetryFromReset(Http::StreamResetReason reset_reason) const override;
+  std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
+  std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override;
+  Upstream::RetryPrioritySharedPtr retryPriority() const override;
+  uint32_t hostSelectionMaxAttempts() const override { return host_selection_attempts_; }
+  uint32_t numRetries() const override { return num_retries_; }
+  uint32_t& remainingRetries() override { return remaining_retries_; }
+  absl::optional<std::chrono::milliseconds> baseInterval() const override { return base_interval_; }
+  absl::optional<std::chrono::milliseconds> maxInterval() const override { return max_interval_; }
+
+private:
+  std::chrono::milliseconds per_try_timeout_{0};
+  // We set the number of retries to 1 by default (i.e. when no route or vhost level retry policy is
+  // set) so that when retries get enabled through the x-envoy-retry-on header we default to 1
+  // retry.
+  uint32_t num_retries_{1};
+  uint32_t remaining_retries_{1};
+  uint32_t retry_on_{};
+  // Each pair contains the name and config proto to be used to create the RetryHostPredicates
+  // that should be used when with this policy.
+  std::vector<std::pair<Upstream::RetryHostPredicateFactory&, ProtobufTypes::MessagePtr>>
+      retry_host_predicate_configs_;
+  // Name and config proto to use to create the RetryPriority to use with this policy. Default
+  // initialized when no RetryPriority should be used.
+  std::pair<Upstream::RetryPriorityFactory*, ProtobufTypes::MessagePtr> retry_priority_config_;
+  uint32_t host_selection_attempts_{1};
+  std::vector<uint32_t> retriable_status_codes_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
+  std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;
+  absl::optional<std::chrono::milliseconds> base_interval_;
+  absl::optional<std::chrono::milliseconds> max_interval_;
+  ProtobufMessage::ValidationVisitor* validation_visitor_{};
+};
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -19,51 +19,38 @@ namespace Router {
 
 // These are defined in envoy/router/router.h, however during certain cases the compiler is
 // refusing to use the header version so allocate space here.
-const uint32_t RetryPolicy::RETRY_ON_5XX;
-const uint32_t RetryPolicy::RETRY_ON_GATEWAY_ERROR;
-const uint32_t RetryPolicy::RETRY_ON_CONNECT_FAILURE;
-const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_4XX;
-const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
-const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES;
-const uint32_t RetryPolicy::RETRY_ON_RESET;
-const uint32_t RetryPolicy::RETRY_ON_GRPC_CANCELLED;
-const uint32_t RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED;
-const uint32_t RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED;
-const uint32_t RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE;
+const uint32_t CoreRetryPolicy::RETRY_ON_5XX;
+const uint32_t CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR;
+const uint32_t CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE;
+const uint32_t CoreRetryPolicy::RETRY_ON_RETRIABLE_4XX;
+const uint32_t CoreRetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
+const uint32_t CoreRetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES;
+const uint32_t CoreRetryPolicy::RETRY_ON_RESET;
+const uint32_t CoreRetryPolicy::RETRY_ON_GRPC_CANCELLED;
+const uint32_t CoreRetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED;
+const uint32_t CoreRetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED;
+const uint32_t CoreRetryPolicy::RETRY_ON_GRPC_UNAVAILABLE;
 
-RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
+RetryStatePtr RetryStateImpl::create(RetryPolicy& route_policy,
                                      Http::RequestHeaderMap& request_headers,
                                      const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                      Runtime::RandomGenerator& random,
                                      Event::Dispatcher& dispatcher,
                                      Upstream::ResourcePriority priority) {
-  RetryStatePtr ret;
-
-  // We short circuit here and do not bother with an allocation if there is no chance we will retry.
-  if (request_headers.EnvoyRetryOn() || request_headers.EnvoyRetryGrpcOn() ||
-      route_policy.retryOn()) {
-    ret.reset(new RetryStateImpl(route_policy, request_headers, cluster, runtime, random,
-                                 dispatcher, priority));
-  }
-
-  request_headers.removeEnvoyRetryOn();
-  request_headers.removeEnvoyRetryGrpcOn();
-  request_headers.removeEnvoyMaxRetries();
+  RetryStatePtr ret{new RetryStateImpl(route_policy, request_headers, cluster, runtime, random,
+                                       dispatcher, priority)};
   return ret;
 }
 
-RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy,
-                               Http::RequestHeaderMap& request_headers,
+RetryStateImpl::RetryStateImpl(RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
                                const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                Upstream::ResourcePriority priority)
     : cluster_(cluster), runtime_(runtime), random_(random), dispatcher_(dispatcher),
-      retry_on_(route_policy.retryOn()), retries_remaining_(route_policy.numRetries()),
       priority_(priority), retry_host_predicates_(route_policy.retryHostPredicates()),
       retry_priority_(route_policy.retryPriority()),
-      retriable_status_codes_(route_policy.retriableStatusCodes()),
-      retriable_headers_(route_policy.retriableHeaders()) {
-
+      host_selection_max_attempts_(route_policy.hostSelectionMaxAttempts()),
+      retry_policy_(route_policy) {
   std::chrono::milliseconds base_interval(
       runtime_.snapshot().getInteger("upstream.base_retry_backoff_ms", 25));
   if (route_policy.baseInterval()) {
@@ -79,64 +66,8 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy,
 
   backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(base_interval.count(),
                                                                 max_interval.count(), random_);
-  host_selection_max_attempts_ = route_policy.hostSelectionMaxAttempts();
 
-  // Merge in the headers.
-  if (request_headers.EnvoyRetryOn()) {
-    retry_on_ |= parseRetryOn(request_headers.EnvoyRetryOn()->value().getStringView()).first;
-  }
-  if (request_headers.EnvoyRetryGrpcOn()) {
-    retry_on_ |=
-        parseRetryGrpcOn(request_headers.EnvoyRetryGrpcOn()->value().getStringView()).first;
-  }
-
-  const auto& retriable_request_headers = route_policy.retriableRequestHeaders();
-  if (!retriable_request_headers.empty()) {
-    // If this route limits retries by request headers, make sure there is a match.
-    bool request_header_match = false;
-    for (const auto& retriable_header : retriable_request_headers) {
-      if (retriable_header->matchesHeaders(request_headers)) {
-        request_header_match = true;
-        break;
-      }
-    }
-
-    if (!request_header_match) {
-      retry_on_ = 0;
-    }
-  }
-  if (retry_on_ != 0 && request_headers.EnvoyMaxRetries()) {
-    uint64_t temp;
-    if (absl::SimpleAtoi(request_headers.EnvoyMaxRetries()->value().getStringView(), &temp)) {
-      // The max retries header takes precedence if set.
-      retries_remaining_ = temp;
-    }
-  }
-
-  if (request_headers.EnvoyRetriableStatusCodes()) {
-    for (const auto code : StringUtil::splitToken(
-             request_headers.EnvoyRetriableStatusCodes()->value().getStringView(), ",")) {
-      unsigned int out;
-      if (absl::SimpleAtoi(code, &out)) {
-        retriable_status_codes_.emplace_back(out);
-      }
-    }
-  }
-
-  if (request_headers.EnvoyRetriableHeaderNames()) {
-    // Retriable headers in the configuration are specified via HeaderMatcher.
-    // Giving the same flexibility via request header would require the user
-    // to provide HeaderMatcher serialized into a string. To avoid this extra
-    // complexity we only support name-only header matchers via request
-    // header. Anything more sophisticated needs to be provided via config.
-    for (const auto header_name : StringUtil::splitToken(
-             request_headers.EnvoyRetriableHeaderNames()->value().getStringView(), ",")) {
-      envoy::config::route::v3::HeaderMatcher header_matcher;
-      header_matcher.set_name(std::string(absl::StripAsciiWhitespace(header_name)));
-      retriable_headers_.emplace_back(
-          std::make_shared<Http::HeaderUtility::HeaderData>(header_matcher));
-    }
-  }
+  retry_policy_.recordRequestHeader(request_headers);
 }
 
 RetryStateImpl::~RetryStateImpl() { resetRetry(); }
@@ -155,21 +86,21 @@ std::pair<uint32_t, bool> RetryStateImpl::parseRetryOn(absl::string_view config)
   bool all_fields_valid = true;
   for (const auto retry_on : StringUtil::splitToken(config, ",", false, true)) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnValues._5xx) {
-      ret |= RetryPolicy::RETRY_ON_5XX;
+      ret |= CoreRetryPolicy::RETRY_ON_5XX;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.GatewayError) {
-      ret |= RetryPolicy::RETRY_ON_GATEWAY_ERROR;
+      ret |= CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.ConnectFailure) {
-      ret |= RetryPolicy::RETRY_ON_CONNECT_FAILURE;
+      ret |= CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.Retriable4xx) {
-      ret |= RetryPolicy::RETRY_ON_RETRIABLE_4XX;
+      ret |= CoreRetryPolicy::RETRY_ON_RETRIABLE_4XX;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.RefusedStream) {
-      ret |= RetryPolicy::RETRY_ON_REFUSED_STREAM;
+      ret |= CoreRetryPolicy::RETRY_ON_REFUSED_STREAM;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.RetriableStatusCodes) {
-      ret |= RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES;
+      ret |= CoreRetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.RetriableHeaders) {
-      ret |= RetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
+      ret |= CoreRetryPolicy::RETRY_ON_RETRIABLE_HEADERS;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.Reset) {
-      ret |= RetryPolicy::RETRY_ON_RESET;
+      ret |= CoreRetryPolicy::RETRY_ON_RESET;
     } else {
       all_fields_valid = false;
     }
@@ -183,15 +114,15 @@ std::pair<uint32_t, bool> RetryStateImpl::parseRetryGrpcOn(absl::string_view ret
   bool all_fields_valid = true;
   for (const auto retry_on : StringUtil::splitToken(retry_grpc_on_header, ",", false, true)) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Cancelled) {
-      ret |= RetryPolicy::RETRY_ON_GRPC_CANCELLED;
+      ret |= CoreRetryPolicy::RETRY_ON_GRPC_CANCELLED;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.DeadlineExceeded) {
-      ret |= RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED;
+      ret |= CoreRetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.ResourceExhausted) {
-      ret |= RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED;
+      ret |= CoreRetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Unavailable) {
-      ret |= RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE;
+      ret |= CoreRetryPolicy::RETRY_ON_GRPC_UNAVAILABLE;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Internal) {
-      ret |= RetryPolicy::RETRY_ON_GRPC_INTERNAL;
+      ret |= CoreRetryPolicy::RETRY_ON_GRPC_INTERNAL;
     } else {
       all_fields_valid = false;
     }
@@ -221,11 +152,11 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
     return RetryStatus::No;
   }
 
-  if (retries_remaining_ == 0) {
+  if (retry_policy_.remainingRetries() == 0) {
     return RetryStatus::NoRetryLimitExceeded;
   }
 
-  retries_remaining_--;
+  retry_policy_.remainingRetries()--;
 
   if (!cluster_.resourceManager(priority_).retries().canCreate()) {
     cluster_.stats().upstream_rq_retry_overflow_.inc();
@@ -246,11 +177,13 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
 
 RetryStatus RetryStateImpl::shouldRetryHeaders(const Http::ResponseHeaderMap& response_headers,
                                                DoRetryCallback callback) {
+  retry_policy_.recordResponseHeaders(response_headers);
   return shouldRetry(wouldRetryFromHeaders(response_headers), callback);
 }
 
 RetryStatus RetryStateImpl::shouldRetryReset(Http::StreamResetReason reset_reason,
                                              DoRetryCallback callback) {
+  retry_policy_.recordReset(reset_reason);
   return shouldRetry(wouldRetryFromReset(reset_reason), callback);
 }
 
@@ -266,102 +199,11 @@ RetryStatus RetryStateImpl::shouldHedgeRetryPerTryTimeout(DoRetryCallback callba
 }
 
 bool RetryStateImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_headers) {
-  if (response_headers.EnvoyOverloaded() != nullptr) {
-    return false;
-  }
-
-  // We never retry if the request is rate limited.
-  if (response_headers.EnvoyRateLimited() != nullptr) {
-    return false;
-  }
-
-  if (retry_on_ & RetryPolicy::RETRY_ON_5XX) {
-    if (Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(response_headers))) {
-      return true;
-    }
-  }
-
-  if (retry_on_ & RetryPolicy::RETRY_ON_GATEWAY_ERROR) {
-    if (Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(response_headers))) {
-      return true;
-    }
-  }
-
-  if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_4XX)) {
-    Http::Code code = static_cast<Http::Code>(Http::Utility::getResponseStatus(response_headers));
-    if (code == Http::Code::Conflict) {
-      return true;
-    }
-  }
-
-  if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES)) {
-    for (auto code : retriable_status_codes_) {
-      if (Http::Utility::getResponseStatus(response_headers) == code) {
-        return true;
-      }
-    }
-  }
-
-  if (retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_HEADERS) {
-    for (const auto& retriable_header : retriable_headers_) {
-      if (retriable_header->matchesHeaders(response_headers)) {
-        return true;
-      }
-    }
-  }
-
-  if (retry_on_ &
-      (RetryPolicy::RETRY_ON_GRPC_CANCELLED | RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
-       RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED | RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE |
-       RetryPolicy::RETRY_ON_GRPC_INTERNAL)) {
-    absl::optional<Grpc::Status::GrpcStatus> status = Grpc::Common::getGrpcStatus(response_headers);
-    if (status) {
-      if ((status.value() == Grpc::Status::Canceled &&
-           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_CANCELLED)) ||
-          (status.value() == Grpc::Status::DeadlineExceeded &&
-           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED)) ||
-          (status.value() == Grpc::Status::ResourceExhausted &&
-           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED)) ||
-          (status.value() == Grpc::Status::Unavailable &&
-           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE)) ||
-          (status.value() == Grpc::Status::Internal &&
-           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_INTERNAL))) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  return retry_policy_.wouldRetryFromHeaders(response_headers);
 }
 
 bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason reset_reason) {
-  // First check "never retry" conditions so we can short circuit (we never
-  // retry if the reset reason is overflow).
-  if (reset_reason == Http::StreamResetReason::Overflow) {
-    return false;
-  }
-
-  if (retry_on_ & RetryPolicy::RETRY_ON_RESET) {
-    return true;
-  }
-
-  if (retry_on_ & (RetryPolicy::RETRY_ON_5XX | RetryPolicy::RETRY_ON_GATEWAY_ERROR)) {
-    // Currently we count an upstream reset as a "5xx" (since it will result in
-    // one). With RETRY_ON_RESET we may eventually remove these policies.
-    return true;
-  }
-
-  if ((retry_on_ & RetryPolicy::RETRY_ON_REFUSED_STREAM) &&
-      reset_reason == Http::StreamResetReason::RemoteRefusedStreamReset) {
-    return true;
-  }
-
-  if ((retry_on_ & RetryPolicy::RETRY_ON_CONNECT_FAILURE) &&
-      reset_reason == Http::StreamResetReason::ConnectionFailure) {
-    return true;
-  }
-
-  return false;
+  return retry_policy_.wouldRetryFromReset(reset_reason);
 }
 
 } // namespace Router

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -24,8 +24,7 @@ namespace Router {
  */
 class RetryStateImpl : public RetryState {
 public:
-  static RetryStatePtr create(const RetryPolicy& route_policy,
-                              Http::RequestHeaderMap& request_headers,
+  static RetryStatePtr create(RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
                               const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                               Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                               Upstream::ResourcePriority priority);
@@ -50,7 +49,7 @@ public:
   static std::pair<uint32_t, bool> parseRetryGrpcOn(absl::string_view retry_grpc_on_header);
 
   // Router::RetryState
-  bool enabled() override { return retry_on_ != 0; }
+  bool enabled() override { return retry_policy_.enabled(); }
   RetryStatus shouldRetryHeaders(const Http::ResponseHeaderMap& response_headers,
                                  DoRetryCallback callback) override;
   // Returns true if the retry policy would retry the passed headers. Does not
@@ -86,7 +85,7 @@ public:
   uint32_t hostSelectionMaxAttempts() const override { return host_selection_max_attempts_; }
 
 private:
-  RetryStateImpl(const RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
+  RetryStateImpl(RetryPolicy& route_policy, Http::RequestHeaderMap& request_headers,
                  const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                  Upstream::ResourcePriority priority);
@@ -100,8 +99,6 @@ private:
   Runtime::Loader& runtime_;
   Runtime::RandomGenerator& random_;
   Event::Dispatcher& dispatcher_;
-  uint32_t retry_on_{};
-  uint32_t retries_remaining_{};
   DoRetryCallback callback_;
   Event::TimerPtr retry_timer_;
   Upstream::ResourcePriority priority_;
@@ -109,8 +106,7 @@ private:
   std::vector<Upstream::RetryHostPredicateSharedPtr> retry_host_predicates_;
   Upstream::RetryPrioritySharedPtr retry_priority_;
   uint32_t host_selection_max_attempts_;
-  std::vector<uint32_t> retriable_status_codes_;
-  std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
+  RetryPolicy& retry_policy_;
 };
 
 } // namespace Router

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1460,7 +1460,7 @@ uint32_t Filter::numRequestsAwaitingHeaders() {
 }
 
 RetryStatePtr
-ProdFilter::createRetryState(const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
+ProdFilter::createRetryState(RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
                              const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                              Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                              Upstream::ResourcePriority priority) {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -393,7 +393,7 @@ private:
                           bool dropped);
   void chargeUpstreamAbort(Http::Code code, bool dropped, UpstreamRequest& upstream_request);
   void cleanup();
-  virtual RetryStatePtr createRetryState(const RetryPolicy& policy,
+  virtual RetryStatePtr createRetryState(RetryPolicy& policy,
                                          Http::RequestHeaderMap& request_headers,
                                          const Upstream::ClusterInfo& cluster,
                                          Runtime::Loader& runtime, Runtime::RandomGenerator& random,
@@ -492,7 +492,7 @@ public:
 
 private:
   // Filter
-  RetryStatePtr createRetryState(const RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
+  RetryStatePtr createRetryState(RetryPolicy& policy, Http::RequestHeaderMap& request_headers,
                                  const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                  Upstream::ResourcePriority priority) override;

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -165,6 +165,16 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "retry_policy_impl_test",
+    srcs = ["retry_policy_impl_test.cc"],
+    deps = [
+        "//source/common/router:retry_policy_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+    ],
+)
+
 envoy_proto_library(
     name = "route_fuzz_proto",
     srcs = ["route_fuzz.proto"],

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3076,11 +3076,11 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE,
-            config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
 
   EXPECT_EQ(std::chrono::milliseconds(0),
             config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
@@ -3091,10 +3091,11 @@ virtual_hosts:
                    ->routeEntry()
                    ->retryPolicy()
                    .numRetries());
-  EXPECT_EQ(0U, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
-                    ->routeEntry()
-                    ->retryPolicy()
-                    .retryOn());
+  EXPECT_EQ(
+      0U,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
 
   EXPECT_EQ(std::chrono::milliseconds(1000),
             config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
@@ -3105,12 +3106,12 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE | RetryPolicy::RETRY_ON_5XX |
-                RetryPolicy::RETRY_ON_GATEWAY_ERROR | RetryPolicy::RETRY_ON_RESET,
-            config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE | CoreRetryPolicy::RETRY_ON_5XX |
+          CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR | CoreRetryPolicy::RETRY_ON_RESET,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
 }
 
 TEST_F(RouteMatcherTest, RetryVirtualHostLevel) {
@@ -3145,11 +3146,11 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE,
-            config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
   EXPECT_EQ(7U, config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
                     ->routeEntry()
                     ->retryShadowBufferLimit());
@@ -3164,12 +3165,12 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE | RetryPolicy::RETRY_ON_5XX |
-                RetryPolicy::RETRY_ON_GATEWAY_ERROR | RetryPolicy::RETRY_ON_RESET,
-            config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE | CoreRetryPolicy::RETRY_ON_5XX |
+          CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR | CoreRetryPolicy::RETRY_ON_RESET,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
   EXPECT_EQ(std::chrono::milliseconds(1000),
             config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
                 ->routeEntry()
@@ -3179,12 +3180,12 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE | RetryPolicy::RETRY_ON_5XX |
-                RetryPolicy::RETRY_ON_GATEWAY_ERROR | RetryPolicy::RETRY_ON_RESET,
-            config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE | CoreRetryPolicy::RETRY_ON_5XX |
+          CoreRetryPolicy::RETRY_ON_GATEWAY_ERROR | CoreRetryPolicy::RETRY_ON_RESET,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
   EXPECT_EQ(8U, config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
                     ->routeEntry()
                     ->retryShadowBufferLimit());
@@ -3228,11 +3229,11 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE,
-            config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_CONNECT_FAILURE,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
 
   EXPECT_EQ(std::chrono::milliseconds(0),
             config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
@@ -3243,10 +3244,11 @@ virtual_hosts:
                    ->routeEntry()
                    ->retryPolicy()
                    .numRetries());
-  EXPECT_EQ(0U, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
-                    ->routeEntry()
-                    ->retryPolicy()
-                    .retryOn());
+  EXPECT_EQ(
+      0U,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
 
   EXPECT_EQ(std::chrono::milliseconds(1000),
             config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
@@ -3257,12 +3259,12 @@ virtual_hosts:
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_5XX | RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
-                RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED,
-            config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
-                ->routeEntry()
-                ->retryPolicy()
-                .retryOn());
+  EXPECT_EQ(
+      CoreRetryPolicy::RETRY_ON_5XX | CoreRetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
+          CoreRetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED,
+      dynamic_cast<CoreRetryPolicy&>(
+          config.route(genHeaders("www.lyft.com", "/", "GET"), 0)->routeEntry()->retryPolicy())
+          .retryOn());
 }
 
 // Test route-specific retry back-off intervals.
@@ -6603,7 +6605,8 @@ virtual_hosts:
                         true);
   Http::TestRequestHeaderMapImpl headers =
       genRedirectHeaders("idle.lyft.com", "/regex", true, false);
-  const auto& retry_policy = config.route(headers, 0)->routeEntry()->retryPolicy();
+  const auto& retry_policy =
+      dynamic_cast<CoreRetryPolicy&>(config.route(headers, 0)->routeEntry()->retryPolicy());
   const std::vector<uint32_t> expected_codes{100, 200};
   EXPECT_EQ(expected_codes, retry_policy.retriableStatusCodes());
 }
@@ -6632,7 +6635,8 @@ virtual_hosts:
                         true);
   Http::TestRequestHeaderMapImpl headers =
       genRedirectHeaders("idle.lyft.com", "/regex", true, false);
-  const auto& retry_policy = config.route(headers, 0)->routeEntry()->retryPolicy();
+  const auto& retry_policy =
+      dynamic_cast<CoreRetryPolicy&>(config.route(headers, 0)->routeEntry()->retryPolicy());
   ASSERT_EQ(2, retry_policy.retriableHeaders().size());
 
   Http::TestHeaderMapImpl expected_0{{":status", "500"}};

--- a/test/common/router/retry_policy_impl_test.cc
+++ b/test/common/router/retry_policy_impl_test.cc
@@ -1,0 +1,632 @@
+#include "envoy/config/route/v3/route_components.pb.validate.h"
+
+#include "common/http/header_map_impl.h"
+#include "common/router/retry_policy_impl.h"
+
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+
+namespace Envoy {
+namespace Router {
+namespace {
+
+envoy::config::route::v3::RetryPolicy
+parseRetryPolicyConfigurationFromYaml(const std::string& yaml) {
+  envoy::config::route::v3::RetryPolicy policy;
+  TestUtility::loadFromYaml(yaml, policy);
+  TestUtility::validate(policy);
+  return policy;
+}
+
+class RetryPolicyImplTest : public testing::Test {
+public:
+  void setup(const envoy::config::route::v3::RetryPolicy& retry_policy) {
+    policy_ = RetryPolicyImpl(retry_policy, ProtobufMessage::getStrictValidationVisitor());
+  }
+
+  const Http::StreamResetReason remote_reset_{Http::StreamResetReason::RemoteReset};
+  const Http::StreamResetReason remote_refused_stream_reset_{
+      Http::StreamResetReason::RemoteRefusedStreamReset};
+  const Http::StreamResetReason overflow_reset_{Http::StreamResetReason::Overflow};
+  const Http::StreamResetReason connect_failure_{Http::StreamResetReason::ConnectionFailure};
+
+  RetryPolicyImpl policy_;
+};
+
+TEST_F(RetryPolicyImplTest, DefaultRetryPolicy) {
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
+
+  EXPECT_EQ(policy_.retryOn(), 0);
+  EXPECT_TRUE(policy_.retriableHeaders().empty());
+  EXPECT_TRUE(policy_.retriableRequestHeaders().empty());
+  EXPECT_FALSE(policy_.enabled());
+  EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  EXPECT_FALSE(policy_.wouldRetryFromReset(connect_failure_));
+  EXPECT_EQ(policy_.perTryTimeout(), std::chrono::milliseconds(0));
+  EXPECT_TRUE(policy_.retryHostPredicates().empty());
+  EXPECT_EQ(policy_.retryPriority(), nullptr);
+  EXPECT_EQ(policy_.hostSelectionMaxAttempts(), 1);
+  EXPECT_EQ(policy_.numRetries(), 1);
+  EXPECT_EQ(policy_.remainingRetries(), 1);
+  EXPECT_EQ(policy_.baseInterval(), absl::nullopt);
+  EXPECT_EQ(policy_.maxInterval(), absl::nullopt);
+}
+
+TEST_F(RetryPolicyImplTest, PolicyRefusedStream) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "refused-stream"}};
+  policy_.recordRequestHeader(request_headers);
+
+  EXPECT_NE(policy_.retryOn() & CoreRetryPolicy::RETRY_ON_REFUSED_STREAM, 0);
+  EXPECT_TRUE(policy_.enabled());
+  EXPECT_TRUE(policy_.wouldRetryFromReset(remote_refused_stream_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, Policy5xxResetOverflow) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
+  policy_.recordRequestHeader(request_headers);
+
+  EXPECT_TRUE(policy_.enabled());
+  EXPECT_FALSE(policy_.wouldRetryFromReset(overflow_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, Policy5xxRemoteReset) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
+  policy_.recordRequestHeader(request_headers);
+
+  EXPECT_TRUE(policy_.enabled());
+  EXPECT_TRUE(policy_.wouldRetryFromReset(remote_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, Policy5xxRemote503) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, Policy5xxRemote503Overloaded) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"},
+                                                   {"x-envoy-overloaded", "true"}};
+  EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyResourceExhaustedRemoteRateLimited) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "resource-exhausted"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "200"}, {"grpc-status", "8"}, {"x-envoy-ratelimited", "true"}};
+  EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGatewayErrorRemote502) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "502"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGatewayErrorRemote503) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGatewayErrorRemote504) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "504"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGatewayErrorResetOverflow) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_FALSE(policy_.wouldRetryFromReset(overflow_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGatewayErrorRemoteReset) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_TRUE(policy_.wouldRetryFromReset(remote_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGrpcCancelled) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "cancelled"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGrpcDeadlineExceeded) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "deadline-exceeded"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "4"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGrpcResourceExhausted) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "resource-exhausted"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "8"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGrpcUnavilable) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "unavailable"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "14"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyGrpcInternal) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "internal"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "13"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyConnectFailureOtherReset) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_FALSE(policy_.wouldRetryFromReset(remote_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyConnectFailureResetConnectFailure) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_TRUE(policy_.wouldRetryFromReset(connect_failure_));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyRetriable4xxRetry) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-4xx"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "409"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyRetriable4xxNoRetry) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-4xx"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "400"}};
+  EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyRetriable4xxReset) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-4xx"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_FALSE(policy_.wouldRetryFromReset(remote_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, RetriableStatusCodes) {
+  const std::string yaml = R"EOF(
+    retriable_status_codes: [409]
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "409"}};
+  EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+}
+
+TEST_F(RetryPolicyImplTest, RetriableStatusCodesUpstreamReset) {
+  const std::string yaml = R"EOF(
+    retriable_status_codes: [409]
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_FALSE(policy_.wouldRetryFromReset(remote_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, RetriableStatusCodesHeader) {
+  auto setup = [this](Http::TestRequestHeaderMapImpl request_headers) {
+    policy_ = RetryPolicyImpl();
+    policy_.recordRequestHeader(request_headers);
+    EXPECT_TRUE(policy_.enabled());
+  };
+
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"},
+                                                   {"x-envoy-retriable-status-codes", "200"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"},
+                                                   {"x-envoy-retriable-status-codes", "418,200"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "retriable-status-codes"},
+        {"x-envoy-retriable-status-codes", "   418 junk,200"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "retriable-status-codes"},
+        {"x-envoy-retriable-status-codes", "   418 junk,xxx200"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+}
+
+// Test that when 'retriable-headers' policy is set via request header, certain configured headers
+// trigger retries.
+TEST_F(RetryPolicyImplTest, RetriableHeadersPolicySetViaRequestHeader) {
+  const std::string yaml = R"EOF(
+    retry_on: "5xx"
+    retriable_headers: 
+    - name: "X-Upstream-Pushback"
+  )EOF";
+
+  auto config = parseRetryPolicyConfigurationFromYaml(yaml);
+  auto setup = [this, config](Http::TestRequestHeaderMapImpl request_headers) {
+    this->setup(config);
+    policy_.recordRequestHeader(request_headers);
+    EXPECT_TRUE(policy_.enabled());
+  };
+
+  // No retries based on response headers: retry mode isn't enabled.
+  {
+    Http::TestRequestHeaderMapImpl request_headers;
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-upstream-pushback", "true"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  // Retries based on response headers: retry mode enabled via request header.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-headers"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-upstream-pushback", "true"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+}
+
+// Test that when 'retriable-headers' policy is set via retry policy configuration,
+// configured header matcher conditions trigger retries.
+TEST_F(RetryPolicyImplTest, RetriableHeadersPolicyViaRetryPolicyConfiguration) {
+  const std::string yaml = R"EOF(
+    retry_on: "retriable-headers"
+    retriable_headers: 
+    - name: "X-Upstream-Pushback"
+    - name: "should-retry"
+      exact_match: "yes"
+    - name: "X-Verdict"
+      prefix_match: "retry"
+    - name: ":status"
+      range_match: 
+        start: 500
+        end: 505
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+
+  // matcher1: header presence (any value).
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-upstream-pushback", "true"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-upstream-pushback", "false"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  // matcher2: exact header value match.
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"should-retry", "yes"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"should-retry", "no"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  // matcher3: prefix match.
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-verdict", "retry-please"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-verdict", "dont-retry-please"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  // matcher4: status code range (note half-open semantics: [start, end)).
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "499"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "504"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "505"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+}
+
+// Test various combinations of retry headers set via request headers.
+TEST_F(RetryPolicyImplTest, RetriableHeadersSetViaRequestHeader) {
+  auto setup = [this](Http::TestRequestHeaderMapImpl request_headers) {
+    policy_ = RetryPolicyImpl();
+    policy_.recordRequestHeader(request_headers);
+    EXPECT_TRUE(policy_.enabled());
+  };
+
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "retriable-headers"},
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback,FOOBAR"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{"x-upstream-pushback", "yes"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "retriable-headers"},
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback,  FOOBAR  "}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{"foobar", "false"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "retriable-headers"},
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback,,FOOBAR"}};
+    setup(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+}
+
+// Test merging retriable headers set via request headers and via config file.
+TEST_F(RetryPolicyImplTest, RetriableHeadersMergedConfigAndRequestHeaders) {
+  // Config says: retry if response is not 200.
+  const std::string yaml = R"EOF(
+    retry_on: "retriable-headers"
+    retriable_headers:
+    - name: ":status"
+      exact_match: "200"
+      invert_match: true
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+
+  // No retries according to config.
+  {
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  // Request header supplements the config: as a result we retry on 200.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retriable-header-names", "  :status,  FOOBAR  "}};
+    policy_.recordRequestHeader(request_headers);
+    EXPECT_TRUE(policy_.enabled());
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+}
+
+TEST_F(RetryPolicyImplTest, PolicyResetRemoteReset) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "reset"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_TRUE(policy_.wouldRetryFromReset(remote_reset_));
+}
+
+TEST_F(RetryPolicyImplTest, PolicyLimitedByRequestHeaders) {
+  const std::string yaml = R"EOF(
+    retry_on: "retriable-headers"
+    retriable_request_headers:
+    - name: ":method"
+      exact_match: "GET"
+    - name: ":method"
+      exact_match: "HEAD"
+  )EOF";
+  auto config = parseRetryPolicyConfigurationFromYaml(yaml);
+
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
+    setup(config);
+    policy_.recordRequestHeader(request_headers);
+    EXPECT_FALSE(policy_.enabled());
+  }
+
+  {
+
+    Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                   {"x-envoy-retry-on", "retriable-4xx"}};
+    setup(config);
+    policy_.recordRequestHeader(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "409"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {"x-envoy-retry-on", "5xx"}};
+    setup(config);
+    policy_.recordRequestHeader(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":method", "HEAD"},
+                                                   {"x-envoy-retry-on", "5xx"}};
+    setup(config);
+    policy_.recordRequestHeader(request_headers);
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+    EXPECT_TRUE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  // Sanity check that we're only enabling retries for the configured retry-on.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":method", "HEAD"},
+                                                   {"x-envoy-retry-on", "retriable-4xx"}};
+    setup(config);
+    policy_.recordRequestHeader(request_headers);
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "500"}};
+    EXPECT_FALSE(policy_.wouldRetryFromHeaders(response_headers));
+  }
+
+  {
+    Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                   {"x-envoy-retry-on", "5xx"}};
+    setup(config);
+    policy_.recordRequestHeader(request_headers);
+    EXPECT_FALSE(policy_.enabled());
+  }
+}
+
+TEST_F(RetryPolicyImplTest, RouteConfigNoRetriesAllowed) {
+  const std::string yaml = R"EOF(
+    num_retries: 0
+    retry_on: "connect-failure"
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+
+  EXPECT_TRUE(policy_.enabled());
+  EXPECT_EQ(policy_.numRetries(), 0);
+  EXPECT_EQ(policy_.remainingRetries(), 0);
+}
+
+TEST_F(RetryPolicyImplTest, RouteConfigNoHeaderConfig) {
+  const std::string yaml = R"EOF(
+    num_retries: 1
+    retry_on: "connect-failure"
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_TRUE(policy_.wouldRetryFromReset(connect_failure_));
+}
+
+TEST_F(RetryPolicyImplTest, MaxRetriesHeader) {
+  // The max retries header will take precedence over the policy
+  const std::string yaml = R"EOF(
+    num_retries: 4
+  )EOF";
+  setup(parseRetryPolicyConfigurationFromYaml(yaml));
+
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"},
+                                                 {"x-envoy-retry-grpc-on", "cancelled"},
+                                                 {"x-envoy-max-retries", "3"}};
+  policy_.recordRequestHeader(request_headers);
+
+  EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
+  EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
+  EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_TRUE(policy_.wouldRetryFromReset(connect_failure_));
+  EXPECT_EQ(policy_.numRetries(), 3);
+  EXPECT_EQ(policy_.remainingRetries(), 3);
+}
+
+TEST_F(RetryPolicyImplTest, ZeroMaxRetriesHeader) {
+  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"},
+                                                 {"x-envoy-retry-grpc-on", "cancelled"},
+                                                 {"x-envoy-max-retries", "0"}};
+  policy_.recordRequestHeader(request_headers);
+  EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
+  EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
+  EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
+  EXPECT_TRUE(policy_.enabled());
+
+  EXPECT_EQ(policy_.numRetries(), 0);
+  EXPECT_EQ(policy_.remainingRetries(), 0);
+}
+
+} // namespace
+} // namespace Router
+} // namespace Envoy

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -66,7 +66,7 @@ class RouterTestFilter : public Filter {
 public:
   using Filter::Filter;
   // Filter
-  RetryStatePtr createRetryState(const RetryPolicy&, Http::RequestHeaderMap&,
+  RetryStatePtr createRetryState(RetryPolicy&, Http::RequestHeaderMap&,
                                  const Upstream::ClusterInfo&, Runtime::Loader&,
                                  Runtime::RandomGenerator&, Event::Dispatcher&,
                                  Upstream::ResourcePriority) override {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -60,7 +60,7 @@ public:
   using Filter::Filter;
 
   // Filter
-  RetryStatePtr createRetryState(const RetryPolicy&, Http::RequestHeaderMap&,
+  RetryStatePtr createRetryState(RetryPolicy&, Http::RequestHeaderMap&,
                                  const Upstream::ClusterInfo&, Runtime::Loader&,
                                  Runtime::RandomGenerator&, Event::Dispatcher&,
                                  Upstream::ResourcePriority) override {

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -18,7 +18,7 @@ namespace Router {
 MockDirectResponseEntry::MockDirectResponseEntry() = default;
 MockDirectResponseEntry::~MockDirectResponseEntry() = default;
 
-TestRetryPolicy::TestRetryPolicy() { num_retries_ = 1; }
+TestRetryPolicy::TestRetryPolicy() { num_retries_ = remaining_retries_ = 1; }
 
 TestRetryPolicy::~TestRetryPolicy() = default;
 


### PR DESCRIPTION
Signed-off-by: Yan Xue <yxyan@google.com>

1. Introduce a base class `RetryPolicy`
2. Rename current RetryPolicy to `CoreRetryPolicy`
3. Extract `RetryPolicyImpl` from config_impl.cc

Description: refactor RetryPolicy
Risk Level: High
Testing: Existing Tests + Unit tests
Docs Changes: N/A
Release Notes: N/A
Fixes #Issue: https://github.com/envoyproxy/envoy/issues/9946
[Optional Deprecated:]
