### PR TITLE
tracing: Fix X-Ray header values

### DIFF
--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -28,7 +28,7 @@ Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers) {
         // Skip headers that are likely to mutate, when crossing proxies
         const auto key = entry.key().getStringView();
         if (key == Http::Headers::get().ForwardedFor.get() ||
-            key == Http::Headers::get().ForwardedProto.get()) {
+            key == Http::Headers::get().ForwardedProto.get() || key == "x-amzn-trace-id") {
           return Http::HeaderMap::Iterate::Continue;
         }
 

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -89,17 +89,6 @@ void Span::finishSpan() {
     s.mutable_http()->mutable_response()->insert(KeyValue{item.first, item.second});
   }
 
-#ifndef NDEBUG
-  // invalid JSON messages will be discarded by the X-Ray daemon.
-  try {
-    MessageUtil::validate(s, ProtobufMessage::getStrictValidationVisitor());
-  } catch (Envoy::ProtoValidationException& ex) {
-    auto& logger = Logger::Registry::getLog(Logger::Id::tracing);
-    ENVOY_LOG_TO_LOGGER(logger, trace, "X-Ray Span Validation Error: {}", ex.what());
-    return;
-  }
-#endif
-
   const std::string json = MessageUtil::getJsonStringFromMessage(
       s, false /* pretty_print  */, false /* always_print_primitive_fields */);
 

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -89,23 +89,27 @@ void Span::finishSpan() {
     s.mutable_http()->mutable_response()->insert(KeyValue{item.first, item.second});
   }
 
-  // TODO(marcomagdy): test how expensive this validation is. Might be worth turning off in
-  // optimized builds..
-  MessageUtil::validate(s, ProtobufMessage::getStrictValidationVisitor());
-  Protobuf::util::JsonPrintOptions json_options;
-  json_options.preserve_proto_field_names = true;
-  std::string json;
-  const auto status = Protobuf::util::MessageToJsonString(s, &json, json_options);
-  ASSERT(status.ok());
+#ifndef NDEBUG
+  // invalid JSON messages will be discarded by the X-Ray daemon.
+  try {
+    MessageUtil::validate(s, ProtobufMessage::getStrictValidationVisitor());
+  } catch (Envoy::ProtoValidationException& ex) {
+    auto& logger = Logger::Registry::getLog(Logger::Id::tracing);
+    ENVOY_LOG_TO_LOGGER(logger, trace, "X-Ray Span Validation Error: {}", ex.what());
+    return;
+  }
+#endif
+
+  const std::string json = MessageUtil::getJsonStringFromMessage(
+      s, false /* pretty_print  */, false /* always_print_primitive_fields */);
+
   broker_.send(json);
 } // namespace XRay
 
 void Span::injectContext(Http::RequestHeaderMap& request_headers) {
   const std::string xray_header_value =
-      fmt::format("root={};parent={};sampled={}", traceId(), Id(), sampled() ? "1" : "0");
-
-  // Set the XRay header into envoy header map for visibility to upstream
-  request_headers.addCopy(Http::LowerCaseString(XRayTraceHeader), xray_header_value);
+      fmt::format("Root={};Parent={};Sampled={}", traceId(), Id(), sampled() ? "1" : "0");
+  request_headers.setCopy(Http::LowerCaseString(XRayTraceHeader), xray_header_value);
 }
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& operation_name,
@@ -113,7 +117,7 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& ope
   auto child_span = std::make_unique<XRay::Span>(time_source_, broker_);
   const auto ticks = time_source_.monotonicTime().time_since_epoch().count();
   child_span->setId(ticks);
-  child_span->setName(operation_name);
+  child_span->setName(name());
   child_span->setOperation(operation_name);
   child_span->setStartTime(start_time);
   child_span->setParentId(Id());

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -107,7 +107,7 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
     daemon::Segment s;
     MessageUtil::loadFromJson(json, s, ProtobufMessage::getNullValidationVisitor());
     ASSERT_STREQ(expected_parent_id.c_str(), s.parent_id().c_str());
-    ASSERT_STREQ(expected_operation_name, s.name().c_str());
+    ASSERT_STREQ(expected_span_name, s.name().c_str());
     ASSERT_STREQ(xray_parent_span->traceId().c_str(), s.trace_id().c_str());
     ASSERT_STRNE(xray_parent_span->Id().c_str(), s.id().c_str());
   };
@@ -145,9 +145,9 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
   span->injectContext(request_headers);
   auto* header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
   ASSERT_NE(header, nullptr);
-  ASSERT_NE(header->value().getStringView().find("root="), absl::string_view::npos);
-  ASSERT_NE(header->value().getStringView().find("parent="), absl::string_view::npos);
-  ASSERT_NE(header->value().getStringView().find("sampled=1"), absl::string_view::npos);
+  ASSERT_NE(header->value().getStringView().find("Root="), absl::string_view::npos);
+  ASSERT_NE(header->value().getStringView().find("Parent="), absl::string_view::npos);
+  ASSERT_NE(header->value().getStringView().find("Sampled=1"), absl::string_view::npos);
 }
 
 TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
@@ -158,9 +158,9 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
   span->injectContext(request_headers);
   auto* header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
   ASSERT_NE(header, nullptr);
-  ASSERT_NE(header->value().getStringView().find("root="), absl::string_view::npos);
-  ASSERT_NE(header->value().getStringView().find("parent="), absl::string_view::npos);
-  ASSERT_NE(header->value().getStringView().find("sampled=0"), absl::string_view::npos);
+  ASSERT_NE(header->value().getStringView().find("Root="), absl::string_view::npos);
+  ASSERT_NE(header->value().getStringView().find("Parent="), absl::string_view::npos);
+  ASSERT_NE(header->value().getStringView().find("Sampled=0"), absl::string_view::npos);
 }
 
 TEST_F(XRayTracerTest, TraceIDFormatTest) {


### PR DESCRIPTION
X-Ray values are expected by the SDKs to be PascalCase otherwise they
are not parsed and dropped.

Also, we must ensure to _set_ rather than _add_ the X-Ray header.

Finally, validate the segment JSON in debug builds only. The X-Ray
daemon/service discards invalid messages.

Signed-off-by: Marco Magdy <mmagdy@gmail.com>

Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
