### PR TITLE
logger: Make log prefix configurable

### DIFF
--- a/source/common/common/base_logger.cc
+++ b/source/common/common/base_logger.cc
@@ -3,7 +3,7 @@
 namespace Envoy {
 namespace Logger {
 
-const char* Logger::DEFAULT_LOG_FORMAT = "[%Y-%m-%d %T.%e][%t][%l][%n] %v";
+const char* Logger::DEFAULT_LOG_FORMAT = "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v";
 
 Logger::Logger(std::shared_ptr<spdlog::logger> logger) : logger_(logger) {
   logger_->set_pattern(DEFAULT_LOG_FORMAT);

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -282,19 +282,15 @@ protected:
 
 } // namespace Logger
 
-// Convert the line macro to a string literal for concatenation in log macros.
-#define DO_STRINGIZE(x) STRINGIZE(x)
-#define STRINGIZE(x) #x
-#define LINE_STRING DO_STRINGIZE(__LINE__)
-#define LOG_PREFIX "[" __FILE__ ":" LINE_STRING "] "
-
 /**
  * Base logging macros. It is expected that users will use the convenience macros below rather than
  * invoke these directly.
  */
 
-#define ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)                                                        \
-  (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level())
+#define ENVOY_SPDLOG_LEVEL(LEVEL)                                                                  \
+  (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL))
+
+#define ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL) (ENVOY_SPDLOG_LEVEL(LEVEL) >= LOGGER.level())
 
 // Compare levels before invoking logger. This is an optimization to avoid
 // executing expressions computing log contents when they would be suppressed.
@@ -302,7 +298,8 @@ protected:
 #define ENVOY_LOG_COMP_AND_LOG(LOGGER, LEVEL, ...)                                                 \
   do {                                                                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
-      LOGGER.LEVEL(LOG_PREFIX __VA_ARGS__);                                                        \
+      LOGGER.log(::spdlog::source_loc{__FILE__, __LINE__, __func__}, ENVOY_SPDLOG_LEVEL(LEVEL),    \
+                 __VA_ARGS__);                                                                     \
     }                                                                                              \
   } while (0)
 


### PR DESCRIPTION
Description: Move `[%g:%#] ` message prefix from compile-time macros to log format.
Please note that this change does not change behavior iff envoy is used with none logger formatting-related command line options.
Risk Level: medium (no-op by default but can affect customers if they configure command line options)
Testing: manual run of test & verifying output
Docs Changes: TODO
Release Notes: TODO
Fixes #10688
