### PR TITLE
fix a potential use-after-move

### DIFF
--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -353,10 +353,10 @@ void ConnectionHandlerImpl::ActiveTcpListener::newConnection(
   auto transport_socket = filter_chain->transportSocketFactory().createTransportSocket(nullptr);
   stream_info->setDownstreamSslConnection(transport_socket->ssl());
   auto& active_connections = getOrCreateActiveConnections(*filter_chain);
+  auto server_conn_ptr = parent_.dispatcher_.createServerConnection(
+      std::move(socket), std::move(transport_socket), *stream_info);
   ActiveTcpConnectionPtr active_connection(
-      new ActiveTcpConnection(active_connections,
-                              parent_.dispatcher_.createServerConnection(
-                                  std::move(socket), std::move(transport_socket), *stream_info),
+      new ActiveTcpConnection(active_connections, std::move(server_conn_ptr);
                               parent_.dispatcher_.timeSource(), config_, std::move(stream_info)));
   active_connection->connection_->setBufferLimits(config_.perConnectionBufferLimitBytes());
 

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -356,7 +356,7 @@ void ConnectionHandlerImpl::ActiveTcpListener::newConnection(
   auto server_conn_ptr = parent_.dispatcher_.createServerConnection(
       std::move(socket), std::move(transport_socket), *stream_info);
   ActiveTcpConnectionPtr active_connection(
-      new ActiveTcpConnection(active_connections, std::move(server_conn_ptr);
+      new ActiveTcpConnection(active_connections, std::move(server_conn_ptr),
                               parent_.dispatcher_.timeSource(), config_, std::move(stream_info)));
   active_connection->connection_->setBufferLimits(config_.perConnectionBufferLimitBytes());
 


### PR DESCRIPTION
Description:
```
note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
std::move(socket), std::move(transport_socket), *stream_info),
```
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
