### PR TITLE
ci: set explicit timeout for release builds.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -40,6 +40,7 @@ jobs:
     dependsOn: ["format"]
     # For master builds, continue even if format fails
     condition: and(not(canceled()), or(succeeded(), ne(variables['Build.Reason'], 'PullRequest')))
+    timeoutInMinutes: 360
     pool:
       vmImage: "ubuntu-16.04"
     steps:


### PR DESCRIPTION
Otherwise we hit the default limit of 60 mins in
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts.

Risk level: Low (CI only)
Testing: CI

Signed-off-by: Harvey Tuch <htuch@google.com>