### PR TITLE
Add some debug logs during server shutdown

### DIFF
--- a/source/common/access_log/BUILD
+++ b/source/common/access_log/BUILD
@@ -62,6 +62,7 @@ envoy_cc_library(
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/api:api_interface",
         "//source/common/buffer:buffer_lib",
+        "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",
     ],
 )

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -11,6 +11,14 @@
 namespace Envoy {
 namespace AccessLog {
 
+AccessLogManagerImpl::~AccessLogManagerImpl() {
+  for (auto& access_log : access_logs_) {
+    ENVOY_LOG(debug, "destroying access logger {}", access_log.first);
+    access_log.second = nullptr;
+  }
+  ENVOY_LOG(debug, "destroyed access loggers");
+}
+
 void AccessLogManagerImpl::reopen() {
   for (auto& access_log : access_logs_) {
     access_log.second->reopen();

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -14,7 +14,7 @@ namespace AccessLog {
 AccessLogManagerImpl::~AccessLogManagerImpl() {
   for (auto& access_log : access_logs_) {
     ENVOY_LOG(debug, "destroying access logger {}", access_log.first);
-    access_log.second = nullptr;
+    access_log.second.reset();
   }
   ENVOY_LOG(debug, "destroyed access loggers");
 }

--- a/source/common/access_log/access_log_manager_impl.h
+++ b/source/common/access_log/access_log_manager_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/stats/store.h"
 
 #include "common/buffer/buffer_impl.h"
+#include "common/common/logger.h"
 #include "common/common/thread.h"
 
 namespace Envoy {
@@ -29,7 +30,7 @@ struct AccessLogFileStats {
 
 namespace AccessLog {
 
-class AccessLogManagerImpl : public AccessLogManager {
+class AccessLogManagerImpl : public AccessLogManager, Logger::Loggable<Logger::Id::main> {
 public:
   AccessLogManagerImpl(std::chrono::milliseconds file_flush_interval_msec, Api::Api& api,
                        Event::Dispatcher& dispatcher, Thread::BasicLockable& lock,
@@ -38,6 +39,7 @@ public:
         lock_(lock), file_stats_{
                          ACCESS_LOG_FILE_STATS(POOL_COUNTER_PREFIX(stats_store, "filesystem."),
                                                POOL_GAUGE_PREFIX(stats_store, "filesystem."))} {}
+  ~AccessLogManagerImpl() override;
 
   // AccessLog::AccessLogManager
   void reopen() override;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -122,7 +122,9 @@ InstanceImpl::~InstanceImpl() {
   // RdsRouteConfigSubscription is an Init::Target, ~RdsRouteConfigSubscription triggers a callback
   // set at initialization, which goes to unregister it from the top-level InitManager, which has
   // already been destructed (use-after-free) causing a segfault.
+  ENVOY_LOG(debug, "destroying listener manager");
   listener_manager_.reset();
+  ENVOY_LOG(debug, "destroyed listener manager");
 }
 
 Upstream::ClusterManager& InstanceImpl::clusterManager() { return *config_.clusterManager(); }


### PR DESCRIPTION
Description: add debug logs to some destructors to help debug slow Envoy shutdown which happens sometimes in our production environment
Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
