### PR TITLE
use constexpr string_view to avoid static initialized string

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -28,9 +28,10 @@
 namespace Envoy {
 namespace Network {
 
-const std::string Utility::TCP_SCHEME = "tcp://";
-const std::string Utility::UDP_SCHEME = "udp://";
-const std::string Utility::UNIX_SCHEME = "unix://";
+// TODO(lambdai): Remove below redeclare in C++17.
+constexpr absl::string_view Utility::TCP_SCHEME;
+constexpr absl::string_view Utility::UDP_SCHEME;
+constexpr absl::string_view Utility::UNIX_SCHEME;
 
 Address::InstanceConstSharedPtr Utility::resolveUrl(const std::string& url) {
   if (urlIsTcpScheme(url)) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -28,7 +28,7 @@
 namespace Envoy {
 namespace Network {
 
-// TODO(lambdai): Remove below redeclare in C++17.
+// TODO(lambdai): Remove below re-declare in C++17.
 constexpr absl::string_view Utility::TCP_SCHEME;
 constexpr absl::string_view Utility::UDP_SCHEME;
 constexpr absl::string_view Utility::UNIX_SCHEME;

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -64,9 +64,9 @@ static const uint64_t MAX_UDP_PACKET_SIZE = 1500;
  */
 class Utility {
 public:
-  static const std::string TCP_SCHEME;
-  static const std::string UDP_SCHEME;
-  static const std::string UNIX_SCHEME;
+  static constexpr absl::string_view TCP_SCHEME{"tcp://"};
+  static constexpr absl::string_view UDP_SCHEME{"udp://"};
+  static constexpr absl::string_view UNIX_SCHEME{"unix://"};
 
   /**
    * Resolve a URL.

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -216,8 +216,8 @@ Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(
   }
 
   const std::string scheme = (socket_type == Network::Address::SocketType::Stream)
-                                 ? Network::Utility::TCP_SCHEME
-                                 : Network::Utility::UDP_SCHEME;
+                                 ? std::string(Network::Utility::TCP_SCHEME)
+                                 : std::string(Network::Utility::UDP_SCHEME);
   const std::string addr = absl::StrCat(scheme, address->asString());
 
   if (params.bind_to_port && params.duplicate_parent_socket) {


### PR DESCRIPTION
Fix the flaky test filter_chain_benchmark_test. Other tests may also benefit.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
