### PR TITLE
platform: remove re-definition of mmsghdr for Android targets

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -187,7 +187,7 @@ using os_fd_t = int;
 #endif
 
 // Note: chromium disabled recvmmsg regardless of ndk version. However, the only Android target
-// currently actively using Envoy is Envoy Mobile, where recvmmsg is not actively disbled. In fact,
+// currently actively using Envoy is Envoy Mobile, where recvmmsg is not actively disabled. In fact,
 // defining mmsghdr here caused a conflicting definition with the ndk's definition of the struct
 // (https://github.com/lyft/envoy-mobile/pull/772/checks?check_run_id=534152886#step:4:64).
 // Therefore, we decided to remove the Android check introduced here in

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -186,7 +186,14 @@ using os_fd_t = int;
 
 #endif
 
-#if defined(__linux__) && !defined(__ANDROID__)
+// Note: chromium disabled recvmmsg regardless of ndk version. However, the only Android target
+// currently actively using Envoy is Envoy Mobile, where recvmmsg is not actively disbled. In fact,
+// defining mmsghdr here caused a conflicting definition with the ndk's definition of the struct
+// (https://github.com/lyft/envoy-mobile/pull/772/checks?check_run_id=534152886#step:4:64).
+// Therefore, we decided to remove the Android check introduced here in
+// https://github.com/envoyproxy/envoy/pull/10120. If someone out there encounters problems with
+// this please bring up in Envoy's slack channel #envoy-udp-quic-dev.
+#if defined(__linux__)
 #define ENVOY_MMSG_MORE 1
 #else
 #define ENVOY_MMSG_MORE 0

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -733,6 +733,7 @@ mixin
 mkdir
 mmap
 mmsg
+mmsghdr
 mongo
 moveable
 msec
@@ -754,6 +755,7 @@ namespaces
 namespacing
 nan
 natively
+ndk
 netblock
 netblocks
 netfilter


### PR DESCRIPTION
Description: remove Android flag that caused re-definition issues with Android's ndk for `mmsghdr`.
Risk Level: low given Envoy Mobile is the only active, well-known Android target for Envoy.
Testing: built Envoy Mobile for Android successfully.

Signed-off-by: Jose Nino <jnino@lyft.com>