### PR TITLE
Wrong target port in ambassador quick start

### DIFF
--- a/docs/root/start/distro/ambassador.rst
+++ b/docs/root/start/distro/ambassador.rst
@@ -52,7 +52,7 @@ cluster doesn't support ``LoadBalancer`` services, you'll need to change to a
     type: LoadBalancer
     ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080
     selector:
       service: ambassador
 


### PR DESCRIPTION

Description: It only works with 8080.
Risk Level: Low
Docs Changes: yes
