### PR TITLE
request_id_extension: Add noop impl by default

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -407,17 +407,8 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:request_id_extension_interface",
         "//include/envoy/server:request_id_extension_config_interface",
-        "//include/envoy/upstream:upstream_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/common:utility_lib",
         "//source/common/config:utility_lib",
-        "//source/common/http:header_map_lib",
-        "//source/common/http:header_utility_lib",
-        "//source/common/http:headers_lib",
-        "//source/common/http:utility_lib",
-        "//source/common/protobuf:utility_lib",
-        "//source/common/stream_info:stream_info_lib",
-        "//source/common/tracing:http_tracer_lib",
+        "//source/common/runtime:runtime_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/http/request_id_extension_impl.cc
+++ b/source/common/http/request_id_extension_impl.cc
@@ -7,6 +7,20 @@
 namespace Envoy {
 namespace Http {
 
+namespace {
+
+// NoopRequestIDExtension is the implementation used outside of HTTP context.
+class NoopRequestIDExtension : public RequestIDExtension {
+public:
+  void set(RequestHeaderMap&, bool) override {}
+  void setInResponse(ResponseHeaderMap&, const RequestHeaderMap&) override {}
+  bool modBy(const RequestHeaderMap&, uint64_t&, uint64_t) override { return false; }
+  TraceStatus getTraceStatus(const RequestHeaderMap&) override { return TraceStatus::NoTrace; }
+  void setTraceStatus(RequestHeaderMap&, TraceStatus) override {}
+};
+
+} // namespace
+
 RequestIDExtensionSharedPtr RequestIDExtensionFactory::fromProto(
     const envoy::extensions::filters::network::http_connection_manager::v3::RequestIDExtension&
         config,
@@ -28,6 +42,11 @@ RequestIDExtensionSharedPtr RequestIDExtensionFactory::fromProto(
 RequestIDExtensionSharedPtr
 RequestIDExtensionFactory::defaultInstance(Envoy::Runtime::RandomGenerator& random) {
   return std::make_shared<UUIDRequestIDExtension>(random);
+}
+
+RequestIDExtensionSharedPtr RequestIDExtensionFactory::noopInstance() {
+  static RequestIDExtensionSharedPtr global = std::make_shared<NoopRequestIDExtension>();
+  return global;
 }
 
 } // namespace Http

--- a/source/common/http/request_id_extension_impl.h
+++ b/source/common/http/request_id_extension_impl.h
@@ -19,6 +19,11 @@ public:
   static RequestIDExtensionSharedPtr defaultInstance(Envoy::Runtime::RandomGenerator& random);
 
   /**
+   * Return a globally shared instance of the noop RequestIDExtension implementation.
+   */
+  static RequestIDExtensionSharedPtr noopInstance();
+
+  /**
    * Read a RequestIDExtension definition from proto and create it.
    */
   static RequestIDExtensionSharedPtr fromProto(

--- a/source/common/stream_info/BUILD
+++ b/source/common/stream_info/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
         "//include/envoy/stream_info:stream_info_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:dump_state_utils",
+        "//source/common/http:request_id_extension_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -11,6 +11,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/dump_state_utils.h"
+#include "common/http/request_id_extension_impl.h"
 #include "common/stream_info/filter_state_impl.h"
 
 namespace Envoy {
@@ -20,12 +21,14 @@ struct StreamInfoImpl : public StreamInfo {
   StreamInfoImpl(TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()),
-        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
+        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
+        request_id_extension_(Http::RequestIDExtensionFactory::noopInstance()) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
-        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
+        filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
+        request_id_extension_(Http::RequestIDExtensionFactory::noopInstance()) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
                  std::shared_ptr<FilterState>& parent_filter_state)
@@ -34,7 +37,8 @@ struct StreamInfoImpl : public StreamInfo {
         filter_state_(std::make_shared<FilterStateImpl>(
             FilterStateImpl::LazyCreateAncestor(parent_filter_state,
                                                 FilterState::LifeSpan::DownstreamConnection),
-            FilterState::LifeSpan::FilterChain)) {}
+            FilterState::LifeSpan::FilterChain)),
+        request_id_extension_(Http::RequestIDExtensionFactory::noopInstance()) {}
 
   SystemTime startTime() const override { return start_time_; }
 

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -237,6 +237,16 @@ TEST_F(StreamInfoImplTest, RequestHeadersTest) {
   EXPECT_EQ(&headers, stream_info.getRequestHeaders());
 }
 
+TEST_F(StreamInfoImplTest, DefaultRequestIDExtensionTest) {
+  StreamInfoImpl stream_info(test_time_.timeSystem());
+  EXPECT_TRUE(stream_info.getRequestIDExtension());
+
+  Http::RequestHeaderMapImpl headers;
+  uint64_t out = 123;
+  EXPECT_FALSE(stream_info.getRequestIDExtension()->modBy(headers, out, 10000));
+  EXPECT_EQ(out, 123);
+}
+
 } // namespace
 } // namespace StreamInfo
 } // namespace Envoy

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -241,10 +241,18 @@ TEST_F(StreamInfoImplTest, DefaultRequestIDExtensionTest) {
   StreamInfoImpl stream_info(test_time_.timeSystem());
   EXPECT_TRUE(stream_info.getRequestIDExtension());
 
-  Http::RequestHeaderMapImpl headers;
+  auto rid_extension = stream_info.getRequestIDExtension();
+
+  Http::RequestHeaderMapImpl request_headers;
+  Http::ResponseHeaderMapImpl response_headers;
+  rid_extension->set(request_headers, false);
+  rid_extension->set(request_headers, true);
+  rid_extension->setInResponse(response_headers, request_headers);
   uint64_t out = 123;
-  EXPECT_FALSE(stream_info.getRequestIDExtension()->modBy(headers, out, 10000));
+  EXPECT_FALSE(rid_extension->modBy(request_headers, out, 10000));
   EXPECT_EQ(out, 123);
+  rid_extension->setTraceStatus(request_headers, Http::TraceStatus::Forced);
+  EXPECT_EQ(rid_extension->getTraceStatus(request_headers), Http::TraceStatus::NoTrace);
 }
 
 } // namespace

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -255,6 +255,12 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
         "upstreamhost=%UPSTREAM_HOST% downstream=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% "
         "sent=%BYTES_SENT% received=%BYTES_RECEIVED%\n");
     access_log->mutable_typed_config()->PackFrom(access_log_config);
+    auto* runtime_filter = access_log->mutable_filter()->mutable_runtime_filter();
+    runtime_filter->set_runtime_key("unused-key");
+    auto* percent_sampled = runtime_filter->mutable_percent_sampled();
+    percent_sampled->set_numerator(100);
+    percent_sampled->set_denominator(
+        envoy::type::FractionalPercent::DenominatorType::FractionalPercent_DenominatorType_HUNDRED);
     config_blob->PackFrom(tcp_proxy_config);
   });
   initialize();


### PR DESCRIPTION
Description: By default use noop `RequestIDExtension` implementation in `StreamInfo`. This allows avoiding nullptr checks outside of HTTP context.
Risk Level: low
Testing: added unit test, updated integration test (crashes without `StreamInfoImpl` changes)
Docs Changes: n/a
Release Notes: n/a
Fixes #10686
