### PR TITLE
compressor: simplify logic

### DIFF
--- a/source/extensions/filters/http/common/compressor/compressor.cc
+++ b/source/extensions/filters/http/common/compressor/compressor.cc
@@ -73,8 +73,6 @@ Http::FilterHeadersStatus CompressorFilter::decodeHeaders(Http::RequestHeaderMap
     if (config_->removeAcceptEncodingHeader()) {
       headers.removeAcceptEncoding();
     }
-  } else {
-    config_->stats().not_compressed_.inc();
   }
 
   return Http::FilterHeadersStatus::Continue;
@@ -116,7 +114,7 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
     config_->stats().compressed_.inc();
     // Finally instantiate the compressor.
     compressor_ = config_->makeCompressor();
-  } else if (!skip_compression_) {
+  } else {
     skip_compression_ = true;
     config_->stats().not_compressed_.inc();
   }

--- a/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
@@ -174,7 +174,9 @@ TEST_F(CompressorFilterTest, DecodeHeadersWithRuntimeDisabled) {
   }
 }
 )EOF");
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillRepeatedly(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true))
+      .Times(2)
+      .WillRepeatedly(Return(false));
   doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
   doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
 }

--- a/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
@@ -174,7 +174,7 @@ TEST_F(CompressorFilterTest, DecodeHeadersWithRuntimeDisabled) {
   }
 }
 )EOF");
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillOnce(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillRepeatedly(Return(false));
   doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
   doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
 }

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -176,7 +176,9 @@ TEST_F(GzipFilterTest, RuntimeDisabled) {
   }
 }
 )EOF");
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillRepeatedly(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true))
+      .Times(2)
+      .WillRepeatedly(Return(false));
   doRequest({{":method", "get"}, {"accept-encoding", "deflate, gzip"}}, false);
   doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
 }

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -176,7 +176,7 @@ TEST_F(GzipFilterTest, RuntimeDisabled) {
   }
 }
 )EOF");
-  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillOnce(Return(false));
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillRepeatedly(Return(false));
   doRequest({{":method", "get"}, {"accept-encoding", "deflate, gzip"}}, false);
   doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
 }


### PR DESCRIPTION
This confused me the first time I read it, so make it simpler
for the next reader -- there's no need to handle `not_compressed_.inc()`
from the two different places. Delay it until encodeHeaders() and
do it once.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
