### PR TITLE
tools/api: fix handling of new messages/enums in merge_active_shadow.py.

### DIFF
--- a/tools/protoxform/merge_active_shadow.py
+++ b/tools/protoxform/merge_active_shadow.py
@@ -36,6 +36,8 @@ def AdjustReservedRange(target_proto, previous_reserved_range, skip_reserved_num
 # Merge active/shadow EnumDescriptorProtos to a fresh target EnumDescriptorProto.
 def MergeActiveShadowEnum(active_proto, shadow_proto, target_proto):
   target_proto.MergeFrom(active_proto)
+  if not shadow_proto:
+    return
   shadow_values = {v.name: v for v in shadow_proto.value}
   skip_reserved_numbers = []
   # For every reserved name, check to see if it's in the shadow, and if so,
@@ -62,6 +64,8 @@ def MergeActiveShadowEnum(active_proto, shadow_proto, target_proto):
 # Merge active/shadow DescriptorProtos to a fresh target DescriptorProto.
 def MergeActiveShadowMessage(active_proto, shadow_proto, target_proto):
   target_proto.MergeFrom(active_proto)
+  if not shadow_proto:
+    return
   shadow_fields = {f.name: f for f in shadow_proto.field}
   skip_reserved_numbers = []
   # For every reserved name, check to see if it's in the shadow, and if so,
@@ -99,12 +103,12 @@ def MergeActiveShadowMessage(active_proto, shadow_proto, target_proto):
   del target_proto.nested_type[:]
   shadow_msgs = {msg.name: msg for msg in shadow_proto.nested_type}
   for msg in active_proto.nested_type:
-    MergeActiveShadowMessage(msg, shadow_msgs[msg.name], target_proto.nested_type.add())
+    MergeActiveShadowMessage(msg, shadow_msgs.get(msg.name), target_proto.nested_type.add())
   # Visit nested enum types
   del target_proto.enum_type[:]
   shadow_enums = {msg.name: msg for msg in shadow_proto.enum_type}
   for enum in active_proto.enum_type:
-    MergeActiveShadowEnum(enum, shadow_enums[enum.name], target_proto.enum_type.add())
+    MergeActiveShadowEnum(enum, shadow_enums.get(enum.name), target_proto.enum_type.add())
   # Ensure target has any deprecated sub-message types in case they are needed.
   active_msg_names = set([msg.name for msg in active_proto.nested_type])
   for msg in shadow_proto.nested_type:
@@ -119,12 +123,12 @@ def MergeActiveShadowFile(active_file_proto, shadow_file_proto):
   del target_file_proto.message_type[:]
   shadow_msgs = {msg.name: msg for msg in shadow_file_proto.message_type}
   for msg in active_file_proto.message_type:
-    MergeActiveShadowMessage(msg, shadow_msgs[msg.name], target_file_proto.message_type.add())
+    MergeActiveShadowMessage(msg, shadow_msgs.get(msg.name), target_file_proto.message_type.add())
   # Visit enum types
   del target_file_proto.enum_type[:]
   shadow_enums = {msg.name: msg for msg in shadow_file_proto.enum_type}
   for enum in active_file_proto.enum_type:
-    MergeActiveShadowEnum(enum, shadow_enums[enum.name], target_file_proto.enum_type.add())
+    MergeActiveShadowEnum(enum, shadow_enums.get(enum.name), target_file_proto.enum_type.add())
   # Ensure target has any deprecated message types in case they are needed.
   active_msg_names = set([msg.name for msg in active_file_proto.message_type])
   for msg in shadow_file_proto.message_type:

--- a/tools/protoxform/merge_active_shadow_test.py
+++ b/tools/protoxform/merge_active_shadow_test.py
@@ -216,6 +216,24 @@ oneof_decl {
     """
     self.assertTextProtoEq(target_pb_text, str(target_proto))
 
+  def testMergeActiveShadowMessageNoShadowMessage(self):
+    """MergeActiveShadowMessage doesn't require a shadow message for new nested active messages."""
+    active_proto = descriptor_pb2.DescriptorProto()
+    shadow_proto = descriptor_pb2.DescriptorProto()
+    active_proto.nested_type.add().name = 'foo'
+    target_proto = descriptor_pb2.DescriptorProto()
+    merge_active_shadow.MergeActiveShadowMessage(active_proto, shadow_proto, target_proto)
+    self.assertEqual(target_proto.nested_type[0].name, 'foo')
+
+  def testMergeActiveShadowMessageNoShadowEnum(self):
+    """MergeActiveShadowMessage doesn't require a shadow enum for new nested active enums."""
+    active_proto = descriptor_pb2.DescriptorProto()
+    shadow_proto = descriptor_pb2.DescriptorProto()
+    active_proto.enum_type.add().name = 'foo'
+    target_proto = descriptor_pb2.DescriptorProto()
+    merge_active_shadow.MergeActiveShadowMessage(active_proto, shadow_proto, target_proto)
+    self.assertEqual(target_proto.enum_type[0].name, 'foo')
+
   def testMergeActiveShadowMessageMissing(self):
     """MergeActiveShadowMessage recovers missing messages from shadow."""
     active_proto = descriptor_pb2.DescriptorProto()
@@ -233,6 +251,24 @@ oneof_decl {
     target_proto = descriptor_pb2.DescriptorProto()
     target_proto = merge_active_shadow.MergeActiveShadowFile(active_proto, shadow_proto)
     self.assertEqual(target_proto.message_type[0].name, 'foo')
+
+  def testMergeActiveShadowFileNoShadowMessage(self):
+    """MergeActiveShadowFile doesn't require a shadow message for new active messages."""
+    active_proto = descriptor_pb2.FileDescriptorProto()
+    shadow_proto = descriptor_pb2.FileDescriptorProto()
+    active_proto.message_type.add().name = 'foo'
+    target_proto = descriptor_pb2.DescriptorProto()
+    target_proto = merge_active_shadow.MergeActiveShadowFile(active_proto, shadow_proto)
+    self.assertEqual(target_proto.message_type[0].name, 'foo')
+
+  def testMergeActiveShadowFileNoShadowEnum(self):
+    """MergeActiveShadowFile doesn't require a shadow enum for new active enums."""
+    active_proto = descriptor_pb2.FileDescriptorProto()
+    shadow_proto = descriptor_pb2.FileDescriptorProto()
+    active_proto.enum_type.add().name = 'foo'
+    target_proto = descriptor_pb2.DescriptorProto()
+    target_proto = merge_active_shadow.MergeActiveShadowFile(active_proto, shadow_proto)
+    self.assertEqual(target_proto.enum_type[0].name, 'foo')
 
 
 # TODO(htuch): add some test for recursion.


### PR DESCRIPTION
Previously, merge_active_shadow.py was incapable of handling the situation where there was a new v3
message, with no corresponding v2 shadow entry. This was impacting
https://github.com/envoyproxy/envoy/pull/10553. This patch fixes the bug and adds regression tests.

Risk level: Low (API tooling only)
Testing: merge_active_shadow_test.py unit tests added.

Signed-off-by: Harvey Tuch <htuch@google.com>