### PR TITLE
virtual clusters: add upstream_rq_retry_overflow to stats

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -405,11 +405,12 @@ statistics:
 
   upstream_rq_<\*xx>, Counter, "Aggregate HTTP response codes (e.g., 2xx, 3xx, etc.)"
   upstream_rq_<\*>, Counter, "Specific HTTP response codes (e.g., 201, 302, etc.)"
+  upstream_rq_retry, Counter, Total request retries
+  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
+  upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_time, Histogram, Request time milliseconds
   upstream_rq_total, Counter, Total requests initiated by the router to the upstream
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
-  upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_success, Counter, Total request retry successes
 
 Runtime
 -------

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -409,8 +409,8 @@ statistics:
   upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
   upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_time, Histogram, Request time milliseconds
-  upstream_rq_total, Counter, Total requests initiated by the router to the upstream
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
+  upstream_rq_total, Counter, Total requests initiated by the router to the upstream
 
 Runtime
 -------

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -375,6 +375,7 @@ using ShadowPolicyPtr = std::unique_ptr<ShadowPolicy>;
  */
 #define ALL_VIRTUAL_CLUSTER_STATS(COUNTER)                                                         \
   COUNTER(upstream_rq_retry)                                                                       \
+  COUNTER(upstream_rq_retry_overflow)                                                              \
   COUNTER(upstream_rq_retry_success)                                                               \
   COUNTER(upstream_rq_timeout)                                                                     \
   COUNTER(upstream_rq_total)

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -232,6 +232,9 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
 
   if (!cluster_.resourceManager(priority_).retries().canCreate()) {
     cluster_.stats().upstream_rq_retry_overflow_.inc();
+    if (vcluster_) {
+      vcluster_->stats().upstream_rq_retry_overflow_.inc();
+    }
     return RetryStatus::NoOverflow;
   }
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -791,6 +791,7 @@ TEST_F(RouterRetryStateImplTest, NoAvailableRetries) {
 
   EXPECT_EQ(RetryStatus::NoOverflow, state_->shouldRetryReset(connect_failure_, callback_));
   EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_overflow_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_overflow_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, MaxRetriesHeader) {


### PR DESCRIPTION
Description: adding one more stat in the style of #10474. This should give a full picture of retries happening at the router level for virtual clusters
Risk Level: low
Testing: modified unit test
Docs Changes: added docs
Release Notes: release notes from #10474 are still valid.

Signed-off-by: Jose Nino <jnino@lyft.com>