### PR TITLE
retries: add upstream_rq_retry_limit_exceeded to cluster and virtual cluster stats

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -409,6 +409,7 @@ statistics:
   upstream_rq_total, Counter, Total requests initiated by the router to the upstream
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
   upstream_rq_retry, Counter, Total request retries
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding the retry budget
   upstream_rq_retry_success, Counter, Total request retry successes
 
 Runtime

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -407,7 +407,7 @@ statistics:
   upstream_rq_<\*>, Counter, "Specific HTTP response codes (e.g., 201, 302, etc.)"
   upstream_rq_retry, Counter, Total request retries
   upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <common_configuration_transient_failures_retries>`
-  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
+  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the :ref:`retry budgets <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`
   upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_time, Histogram, Request time milliseconds
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -406,7 +406,7 @@ statistics:
   upstream_rq_<\*xx>, Counter, "Aggregate HTTP response codes (e.g., 2xx, 3xx, etc.)"
   upstream_rq_<\*>, Counter, "Specific HTTP response codes (e.g., 201, 302, etc.)"
   upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <common_configuration_transient_failures_retries>`
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <config_http_filters_router_x-envoy-max-retries>`
   upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the :ref:`retry budgets <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`
   upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_time, Histogram, Request time milliseconds

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -406,7 +406,7 @@ statistics:
   upstream_rq_<\*xx>, Counter, "Aggregate HTTP response codes (e.g., 2xx, 3xx, etc.)"
   upstream_rq_<\*>, Counter, "Specific HTTP response codes (e.g., 201, 302, etc.)"
   upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding alloted number of retries
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <common_configuration_transient_failures_retries>`
   upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
   upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_time, Histogram, Request time milliseconds

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -409,7 +409,7 @@ statistics:
   upstream_rq_total, Counter, Total requests initiated by the router to the upstream
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
   upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding the retry budget
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding alloted number of retries
   upstream_rq_retry_success, Counter, Total request retry successes
 
 Runtime

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -73,9 +73,9 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely
   upstream_rq_tx_reset, Counter, Total requests that were reset locally
   upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding the retry budget
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding alloted number of retried
   upstream_rq_retry_success, Counter, Total request retry successes
-  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking
+  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
   upstream_flow_control_paused_reading_total, Counter, Total number of times flow control paused reading from upstream
   upstream_flow_control_resumed_reading_total, Counter, Total number of times flow control resumed reading from upstream
   upstream_flow_control_backed_up_total, Counter, Total number of times the upstream connection backed up and paused reads from downstream

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -73,8 +73,9 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely
   upstream_rq_tx_reset, Counter, Total requests that were reset locally
   upstream_rq_retry, Counter, Total request retries
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding the retry budget
   upstream_rq_retry_success, Counter, Total request retry successes
-  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
+  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking
   upstream_flow_control_paused_reading_total, Counter, Total number of times flow control paused reading from upstream
   upstream_flow_control_resumed_reading_total, Counter, Total number of times flow control resumed reading from upstream
   upstream_flow_control_backed_up_total, Counter, Total number of times the upstream connection backed up and paused reads from downstream

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -75,7 +75,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_retry, Counter, Total request retries
   upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <common_configuration_transient_failures_retries>`
   upstream_rq_retry_success, Counter, Total request retry successes
-  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
+  upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the :ref:`retry budget <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`
   upstream_flow_control_paused_reading_total, Counter, Total number of times flow control paused reading from upstream
   upstream_flow_control_resumed_reading_total, Counter, Total number of times flow control resumed reading from upstream
   upstream_flow_control_backed_up_total, Counter, Total number of times the upstream connection backed up and paused reads from downstream

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -73,7 +73,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely
   upstream_rq_tx_reset, Counter, Total requests that were reset locally
   upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding alloted number of retried
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <common_configuration_transient_failures_retries>`
   upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the retry budget
   upstream_flow_control_paused_reading_total, Counter, Total number of times flow control paused reading from upstream

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -73,7 +73,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely
   upstream_rq_tx_reset, Counter, Total requests that were reset locally
   upstream_rq_retry, Counter, Total request retries
-  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <common_configuration_transient_failures_retries>`
+  upstream_rq_retry_limit_exceeded, Counter, Total requests not retried due to exceeding :ref:`the configured number of maximum retries <config_http_filters_router_x-envoy-max-retries>`
   upstream_rq_retry_success, Counter, Total request retry successes
   upstream_rq_retry_overflow, Counter, Total requests not retried due to circuit breaking or exceeding the :ref:`retry budget <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`
   upstream_flow_control_paused_reading_total, Counter, Total number of times flow control paused reading from upstream

--- a/docs/root/faq/load_balancing/transient_failures.rst
+++ b/docs/root/faq/load_balancing/transient_failures.rst
@@ -3,30 +3,32 @@
 How do I handle transient failures?
 ===================================
 
-One of the biggest advantages of using Envoy in a service mesh is that it frees up services 
-from implementing complex resiliency features like circuit breaking, outlier detection and retries 
-that enable services to be resilient to realities such as rolling upgrades, dynamic infrastructure, 
-and network failures. Having these features implemented at Envoy not only improves the availability 
-and resiliency of services but also brings in consistency in terms of the behaviour and observability. 
+One of the biggest advantages of using Envoy in a service mesh is that it frees up services
+from implementing complex resiliency features like circuit breaking, outlier detection and retries
+that enable services to be resilient to realities such as rolling upgrades, dynamic infrastructure,
+and network failures. Having these features implemented at Envoy not only improves the availability
+and resiliency of services but also brings in consistency in terms of the behaviour and observability.
 
-This section explains at a high level the configuration supported by Envoy and how these features can be 
+This section explains at a high level the configuration supported by Envoy and how these features can be
 used together to handle these scenarios.
 
 Circuit Breaking
 ----------------
 
-:ref:`Circuit Breaking <arch_overview_circuit_break>` is a critical component of distributed systems. 
+:ref:`Circuit Breaking <arch_overview_circuit_break>` is a critical component of distributed systems.
 Circuit breaking lets applications configure failure thresholds that ensure safe maximums, allowing components
 to fail quickly and apply back pressure as soon as possible. Applying correct circuit breaking thresholds helps
-to save resources which otherwise are wasted in waiting for requests (timeouts) or retrying requests unnecessarily. 
+to save resources which otherwise are wasted in waiting for requests (timeouts) or retrying requests unnecessarily.
 One of the main advantages of the circuit breaking implementation in Envoy is that the circuit breaking limits are applied
 at the network level.
+
+.. _common_configuration_transient_failures_retries:
 
 Retries
 -------
 
-Automatic :ref:`request retries <config_http_filters_router>` is another method of ensuring service resilience. Request retries should 
-typically be used to guard against transient failures. Envoy supports very rich set of configurable parameters that dictate what type 
+Automatic :ref:`request retries <config_http_filters_router>` is another method of ensuring service resilience. Request retries should
+typically be used to guard against transient failures. Envoy supports very rich set of configurable parameters that dictate what type
 of requests are retried, how many times the request should be retried, timeouts for retries, etc.
 
 Retries in gRPC services
@@ -37,24 +39,24 @@ For gRPC services, Envoy looks at the gRPC status in the response and attempts a
 The following application status codes in gRPC are considered safe for automatic retry.
 
 * *CANCELLED* - Return this code if there is an error that can be retried in the service.
-* *RESOURCE_EXHAUSTED* - Return this code if some of the resources that service depends on are exhausted in that instance so that retrying 
+* *RESOURCE_EXHAUSTED* - Return this code if some of the resources that service depends on are exhausted in that instance so that retrying
   to another instance would help. Please note that for shared resource exhaustion, returning this will not help. Instead :ref:`rate limiting <arch_overview_global_rate_limit>`
   should be used to handle such cases.
 
-The HTTP Status codes *502 (Bad Gateway)*, *503 (Service Unavailable)* and *504 (Gateway Timeout)* are all mapped to gRPC status code *UNAVAILABLE*. 
+The HTTP Status codes *502 (Bad Gateway)*, *503 (Service Unavailable)* and *504 (Gateway Timeout)* are all mapped to gRPC status code *UNAVAILABLE*.
 This can also be considered safe for automatic retry.
 
 The idempotency of a request is an important consideration when configuring retries.
 
-Envoy also supports extensions to its retry policies. The :ref:`retry plugins <arch_overview_http_retry_plugins>` 
+Envoy also supports extensions to its retry policies. The :ref:`retry plugins <arch_overview_http_retry_plugins>`
 allow you to customize the Envoy retry implementation to your application.
 
 Outlier Detection
 -----------------
 
 :ref:`Outlier detection <arch_overview_outlier_detection>` is a way of dynamically detecting misbehaving hosts
-in the upstream cluster. By detecting such hosts and ejecting them for a temporary period of time from the healthy 
-load balancing set, Envoy can increase the success rate of a cluster. Envoy supports configuring outlier detection 
+in the upstream cluster. By detecting such hosts and ejecting them for a temporary period of time from the healthy
+load balancing set, Envoy can increase the success rate of a cluster. Envoy supports configuring outlier detection
 based on continuous *5xx*, continuous gateway failures and success rate.
 
 Envoy also allows you to configure the ejection period.
@@ -63,8 +65,8 @@ Envoy also allows you to configure the ejection period.
 
 The following settings help to optimize some combination of:
 
-* Maximum request success for common scenarios (i.e. rolling upgrade) 
-* Speed 
+* Maximum request success for common scenarios (i.e. rolling upgrade)
+* Speed
 * Avoid cascading failures
 
 
@@ -81,9 +83,9 @@ The following settings help to optimize some combination of:
   }
 
 For the purpose of this specific use case, the retry budget for upstream cluster should be configured to
-enable and control concurrent retries. If the value configured is too low, some requests will not be retried, 
+enable and control concurrent retries. If the value configured is too low, some requests will not be retried,
 which can be measured via :ref:`upstream_rq_retry_overflow <config_cluster_manager_cluster_stats>`.
-If the value configured is too high, the service can be overwhelmed with retry requests. 
+If the value configured is too high, the service can be overwhelmed with retry requests.
 
 
 *Outlier Detection*
@@ -97,9 +99,9 @@ If the value configured is too high, the service can be overwhelmed with retry r
      "consecutive_gateway_failure": 5,
   }
 
-This setting enables outlier detection if there are 5 consecutive *5xx* or *gateway failures* 
-and limits the number of hosts that are ejected to 50% of the upstream cluster size. This configuration 
-places a safe limit on the number of hosts removed. Please note that once a host a ejected, it will be returned 
+This setting enables outlier detection if there are 5 consecutive *5xx* or *gateway failures*
+and limits the number of hosts that are ejected to 50% of the upstream cluster size. This configuration
+places a safe limit on the number of hosts removed. Please note that once a host a ejected, it will be returned
 to the pool after an ejection time is elapsed (which is equal to the *base_ejection_time* multiplied by the number
 of times the host has been ejected).
 
@@ -118,7 +120,7 @@ of times the host has been ejected).
     "host_selection_retry_max_attempts": "5"
   }
 
-The request will be retried based on the conditions documented in *retry_on*. This setting also configures Envoy to use 
+The request will be retried based on the conditions documented in *retry_on*. This setting also configures Envoy to use
 :ref:`Previous Host Retry Predicate <arch_overview_http_retry_plugins>` that allows it to choose a different
-host than the host where previous request has failed, because typically failures on that same host are likely to continue 
-for some time and immediate retry would have less chance of success. 
+host than the host where previous request has failed, because typically failures on that same host are likely to continue
+for some time and immediate retry would have less chance of success.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -69,7 +69,7 @@ Version history
 * tracers: tracer extensions use the "envoy.tracers" name space. A mapping of extension names is
   available in the :ref:`deprecated <deprecated>` documentation.
 * tracing: added gRPC service configuration to the OpenCensus Stackdriver and OpenCensus Agent tracers.
-* uptream: added ``upstream_rq_retry_limit_exceeded`` to :ref:`cluster <config_cluster_manager_cluster_stats>`, and :ref:`virtual cluster <config_http_filters_router_vcluster_stats>` stats.
+* upstream: added ``upstream_rq_retry_limit_exceeded`` to :ref:`cluster <config_cluster_manager_cluster_stats>`, and :ref:`virtual cluster <config_http_filters_router_vcluster_stats>` stats.
 * upstream: combined HTTP/1 and HTTP/2 connection pool code. This means that circuit breaker
   limits for both requests and connections apply to both pool types. Also, HTTP/2 now has
   the option to limit concurrent requests on a connection, and allow multiple draining

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -68,6 +68,7 @@ Version history
 * tracers: tracer extensions use the "envoy.tracers" name space. A mapping of extension names is
   available in the :ref:`deprecated <deprecated>` documentation.
 * tracing: added gRPC service configuration to the OpenCensus Stackdriver and OpenCensus Agent tracers.
+* uptream: added ``upstream_rq_retry_limit_exceeded`` to :ref:`cluster <config_cluster_manager_cluster_stats>`, and :ref:`virtual cluster <config_http_filters_router_vcluster_stats>` stats.
 * upstream: combined HTTP/1 and HTTP/2 connection pool code. This means that circuit breaker
   limits for both requests and connections apply to both pool types. Also, HTTP/2 now has
   the option to limit concurrent requests on a connection, and allow multiple draining

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -375,6 +375,7 @@ using ShadowPolicyPtr = std::unique_ptr<ShadowPolicy>;
  */
 #define ALL_VIRTUAL_CLUSTER_STATS(COUNTER)                                                         \
   COUNTER(upstream_rq_retry)                                                                       \
+  COUNTER(upstream_rq_retry_limit_exceeded)                                                        \
   COUNTER(upstream_rq_retry_success)                                                               \
   COUNTER(upstream_rq_timeout)                                                                     \
   COUNTER(upstream_rq_total)

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -575,6 +575,7 @@ public:
   COUNTER(upstream_rq_pending_total)                                                               \
   COUNTER(upstream_rq_per_try_timeout)                                                             \
   COUNTER(upstream_rq_retry)                                                                       \
+  COUNTER(upstream_rq_retry_limit_exceeded)                                                        \
   COUNTER(upstream_rq_retry_overflow)                                                              \
   COUNTER(upstream_rq_retry_success)                                                               \
   COUNTER(upstream_rq_rx_reset)                                                                    \

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -225,6 +225,10 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
   }
 
   if (retries_remaining_ == 0) {
+    cluster_.stats().upstream_rq_retry_limit_exceeded_.inc();
+    if (vcluster_) {
+      vcluster_->stats().upstream_rq_retry_limit_exceeded_.inc();
+    }
     return RetryStatus::NoRetryLimitExceeded;
   }
 

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -224,6 +224,8 @@ RetryStatus RetryStateImpl::shouldRetry(bool would_retry, DoRetryCallback callba
     return RetryStatus::No;
   }
 
+  // The request has exhausted the number of retries allotted to it by the retry policy configured
+  // (or the x-envoy-max-retries header).
   if (retries_remaining_ == 0) {
     cluster_.stats().upstream_rq_retry_limit_exceeded_.inc();
     if (vcluster_) {

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -87,6 +87,39 @@ public:
     resource_manager_cleanup_tasks_.clear();
   }
 
+  void verifyPolicyWithRemoteResponse(const std::string& retry_on,
+                                      const std::string& response_status, const bool is_grpc) {
+    Http::TestRequestHeaderMapImpl request_headers;
+    if (is_grpc) {
+      request_headers.setEnvoyRetryGrpcOn(retry_on);
+    } else {
+      request_headers.setEnvoyRetryOn(retry_on);
+    }
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+
+    Http::TestResponseHeaderMapImpl response_headers;
+    if (is_grpc) {
+      response_headers.setStatus("200");
+      response_headers.setGrpcStatus(response_status);
+    } else {
+      response_headers.setStatus(response_status);
+    }
+
+    expectTimerCreateAndEnable();
+    EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+    EXPECT_CALL(callback_ready_, ready());
+    retry_timer_->invokeCallback();
+
+    EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
+              state_->shouldRetryHeaders(response_headers, callback_));
+
+    EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+    EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+    EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+    EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
+  }
+
   void TearDown() override { cleanupOutstandingResources(); }
 
   NiceMock<TestRetryPolicy> policy_;
@@ -126,6 +159,11 @@ TEST_F(RouterRetryStateImplTest, PolicyRefusedStream) {
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryReset(remote_refused_stream_reset_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxResetOverflow) {
@@ -146,21 +184,16 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemoteReset) {
   retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote503) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("5xx" /* retry_on */, "503" /* response_status */,
+                                 false /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote503Overloaded) {
@@ -184,48 +217,18 @@ TEST_F(RouterRetryStateImplTest, PolicyResourceExhaustedRemoteRateLimited) {
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote502) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "502"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("gateway-error" /* retry_on */, "502" /* response_status */,
+                                 false /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote503) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("gateway-error" /* retry_on */, "503" /* response_status */,
+                                 false /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote504) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "504"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("gateway-error" /* retry_on */, "504" /* response_status */,
+                                 false /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorResetOverflow) {
@@ -246,81 +249,36 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemoteReset) {
   retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "cancelled"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("cancelled" /* retry_on */, "1" /* response_status */,
+                                 true /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcDeadlineExceeded) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "deadline-exceeded"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "4"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("deadline-exceeded" /* retry_on */, "4" /* response_status */,
+                                 true /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "resource-exhausted"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "8"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("resource-exhausted" /* retry_on */, "8" /* response_status */,
+                                 true /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcUnavilable) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "unavailable"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "14"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("unavailable" /* retry_on */, "14" /* response_status */,
+                                 true /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcInternal) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "internal"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "13"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
-
-  EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
-            state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("internal" /* retry_on */, "13" /* response_status */,
+                                 true /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
@@ -333,6 +291,11 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
   expectTimerCreateAndEnable();
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryReset(remote_reset_, callback_));
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, RuntimeGuard) {
@@ -364,15 +327,7 @@ TEST_F(RouterRetryStateImplTest, PolicyConnectFailureResetConnectFailure) {
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxRetry) {
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-4xx"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "409"}};
-  expectTimerCreateAndEnable();
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
-  EXPECT_CALL(callback_ready_, ready());
-  retry_timer_->invokeCallback();
+  verifyPolicyWithRemoteResponse("retriable-4xx", "409", false /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxNoRetry) {
@@ -394,14 +349,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxReset) {
 
 TEST_F(RouterRetryStateImplTest, RetriableStatusCodes) {
   policy_.retriable_status_codes_.push_back(409);
-  Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"}};
-  setup(request_headers);
-  EXPECT_TRUE(state_->enabled());
-
-  expectTimerCreateAndEnable();
-
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "409"}};
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetryHeaders(response_headers, callback_));
+  verifyPolicyWithRemoteResponse("retriable-status-codes", "409", false /* is_grpc */);
 }
 
 TEST_F(RouterRetryStateImplTest, RetriableStatusCodesUpstreamReset) {
@@ -692,6 +640,11 @@ TEST_F(RouterRetryStateImplTest, PolicyResetRemoteReset) {
   retry_timer_->invokeCallback();
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded, state_->shouldRetryReset(remote_reset_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyLimitedByRequestHeaders) {
@@ -767,6 +720,11 @@ TEST_F(RouterRetryStateImplTest, RouteConfigNoRetriesAllowed) {
   EXPECT_TRUE(state_->enabled());
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryReset(connect_failure_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(0UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(0UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, RouteConfigNoHeaderConfig) {
@@ -826,8 +784,10 @@ TEST_F(RouterRetryStateImplTest, MaxRetriesHeader) {
 
   EXPECT_EQ(3UL, cluster_.stats().upstream_rq_retry_.value());
   EXPECT_EQ(0UL, cluster_.stats().upstream_rq_retry_success_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
   EXPECT_EQ(3UL, virtual_cluster_.stats().upstream_rq_retry_.value());
   EXPECT_EQ(0UL, virtual_cluster_.stats().upstream_rq_retry_success_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, Backoff) {
@@ -981,6 +941,11 @@ TEST_F(RouterRetryStateImplTest, ZeroMaxRetriesHeader) {
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
             state_->shouldRetryReset(connect_failure_, callback_));
+
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(0UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(0UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 // Check that if there are 0 remaining retries available but we get
@@ -996,6 +961,11 @@ TEST_F(RouterRetryStateImplTest, NoPreferredOverLimitExceeded) {
 
   Http::TestResponseHeaderMapImpl good_response_headers{{":status", "200"}};
   EXPECT_EQ(RetryStatus::No, state_->shouldRetryHeaders(good_response_headers, callback_));
+
+  EXPECT_EQ(0UL, cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(0UL, virtual_cluster_.stats().upstream_rq_retry_limit_exceeded_.value());
+  EXPECT_EQ(1UL, cluster_.stats().upstream_rq_retry_.value());
+  EXPECT_EQ(1UL, virtual_cluster_.stats().upstream_rq_retry_.value());
 }
 
 TEST_F(RouterRetryStateImplTest, BudgetAvailableRetries) {

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -268,6 +268,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
   // 2020/02/13  10042    43797       44136   Metadata: Metadata are shared across different
   //                                          clusters and hosts.
   // 2020/03/16  9964     44085       44600   http2: support custom SETTINGS parameters.
+  // 2020/03/24  10501    44261       44600   upstream: upstream_rq_retry_limit_exceeded.
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -281,7 +282,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
   // If you encounter a failure here, please see
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
-  EXPECT_MEMORY_EQ(m_per_cluster, 44085);
+  EXPECT_MEMORY_EQ(m_per_cluster, 44261);
   EXPECT_MEMORY_LE(m_per_cluster, 44600);
 }
 
@@ -323,6 +324,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // 2020/01/12  9633     35932       36500   config: support recovery of original message when
   //                                          upgrading.
   // 2020/03/16  9964     36220       36800   http2: support custom SETTINGS parameters.
+  // 2020/03/24  10501    36300       36800   upstream: upstream_rq_retry_limit_exceeded.
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -336,7 +338,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // If you encounter a failure here, please see
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
-  EXPECT_MEMORY_EQ(m_per_cluster, 36220);
+  EXPECT_MEMORY_EQ(m_per_cluster, 36300);
   EXPECT_MEMORY_LE(m_per_cluster, 36800);
 }
 


### PR DESCRIPTION
Description: working through #10474 and #10499 I noticed that there was not stat for exceeding the allotted number of retries for a particular request. This PR adds `upstream_rq_retry_limit_exceeded` to track requests not retried due to exceeding the configured number of maximum retries.
Risk Level: low, new stat.
Testing: modified unit tests to check for the new stat and cleaned up existing unit tests.
Docs Changes: added docs about the new stat.
Release Notes: added a release note under "upstream"

Signed-off-by: Jose Nino <jnino@lyft.com>
