### PR TITLE
Support more propagation modes with LightStep

### DIFF
--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -84,10 +84,8 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
-    unique: true
-    items {enum {defined_only: true}}
-  }];
+  repeated PropagationMode propagation_modes = 3
+      [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -84,7 +84,10 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
+    unique: true
+    items {enum {defined_only: true}}
+  }];
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -61,12 +61,30 @@ message Tracing {
 // Configuration for the LightStep tracer.
 // [#extension: envoy.tracers.lightstep]
 message LightstepConfig {
+  // Available propagation modes
+  enum PropagationMode {
+    // Propagate trace context in the single header x-ot-span-context.
+    ENVOY = 0;
+
+    // Propagate trace context using LightStep's native format.
+    LIGHTSTEP = 1;
+
+    // Propagate trace context using the b3 format.
+    B3 = 2;
+
+    // Propagation trace context using the w3 trace-context standard.
+    TRACE_CONTEXT = 3;
+  }
+
   // The cluster manager cluster that hosts the LightStep collectors.
   string collector_cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // File containing the access token to the `LightStep
   // <https://lightstep.com/>`_ API.
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
+
+  // Propagation modes to use by LightStep's tracer.
+  repeated PropagationMode propagation_modes = 3;
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -84,7 +84,7 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3;
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v3/trace.proto
+++ b/api/envoy/config/trace/v3/trace.proto
@@ -72,12 +72,30 @@ message LightstepConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.trace.v2.LightstepConfig";
 
+  // Available propagation modes
+  enum PropagationMode {
+    // Propagate trace context in the single header x-ot-span-context.
+    ENVOY = 0;
+
+    // Propagate trace context using LightStep's native format.
+    LIGHTSTEP = 1;
+
+    // Propagate trace context using the b3 format.
+    B3 = 2;
+
+    // Propagation trace context using the w3 trace-context standard.
+    TRACE_CONTEXT = 3;
+  }
+
   // The cluster manager cluster that hosts the LightStep collectors.
   string collector_cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // File containing the access token to the `LightStep
   // <https://lightstep.com/>`_ API.
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
+
+  // Propagation modes to use by LightStep's tracer.
+  repeated PropagationMode propagation_modes = 3;
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v3/trace.proto
+++ b/api/envoy/config/trace/v3/trace.proto
@@ -95,7 +95,7 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3;
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v3/trace.proto
+++ b/api/envoy/config/trace/v3/trace.proto
@@ -95,10 +95,8 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
-    unique: true
-    items {enum {defined_only: true}}
-  }];
+  repeated PropagationMode propagation_modes = 3
+      [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/api/envoy/config/trace/v3/trace.proto
+++ b/api/envoy/config/trace/v3/trace.proto
@@ -95,7 +95,10 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
+    unique: true
+    items {enum {defined_only: true}}
+  }];
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v2/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/trace.proto
@@ -84,10 +84,8 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
-    unique: true
-    items {enum {defined_only: true}}
-  }];
+  repeated PropagationMode propagation_modes = 3
+      [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v2/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/trace.proto
@@ -84,7 +84,10 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
+    unique: true
+    items {enum {defined_only: true}}
+  }];
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v2/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/trace.proto
@@ -61,12 +61,30 @@ message Tracing {
 // Configuration for the LightStep tracer.
 // [#extension: envoy.tracers.lightstep]
 message LightstepConfig {
+  // Available propagation modes
+  enum PropagationMode {
+    // Propagate trace context in the single header x-ot-span-context.
+    ENVOY = 0;
+
+    // Propagate trace context using LightStep's native format.
+    LIGHTSTEP = 1;
+
+    // Propagate trace context using the b3 format.
+    B3 = 2;
+
+    // Propagation trace context using the w3 trace-context standard.
+    TRACE_CONTEXT = 3;
+  }
+
   // The cluster manager cluster that hosts the LightStep collectors.
   string collector_cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // File containing the access token to the `LightStep
   // <https://lightstep.com/>`_ API.
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
+
+  // Propagation modes to use by LightStep's tracer.
+  repeated PropagationMode propagation_modes = 3;
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v2/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/trace.proto
@@ -84,7 +84,7 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3;
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v3/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/trace.proto
@@ -70,12 +70,30 @@ message LightstepConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.trace.v2.LightstepConfig";
 
+  // Available propagation modes
+  enum PropagationMode {
+    // Propagate trace context in the single header x-ot-span-context.
+    ENVOY = 0;
+
+    // Propagate trace context using LightStep's native format.
+    LIGHTSTEP = 1;
+
+    // Propagate trace context using the b3 format.
+    B3 = 2;
+
+    // Propagation trace context using the w3 trace-context standard.
+    TRACE_CONTEXT = 3;
+  }
+
   // The cluster manager cluster that hosts the LightStep collectors.
   string collector_cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
   // File containing the access token to the `LightStep
   // <https://lightstep.com/>`_ API.
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
+
+  // Propagation modes to use by LightStep's tracer.
+  repeated PropagationMode propagation_modes = 3;
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v3/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/trace.proto
@@ -93,10 +93,8 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
-    unique: true
-    items {enum {defined_only: true}}
-  }];
+  repeated PropagationMode propagation_modes = 3
+      [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v3/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/trace.proto
@@ -93,7 +93,10 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).repeated = {
+    unique: true
+    items {enum {defined_only: true}}
+  }];
 }
 
 // Configuration for the Zipkin tracer.

--- a/generated_api_shadow/envoy/config/trace/v3/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/trace.proto
@@ -93,7 +93,7 @@ message LightstepConfig {
   string access_token_file = 2 [(validate.rules).string = {min_bytes: 1}];
 
   // Propagation modes to use by LightStep's tracer.
-  repeated PropagationMode propagation_modes = 3;
+  repeated PropagationMode propagation_modes = 3 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Configuration for the Zipkin tracer.

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -36,6 +36,34 @@ static Buffer::InstancePtr serializeGrpcMessage(const lightstep::BufferChain& bu
   return body;
 }
 
+static std::vector<lightstep::PropagationMode>
+MakePropagationModes(const envoy::config::trace::v3::LightstepConfig& lightstep_config) {
+  if (lightstep_config.propagation_modes().empty()) {
+    return {lightstep::PropagationMode::envoy};
+  }
+  std::vector<lightstep::PropagationMode> result;
+  result.reserve(lightstep_config.propagation_modes().size());
+  for (auto propagation_mode : lightstep_config.propagation_modes()) {
+    switch (propagation_mode) {
+    case envoy::config::trace::v3::LightstepConfig::ENVOY:
+      result.push_back(lightstep::PropagationMode::envoy);
+      break;
+    case envoy::config::trace::v3::LightstepConfig::LIGHTSTEP:
+      result.push_back(lightstep::PropagationMode::lightstep);
+      break;
+    case envoy::config::trace::v3::LightstepConfig::B3:
+      result.push_back(lightstep::PropagationMode::b3);
+      break;
+    case envoy::config::trace::v3::LightstepConfig::TRACE_CONTEXT:
+      result.push_back(lightstep::PropagationMode::trace_context);
+      break;
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+    }
+  }
+  return result;
+}
+
 void LightStepLogger::operator()(lightstep::LogLevel level,
                                  opentracing::string_view message) const {
   const fmt::string_view fmt_message{message.data(), message.size()};
@@ -170,12 +198,15 @@ LightStepDriver::LightStepDriver(const envoy::config::trace::v3::LightstepConfig
         fmt::format("{} collector cluster must support http2 for gRPC calls", cluster_->name()));
   }
 
-  tls_->set([this](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+  auto propagation_modes = MakePropagationModes(lightstep_config);
+
+  tls_->set([this, &propagation_modes](
+                Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     lightstep::LightStepTracerOptions tls_options;
     tls_options.access_token = options_->access_token;
     tls_options.component_name = options_->component_name;
     tls_options.use_thread = false;
-    tls_options.use_single_key_propagation = true;
+    tls_options.propagation_modes = propagation_modes;
     tls_options.logger_sink = LightStepLogger{};
 
     tls_options.max_buffered_spans = std::function<size_t()>{[this] {


### PR DESCRIPTION
Adds additional propagation modes for LightStep's tracer.

Fixes https://github.com/envoyproxy/envoy/issues/10273
