### PR TITLE
config: use cluster check utility in grpc async client

### DIFF
--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -61,12 +61,12 @@ void Utility::translateApiConfigSource(
 
 void Utility::checkCluster(absl::string_view error_prefix, absl::string_view cluster_name,
                            Upstream::ClusterManager& cm, bool allow_added_via_api) {
-  Upstream::ThreadLocalCluster* cluster = cm.get(cluster_name);
-  if (cluster == nullptr) {
+  auto clusters = cm.clusters();
+  const auto& it = clusters.find(std::string(cluster_name));
+  if (it == clusters.end()) {
     throw EnvoyException(fmt::format("{}: unknown cluster '{}'", error_prefix, cluster_name));
   }
-
-  if (!allow_added_via_api && cluster->info()->addedViaApi()) {
+  if (!allow_added_via_api && it->second.get().info()->addedViaApi()) {
     throw EnvoyException(fmt::format("{}: invalid cluster '{}': currently only "
                                      "static (non-CDS) clusters are supported",
                                      error_prefix, cluster_name));

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
         "//include/envoy/singleton:manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/config:utility_lib",
     ] + envoy_select_google_grpc([":google_async_client_lib"]),
 )
 

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -3,6 +3,7 @@
 #include "envoy/config/core/v3/grpc_service.pb.h"
 #include "envoy/stats/scope.h"
 
+#include "common/config/utility.h"
 #include "common/grpc/async_client_impl.h"
 
 #ifdef ENVOY_GOOGLE_GRPC
@@ -19,16 +20,8 @@ AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
   if (skip_cluster_check) {
     return;
   }
-
-  const std::string& cluster_name = config.envoy_grpc().cluster_name();
-  auto clusters = cm_.clusters();
-  const auto& it = clusters.find(cluster_name);
-  if (it == clusters.end()) {
-    throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
-  }
-  if (it->second.get().info()->addedViaApi()) {
-    throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
-  }
+  Config::Utility::checkCluster("AsyncClientFactory", config.envoy_grpc().cluster_name(), cm_,
+                                false);
 }
 
 AsyncClientManagerImpl::AsyncClientManagerImpl(Upstream::ClusterManager& cm,

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -54,7 +54,7 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknown) {
   EXPECT_CALL(cm_, clusters());
   EXPECT_THROW_WITH_MESSAGE(
       async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "Unknown gRPC client cluster 'foo'");
+      "AsyncClientFactory: unknown cluster 'foo'");
 }
 
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcDynamicCluster) {
@@ -69,7 +69,8 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcDynamicCluster) {
   EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(true));
   EXPECT_THROW_WITH_MESSAGE(
       async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "gRPC client cluster 'foo' is not static");
+      "AsyncClientFactory: invalid cluster 'foo': currently only static (non-CDS) clusters are "
+      "supported");
 }
 
 TEST_F(AsyncClientManagerImplTest, GoogleGrpc) {


### PR DESCRIPTION
Description: https://github.com/envoyproxy/envoy/pull/10526 added support in `checkCluster`  method to validate the type of cluster that can be used for calling external services. This PR refactors `AsyncClientFactoryImpl` to reuse that method and adds unit tests for that method.
 
Risk Level: Low
Testing: Added unit tests
Docs Changes: N/A
Release Notes: N/A

