### PR TITLE
tracing: ensure that OpenCensus is configured at most once

### DIFF
--- a/include/envoy/server/tracer_config.h
+++ b/include/envoy/server/tracer_config.h
@@ -45,11 +45,18 @@ public:
    * HttpTracer with the provided parameters, it should throw an EnvoyException in the case of
    * general error or a Json::Exception if the json configuration is erroneous. The returned
    * pointer should always be valid.
+   *
+   * NOTE: Due to the corner case of OpenCensus, who can only support a single tracing
+   *       configuration per entire process, the returned HttpTracer instance is not guaranteed
+   *       to be unique.
+   *       That is why the return type has been changed to std::shared_ptr<> instead of a more
+   *       idiomatic std::unique_ptr<>.
+   *
    * @param config supplies the proto configuration for the HttpTracer
    * @param context supplies the factory context
    */
-  virtual Tracing::HttpTracerPtr createHttpTracer(const Protobuf::Message& config,
-                                                  TracerFactoryContext& context) PURE;
+  virtual Tracing::HttpTracerSharedPtr createHttpTracer(const Protobuf::Message& config,
+                                                        TracerFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.tracers"; }
 };

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -190,9 +190,6 @@ public:
                             const Tracing::Decision tracing_decision) PURE;
 };
 
-// HttpTracerPtr is intended for use by Server::Configuration::TracerFactory implementations.
-using HttpTracerPtr = std::unique_ptr<HttpTracer>;
-// HttpTracerSharedPtr should be used wherever an HttpTracer instance is necessary.
 using HttpTracerSharedPtr = std::shared_ptr<HttpTracer>;
 
 } // namespace Tracing

--- a/source/extensions/tracers/common/factory_base.h
+++ b/source/extensions/tracers/common/factory_base.h
@@ -14,7 +14,7 @@ namespace Common {
 template <class ConfigProto> class FactoryBase : public Server::Configuration::TracerFactory {
 public:
   // Server::Configuration::TracerFactory
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracer(const Protobuf::Message& config,
                    Server::Configuration::TracerFactoryContext& context) override {
     return createHttpTracerTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
@@ -32,7 +32,7 @@ protected:
   FactoryBase(const std::string& name) : name_(name) {}
 
 private:
-  virtual Tracing::HttpTracerPtr
+  virtual Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const ConfigProto& proto_config,
                         Server::Configuration::TracerFactoryContext& context) PURE;
 

--- a/source/extensions/tracers/datadog/config.cc
+++ b/source/extensions/tracers/datadog/config.cc
@@ -19,14 +19,14 @@ namespace Datadog {
 
 DatadogTracerFactory::DatadogTracerFactory() : FactoryBase(TracerNames::get().Datadog) {}
 
-Tracing::HttpTracerPtr DatadogTracerFactory::createHttpTracerTyped(
+Tracing::HttpTracerSharedPtr DatadogTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v3::DatadogConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
   Tracing::DriverPtr datadog_driver = std::make_unique<Driver>(
       proto_config, context.serverFactoryContext().clusterManager(),
       context.serverFactoryContext().scope(), context.serverFactoryContext().threadLocal(),
       context.serverFactoryContext().runtime());
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(datadog_driver),
+  return std::make_shared<Tracing::HttpTracerImpl>(std::move(datadog_driver),
                                                    context.serverFactoryContext().localInfo());
 }
 

--- a/source/extensions/tracers/datadog/config.h
+++ b/source/extensions/tracers/datadog/config.h
@@ -21,7 +21,7 @@ public:
 
 private:
   // FactoryBase
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::DatadogConfig& proto_config,
                         Server::Configuration::TracerFactoryContext& context) override;
 };

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -18,14 +18,14 @@ namespace DynamicOt {
 DynamicOpenTracingTracerFactory::DynamicOpenTracingTracerFactory()
     : FactoryBase(TracerNames::get().DynamicOt) {}
 
-Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracerTyped(
+Tracing::HttpTracerSharedPtr DynamicOpenTracingTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v3::DynamicOtConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
   const std::string& library = proto_config.library();
   const std::string config = MessageUtil::getJsonStringFromMessage(proto_config.config());
   Tracing::DriverPtr dynamic_driver = std::make_unique<DynamicOpenTracingDriver>(
       context.serverFactoryContext().scope(), library, config);
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(dynamic_driver),
+  return std::make_shared<Tracing::HttpTracerImpl>(std::move(dynamic_driver),
                                                    context.serverFactoryContext().localInfo());
 }
 

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -20,7 +20,7 @@ public:
 
 private:
   // FactoryBase
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::DynamicOtConfig& configuration,
                         Server::Configuration::TracerFactoryContext& context) override;
 };

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -19,7 +19,7 @@ namespace Lightstep {
 
 LightstepTracerFactory::LightstepTracerFactory() : FactoryBase(TracerNames::get().Lightstep) {}
 
-Tracing::HttpTracerPtr LightstepTracerFactory::createHttpTracerTyped(
+Tracing::HttpTracerSharedPtr LightstepTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v3::LightstepConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
   auto opts = std::make_unique<lightstep::LightStepTracerOptions>();
@@ -35,7 +35,7 @@ Tracing::HttpTracerPtr LightstepTracerFactory::createHttpTracerTyped(
       context.serverFactoryContext().runtime(), std::move(opts),
       Common::Ot::OpenTracingDriver::PropagationMode::TracerNative,
       context.serverFactoryContext().grpcContext());
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver),
+  return std::make_shared<Tracing::HttpTracerImpl>(std::move(lightstep_driver),
                                                    context.serverFactoryContext().localInfo());
 }
 

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -20,7 +20,7 @@ public:
 
 private:
   // FactoryBase
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::LightstepConfig& proto_config,
                         Server::Configuration::TracerFactoryContext& context) override;
 };

--- a/source/extensions/tracers/opencensus/config.cc
+++ b/source/extensions/tracers/opencensus/config.cc
@@ -19,11 +19,22 @@ OpenCensusTracerFactory::OpenCensusTracerFactory() : FactoryBase(TracerNames::ge
 Tracing::HttpTracerSharedPtr OpenCensusTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v3::OpenCensusConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
+  // Since OpenCensus can only support a single tracing configuration per entire process,
+  // we need to make sure that it is configured at most once.
+  if (tracer_) {
+    if (Envoy::Protobuf::util::MessageDifferencer::Equals(config_, proto_config)) {
+      return tracer_;
+    } else {
+      throw EnvoyException("Opencensus has already been configured with a different config.");
+    }
+  }
   Tracing::DriverPtr driver =
       std::make_unique<Driver>(proto_config, context.serverFactoryContext().localInfo(),
                                context.serverFactoryContext().api());
-  return std::make_shared<Tracing::HttpTracerImpl>(std::move(driver),
-                                                   context.serverFactoryContext().localInfo());
+  tracer_ = std::make_shared<Tracing::HttpTracerImpl>(std::move(driver),
+                                                      context.serverFactoryContext().localInfo());
+  config_ = proto_config;
+  return tracer_;
 }
 
 /**

--- a/source/extensions/tracers/opencensus/config.cc
+++ b/source/extensions/tracers/opencensus/config.cc
@@ -16,13 +16,13 @@ namespace OpenCensus {
 
 OpenCensusTracerFactory::OpenCensusTracerFactory() : FactoryBase(TracerNames::get().OpenCensus) {}
 
-Tracing::HttpTracerPtr OpenCensusTracerFactory::createHttpTracerTyped(
+Tracing::HttpTracerSharedPtr OpenCensusTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v3::OpenCensusConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
   Tracing::DriverPtr driver =
       std::make_unique<Driver>(proto_config, context.serverFactoryContext().localInfo(),
                                context.serverFactoryContext().api());
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(driver),
+  return std::make_shared<Tracing::HttpTracerImpl>(std::move(driver),
                                                    context.serverFactoryContext().localInfo());
 }
 

--- a/source/extensions/tracers/opencensus/config.h
+++ b/source/extensions/tracers/opencensus/config.h
@@ -25,6 +25,11 @@ private:
   Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::OpenCensusConfig& proto_config,
                         Server::Configuration::TracerFactoryContext& context) override;
+
+  // Since OpenCensus can only support a single tracing configuration per entire process,
+  // we need to make sure that it is configured at most once.
+  Tracing::HttpTracerSharedPtr tracer_;
+  envoy::config::trace::v3::OpenCensusConfig config_;
 };
 
 } // namespace OpenCensus

--- a/source/extensions/tracers/opencensus/config.h
+++ b/source/extensions/tracers/opencensus/config.h
@@ -22,7 +22,7 @@ public:
 
 private:
   // FactoryBase
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::OpenCensusConfig& proto_config,
                         Server::Configuration::TracerFactoryContext& context) override;
 };

--- a/source/extensions/tracers/xray/config.cc
+++ b/source/extensions/tracers/xray/config.cc
@@ -21,7 +21,7 @@ namespace XRay {
 
 XRayTracerFactory::XRayTracerFactory() : FactoryBase(TracerNames::get().XRay) {}
 
-Tracing::HttpTracerPtr
+Tracing::HttpTracerSharedPtr
 XRayTracerFactory::createHttpTracerTyped(const envoy::config::trace::v3::XRayConfig& proto_config,
                                          Server::Configuration::TracerFactoryContext& context) {
   std::string sampling_rules_json;
@@ -47,7 +47,7 @@ XRayTracerFactory::createHttpTracerTyped(const envoy::config::trace::v3::XRayCon
   XRayConfiguration xconfig{endpoint, proto_config.segment_name(), sampling_rules_json};
   auto xray_driver = std::make_unique<XRay::Driver>(xconfig, context);
 
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(xray_driver),
+  return std::make_shared<Tracing::HttpTracerImpl>(std::move(xray_driver),
                                                    context.serverFactoryContext().localInfo());
 }
 

--- a/source/extensions/tracers/xray/config.h
+++ b/source/extensions/tracers/xray/config.h
@@ -21,7 +21,7 @@ public:
   XRayTracerFactory();
 
 private:
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::XRayConfig& proto_config,
                         Server::Configuration::TracerFactoryContext& context) override;
 };

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -17,7 +17,7 @@ namespace Zipkin {
 
 ZipkinTracerFactory::ZipkinTracerFactory() : FactoryBase(TracerNames::get().Zipkin) {}
 
-Tracing::HttpTracerPtr ZipkinTracerFactory::createHttpTracerTyped(
+Tracing::HttpTracerSharedPtr ZipkinTracerFactory::createHttpTracerTyped(
     const envoy::config::trace::v3::ZipkinConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
   Tracing::DriverPtr zipkin_driver = std::make_unique<Zipkin::Driver>(
@@ -26,7 +26,7 @@ Tracing::HttpTracerPtr ZipkinTracerFactory::createHttpTracerTyped(
       context.serverFactoryContext().runtime(), context.serverFactoryContext().localInfo(),
       context.serverFactoryContext().random(), context.serverFactoryContext().timeSource());
 
-  return std::make_unique<Tracing::HttpTracerImpl>(std::move(zipkin_driver),
+  return std::make_shared<Tracing::HttpTracerImpl>(std::move(zipkin_driver),
                                                    context.serverFactoryContext().localInfo());
 }
 

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -19,7 +19,7 @@ public:
 
 private:
   // FactoryBase
-  Tracing::HttpTracerPtr
+  Tracing::HttpTracerSharedPtr
   createHttpTracerTyped(const envoy::config::trace::v3::ZipkinConfig& proto_config,
                         Server::Configuration::TracerFactoryContext& context) override;
 };

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -715,7 +715,7 @@ public:
   HttpTracerImplTest() {
     driver_ = new MockDriver();
     DriverPtr driver_ptr(driver_);
-    tracer_ = std::make_unique<HttpTracerImpl>(std::move(driver_ptr), local_info_);
+    tracer_ = std::make_shared<HttpTracerImpl>(std::move(driver_ptr), local_info_);
   }
 
   Http::TestRequestHeaderMapImpl request_headers_{
@@ -726,7 +726,7 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   MockConfig config_;
   MockDriver* driver_;
-  HttpTracerPtr tracer_;
+  HttpTracerSharedPtr tracer_;
 };
 
 TEST_F(HttpTracerImplTest, BasicFunctionalityNullSpan) {

--- a/test/common/tracing/http_tracer_manager_impl_test.cc
+++ b/test/common/tracing/http_tracer_manager_impl_test.cc
@@ -26,9 +26,10 @@ public:
 
 class SampleTracerFactory : public Server::Configuration::TracerFactory {
 public:
-  Tracing::HttpTracerPtr createHttpTracer(const Protobuf::Message&,
-                                          Server::Configuration::TracerFactoryContext&) override {
-    return std::make_unique<SampleTracer>();
+  Tracing::HttpTracerSharedPtr
+  createHttpTracer(const Protobuf::Message&,
+                   Server::Configuration::TracerFactoryContext&) override {
+    return std::make_shared<SampleTracer>();
   }
 
   std::string name() const override { return "envoy.tracers.sample"; }

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -41,7 +41,7 @@ TEST(DatadogTracerConfigTest, DatadogHttpTracer) {
   DatadogTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr datadog_tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr datadog_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, datadog_tracer);
 }
 

--- a/test/extensions/tracers/dynamic_ot/config_test.cc
+++ b/test/extensions/tracers/dynamic_ot/config_test.cc
@@ -45,7 +45,7 @@ TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
   DynamicOpenTracingTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  const Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
+  const Tracing::HttpTracerSharedPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 }
 

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -41,7 +41,7 @@ TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
   LightstepTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr lightstep_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, lightstep_tracer);
 }
 

--- a/test/extensions/tracers/opencensus/config_test.cc
+++ b/test/extensions/tracers/opencensus/config_test.cc
@@ -29,7 +29,7 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracer) {
   OpenCensusTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 }
 
@@ -67,7 +67,7 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerWithTypedConfig) {
   OpenCensusTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 
   // Reset TraceParams back to default.
@@ -107,7 +107,7 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerGrpc) {
   OpenCensusTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, tracer);
 
   // Reset TraceParams back to default.

--- a/test/extensions/tracers/opencensus/config_test.cc
+++ b/test/extensions/tracers/opencensus/config_test.cc
@@ -115,6 +115,142 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerGrpc) {
       {32, 32, 128, 32, ::opencensus::trace::ProbabilitySampler(1e-4)});
 }
 
+TEST(OpenCensusTracerConfigTest, ShouldCreateAtMostOneOpenCensusTracer) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  OpenCensusTracerFactory factory;
+
+  const std::string yaml_string = R"EOF(
+  http:
+    name: envoy.tracers.opencensus
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig
+      trace_config:
+        rate_limiting_sampler:
+          qps: 123
+  )EOF";
+  envoy::config::trace::v3::Tracing configuration;
+  TestUtility::loadFromYaml(yaml_string, configuration);
+
+  auto message_one = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  Tracing::HttpTracerSharedPtr tracer_one = factory.createHttpTracer(*message_one, context);
+  EXPECT_NE(nullptr, tracer_one);
+
+  auto message_two = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  Tracing::HttpTracerSharedPtr tracer_two = factory.createHttpTracer(*message_two, context);
+  // Verify that no new tracer has been created.
+  EXPECT_EQ(tracer_two, tracer_one);
+}
+
+TEST(OpenCensusTracerConfigTest, ShouldCacheFirstCreatedTracerUsingStrongReference) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  OpenCensusTracerFactory factory;
+
+  const std::string yaml_string = R"EOF(
+  http:
+    name: envoy.tracers.opencensus
+  )EOF";
+  envoy::config::trace::v3::Tracing configuration;
+  TestUtility::loadFromYaml(yaml_string, configuration);
+
+  auto message_one = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  std::weak_ptr<Tracing::HttpTracer> tracer_one = factory.createHttpTracer(*message_one, context);
+  // Verify that tracer factory keeps a strong reference.
+  EXPECT_NE(nullptr, tracer_one.lock());
+
+  auto message_two = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  Tracing::HttpTracerSharedPtr tracer_two = factory.createHttpTracer(*message_two, context);
+  EXPECT_NE(nullptr, tracer_two);
+  // Verify that no new tracer has been created.
+  EXPECT_EQ(tracer_two, tracer_one.lock());
+}
+
+TEST(OpenCensusTracerConfigTest, ShouldNotCacheInvalidConfiguration) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  OpenCensusTracerFactory factory;
+
+  const std::string yaml_one = R"EOF(
+  http:
+    name: envoy.tracers.opencensus
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig
+      ocagent_exporter_enabled: true
+      ocagent_grpc_service:
+        envoy_grpc:
+          cluster_name: opencensus
+  )EOF";
+  envoy::config::trace::v3::Tracing configuration_one;
+  TestUtility::loadFromYaml(yaml_one, configuration_one);
+
+  auto message_one = Config::Utility::translateToFactoryConfig(
+      configuration_one.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  EXPECT_THROW_WITH_MESSAGE((factory.createHttpTracer(*message_one, context)), EnvoyException,
+                            "Opencensus ocagent tracer only supports GoogleGrpc.");
+
+  const std::string yaml_two = R"EOF(
+  http:
+    name: envoy.tracers.opencensus
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig
+      ocagent_exporter_enabled: true
+      ocagent_grpc_service:
+        google_grpc:
+          target_uri: 127.0.0.1:55678
+          stat_prefix: test
+  )EOF";
+  envoy::config::trace::v3::Tracing configuration_two;
+  TestUtility::loadFromYaml(yaml_two, configuration_two);
+
+  auto message_two = Config::Utility::translateToFactoryConfig(
+      configuration_two.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  Tracing::HttpTracerSharedPtr tracer_two = factory.createHttpTracer(*message_two, context);
+  // Verify that a new tracer has been created despite an earlier failed attempt.
+  EXPECT_NE(nullptr, tracer_two);
+}
+
+TEST(OpenCensusTracerConfigTest, ShouldRejectSubsequentCreateAttemptsWithDifferentConfig) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  OpenCensusTracerFactory factory;
+
+  const std::string yaml_one = R"EOF(
+  http:
+    name: envoy.tracers.opencensus
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig
+      trace_config:
+        rate_limiting_sampler:
+          qps: 123
+  )EOF";
+  envoy::config::trace::v3::Tracing configuration_one;
+  TestUtility::loadFromYaml(yaml_one, configuration_one);
+
+  auto message_one = Config::Utility::translateToFactoryConfig(
+      configuration_one.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  Tracing::HttpTracerSharedPtr tracer_one = factory.createHttpTracer(*message_one, context);
+  EXPECT_NE(nullptr, tracer_one);
+
+  const std::string yaml_two = R"EOF(
+  http:
+    name: envoy.tracers.opencensus
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig
+      trace_config:
+        rate_limiting_sampler:
+          qps: 321
+  )EOF";
+  envoy::config::trace::v3::Tracing configuration_two;
+  TestUtility::loadFromYaml(yaml_two, configuration_two);
+
+  auto message_two = Config::Utility::translateToFactoryConfig(
+      configuration_two.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  // Verify that OpenCensus is only configured once in a lifetime.
+  EXPECT_THROW_WITH_MESSAGE((factory.createHttpTracer(*message_two, context)), EnvoyException,
+                            "Opencensus has already been configured with a different config.");
+}
+
 TEST(OpenCensusTracerConfigTest, DoubleRegistrationTest) {
   EXPECT_THROW_WITH_MESSAGE(
       (Registry::RegisterFactory<OpenCensusTracerFactory, Server::Configuration::TracerFactory>()),

--- a/test/extensions/tracers/xray/config_test.cc
+++ b/test/extensions/tracers/xray/config_test.cc
@@ -41,7 +41,7 @@ TEST(XRayTracerConfigTest, XRayHttpTracerWithTypedConfig) {
   XRayTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr xray_tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr xray_tracer = factory.createHttpTracer(*message, context);
   ASSERT_NE(nullptr, xray_tracer);
 }
 
@@ -76,7 +76,7 @@ TEST(XRayTracerConfigTest, XRayHttpTracerWithInvalidFileName) {
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
 
-  Tracing::HttpTracerPtr xray_tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr xray_tracer = factory.createHttpTracer(*message, context);
   ASSERT_NE(nullptr, xray_tracer);
 }
 

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -40,7 +40,7 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
   ZipkinTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr zipkin_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 
@@ -67,7 +67,7 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithTypedConfig) {
   ZipkinTracerFactory factory;
   auto message = Config::Utility::translateToFactoryConfig(
       configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, context);
+  Tracing::HttpTracerSharedPtr zipkin_tracer = factory.createHttpTracer(*message, context);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 


### PR DESCRIPTION
Description: tracing: ensure that OpenCensus is configured at most once
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A

Context:
* part of #9998

Motivation:
* Since `OpenCensus` can only support a single tracing configuration per entire process, we need to make sure that it is configured at most once
* In case of a re-configuration attempt, reject it and provide a clear error message explaining why it is happening 