### PR TITLE
WIP: ext_authz: Use HTTP service URI

### DIFF
--- a/api/envoy/config/filter/http/ext_authz/v2/BUILD
+++ b/api/envoy/config/filter/http/ext_authz/v2/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/api/v2/core:pkg",
+        "//envoy/config/common/dynamic_forward_proxy/v2alpha:pkg",
         "//envoy/type:pkg",
         "//envoy/type/matcher:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -5,6 +5,7 @@ package envoy.config.filter.http.ext_authz.v2;
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/grpc_service.proto";
 import "envoy/api/v2/core/http_uri.proto";
+import "envoy/config/common/dynamic_forward_proxy/v2alpha/dns_cache.proto";
 import "envoy/type/http_status.proto";
 import "envoy/type/matcher/string.proto";
 
@@ -143,7 +144,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_api_field_config.filter.http.ext_authz.v2.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message HttpService {
   reserved 3, 4, 5, 6;
 
@@ -158,6 +159,8 @@ message HttpService {
 
   // Settings used for controlling authorization response metadata.
   AuthorizationResponse authorization_response = 8;
+
+  common.dynamic_forward_proxy.v2alpha.DnsCacheConfig dns_cache_config = 9;
 }
 
 message AuthorizationRequest {

--- a/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/ext_authz/v2:pkg",
+        "//envoy/extensions/common/dynamic_forward_proxy/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -5,6 +5,7 @@ package envoy.extensions.filters.http.ext_authz.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/core/v3/http_uri.proto";
+import "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
@@ -145,7 +146,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message HttpService {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.HttpService";
@@ -163,6 +164,8 @@ message HttpService {
 
   // Settings used for controlling authorization response metadata.
   AuthorizationResponse authorization_response = 8;
+
+  common.dynamic_forward_proxy.v3.DnsCacheConfig dns_cache_config = 9;
 }
 
 message AuthorizationRequest {

--- a/generated_api_shadow/envoy/config/filter/http/ext_authz/v2/BUILD
+++ b/generated_api_shadow/envoy/config/filter/http/ext_authz/v2/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/api/v2/core:pkg",
+        "//envoy/config/common/dynamic_forward_proxy/v2alpha:pkg",
         "//envoy/type:pkg",
         "//envoy/type/matcher:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/generated_api_shadow/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -5,6 +5,7 @@ package envoy.config.filter.http.ext_authz.v2;
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/grpc_service.proto";
 import "envoy/api/v2/core/http_uri.proto";
+import "envoy/config/common/dynamic_forward_proxy/v2alpha/dns_cache.proto";
 import "envoy/type/http_status.proto";
 import "envoy/type/matcher/string.proto";
 
@@ -143,7 +144,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_api_field_config.filter.http.ext_authz.v2.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message HttpService {
   reserved 3, 4, 5, 6;
 
@@ -158,6 +159,8 @@ message HttpService {
 
   // Settings used for controlling authorization response metadata.
   AuthorizationResponse authorization_response = 8;
+
+  common.dynamic_forward_proxy.v2alpha.DnsCacheConfig dns_cache_config = 9;
 }
 
 message AuthorizationRequest {

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/ext_authz/v2:pkg",
+        "//envoy/extensions/common/dynamic_forward_proxy/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -5,6 +5,7 @@ package envoy.extensions.filters.http.ext_authz.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/core/v3/http_uri.proto";
+import "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
@@ -148,7 +149,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message HttpService {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.HttpService";
@@ -166,6 +167,8 @@ message HttpService {
 
   // Settings used for controlling authorization response metadata.
   AuthorizationResponse authorization_response = 8;
+
+  common.dynamic_forward_proxy.v3.DnsCacheConfig dns_cache_config = 9;
 }
 
 message AuthorizationRequest {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -102,14 +102,16 @@ namespace Utility {
 class Url {
 public:
   bool initialize(absl::string_view absolute_url);
-  absl::string_view scheme() { return scheme_; }
-  absl::string_view host_and_port() { return host_and_port_; }
-  absl::string_view path_and_query_params() { return path_and_query_params_; }
+  absl::string_view scheme() const { return scheme_; }
+  absl::string_view host_and_port() const { return host_and_port_; }
+  absl::string_view path_and_query_params() const { return path_and_query_params_; }
+  uint16_t port() const { return port_; }
 
 private:
   absl::string_view scheme_;
   absl::string_view host_and_port_;
   absl::string_view path_and_query_params_;
+  uint16_t port_{0};
 };
 
 class PercentEncoding {

--- a/source/extensions/filters/common/ext_authz/BUILD
+++ b/source/extensions/filters/common/ext_authz/BUILD
@@ -61,6 +61,7 @@ envoy_cc_library(
         "//source/common/http:async_client_lib",
         "//source/common/http:codes_lib",
         "//source/common/tracing:http_tracer_lib",
+        "//source/extensions/common/dynamic_forward_proxy:dns_cache_manager_impl",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/ext_authz/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/auth/v3:pkg_cc_proto",

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -205,7 +205,7 @@ private:
   ResponsePtr toResponse(Http::ResponseMessagePtr message);
   Upstream::ClusterManager& cm_;
   ClientConfigSharedPtr config_;
-  Http::AsyncClient::Request* request_;
+  Http::AsyncClient::Request* request_{nullptr};
   RequestCallbacks* callbacks_{nullptr};
   TimeSource& time_source_;
   Tracing::SpanPtr span_{nullptr};

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -10,6 +10,7 @@
 
 #include "common/protobuf/utility.h"
 
+#include "extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h"
 #include "extensions/filters/common/ext_authz/ext_authz_grpc_impl.h"
 #include "extensions/filters/common/ext_authz/ext_authz_http_impl.h"
 #include "extensions/filters/http/ext_authz/ext_authz.h"
@@ -22,18 +23,23 @@ namespace ExtAuthz {
 Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  Stats::Scope& scope = context.scope();
   const auto filter_config =
-      std::make_shared<FilterConfig>(proto_config, context.localInfo(), context.scope(),
-                                     context.runtime(), context.httpContext(), stats_prefix);
+      std::make_shared<FilterConfig>(proto_config, context.localInfo(), scope, context.runtime(),
+                                     context.httpContext(), stats_prefix);
   Http::FilterFactoryCb callback;
 
   if (proto_config.has_http_service()) {
+    Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactoryImpl dns_cache_manager_factory(
+        context.singletonManager(), context.dispatcher(), context.threadLocal(), context.random(),
+        scope);
+
     // Raw HTTP client.
     const uint32_t timeout_ms = PROTOBUF_GET_MS_OR_DEFAULT(proto_config.http_service().server_uri(),
                                                            timeout, DefaultTimeout);
     const auto client_config =
         std::make_shared<Extensions::Filters::Common::ExtAuthz::ClientConfig>(
-            proto_config, timeout_ms, proto_config.http_service().path_prefix());
+            proto_config, timeout_ms, dns_cache_manager_factory);
     callback = [filter_config, client_config,
                 &context](Http::FilterChainFactoryCallbacks& callbacks) {
       auto client = std::make_unique<Extensions::Filters::Common::ExtAuthz::RawHttpClientImpl>(

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -1080,65 +1080,73 @@ TEST(Url, ParsingFails) {
 }
 
 void ValidateUrl(absl::string_view raw_url, absl::string_view expected_scheme,
-                 absl::string_view expected_host_port, absl::string_view expected_path) {
+                 absl::string_view expected_host_port, absl::string_view expected_path,
+                 uint16_t expect_port) {
   Utility::Url url;
   ASSERT_TRUE(url.initialize(raw_url)) << "Failed to initialize " << raw_url;
   EXPECT_EQ(url.scheme(), expected_scheme);
   EXPECT_EQ(url.host_and_port(), expected_host_port);
   EXPECT_EQ(url.path_and_query_params(), expected_path);
+  EXPECT_EQ(url.port(), expect_port);
 }
 
 TEST(Url, ParsingTest) {
-  // Test url with no explicit path (with and without port)
-  ValidateUrl("http://www.host.com", "http", "www.host.com", "/");
-  ValidateUrl("http://www.host.com:80", "http", "www.host.com:80", "/");
+  // Test URL with no explicit path (with and without port).
+  ValidateUrl("http://www.host.com", "http", "www.host.com", "/", 80);
+  ValidateUrl("http://www.host.com:80", "http", "www.host.com:80", "/", 80);
 
-  // Test url with "/" path.
-  ValidateUrl("http://www.host.com:80/", "http", "www.host.com:80", "/");
-  ValidateUrl("http://www.host.com/", "http", "www.host.com", "/");
+  // Test URL with "/" path.
+  ValidateUrl("http://www.host.com:80/", "http", "www.host.com:80", "/", 80);
+  ValidateUrl("http://www.host.com/", "http", "www.host.com", "/", 80);
 
-  // Test url with "?".
-  ValidateUrl("http://www.host.com:80/?", "http", "www.host.com:80", "/?");
-  ValidateUrl("http://www.host.com/?", "http", "www.host.com", "/?");
+  // Test URL with "?".
+  ValidateUrl("http://www.host.com:80/?", "http", "www.host.com:80", "/?", 80);
+  ValidateUrl("http://www.host.com/?", "http", "www.host.com", "/?", 80);
 
-  // Test url with "?" but without slash.
-  ValidateUrl("http://www.host.com:80?", "http", "www.host.com:80", "?");
-  ValidateUrl("http://www.host.com?", "http", "www.host.com", "?");
+  // Test URL with "?" but without slash.
+  ValidateUrl("http://www.host.com:80?", "http", "www.host.com:80", "?", 80);
+  ValidateUrl("http://www.host.com?", "http", "www.host.com", "?", 80);
 
-  // Test url with multi-character path
-  ValidateUrl("http://www.host.com:80/path", "http", "www.host.com:80", "/path");
-  ValidateUrl("http://www.host.com/path", "http", "www.host.com", "/path");
+  // Test URL with multi-character path.
+  ValidateUrl("http://www.host.com:80/path", "http", "www.host.com:80", "/path", 80);
+  ValidateUrl("http://www.host.com/path", "http", "www.host.com", "/path", 80);
 
-  // Test url with multi-character path and ? at the end
-  ValidateUrl("http://www.host.com:80/path?", "http", "www.host.com:80", "/path?");
-  ValidateUrl("http://www.host.com/path?", "http", "www.host.com", "/path?");
+  // Test URL with multi-character path and ? at the end.
+  ValidateUrl("http://www.host.com:80/path?", "http", "www.host.com:80", "/path?", 80);
+  ValidateUrl("http://www.host.com/path?", "http", "www.host.com", "/path?", 80);
 
-  // Test https scheme
-  ValidateUrl("https://www.host.com", "https", "www.host.com", "/");
+  // Test https scheme. Since the port is not part of the URL, 443 is used as the port value.
+  ValidateUrl("https://www.host.com", "https", "www.host.com", "/", 443);
 
-  // Test url with query parameter
-  ValidateUrl("http://www.host.com:80/?query=param", "http", "www.host.com:80", "/?query=param");
-  ValidateUrl("http://www.host.com/?query=param", "http", "www.host.com", "/?query=param");
+  // Test URL with query parameter.
+  ValidateUrl("http://www.host.com:80/?query=param", "http", "www.host.com:80", "/?query=param",
+              80);
+  ValidateUrl("http://www.host.com/?query=param", "http", "www.host.com", "/?query=param", 80);
 
-  // Test url with query parameter but without slash
-  ValidateUrl("http://www.host.com:80?query=param", "http", "www.host.com:80", "?query=param");
-  ValidateUrl("http://www.host.com?query=param", "http", "www.host.com", "?query=param");
+  // Test URL with query parameter but without slash.
+  ValidateUrl("http://www.host.com:80?query=param", "http", "www.host.com:80", "?query=param", 80);
+  ValidateUrl("http://www.host.com?query=param", "http", "www.host.com", "?query=param", 80);
 
-  // Test url with multi-character path and query parameter
+  // Test URL with multi-character path and query parameter.
   ValidateUrl("http://www.host.com:80/path?query=param", "http", "www.host.com:80",
-              "/path?query=param");
-  ValidateUrl("http://www.host.com/path?query=param", "http", "www.host.com", "/path?query=param");
+              "/path?query=param", 80);
+  ValidateUrl("http://www.host.com/path?query=param", "http", "www.host.com", "/path?query=param",
+              80);
 
-  // Test url with multi-character path and more than one query parameter
+  // Test URL with multi-character path and more than one query parameter.
   ValidateUrl("http://www.host.com:80/path?query=param&query2=param2", "http", "www.host.com:80",
-              "/path?query=param&query2=param2");
+              "/path?query=param&query2=param2", 80);
   ValidateUrl("http://www.host.com/path?query=param&query2=param2", "http", "www.host.com",
-              "/path?query=param&query2=param2");
-  // Test url with multi-character path, more than one query parameter and fragment
+              "/path?query=param&query2=param2", 80);
+
+  // Test URL with multi-character path, more than one query parameter and fragment.
   ValidateUrl("http://www.host.com:80/path?query=param&query2=param2#fragment", "http",
-              "www.host.com:80", "/path?query=param&query2=param2#fragment");
+              "www.host.com:80", "/path?query=param&query2=param2#fragment", 80);
   ValidateUrl("http://www.host.com/path?query=param&query2=param2#fragment", "http", "www.host.com",
-              "/path?query=param&query2=param2#fragment");
+              "/path?query=param&query2=param2#fragment", 80);
+
+  // Test URL when the port is not 80 or 443.
+  ValidateUrl("http://www.host.com:3000/", "http", "www.host.com:3000", "/", 3000);
 }
 
 void validatePercentEncodingEncodeDecode(absl::string_view source,

--- a/test/extensions/filters/common/ext_authz/BUILD
+++ b/test/extensions/filters/common/ext_authz/BUILD
@@ -57,7 +57,6 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//source/extensions/filters/common/ext_authz:ext_authz_interface",
-        "//test/mocks/upstream:upstream_mocks",
         "@envoy_api//envoy/service/auth/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/common/ext_authz/BUILD
+++ b/test/extensions/filters/common/ext_authz/BUILD
@@ -43,6 +43,7 @@ envoy_cc_test(
     srcs = ["ext_authz_http_impl_test.cc"],
     deps = [
         "//source/extensions/filters/common/ext_authz:ext_authz_http_lib",
+        "//test/extensions/common/dynamic_forward_proxy:mocks",
         "//test/extensions/filters/common/ext_authz:ext_authz_test_common",
         "//test/mocks/stream_info:stream_info_mocks",
         "@envoy_api//envoy/extensions/filters/http/ext_authz/v3:pkg_cc_proto",
@@ -56,6 +57,7 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//source/extensions/filters/common/ext_authz:ext_authz_interface",
+        "//test/mocks/upstream:upstream_mocks",
         "@envoy_api//envoy/service/auth/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -43,8 +43,6 @@ class ExtAuthzHttpClientTest
     : public testing::Test,
       public Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactory {
 public:
-  ExtAuthzHttpClientTest() {}
-
   void initialize(const std::string& yaml = EMPTY_STRING) {
     config_ = createConfig(yaml);
     client_ = std::make_unique<RawHttpClientImpl>(cm_, config_, time_source_);

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -9,6 +9,7 @@
 
 #include "extensions/filters/common/ext_authz/ext_authz_http_impl.h"
 
+#include "test/extensions/common/dynamic_forward_proxy/mocks.h"
 #include "test/extensions/filters/common/ext_authz/mocks.h"
 #include "test/extensions/filters/common/ext_authz/test_common.h"
 #include "test/mocks/stream_info/mocks.h"
@@ -33,28 +34,60 @@ namespace Common {
 namespace ExtAuthz {
 namespace {
 
-class ExtAuthzHttpClientTest : public testing::Test {
-public:
-  ExtAuthzHttpClientTest()
-      : async_request_{&async_client_}, time_source_{async_client_.dispatcher().timeSource()} {
-    initialize(EMPTY_STRING);
-  }
+using LoadDnsCacheEntryStatus =
+    Envoy::Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus;
+using MockLoadDnsCacheEntryResult =
+    Envoy::Extensions::Common::DynamicForwardProxy::MockDnsCache::MockLoadDnsCacheEntryResult;
 
-  void initialize(const std::string& yaml) {
+class ExtAuthzHttpClientTest
+    : public testing::Test,
+      public Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactory {
+public:
+  ExtAuthzHttpClientTest() {}
+
+  void initialize(const std::string& yaml = EMPTY_STRING) {
     config_ = createConfig(yaml);
     client_ = std::make_unique<RawHttpClientImpl>(cm_, config_, time_source_);
-    ON_CALL(cm_, httpAsyncClientForCluster(config_->cluster()))
-        .WillByDefault(ReturnRef(async_client_));
+    ON_CALL(cm_, httpAsyncClientForCluster(config_->clusterName()))
+        .WillByDefault(ReturnRef(cm_.async_client_));
   }
 
-  ClientConfigSharedPtr createConfig(const std::string& yaml = EMPTY_STRING, uint32_t timeout = 250,
-                                     const std::string& path_prefix = "/bar") {
-    envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config{};
+  Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr get() override {
+    return dns_cache_manager_;
+  }
+
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz
+  createConfigWithDnsCache(const std::string& cluster_name) {
+    // Prepare a configuration which uses "dns_cache_config",
+    //    http_service:
+    //      server_uri:
+    //        uri: "http://localhost:3000/verify"
+    //        cluster: service_dynamic_forward_proxy
+    //        timeout: 1s
+    //      dns_cache_config:
+    //        name: dynamic_forward_proxy_cache_config
+    //        dns_lookup_family: V4_ONLY
+    envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config;
+    auto* server_uri = proto_config.mutable_http_service()->mutable_server_uri();
+    server_uri->set_uri("http://ext-authz.io:9000/auth");
+    server_uri->set_cluster(cluster_name);
+    server_uri->mutable_timeout()->set_seconds(1);
+
+    auto* dns_cache = proto_config.mutable_http_service()->mutable_dns_cache_config();
+    dns_cache->set_name("dynamic_forward_proxy_cache_config");
+    dns_cache->set_dns_lookup_family(envoy::config::cluster::v3::Cluster::V4_ONLY);
+
+    return proto_config;
+  }
+
+  ClientConfigSharedPtr createConfig(const std::string& yaml, uint32_t timeout = 250,
+                                     const std::string& path_prefix = "/prefix") {
+    envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config;
     if (yaml.empty()) {
       const std::string default_yaml = R"EOF(
         http_service:
           server_uri:
-            uri: "ext_authz:9000"
+            uri: "http://ext-authz.io:9000"
             cluster: "ext_authz"
             timeout: 0.25s
 
@@ -92,20 +125,15 @@ public:
     } else {
       TestUtility::loadFromYaml(yaml, proto_config);
     }
-
-    return std::make_shared<ClientConfig>(proto_config, timeout, path_prefix);
+    proto_config.mutable_http_service()->set_path_prefix(path_prefix);
+    return std::make_shared<ClientConfig>(proto_config, timeout, *this);
   }
 
-  Http::RequestMessagePtr sendRequest(std::unordered_map<std::string, std::string>&& headers) {
-    envoy::service::auth::v3::CheckRequest request{};
-    auto mutable_headers =
-        request.mutable_attributes()->mutable_request()->mutable_http()->mutable_headers();
-    for (const auto& header : headers) {
-      (*mutable_headers)[header.first] = header.second;
-    }
-
+  Http::RequestMessagePtr sendRequest(
+      std::unordered_map<std::string, std::string>&& headers,
+      LoadDnsCacheEntryStatus load_dns_cache_entry_status = LoadDnsCacheEntryStatus::InCache) {
     Http::RequestMessagePtr message_ptr;
-    EXPECT_CALL(async_client_, send_(_, _, _))
+    EXPECT_CALL(cm_.async_client_, send_(_, _, _))
         .WillOnce(Invoke(
             [&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks&,
                 const Envoy::Http::AsyncClient::RequestOptions) -> Http::AsyncClient::Request* {
@@ -113,31 +141,60 @@ public:
               return nullptr;
             }));
 
+    envoy::service::auth::v3::CheckRequest request;
+    auto mutable_headers =
+        request.mutable_attributes()->mutable_request()->mutable_http()->mutable_headers();
+    for (const auto& header : headers) {
+      (*mutable_headers)[header.first] = header.second;
+    }
+
+    client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
+
+    if (load_dns_cache_entry_status == LoadDnsCacheEntryStatus::Loading) {
+      client_->onLoadDnsCacheComplete();
+    }
+
     const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "200", false}});
     const auto authz_response = TestCommon::makeAuthzResponse(CheckStatus::OK);
     auto check_response = TestCommon::makeMessageResponse(expected_headers);
-
-    client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
     EXPECT_CALL(request_callbacks_,
                 onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzOkResponse(authz_response))));
-    client_->onSuccess(async_request_, std::move(check_response));
 
+    client_->onSuccess(async_request_, std::move(check_response));
     return message_ptr;
   }
 
+  std::shared_ptr<Extensions::Common::DynamicForwardProxy::MockDnsCacheManager> dns_cache_manager_{
+      new Extensions::Common::DynamicForwardProxy::MockDnsCacheManager()};
   NiceMock<Upstream::MockClusterManager> cm_;
-  NiceMock<Http::MockAsyncClient> async_client_;
-  NiceMock<Http::MockAsyncClientRequest> async_request_;
+  NiceMock<Http::MockAsyncClientRequest> async_request_{&cm_.async_client_};
   ClientConfigSharedPtr config_;
-  TimeSource& time_source_;
+  TimeSource& time_source_{cm_.async_client_.dispatcher().timeSource()};
   std::unique_ptr<RawHttpClientImpl> client_;
   MockRequestCallbacks request_callbacks_;
   Tracing::MockSpan active_span_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 };
 
+// Test initializing the HTTP client with an invalid server URI value.
+TEST_F(ExtAuthzHttpClientTest, TestInvalidServerUri) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "invalid"
+      cluster: "ext_authz"
+      timeout: 0.25s
+  failure_mode_allow: true
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(initialize(yaml), EnvoyException,
+                            "server URI 'invalid' is not a valid URI");
+}
+
 // Test HTTP client config default values.
 TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
+  initialize();
+
   const Http::LowerCaseString foo{"foo"};
   const Http::LowerCaseString baz{"baz"};
   const Http::LowerCaseString bar{"bar"};
@@ -162,8 +219,8 @@ TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
   EXPECT_TRUE(config_->upstreamHeaderMatchers()->matches(bar.get()));
 
   // // Check other attributes.
-  EXPECT_EQ(config_->pathPrefix(), "/bar");
-  EXPECT_EQ(config_->cluster(), "ext_authz");
+  EXPECT_EQ(config_->pathPrefix(), "/prefix");
+  EXPECT_EQ(config_->clusterName(), "ext_authz");
   EXPECT_EQ(config_->tracingName(), "async ext_authz egress");
   EXPECT_EQ(config_->timeout(), std::chrono::milliseconds{250});
 }
@@ -173,7 +230,7 @@ TEST_F(ExtAuthzHttpClientTest, TestDefaultAllowedHeaders) {
   const std::string yaml = R"EOF(
   http_service:
     server_uri:
-      uri: "ext_authz:9000"
+      uri: "http://ext-authz.io:9000"
       cluster: "ext_authz"
       timeout: 0.25s
   failure_mode_allow: true
@@ -199,15 +256,21 @@ TEST_F(ExtAuthzHttpClientTest, TestDefaultAllowedHeaders) {
 // Verify client response when the authorization server returns a 200 OK and path_prefix is
 // configured.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithPathRewrite) {
+  initialize();
+
   Http::RequestMessagePtr message_ptr = sendRequest({{":path", "/foo"}, {"foo", "bar"}});
 
   const auto* path = message_ptr->headers().get(Http::Headers::get().Path);
   ASSERT_NE(path, nullptr);
-  EXPECT_EQ(path->value().getStringView(), "/bar/foo");
+  // The path_prefix is "/prefix", and the path configured in server_uri.uri is "/"
+  // (http://ext-authz.io:9000 is parsed with "/" as path).
+  EXPECT_EQ(path->value().getStringView(), "/prefix/");
 }
 
 // Test the client when a request contains Content-Length greater than 0.
 TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZero) {
+  initialize();
+
   Http::RequestMessagePtr message_ptr =
       sendRequest({{Http::Headers::get().ContentLength.get(), std::string{"47"}},
                    {Http::Headers::get().Method.get(), std::string{"POST"}}});
@@ -226,7 +289,7 @@ TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZeroWithAllowedHeaders) {
   const std::string yaml = R"EOF(
   http_service:
     server_uri:
-      uri: "ext_authz:9000"
+      uri: "http://ext-authz.io:9000"
       cluster: "ext_authz"
       timeout: 0.25s
     authorization_request:
@@ -255,6 +318,8 @@ TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZeroWithAllowedHeaders) {
 
 // Test the client when a request contains headers in the prefix matchers.
 TEST_F(ExtAuthzHttpClientTest, AllowedRequestHeadersPrefix) {
+  initialize();
+
   const Http::LowerCaseString regexFood{"regex-food"};
   const Http::LowerCaseString regexFool{"regex-fool"};
   Http::RequestMessagePtr message_ptr =
@@ -284,6 +349,8 @@ TEST_F(ExtAuthzHttpClientTest, AllowedRequestHeadersPrefix) {
 
 // Verify client response when authorization server returns a 200 OK.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationOk) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "200", false}});
   const auto authz_response = TestCommon::makeAuthzResponse(CheckStatus::OK);
@@ -292,7 +359,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOk) {
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   client_->check(request_callbacks_, request, active_span_, stream_info_);
@@ -309,6 +376,8 @@ using HeaderValuePair = std::pair<const Http::LowerCaseString, const std::string
 
 // Verify client response headers when authorization_headers_to_add is configured.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeaders) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "200", false}});
   const auto authz_response = TestCommon::makeAuthzResponse(CheckStatus::OK);
@@ -320,13 +389,13 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeaders) {
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
   // Expect that header1 will be added and header2 correctly overwritten. Due to this behavior, the
   // append property of header value option should always be false.
   const HeaderValuePair header1{"x-authz-header1", "value"};
   const HeaderValuePair header2{"x-authz-header2", "value"};
-  EXPECT_CALL(async_client_,
+  EXPECT_CALL(cm_.async_client_,
               send_(AllOf(ContainsPairAsHeader(header1), ContainsPairAsHeader(header2)), _, _));
   client_->check(request_callbacks_, request, active_span_, stream_info_);
 
@@ -344,7 +413,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeadersFromStreamInf
   const std::string yaml = R"EOF(
   http_service:
     server_uri:
-      uri: "ext_authz:9000"
+      uri: "http://ext-authz.io:9000"
       cluster: "ext_authz"
       timeout: 0.25s
     authorization_request:
@@ -363,11 +432,11 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeadersFromStreamInf
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   const HeaderValuePair expected_header{"x-authz-header1", "123"};
-  EXPECT_CALL(async_client_, send_(ContainsPairAsHeader(expected_header), _, _));
+  EXPECT_CALL(cm_.async_client_, send_(ContainsPairAsHeader(expected_header), _, _));
 
   Http::RequestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::LowerCaseString(std::string("x-request-id")),
@@ -389,6 +458,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeadersFromStreamInf
 
 // Verify client response headers when allow_upstream_headers is configured.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAllowHeader) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   const std::string empty_body{};
   const auto expected_headers =
@@ -401,18 +472,16 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAllowHeader) {
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzOkResponse(authz_response))));
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
   client_->check(request_callbacks_, request, active_span_, stream_info_);
 
-  const auto check_response_headers =
-      TestCommon::makeHeaderValueOption({{":status", "200", false},
-                                         {":path", "/bar", false},
-                                         {":method", "post", false},
-                                         {"content-length", "post", false},
-                                         {"bar", "foo", false},
-                                         {"x-baz", "foo", false},
-                                         {"foobar", "foo", false}});
+  const auto check_response_headers = TestCommon::makeHeaderValueOption({{":status", "200", false},
+                                                                         {":path", "/bar", false},
+                                                                         {":method", "post", false},
+                                                                         {"bar", "foo", false},
+                                                                         {"x-baz", "foo", false},
+                                                                         {"foobar", "foo", false}});
 
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
   EXPECT_CALL(*child_span, setTag(Eq("ext_authz_http_status"), Eq("OK")));
@@ -423,6 +492,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAllowHeader) {
 
 // Test the client when a denied response is received.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationDenied) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "403", false}});
   const auto authz_response = TestCommon::makeAuthzResponse(
@@ -431,7 +502,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDenied) {
   envoy::service::auth::v3::CheckRequest request;
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
   client_->check(request_callbacks_, request, active_span_, stream_info_);
 
@@ -445,6 +516,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDenied) {
 
 // Verify client response headers and body when the authorization server denies the request.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedWithAllAttributes) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   const auto expected_body = std::string{"test"};
   const auto expected_headers = TestCommon::makeHeaderValueOption(
@@ -454,7 +527,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedWithAllAttributes) {
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   envoy::service::auth::v3::CheckRequest request;
@@ -472,6 +545,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedWithAllAttributes) {
 // Verify client response headers when the authorization server denies the request and
 // allowed_client_headers is configured.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   const auto expected_body = std::string{"test"};
   const auto authz_response = TestCommon::makeAuthzResponse(
@@ -481,7 +556,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   envoy::service::auth::v3::CheckRequest request;
@@ -501,12 +576,14 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
 
 // Test the client when an unknown error occurs.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   envoy::service::auth::v3::CheckRequest request;
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   client_->check(request_callbacks_, request, active_span_, stream_info_);
@@ -520,6 +597,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
 
 // Test the client when a call to authorization server returns a 5xx error status.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
+  initialize();
+
   Http::ResponseMessagePtr check_response(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "503"}}}));
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
@@ -527,7 +606,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   client_->check(request_callbacks_, request, active_span_, stream_info_);
@@ -542,6 +621,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequest5xxError) {
 // Test the client when a call to authorization server returns a status code that cannot be
 // parsed.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestErrorParsingStatusCode) {
+  initialize();
+
   Http::ResponseMessagePtr check_response(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "foo"}}}));
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
@@ -549,7 +630,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestErrorParsingStatusCode) {
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
 
   client_->check(request_callbacks_, request, active_span_, stream_info_);
@@ -563,14 +644,16 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestErrorParsingStatusCode) {
 
 // Test the client when the request is canceled.
 TEST_F(ExtAuthzHttpClientTest, CancelledAuthorizationRequest) {
+  initialize();
+
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   envoy::service::auth::v3::CheckRequest request;
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(*child_span, injectContext(_));
-  EXPECT_CALL(async_client_, send_(_, _, _)).WillOnce(Return(&async_request_));
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _)).WillOnce(Return(&async_request_));
   client_->check(request_callbacks_, request, active_span_, stream_info_);
 
   EXPECT_CALL(async_request_, cancel());
@@ -582,12 +665,14 @@ TEST_F(ExtAuthzHttpClientTest, CancelledAuthorizationRequest) {
 
 // Test the client when the configured cluster is missing/removed.
 TEST_F(ExtAuthzHttpClientTest, NoCluster) {
+  initialize();
+
   InSequence s;
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
 
   EXPECT_CALL(active_span_, spawnChild_(_, config_->tracingName(), _)).WillOnce(Return(child_span));
   EXPECT_CALL(*child_span,
-              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->cluster())));
+              setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq(config_->clusterName())));
   EXPECT_CALL(cm_, get(Eq("ext_authz"))).WillOnce(Return(nullptr));
   EXPECT_CALL(cm_, httpAsyncClientForCluster("ext_authz")).Times(0);
   EXPECT_CALL(request_callbacks_,
@@ -596,6 +681,108 @@ TEST_F(ExtAuthzHttpClientTest, NoCluster) {
   EXPECT_CALL(*child_span, finishSpan());
   client_->check(request_callbacks_, envoy::service::auth::v3::CheckRequest{}, active_span_,
                  stream_info_);
+}
+
+// Test forwarding original path.
+TEST_F(ExtAuthzHttpClientTest, TestForwardingRequestPath) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "http://ext-authz.io:9000/auth"
+      cluster: "ext_authz"
+      timeout: 0.25s
+    authorization_request:
+      allowed_headers:
+        patterns:
+        - exact: ":path" # we are forwarding the downstream request path to the authorization
+                         # server.
+          ignore_case: true
+  )EOF";
+
+  initialize(yaml);
+  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Method.get()));
+  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Path.get()));
+
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{Http::Headers::get().Method.get(), std::string{"POST"}},
+                   {Http::Headers::get().Path.get(), std::string{"/original"}}});
+
+  // The check-request's path to the authorization server is as specified by server_uri.uri.
+  const auto* path = message_ptr->headers().get(Http::Headers::get().Path);
+  ASSERT_NE(nullptr, path);
+  // In this test setup, the check-request's path is prefixed by "/prefix" by default.
+  EXPECT_EQ("/prefix/auth", path->value().getStringView());
+
+  // While the downstream request path is preserved as x-envoy-original-path.
+  const auto* original_path = message_ptr->headers().get(Http::Headers::get().EnvoyOriginalPath);
+  ASSERT_NE(nullptr, original_path);
+  EXPECT_EQ("/original", original_path->value().getStringView());
+
+  const auto* method = message_ptr->headers().get(Http::Headers::get().Method);
+  ASSERT_NE(nullptr, method);
+  EXPECT_EQ("POST", method->value().getStringView());
+}
+
+TEST_F(ExtAuthzHttpClientTest, TestSendingRequestToDynamicClusterInLoading) {
+  const std::string cluster_name = "dynamic_forward_proxy_cluster";
+  Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
+      new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
+  ON_CALL(cm_, httpAsyncClientForCluster(cluster_name)).WillByDefault(ReturnRef(cm_.async_client_));
+
+  EXPECT_CALL(*dns_cache_manager_, getCache(_));
+  EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("ext-authz.io:9000"), 9000, _))
+      .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Loading, handle}));
+  EXPECT_CALL(*handle, onDestroy());
+
+  const auto proto_config = createConfigWithDnsCache(cluster_name);
+  config_ = std::make_shared<ClientConfig>(proto_config, 1000, *this);
+  client_ = std::make_unique<RawHttpClientImpl>(cm_, config_, time_source_);
+
+  sendRequest({{":path", "/foo"}, {"foo", "bar"}}, LoadDnsCacheEntryStatus::Loading);
+}
+
+TEST_F(ExtAuthzHttpClientTest, TestSendingRequestToDynamicClusterInCache) {
+  const std::string cluster_name = "dynamic_forward_proxy_cluster";
+  ON_CALL(cm_, httpAsyncClientForCluster(cluster_name)).WillByDefault(ReturnRef(cm_.async_client_));
+
+  EXPECT_CALL(*dns_cache_manager_, getCache(_));
+  EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("ext-authz.io:9000"), 9000, _))
+      .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::InCache, nullptr}));
+
+  const auto proto_config = createConfigWithDnsCache(cluster_name);
+  config_ = std::make_shared<ClientConfig>(proto_config, 1000, *this);
+  client_ = std::make_unique<RawHttpClientImpl>(cm_, config_, time_source_);
+
+  sendRequest({{":path", "/foo"}, {"foo", "bar"}}, LoadDnsCacheEntryStatus::InCache);
+}
+
+TEST_F(ExtAuthzHttpClientTest, TestSendingRequestToDynamicClusterOverflow) {
+  const std::string cluster_name = "dynamic_forward_proxy_cluster";
+  ON_CALL(cm_, httpAsyncClientForCluster(cluster_name)).WillByDefault(ReturnRef(cm_.async_client_));
+
+  EXPECT_CALL(*dns_cache_manager_, getCache(_));
+  EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("ext-authz.io:9000"), 9000, _))
+      .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Overflow, nullptr}));
+
+  const auto proto_config = createConfigWithDnsCache(cluster_name);
+  config_ = std::make_shared<ClientConfig>(proto_config, 1000, *this);
+  client_ = std::make_unique<RawHttpClientImpl>(cm_, config_, time_source_);
+
+  std::unordered_map<std::string, std::string> headers{{":path", "/foo"}, {"foo", "bar"}};
+  envoy::service::auth::v3::CheckRequest request;
+  auto mutable_headers =
+      request.mutable_attributes()->mutable_request()->mutable_http()->mutable_headers();
+  for (const auto& header : headers) {
+    (*mutable_headers)[header.first] = header.second;
+  }
+
+  EXPECT_CALL(request_callbacks_,
+              onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
+
+  client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 }
 
 } // namespace

--- a/test/extensions/filters/common/ext_authz/mocks.h
+++ b/test/extensions/filters/common/ext_authz/mocks.h
@@ -25,8 +25,6 @@ public:
   MOCK_METHOD(void, check,
               (RequestCallbacks & callbacks, const envoy::service::auth::v3::CheckRequest& request,
                Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info));
-
-  testing::NiceMock<Upstream::MockClusterManager> cm_;
 };
 
 class MockRequestCallbacks : public RequestCallbacks {
@@ -35,6 +33,8 @@ public:
   ~MockRequestCallbacks() override;
 
   void onComplete(ResponsePtr&& response) override { onComplete_(response); }
+
+  MOCK_METHOD(void, onComplete_, (ResponsePtr & response));
 };
 
 } // namespace ExtAuthz

--- a/test/extensions/filters/common/ext_authz/mocks.h
+++ b/test/extensions/filters/common/ext_authz/mocks.h
@@ -7,6 +7,8 @@
 
 #include "extensions/filters/common/ext_authz/ext_authz.h"
 
+#include "test/mocks/upstream/mocks.h"
+
 #include "gmock/gmock.h"
 
 namespace Envoy {
@@ -25,6 +27,8 @@ public:
   MOCK_METHOD(void, check,
               (RequestCallbacks & callbacks, const envoy::service::auth::v3::CheckRequest& request,
                Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info));
+
+  testing::NiceMock<Upstream::MockClusterManager> cm_;
 };
 
 class MockRequestCallbacks : public RequestCallbacks {

--- a/test/extensions/filters/common/ext_authz/mocks.h
+++ b/test/extensions/filters/common/ext_authz/mocks.h
@@ -7,8 +7,6 @@
 
 #include "extensions/filters/common/ext_authz/ext_authz.h"
 
-#include "test/mocks/upstream/mocks.h"
-
 #include "gmock/gmock.h"
 
 namespace Envoy {
@@ -37,8 +35,6 @@ public:
   ~MockRequestCallbacks() override;
 
   void onComplete(ResponsePtr&& response) override { onComplete_(response); }
-
-  MOCK_METHOD(void, onComplete_, (ResponsePtr & response));
 };
 
 } // namespace ExtAuthz

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -26,6 +26,7 @@ envoy_extension_cc_test(
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/common/ext_authz:ext_authz_grpc_lib",
         "//source/extensions/filters/http/ext_authz",
+        "//test/extensions/common/dynamic_forward_proxy:mocks",
         "//test/extensions/filters/common/ext_authz:ext_authz_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/local_info:local_info_mocks",
@@ -38,6 +39,33 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/filters/http/ext_authz/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/auth/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "ext_authz_http_service_test",
+    srcs = ["ext_authz_http_service_test.cc"],
+    extension_name = "envoy.filters.http.ext_authz",
+    deps = [
+        "//include/envoy/http:codes_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:empty_string",
+        "//source/common/http:context_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/network:address_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/extensions/filters/common/ext_authz:ext_authz_grpc_lib",
+        "//source/extensions/filters/http/ext_authz",
+        "//test/extensions/common/dynamic_forward_proxy:mocks",
+        "//test/extensions/filters/common/ext_authz:ext_authz_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/tracing:tracing_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -43,33 +43,6 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
-    name = "ext_authz_http_service_test",
-    srcs = ["ext_authz_http_service_test.cc"],
-    extension_name = "envoy.filters.http.ext_authz",
-    deps = [
-        "//include/envoy/http:codes_interface",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:empty_string",
-        "//source/common/http:context_lib",
-        "//source/common/http:headers_lib",
-        "//source/common/json:json_loader_lib",
-        "//source/common/network:address_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/extensions/filters/common/ext_authz:ext_authz_grpc_lib",
-        "//source/extensions/filters/http/ext_authz",
-        "//test/extensions/common/dynamic_forward_proxy:mocks",
-        "//test/extensions/filters/common/ext_authz:ext_authz_mocks",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/local_info:local_info_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/mocks/runtime:runtime_mocks",
-        "//test/mocks/tracing:tracing_mocks",
-        "//test/mocks/upstream:upstream_mocks",
-        "//test/test_common:utility_lib",
-    ],
-)
-
-envoy_extension_cc_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     extension_name = "envoy.filters.http.ext_authz",

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -52,7 +52,7 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
   std::string yaml = R"EOF(
   http_service:
     server_uri:
-      uri: "ext_authz:9000"
+      uri: "http://ext-authz.io:9000"
       cluster: "ext_authz"
       timeout: 0.25s
 
@@ -94,6 +94,10 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
   EXPECT_CALL(context, runtime()).Times(1);
   EXPECT_CALL(context, scope()).Times(1);
   EXPECT_CALL(context, timeSource()).Times(1);
+  EXPECT_CALL(context, dispatcher()).Times(1);
+  EXPECT_CALL(context, singletonManager()).Times(1);
+  EXPECT_CALL(context, threadLocal()).Times(1);
+  EXPECT_CALL(context, random()).Times(1);
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   testing::StrictMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -282,7 +282,7 @@ public:
   const std::string default_config_ = R"EOF(
   http_service:
     server_uri:
-      uri: "ext_authz:9000"
+      uri: "http://ext-authz.io:9000"
       cluster: "ext_authz"
       timeout: 0.25s
     authorization_request:


### PR DESCRIPTION
Description:

This is a WIP to use the configured HTTP Service server URI as authorization service target.

Risk Level: Low
Testing: Unit, TBA integration
Docs Changes: TBA
Release Notes: TBA
Fixes #5357
Fixes #10104 


