### PR TITLE
Shorten adaptive_concurrency/concurrency_controller paths

### DIFF
--- a/source/extensions/filters/http/adaptive_concurrency/BUILD
+++ b/source/extensions/filters/http/adaptive_concurrency/BUILD
@@ -20,7 +20,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:filter_interface",
         "//source/extensions/filters/http:well_known_names",
-        "//source/extensions/filters/http/adaptive_concurrency/concurrency_controller:concurrency_controller_lib",
+        "//source/extensions/filters/http/adaptive_concurrency/controller:controller_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy_api//envoy/extensions/filters/http/adaptive_concurrency/v3:pkg_cc_proto",
     ],
@@ -36,7 +36,7 @@ envoy_cc_extension(
         "//include/envoy/registry",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/adaptive_concurrency:adaptive_concurrency_filter_lib",
-        "//source/extensions/filters/http/adaptive_concurrency/concurrency_controller:concurrency_controller_lib",
+        "//source/extensions/filters/http/adaptive_concurrency/controller:controller_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@envoy_api//envoy/extensions/filters/http/adaptive_concurrency/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.cc
@@ -10,7 +10,7 @@
 #include "common/common/assert.h"
 #include "common/protobuf/utility.h"
 
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/concurrency_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/controller.h"
 #include "extensions/filters/http/well_known_names.h"
 
 namespace Envoy {
@@ -37,7 +37,7 @@ Http::FilterHeadersStatus AdaptiveConcurrencyFilter::decodeHeaders(Http::Request
     return Http::FilterHeadersStatus::Continue;
   }
 
-  if (controller_->forwardingDecision() == ConcurrencyController::RequestForwardingAction::Block) {
+  if (controller_->forwardingDecision() == Controller::RequestForwardingAction::Block) {
     decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "", nullptr, absl::nullopt,
                                        "reached concurrency limit");
     return Http::FilterHeadersStatus::StopIteration;

--- a/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h
+++ b/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h
@@ -14,7 +14,7 @@
 #include "common/common/cleanup.h"
 #include "common/runtime/runtime_protos.h"
 
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/concurrency_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/controller.h"
 #include "extensions/filters/http/common/pass_through_filter.h"
 
 namespace Envoy {
@@ -44,8 +44,7 @@ private:
 
 using AdaptiveConcurrencyFilterConfigSharedPtr =
     std::shared_ptr<const AdaptiveConcurrencyFilterConfig>;
-using ConcurrencyControllerSharedPtr =
-    std::shared_ptr<ConcurrencyController::ConcurrencyController>;
+using ConcurrencyControllerSharedPtr = std::shared_ptr<Controller::ConcurrencyController>;
 
 /**
  * A filter that samples request latencies and dynamically adjusts the request

--- a/source/extensions/filters/http/adaptive_concurrency/config.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/config.cc
@@ -5,7 +5,7 @@
 #include "envoy/registry/registry.h"
 
 #include "extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h"
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -18,13 +18,13 @@ Http::FilterFactoryCb AdaptiveConcurrencyFilterFactory::createFilterFactoryFromP
 
   auto acc_stats_prefix = stats_prefix + "adaptive_concurrency.";
 
-  std::shared_ptr<ConcurrencyController::ConcurrencyController> controller;
+  std::shared_ptr<Controller::ConcurrencyController> controller;
   using Proto = envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency;
   ASSERT(config.concurrency_controller_config_case() ==
          Proto::ConcurrencyControllerConfigCase::kGradientControllerConfig);
-  auto gradient_controller_config = ConcurrencyController::GradientControllerConfig(
-      config.gradient_controller_config(), context.runtime());
-  controller = std::make_shared<ConcurrencyController::GradientController>(
+  auto gradient_controller_config =
+      Controller::GradientControllerConfig(config.gradient_controller_config(), context.runtime());
+  controller = std::make_shared<Controller::GradientController>(
       std::move(gradient_controller_config), context.dispatcher(), context.runtime(),
       acc_stats_prefix + "gradient_controller.", context.scope(), context.random());
 

--- a/source/extensions/filters/http/adaptive_concurrency/controller/BUILD
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/BUILD
@@ -13,10 +13,10 @@ load(
 envoy_package()
 
 envoy_cc_library(
-    name = "concurrency_controller_lib",
+    name = "controller_lib",
     srcs = ["gradient_controller.cc"],
     hdrs = [
-        "concurrency_controller.h",
+        "controller.h",
         "gradient_controller.h",
     ],
     external_deps = [

--- a/source/extensions/filters/http/adaptive_concurrency/controller/controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/controller.h
@@ -8,7 +8,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AdaptiveConcurrency {
-namespace ConcurrencyController {
+namespace Controller {
 
 /**
  * The controller's decision on whether a request will be forwarded.
@@ -57,7 +57,7 @@ public:
   virtual uint32_t concurrencyLimit() const PURE;
 };
 
-} // namespace ConcurrencyController
+} // namespace Controller
 } // namespace AdaptiveConcurrency
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -1,4 +1,4 @@
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h"
 
 #include <atomic>
 #include <chrono>
@@ -12,7 +12,7 @@
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
 
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/concurrency_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/controller.h"
 
 #include "absl/synchronization/mutex.h"
 
@@ -20,7 +20,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AdaptiveConcurrency {
-namespace ConcurrencyController {
+namespace Controller {
 
 GradientControllerConfig::GradientControllerConfig(
     const envoy::extensions::filters::http::adaptive_concurrency::v3::GradientControllerConfig&
@@ -209,7 +209,7 @@ void GradientController::cancelLatencySample() {
   --num_rq_outstanding_;
 }
 
-} // namespace ConcurrencyController
+} // namespace Controller
 } // namespace AdaptiveConcurrency
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
@@ -8,7 +8,7 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats_macros.h"
 
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/concurrency_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/controller.h"
 
 #include "absl/base/thread_annotations.h"
 #include "absl/strings/numbers.h"
@@ -19,7 +19,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AdaptiveConcurrency {
-namespace ConcurrencyController {
+namespace Controller {
 
 /**
  * All stats for the gradient controller.
@@ -276,7 +276,7 @@ private:
 };
 using GradientControllerSharedPtr = std::shared_ptr<GradientController>;
 
-} // namespace ConcurrencyController
+} // namespace Controller
 } // namespace AdaptiveConcurrency
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/adaptive_concurrency/BUILD
+++ b/test/extensions/filters/http/adaptive_concurrency/BUILD
@@ -19,7 +19,7 @@ envoy_extension_cc_test(
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/extensions/filters/http/adaptive_concurrency:adaptive_concurrency_filter_lib",
-        "//source/extensions/filters/http/adaptive_concurrency/concurrency_controller:concurrency_controller_lib",
+        "//source/extensions/filters/http/adaptive_concurrency/controller:controller_lib",
         "//test/mocks/http:http_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -23,9 +23,9 @@ namespace HttpFilters {
 namespace AdaptiveConcurrency {
 namespace {
 
-using ConcurrencyController::RequestForwardingAction;
+using Controller::RequestForwardingAction;
 
-class MockConcurrencyController : public ConcurrencyController::ConcurrencyController {
+class MockConcurrencyController : public Controller::ConcurrencyController {
 public:
   MOCK_METHOD(RequestForwardingAction, forwardingDecision, ());
   MOCK_METHOD(void, cancelLatencySample, ());

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -4,7 +4,7 @@
 #include "envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.pb.validate.h"
 
 #include "extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h"
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/concurrency_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/controller.h"
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/stream_info/mocks.h"

--- a/test/extensions/filters/http/adaptive_concurrency/controller/BUILD
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/BUILD
@@ -18,7 +18,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/filters/http/adaptive_concurrency:adaptive_concurrency_filter_lib",
-        "//source/extensions/filters/http/adaptive_concurrency/concurrency_controller:concurrency_controller_lib",
+        "//source/extensions/filters/http/adaptive_concurrency/controller:controller_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/test_common:simulated_time_system_lib",

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -28,7 +28,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AdaptiveConcurrency {
-namespace ConcurrencyController {
+namespace Controller {
 namespace {
 
 GradientControllerConfig makeConfig(const std::string& yaml_config,
@@ -624,7 +624,7 @@ min_rtt_calc_params:
 }
 
 } // namespace
-} // namespace ConcurrencyController
+} // namespace Controller
 } // namespace AdaptiveConcurrency
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -7,8 +7,8 @@
 #include "common/stats/isolated_store_impl.h"
 
 #include "extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.h"
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/concurrency_controller.h"
-#include "extensions/filters/http/adaptive_concurrency/concurrency_controller/gradient_controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/controller.h"
+#include "extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h"
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/runtime/mocks.h"


### PR DESCRIPTION
Description:
Windows include paths must net out to no more than 240 characters in our observations.

This specific extension directory path is both redundant and breaks test compilation
on the Windows architecture. The C++ namespace is similarly redundant.

The controller is always identified in the context of the adaptive_concurrency scope.

The class name might be potentially ambiguous, so this is left as ConcurrencyController, while the namespace is simplified to AdaptiveConcurrency.Controller, but that aspect is up for discussion.

Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
