### PR TITLE
Remove the redundant advancing of clock that caused the race.

### DIFF
--- a/test/extensions/common/redis/cluster_refresh_manager_test.cc
+++ b/test/extensions/common/redis/cluster_refresh_manager_test.cc
@@ -131,17 +131,15 @@ TEST_F(ClusterRefreshManagerTest, Basic) {
     // as wait for 2 would only ensure onRedirection was started
     waitForTime(MonotonicTime(std::chrono::seconds(3)));
     refresh_manager_->onRedirection(cluster_name_);
-    waitForTime(MonotonicTime(std::chrono::seconds(4)));
   });
   Thread::ThreadPtr thread_2 = platform_.threadFactory().createThread([&]() {
     // wait for 3 ensures that thread_1's first onRedirection is completed,
     // as wait for 2 would only ensure onRedirection was started
     waitForTime(MonotonicTime(std::chrono::seconds(3)));
     refresh_manager_->onRedirection(cluster_name_);
-    waitForTime(MonotonicTime(std::chrono::seconds(4)));
   });
 
-  advanceTime(MonotonicTime(std::chrono::seconds(4)), 2);
+  advanceTime(MonotonicTime(std::chrono::seconds(3)), 2);
   thread_1->join();
   thread_2->join();
 
@@ -177,17 +175,15 @@ TEST_F(ClusterRefreshManagerTest, BasicFailureEvents) {
     // as wait for 2 would only ensure onRedirection was started
     waitForTime(MonotonicTime(std::chrono::seconds(3)));
     refresh_manager_->onFailure(cluster_name_);
-    waitForTime(MonotonicTime(std::chrono::seconds(4)));
   });
   Thread::ThreadPtr thread_2 = platform_.threadFactory().createThread([&]() {
     // wait for 3 ensures that thread_1's first onRedirection is completed,
     // as wait for 2 would only ensure onRedirection was started
     waitForTime(MonotonicTime(std::chrono::seconds(3)));
     refresh_manager_->onFailure(cluster_name_);
-    waitForTime(MonotonicTime(std::chrono::seconds(4)));
   });
 
-  advanceTime(MonotonicTime(std::chrono::seconds(4)), 2);
+  advanceTime(MonotonicTime(std::chrono::seconds(3)), 2);
   thread_1->join();
   thread_2->join();
 
@@ -223,17 +219,15 @@ TEST_F(ClusterRefreshManagerTest, BasicDegradedEvents) {
     // as wait for 2 would only ensure onRedirection was started
     waitForTime(MonotonicTime(std::chrono::seconds(3)));
     refresh_manager_->onHostDegraded(cluster_name_);
-    waitForTime(MonotonicTime(std::chrono::seconds(4)));
   });
   Thread::ThreadPtr thread_2 = platform_.threadFactory().createThread([&]() {
     // wait for 3 ensures that thread_1's first onRedirection is completed,
     // as wait for 2 would only ensure onRedirection was started
     waitForTime(MonotonicTime(std::chrono::seconds(3)));
     refresh_manager_->onHostDegraded(cluster_name_);
-    waitForTime(MonotonicTime(std::chrono::seconds(4)));
   });
 
-  advanceTime(MonotonicTime(std::chrono::seconds(4)), 2);
+  advanceTime(MonotonicTime(std::chrono::seconds(3)), 2);
   thread_1->join();
   thread_2->join();
 


### PR DESCRIPTION
Signed-off-by: Henry Yang <hyang@lyft.com>

Description: The additional waitForTime call is not necessary since the threads are synchronized with the thread->join() calls.  Additionally this advance the clock which introduced a race.
Risk Level: Low
Testing: The test was ran 100 times without failures
Docs Changes: N/A
Release Notes: N/A
Fixes: #10384 
