### PR TITLE
ci: fix clang-tidy for headers

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -128,6 +128,7 @@ def envoy_cc_library(
         hdrs = hdrs,
         copts = envoy_copts(repository) + copts,
         visibility = visibility,
+        tags = ["nocompdb"],
         deps = [":" + name],
         strip_include_prefix = strip_include_prefix,
     )

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -32,6 +32,7 @@
 #include "common/router/config_impl.h"
 #include "common/router/debug_config.h"
 #include "common/router/retry_state_impl.h"
+#include "common/router/router.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/stream_info/uint32_accessor_impl.h"
 #include "common/tracing/http_tracer_impl.h"

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -8,6 +8,7 @@
 
 #include "envoy/http/codec.h"
 #include "envoy/http/codes.h"
+#include "envoy/http/conn_pool.h"
 #include "envoy/http/filter.h"
 #include "envoy/stats/scope.h"
 #include "envoy/tcp/conn_pool.h"
@@ -19,7 +20,6 @@
 #include "common/common/linked_object.h"
 #include "common/common/logger.h"
 #include "common/config/well_known_names.h"
-#include "common/router/router.h"
 #include "common/stream_info/stream_info_impl.h"
 
 namespace Envoy {

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -21,14 +21,13 @@ def generateCompilationDatabase(args):
   # We need to download all remote outputs for generated source code, we don't care about built
   # binaries so just always strip and use dynamic link to minimize download size.
   bazel_options = shlex.split(os.environ.get("BAZEL_BUILD_OPTIONS", "")) + [
-      "-c", "fastbuild", "--build_tag_filters=-manual,-nocompdb",
+      "-c", "fastbuild", "--build_tag_filters=-nocompdb",
       "--experimental_remote_download_outputs=all", "--strip=always"
   ]
   if args.run_bazel_build:
     runBazelBuildForCompilationDatabase(bazel_options, args.bazel_targets)
 
   subprocess.check_call(["bazel", "build"] + bazel_options + [
-      "--build_tag_filters=-nocompdb",
       "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
       "--output_groups=compdb_files"
   ] + args.bazel_targets)

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -21,13 +21,14 @@ def generateCompilationDatabase(args):
   # We need to download all remote outputs for generated source code, we don't care about built
   # binaries so just always strip and use dynamic link to minimize download size.
   bazel_options = shlex.split(os.environ.get("BAZEL_BUILD_OPTIONS", "")) + [
-      "-c", "fastbuild", "--build_tag_filters=-manual",
+      "-c", "fastbuild", "--build_tag_filters=-manual,-nocompdb",
       "--experimental_remote_download_outputs=all", "--strip=always"
   ]
   if args.run_bazel_build:
     runBazelBuildForCompilationDatabase(bazel_options, args.bazel_targets)
 
   subprocess.check_call(["bazel", "build"] + bazel_options + [
+      "--build_tag_filters=-nocompdb",
       "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
       "--output_groups=compdb_files"
   ] + args.bazel_targets)


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Description:
The `_with_external_headers` cc_libraries contains header only so bazel think it is C only and generates compile database for header twice, exclude those from compile database generation.

Also resolve a cyclic dependency between common/router/router.h and common/router/upstream_request.h for the test.

Risk Level: Low