### PR TITLE
Fixing pending_response_done_ assertion location in HTTP/1.x codec_impl

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -948,10 +948,11 @@ ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, Stat
                      max_response_headers_count, formatter(settings), settings.enable_trailers_) {}
 
 bool ClientConnectionImpl::cannotHaveBody() {
-  if ((pending_response_.has_value() && pending_response_.value().encoder_.headRequest()) ||
-      parser_.status_code == 204 || parser_.status_code == 304 ||
-      (parser_.status_code >= 200 && parser_.content_length == 0)) {
+  if (pending_response_.has_value() && pending_response_.value().encoder_.headRequest()) {
     ASSERT(!pending_response_done_);
+    return true;
+  } else if (parser_.status_code == 204 || parser_.status_code == 304 ||
+             (parser_.status_code >= 200 && parser_.content_length == 0)) {
     return true;
   } else {
     return false;

--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5102523695497216
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5102523695497216
@@ -1,0 +1,35 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+      }
+      end_stream: true
+    }
+  }
+}


### PR DESCRIPTION
Fixing an assertion on `pending_response_done_` that was added in #10561, and should only be called for certain case.

Risk Level: Low
Testing: Added the fuzz testcase that caused a failure
Fixes OSS fuzz test: [5102523695497216](https://oss-fuzz.com/testcase-detail/5102523695497216)

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
