### PR TITLE
deps: update curl to 7.69.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -265,9 +265,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/census-instrumentation/opencensus-cpp/archive/13b1a2f29f541b6b2c4cb8bc3f6fbf3589d44227.tar.gz"],
     ),
     com_github_curl = dict(
-        sha256 = "1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358",
-        strip_prefix = "curl-7.68.0",
-        urls = ["https://github.com/curl/curl/releases/download/curl-7_68_0/curl-7.68.0.tar.gz"],
+        sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",
+        strip_prefix = "curl-7.69.1",
+        urls = ["https://github.com/curl/curl/releases/download/curl-7_69_1/curl-7.69.1.tar.gz"],
     ),
     com_googlesource_chromium_v8 = dict(
         # This archive was created using https://storage.googleapis.com/envoyproxy-wee8/wee8-archive.sh


### PR DESCRIPTION
Description: Minor dependency update
* [7.69.0 changelog](https://curl.haxx.se/changes.html#7_69_0)
* [7.69.1 changelog (bugfix-only release)](https://curl.haxx.se/changes.html#7_69_1)

Risk Level: low - only used by AWS extension, and release notes seem harmless; mostly things we don't use.
Testing: existing
