### PR TITLE
handling header-only envoy_cc_test_library better

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -221,6 +221,12 @@ def envoy_cc_test_library(
     deps = deps + [
         repository + "//test/test_common:printers_includes",
     ]
+
+    # Same as envoy_cc_library
+    srcs += select({
+        "@envoy//bazel:compdb_build": ["@envoy//bazel/external:empty.cc"],
+        "//conditions:default": [],
+    })
     _envoy_cc_test_infrastructure_library(
         name,
         srcs,


### PR DESCRIPTION
Mostly copied from #10583 but apply to envoy_cc_test_library
Confirmed it fix a little bit in #10491 wrt //test/server:listener_manager_impl_test_lib
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
