### PR TITLE
[clang_tidy] Don't call virtual function from destructor

### DIFF
--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -15,8 +15,6 @@ namespace Network {
 
 class SocketImpl : public virtual Socket {
 public:
-  ~SocketImpl() override{};
-
   // Network::Socket
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }
   void setLocalAddress(const Address::InstanceConstSharedPtr& local_address) override {

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -15,7 +15,7 @@ namespace Network {
 
 class SocketImpl : public virtual Socket {
 public:
-  ~SocketImpl() override;
+  ~SocketImpl() override{};
 
   // Network::Socket
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -15,11 +15,7 @@ namespace Network {
 
 class SocketImpl : public virtual Socket {
 public:
-  ~SocketImpl() override {
-    if (io_handle_->isOpen()) {
-      io_handle_->close();
-    }
-  }
+  ~SocketImpl() override;
 
   // Network::Socket
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -15,7 +15,11 @@ namespace Network {
 
 class SocketImpl : public virtual Socket {
 public:
-  ~SocketImpl() override { close(); }
+  ~SocketImpl() override {
+    if (io_handle_->isOpen()) {
+      io_handle_->close();
+    }
+  }
 
   // Network::Socket
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }


### PR DESCRIPTION
Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>

Description: This is small clean up for clang_tidy violation, encountered while working with #9679.  Is a common best practise not to call virtual functions from constructors/destructors. Proposed approach is to execute all needed resource clean up code directly instead of calling virtual function, though it contributes to small code duplication. 
Risk Level: Low
Testing: Existing test should cover the fix.
Docs Changes: NA
Release Notes: NA

