### PR TITLE
ext_authz: Set XFP as scheme of the HTTP check request  when it is available

### DIFF
--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -81,6 +81,14 @@ void CheckRequestUtils::setAttrContextPeer(envoy::service::auth::v3::AttributeCo
   }
 }
 
+std::string CheckRequestUtils::getScheme(const Envoy::Http::RequestHeaderMap& headers) {
+  const auto* scheme_xfp = headers.ForwardedProto();
+  if (scheme_xfp == nullptr || scheme_xfp->value().empty()) {
+    return getHeaderStr(headers.Scheme());
+  }
+  return std::string(scheme_xfp->value().getStringView());
+}
+
 std::string CheckRequestUtils::getHeaderStr(const Envoy::Http::HeaderEntry* entry) {
   if (entry) {
     // TODO(jmarantz): plumb absl::string_view further here; there's no need
@@ -107,7 +115,7 @@ void CheckRequestUtils::setHttpRequest(
   httpreq.set_method(getHeaderStr(headers.Method()));
   httpreq.set_path(getHeaderStr(headers.Path()));
   httpreq.set_host(getHeaderStr(headers.Host()));
-  httpreq.set_scheme(getHeaderStr(headers.Scheme()));
+  httpreq.set_scheme(getScheme(headers));
   httpreq.set_size(stream_info.bytesReceived());
 
   if (stream_info.protocol()) {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -84,6 +84,7 @@ private:
                                     const Envoy::Http::RequestHeaderMap& headers,
                                     uint64_t max_request_bytes);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
+  static std::string getScheme(const Envoy::Http::RequestHeaderMap& headers);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);
 };
 

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -294,7 +294,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerCertificate) {
   callHttpCheckAndValidateRequestAttributes(request_headers_, true);
 }
 
-// Verify that the source certificate is populated correctly.
+// Verify that the http request scheme attribute is populated correctly.
 TEST_F(CheckRequestUtilsTest, CheckScheme) {
   expectBasicHttp(4);
 
@@ -307,14 +307,14 @@ TEST_F(CheckRequestUtilsTest, CheckScheme) {
   // This request has scheme entry.
   const Http::TestRequestHeaderMapImpl request_headers_scheme_http{
       {":scheme", "https"}, {"x-envoy-downstream-service-cluster", "foo"}, {":path", "/bar"}};
-  callHttpCheckAndValidateRequestAttributes(request_headers_scheme_http, true, "https");
+  callHttpCheckAndValidateRequestAttributes(request_headers_scheme_http, false, "https");
 
   // This request has empty scheme entry, but it has x-forwarded-proto set.
   const Http::TestRequestHeaderMapImpl request_headers_xfp_http{
       {"x-forwarded-proto", "http"},
       {"x-envoy-downstream-service-cluster", "foo"},
       {":path", "/bar"}};
-  callHttpCheckAndValidateRequestAttributes(request_headers_xfp_http, true, "http");
+  callHttpCheckAndValidateRequestAttributes(request_headers_xfp_http, false, "http");
 
   // This request has both scheme and x-forwarded-proto set.
   const Http::TestRequestHeaderMapImpl request_headers_scheme_xfp_http{
@@ -322,7 +322,7 @@ TEST_F(CheckRequestUtilsTest, CheckScheme) {
       {"x-forwarded-proto", "http"},
       {"x-envoy-downstream-service-cluster", "foo"},
       {":path", "/bar"}};
-  callHttpCheckAndValidateRequestAttributes(request_headers_scheme_xfp_http, true, "http");
+  callHttpCheckAndValidateRequestAttributes(request_headers_scheme_xfp_http, false, "http");
 
   // This request has both scheme and x-forwarded-proto set. However, the x-forwarded-proto is set
   // to empty.
@@ -331,7 +331,7 @@ TEST_F(CheckRequestUtilsTest, CheckScheme) {
       {"x-forwarded-proto", ""},
       {"x-envoy-downstream-service-cluster", "foo"},
       {":path", "/bar"}};
-  callHttpCheckAndValidateRequestAttributes(request_headers_scheme_xfp_empty_http, true, "https");
+  callHttpCheckAndValidateRequestAttributes(request_headers_scheme_xfp_empty_http, false, "https");
 }
 
 } // namespace ExtAuthz


### PR DESCRIPTION
This patch sets the check request's HTTP scheme attribute to XFP when it is available.

Risk Level: Low
Testing: Unit tested
Docs Changes: N/A
Release Notes: N/A
Fixes #10436