### PR TITLE
http1: Allocate encoder on heap to survive move

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -976,8 +976,6 @@ void ClientConnectionImpl::onMessageComplete() {
       }
     }
 
-    ENVOY_CONN_LOG(trace, "before decode headers, decoder: {}", connection_,
-                   reinterpret_cast<uint64_t>(response.decoder_));
     if (deferred_end_stream_headers_) {
       response.decoder_->decodeHeaders(
           std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)), true);
@@ -989,8 +987,6 @@ void ClientConnectionImpl::onMessageComplete() {
       Buffer::OwnedImpl buffer;
       response.decoder_->decodeData(buffer, true);
     }
-    ENVOY_CONN_LOG(trace, "after decode headers, decoder: {}", connection_,
-                   reinterpret_cast<uint64_t>(response.decoder_));
 
     // Reset to ensure no information from one requests persists to the next.
     headers_or_trailers_.emplace<ResponseHeaderMapPtr>(nullptr);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -976,6 +976,8 @@ void ClientConnectionImpl::onMessageComplete() {
       }
     }
 
+    ENVOY_CONN_LOG(trace, "before decode headers, decoder: {}", connection_,
+                   reinterpret_cast<uint64_t>(response.decoder_));
     if (deferred_end_stream_headers_) {
       response.decoder_->decodeHeaders(
           std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)), true);
@@ -987,6 +989,8 @@ void ClientConnectionImpl::onMessageComplete() {
       Buffer::OwnedImpl buffer;
       response.decoder_->decodeData(buffer, true);
     }
+    ENVOY_CONN_LOG(trace, "after decode headers, decoder: {}", connection_,
+                   reinterpret_cast<uint64_t>(response.decoder_));
 
     // Reset to ensure no information from one requests persists to the next.
     headers_or_trailers_.emplace<ResponseHeaderMapPtr>(nullptr);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -890,7 +890,7 @@ ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, Stat
                      max_response_headers_count, formatter(settings), settings.enable_trailers_) {}
 
 bool ClientConnectionImpl::cannotHaveBody() {
-  if ((pending_response_.has_value() && pending_response_.value().encoder_->headRequest()) ||
+  if ((pending_response_.has_value() && pending_response_.value().encoder_.headRequest()) ||
       parser_.status_code == 204 || parser_.status_code == 304 ||
       (parser_.status_code >= 200 && parser_.content_length == 0)) {
     return true;
@@ -910,7 +910,7 @@ RequestEncoder& ClientConnectionImpl::newStream(ResponseDecoder& response_decode
 
   ASSERT(!pending_response_.has_value());
   pending_response_.emplace(*this, header_key_formatter_.get(), &response_decoder);
-  return *pending_response_.value().encoder_;
+  return pending_response_.value().encoder_;
 }
 
 int ClientConnectionImpl::onHeadersComplete() {
@@ -976,8 +976,6 @@ void ClientConnectionImpl::onMessageComplete() {
       }
     }
 
-    ENVOY_CONN_LOG(trace, "before decode headers, decoder: {}", connection_,
-                   reinterpret_cast<uint64_t>(response.decoder_));
     if (deferred_end_stream_headers_) {
       response.decoder_->decodeHeaders(
           std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)), true);
@@ -989,8 +987,6 @@ void ClientConnectionImpl::onMessageComplete() {
       Buffer::OwnedImpl buffer;
       response.decoder_->decodeData(buffer, true);
     }
-    ENVOY_CONN_LOG(trace, "after decode headers, decoder: {}", connection_,
-                   reinterpret_cast<uint64_t>(response.decoder_));
 
     // Reset to ensure no information from one requests persists to the next.
     headers_or_trailers_.emplace<ResponseHeaderMapPtr>(nullptr);
@@ -1000,20 +996,20 @@ void ClientConnectionImpl::onMessageComplete() {
 void ClientConnectionImpl::onResetStream(StreamResetReason reason) {
   // Only raise reset if we did not already dispatch a complete response.
   if (pending_response_.has_value()) {
-    pending_response_.value().encoder_->runResetCallbacks(reason);
+    pending_response_.value().encoder_.runResetCallbacks(reason);
     pending_response_.reset();
   }
 }
 
 void ClientConnectionImpl::sendProtocolError(absl::string_view details) {
   if (pending_response_.has_value()) {
-    pending_response_.value().encoder_->setDetails(details);
+    pending_response_.value().encoder_.setDetails(details);
   }
 }
 
 void ClientConnectionImpl::onAboveHighWatermark() {
   // This should never happen without an active stream/request.
-  pending_response_.value().encoder_->runHighWatermarkCallbacks();
+  pending_response_.value().encoder_.runHighWatermarkCallbacks();
 }
 
 void ClientConnectionImpl::onBelowLowWatermark() {
@@ -1021,7 +1017,7 @@ void ClientConnectionImpl::onBelowLowWatermark() {
   // such as sending multiple responses to the same request, causing us to close the connection, but
   // in doing so go below low watermark.
   if (pending_response_.has_value()) {
-    pending_response_.value().encoder_->runLowWatermarkCallbacks();
+    pending_response_.value().encoder_.runLowWatermarkCallbacks();
   }
 }
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -476,6 +476,7 @@ private:
   }
 
   absl::optional<PendingResponse> pending_response_;
+  bool pending_response_done_{true};
   // Set true between receiving 100-Continue headers and receiving the spurious onMessageComplete.
   bool ignore_message_complete_for_100_continue_{};
   // TODO(mattklein123): This should be a member of PendingResponse but this change needs dedicated

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -434,10 +434,9 @@ private:
   struct PendingResponse {
     PendingResponse(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter,
                     ResponseDecoder* decoder)
-        : encoder_(std::make_unique<RequestEncoderImpl>(connection, header_key_formatter)),
-          decoder_(decoder) {}
+        : encoder_(connection, header_key_formatter), decoder_(decoder) {}
 
-    std::unique_ptr<RequestEncoderImpl> encoder_;
+    RequestEncoderImpl encoder_;
     ResponseDecoder* decoder_;
   };
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -434,9 +434,10 @@ private:
   struct PendingResponse {
     PendingResponse(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter,
                     ResponseDecoder* decoder)
-        : encoder_(connection, header_key_formatter), decoder_(decoder) {}
+        : encoder_(std::make_unique<RequestEncoderImpl>(connection, header_key_formatter)),
+          decoder_(decoder) {}
 
-    RequestEncoderImpl encoder_;
+    std::unique_ptr<RequestEncoderImpl> encoder_;
     ResponseDecoder* decoder_;
   };
 


### PR DESCRIPTION
Description: `ClientConnectionImpl::onMessageComplete()` moves `PendingResponse` (and therefore `Encoder`) and tries to use it after that. As move invalidates the object - accessing it by pointer is not valid anymore.
It looks like clang keeps objects roughly intact so it's uncaught by existing envoy tests. GCC on the other hand does invalidate the memory region, which leads to crash.
Risk Level: low
Testing: n/a (was only able to repro in gcc)
Docs Changes: n/a
Release Notes: n/a
