### PR TITLE
tcp: making the host available from the connection pool

### DIFF
--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -203,6 +203,11 @@ public:
    *                      should be done by resetting the connection.
    */
   virtual Cancellable* newConnection(Callbacks& callbacks) PURE;
+
+  /**
+   * @return the description of the host this connection pool is for.
+   */
+  virtual Upstream::HostDescriptionConstSharedPtr host() const PURE;
 };
 
 using InstancePtr = std::unique_ptr<Instance>;

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -31,6 +31,7 @@ public:
   void addDrainedCallback(DrainedCb cb) override;
   void drainConnections() override;
   ConnectionPool::Cancellable* newConnection(ConnectionPool::Callbacks& callbacks) override;
+  Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
 
 protected:
   struct ActiveConn;

--- a/test/mocks/tcp/mocks.cc
+++ b/test/mocks/tcp/mocks.cc
@@ -29,6 +29,7 @@ MockInstance::MockInstance() {
   ON_CALL(*this, newConnection(_)).WillByDefault(Invoke([&](Callbacks& cb) -> Cancellable* {
     return newConnectionImpl(cb);
   }));
+  ON_CALL(*this, host()).WillByDefault(Return(host_));
 }
 MockInstance::~MockInstance() = default;
 

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -63,6 +63,7 @@ public:
   MOCK_METHOD(void, addDrainedCallback, (DrainedCb cb));
   MOCK_METHOD(void, drainConnections, ());
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
+  MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
 
   MockCancellable* newConnectionImpl(Callbacks& cb);
   void poolFailure(PoolFailureReason reason);


### PR DESCRIPTION
Risk Level: n/a
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
part of #1451 #1630
