### PR TITLE
tools: enhance type DB to span frozen/active major versions.

### DIFF
--- a/tools/api_proto_plugin/traverse.py
+++ b/tools/api_proto_plugin/traverse.py
@@ -50,12 +50,14 @@ def TraverseMessage(type_context, msg_proto, visitor):
       if nested_msg.options.map_entry
   }
   nested_msgs = [
-      TraverseMessage(type_context.ExtendNestedMessage(index, nested_msg.name), nested_msg, visitor)
-      for index, nested_msg in enumerate(msg_proto.nested_type)
+      TraverseMessage(
+          type_context.ExtendNestedMessage(index, nested_msg.name, nested_msg.options.deprecated),
+          nested_msg, visitor) for index, nested_msg in enumerate(msg_proto.nested_type)
   ]
   nested_enums = [
-      TraverseEnum(type_context.ExtendNestedEnum(index, nested_enum.name), nested_enum, visitor)
-      for index, nested_enum in enumerate(msg_proto.enum_type)
+      TraverseEnum(
+          type_context.ExtendNestedEnum(index, nested_enum.name, nested_enum.options.deprecated),
+          nested_enum, visitor) for index, nested_enum in enumerate(msg_proto.enum_type)
   ]
   return visitor.VisitMessage(msg_proto, type_context, nested_msgs, nested_enums)
 
@@ -77,11 +79,11 @@ def TraverseFile(file_proto, visitor):
       for index, service in enumerate(file_proto.service)
   ]
   msgs = [
-      TraverseMessage(package_type_context.ExtendMessage(index, msg.name), msg, visitor)
-      for index, msg in enumerate(file_proto.message_type)
+      TraverseMessage(package_type_context.ExtendMessage(index, msg.name, msg.options.deprecated),
+                      msg, visitor) for index, msg in enumerate(file_proto.message_type)
   ]
   enums = [
-      TraverseEnum(package_type_context.ExtendEnum(index, enum.name), enum, visitor)
-      for index, enum in enumerate(file_proto.enum_type)
+      TraverseEnum(package_type_context.ExtendEnum(index, enum.name, enum.options.deprecated), enum,
+                   visitor) for index, enum in enumerate(file_proto.enum_type)
   ]
   return visitor.VisitFile(file_proto, package_type_context, services, msgs, enums)

--- a/tools/api_proto_plugin/type_context.py
+++ b/tools/api_proto_plugin/type_context.py
@@ -152,8 +152,9 @@ class TypeContext(object):
     # Map from a message's oneof index to the "required" bool property.
     self.oneof_required = {}
     self.type_name = 'file'
+    self.deprecated = False
 
-  def _Extend(self, path, type_name, name):
+  def _Extend(self, path, type_name, name, deprecated=False):
     if not self.name:
       extended_name = name
     else:
@@ -165,25 +166,28 @@ class TypeContext(object):
     extended.oneof_fields = self.oneof_fields.copy()
     extended.oneof_names = self.oneof_names.copy()
     extended.oneof_required = self.oneof_required.copy()
+    extended.deprecated = self.deprecated or deprecated
     return extended
 
-  def ExtendMessage(self, index, name):
+  def ExtendMessage(self, index, name, deprecated):
     """Extend type context with a message.
 
     Args:
       index: message index in file.
       name: message name.
+      deprecated: is the message depreacted?
     """
-    return self._Extend([4, index], 'message', name)
+    return self._Extend([4, index], 'message', name, deprecated)
 
-  def ExtendNestedMessage(self, index, name):
+  def ExtendNestedMessage(self, index, name, deprecated):
     """Extend type context with a nested message.
 
     Args:
       index: nested message index in message.
       name: message name.
+      deprecated: is the message depreacted?
     """
-    return self._Extend([3, index], 'message', name)
+    return self._Extend([3, index], 'message', name, deprecated)
 
   def ExtendField(self, index, name):
     """Extend type context with a field.
@@ -194,14 +198,15 @@ class TypeContext(object):
     """
     return self._Extend([2, index], 'field', name)
 
-  def ExtendEnum(self, index, name):
+  def ExtendEnum(self, index, name, deprecated):
     """Extend type context with an enum.
 
     Args:
       index: enum index in file.
       name: enum name.
+      deprecated: is the message depreacted?
     """
-    return self._Extend([5, index], 'enum', name)
+    return self._Extend([5, index], 'enum', name, deprecated)
 
   def ExtendService(self, index, name):
     """Extend type context with a service.
@@ -212,14 +217,15 @@ class TypeContext(object):
     """
     return self._Extend([6, index], 'service', name)
 
-  def ExtendNestedEnum(self, index, name):
+  def ExtendNestedEnum(self, index, name, deprecated):
     """Extend type context with a nested enum.
 
     Args:
       index: enum index in message.
       name: enum name.
+      deprecated: is the message depreacted?
     """
-    return self._Extend([4, index], 'enum', name)
+    return self._Extend([4, index], 'enum', name, deprecated)
 
   def ExtendEnumValue(self, index, name):
     """Extend type context with an enum enum.

--- a/tools/type_whisperer/typedb_gen.py
+++ b/tools/type_whisperer/typedb_gen.py
@@ -153,7 +153,8 @@ if __name__ == '__main__':
   type_map.update([
       UpgradedTypeWithDescription(type_name, type_desc)
       for type_name, type_desc in type_map.items()
-      if type_desc.qualified_package in next_versions_pkgs
+      if type_desc.qualified_package in next_versions_pkgs and
+      (type_desc.active or type_desc.deprecated_type)
   ])
 
   # Generate the type database proto. To provide some stability across runs, in
@@ -166,7 +167,8 @@ if __name__ == '__main__':
     type_desc = type_db.types[t]
     type_desc.qualified_package = type_map[t].qualified_package
     type_desc.proto_path = type_map[t].proto_path
-    if type_desc.qualified_package in next_versions_pkgs:
+    if type_desc.qualified_package in next_versions_pkgs and (not type_map[t].map_entry or
+                                                              type_map[t].active):
       type_desc.next_version_type_name = UpgradedType(t, type_map[t])
       assert (type_desc.next_version_type_name != t)
       next_proto_info[type_map[t].proto_path] = (

--- a/tools/type_whisperer/types.proto
+++ b/tools/type_whisperer/types.proto
@@ -19,6 +19,15 @@ message TypeDescription {
 
   // The package of the type in next version
   string next_version_package = 6;
+
+  // Is this a type in an active package?
+  bool active = 7;
+
+  // Is this type a synthesized map entry?
+  bool map_entry = 8;
+
+  // Is this type deprecated?
+  bool deprecated_type = 9;
 }
 
 message Types {


### PR DESCRIPTION
As part of #10355, this patch introduces the ability to build a type database that includes types
spanning across frozen, active and next major version, e.g. v2/v3/v4alpha.

The main trick here is to allow the type whispers of active versions to take precedence, but
to still forward propagate deprecated types to the next version for shadowing. It was also necessary
to introduce a workaround to handle missing synthesized map entry types, since they aren't real
types that we want to forward propagate.

Risk level: Low (API tooling only)
Testing: Part of a larger PR where the type DB spanned v2/v3/v4alpha.

Signed-off-by: Harvey Tuch <htuch@google.com>