### PR TITLE
[DO NOT REVIEW] Platform-specific test cases for std::regex_match operations that throw

### DIFF
--- a/source/common/common/regex.cc
+++ b/source/common/common/regex.cc
@@ -19,7 +19,11 @@ public:
 
   // CompiledMatcher
   bool match(absl::string_view value) const override {
-    return std::regex_match(value.begin(), value.end(), regex_);
+    try {
+      return std::regex_match(value.begin(), value.end(), regex_);
+    } catch (const std::regex_error& e) {
+      throw EnvoyException(fmt::format("Invalid regex match: {}", e.what()));
+    }
   }
 
   // CompiledMatcher

--- a/test/common/common/regex_test.cc
+++ b/test/common/common/regex_test.cc
@@ -15,6 +15,9 @@ TEST(Utility, ParseStdRegex) {
   EXPECT_THROW_WITH_REGEX(Utility::parseStdRegex("(+invalid)"), EnvoyException,
                           "Invalid regex '\\(\\+invalid\\)': .+");
 
+  EXPECT_THROW_WITH_REGEX(Utility::parseStdRegexAsCompiledMatcher("(+invalid)"), EnvoyException,
+                          "Invalid regex '\\(\\+invalid\\)': .+");
+
   {
     std::regex regex = Utility::parseStdRegex("x*");
     EXPECT_NE(0, regex.flags() & std::regex::optimize);
@@ -24,6 +27,23 @@ TEST(Utility, ParseStdRegex) {
     std::regex regex = Utility::parseStdRegex("x*", std::regex::icase);
     EXPECT_NE(0, regex.flags() & std::regex::icase);
     EXPECT_EQ(0, regex.flags() & std::regex::optimize);
+  }
+
+  {
+    auto matcher = Utility::parseStdRegexAsCompiledMatcher(
+        "|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
+    EXPECT_THROW_WITH_REGEX(matcher->match("0"), EnvoyException,
+                            "Invalid regex match: The complexity of an attempted match against a "
+                            "regular expression exceeded a pre-set level.");
+  }
+
+  {
+    auto matcher = Utility::parseStdRegexAsCompiledMatcher(
+        "|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+        "|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
+    EXPECT_THROW_WITH_REGEX(matcher->match("0"), EnvoyException,
+                            "Invalid regex match: The complexity of an attempted match against a "
+                            "regular expression exceeded a pre-set level.");
   }
 }
 


### PR DESCRIPTION
Description:  Do not review.  I'm just gathering info about how this test behaves in platform specific CIs.
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
