### PR TITLE
test: avoid unnecessary copy triggering warning on Google import.

### DIFF
--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -341,7 +341,7 @@ public:
     auto* resource = response.add_resources();
     resource->set_name("cannot-resolve-alias");
     resource->set_version(version);
-    for (const auto alias : aliases) {
+    for (const auto& alias : aliases) {
       resource->add_aliases(alias);
     }
     response.set_nonce("noncense");


### PR DESCRIPTION
This occurs becaue of a new range loop "unnnecesary copy" warning in -Wall for latest Clang
(-Wrange-loop-construct). This is not available in Clang 9.

The related -Wrange-loop-analysis seems to have been disabled in Absl due to its lack of
precision for small value types, see https://abseil.io/docs/cpp/platforms/compilerflags.

Risk level: Low
Testing: Build

Signed-off-by: Harvey Tuch <htuch@google.com>
