### PR TITLE
[http] Move HTTP1 request flood checks from response encode to request decode.

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -267,9 +267,11 @@ void ServerConnectionImpl::doFloodProtectionChecks() const {
   if (!flood_protection_) {
     return;
   }
-  // Before sending another response, make sure it won't exceed flood protection thresholds.
+  // Before processing another request, make sure that we are below the response flood protection
+  // threshold.
   if (outbound_responses_ >= max_outbound_responses_) {
-    ENVOY_CONN_LOG(trace, "error sending response: Too many pending responses queued", connection_);
+    ENVOY_CONN_LOG(trace, "error accepting request: Too many pending responses queued",
+                   connection_);
     stats_.response_flood_.inc();
     throw FrameFloodException("Too many responses queued.");
   }

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -270,7 +270,7 @@ void ServerConnectionImpl::doFloodProtectionChecks() const {
   // Before processing another request, make sure that we are below the response flood protection
   // threshold.
   if (outbound_responses_ >= max_outbound_responses_) {
-    ENVOY_CONN_LOG(trace, "error accepting request: Too many pending responses queued",
+    ENVOY_CONN_LOG(trace, "error accepting request: too many pending responses queued",
                    connection_);
     stats_.response_flood_.inc();
     throw FrameFloodException("Too many responses queued.");

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -114,9 +114,8 @@ class ResponseEncoderImpl : public StreamEncoderImpl, public ResponseEncoder {
 public:
   using FloodChecks = std::function<void()>;
 
-  ResponseEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter,
-                      FloodChecks& flood_checks)
-      : StreamEncoderImpl(connection, header_key_formatter), flood_checks_(flood_checks) {}
+  ResponseEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter)
+      : StreamEncoderImpl(connection, header_key_formatter) {}
 
   bool startedResponse() { return started_response_; }
 
@@ -126,7 +125,6 @@ public:
   void encodeTrailers(const ResponseTrailerMap& trailers) override { encodeTrailersBase(trailers); }
 
 private:
-  FloodChecks& flood_checks_;
   bool started_response_{};
 };
 
@@ -343,9 +341,8 @@ private:
    * An active HTTP/1.1 request.
    */
   struct ActiveRequest {
-    ActiveRequest(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter,
-                  FloodChecks& flood_checks)
-        : response_encoder_(connection, header_key_formatter, flood_checks) {}
+    ActiveRequest(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter)
+        : response_encoder_(connection, header_key_formatter) {}
 
     HeaderString request_url_;
     RequestDecoder* request_decoder_{};
@@ -400,7 +397,6 @@ private:
   void doFloodProtectionChecks() const;
 
   ServerConnectionCallbacks& callbacks_;
-  std::function<void()> flood_checks_{[&]() { this->doFloodProtectionChecks(); }};
   absl::optional<ActiveRequest> active_request_;
   Http1Settings codec_settings_;
   const Buffer::OwnedBufferFragmentImpl::Releasor response_buffer_releasor_;

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -112,8 +112,6 @@ private:
  */
 class ResponseEncoderImpl : public StreamEncoderImpl, public ResponseEncoder {
 public:
-  using FloodChecks = std::function<void()>;
-
   ResponseEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter)
       : StreamEncoderImpl(connection, header_key_formatter) {}
 
@@ -329,7 +327,6 @@ private:
  */
 class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
-  using FloodChecks = std::function<void()>;
   ServerConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
                        ServerConnectionCallbacks& callbacks, const Http1Settings& settings,
                        uint32_t max_request_headers_kb, const uint32_t max_request_headers_count);

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -633,7 +633,7 @@ TEST_F(Http1ServerConnectionImplTest, FloodProtection) {
   NiceMock<MockRequestDecoder> decoder;
   Buffer::OwnedImpl local_buffer;
   // Read a request and send a response, without draining the response from the
-  // connection buffer. The first three should not cause problems.
+  // connection buffer. The first two should not cause problems.
   for (int i = 0; i < 2; ++i) {
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -659,7 +659,8 @@ TEST_F(Http1ServerConnectionImplTest, FloodProtection) {
     response_encoder->encodeHeaders(headers, true);
   }
 
-  // Trying to shove a third response in the queue should trigger flood protection.
+  // Trying to accept a third request with two buffered responses in the queue should trigger flood
+  // protection.
   {
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -633,7 +633,7 @@ TEST_F(Http1ServerConnectionImplTest, FloodProtection) {
   NiceMock<MockRequestDecoder> decoder;
   Buffer::OwnedImpl local_buffer;
   // Read a request and send a response, without draining the response from the
-  // connection buffer. The first two should not cause problems.
+  // connection buffer. The first three should not cause problems.
   for (int i = 0; i < 2; ++i) {
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))
@@ -669,10 +669,7 @@ TEST_F(Http1ServerConnectionImplTest, FloodProtection) {
         }));
 
     Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
-    codec_->dispatch(buffer);
-
-    TestResponseHeaderMapImpl headers{{":status", "200"}};
-    EXPECT_THROW_WITH_MESSAGE(response_encoder->encodeHeaders(headers, true), FrameFloodException,
+    EXPECT_THROW_WITH_MESSAGE(codec_->dispatch(buffer), FrameFloodException,
                               "Too many responses queued.");
     EXPECT_EQ(1, store_.counter("http1.response_flood").value());
   }

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -52,7 +52,10 @@ public:
         crypto_config_(std::make_unique<EnvoyQuicFakeProofVerifier>()), conn_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *conn_helper_.GetClock()) {}
 
-  Network::ClientConnectionPtr makeClientConnection(uint32_t port) override {
+  Network::ClientConnectionPtr makeClientConnectionWithOptions(
+      uint32_t port, const Network::ConnectionSocket::OptionsSharedPtr& options) override {
+    // Setting socket options is not supported.
+    ASSERT(!options);
     server_addr_ = Network::Utility::resolveUrl(
         fmt::format("udp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
     Network::Address::InstanceConstSharedPtr local_addr =

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -281,10 +281,15 @@ BaseIntegrationTest::BaseIntegrationTest(Network::Address::IpVersion version,
           version, config) {}
 
 Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t port) {
+  return makeClientConnectionWithOptions(port, nullptr);
+}
+
+Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnectionWithOptions(
+    uint32_t port, const Network::ConnectionSocket::OptionsSharedPtr& options) {
   Network::ClientConnectionPtr connection(dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr));
+      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), options));
 
   connection->enableHalfClose(enable_half_close_);
   return connection;

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -198,7 +198,7 @@ public:
                           envoy::config::endpoint::v3::LbEndpoint& endpoint) const;
 
   Network::ClientConnectionPtr makeClientConnection(uint32_t port);
-  Network::ClientConnectionPtr
+  virtual Network::ClientConnectionPtr
   makeClientConnectionWithOptions(uint32_t port,
                                   const Network::ConnectionSocket::OptionsSharedPtr& options);
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -197,7 +197,10 @@ public:
   void setUpstreamAddress(uint32_t upstream_index,
                           envoy::config::endpoint::v3::LbEndpoint& endpoint) const;
 
-  virtual Network::ClientConnectionPtr makeClientConnection(uint32_t port);
+  Network::ClientConnectionPtr makeClientConnection(uint32_t port);
+  Network::ClientConnectionPtr
+  makeClientConnectionWithOptions(uint32_t port,
+                                  const Network::ConnectionSocket::OptionsSharedPtr& options);
 
   void registerTestServerPorts(const std::vector<std::string>& port_names);
   void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1254,7 +1254,7 @@ TEST_P(IntegrationTest, TestManyBadRequests) {
   Http::TestRequestHeaderMapImpl bad_request{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}};
 
-  for (int i = 0; i < 1; ++i) {
+  for (int i = 0; i < 1000; ++i) {
     IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(bad_request);
     response->waitForEndStream();
     ASSERT_TRUE(response->complete());


### PR DESCRIPTION
Description: Move HTTP1 request flood checks from response encode to request decode.
Decode of a new request is guaranteed to happen on a shallow call stack under HCM, which makes it a better choice for flood checks since it reduces the number of unique call stacks under which FrameFloodException may be thrown.
Fixes several cases where FrameFloodException was thrown outside a try/catch block, resulting in an Envoy crash.
Risk Level: low
Testing: unit and integration
Docs Changes: n/a
Release Notes: n/a