### PR TITLE
Add serializeAsString for FilterState

### DIFF
--- a/docs/root/configuration/observability/access_log.rst
+++ b/docs/root/configuration/observability/access_log.rst
@@ -410,12 +410,17 @@ The following command operators are supported:
     JSON struct or list is rendered. Structs and lists may be nested. In any event, the maximum
     length is ignored
 
-%FILTER_STATE(KEY):Z%
+.. _config_access_log_format_filter_state:
+
+%FILTER_STATE(KEY:F):Z%
   HTTP
     :ref:`Filter State <arch_overview_data_sharing_between_filters>` info, where the KEY is required to
     look up the filter state object. The serialized proto will be logged as JSON string if possible.
     If the serialized proto is unknown to Envoy it will be logged as protobuf debug string.
     Z is an optional parameter denoting string truncation up to Z characters long.
+    F is an optional parameter used to indicate which method FilterState uses for serialization. 
+    If 'PLAIN' is set, the filter state object will be serialized as an unstructured string. 
+    If 'TYPED' is set or no F provided, the filter state object will be serialized as an JSON string.
 
   TCP
     Same as HTTP, the filter state is from connection instead of a L7 request.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -5,6 +5,7 @@ Changes
 -------
 
 * access loggers: added GRPC_STATUS operator on logging format.
+* access loggers: extened specifier for FilterStateFormatter to output :ref:`unstructured log string <config_access_log_format_filter_state>`.
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults 
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.

--- a/include/envoy/stream_info/filter_state.h
+++ b/include/envoy/stream_info/filter_state.h
@@ -10,6 +10,7 @@
 #include "common/protobuf/protobuf.h"
 
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace StreamInfo {
@@ -51,6 +52,13 @@ public:
      * logging. nullptr if the filter state cannot be serialized or serialization is not supported.
      */
     virtual ProtobufTypes::MessagePtr serializeAsProto() const { return nullptr; }
+
+    /**
+     * @return absl::optional<std::string> a optional string to the serialization of the filter
+     * state. No value if the filter state cannot be serialized or serialization is not supported.
+     * This method can be used to get an unstructured serialization result.
+     */
+    virtual absl::optional<std::string> serializeAsString() const { return absl::nullopt; }
   };
 
   virtual ~FilterState() = default;

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -293,7 +293,8 @@ public:
  */
 class FilterStateFormatter : public FormatterProvider {
 public:
-  FilterStateFormatter(const std::string& key, absl::optional<size_t> max_length);
+  FilterStateFormatter(const std::string& key, absl::optional<size_t> max_length,
+                       bool serialize_as_string);
 
   // FormatterProvider
   std::string format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
@@ -303,10 +304,13 @@ public:
                                  const StreamInfo::StreamInfo&) const override;
 
 private:
-  ProtobufTypes::MessagePtr filterState(const StreamInfo::StreamInfo& stream_info) const;
+  const Envoy::StreamInfo::FilterState::Object*
+  filterState(const StreamInfo::StreamInfo& stream_info) const;
 
   std::string key_;
   absl::optional<size_t> max_length_;
+
+  bool serialize_as_string_;
 };
 
 /**

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -75,6 +75,23 @@ private:
   ProtobufWkt::Duration duration_;
 };
 
+// Class used to test serializeAsString and serializeAsProto of FilterState
+class TestSerializedStringFilterState : public StreamInfo::FilterState::Object {
+public:
+  TestSerializedStringFilterState(std::string str) : raw_string_(str) {}
+  absl::optional<std::string> serializeAsString() const override {
+    return raw_string_ + " By PLAIN";
+  }
+  ProtobufTypes::MessagePtr serializeAsProto() const override {
+    auto message = std::make_unique<ProtobufWkt::StringValue>();
+    message->set_value(raw_string_ + " By TYPED");
+    return message;
+  }
+
+private:
+  std::string raw_string_;
+};
+
 TEST(AccessLogFormatUtilsTest, protocolToString) {
   EXPECT_EQ("HTTP/1.0", AccessLogFormatUtils::protocolToString(Http::Protocol::Http10));
   EXPECT_EQ("HTTP/1.1", AccessLogFormatUtils::protocolToString(Http::Protocol::Http11));
@@ -1241,10 +1258,13 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
       "key-serialization-error",
       std::make_unique<TestSerializedStructFilterState>(std::chrono::seconds(-281474976710656)),
       StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData(
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
+      StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   {
-    FilterStateFormatter formatter("key", absl::optional<size_t>());
+    FilterStateFormatter formatter("key", absl::optional<size_t>(), false);
 
     EXPECT_EQ("\"test_value\"",
               formatter.format(request_headers, response_headers, response_trailers, stream_info));
@@ -1253,7 +1273,7 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
         ProtoEq(ValueUtil::stringValue("test_value")));
   }
   {
-    FilterStateFormatter formatter("key-struct", absl::optional<size_t>());
+    FilterStateFormatter formatter("key-struct", absl::optional<size_t>(), false);
 
     EXPECT_EQ("{\"inner_key\":\"inner_value\"}",
               formatter.format(request_headers, response_headers, response_trailers, stream_info));
@@ -1269,7 +1289,7 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
 
   // not found case
   {
-    FilterStateFormatter formatter("key-not-found", absl::optional<size_t>());
+    FilterStateFormatter formatter("key-not-found", absl::optional<size_t>(), false);
 
     EXPECT_EQ("-",
               formatter.format(request_headers, response_headers, response_trailers, stream_info));
@@ -1280,7 +1300,7 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
 
   // no serialization case
   {
-    FilterStateFormatter formatter("key-no-serialization", absl::optional<size_t>());
+    FilterStateFormatter formatter("key-no-serialization", absl::optional<size_t>(), false);
 
     EXPECT_EQ("-",
               formatter.format(request_headers, response_headers, response_trailers, stream_info));
@@ -1291,7 +1311,7 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
 
   // serialization error case
   {
-    FilterStateFormatter formatter("key-serialization-error", absl::optional<size_t>());
+    FilterStateFormatter formatter("key-serialization-error", absl::optional<size_t>(), false);
 
     EXPECT_EQ("-",
               formatter.format(request_headers, response_headers, response_trailers, stream_info));
@@ -1302,7 +1322,7 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
 
   // size limit
   {
-    FilterStateFormatter formatter("key", absl::optional<size_t>(5));
+    FilterStateFormatter formatter("key", absl::optional<size_t>(5), false);
 
     EXPECT_EQ("\"test",
               formatter.format(request_headers, response_headers, response_trailers, stream_info));
@@ -1311,6 +1331,33 @@ TEST(AccessLogFormatterTest, FilterStateFormatter) {
     EXPECT_THAT(
         formatter.formatValue(request_headers, response_headers, response_trailers, stream_info),
         ProtoEq(ValueUtil::stringValue("test_value")));
+  }
+
+  // serializeAsString case
+  {
+    FilterStateFormatter formatter("test_key", absl::optional<size_t>(), true);
+
+    EXPECT_EQ("test_value By PLAIN",
+              formatter.format(request_headers, response_headers, response_trailers, stream_info));
+  }
+
+  // size limit for serializeAsString
+  {
+    FilterStateFormatter formatter("test_key", absl::optional<size_t>(10), true);
+
+    EXPECT_EQ("test_value",
+              formatter.format(request_headers, response_headers, response_trailers, stream_info));
+  }
+
+  // no serialization case for serializeAsString
+  {
+    FilterStateFormatter formatter("key-no-serialization", absl::optional<size_t>(), true);
+
+    EXPECT_EQ("-",
+              formatter.format(request_headers, response_headers, response_trailers, stream_info));
+    EXPECT_THAT(
+        formatter.formatValue(request_headers, response_headers, response_trailers, stream_info),
+        ProtoEq(ValueUtil::nullValue()));
   }
 }
 
@@ -1569,7 +1616,7 @@ TEST(AccessLogFormatterTest, JsonFormatterTypedDynamicMetadataTest) {
             fields.at("test_obj").struct_value().fields().at("inner_key").string_value());
 }
 
-TEST(AccessLogFormatterTets, JsonFormatterFilterStateTest) {
+TEST(AccessLogFormatterTest, JsonFormatterFilterStateTest) {
   Http::TestRequestHeaderMapImpl request_headers;
   Http::TestResponseHeaderMapImpl response_headers;
   Http::TestResponseTrailerMapImpl response_trailers;
@@ -1595,7 +1642,7 @@ TEST(AccessLogFormatterTets, JsonFormatterFilterStateTest) {
       expected_json_map);
 }
 
-TEST(AccessLogFormatterTets, JsonFormatterTypedFilterStateTest) {
+TEST(AccessLogFormatterTest, JsonFormatterTypedFilterStateTest) {
   Http::TestRequestHeaderMapImpl request_headers;
   Http::TestResponseHeaderMapImpl response_headers;
   Http::TestResponseTrailerMapImpl response_trailers;
@@ -1622,6 +1669,82 @@ TEST(AccessLogFormatterTets, JsonFormatterTypedFilterStateTest) {
   EXPECT_EQ("test_value", fields.at("test_key").string_value());
   EXPECT_EQ("inner_value",
             fields.at("test_obj").struct_value().fields().at("inner_key").string_value());
+}
+
+// Test new specifier (PLAIN/TYPED) of FilterState. Ensure that after adding additional specifier,
+// the FilterState can call the serializeAsProto or serializeAsString methods correctly.
+TEST(AccessLogFormatterTest, FilterStateSpeciferTest) {
+  Http::TestRequestHeaderMapImpl request_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  stream_info.filter_state_->setData(
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
+      StreamInfo::FilterState::StateType::ReadOnly);
+  EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
+
+  std::unordered_map<std::string, std::string> expected_json_map = {
+      {"test_key_plain", "test_value By PLAIN"},
+      {"test_key_typed", "\"test_value By TYPED\""},
+  };
+
+  std::unordered_map<std::string, std::string> key_mapping = {
+      {"test_key_plain", "%FILTER_STATE(test_key:PLAIN)%"},
+      {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
+
+  JsonFormatterImpl formatter(key_mapping, false);
+
+  verifyJsonOutput(
+      formatter.format(request_headers, response_headers, response_trailers, stream_info),
+      expected_json_map);
+}
+
+// Test new specifier (PLAIN/TYPED) of FilterState and convert the output log string to proto
+// and then verify the result.
+TEST(AccessLogFormatterTest, TypedFilterStateSpeciferTest) {
+  Http::TestRequestHeaderMapImpl request_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  stream_info.filter_state_->setData(
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
+      StreamInfo::FilterState::StateType::ReadOnly);
+  EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
+
+  std::unordered_map<std::string, std::string> key_mapping = {
+      {"test_key_plain", "%FILTER_STATE(test_key:PLAIN)%"},
+      {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
+
+  JsonFormatterImpl formatter(key_mapping, true);
+
+  std::string json =
+      formatter.format(request_headers, response_headers, response_trailers, stream_info);
+
+  ProtobufWkt::Struct output;
+  MessageUtil::loadFromJson(json, output);
+
+  const auto& fields = output.fields();
+  EXPECT_EQ("test_value By PLAIN", fields.at("test_key_plain").string_value());
+  EXPECT_EQ("test_value By TYPED", fields.at("test_key_typed").string_value());
+}
+
+// Error specifier will cause an exception to be thrown.
+TEST(AccessLogFormatterTest, FilterStateErrorSpeciferTest) {
+  Http::TestRequestHeaderMapImpl request_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  stream_info.filter_state_->setData(
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
+      StreamInfo::FilterState::StateType::ReadOnly);
+
+  // 'ABCDE' is error specifier.
+  std::unordered_map<std::string, std::string> key_mapping = {
+      {"test_key_plain", "%FILTER_STATE(test_key:ABCDE)%"},
+      {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
+
+  EXPECT_THROW_WITH_MESSAGE(JsonFormatterImpl formatter(key_mapping, false), EnvoyException,
+                            "Invalid filter state serialize type, only support PLAIN/TYPED.");
 }
 
 TEST(AccessLogFormatterTest, JsonFormatterStartTimeTest) {


### PR DESCRIPTION
Signed-off-by: wbpcode <comems@msn.com>

Description:

Added a virtual method serializeAsString to FilterState for obtaining unstructured serialization results. Related issues and discussion can read issue #10430.
It needs to be emphasized that std::string is special because it is essentially a byte array, so it can be used as a flat buffer.

Extend format specifier for FilterStateFormatter to choose different serialize method.
Here is a example: %FILTER_STATE(example_key:PLAIN)%. SerializeAsString will be used to get log string.
If this specifier not set or not equal PLAIN then serializeAsProto will be used.



Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]