### PR TITLE
Reduce java heap by 1.5G for reduced heap headroom

### DIFF
--- a/windows/.bazelrc
+++ b/windows/.bazelrc
@@ -4,7 +4,8 @@ build --action_env=PATH
 build --action_env=TMPDIR
 
 # see top-level .bazelrc for explanation
-startup --host_jvm_args=-Xmx2g
+# Using only 2 cores, therefore 512m seems to be sufficient for 2 tasks
+startup --host_jvm_args=-Xmx512m
 
 build --define signal_trace=disabled
 build --define hot_restart=disabled


### PR DESCRIPTION
Description:
Windows step of the envoy-presubmit pipeline now fails regularly for the past 3 hours, it appears that the Windows azp worker images have a reduced heap due to upgrades or resizing of ram.

Risk Level: low
Testing: n/a (to be tested on CI pipeline)
Docs Changes: n/a
Release Notes: n/a
