### PR TITLE
tools: Add ability to run clang-tidy against specific ref

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -55,6 +55,9 @@ function filter_excludes() {
   exclude_testdata | exclude_chromium_url | exclude_win32_impl
 }
 
+if [[ -z "${DIFF_REF}" && "${BUILD_REASON}" != "PullRequest" ]]; then
+  DIFF_REF=HEAD^
+fi
 
 if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
   echo "Running full clang-tidy..."
@@ -64,9 +67,9 @@ if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
     -export-fixes=${FIX_YAML} \
     -j ${NUM_CPUS:-0} -p 1 -quiet \
     ${APPLY_CLANG_TIDY_FIXES:+-fix}
-elif [[ "${BUILD_REASON}" != "PullRequest" ]]; then
-  echo "Running clang-tidy-diff against previous commit..."
-  git diff HEAD^ | filter_excludes | \
+elif [[ -n "${DIFF_REF}" ]]; then
+  echo "Running clang-tidy-diff against ref ${DIFF_REF}"
+  git diff ${DIFF_REF} | filter_excludes | \
     python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary=${CLANG_TIDY} \
       -export-fixes=${FIX_YAML} \


### PR DESCRIPTION
Add ability to run clang-tidy against specific ref. This should make it possible to run it against local master or multiple commits away from HEAD

Risk Level: Low
Testing: Ran script
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
