### PR TITLE
ratelimit: allow rate limit names in the global rate limit response

### DIFF
--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -77,6 +77,9 @@ message RateLimitResponse {
       DAY = 4;
     }
 
+    // A name or description of this limit.
+    string name = 3;
+
     // The number of requests per unit of time.
     uint32 requests_per_unit = 1;
 

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -86,6 +86,9 @@ message RateLimitResponse {
       DAY = 4;
     }
 
+    // A name or description of this limit.
+    string name = 3;
+
     // The number of requests per unit of time.
     uint32 requests_per_unit = 1;
 

--- a/generated_api_shadow/envoy/service/ratelimit/v2/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v2/rls.proto
@@ -77,6 +77,9 @@ message RateLimitResponse {
       DAY = 4;
     }
 
+    // A name or description of this limit.
+    string name = 3;
+
     // The number of requests per unit of time.
     uint32 requests_per_unit = 1;
 

--- a/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
@@ -86,6 +86,9 @@ message RateLimitResponse {
       DAY = 4;
     }
 
+    // A name or description of this limit.
+    string name = 3;
+
     // The number of requests per unit of time.
     uint32 requests_per_unit = 1;
 


### PR DESCRIPTION
Description:
This part of the global rate limiter api is not currently used by envoy, but for anyone implementing the envoy global rate limiter api being able to describe what specific limit you've hit in a human-readable and/or machine-readable way will be useful for debugging, alerting, etc.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #10556
