### PR TITLE
tracing: Fix dangling reference

### DIFF
--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -202,7 +202,7 @@ LightStepDriver::LightStepDriver(const envoy::config::trace::v3::LightstepConfig
 
   auto propagation_modes = MakePropagationModes(lightstep_config);
 
-  tls_->set([this, &propagation_modes](
+  tls_->set([this, propagation_modes = std::move(propagation_modes)](
                 Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     lightstep::LightStepTracerOptions tls_options;
     tls_options.access_token = options_->access_token;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -186,6 +186,32 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
   }
 }
 
+TEST_F(LightStepDriverTest, DeferredTlsInitialization) {
+  EXPECT_CALL(cm_, get(Eq("fake_cluster"))).WillRepeatedly(Return(&cm_.thread_local_cluster_));
+  ON_CALL(*cm_.thread_local_cluster_.cluster_.info_, features())
+      .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
+
+  const std::string yaml_string = R"EOF(
+    collector_cluster: fake_cluster
+    )EOF";
+  envoy::config::trace::v3::LightstepConfig lightstep_config;
+  TestUtility::loadFromYaml(yaml_string, lightstep_config);
+
+  std::unique_ptr<lightstep::LightStepTracerOptions> opts(new lightstep::LightStepTracerOptions());
+  opts->access_token = "sample_token";
+  opts->component_name = "component";
+
+  ON_CALL(cm_, httpAsyncClientForCluster("fake_cluster"))
+      .WillByDefault(ReturnRef(cm_.async_client_));
+
+  auto propagation_mode = Common::Ot::OpenTracingDriver::PropagationMode::TracerNative;
+
+  tls_.defer_data = true;
+  driver_ = std::make_unique<LightStepDriver>(lightstep_config, cm_, stats_, tls_, runtime_,
+                                              std::move(opts), propagation_mode, grpc_context_);
+  tls_.call();
+}
+
 TEST_F(LightStepDriverTest, FlushSeveralSpans) {
   setupValidDriver(2);
 


### PR DESCRIPTION
Description:
A lambda functor from https://github.com/envoyproxy/envoy/pull/10494 captures a value by reference when it should be taking by value.

Causes this issue https://github.com/envoyproxy/envoy/pull/10494#issuecomment-605353016
