### PR TITLE
compressor: add more stats

### DIFF
--- a/docs/root/configuration/http/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http/http_filters/gzip_filter.rst
@@ -78,6 +78,8 @@ Every configured Gzip filter has statistics rooted at <stat_prefix>.gzip.* with 
   :widths: 1, 1, 2
 
   compressed, Counter, Number of requests compressed.
+  compressed_finished, Counter, Number of compress calls with finished state.
+  compressed_flushed, Counter, Number of compress calls with flushed state.
   not_compressed, Counter, Number of requests not compressed.
   no_accept_header, Counter, Number of requests with no accept header sent.
   header_identity, Counter, Number of requests sent with "identity" set as the *accept-encoding*.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -16,6 +16,7 @@ Version history
   invokes. This effectively makes Envoy act as an egress gateway to AWS Lambda.
 * aws_request_signing: a few fixes so that it works with S3.
 * buffer: force copy when appending small slices to OwnedImpl buffer to avoid fragmentation.
+* compressor: add flushed vs finished stats (helps with issue #8448).
 * config: use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 * grpc-json: added support for building HTTP request into
   `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.

--- a/source/extensions/filters/http/common/compressor/compressor.h
+++ b/source/extensions/filters/http/common/compressor/compressor.h
@@ -35,6 +35,8 @@ namespace Compressors {
  */
 #define ALL_COMPRESSOR_STATS(COUNTER)                                                              \
   COUNTER(compressed)                                                                              \
+  COUNTER(compressed_flushed)                                                                      \
+  COUNTER(compressed_finished)                                                                     \
   COUNTER(not_compressed)                                                                          \
   COUNTER(no_accept_header)                                                                        \
   COUNTER(header_identity)                                                                         \


### PR DESCRIPTION
We are suspecting that the gzip/compressor filters are under performing
due to excessive flushes. This should help with the investigation and to
support needed changes, if any.

Helps with #8448.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
