### PR TITLE
build: removed unnecessary licenses attributes.

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -90,7 +90,6 @@ envoy_cc_test(
 py_binary(
     name = "capture_fuzz_gen",
     srcs = ["capture_fuzz_gen.py"],
-    licenses = ["notice"],  # Apache 2
     visibility = ["//visibility:public"],
     deps = [
         ":capture_fuzz_proto_py_proto",


### PR DESCRIPTION
Removed unnecessary licenses attributes.
A licenses attribute is unnecessary, when it is the same as as the default licenses() directive in the file.

Risk level: Low (tooling only)
