### PR TITLE
coverage: introduce ONLY_EXTRA_QUERY_PATHS

### DIFF
--- a/test/coverage/gen_build.sh
+++ b/test/coverage/gen_build.sh
@@ -31,13 +31,16 @@ else
   COVERAGE_TARGETS=//test/...
 fi
 
-for target in ${COVERAGE_TARGETS}; do
-  TARGETS="$TARGETS $("${BAZEL_BIN}" query ${BAZEL_QUERY_OPTIONS} "attr('tags', 'coverage_test_lib', ${REPOSITORY}${target})" | grep "^//")"
-done
+# This setting allows consuming projects to only run coverage over private extensions.
+if [ -z "$ONLY_EXTRA_QUERY_PATHS" ]; then
+  for target in ${COVERAGE_TARGETS}; do
+    TARGETS="$TARGETS $("${BAZEL_BIN}" query ${BAZEL_QUERY_OPTIONS} "attr('tags', 'coverage_test_lib', ${REPOSITORY}${target})" | grep "^//")"
+  done
 
-# Run the QUICHE platform api tests for coverage.
-if [[ "${COVERAGE_TARGETS}" == "//test/..." ]]; then
-  TARGETS="$TARGETS $("${BAZEL_BIN}" query ${BAZEL_QUERY_OPTIONS} "attr('tags', 'coverage_test_lib', '@com_googlesource_quiche//:all')" | grep "^@com_googlesource_quiche")"
+  # Run the QUICHE platform api tests for coverage.
+  if [[ "${COVERAGE_TARGETS}" == "//test/..." ]]; then
+    TARGETS="$TARGETS $("${BAZEL_BIN}" query ${BAZEL_QUERY_OPTIONS} "attr('tags', 'coverage_test_lib', '@com_googlesource_quiche//:all')" | grep "^@com_googlesource_quiche")"
+  fi
 fi
 
 if [ -n "${EXTRA_QUERY_PATHS}" ]; then

--- a/test/coverage/gen_build.sh
+++ b/test/coverage/gen_build.sh
@@ -32,7 +32,7 @@ else
 fi
 
 # This setting allows consuming projects to only run coverage over private extensions.
-if [ -z "$ONLY_EXTRA_QUERY_PATHS" ]; then
+if [[ -z "${ONLY_EXTRA_QUERY_PATHS}" ]]; then
   for target in ${COVERAGE_TARGETS}; do
     TARGETS="$TARGETS $("${BAZEL_BIN}" query ${BAZEL_QUERY_OPTIONS} "attr('tags', 'coverage_test_lib', ${REPOSITORY}${target})" | grep "^//")"
   done


### PR DESCRIPTION
Description: introduce an environment variable that allows consuming projects to only run coverage over private extensions.
Risk Level: low
Testing: locally with Envoy Mobile as a consuming project. And existing coverage run in CI
Docs Changes: inline comment

Signed-off-by: Jose Nino <jnino@lyft.com>
