### PR TITLE
util: Simplify string hash

### DIFF
--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -122,8 +122,8 @@ struct HeterogeneousStringEqual {
 using SharedStringSet =
     absl::flat_hash_set<SharedString, HeterogeneousStringHash, HeterogeneousStringEqual>;
 
-template <class Value>
-using StringMap =
-    absl::flat_hash_map<std::string, Value, HeterogeneousStringHash, HeterogeneousStringEqual>;
+// A special heterogeneous comparator is not needed for maps of strings; absl
+// hashes allow for looking up a string-container with a string-view by default.
+template <class Value> using StringMap = absl::flat_hash_map<std::string, Value>;
 
 } // namespace Envoy

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -123,6 +123,7 @@ using SharedStringSet =
     absl::flat_hash_set<SharedString, HeterogeneousStringHash, HeterogeneousStringEqual>;
 
 template <class Value>
-using StringMap = absl::flat_hash_map<std::string, Value>;
+using StringMap =
+    absl::flat_hash_map<std::string, Value, HeterogeneousStringHash, HeterogeneousStringEqual>;
 
 } // namespace Envoy

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -123,7 +123,6 @@ using SharedStringSet =
     absl::flat_hash_set<SharedString, HeterogeneousStringHash, HeterogeneousStringEqual>;
 
 template <class Value>
-using StringMap =
-    absl::flat_hash_map<std::string, Value, HeterogeneousStringHash, HeterogeneousStringEqual>;
+using StringMap = absl::flat_hash_map<std::string, Value>;
 
 } // namespace Envoy


### PR DESCRIPTION
Description: Per discussion, no special hasher/comparators are needed for absl hashes of strings to do lookups with string_view.
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a

