### PR TITLE
[test] Convert access_log_formatter_speed_test to benchmark cc binary and test framework

### DIFF
--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -2,9 +2,10 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
     "envoy_proto_library",
 )
@@ -86,7 +87,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "access_log_formatter_speed_test",
     srcs = ["access_log_formatter_speed_test.cc"],
     external_deps = [
@@ -101,4 +102,9 @@ envoy_cc_test_binary(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:printers_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "access_log_formatter_speed_test_benchmark_test",
+    benchmark_binary = "access_log_formatter_speed_test",
 )

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -8,16 +8,44 @@
 
 namespace {
 
-static std::unique_ptr<Envoy::AccessLog::FormatterImpl> formatter;
-static std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter;
-static std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter;
-static std::unique_ptr<Envoy::TestStreamInfo> stream_info;
+std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> MakeJsonFormatter(bool typed) {
+  std::unordered_map<std::string, std::string> JsonLogFormat = {
+      {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
+      {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
+      {"method", "%REQ(:METHOD)%"},
+      {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
+      {"protocol", "%PROTOCOL%"},
+      {"respoinse_code", "%RESPONSE_CODE%"},
+      {"bytes_sent", "%BYTES_SENT%"},
+      {"duration", "%DURATION%"},
+      {"referer", "%REQ(REFERER)%"},
+      {"user-agent", "%REQ(USER-AGENT)%"}};
+
+  return std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, typed);
+}
+
+std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
+  auto stream_info = std::make_unique<Envoy::TestStreamInfo>();
+  stream_info->setDownstreamRemoteAddress(
+      std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
+  return stream_info;
+}
 
 } // namespace
 
 namespace Envoy {
 
 static void BM_AccessLogFormatter(benchmark::State& state) {
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  static const char* LogFormat =
+      "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
+      "%REQ(:METHOD)% "
+      "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% "
+      "s%RESPONSE_CODE% %BYTES_SENT% %DURATION% %REQ(REFERER)% \"%REQ(USER-AGENT)%\" - - -\n";
+
+  std::unique_ptr<Envoy::AccessLog::FormatterImpl> formatter =
+      std::make_unique<Envoy::AccessLog::FormatterImpl>(LogFormat);
+
   size_t output_bytes = 0;
   Http::TestRequestHeaderMapImpl request_headers;
   Http::TestResponseHeaderMapImpl response_headers;
@@ -32,6 +60,9 @@ static void BM_AccessLogFormatter(benchmark::State& state) {
 BENCHMARK(BM_AccessLogFormatter);
 
 static void BM_JsonAccessLogFormatter(benchmark::State& state) {
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter = MakeJsonFormatter(false);
+
   size_t output_bytes = 0;
   Http::TestRequestHeaderMapImpl request_headers;
   Http::TestResponseHeaderMapImpl response_headers;
@@ -46,6 +77,10 @@ static void BM_JsonAccessLogFormatter(benchmark::State& state) {
 BENCHMARK(BM_JsonAccessLogFormatter);
 
 static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter =
+      MakeJsonFormatter(true);
+
   size_t output_bytes = 0;
   Http::TestRequestHeaderMapImpl request_headers;
   Http::TestResponseHeaderMapImpl response_headers;
@@ -60,38 +95,3 @@ static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
 BENCHMARK(BM_TypedJsonAccessLogFormatter);
 
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  static const char* LogFormat =
-      "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
-      "%REQ(:METHOD)% "
-      "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% "
-      "s%RESPONSE_CODE% %BYTES_SENT% %DURATION% %REQ(REFERER)% \"%REQ(USER-AGENT)%\" - - -\n";
-
-  formatter = std::make_unique<Envoy::AccessLog::FormatterImpl>(LogFormat);
-
-  std::unordered_map<std::string, std::string> JsonLogFormat = {
-      {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
-      {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
-      {"method", "%REQ(:METHOD)%"},
-      {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
-      {"protocol", "%PROTOCOL%"},
-      {"respoinse_code", "%RESPONSE_CODE%"},
-      {"bytes_sent", "%BYTES_SENT%"},
-      {"duration", "%DURATION%"},
-      {"referer", "%REQ(REFERER)%"},
-      {"user-agent", "%REQ(USER-AGENT)%"}};
-
-  json_formatter = std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, false);
-  typed_json_formatter = std::make_unique<Envoy::AccessLog::JsonFormatterImpl>(JsonLogFormat, true);
-
-  stream_info = std::make_unique<Envoy::TestStreamInfo>();
-  stream_info->setDownstreamRemoteAddress(
-      std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}


### PR DESCRIPTION
Description: Convert access_log_formatter_speed_test to benchmark cc binary and test framework
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a