### PR TITLE
Fix static shared_ptr in request id extension

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,10 @@ Version history
 1.15.0 (Pending)
 ================
 
+1.14.1 (April 8, 2020)
+======================
+* request_id_extension: fixed static initialization for noop request id extension.
+
 1.14.0 (April 8, 2020)
 ======================
 * access log: access logger extensions use the "envoy.access_loggers" name space. A mapping

--- a/source/common/http/request_id_extension_impl.cc
+++ b/source/common/http/request_id_extension_impl.cc
@@ -45,8 +45,8 @@ RequestIDExtensionFactory::defaultInstance(Envoy::Runtime::RandomGenerator& rand
 }
 
 RequestIDExtensionSharedPtr RequestIDExtensionFactory::noopInstance() {
-  static RequestIDExtensionSharedPtr global = std::make_shared<NoopRequestIDExtension>();
-  return global;
+  MUTABLE_CONSTRUCT_ON_FIRST_USE(
+      std::shared_ptr<RequestIDExtension>, std::make_shared<NoopRequestIDExtension>());
 }
 
 } // namespace Http


### PR DESCRIPTION
Fixes static shared ptr using `MUTABLE_CONSTRUCT_ON_FIRST_USE`.
Fixes H/1 persistent mode integration fuzz targets.

Testing: bazel test //test/integration:h1_capture_persistent_fuzz_test --test_output=all  --runs_per_test=100 

Signed-off-by: Asra Ali <asraa@google.com>