### PR TITLE
router: API cleanup for unit tests

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -543,6 +543,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
   Http::ConnectionPool::Instance* http_pool = getHttpConnPool();
   Upstream::HostDescriptionConstSharedPtr host;
+
   if (http_pool) {
     host = http_pool->host();
   } else {
@@ -1050,6 +1051,12 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason,
       basic_details, "{", Http::Utility::resetReasonToString(reset_reason),
       transport_failure_reason.empty() ? "" : absl::StrCat(",", transport_failure_reason), "}");
   onUpstreamAbort(Http::Code::ServiceUnavailable, response_flags, body, dropped, details);
+}
+
+void Filter::onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {
+  if (retry_state_ && host) {
+    retry_state_->onHostAttempted(host);
+  }
 }
 
 StreamInfo::ResponseFlag

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -247,7 +247,7 @@ class UpstreamRequest;
 using UpstreamRequestPtr = std::unique_ptr<UpstreamRequest>;
 
 // The interface the UpstreamRequest has to interact with the router filter.
-// Split out primarily for mockable unit tests.
+// Split out primarily for unit test mocks.
 class RouterFilterInterface {
 public:
   virtual ~RouterFilterInterface() = default;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -419,6 +419,7 @@ public:
     return cookie_value;
   }
 
+  // RouterFilterInterface
   void onUpstream100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers,
                                     UpstreamRequest& upstream_request) override;
   void onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPtr&& headers,

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -244,13 +244,52 @@ private:
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 class UpstreamRequest;
+using UpstreamRequestPtr = std::unique_ptr<UpstreamRequest>;
+
+// The interface the UpstreamRequest has to interact with the router filter.
+// Split out primarily for mockable unit tests.
+class RouterFilterInterface {
+public:
+  virtual ~RouterFilterInterface() = default;
+
+  virtual void onUpstream100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers,
+                                            UpstreamRequest& upstream_request) PURE;
+  virtual void onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPtr&& headers,
+                                 UpstreamRequest& upstream_request, bool end_stream) PURE;
+  virtual void onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_request,
+                              bool end_stream) PURE;
+  virtual void onUpstreamTrailers(Http::ResponseTrailerMapPtr&& trailers,
+                                  UpstreamRequest& upstream_request) PURE;
+  virtual void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map) PURE;
+  virtual void onUpstreamReset(Http::StreamResetReason reset_reason,
+                               absl::string_view transport_failure,
+                               UpstreamRequest& upstream_request) PURE;
+  virtual void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) PURE;
+  virtual void onPerTryTimeout(UpstreamRequest& upstream_request) PURE;
+
+  virtual Http::StreamDecoderFilterCallbacks* callbacks() PURE;
+  virtual Upstream::ClusterInfoConstSharedPtr cluster() PURE;
+  virtual FilterConfig& config() PURE;
+  virtual FilterUtility::TimeoutData timeout() PURE;
+  virtual Http::RequestHeaderMap* downstreamHeaders() PURE;
+  virtual Http::RequestTrailerMap* downstreamTrailers() PURE;
+  virtual bool downstreamResponseStarted() const PURE;
+  virtual bool downstreamEndStream() const PURE;
+  virtual uint32_t attemptCount() const PURE;
+  virtual const VirtualCluster* requestVcluster() const PURE;
+  virtual const RouteEntry* routeEntry() const PURE;
+  virtual const std::list<UpstreamRequestPtr>& upstreamRequests() const PURE;
+  virtual const UpstreamRequest* finalUpstreamRequest() const PURE;
+  virtual TimeSource& timeSource() PURE;
+};
 
 /**
  * Service routing filter.
  */
 class Filter : Logger::Loggable<Logger::Id::router>,
                public Http::StreamDecoderFilter,
-               public Upstream::LoadBalancerContextBase {
+               public Upstream::LoadBalancerContextBase,
+               public RouterFilterInterface {
 public:
   Filter(FilterConfig& config)
       : config_(config), final_upstream_request_(nullptr), downstream_response_started_(false),
@@ -258,6 +297,9 @@ public:
         attempting_internal_redirect_with_complete_stream_(false) {}
 
   ~Filter() override;
+
+  static StreamInfo::ResponseFlag
+  streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason);
 
   // Http::StreamFilterBase
   void onDestroy() override;
@@ -377,13 +419,40 @@ public:
     return cookie_value;
   }
 
+  void onUpstream100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers,
+                                    UpstreamRequest& upstream_request) override;
+  void onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPtr&& headers,
+                         UpstreamRequest& upstream_request, bool end_stream) override;
+  void onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_request,
+                      bool end_stream) override;
+  void onUpstreamTrailers(Http::ResponseTrailerMapPtr&& trailers,
+                          UpstreamRequest& upstream_request) override;
+  void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map) override;
+  void onUpstreamReset(Http::StreamResetReason reset_reason, absl::string_view transport_failure,
+                       UpstreamRequest& upstream_request) override;
+  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) override;
+  void onPerTryTimeout(UpstreamRequest& upstream_request) override;
+  Http::StreamDecoderFilterCallbacks* callbacks() override { return callbacks_; }
+  Upstream::ClusterInfoConstSharedPtr cluster() override { return cluster_; }
+  FilterConfig& config() override { return config_; }
+  FilterUtility::TimeoutData timeout() override { return timeout_; }
+  Http::RequestHeaderMap* downstreamHeaders() override { return downstream_headers_; }
+  Http::RequestTrailerMap* downstreamTrailers() override { return downstream_trailers_; }
+  bool downstreamResponseStarted() const override { return downstream_response_started_; }
+  bool downstreamEndStream() const override { return downstream_end_stream_; }
+  uint32_t attemptCount() const override { return attempt_count_; }
+  const VirtualCluster* requestVcluster() const override { return request_vcluster_; }
+  const RouteEntry* routeEntry() const override { return route_entry_; }
+  const std::list<UpstreamRequestPtr>& upstreamRequests() const override {
+    return upstream_requests_;
+  }
+  const UpstreamRequest* finalUpstreamRequest() const override { return final_upstream_request_; }
+  TimeSource& timeSource() override { return config_.timeSource(); }
+
 private:
-  using UpstreamRequestPtr = std::unique_ptr<UpstreamRequest>;
   friend class UpstreamRequest;
 
   RetryStatePtr retry_state_;
-
-  StreamInfo::ResponseFlag streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason);
 
   Stats::StatName upstreamZone(Upstream::HostDescriptionConstSharedPtr upstream_host);
   void chargeUpstreamCode(uint64_t response_status_code,
@@ -403,11 +472,8 @@ private:
   bool maybeRetryReset(Http::StreamResetReason reset_reason, UpstreamRequest& upstream_request);
   uint32_t numRequestsAwaitingHeaders();
   void onGlobalTimeout();
-  void onPerTryTimeout(UpstreamRequest& upstream_request);
   void onRequestComplete();
   void onResponseTimeout();
-  void onUpstream100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers,
-                                    UpstreamRequest& upstream_request);
   // Handle an upstream request aborted due to a local timeout.
   void onSoftPerTryTimeout();
   void onSoftPerTryTimeout(UpstreamRequest& upstream_request);
@@ -417,15 +483,7 @@ private:
   // downstream if appropriate.
   void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag,
                        absl::string_view body, bool dropped, absl::string_view details);
-  void onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPtr&& headers,
-                         UpstreamRequest& upstream_request, bool end_stream);
-  void onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_request, bool end_stream);
-  void onUpstreamTrailers(Http::ResponseTrailerMapPtr&& trailers,
-                          UpstreamRequest& upstream_request);
-  void onUpstreamMetadata(Http::MetadataMapPtr&& metadata_map);
   void onUpstreamComplete(UpstreamRequest& upstream_request);
-  void onUpstreamReset(Http::StreamResetReason reset_reason, absl::string_view transport_failure,
-                       UpstreamRequest& upstream_request);
   // Reset all in-flight upstream requests.
   void resetAll();
   // Reset all in-flight upstream requests that do NOT match the passed argument. This is used
@@ -444,7 +502,6 @@ private:
   void handleNon5xxResponseHeaders(absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                                    UpstreamRequest& upstream_request, bool end_stream,
                                    uint64_t grpc_to_http_status);
-  TimeSource& timeSource() { return config_.timeSource(); }
   Http::Context& httpContext() { return config_.http_context_; }
 
   FilterConfig& config_;

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -31,7 +31,6 @@
 #include "common/network/upstream_subject_alt_names.h"
 #include "common/router/config_impl.h"
 #include "common/router/debug_config.h"
-#include "common/router/retry_state_impl.h"
 #include "common/router/router.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/stream_info/uint32_accessor_impl.h"
@@ -42,26 +41,27 @@
 namespace Envoy {
 namespace Router {
 
-UpstreamRequest::UpstreamRequest(Filter& parent, std::unique_ptr<GenericConnPool>&& conn_pool)
+UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
+                                 std::unique_ptr<GenericConnPool>&& conn_pool)
     : parent_(parent), conn_pool_(std::move(conn_pool)), grpc_rq_success_deferred_(false),
-      stream_info_(parent_.callbacks_->dispatcher().timeSource()),
-      start_time_(parent_.callbacks_->dispatcher().timeSource().monotonicTime()),
+      stream_info_(parent_.callbacks()->dispatcher().timeSource()),
+      start_time_(parent_.callbacks()->dispatcher().timeSource().monotonicTime()),
       calling_encode_headers_(false), upstream_canary_(false), decode_complete_(false),
       encode_complete_(false), encode_trailers_(false), retried_(false), awaiting_headers_(true),
       outlier_detection_timeout_recorded_(false),
       create_per_try_timeout_on_request_complete_(false),
-      record_timeout_budget_(parent_.cluster_->timeoutBudgetStats().has_value()) {
-  if (parent_.config_.start_child_span_) {
-    span_ = parent_.callbacks_->activeSpan().spawnChild(
-        parent_.callbacks_->tracingConfig(), "router " + parent.cluster_->name() + " egress",
+      record_timeout_budget_(parent_.cluster()->timeoutBudgetStats().has_value()) {
+  if (parent_.config().start_child_span_) {
+    span_ = parent_.callbacks()->activeSpan().spawnChild(
+        parent_.callbacks()->tracingConfig(), "router " + parent.cluster()->name() + " egress",
         parent.timeSource().systemTime());
-    if (parent.attempt_count_ != 1) {
+    if (parent.attemptCount() != 1) {
       // This is a retry request, add this metadata to span.
-      span_->setTag(Tracing::Tags::get().RetryCount, std::to_string(parent.attempt_count_ - 1));
+      span_->setTag(Tracing::Tags::get().RetryCount, std::to_string(parent.attemptCount() - 1));
     }
   }
 
-  stream_info_.healthCheck(parent_.callbacks_->streamInfo().healthCheck());
+  stream_info_.healthCheck(parent_.callbacks()->streamInfo().healthCheck());
   if (conn_pool_->protocol().has_value()) {
     stream_info_.protocol(conn_pool_->protocol().value());
   }
@@ -83,40 +83,41 @@ UpstreamRequest::~UpstreamRequest() {
   // If desired, fire the per-try histogram when the UpstreamRequest
   // completes.
   if (record_timeout_budget_) {
-    Event::Dispatcher& dispatcher = parent_.callbacks_->dispatcher();
+    Event::Dispatcher& dispatcher = parent_.callbacks()->dispatcher();
     const MonotonicTime end_time = dispatcher.timeSource().monotonicTime();
     const std::chrono::milliseconds response_time =
         std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time_);
-    parent_.cluster_->timeoutBudgetStats()
+    parent_.cluster()
+        ->timeoutBudgetStats()
         ->upstream_rq_timeout_budget_per_try_percent_used_.recordValue(
-            FilterUtility::percentageOfTimeout(response_time, parent_.timeout_.per_try_timeout_));
+            FilterUtility::percentageOfTimeout(response_time, parent_.timeout().per_try_timeout_));
   }
 
   stream_info_.setUpstreamTiming(upstream_timing_);
   stream_info_.onRequestComplete();
-  for (const auto& upstream_log : parent_.config_.upstream_logs_) {
-    upstream_log->log(parent_.downstream_headers_, upstream_headers_.get(),
+  for (const auto& upstream_log : parent_.config().upstream_logs_) {
+    upstream_log->log(parent_.downstreamHeaders(), upstream_headers_.get(),
                       upstream_trailers_.get(), stream_info_);
   }
 }
 
 void UpstreamRequest::decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) {
-  ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
+  ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
 
   ASSERT(100 == Http::Utility::getResponseStatus(*headers));
   parent_.onUpstream100ContinueHeaders(std::move(headers), *this);
 }
 
 void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
-  ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
+  ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
 
   // TODO(rodaine): This is actually measuring after the headers are parsed and not the first
   // byte.
-  upstream_timing_.onFirstUpstreamRxByteReceived(parent_.callbacks_->dispatcher().timeSource());
+  upstream_timing_.onFirstUpstreamRxByteReceived(parent_.callbacks()->dispatcher().timeSource());
   maybeEndDecode(end_stream);
 
   awaiting_headers_ = false;
-  if (!parent_.config_.upstream_logs_.empty()) {
+  if (!parent_.config().upstream_logs_.empty()) {
     upstream_headers_ = Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*headers);
   }
   const uint64_t response_code = Http::Utility::getResponseStatus(*headers);
@@ -125,7 +126,7 @@ void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool e
 }
 
 void UpstreamRequest::decodeData(Buffer::Instance& data, bool end_stream) {
-  ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
+  ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
 
   maybeEndDecode(end_stream);
   stream_info_.addBytesReceived(data.length());
@@ -133,10 +134,10 @@ void UpstreamRequest::decodeData(Buffer::Instance& data, bool end_stream) {
 }
 
 void UpstreamRequest::decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) {
-  ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
+  ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
 
   maybeEndDecode(true);
-  if (!parent_.config_.upstream_logs_.empty()) {
+  if (!parent_.config().upstream_logs_.empty()) {
     upstream_trailers_ = Http::createHeaderMap<Http::ResponseTrailerMapImpl>(*trailers);
   }
   parent_.onUpstreamTrailers(std::move(trailers), *this);
@@ -148,7 +149,7 @@ void UpstreamRequest::decodeMetadata(Http::MetadataMapPtr&& metadata_map) {
 
 void UpstreamRequest::maybeEndDecode(bool end_stream) {
   if (end_stream) {
-    upstream_timing_.onLastUpstreamRxByteReceived(parent_.callbacks_->dispatcher().timeSource());
+    upstream_timing_.onLastUpstreamRxByteReceived(parent_.callbacks()->dispatcher().timeSource());
     decode_complete_ = true;
   }
 }
@@ -156,10 +157,8 @@ void UpstreamRequest::maybeEndDecode(bool end_stream) {
 void UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {
   stream_info_.onUpstreamHostSelected(host);
   upstream_host_ = host;
-  parent_.callbacks_->streamInfo().onUpstreamHostSelected(host);
-  if (parent_.retry_state_ && host) {
-    parent_.retry_state_->onHostAttempted(host);
-  }
+  parent_.callbacks()->streamInfo().onUpstreamHostSelected(host);
+  parent_.onUpstreamHostSelected(host);
 }
 
 void UpstreamRequest::encodeHeaders(bool end_stream) {
@@ -174,23 +173,23 @@ void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
   encode_complete_ = end_stream;
 
   if (!upstream_) {
-    ENVOY_STREAM_LOG(trace, "buffering {} bytes", *parent_.callbacks_, data.length());
+    ENVOY_STREAM_LOG(trace, "buffering {} bytes", *parent_.callbacks(), data.length());
     if (!buffered_request_body_) {
       buffered_request_body_ = std::make_unique<Buffer::WatermarkBuffer>(
           [this]() -> void { this->enableDataFromDownstreamForFlowControl(); },
           [this]() -> void { this->disableDataFromDownstreamForFlowControl(); });
-      buffered_request_body_->setWatermarks(parent_.callbacks_->decoderBufferLimit());
+      buffered_request_body_->setWatermarks(parent_.callbacks()->decoderBufferLimit());
     }
 
     buffered_request_body_->move(data);
   } else {
     ASSERT(downstream_metadata_map_vector_.empty());
 
-    ENVOY_STREAM_LOG(trace, "proxying {} bytes", *parent_.callbacks_, data.length());
+    ENVOY_STREAM_LOG(trace, "proxying {} bytes", *parent_.callbacks(), data.length());
     stream_info_.addBytesSent(data.length());
     upstream_->encodeData(data, end_stream);
     if (end_stream) {
-      upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks_->dispatcher().timeSource());
+      upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
     }
   }
 }
@@ -201,23 +200,23 @@ void UpstreamRequest::encodeTrailers(const Http::RequestTrailerMap& trailers) {
   encode_trailers_ = true;
 
   if (!upstream_) {
-    ENVOY_STREAM_LOG(trace, "buffering trailers", *parent_.callbacks_);
+    ENVOY_STREAM_LOG(trace, "buffering trailers", *parent_.callbacks());
   } else {
     ASSERT(downstream_metadata_map_vector_.empty());
 
-    ENVOY_STREAM_LOG(trace, "proxying trailers", *parent_.callbacks_);
+    ENVOY_STREAM_LOG(trace, "proxying trailers", *parent_.callbacks());
     upstream_->encodeTrailers(trailers);
-    upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks_->dispatcher().timeSource());
+    upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
   }
 }
 
 void UpstreamRequest::encodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) {
   if (!upstream_) {
     ENVOY_STREAM_LOG(trace, "upstream_ not ready. Store metadata_map to encode later: {}",
-                     *parent_.callbacks_, *metadata_map_ptr);
+                     *parent_.callbacks(), *metadata_map_ptr);
     downstream_metadata_map_vector_.emplace_back(std::move(metadata_map_ptr));
   } else {
-    ENVOY_STREAM_LOG(trace, "Encode metadata: {}", *parent_.callbacks_, *metadata_map_ptr);
+    ENVOY_STREAM_LOG(trace, "Encode metadata: {}", *parent_.callbacks(), *metadata_map_ptr);
     Http::MetadataMapVector metadata_map_vector;
     metadata_map_vector.emplace_back(std::move(metadata_map_ptr));
     upstream_->encodeMetadata(metadata_map_vector);
@@ -226,7 +225,7 @@ void UpstreamRequest::encodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) {
 
 void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
                                     absl::string_view transport_failure_reason) {
-  ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
+  ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
 
   if (span_ != nullptr) {
     // Add tags about reset.
@@ -237,7 +236,7 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
   clearRequestEncoder();
   awaiting_headers_ = false;
   if (!calling_encode_headers_) {
-    stream_info_.setResponseFlag(parent_.streamResetReasonToResponseFlag(reason));
+    stream_info_.setResponseFlag(Filter::streamResetReasonToResponseFlag(reason));
     parent_.onUpstreamReset(reason, transport_failure_reason, *this);
   } else {
     deferred_reset_reason_ = reason;
@@ -256,12 +255,12 @@ void UpstreamRequest::resetStream() {
   }
 
   if (conn_pool_->cancelAnyPendingRequest()) {
-    ENVOY_STREAM_LOG(debug, "canceled pool request", *parent_.callbacks_);
+    ENVOY_STREAM_LOG(debug, "canceled pool request", *parent_.callbacks());
     ASSERT(!upstream_);
   }
 
   if (upstream_) {
-    ENVOY_STREAM_LOG(debug, "resetting pool request", *parent_.callbacks_);
+    ENVOY_STREAM_LOG(debug, "resetting pool request", *parent_.callbacks());
     upstream_->resetStream();
     clearRequestEncoder();
   }
@@ -269,25 +268,25 @@ void UpstreamRequest::resetStream() {
 
 void UpstreamRequest::setupPerTryTimeout() {
   ASSERT(!per_try_timeout_);
-  if (parent_.timeout_.per_try_timeout_.count() > 0) {
+  if (parent_.timeout().per_try_timeout_.count() > 0) {
     per_try_timeout_ =
-        parent_.callbacks_->dispatcher().createTimer([this]() -> void { onPerTryTimeout(); });
-    per_try_timeout_->enableTimer(parent_.timeout_.per_try_timeout_);
+        parent_.callbacks()->dispatcher().createTimer([this]() -> void { onPerTryTimeout(); });
+    per_try_timeout_->enableTimer(parent_.timeout().per_try_timeout_);
   }
 }
 
 void UpstreamRequest::onPerTryTimeout() {
   // If we've sent anything downstream, ignore the per try timeout and let the response continue
   // up to the global timeout
-  if (!parent_.downstream_response_started_) {
-    ENVOY_STREAM_LOG(debug, "upstream per try timeout", *parent_.callbacks_);
+  if (!parent_.downstreamResponseStarted()) {
+    ENVOY_STREAM_LOG(debug, "upstream per try timeout", *parent_.callbacks());
 
     stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout);
     parent_.onPerTryTimeout(*this);
   } else {
     ENVOY_STREAM_LOG(debug,
                      "ignored upstream per try timeout due to already started downstream response",
-                     *parent_.callbacks_);
+                     *parent_.callbacks());
   }
 }
 
@@ -314,15 +313,15 @@ void UpstreamRequest::onPoolReady(
     const Network::Address::InstanceConstSharedPtr& upstream_local_address,
     const StreamInfo::StreamInfo& info) {
   // This may be called under an existing ScopeTrackerScopeState but it will unwind correctly.
-  ScopeTrackerScopeState scope(&parent_.callbacks_->scope(), parent_.callbacks_->dispatcher());
-  ENVOY_STREAM_LOG(debug, "pool ready", *parent_.callbacks_);
+  ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
+  ENVOY_STREAM_LOG(debug, "pool ready", *parent_.callbacks());
   upstream_ = std::move(upstream);
 
-  if (parent_.request_vcluster_) {
+  if (parent_.requestVcluster()) {
     // The cluster increases its upstream_rq_total_ counter right before firing this onPoolReady
     // callback. Hence, the upstream request increases the virtual cluster's upstream_rq_total_ stat
     // here.
-    parent_.request_vcluster_->stats().upstream_rq_total_.inc();
+    parent_.requestVcluster()->stats().upstream_rq_total_.inc();
   }
 
   host->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess);
@@ -330,12 +329,12 @@ void UpstreamRequest::onPoolReady(
   onUpstreamHostSelected(host);
 
   stream_info_.setUpstreamLocalAddress(upstream_local_address);
-  parent_.callbacks_->streamInfo().setUpstreamLocalAddress(upstream_local_address);
+  parent_.callbacks()->streamInfo().setUpstreamLocalAddress(upstream_local_address);
 
   stream_info_.setUpstreamSslConnection(info.downstreamSslConnection());
-  parent_.callbacks_->streamInfo().setUpstreamSslConnection(info.downstreamSslConnection());
+  parent_.callbacks()->streamInfo().setUpstreamSslConnection(info.downstreamSslConnection());
 
-  if (parent_.downstream_end_stream_) {
+  if (parent_.downstreamEndStream()) {
     setupPerTryTimeout();
   } else {
     create_per_try_timeout_on_request_complete_ = true;
@@ -344,24 +343,24 @@ void UpstreamRequest::onPoolReady(
   // Make sure the connection manager will inform the downstream watermark manager when the
   // downstream buffers are overrun. This may result in immediate watermark callbacks referencing
   // the encoder.
-  parent_.callbacks_->addDownstreamWatermarkCallbacks(downstream_watermark_manager_);
+  parent_.callbacks()->addDownstreamWatermarkCallbacks(downstream_watermark_manager_);
 
   calling_encode_headers_ = true;
-  if (parent_.route_entry_->autoHostRewrite() && !host->hostname().empty()) {
-    parent_.downstream_headers_->setHost(host->hostname());
+  if (parent_.routeEntry()->autoHostRewrite() && !host->hostname().empty()) {
+    parent_.downstreamHeaders()->setHost(host->hostname());
   }
 
   if (span_ != nullptr) {
-    span_->injectContext(*parent_.downstream_headers_);
+    span_->injectContext(*parent_.downstreamHeaders());
   }
 
-  upstream_timing_.onFirstUpstreamTxByteSent(parent_.callbacks_->dispatcher().timeSource());
+  upstream_timing_.onFirstUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
 
   const bool end_stream = !buffered_request_body_ && encode_complete_ && !encode_trailers_;
   // If end_stream is set in headers, and there are metadata to send, delays end_stream. The case
   // only happens when decoding headers filters return ContinueAndEndStream.
   const bool delay_headers_end_stream = end_stream && !downstream_metadata_map_vector_.empty();
-  upstream_->encodeHeaders(*parent_.downstream_headers_, end_stream && !delay_headers_end_stream);
+  upstream_->encodeHeaders(*parent_.downstreamHeaders(), end_stream && !delay_headers_end_stream);
   calling_encode_headers_ = false;
 
   // It is possible to get reset in the middle of an encodeHeaders() call. This happens for
@@ -374,7 +373,7 @@ void UpstreamRequest::onPoolReady(
   } else {
     // Encode metadata after headers and before any other frame type.
     if (!downstream_metadata_map_vector_.empty()) {
-      ENVOY_STREAM_LOG(debug, "Send metadata onPoolReady. {}", *parent_.callbacks_,
+      ENVOY_STREAM_LOG(debug, "Send metadata onPoolReady. {}", *parent_.callbacks(),
                        downstream_metadata_map_vector_);
       upstream_->encodeMetadata(downstream_metadata_map_vector_);
       downstream_metadata_map_vector_.clear();
@@ -390,11 +389,11 @@ void UpstreamRequest::onPoolReady(
     }
 
     if (encode_trailers_) {
-      upstream_->encodeTrailers(*parent_.downstream_trailers_);
+      upstream_->encodeTrailers(*parent_.downstreamTrailers());
     }
 
     if (encode_complete_) {
-      upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks_->dispatcher().timeSource());
+      upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
     }
   }
 }
@@ -402,7 +401,7 @@ void UpstreamRequest::onPoolReady(
 void UpstreamRequest::clearRequestEncoder() {
   // Before clearing the encoder, unsubscribe from callbacks.
   if (upstream_) {
-    parent_.callbacks_->removeDownstreamWatermarkCallbacks(downstream_watermark_manager_);
+    parent_.callbacks()->removeDownstreamWatermarkCallbacks(downstream_watermark_manager_);
   }
   upstream_.reset();
 }
@@ -415,13 +414,13 @@ void UpstreamRequest::DownstreamWatermarkManager::onAboveWriteBufferHighWatermar
   // downstream connection, or 2) the watermark was hit due to THIS filter
   // instance writing back the "winning" upstream request. In either case we
   // can disable reads from upstream.
-  ASSERT(!parent_.parent_.final_upstream_request_ ||
-         &parent_ == parent_.parent_.final_upstream_request_);
+  ASSERT(!parent_.parent_.finalUpstreamRequest() ||
+         &parent_ == parent_.parent_.finalUpstreamRequest());
 
   // The downstream connection is overrun. Pause reads from upstream.
   // If there are multiple calls to readDisable either the codec (H2) or the underlying
   // Network::Connection (H1) will handle reference counting.
-  parent_.parent_.cluster_->stats().upstream_flow_control_paused_reading_total_.inc();
+  parent_.parent_.cluster()->stats().upstream_flow_control_paused_reading_total_.inc();
   parent_.upstream_->readDisable(true);
 }
 
@@ -430,7 +429,7 @@ void UpstreamRequest::DownstreamWatermarkManager::onBelowWriteBufferLowWatermark
 
   // One source of connection blockage has buffer available. Pass this on to the stream, which
   // will resume reads if this was the last remaining high watermark.
-  parent_.parent_.cluster_->stats().upstream_flow_control_resumed_reading_total_.inc();
+  parent_.parent_.cluster()->stats().upstream_flow_control_resumed_reading_total_.inc();
   parent_.upstream_->readDisable(false);
 }
 
@@ -440,13 +439,13 @@ void UpstreamRequest::disableDataFromDownstreamForFlowControl() {
   // already seen the full downstream request (downstream_end_stream_) then
   // disabling reads is a noop.
   // This assert condition must be true because
-  // parent_.upstream_requests_.size() can only be greater than 1 in the
+  // parent_.upstreamRequests().size() can only be greater than 1 in the
   // case of a per-try-timeout with hedge_on_per_try_timeout enabled, and
   // the per try timeout timer is started only after downstream_end_stream_
   // is true.
-  ASSERT(parent_.upstream_requests_.size() == 1 || parent_.downstream_end_stream_);
-  parent_.cluster_->stats().upstream_flow_control_backed_up_total_.inc();
-  parent_.callbacks_->onDecoderFilterAboveWriteBufferHighWatermark();
+  ASSERT(parent_.upstreamRequests().size() == 1 || parent_.downstreamEndStream());
+  parent_.cluster()->stats().upstream_flow_control_backed_up_total_.inc();
+  parent_.callbacks()->onDecoderFilterAboveWriteBufferHighWatermark();
 }
 
 void UpstreamRequest::enableDataFromDownstreamForFlowControl() {
@@ -455,21 +454,22 @@ void UpstreamRequest::enableDataFromDownstreamForFlowControl() {
   // requests. If we've already seen the full downstream request
   // (downstream_end_stream_) then enabling reads is a noop.
   // This assert condition must be true because
-  // parent_.upstream_requests_.size() can only be greater than 1 in the
+  // parent_.upstreamRequests().size() can only be greater than 1 in the
   // case of a per-try-timeout with hedge_on_per_try_timeout enabled, and
   // the per try timeout timer is started only after downstream_end_stream_
   // is true.
-  ASSERT(parent_.upstream_requests_.size() == 1 || parent_.downstream_end_stream_);
-  parent_.cluster_->stats().upstream_flow_control_drained_total_.inc();
-  parent_.callbacks_->onDecoderFilterBelowWriteBufferLowWatermark();
+  ASSERT(parent_.upstreamRequests().size() == 1 || parent_.downstreamEndStream());
+  parent_.cluster()->stats().upstream_flow_control_drained_total_.inc();
+  parent_.callbacks()->onDecoderFilterBelowWriteBufferLowWatermark();
 }
 
-void HttpConnPool::newStream(UpstreamRequest* request) {
-  request_ = request;
+void HttpConnPool::newStream(GenericConnectionPoolCallbacks* callbacks) {
+  callbacks_ = callbacks;
   // It's possible for a reset to happen inline within the newStream() call. In this case, we
   // might get deleted inline as well. Only write the returned handle out if it is not nullptr to
   // deal with this case.
-  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(*request, *this);
+  Http::ConnectionPool::Cancellable* handle =
+      conn_pool_.newStream(*callbacks->upstreamRequest(), *this);
   if (handle) {
     conn_pool_stream_handle_ = handle;
   }
@@ -483,21 +483,22 @@ bool HttpConnPool::cancelAnyPendingRequest() {
   }
   return false;
 }
+
 absl::optional<Http::Protocol> HttpConnPool::protocol() const { return conn_pool_.protocol(); }
 
 void HttpConnPool::onPoolFailure(Http::ConnectionPool::PoolFailureReason reason,
                                  absl::string_view transport_failure_reason,
                                  Upstream::HostDescriptionConstSharedPtr host) {
-  request_->onPoolFailure(reason, transport_failure_reason, host);
+  callbacks_->onPoolFailure(reason, transport_failure_reason, host);
 }
 
 void HttpConnPool::onPoolReady(Http::RequestEncoder& request_encoder,
                                Upstream::HostDescriptionConstSharedPtr host,
                                const StreamInfo::StreamInfo& info) {
   conn_pool_stream_handle_ = nullptr;
-  auto upstream = std::make_unique<HttpUpstream>(*request_, &request_encoder);
-  request_->onPoolReady(std::move(upstream), host,
-                        request_encoder.getStream().connectionLocalAddress(), info);
+  auto upstream = std::make_unique<HttpUpstream>(*callbacks_->upstreamRequest(), &request_encoder);
+  callbacks_->onPoolReady(std::move(upstream), host,
+                          request_encoder.getStream().connectionLocalAddress(), info);
 }
 
 } // namespace Router


### PR DESCRIPTION
Cleaning up APIs between router and upstream, and upstream and connection pools for testability.

Risk Level: Medium (router refactor) 
Testing: n/a
Docs Changes: n/a
Release N otes: n/a
Part of #1630 #1451