### PR TITLE
proto_format: extra check for dirty git tree.

### DIFF
--- a/tools/proto_format/proto_format.sh
+++ b/tools/proto_format/proto_format.sh
@@ -30,7 +30,7 @@ TOOLS=$(dirname $(dirname $(realpath $0)))
 export PYTHONPATH="$TOOLS"
 ./tools/proto_format/proto_sync.py "--mode=$1" ${PROTO_TARGETS}
 
-bazel build ${BAZEL_BUILD_OPTIONS} //tools/type_whisperer:api_build_file 
+bazel build ${BAZEL_BUILD_OPTIONS} //tools/type_whisperer:api_build_file
 cp -f bazel-bin/tools/type_whisperer/BUILD.api_build_file api/BUILD
 
 cp -f  ./api/bazel/*.bzl ./api/bazel/BUILD ./generated_api_shadow/bazel

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -245,6 +245,10 @@ def GenerateCurrentApiDir(api_dir, dst_dir):
   shutil.rmtree(str(dst.joinpath("service", "auth", "v2alpha")))
 
 
+def GitStatus(path):
+  return subprocess.check_output(['git', 'status', '--porcelain', str(path)]).decode()
+
+
 def Sync(api_root, mode, labels, shadow):
   pkg_deps = []
   with tempfile.TemporaryDirectory() as tmp:
@@ -280,6 +284,14 @@ def Sync(api_root, mode, labels, shadow):
         print(diff.decode(), file=sys.stderr)
         sys.exit(1)
       if mode == "fix":
+        git_status = GitStatus(api_root)
+        if git_status:
+          print('git status indicates a dirty API tree:\n%s' % git_status)
+          print(
+              'Proto formatting may overwrite or delete files in the above list with no git backup.'
+          )
+          if input('Continue? [yN] ').strip().lower() != 'y':
+            sys.exit(1)
         src_files = set(str(p.relative_to(current_api_dir)) for p in current_api_dir.rglob('*'))
         dst_files = set(str(p.relative_to(dst_dir)) for p in dst_dir.rglob('*'))
         deleted_files = src_files.difference(dst_files)


### PR DESCRIPTION
Avoid accidental API tree overwrites by proto_format.sh via presenting
user with a prompt if the git tree is dirty, i.e. uncommitted changes.

Risk level: Low (developer tooling only)
Testing: Manual

Signed-off-by: Harvey Tuch <htuch@google.com>