### PR TITLE
tracer: ensure x-ray segment field is not empty

### DIFF
--- a/api/envoy/config/trace/v2alpha/xray.proto
+++ b/api/envoy/config/trace/v2alpha/xray.proto
@@ -19,8 +19,8 @@ message XRayConfig {
   // If this value is not set, the default value of 127.0.0.1:2000 will be used.
   api.v2.core.SocketAddress daemon_endpoint = 1;
 
-  // The name of the X-Ray segment. By default this will be set to the cluster name.
-  string segment_name = 2;
+  // The name of the X-Ray segment.
+  string segment_name = 2 [(validate.rules).string = {min_len: 1}];
 
   // The location of a local custom sampling rules JSON file.
   // For an example of the sampling rules see:

--- a/api/envoy/config/trace/v3/xray.proto
+++ b/api/envoy/config/trace/v3/xray.proto
@@ -24,8 +24,8 @@ message XRayConfig {
   // If this value is not set, the default value of 127.0.0.1:2000 will be used.
   core.v3.SocketAddress daemon_endpoint = 1;
 
-  // The name of the X-Ray segment. By default this will be set to the cluster name.
-  string segment_name = 2;
+  // The name of the X-Ray segment.
+  string segment_name = 2 [(validate.rules).string = {min_len: 1}];
 
   // The location of a local custom sampling rules JSON file.
   // For an example of the sampling rules see:

--- a/generated_api_shadow/envoy/config/trace/v2alpha/xray.proto
+++ b/generated_api_shadow/envoy/config/trace/v2alpha/xray.proto
@@ -19,8 +19,8 @@ message XRayConfig {
   // If this value is not set, the default value of 127.0.0.1:2000 will be used.
   api.v2.core.SocketAddress daemon_endpoint = 1;
 
-  // The name of the X-Ray segment. By default this will be set to the cluster name.
-  string segment_name = 2;
+  // The name of the X-Ray segment.
+  string segment_name = 2 [(validate.rules).string = {min_len: 1}];
 
   // The location of a local custom sampling rules JSON file.
   // For an example of the sampling rules see:

--- a/generated_api_shadow/envoy/config/trace/v3/xray.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/xray.proto
@@ -24,8 +24,8 @@ message XRayConfig {
   // If this value is not set, the default value of 127.0.0.1:2000 will be used.
   core.v3.SocketAddress daemon_endpoint = 1;
 
-  // The name of the X-Ray segment. By default this will be set to the cluster name.
-  string segment_name = 2;
+  // The name of the X-Ray segment.
+  string segment_name = 2 [(validate.rules).string = {min_len: 1}];
 
   // The location of a local custom sampling rules JSON file.
   // For an example of the sampling rules see:

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -52,12 +52,8 @@ Driver::Driver(const XRayConfiguration& config,
 
   tls_slot_ptr_->set([this, daemon_endpoint,
                       &context](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    std::string span_name = xray_config_.segment_name_.empty()
-                                ? context.serverFactoryContext().localInfo().clusterName()
-                                : xray_config_.segment_name_;
-
     DaemonBrokerPtr broker = std::make_unique<DaemonBrokerImpl>(daemon_endpoint);
-    TracerPtr tracer = std::make_unique<Tracer>(span_name, std::move(broker),
+    TracerPtr tracer = std::make_unique<Tracer>(xray_config_.segment_name_, std::move(broker),
                                                 context.serverFactoryContext().timeSource());
     return std::make_shared<XRay::Driver::TlsTracer>(std::move(tracer), *this);
   });

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -92,21 +92,6 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
   ASSERT_NE(span, nullptr);
 }
 
-TEST_F(XRayDriverTest, EmptySegmentNameDefaultToClusterName) {
-  const std::string cluster_name = "FooBar";
-  EXPECT_CALL(context_.server_factory_context_.local_info_, clusterName())
-      .WillRepeatedly(ReturnRef(cluster_name));
-  XRayConfiguration config{"" /*daemon_endpoint*/, "", "" /*sampling_rules*/};
-  Driver driver(config, context_);
-
-  Tracing::Decision tracing_decision{Tracing::Reason::Sampling, true /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
-                               tracing_decision);
-  auto* xray_span = static_cast<XRay::Span*>(span.get());
-  ASSERT_STREQ(xray_span->name().c_str(), cluster_name.c_str());
-}
-
 } // namespace
 } // namespace XRay
 } // namespace Tracers


### PR DESCRIPTION
Description:
Initially the name of the segment defaulted to the local cluster/node
name. But since that too can be empty, and this tracer throws and
crashes if the segment is empty, then it's best to make the field
required and not use defaults.

Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
