### PR TITLE
fuzz: fix stream reset handling in codec_impl_fuzz_test.

### DIFF
--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5629973466710016
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5629973466710016
@@ -1,0 +1,21 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    end_stream: true
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+    }
+  }
+}

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -126,6 +126,11 @@ public:
     ON_CALL(response_.stream_callbacks_, onResetStream(_, _))
         .WillByDefault(InvokeWithoutArgs([this] {
           ENVOY_LOG_MISC(trace, "reset response for stream index {}", stream_index_);
+          // Reset the client stream when we know the server stream has been reset. This ensures
+          // that the internal book keeping resetStream() below is consistent with the state of the
+          // client codec state, which is necessary to prevent multiple simultaneous streams for the
+          // HTTP/1 codec.
+          request_.request_encoder_->getStream().resetStream(StreamResetReason::LocalReset);
           resetStream();
         }));
     ON_CALL(request_.request_decoder_, decodeHeaders_(_, true))


### PR DESCRIPTION
This started to trip assertions around multiple in-flight streams in the H1 codec after recent
refactors.

Fixes oss-fuzz bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21277

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>