### PR TITLE
aws: switch this aws integration test to simulated time.

### DIFF
--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
@@ -3,6 +3,7 @@
 #include "source/extensions/filters/http/aws_lambda/request_response.pb.h"
 
 #include "test/integration/http_integration.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -13,6 +14,7 @@ namespace Envoy {
 namespace {
 
 class AwsLambdaFilterIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                       public Event::TestUsingSimulatedTime,
                                        public HttpIntegrationTest {
 public:
   AwsLambdaFilterIntegrationTest()


### PR DESCRIPTION
Description: This test seems to fail frequently for me, but passes all the time (albeit slowly) with simulated time.
Risk Level: medium -- could be hiding a real bug
Testing: just this one test.
Docs Changes: n/a
Release Notes: n/a
