### PR TITLE
Fix identifier naming violations in tests

### DIFF
--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -795,7 +795,7 @@ class DiskLayerTest : public testing::Test {
 protected:
   DiskLayerTest() : api_(Api::createApiForTest()) {}
 
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     TestEnvironment::exec(
         {TestEnvironment::runfilesPath("test/common/runtime/filesystem_setup.sh")});
   }

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -27,7 +27,7 @@ public:
   RoleBasedAccessControlNetworkFilterIntegrationTest()
       : BaseIntegrationTest(GetParam(), rbac_config) {}
 
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     rbac_config = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       filters:

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -22,7 +22,7 @@ class ThriftConnManagerIntegrationTest
     : public testing::TestWithParam<std::tuple<TransportType, ProtocolType, bool>>,
       public BaseThriftIntegrationTest {
 public:
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     thrift_config_ = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       filters:

--- a/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
@@ -23,7 +23,7 @@ class ThriftTranslationIntegrationTest
           std::tuple<TransportType, ProtocolType, TransportType, ProtocolType>>,
       public BaseThriftIntegrationTest {
 public:
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     thrift_config_ = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       filters:

--- a/test/extensions/transport_sockets/tls/ssl_certs_test.h
+++ b/test/extensions/transport_sockets/tls/ssl_certs_test.h
@@ -11,7 +11,7 @@ using testing::ReturnRef;
 namespace Envoy {
 class SslCertsTest : public testing::Test {
 public:
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     TestEnvironment::exec({TestEnvironment::runfilesPath(
         "test/extensions/transport_sockets/tls/gen_unittest_certs.sh")});
   }

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -16,7 +16,7 @@ namespace {
 class ApiListenerIntegrationTest : public BaseIntegrationTest,
                                    public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  ApiListenerIntegrationTest() : BaseIntegrationTest(GetParam(), bootstrap_config()) {
+  ApiListenerIntegrationTest() : BaseIntegrationTest(GetParam(), bootstrapConfig()) {
     use_lds_ = false;
     autonomous_upstream_ = true;
   }
@@ -28,7 +28,7 @@ public:
       // Thus, the ApiListener has to be added in addition to the already existing listener in the
       // config.
       bootstrap.mutable_static_resources()->add_listeners()->MergeFrom(
-          Server::parseListenerFromV2Yaml(api_listener_config()));
+          Server::parseListenerFromV2Yaml(apiListenerConfig()));
     });
   }
 
@@ -37,7 +37,7 @@ public:
     fake_upstreams_.clear();
   }
 
-  static std::string bootstrap_config() {
+  static std::string bootstrapConfig() {
     // At least one empty filter chain needs to be specified.
     return absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
@@ -45,7 +45,7 @@ public:
     )EOF");
   }
 
-  static std::string api_listener_config() {
+  static std::string apiListenerConfig() {
     return R"EOF(
 name: api_listener
 address:

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -13,7 +13,7 @@ public:
   EchoIntegrationTest() : BaseIntegrationTest(GetParam(), echo_config) {}
 
   // Called once by the gtest framework before any EchoIntegrationTests are run.
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     echo_config = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       filters:

--- a/test/integration/filter_manager_integration_test.cc
+++ b/test/integration/filter_manager_integration_test.cc
@@ -433,7 +433,7 @@ protected:
  */
 class InjectDataWithEchoFilterIntegrationTest : public InjectDataToFilterChainIntegrationTest {
 public:
-  static std::string echo_config() {
+  static std::string echoConfig() {
     return absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       filters:
@@ -442,7 +442,7 @@ public:
   }
 
   InjectDataWithEchoFilterIntegrationTest()
-      : InjectDataToFilterChainIntegrationTest(echo_config()) {}
+      : InjectDataToFilterChainIntegrationTest(echoConfig()) {}
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/integration/header_prefix_integration_test.cc
+++ b/test/integration/header_prefix_integration_test.cc
@@ -18,7 +18,7 @@ static const char* custom_prefix_ = "x-custom";
 
 class HeaderPrefixIntegrationTest : public HttpProtocolIntegrationTest {
 public:
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     ThreadSafeSingleton<Http::PrefixValue>::get().setPrefix(custom_prefix_);
   }
 };

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -112,7 +112,7 @@ public:
       : BaseIntegrationTest(GetParam(), tcp_conn_pool_config), filter_resolver_(config_factory_) {}
 
   // Called once by the gtest framework before any tests are run.
-  static void SetUpTestSuite() {
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     tcp_conn_pool_config = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:
       - filters:

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -20,7 +20,9 @@ public:
     directory_ = TestEnvironment::temporaryDirectory() + "/test/config_test/";
   }
 
-  static void SetUpTestSuite() { SetupTestDirectory(); }
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
+    SetupTestDirectory();
+  }
 
 protected:
   ValidationServerTest() : options_(directory_ + GetParam()) {}


### PR DESCRIPTION
After #10477 clang-tidy CI job is failing (partially) because of the
files patched in this PR.

Signed-off-by: Marco Magdy <mmagdy@gmail.com>

Risk Level: Low
Testing: local build
Docs Changes: N/A
Release Notes: N/A
