### PR TITLE
compressor: don't increment not_compressed twice

### DIFF
--- a/source/extensions/filters/http/common/compressor/compressor.cc
+++ b/source/extensions/filters/http/common/compressor/compressor.cc
@@ -118,7 +118,6 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
     compressor_ = config_->makeCompressor();
   } else if (!skip_compression_) {
     skip_compression_ = true;
-    config_->stats().not_compressed_.inc();
   }
   return Http::FilterHeadersStatus::Continue;
 }

--- a/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
@@ -152,7 +152,7 @@ protected:
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, false));
     Http::TestResponseTrailerMapImpl trailers;
     EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(trailers));
-    EXPECT_EQ(1, stats_.counter("test.test.not_compressed").value());
+    EXPECT_EQ(0U, stats_.counter("test.test.compressed").value());
   }
 
   CompressorFilterConfigSharedPtr config_;


### PR DESCRIPTION
No need to increment this stat both on decodeHeaders() _and_
encodeHeaders().

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
