### PR TITLE
access log: add the detected protocol set

### DIFF
--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -18,6 +18,7 @@
 #include "common/singleton/const_singleton.h"
 
 #include "absl/types/optional.h"
+#include "absl/types/span.h"
 
 namespace Envoy {
 
@@ -148,6 +149,18 @@ struct ResponseCodeDetailValues {
 
 using ResponseCodeDetails = ConstSingleton<ResponseCodeDetailValues>;
 
+struct ProtocolStringValues {
+  const std::string TcpString{"TCP"};
+  const std::string UdpString{"UDP"};
+  const std::string HttpString{"HTTP"};
+  const std::string Http10String{"HTTP/1.0"};
+  const std::string Http11String{"HTTP/1.1"};
+  const std::string Http2String{"HTTP/2"};
+  const std::string Http3String{"HTTP/3"};
+};
+
+using ProtocolStrings = ConstSingleton<ProtocolStringValues>;
+
 struct UpstreamTiming {
   /**
    * Sets the time when the first byte of the request was sent upstream.
@@ -238,14 +251,14 @@ public:
   virtual uint64_t bytesReceived() const PURE;
 
   /**
-   * @return the protocol of the request.
+   * @return the set of protocols detected for a stream.
    */
-  virtual absl::optional<Http::Protocol> protocol() const PURE;
+  virtual absl::Span<const std::string> protocols() const PURE;
 
   /**
-   * @param protocol the request's protocol.
+   * @param protocol the request's protocol
    */
-  virtual void protocol(Http::Protocol protocol) PURE;
+  virtual void addProtocol(absl::string_view protocol) PURE;
 
   /**
    * @return the response code.
@@ -486,6 +499,7 @@ public:
    * filters (append only). Both object types can be consumed by multiple filters.
    * @return the filter state associated with this request.
    */
+  virtual FilterStateSharedPtr& mutableFilterState() PURE;
   virtual const FilterStateSharedPtr& filterState() PURE;
   virtual const FilterState& filterState() const PURE;
 

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -73,7 +73,7 @@ private:
 class AccessLogFormatUtils {
 public:
   static FormatterPtr defaultAccessLogFormatter();
-  static const std::string& protocolToString(const absl::optional<Http::Protocol>& protocol);
+  static const std::string protocolToString(absl::Span<const std::string> protocols);
   static const std::string getHostname();
 
 private:

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -102,9 +102,6 @@ public:
 
   TimeSource& timeSource() { return time_source_; }
 
-  // Return a reference to the shared_ptr so that it can be lazy created on demand.
-  std::shared_ptr<StreamInfo::FilterState>& filterState() { return filter_state_; }
-
 private:
   struct ActiveStream;
 
@@ -782,7 +779,6 @@ private:
   const Server::OverloadActionState& overload_stop_accepting_requests_ref_;
   const Server::OverloadActionState& overload_disable_keepalive_ref_;
   TimeSource& time_source_;
-  std::shared_ptr<StreamInfo::FilterState> filter_state_;
 };
 
 } // namespace Http

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -273,13 +273,6 @@ public:
   } CORSValues;
 
   struct {
-    const std::string Http10String{"HTTP/1.0"};
-    const std::string Http11String{"HTTP/1.1"};
-    const std::string Http2String{"HTTP/2"};
-    const std::string Http3String{"HTTP/3"};
-  } ProtocolStrings;
-
-  struct {
     const std::string Gzip{"gzip"};
     const std::string Identity{"identity"};
     const std::string Wildcard{"*"};

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -3,7 +3,6 @@
 #include <http_parser.h>
 
 #include <cstdint>
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -3,6 +3,7 @@
 #include <http_parser.h>
 
 #include <cstdint>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -636,16 +637,32 @@ bool Utility::sanitizeConnectionHeader(Http::RequestHeaderMap& headers) {
 const std::string& Utility::getProtocolString(const Protocol protocol) {
   switch (protocol) {
   case Protocol::Http10:
-    return Headers::get().ProtocolStrings.Http10String;
+    return StreamInfo::ProtocolStrings::get().Http10String;
   case Protocol::Http11:
-    return Headers::get().ProtocolStrings.Http11String;
+    return StreamInfo::ProtocolStrings::get().Http11String;
   case Protocol::Http2:
-    return Headers::get().ProtocolStrings.Http2String;
+    return StreamInfo::ProtocolStrings::get().Http2String;
   case Protocol::Http3:
-    return Headers::get().ProtocolStrings.Http3String;
+    return StreamInfo::ProtocolStrings::get().Http3String;
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;
+}
+
+absl::optional<const Protocol> Utility::getProtocol(absl::Span<const std::string> protocols) {
+  for (auto it = protocols.rbegin(); it != protocols.rend(); it++) {
+    if (*it == StreamInfo::ProtocolStrings::get().Http10String) {
+      return Protocol::Http10;
+    } else if (*it == StreamInfo::ProtocolStrings::get().Http11String) {
+      return Protocol::Http11;
+    } else if (*it == StreamInfo::ProtocolStrings::get().Http2String) {
+      return Protocol::Http2;
+    } else if (*it == StreamInfo::ProtocolStrings::get().Http3String) {
+      return Protocol::Http3;
+    }
+  }
+
+  return {};
 }
 
 void Utility::extractHostPathFromUri(const absl::string_view& uri, absl::string_view& host,

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -315,6 +315,13 @@ bool sanitizeConnectionHeader(Http::RequestHeaderMap& headers);
 const std::string& getProtocolString(const Protocol p);
 
 /**
+ * Get the http protocol from the given protocol list.
+ * @param protocol list from the stream info.
+ * @return the last (most-specific) http protocol in the list.
+ */
+absl::optional<const Protocol> getProtocol(absl::Span<const std::string> protocols);
+
+/**
  * Extract host and path from a URI. The host may contain port.
  * This function doesn't validate if the URI is valid. It only parses the URI with following
  * format: scheme://host/path.

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -222,7 +222,7 @@ StreamInfoHeaderFormatter::StreamInfoHeaderFormatter(absl::string_view field_nam
     : append_(append) {
   if (field_name == "PROTOCOL") {
     field_extractor_ = [](const Envoy::StreamInfo::StreamInfo& stream_info) {
-      return Envoy::AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocol());
+      return Envoy::AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocols());
     };
   } else if (field_name == "DOWNSTREAM_REMOTE_ADDRESS") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -645,7 +645,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 Http::ConnectionPool::Instance* Filter::getConnPool() {
   // Choose protocol based on cluster configuration and downstream connection
   // Note: Cluster may downgrade HTTP2 to HTTP1 based on runtime configuration.
-  Http::Protocol protocol = cluster_->upstreamHttpProtocol(callbacks_->streamInfo().protocol());
+  Http::Protocol protocol = cluster_->upstreamHttpProtocol(
+      Http::Utility::getProtocol(callbacks_->streamInfo().protocols()));
   transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
       *callbacks_->streamInfo().filterState());
 

--- a/source/common/stream_info/BUILD
+++ b/source/common/stream_info/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "//include/envoy/stream_info:stream_info_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:dump_state_utils",
+        "//source/common/http:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/stream_info/filter_state_impl.cc
+++ b/source/common/stream_info/filter_state_impl.cc
@@ -97,8 +97,8 @@ void FilterStateImpl::maybeCreateParent(ParentAccessMode parent_access_mode) {
   if (life_span_ >= FilterState::LifeSpan::TopSpan) {
     return;
   }
-  if (absl::holds_alternative<std::shared_ptr<FilterState>>(ancestor_)) {
-    std::shared_ptr<FilterState> ancestor = absl::get<std::shared_ptr<FilterState>>(ancestor_);
+  if (absl::holds_alternative<FilterStateSharedPtr>(ancestor_)) {
+    FilterStateSharedPtr ancestor = absl::get<FilterStateSharedPtr>(ancestor_);
     if (ancestor == nullptr || ancestor->lifeSpan() != life_span_ + 1) {
       parent_ = std::make_shared<FilterStateImpl>(ancestor, FilterState::LifeSpan(life_span_ + 1));
     } else {

--- a/source/common/stream_info/filter_state_impl.h
+++ b/source/common/stream_info/filter_state_impl.h
@@ -22,12 +22,12 @@ public:
    * @param ancestor a std::shared_ptr storing an already created ancestor.
    * @param life_span the life span this is handling.
    */
-  FilterStateImpl(std::shared_ptr<FilterState> ancestor, FilterState::LifeSpan life_span)
+  FilterStateImpl(FilterStateSharedPtr ancestor, FilterState::LifeSpan life_span)
       : ancestor_(ancestor), life_span_(life_span) {
     maybeCreateParent(ParentAccessMode::ReadOnly);
   }
 
-  using LazyCreateAncestor = std::pair<std::shared_ptr<FilterState>&, FilterState::LifeSpan>;
+  using LazyCreateAncestor = std::pair<FilterStateSharedPtr&, FilterState::LifeSpan>;
   /**
    * @param ancestor a std::pair storing an ancestor, that can be passed in as a way to lazy
    * initialize a FilterState that's owned by an object with bigger scope than this. This is to
@@ -49,7 +49,7 @@ public:
   bool hasDataAtOrAboveLifeSpan(FilterState::LifeSpan life_span) const override;
 
   FilterState::LifeSpan lifeSpan() const override { return life_span_; }
-  std::shared_ptr<FilterState> parent() const override { return parent_; }
+  FilterStateSharedPtr parent() const override { return parent_; }
 
 private:
   // This only checks the local data_storage_ for data_name existence.
@@ -62,8 +62,8 @@ private:
     FilterState::StateType state_type_;
   };
 
-  absl::variant<std::shared_ptr<FilterState>, LazyCreateAncestor> ancestor_;
-  std::shared_ptr<FilterState> parent_;
+  absl::variant<FilterStateSharedPtr, LazyCreateAncestor> ancestor_;
+  FilterStateSharedPtr parent_;
   const FilterState::LifeSpan life_span_;
   absl::flat_hash_map<std::string, std::unique_ptr<FilterObject>> data_storage_;
 };

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -173,7 +173,7 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span,
                 valueOrDefault(request_headers->EnvoyDownstreamServiceCluster(), "-"));
     span.setTag(Tracing::Tags::get().UserAgent, valueOrDefault(request_headers->UserAgent(), "-"));
     span.setTag(Tracing::Tags::get().HttpProtocol,
-                AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocol()));
+                AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocols()));
 
     const auto& remote_address = stream_info.downstreamDirectRemoteAddress();
 
@@ -215,7 +215,7 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
                                              const StreamInfo::StreamInfo& stream_info,
                                              const Config& tracing_config) {
   span.setTag(Tracing::Tags::get().HttpProtocol,
-              AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocol()));
+              AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocols()));
 
   if (stream_info.upstreamHost()) {
     span.setTag(Tracing::Tags::get().UpstreamAddress,

--- a/source/extensions/access_loggers/grpc/BUILD
+++ b/source/extensions/access_loggers/grpc/BUILD
@@ -64,6 +64,7 @@ envoy_cc_library(
     deps = [
         ":grpc_access_log_lib",
         ":grpc_access_log_utils",
+        "//source/common/http:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/data/accesslog/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -5,6 +5,7 @@
 #include "envoy/extensions/access_loggers/grpc/v3/als.pb.h"
 
 #include "common/common/assert.h"
+#include "common/http/utility.h"
 #include "common/network/utility.h"
 #include "common/stream_info/utility.h"
 
@@ -53,8 +54,9 @@ void HttpGrpcAccessLog::emitLog(const Http::RequestHeaderMap& request_headers,
   GrpcCommon::Utility::extractCommonAccessLogProperties(*log_entry.mutable_common_properties(),
                                                         stream_info, config_.common_config());
 
-  if (stream_info.protocol()) {
-    switch (stream_info.protocol().value()) {
+  auto protocol = Http::Utility::getProtocol(stream_info.protocols());
+  if (protocol.has_value()) {
+    switch (protocol.value()) {
     case Http::Protocol::Http10:
       log_entry.set_protocol_version(envoy::data::accesslog::v3::HTTPAccessLogEntry::HTTP10);
       break;

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -82,8 +82,9 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
       return CelValue::CreateDuration(absl::FromChrono(duration.value()));
     }
   } else if (value == Protocol) {
-    if (info_.protocol().has_value()) {
-      return CelValue::CreateString(&Http::Utility::getProtocolString(info_.protocol().value()));
+    auto protocol = Http::Utility::getProtocol(info_.protocols());
+    if (protocol.has_value()) {
+      return CelValue::CreateString(&Http::Utility::getProtocolString(protocol.value()));
     } else {
       return {};
     }

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -110,8 +110,9 @@ void CheckRequestUtils::setHttpRequest(
   httpreq.set_scheme(getHeaderStr(headers.Scheme()));
   httpreq.set_size(stream_info.bytesReceived());
 
-  if (stream_info.protocol()) {
-    httpreq.set_protocol(Envoy::Http::Utility::getProtocolString(stream_info.protocol().value()));
+  auto protocol = Envoy::Http::Utility::getProtocol(stream_info.protocols());
+  if (protocol.has_value()) {
+    httpreq.set_protocol(Envoy::Http::Utility::getProtocolString(protocol.value()));
   }
 
   // Fill in the headers.

--- a/source/extensions/filters/http/grpc_http1_bridge/BUILD
+++ b/source/extensions/filters/http/grpc_http1_bridge/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
         "//source/common/grpc:common_lib",
         "//source/common/grpc:context_lib",
         "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
         "//source/common/http/http1:codec_lib",
     ],
 )

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -12,6 +12,7 @@
 #include "common/grpc/context_impl.h"
 #include "common/http/headers.h"
 #include "common/http/http1/codec_impl.h"
+#include "common/http/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -29,7 +30,8 @@ Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::RequestHeaderMa
     setupStatTracking(headers);
   }
 
-  const absl::optional<Http::Protocol>& protocol = decoder_callbacks_->streamInfo().protocol();
+  const absl::optional<Http::Protocol>& protocol =
+      Http::Utility::getProtocol(decoder_callbacks_->streamInfo().protocols());
   ASSERT(protocol);
   if (protocol.value() < Http::Protocol::Http2 && grpc_request) {
     do_bridging_ = true;

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -588,7 +588,8 @@ void JsonTranscoderFilter::doTrailers(Http::ResponseHeaderOrTrailerMap& headers_
   }
 
   // remove Trailer headers if the client connection was http/1
-  if (encoder_callbacks_->streamInfo().protocol() < Http::Protocol::Http2) {
+  if (Http::Utility::getProtocol(encoder_callbacks_->streamInfo().protocols()) <
+      Http::Protocol::Http2) {
     response_headers_->remove(trailerHeader());
   }
 
@@ -724,7 +725,8 @@ bool JsonTranscoderFilter::maybeConvertGrpcStatus(Grpc::Status::GrpcStatus grpc_
   }
 
   // remove Trailer headers if the client connection was http/1
-  if (encoder_callbacks_->streamInfo().protocol() < Http::Protocol::Http2) {
+  if (Http::Utility::getProtocol(encoder_callbacks_->streamInfo().protocols()) <
+      Http::Protocol::Http2) {
     response_headers_->remove(trailerHeader());
   }
 

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -103,8 +103,12 @@ void HeaderMapWrapper::checkModifiable(lua_State* state) {
 }
 
 int StreamInfoWrapper::luaProtocol(lua_State* state) {
-  lua_pushstring(state, Http::Utility::getProtocolString(stream_info_.protocol().value()).c_str());
-  return 1;
+  auto protocol = Http::Utility::getProtocol(stream_info_.protocols());
+  if (protocol.has_value()) {
+    lua_pushstring(state, Http::Utility::getProtocolString(protocol.value()).c_str());
+    return 1;
+  }
+  return 0;
 }
 
 int StreamInfoWrapper::luaDynamicMetadata(lua_State* state) {

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -153,10 +153,10 @@ ParseState Filter::parseHttpHeader(absl::string_view data) {
       }
 
       if (parser_.http_major == 1 && parser_.http_minor == 1) {
-        protocol_ = Http::Headers::get().ProtocolStrings.Http11String;
+        protocol_ = StreamInfo::ProtocolStrings::get().Http11String;
       } else {
         // Set other HTTP protocols to HTTP/1.0
-        protocol_ = Http::Headers::get().ProtocolStrings.Http10String;
+        protocol_ = StreamInfo::ProtocolStrings::get().Http10String;
       }
       return ParseState::Done;
     } else {
@@ -179,10 +179,10 @@ void Filter::done(bool success) {
 
   if (success) {
     absl::string_view protocol;
-    if (protocol_ == Http::Headers::get().ProtocolStrings.Http10String) {
+    if (protocol_ == StreamInfo::ProtocolStrings::get().Http10String) {
       config_->stats().http10_found_.inc();
       protocol = "http/1.0";
-    } else if (protocol_ == Http::Headers::get().ProtocolStrings.Http11String) {
+    } else if (protocol_ == StreamInfo::ProtocolStrings::get().Http11String) {
       config_->stats().http11_found_.inc();
       protocol = "http/1.1";
     } else {

--- a/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.cc
+++ b/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.cc
@@ -15,7 +15,7 @@ QuicFilterManagerConnectionImpl::QuicFilterManagerConnectionImpl(EnvoyQuicConnec
       write_buffer_watermark_simulation_(
           send_buffer_limit / 2, send_buffer_limit, [this]() { onSendBufferLowWatermark(); },
           [this]() { onSendBufferHighWatermark(); }, ENVOY_LOGGER()) {
-  stream_info_.protocol(Http::Protocol::Http3);
+  stream_info_.addProtocol(Http::Utility::getProtocolString(Http::Protocol::Http3));
 }
 
 void QuicFilterManagerConnectionImpl::addWriteFilter(Network::WriteFilterSharedPtr filter) {

--- a/source/extensions/stat_sinks/hystrix/BUILD
+++ b/source/extensions/stat_sinks/hystrix/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/config:well_known_names",
         "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
         "//source/common/stats:symbol_table_lib",
         "//source/common/stats:utility_lib",
     ],

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -11,6 +11,7 @@
 #include "common/common/logger.h"
 #include "common/config/well_known_names.h"
 #include "common/http/headers.h"
+#include "common/http/utility.h"
 #include "common/stats/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -301,7 +302,8 @@ Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
   // Disable chunk-encoding in HTTP/1.x.
   // TODO: This request should be propagated to codecs via API, instead of using a pseudo-header.
   //       See: https://github.com/envoyproxy/envoy/issues/9749
-  if (stream_decoder_filter_callbacks.streamInfo().protocol() < Http::Protocol::Http2) {
+  if (Http::Utility::getProtocol(stream_decoder_filter_callbacks.streamInfo().protocols()) <
+      Http::Protocol::Http2) {
     response_headers.setNoChunks(0);
   }
 

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -334,6 +334,7 @@ void emitLogs(Network::ListenerConfig& config, StreamInfo::StreamInfo& stream_in
 void ConnectionHandlerImpl::ActiveTcpListener::newConnection(
     Network::ConnectionSocketPtr&& socket) {
   auto stream_info = std::make_unique<StreamInfo::StreamInfoImpl>(parent_.dispatcher_.timeSource());
+  stream_info->addProtocol(StreamInfo::ProtocolStrings::get().TcpString);
   stream_info->setDownstreamLocalAddress(socket->localAddress());
   stream_info->setDownstreamRemoteAddress(socket->remoteAddress());
   stream_info->setDownstreamDirectRemoteAddress(socket->directRemoteAddress());

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -1354,7 +1354,7 @@ TEST_F(AsyncClientImplTest, DumpState) {
   std::stringstream out;
   filter_callbacks->scope().dumpState(out);
   std::string state = out.str();
-  EXPECT_THAT(state, testing::HasSubstr("protocol_: 1"));
+  EXPECT_THAT(state, testing::HasSubstr("protocols_): 1"));
 
   EXPECT_CALL(stream_callbacks_, onReset());
 }

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -131,8 +131,8 @@ TEST_F(StreamInfoHeaderFormatterTest, TestformatWithHostnameVariable) {
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithProtocolVariable) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  absl::optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
-  ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
+  std::vector<std::string> protocols = {StreamInfo::ProtocolStrings::get().Http11String};
+  ON_CALL(stream_info, protocols()).WillByDefault(Return(protocols));
 
   testFormatting(stream_info, "PROTOCOL", "HTTP/1.1");
 }
@@ -839,8 +839,8 @@ TEST(HeaderParserTest, TestParseInternal) {
   };
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  absl::optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
-  ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
+  std::vector<std::string> protocols = {StreamInfo::ProtocolStrings::get().Http11String};
+  ON_CALL(stream_info, protocols()).WillByDefault(Return(protocols));
 
   std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> host(
       new NiceMock<Envoy::Upstream::MockHostDescription>());
@@ -1020,8 +1020,8 @@ request_headers_to_remove: ["x-nope"]
       HeaderParser::configure(route.request_headers_to_add(), route.request_headers_to_remove());
   Http::TestHeaderMapImpl header_map{{":method", "POST"}, {"x-safe", "safe"}, {"x-nope", "nope"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  absl::optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
-  ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
+  std::vector<std::string> protocols = {StreamInfo::ProtocolStrings::get().Http11String};
+  ON_CALL(stream_info, protocols()).WillByDefault(Return(protocols));
 
   std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> host(
       new NiceMock<Envoy::Upstream::MockHostDescription>());

--- a/test/common/stream_info/BUILD
+++ b/test/common/stream_info/BUILD
@@ -25,6 +25,7 @@ envoy_cc_test(
         ":test_int_accessor_lib",
         "//include/envoy/http:protocol_interface",
         "//include/envoy/upstream:host_description_interface",
+        "//source/common/http:utility_lib",
         "//source/common/stream_info:stream_info_lib",
         "//test/mocks/router:router_mocks",
         "//test/mocks/upstream:upstream_mocks",

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -6,6 +6,7 @@
 #include "envoy/upstream/host_description.h"
 
 #include "common/common/fmt.h"
+#include "common/http/utility.h"
 #include "common/protobuf/utility.h"
 #include "common/stream_info/stream_info_impl.h"
 
@@ -134,10 +135,10 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
   {
     StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem());
 
-    EXPECT_EQ(Http::Protocol::Http2, stream_info.protocol().value());
+    EXPECT_EQ(Http::Protocol::Http2, Http::Utility::getProtocol(stream_info.protocols()).value());
 
-    stream_info.protocol(Http::Protocol::Http10);
-    EXPECT_EQ(Http::Protocol::Http10, stream_info.protocol().value());
+    stream_info.addProtocol(Http::Utility::getProtocolString(Http::Protocol::Http10));
+    EXPECT_EQ(Http::Protocol::Http10, Http::Utility::getProtocol(stream_info.protocols()).value());
 
     EXPECT_FALSE(stream_info.responseCode());
     stream_info.response_code_ = 200;
@@ -223,7 +224,7 @@ TEST_F(StreamInfoImplTest, DumpStateTest) {
     stream_info.dumpState(out, i);
     std::string state = out.str();
     EXPECT_TRUE(absl::StartsWith(state, prefix));
-    EXPECT_THAT(state, testing::HasSubstr("protocol_: 2"));
+    EXPECT_THAT(state, testing::HasSubstr("protocols_): 2"));
     prefix = prefix + "  ";
   }
 }

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -29,8 +29,10 @@ public:
 
   void addBytesReceived(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesReceived() const override { return 1; }
-  absl::optional<Http::Protocol> protocol() const override { return protocol_; }
-  void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
+  absl::Span<const std::string> protocols() const override { return protocols_; }
+  void addProtocol(absl::string_view protocol) override {
+    protocols_.push_back(std::string(protocol));
+  }
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
   const absl::optional<std::string>& responseCodeDetails() const override {
     return response_code_details_;
@@ -176,6 +178,7 @@ public:
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
+  Envoy::StreamInfo::FilterStateSharedPtr& mutableFilterState() override { return filter_state_; }
   const Envoy::StreamInfo::FilterStateSharedPtr& filterState() override { return filter_state_; }
   const Envoy::StreamInfo::FilterState& filterState() const override { return *filter_state_; }
 
@@ -229,7 +232,7 @@ public:
   absl::optional<MonotonicTime> last_downstream_tx_byte_sent_;
   absl::optional<MonotonicTime> end_time_;
 
-  absl::optional<Http::Protocol> protocol_{Http::Protocol::Http11};
+  std::vector<std::string> protocols_{Envoy::StreamInfo::ProtocolStrings::get().Http11String};
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   uint64_t response_flags_{};

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -158,10 +158,10 @@ TEST_F(HttpConnManFinalizerImplTest, OriginalAndLongPath) {
   Http::TestResponseHeaderMapImpl response_headers;
   Http::TestResponseTrailerMapImpl response_trailers;
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http2String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
@@ -190,10 +190,10 @@ TEST_F(HttpConnManFinalizerImplTest, NoGeneratedId) {
   Http::TestResponseHeaderMapImpl response_headers;
   Http::TestResponseTrailerMapImpl response_trailers;
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http2String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
@@ -316,9 +316,9 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
   const auto remote_address =
       Network::Address::InstanceConstSharedPtr{new Network::Address::Ipv4Instance(expected_ip, 0)};
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http10String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
       .WillRepeatedly(ReturnPointee(&remote_address));
 
@@ -401,9 +401,9 @@ ree:
   (*stream_info.host_->cluster_.metadata_.mutable_filter_metadata())["m.cluster"].MergeFrom(
       fake_struct);
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http10String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(100));
@@ -506,8 +506,8 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   request_headers.setEnvoyDownstreamServiceCluster("downstream_cluster");
   request_headers.setClientTraceId("client_trace_id");
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http10String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
       .WillRepeatedly(ReturnPointee(&remote_address));
@@ -563,12 +563,12 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
                                                    {"content-type", "application/grpc"}};
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}, {"grpc-message", ""}};
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   absl::optional<uint32_t> response_code(200);
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http2String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
       .WillRepeatedly(ReturnPointee(&remote_address));
 
@@ -615,12 +615,12 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "7"},
                                                      {"grpc-message", "permission denied"}};
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   absl::optional<uint32_t> response_code(200);
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http2String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
       .WillRepeatedly(ReturnPointee(&remote_address));
 
@@ -661,12 +661,12 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
                                                    {"grpc-message", "permission denied"}};
   Http::TestResponseTrailerMapImpl response_trailers;
 
-  absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   absl::optional<uint32_t> response_code(200);
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(ReturnPointee(&protocol));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http2String});
+  EXPECT_CALL(stream_info, protocols()).WillRepeatedly(Return(protocols));
   EXPECT_CALL(stream_info, downstreamDirectRemoteAddress())
       .WillRepeatedly(ReturnPointee(&remote_address));
 

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -231,7 +231,7 @@ response: {}
 
     stream_info.setUpstreamLocalAddress(
         std::make_shared<Network::Address::Ipv4Instance>("10.0.0.2"));
-    stream_info.protocol_ = Http::Protocol::Http10;
+    stream_info.protocols_ = {StreamInfo::ProtocolStrings::get().Http10String};
     stream_info.addBytesReceived(10);
     stream_info.addBytesSent(20);
     stream_info.response_code_ = 200;

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -47,7 +47,8 @@ TEST(Context, RequestAttributes) {
   EXPECT_CALL(info, startTime()).WillRepeatedly(Return(start_time));
   absl::optional<std::chrono::nanoseconds> dur = std::chrono::nanoseconds(15000000);
   EXPECT_CALL(info, requestComplete()).WillRepeatedly(Return(dur));
-  EXPECT_CALL(info, protocol()).WillRepeatedly(Return(Http::Protocol::Http2));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http2String});
+  EXPECT_CALL(info, protocols()).WillRepeatedly(Return(protocols));
 
   // stub methods
   EXPECT_EQ(0, request.size());

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -29,7 +29,7 @@ class CheckRequestUtilsTest : public testing::Test {
 public:
   CheckRequestUtilsTest() {
     addr_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 1111);
-    protocol_ = Envoy::Http::Protocol::Http10;
+    protocol_ = {StreamInfo::ProtocolStrings::get().Http10String};
     buffer_ = CheckRequestUtilsTest::newTestBuffer(8192);
     ssl_ = std::make_shared<NiceMock<Envoy::Ssl::MockConnectionInfo>>();
   };
@@ -42,7 +42,7 @@ public:
     EXPECT_CALL(callbacks_, streamId()).Times(1).WillOnce(Return(0));
     EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
     EXPECT_CALL(callbacks_, streamInfo()).Times(1).WillOnce(ReturnRef(req_info_));
-    EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
+    EXPECT_CALL(req_info_, protocols()).Times(1).WillRepeatedly(Return(protocol_));
     EXPECT_CALL(req_info_, startTime()).Times(1).WillOnce(Return(SystemTime()));
   }
 
@@ -91,7 +91,7 @@ public:
   }
 
   Network::Address::InstanceConstSharedPtr addr_;
-  absl::optional<Http::Protocol> protocol_;
+  std::vector<std::string> protocol_;
   CheckRequestUtils check_request_generator_;
   NiceMock<Envoy::Http::MockStreamDecoderFilterCallbacks> callbacks_;
   NiceMock<Envoy::Network::MockReadFilterCallbacks> net_callbacks_;
@@ -216,7 +216,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeer) {
   EXPECT_CALL(callbacks_, streamId()).WillRepeatedly(Return(0));
   EXPECT_CALL(callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
-  EXPECT_CALL(req_info_, protocol()).WillRepeatedly(ReturnPointee(&protocol_));
+  EXPECT_CALL(req_info_, protocols()).WillRepeatedly(Return(protocol_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -45,7 +45,8 @@ public:
     ON_CALL(callbacks_, connection()).WillByDefault(testing::Return(&connection_));
     ON_CALL(callbacks_, activeSpan())
         .WillByDefault(testing::ReturnRef(Tracing::NullSpan::instance()));
-    callbacks_.stream_info_.protocol_ = Envoy::Http::Protocol::Http2;
+    callbacks_.stream_info_.protocols_ =
+        std::vector<std::string>({StreamInfo::ProtocolStrings::get().Http2String});
   }
 
   void prepareCache() {

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -517,7 +517,7 @@ TEST_F(HttpFilterTest, H2UpgradeRequest) {
 
   request_headers_.addCopy(Http::Headers::get().Method, Http::Headers::get().MethodValues.Connect);
   request_headers_.addCopy(Http::Headers::get().Protocol,
-                           Http::Headers::get().ProtocolStrings.Http2String);
+                           StreamInfo::ProtocolStrings::get().Http2String);
 
   EXPECT_CALL(*client_, check(_, _, testing::A<Tracing::Span&>()))
       .WillOnce(

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1720,7 +1720,8 @@ TEST_F(LuaHttpFilterTest, GetCurrentProtocol) {
   setup(SCRIPT);
 
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info_));
-  EXPECT_CALL(stream_info_, protocol()).WillOnce(Return(Http::Protocol::Http11));
+  std::vector<std::string> protocols({StreamInfo::ProtocolStrings::get().Http11String});
+  EXPECT_CALL(stream_info_, protocols()).WillOnce(Return(protocols));
 
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("HTTP/1.1")));

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -10,7 +10,7 @@
 #include "test/test_common/utility.h"
 
 using testing::InSequence;
-using testing::ReturnPointee;
+using testing::Return;
 
 namespace Envoy {
 namespace Extensions {
@@ -239,7 +239,8 @@ protected:
     setup(SCRIPT);
 
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-    ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
+    std::vector<std::string> protocols({Envoy::Http::Utility::getProtocolString(protocol.value())});
+    ON_CALL(stream_info, protocols()).WillByDefault(Return(protocols));
     Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
         StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
     EXPECT_CALL(*this,

--- a/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
+++ b/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
@@ -25,7 +25,7 @@ public:
    * Initializer for an individual test.
    */
   void SetUp() override {
-    useListenerAccessLog("%RESPONSE_CODE_DETAILS%");
+    useListenerAccessLog("%RESPONSE_CODE_DETAILS% %PROTOCOL%");
     BaseIntegrationTest::initialize();
   }
 
@@ -54,9 +54,10 @@ TEST_P(DirectResponseIntegrationTest, Hello) {
       version_);
 
   connection.run();
+  auto expected = absl::StrCat(StreamInfo::ResponseCodeDetails::get().DirectResponse, " ",
+                               StreamInfo::ProtocolStrings::get().TcpString);
   EXPECT_EQ("hello, world!\n", response);
-  EXPECT_THAT(waitForAccessLog(listener_access_log_name_),
-              testing::HasSubstr(StreamInfo::ResponseCodeDetails::get().DirectResponse));
+  EXPECT_THAT(waitForAccessLog(listener_access_log_name_), testing::HasSubstr(expected));
 }
 
 } // namespace Envoy

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
@@ -144,7 +144,8 @@ public:
     // Setup read filter.
     envoy_quic_session_.addReadFilter(read_filter_);
     EXPECT_EQ(Http::Protocol::Http3,
-              read_filter_->callbacks_->connection().streamInfo().protocol().value());
+              Http::Utility::getProtocol(
+                  read_filter_->callbacks_->connection().streamInfo().protocols()));
     EXPECT_EQ(envoy_quic_session_.id(), read_filter_->callbacks_->connection().id());
     EXPECT_EQ(&envoy_quic_session_, &read_filter_->callbacks_->connection());
     read_filter_->callbacks_->connection().addConnectionCallbacks(network_connection_callbacks_);

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -83,7 +83,9 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, upstreamSslConnection()).WillByDefault(Invoke([this]() {
     return upstream_connection_info_;
   }));
-  ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));
+  ON_CALL(*this, protocols()).WillByDefault(Invoke([this]() {
+    return absl::Span<const std::string>(protocols_);
+  }));
   ON_CALL(*this, responseCode()).WillByDefault(ReturnPointee(&response_code_));
   ON_CALL(*this, responseCodeDetails()).WillByDefault(ReturnPointee(&response_code_details_));
   ON_CALL(*this, addBytesReceived(_)).WillByDefault(Invoke([this](uint64_t bytes_received) {
@@ -108,6 +110,7 @@ MockStreamInfo::MockStreamInfo()
 
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
+  ON_CALL(*this, mutableFilterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(Const(*this), filterState()).WillByDefault(ReturnRef(*filter_state_));
   ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(upstream_filter_state_));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -46,8 +46,8 @@ public:
   MOCK_METHOD(uint64_t, bytesReceived, (), (const));
   MOCK_METHOD(void, setRouteName, (absl::string_view route_name));
   MOCK_METHOD(const std::string&, getRouteName, (), (const));
-  MOCK_METHOD(absl::optional<Http::Protocol>, protocol, (), (const));
-  MOCK_METHOD(void, protocol, (Http::Protocol protocol));
+  MOCK_METHOD(absl::Span<const std::string>, protocols, (), (const));
+  MOCK_METHOD(void, addProtocol, (absl::string_view protocol));
   MOCK_METHOD(absl::optional<uint32_t>, responseCode, (), (const));
   MOCK_METHOD(const absl::optional<std::string>&, responseCodeDetails, (), (const));
   MOCK_METHOD(void, addBytesSent, (uint64_t));
@@ -79,6 +79,7 @@ public:
   MOCK_METHOD(void, setDynamicMetadata, (const std::string&, const ProtobufWkt::Struct&));
   MOCK_METHOD(void, setDynamicMetadata,
               (const std::string&, const std::string&, const std::string&));
+  MOCK_METHOD(FilterStateSharedPtr&, mutableFilterState, ());
   MOCK_METHOD(const FilterStateSharedPtr&, filterState, ());
   MOCK_METHOD(const FilterState&, filterState, (), (const));
   MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, (), (const));
@@ -106,7 +107,7 @@ public:
   absl::optional<std::chrono::nanoseconds> first_downstream_tx_byte_sent_;
   absl::optional<std::chrono::nanoseconds> last_downstream_tx_byte_sent_;
   absl::optional<std::chrono::nanoseconds> end_time_;
-  absl::optional<Http::Protocol> protocol_;
+  std::vector<std::string> protocols_;
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   uint64_t response_flags_{};


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Description: Change `StreamInfo` to carry a list of the detected protocols instead of just HTTP versions. For example, the common case should have TCP, HTTP, HTTP/2 as the value.
Risk Level: low, I tried to keep the usage in HTTP context identical
Testing: updated all tests
Docs Changes: none
Release Notes: none
Fixes #10487 