### PR TITLE
build: Add prefix to protobuf symbols

### DIFF
--- a/api/test/build/build_test.cc
+++ b/api/test/build/build_test.cc
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
   };
 
   for (const auto& method : methods) {
-    if (google::protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) == nullptr) {
+    if (envoy::google::protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) == nullptr) {
       std::cout << "Unable to find method descriptor for " << method << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/api/test/validate/pgv_test.cc
+++ b/api/test/validate/pgv_test.cc
@@ -68,7 +68,7 @@ int main(int argc, char* argv[]) {
   }
   )EOF";
   envoy::config::bootstrap::v2::Bootstrap valid_bootstrap;
-  if (!google::protobuf::TextFormat::ParseFromString(valid_bootstrap_text, &valid_bootstrap)) {
+  if (!envoy::google::protobuf::TextFormat::ParseFromString(valid_bootstrap_text, &valid_bootstrap)) {
     std::cerr << "Unable to parse text proto: " << valid_bootstrap_text << std::endl;
     exit(EXIT_FAILURE);
   }

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -148,3 +148,25 @@ index 5fa5543b1..484bc41a7 100644
                  executable = ctx.executable.protoc,
                  mnemonic = "ProtoCompile",
                  use_default_shell_env = True,
+
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index 1f9003753..4764afc51 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -138,12 +138,14 @@
+ #endif
+
+
+-#define PROTOBUF_NAMESPACE "google::protobuf"
+-#define PROTOBUF_NAMESPACE_ID google::protobuf
++#define PROTOBUF_NAMESPACE "envoy::google::protobuf"
++#define PROTOBUF_NAMESPACE_ID envoy::google::protobuf
+ #define PROTOBUF_NAMESPACE_OPEN \
++  namespace envoy {             \
+   namespace google {            \
+   namespace protobuf {
+ #define PROTOBUF_NAMESPACE_CLOSE \
++  } /* namespace envoy    */     \
+   } /* namespace protobuf */     \
+   } /* namespace google */
+ #define PROTOBUF_DEPRECATED

--- a/source/common/protobuf/protobuf.h
+++ b/source/common/protobuf/protobuf.h
@@ -36,14 +36,14 @@ namespace Envoy {
 // Envoy::Protobuf namespace. This is required to allow remapping of protobuf to
 // alternative implementations during import into other repositories. E.g. at
 // Google we have more than one protobuf implementation.
-namespace Protobuf = google::protobuf;
+namespace Protobuf = envoy::google::protobuf;
 
 // Allows mapping from google::protobuf::util to other util libraries.
-namespace ProtobufUtil = google::protobuf::util;
+namespace ProtobufUtil = envoy::google::protobuf::util;
 
 // Protobuf well-known types (WKT) should be referenced via the ProtobufWkt
 // namespace.
-namespace ProtobufWkt = google::protobuf;
+namespace ProtobufWkt = envoy::google::protobuf;
 
 // Alternative protobuf implementations might not have the same basic types.
 // Below we provide wrappers to facilitate remapping of the type during import.

--- a/tools/testdata/check_format/serialize_as_string.cc
+++ b/tools/testdata/check_format/serialize_as_string.cc
@@ -1,7 +1,7 @@
 namespace Envoy {
 
 void use_serialize_as_string() {
-  google::protobuf::FieldMask mask;
+  envoy::google::protobuf::FieldMask mask;
   const std::string key = mask.SerializeAsString();
 }
 


### PR DESCRIPTION
When building envoy as a library, like with envoy-mobile, if the final
binary already contains protobuf symbols, it leads to conflicts. This
change prefixes the protobuf symbols with the `envoy` namespace, to
avoid these conflicts.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>