### PR TITLE
test: deflake Http2FloodMitigationTest RST_STREAM test

### DIFF
--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1622,6 +1622,10 @@ TEST_P(Http2FloodMitigationTest, RST_STREAM) {
   auto response = readFrame();
   // Make sure we've got RST_STREAM from the server
   EXPECT_EQ(Http2Frame::Type::RstStream, response.type());
+
+  // Disable reading to make sure that the RST_STREAM frames stack up on the server.
+  tcp_client_->readDisable(true);
+
   uint64_t total_bytes_sent = 0;
   while (total_bytes_sent < TransmitThreshold && tcp_client_->connected()) {
     request = Http::Http2::Http2Frame::makeMalformedRequest(++i);


### PR DESCRIPTION
Because of the vagaries of the macOS TCP stack, the RST_STREAM
test seems to routinely manage to limit itself to a few outstanding
RST_STREAM packets and the connection closure is never triggered.
Force the backlog to grow by disabling client reads.

Risk Level: low (test only)
Testing: integration test fixed
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
