### PR TITLE
test: fuzzer binaries should parse gmock flags.

### DIFF
--- a/bazel/external/compiler_rt.BUILD
+++ b/bazel/external/compiler_rt.BUILD
@@ -2,8 +2,6 @@ licenses(["notice"])  # Apache 2
 
 cc_library(
     name = "fuzzed_data_provider",
-    hdrs = ["utils/FuzzedDataProvider.h"],
-    # This is moving from lib/fuzzer/utils to include/fuzzer after LLVM 9.0.
-    include_prefix = "compiler_rt/fuzzer",
+    hdrs = ["fuzzer/utils/FuzzedDataProvider.h"],
     visibility = ["//visibility:public"],
 )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -302,7 +302,7 @@ REPOSITORY_LOCATIONS = dict(
     org_llvm_releases_compiler_rt = dict(
         sha256 = "56e4cd96dd1d8c346b07b4d6b255f976570c6f2389697347a6c3dcb9e820d10e",
         # Only allow peeking at fuzzer related files for now.
-        strip_prefix = "compiler-rt-9.0.0.src/lib/fuzzer",
+        strip_prefix = "compiler-rt-9.0.0.src/lib",
         urls = ["http://releases.llvm.org/9.0.0/compiler-rt-9.0.0.src.tar.xz"],
     ),
     fuzzit_linux = dict(

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -9,6 +9,8 @@
 
 #include "test/test_common/environment.h"
 
+#include "gmock/gmock.h"
+
 namespace Envoy {
 namespace Fuzz {
 
@@ -50,7 +52,13 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
 } // namespace Fuzz
 } // namespace Envoy
 
-extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** argv) {
+// LLVMFuzzerInitialize() is called by LibFuzzer once before fuzzing starts.
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
+  // Before parsing gmock flags, set the default value of flag --gmock_verbose to "error".
+  // This suppresses logs from NiceMock objects, which can be noisy and provide little value.
+  testing::GMOCK_FLAG(verbose) = "error";
+  testing::InitGoogleMock(argc, *argv);
   Envoy::Fuzz::Runner::setupEnvironment(1, *argv, spdlog::level::critical);
   return 0;
 }

--- a/test/fuzz/fuzz_runner.h
+++ b/test/fuzz/fuzz_runner.h
@@ -8,7 +8,7 @@
 #include "libprotobuf_mutator/src/libfuzzer/libfuzzer_macro.h"
 // Bring in FuzzedDataProvider, see
 // https://github.com/google/fuzzing/blob/master/docs/split-inputs.md#fuzzed-data-provider
-#include "compiler_rt/fuzzer/utils/FuzzedDataProvider.h"
+#include "fuzzer/utils/FuzzedDataProvider.h"
 #include "spdlog/spdlog.h"
 
 namespace Envoy {

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -26,6 +26,7 @@
 #endif
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 namespace Envoy {
 namespace {
@@ -90,6 +91,7 @@ int main(int argc, char** argv) {
   }
 
   testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   Envoy::Fuzz::Runner::setupEnvironment(argc, argv, spdlog::level::info);
 
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Description: Parsing gmock flags is important for fuzzers that make use of NiceMock. The mocks log all interactions that are not expected. The volume of logging can be overwhelming. This change allows the use of the flag --gmock_verbose=error, which suppresses these logs.

Risk Level: Low
Testing: Run Fuzzers with the flag --gmock_verbose, see that they change their output level.
Docs Changes: None
Release Notes: None


Signed-off-by: Sam Kerner <skerner@chromium.org>
