### PR TITLE
WIP: Add serializeAsString for FilterState

### DIFF
--- a/include/envoy/stream_info/filter_state.h
+++ b/include/envoy/stream_info/filter_state.h
@@ -10,6 +10,7 @@
 #include "common/protobuf/protobuf.h"
 
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace StreamInfo {
@@ -56,6 +57,13 @@ public:
      * logging. nullptr if the filter state cannot be serialized or serialization is not supported.
      */
     virtual ProtobufTypes::MessagePtr serializeAsProto() const { return nullptr; }
+
+    /**
+     * @return absl::optional<std::string> a optional string to the serialization of the filter
+     * state. No value if the filter state cannot be serialized or serialization is not supported.
+     * This method can be used to get a unstructured serialization result.
+     */
+    virtual absl::optional<std::string> serializeAsString() const { return absl::nullopt; }
   };
 
   virtual ~FilterState() = default;

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -232,6 +232,9 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
   static constexpr absl::string_view FILTER_STATE_TOKEN{"FILTER_STATE("};
   const std::regex command_w_args_regex(R"EOF(%([A-Z]|_)+(\([^\)]*\))?(:[0-9]+)?(%))EOF");
 
+  static constexpr absl::string_view PLAIN_SERIALIZATION{"PLAIN"};
+  static constexpr absl::string_view TYPED_SERIALIZATION{"TYPED"};
+
   for (size_t pos = 0; pos < format.length(); ++pos) {
     if (format[pos] == '%') {
       if (!current_token.empty()) {
@@ -291,12 +294,20 @@ std::vector<FormatterProviderPtr> AccessLogFormatParser::parse(const std::string
         std::vector<std::string> path;
         const size_t start = FILTER_STATE_TOKEN.size();
 
-        parseCommand(token, start, "", key, path, max_length);
+        parseCommand(token, start, ":", key, path, max_length);
         if (key.empty()) {
           throw EnvoyException("Invalid filter state configuration, key cannot be empty.");
         }
 
-        formatters.push_back(std::make_unique<FilterStateFormatter>(key, max_length));
+        auto serialize_type = !path.empty() ? path[path.size() - 1] : TYPED_SERIALIZATION;
+
+        if (serialize_type != PLAIN_SERIALIZATION && serialize_type != TYPED_SERIALIZATION) {
+          throw EnvoyException("Invalid filter state serailize type, only support PLAIN/TYPED.");
+        }
+        bool serialize_as_string = serialize_type == PLAIN_SERIALIZATION;
+
+        formatters.push_back(
+            std::make_unique<FilterStateFormatter>(key, max_length, serialize_as_string));
       } else if (absl::StartsWith(token, "START_TIME")) {
         const size_t parameters_length = pos + StartTimeParamStart + 1;
         const size_t parameters_end = command_end_position - parameters_length;
@@ -909,25 +920,38 @@ DynamicMetadataFormatter::formatValue(const Http::RequestHeaderMap&, const Http:
 }
 
 FilterStateFormatter::FilterStateFormatter(const std::string& key,
-                                           absl::optional<size_t> max_length)
-    : key_(key), max_length_(max_length) {}
+                                           absl::optional<size_t> max_length,
+                                           bool serialize_as_string)
+    : key_(key), max_length_(max_length), serialize_as_string_(serialize_as_string) {}
 
-ProtobufTypes::MessagePtr
+const Envoy::StreamInfo::FilterState::Object*
 FilterStateFormatter::filterState(const StreamInfo::StreamInfo& stream_info) const {
   const StreamInfo::FilterState& filter_state = stream_info.filterState();
   if (!filter_state.hasDataWithName(key_)) {
     return nullptr;
   }
-
-  const auto& object = filter_state.getDataReadOnly<StreamInfo::FilterState::Object>(key_);
-  return object.serializeAsProto();
+  return &filter_state.getDataReadOnly<StreamInfo::FilterState::Object>(key_);
 }
 
 std::string FilterStateFormatter::format(const Http::RequestHeaderMap&,
                                          const Http::ResponseHeaderMap&,
                                          const Http::ResponseTrailerMap&,
                                          const StreamInfo::StreamInfo& stream_info) const {
-  ProtobufTypes::MessagePtr proto = filterState(stream_info);
+  const Envoy::StreamInfo::FilterState::Object* state = filterState(stream_info);
+  if (!state) {
+    return UnspecifiedValueString;
+  }
+
+  if (serialize_as_string_) {
+    absl::optional<std::string> plain_value = state->serializeAsString();
+    if (plain_value.has_value()) {
+      truncate(plain_value.value(), max_length_);
+      return plain_value.value();
+    }
+    return UnspecifiedValueString;
+  }
+
+  ProtobufTypes::MessagePtr proto = state->serializeAsProto();
   if (proto == nullptr) {
     return UnspecifiedValueString;
   }
@@ -948,8 +972,22 @@ ProtobufWkt::Value
 FilterStateFormatter::formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
                                   const Http::ResponseTrailerMap&,
                                   const StreamInfo::StreamInfo& stream_info) const {
-  ProtobufTypes::MessagePtr proto = filterState(stream_info);
-  if (proto == nullptr) {
+  const Envoy::StreamInfo::FilterState::Object* state = filterState(stream_info);
+  if (!state) {
+    return unspecifiedValue();
+  }
+
+  if (serialize_as_string_) {
+    absl::optional<std::string> plain_value = state->serializeAsString();
+    if (plain_value.has_value()) {
+      truncate(plain_value.value(), max_length_);
+      return ValueUtil::stringValue(plain_value.value());
+    }
+    return unspecifiedValue();
+  }
+
+  ProtobufTypes::MessagePtr proto = state->serializeAsProto();
+  if (!proto) {
     return unspecifiedValue();
   }
 

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -274,7 +274,8 @@ public:
  */
 class FilterStateFormatter : public FormatterProvider {
 public:
-  FilterStateFormatter(const std::string& key, absl::optional<size_t> max_length);
+  FilterStateFormatter(const std::string& key, absl::optional<size_t> max_length,
+                       bool serialize_as_string);
 
   // FormatterProvider
   std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
@@ -284,10 +285,13 @@ public:
                                  const StreamInfo::StreamInfo&) const override;
 
 private:
-  ProtobufTypes::MessagePtr filterState(const StreamInfo::StreamInfo& stream_info) const;
+  const Envoy::StreamInfo::FilterState::Object*
+  filterState(const StreamInfo::StreamInfo& stream_info) const;
 
   std::string key_;
   absl::optional<size_t> max_length_;
+
+  bool serialize_as_string_;
 };
 
 /**


### PR DESCRIPTION
Description:

1. Added a virtual method serializeAsString  to FilterState for obtaining unstructured serialization results. Related issues and discussion can read  issue #10430.
It needs to be emphasized that std::string is special because it is essentially a byte array, so it can be used as a flat buffer.

2. Extend format specifier for FilterStateFormatter to choose different serialize method.
Here is a example: %FILTER_STATE(example_key:PLAIN)%.  SerializeAsString will be used to get log string.
If this specifier not set or not equal PLAIN then serializeAsProto will be used.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
