### PR TITLE
docs: clarify static route config in config dump

### DIFF
--- a/api/envoy/admin/v2alpha/config_dump.proto
+++ b/api/envoy/admin/v2alpha/config_dump.proto
@@ -170,10 +170,10 @@ message ClustersConfigDump {
 }
 
 // Envoy's RDS implementation fills this message with all currently loaded routes, as described by
-// their RouteConfiguration objects. Static routes configured in the bootstrap configuration are
-// separated from those configured dynamically via RDS. Route configuration information can be used
-// to recreate an Envoy configuration by populating all routes as static routes or by returning them
-// in RDS responses.
+// their RouteConfiguration objects. Static routes that are either defined in the bootstrap configuration
+// or defined inline while configuring listeners are separated from those configured dynamically via RDS.
+// Route configuration information can be used to recreate an Envoy configuration by populating all routes
+// as static routes or by returning them in RDS responses.
 message RoutesConfigDump {
   message StaticRouteConfig {
     // The route config.

--- a/api/envoy/admin/v3/config_dump.proto
+++ b/api/envoy/admin/v3/config_dump.proto
@@ -201,10 +201,10 @@ message ClustersConfigDump {
 }
 
 // Envoy's RDS implementation fills this message with all currently loaded routes, as described by
-// their RouteConfiguration objects. Static routes configured in the bootstrap configuration are
-// separated from those configured dynamically via RDS. Route configuration information can be used
-// to recreate an Envoy configuration by populating all routes as static routes or by returning them
-// in RDS responses.
+// their RouteConfiguration objects. Static routes that are either defined in the bootstrap configuration
+// or defined inline while configuring listeners are separated from those configured dynamically via RDS.
+// Route configuration information can be used to recreate an Envoy configuration by populating all routes
+// as static routes or by returning them in RDS responses.
 message RoutesConfigDump {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.admin.v2alpha.RoutesConfigDump";

--- a/generated_api_shadow/envoy/admin/v2alpha/config_dump.proto
+++ b/generated_api_shadow/envoy/admin/v2alpha/config_dump.proto
@@ -170,10 +170,10 @@ message ClustersConfigDump {
 }
 
 // Envoy's RDS implementation fills this message with all currently loaded routes, as described by
-// their RouteConfiguration objects. Static routes configured in the bootstrap configuration are
-// separated from those configured dynamically via RDS. Route configuration information can be used
-// to recreate an Envoy configuration by populating all routes as static routes or by returning them
-// in RDS responses.
+// their RouteConfiguration objects. Static routes that are either defined in the bootstrap configuration
+// or defined inline while configuring listeners are separated from those configured dynamically via RDS.
+// Route configuration information can be used to recreate an Envoy configuration by populating all routes
+// as static routes or by returning them in RDS responses.
 message RoutesConfigDump {
   message StaticRouteConfig {
     // The route config.

--- a/generated_api_shadow/envoy/admin/v3/config_dump.proto
+++ b/generated_api_shadow/envoy/admin/v3/config_dump.proto
@@ -201,10 +201,10 @@ message ClustersConfigDump {
 }
 
 // Envoy's RDS implementation fills this message with all currently loaded routes, as described by
-// their RouteConfiguration objects. Static routes configured in the bootstrap configuration are
-// separated from those configured dynamically via RDS. Route configuration information can be used
-// to recreate an Envoy configuration by populating all routes as static routes or by returning them
-// in RDS responses.
+// their RouteConfiguration objects. Static routes that are either defined in the bootstrap configuration
+// or defined inline while configuring listeners are separated from those configured dynamically via RDS.
+// Route configuration information can be used to recreate an Envoy configuration by populating all routes
+// as static routes or by returning them in RDS responses.
 message RoutesConfigDump {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.admin.v2alpha.RoutesConfigDump";


### PR DESCRIPTION
Description: A minor doc change to indicate the static routes in config dump can also come from inlined route definitions.
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

