### PR TITLE
test: fuzzer binaries should parse gmock flags.

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -9,6 +9,8 @@
 
 #include "test/test_common/environment.h"
 
+#include "gmock/gmock.h"
+
 namespace Envoy {
 namespace Fuzz {
 
@@ -50,7 +52,8 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
 } // namespace Fuzz
 } // namespace Envoy
 
-extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** argv) {
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
+  testing::InitGoogleMock(argc, *argv);
   Envoy::Fuzz::Runner::setupEnvironment(1, *argv, spdlog::level::critical);
   return 0;
 }

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -26,6 +26,7 @@
 #endif
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 namespace Envoy {
 namespace {
@@ -90,6 +91,7 @@ int main(int argc, char** argv) {
   }
 
   testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   Envoy::Fuzz::Runner::setupEnvironment(argc, argv, spdlog::level::info);
 
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Description: Parsing gmock flags is important for fuzzers that make use of NiceMock.  The mocks log all interactions that are not expected.  The volume of logging can be overwhelming.  This change allows the use of the flag --gmock_verbose=error, which suppresses these logs.
Risk Level: Low
Testing: Run Fuzzers with the flag --gmock_verbose, see that they change their output level.
Docs Changes: None
Release Notes: None

Signed-off-by: Sam Kerner <skerner@chromium.org>