### PR TITLE
zlib: use Z_DEFAULT_STRATEGY by default instead of Z_FIXED

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -91,6 +91,9 @@ Version history
   restart Envoy. The behavior will not switch until the connection pools are recreated. The new
   circuit breaker behavior is described :ref:`here <arch_overview_circuit_break>`.
 * upstream: changed load distribution algorithm when all priorities enter :ref:`panic mode<arch_overview_load_balancing_panic_threshold>`.
+* zlib: by default zlib is initialized to use its default strategy (Z_DEFAULT_STRATEGY)
+  instead of the fixed one (Z_FIXED). The difference is that the use of dynammic
+  Huffman codes is enabled now resulting in better compression ratio for normal data.
 
 1.13.1 (March 3, 2020)
 ======================

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -50,7 +50,7 @@ public:
     Filtered = 1,
     Huffman = 2,
     Rle = 3,
-    Standard = 4,
+    Standard = 0,
   };
 
   /**

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -34,9 +34,9 @@ public:
    * manual.
    */
   enum class CompressionLevel : int64_t {
-    Best = 9,
-    Speed = 1,
-    Standard = -1,
+    Best = Z_BEST_COMPRESSION,
+    Speed = Z_BEST_SPEED,
+    Standard = Z_DEFAULT_COMPRESSION,
   };
 
   /**
@@ -47,10 +47,10 @@ public:
    * standard: used for normal data. (default) @see Z_DEFAULT_STRATEGY in zlib manual.
    */
   enum class CompressionStrategy : uint64_t {
-    Filtered = 1,
-    Huffman = 2,
-    Rle = 3,
-    Standard = 0,
+    Filtered = Z_FILTERED,
+    Huffman = Z_HUFFMAN_ONLY,
+    Rle = Z_RLE,
+    Standard = Z_DEFAULT_STRATEGY,
   };
 
   /**


### PR DESCRIPTION
Description:

Since `Envoy::Compressor::ZlibCompressorImpl::CompressionStrategy` is simply static_cast'ed to `uint64_t` the `Standard` strategy (4) becomes `Z_FIXED` (4 as well). This basically disables the use of
dynamic Huffman codes when the gzip filter is configured to use default values.

Make the `Standard` strategy equal to 0 to translate to `Z_DEFAULT_STRATEGY`.

Contributes to #8448
Risk Level: Low
Testing: Manual testing
