### PR TITLE
docs: fix link to stats_server_version_override field

### DIFF
--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -23,7 +23,7 @@ Server related statistics are rooted at *server.* with following statistics:
   state, Gauge, Current :ref:`State <envoy_api_enum_admin.v2alpha.ServerInfo.state>` of the Server.
   parent_connections, Gauge, Total connections of the old Envoy process on hot restart
   total_connections, Gauge, Total connections of both new and old Envoy processes
-  version, Gauge, Integer represented version number based on SCM revision or :ref:stats_server_version_override` <envoy_api_field_config.bootstrap.v2.Bootstrap.header_prefix>` if set.
+  version, Gauge, Integer represented version number based on SCM revision or :ref:`stats_server_version_override <envoy_api_field_config.bootstrap.v2.Bootstrap.stats_server_version_override>` if set.
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
   hot_restart_epoch, Gauge, Current hot restart epoch -- an integer passed via command line flag `--restart-epoch` usually indicating generation.
   hot_restart_generation, Gauge, Current hot restart generation -- like hot_restart_epoch but computed automatically by incrementing from parent.


### PR DESCRIPTION

Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A
