### PR TITLE
stats: introduce `Event::Dispatcher::name()` to unify per-handler/worker statistics, such as `server.worker_2.watchdog_miss`

### DIFF
--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -22,8 +22,8 @@ public:
 
   /**
    * Allocate a dispatcher.
-   * @param name the name for a dispatcher, such as "worker_2" or "main_thread".
-   *             This name will appear in per-handler/worker statistics, e.g.
+   * @param name the identity name for a dispatcher, e.g. "worker_2" or "main_thread".
+   *             This name will appear in per-handler/worker statistics, such as
    *             "server.worker_2.watchdog_miss".
    * @return Event::DispatcherPtr which is owned by the caller.
    */
@@ -31,8 +31,8 @@ public:
 
   /**
    * Allocate a dispatcher.
-   * @param name the name for a dispatcher, such as "worker_2" or "main_thread".
-   *             This name will appear in per-handler/worker statistics, e.g.
+   * @param name the identity name for a dispatcher, e.g. "worker_2" or "main_thread".
+   *             This name will appear in per-handler/worker statistics, such as
    *             "server.worker_2.watchdog_miss".
    * @param watermark_factory the watermark factory, ownership is transferred to the dispatcher.
    * @return Event::DispatcherPtr which is owned by the caller.

--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -22,17 +22,23 @@ public:
 
   /**
    * Allocate a dispatcher.
+   * @param name the name for a dispatcher, such as "worker_2" or "main_thread".
+   *             This name will appear in per-handler/worker statistics, e.g.
+   *             "server.worker_2.watchdog_miss".
    * @return Event::DispatcherPtr which is owned by the caller.
    */
-  virtual Event::DispatcherPtr allocateDispatcher() PURE;
+  virtual Event::DispatcherPtr allocateDispatcher(const std::string& name) PURE;
 
   /**
    * Allocate a dispatcher.
+   * @param name the name for a dispatcher, such as "worker_2" or "main_thread".
+   *             This name will appear in per-handler/worker statistics, e.g.
+   *             "server.worker_2.watchdog_miss".
    * @param watermark_factory the watermark factory, ownership is transferred to the dispatcher.
    * @return Event::DispatcherPtr which is owned by the caller.
    */
   virtual Event::DispatcherPtr
-  allocateDispatcher(Buffer::WatermarkFactoryPtr&& watermark_factory) PURE;
+  allocateDispatcher(const std::string& name, Buffer::WatermarkFactoryPtr&& watermark_factory) PURE;
 
   /**
    * @return a reference to the ThreadFactory

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -53,8 +53,8 @@ public:
   virtual ~Dispatcher() = default;
 
   /**
-   * Returns the name associated with this dispatcher, such as "worker_2" or "main_thread".
-   * @return const std::string& the name associated with this dispatcher.
+   * Returns the name that identifies this dispatcher, such as "worker_2" or "main_thread".
+   * @return const std::string& the name that identifies this dispatcher.
    */
   virtual const std::string& name() PURE;
 

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -53,6 +53,12 @@ public:
   virtual ~Dispatcher() = default;
 
   /**
+   * Returns the name associated with this dispatcher, such as "worker_2" or "main_thread".
+   * @return const std::string& the name associated with this dispatcher.
+   */
+  virtual const std::string& name() PURE;
+
+  /**
    * Returns a time-source to use with this dispatcher.
    */
   virtual TimeSource& timeSource() PURE;
@@ -62,9 +68,11 @@ public:
    * time, since the main and worker thread dispatchers are constructed before
    * ThreadLocalStoreImpl::initializeThreading.
    * @param scope the scope to contain the new per-dispatcher stats created here.
-   * @param prefix the stats prefix to identify this dispatcher.
+   * @param prefix the stats prefix to identify this dispatcher. If empty, the dispatcher will be
+   *               identified by its name.
    */
-  virtual void initializeStats(Stats::Scope& scope, const std::string& prefix) PURE;
+  virtual void initializeStats(Stats::Scope& scope,
+                               const absl::optional<std::string>& prefix = absl::nullopt) PURE;
 
   /**
    * Clears any items in the deferred deletion queue.

--- a/include/envoy/server/worker.h
+++ b/include/envoy/server/worker.h
@@ -47,9 +47,8 @@ public:
    * Initialize stats for this worker's dispatcher, if available. The worker will output
    * thread-specific stats under the given scope.
    * @param scope the scope to contain the new per-dispatcher stats created here.
-   * @param prefix the stats prefix to identify this dispatcher.
    */
-  virtual void initializeStats(Stats::Scope& scope, const std::string& prefix) PURE;
+  virtual void initializeStats(Stats::Scope& scope) PURE;
 
   /**
    * Stop the worker thread.

--- a/source/common/api/api_impl.cc
+++ b/source/common/api/api_impl.cc
@@ -15,12 +15,13 @@ Impl::Impl(Thread::ThreadFactory& thread_factory, Stats::Store& store,
     : thread_factory_(thread_factory), store_(store), time_system_(time_system),
       file_system_(file_system), process_context_(process_context) {}
 
-Event::DispatcherPtr Impl::allocateDispatcher() {
-  return std::make_unique<Event::DispatcherImpl>(*this, time_system_);
+Event::DispatcherPtr Impl::allocateDispatcher(const std::string& name) {
+  return std::make_unique<Event::DispatcherImpl>(name, *this, time_system_);
 }
 
-Event::DispatcherPtr Impl::allocateDispatcher(Buffer::WatermarkFactoryPtr&& factory) {
-  return std::make_unique<Event::DispatcherImpl>(std::move(factory), *this, time_system_);
+Event::DispatcherPtr Impl::allocateDispatcher(const std::string& name,
+                                              Buffer::WatermarkFactoryPtr&& factory) {
+  return std::make_unique<Event::DispatcherImpl>(name, std::move(factory), *this, time_system_);
 }
 
 } // namespace Api

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -21,8 +21,9 @@ public:
        const ProcessContextOptRef& process_context = absl::nullopt);
 
   // Api::Api
-  Event::DispatcherPtr allocateDispatcher() override;
-  Event::DispatcherPtr allocateDispatcher(Buffer::WatermarkFactoryPtr&& watermark_factory) override;
+  Event::DispatcherPtr allocateDispatcher(const std::string& name) override;
+  Event::DispatcherPtr allocateDispatcher(const std::string& name,
+                                          Buffer::WatermarkFactoryPtr&& watermark_factory) override;
   Thread::ThreadFactory& threadFactory() override { return thread_factory_; }
   Filesystem::Instance& fileSystem() override { return file_system_; }
   TimeSource& timeSource() override { return time_system_; }

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -60,7 +60,7 @@ DispatcherImpl::~DispatcherImpl() {
 
 void DispatcherImpl::initializeStats(Stats::Scope& scope,
                                      const absl::optional<std::string>& prefix) {
-  std::string effective_prefix = prefix.has_value() ? *prefix : absl::StrCat(name_, ".");
+  const std::string effective_prefix = prefix.has_value() ? *prefix : absl::StrCat(name_, ".");
   // This needs to be run in the dispatcher's thread, so that we have a thread id to log.
   post([this, &scope, effective_prefix] {
     stats_prefix_ = effective_prefix + "dispatcher";

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -43,7 +43,6 @@ DispatcherImpl::DispatcherImpl(const std::string& name, Buffer::WatermarkFactory
       deferred_delete_timer_(createTimerInternal([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimerInternal([this]() -> void { runPostCallbacks(); })),
       current_to_delete_(&to_delete_1_) {
-  ASSERT(!name.empty());
 #ifdef ENVOY_HANDLE_SIGNALS
   SignalAction::registerFatalErrorHandler(*this);
 #endif

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -43,6 +43,7 @@ DispatcherImpl::DispatcherImpl(const std::string& name, Buffer::WatermarkFactory
       deferred_delete_timer_(createTimerInternal([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimerInternal([this]() -> void { runPostCallbacks(); })),
       current_to_delete_(&to_delete_1_) {
+  ASSERT(!name.empty());
 #ifdef ENVOY_HANDLE_SIGNALS
   SignalAction::registerFatalErrorHandler(*this);
 #endif

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -91,6 +91,7 @@ public:
 
 private:
   TimerPtr createTimerInternal(TimerCb cb);
+  void updateApproximateMonotonicTimeInternal();
   void runPostCallbacks();
 
   // Validate that an operation is thread safe, i.e. it's invoked on the same thread that the

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -101,7 +101,7 @@ private:
     return run_tid_.isEmpty() || run_tid_ == api_.threadFactory().currentThreadId();
   }
 
-  std::string name_;
+  const std::string name_;
   Api::Api& api_;
   std::string stats_prefix_;
   std::unique_ptr<DispatcherStats> stats_;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -30,8 +30,8 @@ class DispatcherImpl : Logger::Loggable<Logger::Id::main>,
                        public Dispatcher,
                        public FatalErrorHandlerInterface {
 public:
-  DispatcherImpl(Api::Api& api, Event::TimeSystem& time_system);
-  DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory, Api::Api& api,
+  DispatcherImpl(const std::string& name, Api::Api& api, Event::TimeSystem& time_system);
+  DispatcherImpl(const std::string& name, Buffer::WatermarkFactoryPtr&& factory, Api::Api& api,
                  Event::TimeSystem& time_system);
   ~DispatcherImpl() override;
 
@@ -41,8 +41,9 @@ public:
   event_base& base() { return base_scheduler_.base(); }
 
   // Event::Dispatcher
+  const std::string& name() override { return name_; }
   TimeSource& timeSource() override { return api_.timeSource(); }
-  void initializeStats(Stats::Scope& scope, const std::string& prefix) override;
+  void initializeStats(Stats::Scope& scope, const absl::optional<std::string>& prefix) override;
   void clearDeferredDeleteList() override;
   Network::ConnectionPtr createServerConnection(Network::ConnectionSocketPtr&& socket,
                                                 Network::TransportSocketPtr&& transport_socket,
@@ -99,6 +100,7 @@ private:
     return run_tid_.isEmpty() || run_tid_ == api_.threadFactory().currentThreadId();
   }
 
+  std::string name_;
   Api::Api& api_;
   std::string stats_prefix_;
   std::unique_ptr<DispatcherStats> stats_;

--- a/source/server/config_validation/api.cc
+++ b/source/server/config_validation/api.cc
@@ -11,11 +11,12 @@ ValidationImpl::ValidationImpl(Thread::ThreadFactory& thread_factory, Stats::Sto
                                Event::TimeSystem& time_system, Filesystem::Instance& file_system)
     : Impl(thread_factory, stats_store, time_system, file_system), time_system_(time_system) {}
 
-Event::DispatcherPtr ValidationImpl::allocateDispatcher() {
-  return Event::DispatcherPtr{new Event::ValidationDispatcher(*this, time_system_)};
+Event::DispatcherPtr ValidationImpl::allocateDispatcher(const std::string& name) {
+  return Event::DispatcherPtr{new Event::ValidationDispatcher(name, *this, time_system_)};
 }
 
-Event::DispatcherPtr ValidationImpl::allocateDispatcher(Buffer::WatermarkFactoryPtr&&) {
+Event::DispatcherPtr ValidationImpl::allocateDispatcher(const std::string&,
+                                                        Buffer::WatermarkFactoryPtr&&) {
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 

--- a/source/server/config_validation/api.h
+++ b/source/server/config_validation/api.h
@@ -18,8 +18,9 @@ public:
   ValidationImpl(Thread::ThreadFactory& thread_factory, Stats::Store& stats_store,
                  Event::TimeSystem& time_system, Filesystem::Instance& file_system);
 
-  Event::DispatcherPtr allocateDispatcher() override;
-  Event::DispatcherPtr allocateDispatcher(Buffer::WatermarkFactoryPtr&& watermark_factory) override;
+  Event::DispatcherPtr allocateDispatcher(const std::string& name) override;
+  Event::DispatcherPtr allocateDispatcher(const std::string& name,
+                                          Buffer::WatermarkFactoryPtr&& watermark_factory) override;
 
 private:
   Event::TimeSystem& time_system_;

--- a/source/server/config_validation/async_client.cc
+++ b/source/server/config_validation/async_client.cc
@@ -4,7 +4,7 @@ namespace Envoy {
 namespace Http {
 
 ValidationAsyncClient::ValidationAsyncClient(Api::Api& api, Event::TimeSystem& time_system)
-    : dispatcher_(api, time_system) {}
+    : dispatcher_("validation_async_client", api, time_system) {}
 
 AsyncClient::Request* ValidationAsyncClient::send(RequestMessagePtr&&, Callbacks&,
                                                   const RequestOptions&) {

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -16,8 +16,8 @@ namespace Event {
  */
 class ValidationDispatcher : public DispatcherImpl {
 public:
-  ValidationDispatcher(Api::Api& api, Event::TimeSystem& time_system)
-      : DispatcherImpl(api, time_system) {}
+  ValidationDispatcher(const std::string& name, Api::Api& api, Event::TimeSystem& time_system)
+      : DispatcherImpl(name, api, time_system) {}
 
   Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr,

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -45,7 +45,7 @@ ValidationInstance::ValidationInstance(
                                              !options.rejectUnknownDynamicFields()),
       stats_store_(store),
       api_(new Api::ValidationImpl(thread_factory, store, time_system, file_system)),
-      dispatcher_(api_->allocateDispatcher()),
+      dispatcher_(api_->allocateDispatcher("main_thread")),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory())),
       access_log_manager_(options.fileFlushIntervalMsec(), *api_, *dispatcher_, access_log_lock,
                           store),

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -15,9 +15,8 @@
 namespace Envoy {
 namespace Server {
 
-ConnectionHandlerImpl::ConnectionHandlerImpl(Event::Dispatcher& dispatcher,
-                                             const std::string& per_handler_stat_prefix)
-    : dispatcher_(dispatcher), per_handler_stat_prefix_(per_handler_stat_prefix + "."),
+ConnectionHandlerImpl::ConnectionHandlerImpl(Event::Dispatcher& dispatcher)
+    : dispatcher_(dispatcher), per_handler_stat_prefix_(dispatcher.name() + "."),
       disable_listeners_(false) {}
 
 void ConnectionHandlerImpl::incNumConnections() { ++num_handler_connections_; }

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -61,7 +61,7 @@ class ConnectionHandlerImpl : public Network::ConnectionHandler,
                               NonCopyable,
                               Logger::Loggable<Logger::Id::conn_handler> {
 public:
-  ConnectionHandlerImpl(Event::Dispatcher& dispatcher, const std::string& per_handler_stat_prefix);
+  ConnectionHandlerImpl(Event::Dispatcher& dispatcher);
 
   // Network::ConnectionHandler
   uint64_t numConnections() const override { return num_handler_connections_; }

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -38,7 +38,7 @@ GuardDogImpl::GuardDogImpl(Stats::Scope& stats_scope, const Server::Configuratio
       watchdog_megamiss_counter_(stats_scope.counterFromStatName(
           Stats::StatNameManagedStorage("server.watchdog_mega_miss", stats_scope.symbolTable())
               .statName())),
-      dispatcher_(api.allocateDispatcher()),
+      dispatcher_(api.allocateDispatcher("guarddog_thread")),
       loop_timer_(dispatcher_->createTimer([this]() { step(); })), run_thread_(true) {
   start(api);
 }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -744,7 +744,7 @@ void ListenerManagerImpl::startWorkers(GuardDog& guard_dog) {
     }
     worker->start(guard_dog);
     if (enable_dispatcher_stats_) {
-      worker->initializeStats(*scope_, fmt::format("worker_{}.", i));
+      worker->initializeStats(*scope_);
     }
     i++;
   }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -63,9 +63,9 @@ InstanceImpl::InstanceImpl(
       api_(new Api::Impl(thread_factory, store, time_system, file_system,
                          process_context ? ProcessContextOptRef(std::ref(*process_context))
                                          : absl::nullopt)),
-      dispatcher_(api_->allocateDispatcher()),
+      dispatcher_(api_->allocateDispatcher("main_thread")),
       singleton_manager_(new Singleton::ManagerImpl(api_->threadFactory())),
-      handler_(new ConnectionHandlerImpl(*dispatcher_, "main_thread")),
+      handler_(new ConnectionHandlerImpl(*dispatcher_)),
       random_generator_(std::move(random_generator)), listener_component_factory_(*this),
       worker_factory_(thread_local_, *api_, hooks),
       access_log_manager_(options.fileFlushIntervalMsec(), *api_, *dispatcher_, access_log_lock,

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -39,14 +39,14 @@ class WorkerImpl : public Worker, Logger::Loggable<Logger::Id::main> {
 public:
   WorkerImpl(ThreadLocal::Instance& tls, ListenerHooks& hooks, Event::DispatcherPtr&& dispatcher,
              Network::ConnectionHandlerPtr handler, OverloadManager& overload_manager,
-             Api::Api& api, const std::string& worker_name);
+             Api::Api& api);
 
   // Server::Worker
   void addListener(Network::ListenerConfig& listener, AddListenerCompletion completion) override;
   uint64_t numConnections() const override;
   void removeListener(Network::ListenerConfig& listener, std::function<void()> completion) override;
   void start(GuardDog& guard_dog) override;
-  void initializeStats(Stats::Scope& scope, const std::string& prefix) override;
+  void initializeStats(Stats::Scope& scope) override;
   void stop() override;
   void stopListener(Network::ListenerConfig& listener, std::function<void()> completion) override;
 
@@ -60,7 +60,6 @@ private:
   Network::ConnectionHandlerPtr handler_;
   Api::Api& api_;
   Thread::ThreadPtr thread_;
-  const std::string worker_name_;
   WatchDogSharedPtr watch_dog_;
 };
 

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -30,7 +30,7 @@ public:
   FilesystemSubscriptionTestHarness()
       : path_(TestEnvironment::temporaryPath("eds.json")),
         api_(Api::createApiForTest(stats_store_, simTime())),
-        dispatcher_(api_->allocateDispatcher()),
+        dispatcher_(api_->allocateDispatcher("test_thread")),
         subscription_(*dispatcher_, path_, callbacks_, stats_, validation_visitor_, *api_) {}
 
   ~FilesystemSubscriptionTestHarness() override { TestEnvironment::removePath(path_); }

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -36,7 +36,7 @@ private:
 TEST(DeferredDeleteTest, DeferredDelete) {
   InSequence s;
   Api::ApiPtr api = Api::createApiForTest();
-  DispatcherPtr dispatcher(api->allocateDispatcher());
+  DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   ReadyWatcher watcher1;
 
   dispatcher->deferredDelete(
@@ -66,7 +66,8 @@ TEST(DeferredDeleteTest, DeferredDelete) {
 
 class DispatcherImplTest : public testing::Test {
 protected:
-  DispatcherImplTest() : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {
+  DispatcherImplTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {
     dispatcher_thread_ = api_->threadFactory().createThread([this]() {
       // Must create a keepalive timer to keep the dispatcher from exiting.
       std::chrono::milliseconds time_interval(500);
@@ -246,7 +247,7 @@ TEST_F(DispatcherImplTest, IsThreadSafe) {
 class NotStartedDispatcherImplTest : public testing::Test {
 protected:
   NotStartedDispatcherImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   Api::ApiPtr api_;
   DispatcherPtr dispatcher_;
@@ -261,7 +262,7 @@ TEST_F(NotStartedDispatcherImplTest, IsThreadSafe) {
 class DispatcherMonotonicTimeTest : public testing::Test {
 protected:
   DispatcherMonotonicTimeTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
   ~DispatcherMonotonicTimeTest() override = default;
 
   Api::ApiPtr api_;
@@ -303,7 +304,7 @@ TEST_F(DispatcherMonotonicTimeTest, ApproximateMonotonicTime) {
 
 TEST(TimerImplTest, TimerEnabledDisabled) {
   Api::ApiPtr api = Api::createApiForTest();
-  DispatcherPtr dispatcher(api->allocateDispatcher());
+  DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   Event::TimerPtr timer = dispatcher->createTimer([] {});
   EXPECT_FALSE(timer->enabled());
   timer->enableTimer(std::chrono::milliseconds(0));
@@ -341,7 +342,7 @@ public:
 TEST_F(TimerImplTimingTest, TheoreticalTimerTiming) {
   Event::SimulatedTimeSystem time_system;
   Api::ApiPtr api = Api::createApiForTest(time_system);
-  DispatcherPtr dispatcher(api->allocateDispatcher());
+  DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   Event::TimerPtr timer = dispatcher->createTimer([&dispatcher] { dispatcher->exit(); });
 
   const uint64_t timings[] = {0, 10, 50, 1234};

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -19,7 +19,7 @@ namespace {
 class FileEventImplTest : public testing::Test {
 public:
   FileEventImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")),
         os_sys_calls_(Api::OsSysCallsSingleton::get()) {}
 
   void SetUp() override {
@@ -65,7 +65,7 @@ TEST_P(FileEventImplActivateTest, Activate) {
   ASSERT_TRUE(SOCKET_VALID(fd));
 
   Api::ApiPtr api = Api::createApiForTest();
-  DispatcherPtr dispatcher(api->allocateDispatcher());
+  DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   ReadyWatcher read_event;
   EXPECT_CALL(read_event, ready()).Times(1);
   ReadyWatcher write_event;

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -16,7 +16,8 @@ namespace Filesystem {
 
 class WatcherImplTest : public testing::Test {
 protected:
-  WatcherImplTest() : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+  WatcherImplTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -50,7 +50,7 @@ class EnvoyGoogleAsyncClientImplTest : public testing::Test {
 public:
   EnvoyGoogleAsyncClientImplTest()
       : stats_store_(new Stats::IsolatedStoreImpl), api_(Api::createApiForTest(*stats_store_)),
-        dispatcher_(api_->allocateDispatcher()), scope_(stats_store_),
+        dispatcher_(api_->allocateDispatcher("test_thread")), scope_(stats_store_),
         method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
         stat_names_(scope_->symbolTable()) {
 

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -226,7 +226,8 @@ public:
   GrpcClientIntegrationTest()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
         api_(Api::createApiForTest(*stats_store_, test_time_.timeSystem())),
-        dispatcher_(api_->allocateDispatcher()), http_context_(stats_store_->symbolTable()) {}
+        dispatcher_(api_->allocateDispatcher("test_thread")),
+        http_context_(stats_store_->symbolTable()) {}
 
   virtual void initialize() {
     if (fake_upstream_ == nullptr) {

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -286,7 +286,7 @@ TEST_F(CodecClientTest, SSLConnectionInfo) {
 class CodecNetworkTest : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   CodecNetworkTest() : api_(Api::createApiForTest()), stream_info_(api_->timeSource()) {
-    dispatcher_ = api_->allocateDispatcher();
+    dispatcher_ = api_->allocateDispatcher("test_thread");
     auto socket = std::make_shared<Network::TcpListenSocket>(
         Network::Test::getAnyAddress(GetParam()), nullptr, true);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(

--- a/test/common/http/http1/conn_pool_legacy_test.cc
+++ b/test/common/http/http1/conn_pool_legacy_test.cc
@@ -85,7 +85,7 @@ public:
     test_client.codec_ = new NiceMock<Http::MockClientConnection>();
     test_client.connect_timer_ = new NiceMock<Event::MockTimer>(&mock_dispatcher_);
     std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
-    test_client.client_dispatcher_ = api_->allocateDispatcher();
+    test_client.client_dispatcher_ = api_->allocateDispatcher("test_thread");
     Network::ClientConnectionPtr connection{test_client.connection_};
     test_client.codec_client_ = new CodecClientForTest(
         CodecClient::Type::HTTP1, std::move(connection), test_client.codec_,

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -84,7 +84,7 @@ public:
     test_client.codec_ = new NiceMock<Http::MockClientConnection>();
     test_client.connect_timer_ = new NiceMock<Event::MockTimer>(&mock_dispatcher_);
     std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
-    test_client.client_dispatcher_ = api_->allocateDispatcher();
+    test_client.client_dispatcher_ = api_->allocateDispatcher("test_thread");
     Network::ClientConnectionPtr connection{test_client.connection_};
     test_client.codec_client_ = new CodecClientForTest(
         CodecClient::Type::HTTP1, std::move(connection), test_client.codec_,

--- a/test/common/http/http2/conn_pool_legacy_test.cc
+++ b/test/common/http/http2/conn_pool_legacy_test.cc
@@ -79,7 +79,7 @@ public:
     test_client.connection_ = new NiceMock<Network::MockClientConnection>();
     test_client.codec_ = new NiceMock<Http::MockClientConnection>();
     test_client.connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-    test_client.client_dispatcher_ = api_->allocateDispatcher();
+    test_client.client_dispatcher_ = api_->allocateDispatcher("test_thread");
     EXPECT_CALL(*test_client.connect_timer_, enableTimer(_, _));
     EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _))
         .WillOnce(Return(test_client.connection_));

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -78,7 +78,7 @@ public:
     test_client.connection_ = new NiceMock<Network::MockClientConnection>();
     test_client.codec_ = new NiceMock<Http::MockClientConnection>();
     test_client.connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-    test_client.client_dispatcher_ = api_->allocateDispatcher();
+    test_client.client_dispatcher_ = api_->allocateDispatcher("test_thread");
     EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _))
         .WillOnce(Return(test_client.connection_));
     auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();

--- a/test/common/memory/heap_shrinker_test.cc
+++ b/test/common/memory/heap_shrinker_test.cc
@@ -21,7 +21,8 @@ namespace {
 class HeapShrinkerTest : public testing::Test {
 protected:
   HeapShrinkerTest()
-      : api_(Api::createApiForTest(stats_, time_system_)), dispatcher_(*api_, time_system_) {}
+      : api_(Api::createApiForTest(stats_, time_system_)),
+        dispatcher_("test_thread", *api_, time_system_) {}
 
   void step() {
     time_system_.sleep(std::chrono::milliseconds(10000));

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -83,7 +83,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectionImplDeathTest,
 
 TEST_P(ConnectionImplDeathTest, BadFd) {
   Api::ApiPtr api = Api::createApiForTest();
-  Event::DispatcherPtr dispatcher(api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>();
   StreamInfo::StreamInfoImpl stream_info(dispatcher->timeSource());
   EXPECT_DEATH_LOG_TO_STDERR(
@@ -99,7 +99,7 @@ protected:
 
   void setUpBasicConnection() {
     if (dispatcher_.get() == nullptr) {
-      dispatcher_ = api_->allocateDispatcher();
+      dispatcher_ = api_->allocateDispatcher("test_thread");
     }
     socket_ = std::make_shared<Network::TcpListenSocket>(Network::Test::getAnyAddress(GetParam()),
                                                          nullptr, true);
@@ -163,7 +163,7 @@ protected:
     ASSERT(dispatcher_.get() == nullptr);
 
     MockBufferFactory* factory = new StrictMock<MockBufferFactory>;
-    dispatcher_ = api_->allocateDispatcher(Buffer::WatermarkFactoryPtr{factory});
+    dispatcher_ = api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{factory});
     // The first call to create a client session will get a MockBuffer.
     // Other calls for server sessions will by default get a normal OwnedImpl.
     EXPECT_CALL(*factory, create_(_, _))
@@ -275,7 +275,7 @@ TEST_P(ConnectionImplTest, CloseDuringConnectCallback) {
 }
 
 TEST_P(ConnectionImplTest, ImmediateConnectError) {
-  dispatcher_ = api_->allocateDispatcher();
+  dispatcher_ = api_->allocateDispatcher("test_thread");
 
   // Using a broadcast/multicast address as the connection destinations address causes an
   // immediate error return from connect().
@@ -987,7 +987,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
     source_address_ = Network::Address::InstanceConstSharedPtr{
         new Network::Address::Ipv6Instance(address_string, 0)};
   }
-  dispatcher_ = api_->allocateDispatcher();
+  dispatcher_ = api_->allocateDispatcher("test_thread");
   socket_ = std::make_shared<Network::TcpListenSocket>(Network::Test::getAnyAddress(GetParam()),
                                                        nullptr, true);
   listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
@@ -1992,7 +1992,7 @@ class ReadBufferLimitTest : public ConnectionImplTest {
 public:
   void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size) {
     const uint32_t buffer_size = 256 * 1024;
-    dispatcher_ = api_->allocateDispatcher();
+    dispatcher_ = api_->allocateDispatcher("test_thread");
     socket_ = std::make_shared<Network::TcpListenSocket>(Network::Test::getAnyAddress(GetParam()),
                                                          nullptr, true);
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
@@ -2061,7 +2061,7 @@ TEST_P(ReadBufferLimitTest, SomeLimit) {
 class TcpClientConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {
 protected:
   TcpClientConnectionImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
@@ -2104,7 +2104,7 @@ TEST_P(TcpClientConnectionImplTest, BadConnectConnRefused) {
 class PipeClientConnectionImplTest : public testing::Test {
 protected:
   PipeClientConnectionImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -337,7 +337,8 @@ private:
 
 class DnsImplConstructor : public testing::Test {
 protected:
-  DnsImplConstructor() : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+  DnsImplConstructor()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
@@ -417,7 +418,8 @@ TEST_F(DnsImplConstructor, BadCustomResolvers) {
 
 class DnsImplTest : public testing::TestWithParam<Address::IpVersion> {
 public:
-  DnsImplTest() : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+  DnsImplTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   void SetUp() override {
     resolver_ = dispatcher_->createDnsResolver({}, use_tcp_for_dns_lookups());

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -26,7 +26,7 @@ static void errorCallbackTest(Address::IpVersion version) {
   // Force the error callback to fire by closing the socket under the listener. We run this entire
   // test in the forked process to avoid confusion when the fork happens.
   Api::ApiPtr api = Api::createApiForTest();
-  Event::DispatcherPtr dispatcher(api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
 
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(version), nullptr, true);

--- a/test/common/network/listener_impl_test_base.h
+++ b/test/common/network/listener_impl_test_base.h
@@ -21,7 +21,7 @@ protected:
       : version_(GetParam()),
         alt_address_(Network::Test::findOrCheckFreePort(
             Network::Test::getCanonicalLoopbackAddress(version_), Address::SocketType::Stream)),
-        api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+        api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   Event::DispatcherImpl& dispatcherImpl() {
     // We need access to the concrete impl type in order to instantiate a

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -31,7 +31,8 @@ namespace {
 
 class SdsApiTest : public testing::Test {
 protected:
-  SdsApiTest() : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {
+  SdsApiTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {
     EXPECT_CALL(init_manager_, add(_)).WillOnce(Invoke([this](const Init::Target& target) {
       init_target_handle_ = target.createHandle("test");
     }));

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -33,7 +33,7 @@ namespace {
 class SecretManagerImplTest : public testing::Test, public Logger::Loggable<Logger::Id::secret> {
 protected:
   SecretManagerImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {}
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   void checkConfigDump(const std::string& expected_dump_yaml) {
     auto message_ptr = config_tracker_.config_tracker_callbacks_["secrets"]();

--- a/test/common/shared_pool/shared_pool_test.cc
+++ b/test/common/shared_pool/shared_pool_test.cc
@@ -15,7 +15,8 @@ namespace SharedPool {
 
 class SharedPoolTest : public testing::Test {
 protected:
-  SharedPoolTest() : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()) {
+  SharedPoolTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {
     dispatcher_thread_ = api_->threadFactory().createThread([this]() {
       // Must create a keepalive timer to keep the dispatcher from exiting.
       std::chrono::milliseconds time_interval(500);

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -50,7 +50,7 @@ public:
   }
 
   void initThreading() {
-    dispatcher_ = api_->allocateDispatcher();
+    dispatcher_ = api_->allocateDispatcher("test_thread");
     tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
     store_.initializeThreading(*dispatcher_, *tls_);
   }

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -1033,7 +1033,7 @@ TEST_F(StatsThreadLocalStoreTest, MergeDuringShutDown) {
 TEST(ThreadLocalStoreThreadTest, ConstructDestruct) {
   SymbolTablePtr symbol_table(SymbolTableCreator::makeSymbolTable());
   Api::ApiPtr api = Api::createApiForTest();
-  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
   NiceMock<ThreadLocal::MockInstance> tls;
   AllocatorImpl alloc(*symbol_table);
   ThreadLocalStoreImpl store(alloc);
@@ -1335,13 +1335,14 @@ public:
   }
 
   void workerThreadFn(uint32_t thread_index, BlockingBarrier& blocking_barrier) {
-    thread_dispatchers_[thread_index] = api_->allocateDispatcher();
+    thread_dispatchers_[thread_index] =
+        api_->allocateDispatcher(absl::StrCat("test_worker_", thread_index));
     blocking_barrier.decrementCount();
     thread_dispatchers_[thread_index]->run(Event::Dispatcher::RunType::RunUntilExit);
   }
 
   void mainThreadFn(BlockingBarrier& blocking_barrier) {
-    main_dispatcher_ = api_->allocateDispatcher();
+    main_dispatcher_ = api_->allocateDispatcher("test_main_thread");
     blocking_barrier.decrementCount();
     main_dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
   }

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -49,8 +49,8 @@ public:
   int freeSlotIndexesListSize() { return tls_.free_slot_indexes_.size(); }
   InstanceImpl tls_;
 
-  Event::MockDispatcher main_dispatcher_;
-  Event::MockDispatcher thread_dispatcher_;
+  Event::MockDispatcher main_dispatcher_{"test_main_thread"};
+  Event::MockDispatcher thread_dispatcher_{"test_worker_thread"};
 };
 
 TEST_F(ThreadLocalInstanceImplTest, All) {
@@ -199,8 +199,8 @@ TEST(ThreadLocalInstanceImplDispatcherTest, Dispatcher) {
   InstanceImpl tls;
 
   Api::ApiPtr api = Api::createApiForTest();
-  Event::DispatcherPtr main_dispatcher(api->allocateDispatcher());
-  Event::DispatcherPtr thread_dispatcher(api->allocateDispatcher());
+  Event::DispatcherPtr main_dispatcher(api->allocateDispatcher("test_main_thread"));
+  Event::DispatcherPtr thread_dispatcher(api->allocateDispatcher("test_worker_thread"));
 
   tls.registerThread(*main_dispatcher, true);
   tls.registerThread(*thread_dispatcher, false);

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -41,11 +41,12 @@ class ProxyProtocolRegressionTest : public testing::TestWithParam<Network::Addre
                                     protected Logger::Loggable<Logger::Id::main> {
 public:
   ProxyProtocolRegressionTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest(stats_store_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")),
         socket_(std::make_shared<Network::TcpListenSocket>(
             Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true)),
-        connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_, "test_thread")),
-        name_("proxy"), filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
+        connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_)), name_("proxy"),
+        filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
     EXPECT_CALL(socket_factory_, socketType())
         .WillOnce(Return(Network::Address::SocketType::Stream));
     EXPECT_CALL(socket_factory_, localAddress()).WillOnce(ReturnRef(socket_->localAddress()));

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -37,7 +37,7 @@ public:
   }
 
   Server::MockAdmin admin_;
-  Event::MockDispatcher main_thread_dispatcher_;
+  Event::MockDispatcher main_thread_dispatcher_{"test_main_thread"};
   std::unique_ptr<AdminHandler> handler_;
   Server::Admin::HandlerCb cb_;
   Http::TestResponseHeaderMapImpl response_headers_;

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -47,7 +47,8 @@ protected:
 class GradientControllerTest : public testing::Test {
 public:
   GradientControllerTest()
-      : api_(Api::createApiForTest(time_system_)), dispatcher_(api_->allocateDispatcher()) {}
+      : api_(Api::createApiForTest(time_system_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   GradientControllerSharedPtr makeController(const std::string& yaml_config) {
     return std::make_shared<GradientController>(makeConfig(yaml_config, runtime_), *dispatcher_,

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -54,11 +54,12 @@ class ProxyProtocolTest : public testing::TestWithParam<Network::Address::IpVers
                           protected Logger::Loggable<Logger::Id::main> {
 public:
   ProxyProtocolTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest(stats_store_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")),
         socket_(std::make_shared<Network::TcpListenSocket>(
             Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true)),
-        connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_, "test_thread")),
-        name_("proxy"), filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
+        connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_)), name_("proxy"),
+        filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
     EXPECT_CALL(socket_factory_, socketType())
         .WillOnce(Return(Network::Address::SocketType::Stream));
     EXPECT_CALL(socket_factory_, localAddress()).WillOnce(ReturnRef(socket_->localAddress()));
@@ -991,14 +992,15 @@ class WildcardProxyProtocolTest : public testing::TestWithParam<Network::Address
                                   protected Logger::Loggable<Logger::Id::main> {
 public:
   WildcardProxyProtocolTest()
-      : api_(Api::createApiForTest(stats_store_)), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest(stats_store_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")),
         socket_(std::make_shared<Network::TcpListenSocket>(Network::Test::getAnyAddress(GetParam()),
                                                            nullptr, true)),
         local_dst_address_(Network::Utility::getAddressWithPort(
             *Network::Test::getCanonicalLoopbackAddress(GetParam()),
             socket_->localAddress()->ip()->port())),
-        connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_, "test_thread")),
-        name_("proxy"), filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
+        connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_)), name_("proxy"),
+        filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
     EXPECT_CALL(socket_factory_, socketType())
         .WillOnce(Return(Network::Address::SocketType::Stream));
     EXPECT_CALL(socket_factory_, localAddress()).WillOnce(ReturnRef(socket_->localAddress()));

--- a/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
+++ b/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
@@ -55,9 +55,9 @@ protected:
 
   ActiveQuicListenerTest()
       : version_(GetParam()), api_(Api::createApiForTest(simulated_time_system_)),
-        dispatcher_(api_->allocateDispatcher()), clock_(*dispatcher_),
+        dispatcher_(api_->allocateDispatcher("test_thread")), clock_(*dispatcher_),
         local_address_(Network::Test::getCanonicalLoopbackAddress(version_)),
-        connection_handler_(*dispatcher_, "test_thread") {}
+        connection_handler_(*dispatcher_) {}
 
   void SetUp() override {
     listen_socket_ =

--- a/test/extensions/quic_listeners/quiche/envoy_quic_alarm_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_alarm_test.cc
@@ -31,8 +31,9 @@ private:
 class EnvoyQuicAlarmTest : public ::testing::Test {
 public:
   EnvoyQuicAlarmTest()
-      : api_(Api::createApiForTest(time_system_)), dispatcher_(api_->allocateDispatcher()),
-        clock_(*dispatcher_), alarm_factory_(*dispatcher_, clock_) {}
+      : api_(Api::createApiForTest(time_system_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")), clock_(*dispatcher_),
+        alarm_factory_(*dispatcher_, clock_) {}
 
   void advanceMsAndLoop(int64_t delay_ms) {
     time_system_.sleep(std::chrono::milliseconds(delay_ms));

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
@@ -91,8 +91,8 @@ public:
 class EnvoyQuicClientSessionTest : public testing::TestWithParam<bool> {
 public:
   EnvoyQuicClientSessionTest()
-      : api_(Api::createApiForTest(time_system_)), dispatcher_(api_->allocateDispatcher()),
-        connection_helper_(*dispatcher_),
+      : api_(Api::createApiForTest(time_system_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")), connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_enable_version_draft_27, GetParam());
           return quic::ParsedVersionOfIndex(quic::CurrentSupportedVersions(), 0);

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
@@ -22,7 +22,7 @@ using testing::Invoke;
 class EnvoyQuicClientStreamTest : public testing::TestWithParam<bool> {
 public:
   EnvoyQuicClientStreamTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")),
         connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_enable_version_draft_27, GetParam());

--- a/test/extensions/quic_listeners/quiche/envoy_quic_dispatcher_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_dispatcher_test.cc
@@ -49,7 +49,7 @@ class EnvoyQuicDispatcherTest : public testing::TestWithParam<Network::Address::
 public:
   EnvoyQuicDispatcherTest()
       : version_(GetParam()), api_(Api::createApiForTest(time_system_)),
-        dispatcher_(api_->allocateDispatcher()),
+        dispatcher_(api_->allocateDispatcher("test_thread")),
         listen_socket_(std::make_unique<Network::NetworkListenSocket<
                            Network::NetworkSocketTrait<Network::Address::SocketType::Datagram>>>(
             Network::Test::getCanonicalLoopbackAddress(version_), nullptr, /*bind*/ true)),
@@ -64,7 +64,7 @@ public:
         per_worker_stats_({ALL_PER_HANDLER_LISTENER_STATS(
             POOL_COUNTER_PREFIX(listener_config_.listenerScope(), "worker."),
             POOL_GAUGE_PREFIX(listener_config_.listenerScope(), "worker."))}),
-        connection_handler_(*dispatcher_, "test_thread"),
+        connection_handler_(*dispatcher_),
         envoy_quic_dispatcher_(
             &crypto_config_, quic_config_, &version_manager_,
             std::make_unique<EnvoyQuicConnectionHelper>(*dispatcher_),

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
@@ -100,8 +100,8 @@ public:
 class EnvoyQuicServerSessionTest : public testing::TestWithParam<bool> {
 public:
   EnvoyQuicServerSessionTest()
-      : api_(Api::createApiForTest(time_system_)), dispatcher_(api_->allocateDispatcher()),
-        connection_helper_(*dispatcher_),
+      : api_(Api::createApiForTest(time_system_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")), connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_enable_version_draft_27, GetParam());
           return quic::ParsedVersionOfIndex(quic::CurrentSupportedVersions(), 0);

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
@@ -27,7 +27,7 @@ namespace Quic {
 class EnvoyQuicServerStreamTest : public testing::TestWithParam<bool> {
 public:
   EnvoyQuicServerStreamTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")),
         connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_enable_version_draft_27, GetParam());

--- a/test/extensions/quic_listeners/quiche/platform/envoy_quic_clock_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/envoy_quic_clock_test.cc
@@ -15,7 +15,7 @@ namespace Quic {
 TEST(EnvoyQuicClockTest, TestNow) {
   Event::SimulatedTimeSystemHelper time_system;
   Api::ApiPtr api = Api::createApiForTest(time_system);
-  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
   EnvoyQuicClock clock(*dispatcher);
   uint64_t mono_time = std::chrono::duration_cast<std::chrono::microseconds>(
                            time_system.monotonicTime().time_since_epoch())
@@ -44,7 +44,7 @@ TEST(EnvoyQuicClockTest, TestNow) {
 TEST(EnvoyQuicClockTest, TestMonotonicityWithReadTimeSystem) {
   Event::TestRealTimeSystem time_system;
   Api::ApiPtr api = Api::createApiForTest(time_system);
-  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
   EnvoyQuicClock clock(*dispatcher);
   quic::QuicTime last_now = clock.Now();
   for (int i = 0; i < 1000; ++i) {
@@ -57,7 +57,7 @@ TEST(EnvoyQuicClockTest, TestMonotonicityWithReadTimeSystem) {
 TEST(EnvoyQuicClockTest, ApproximateNow) {
   Event::SimulatedTimeSystemHelper time_system;
   Api::ApiPtr api = Api::createApiForTest(time_system);
-  Event::DispatcherPtr dispatcher = api->allocateDispatcher();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
   EnvoyQuicClock clock(*dispatcher);
 
   // ApproximateTime() is cached, it not change only because time passes.

--- a/test/extensions/resource_monitors/injected_resource/config_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/config_test.cc
@@ -28,7 +28,7 @@ TEST(InjectedResourceMonitorFactoryTest, CreateMonitor) {
   envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig config;
   config.set_filename(TestEnvironment::temporaryPath("injected_resource"));
   Api::ApiPtr api = Api::createApiForTest();
-  Event::DispatcherPtr dispatcher(api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   Server::Configuration::ResourceMonitorFactoryContextImpl context(
       *dispatcher, *api, ProtobufMessage::getStrictValidationVisitor());
   Server::ResourceMonitorPtr monitor = factory->createResourceMonitor(config, context);

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -48,7 +48,7 @@ public:
 class InjectedResourceMonitorTest : public testing::Test {
 protected:
   InjectedResourceMonitorTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")),
         resource_filename_(TestEnvironment::temporaryPath("injected_resource")),
         file_updater_(resource_filename_), monitor_(createMonitor()) {}
 

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -294,7 +294,7 @@ void testUtil(const TestUtilOptions& options) {
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
                                                    server_stats_store, std::vector<std::string>{});
 
-  Event::DispatcherPtr dispatcher = server_api->allocateDispatcher();
+  Event::DispatcherPtr dispatcher = server_api->allocateDispatcher("test_thread");
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(options.version()), nullptr, true);
   Network::MockListenerCallbacks callbacks;
@@ -582,7 +582,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
                                                    server_stats_store, server_names);
 
-  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(options.version()), nullptr, true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
@@ -774,7 +774,8 @@ void configureServerAndExpiredClientCertificate(
 class SslSocketTest : public SslCertsTest,
                       public testing::WithParamInterface<Network::Address::IpVersion> {
 protected:
-  SslSocketTest() : dispatcher_(api_->allocateDispatcher()), stream_info_(api_->timeSource()) {}
+  SslSocketTest()
+      : dispatcher_(api_->allocateDispatcher("test_thread")), stream_info_(api_->timeSource()) {}
 
   void testClientSessionResumption(const std::string& server_ctx_yaml,
                                    const std::string& client_ctx_yaml, bool expect_reuse,
@@ -2583,7 +2584,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
       Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr, true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
-  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   Network::ListenerPtr listener1 = dispatcher->createListener(socket1, callbacks, true);
   Network::ListenerPtr listener2 = dispatcher->createListener(socket2, callbacks, true);
 
@@ -2719,7 +2720,7 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
       Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr, true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
-  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   Network::ListenerPtr listener = dispatcher->createListener(tcp_socket, callbacks, true);
 
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client_tls_context;
@@ -3276,7 +3277,7 @@ void SslSocketTest::testClientSessionResumption(const std::string& server_ctx_ya
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
   Api::ApiPtr api = Api::createApiForTest(server_stats_store, time_system_);
-  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher());
+  Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   Network::ListenerPtr listener = dispatcher->createListener(socket, callbacks, true);
 
   Network::ConnectionPtr server_connection;
@@ -4364,7 +4365,7 @@ protected:
   void singleWriteTest(uint32_t read_buffer_limit, uint32_t bytes_to_write) {
     MockWatermarkBuffer* client_write_buffer = nullptr;
     MockBufferFactory* factory = new StrictMock<MockBufferFactory>;
-    dispatcher_ = api_->allocateDispatcher(Buffer::WatermarkFactoryPtr{factory});
+    dispatcher_ = api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{factory});
 
     // By default, expect 4 buffers to be created - the client and server read and write buffers.
     EXPECT_CALL(*factory, create_(_, _))

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -423,8 +423,8 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
     : http_type_(type), socket_(Network::SocketSharedPtr(listen_socket.release())),
       socket_factory_(std::make_shared<FakeListenSocketFactory>(socket_)),
       api_(Api::createApiForTest(stats_store_)), time_system_(time_system),
-      dispatcher_(api_->allocateDispatcher()),
-      handler_(new Server::ConnectionHandlerImpl(*dispatcher_, "fake_upstream")),
+      dispatcher_(api_->allocateDispatcher("fake_upstream")),
+      handler_(new Server::ConnectionHandlerImpl(*dispatcher_)),
       allow_unexpected_disconnects_(false), read_disable_on_new_connection_(true),
       enable_half_close_(enable_half_close), listener_(*this),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -252,7 +252,8 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
                                          const std::string& config)
     : api_(Api::createApiForTest(stats_store_)),
       mock_buffer_factory_(new NiceMock<MockBufferFactory>),
-      dispatcher_(api_->allocateDispatcher(Buffer::WatermarkFactoryPtr{mock_buffer_factory_})),
+      dispatcher_(api_->allocateDispatcher("test_thread",
+                                           Buffer::WatermarkFactoryPtr{mock_buffer_factory_})),
       version_(version), upstream_address_fn_(upstream_address_fn),
       config_helper_(version, *api_, config),
       default_log_level_(TestEnvironment::getOptions().logLevel()) {

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -68,7 +68,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
   Event::GlobalTimeSystem time_system;
   Api::Impl api(Thread::threadFactoryForTest(), mock_stats_store, time_system,
                 Filesystem::fileSystemForTest());
-  Event::DispatcherPtr dispatcher(api.allocateDispatcher());
+  Event::DispatcherPtr dispatcher(api.allocateDispatcher("test_thread"));
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionConstSharedPtr host_description{
       Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80")};
@@ -117,7 +117,7 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
                                          Network::Address::IpVersion version) {
   api_ = Api::createApiForTest(stats_store_);
   Event::GlobalTimeSystem time_system;
-  dispatcher_ = api_->allocateDispatcher();
+  dispatcher_ = api_->allocateDispatcher("test_thread");
   callbacks_ = std::make_unique<ConnectionCallbacks>();
   client_ = dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(

--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -19,11 +19,13 @@ MockApi::MockApi() {
 
 MockApi::~MockApi() = default;
 
-Event::DispatcherPtr MockApi::allocateDispatcher() {
-  return Event::DispatcherPtr{allocateDispatcher_(time_system_)};
+Event::DispatcherPtr MockApi::allocateDispatcher(const std::string& name) {
+  return Event::DispatcherPtr{allocateDispatcher_(name, time_system_)};
 }
-Event::DispatcherPtr MockApi::allocateDispatcher(Buffer::WatermarkFactoryPtr&& watermark_factory) {
-  return Event::DispatcherPtr{allocateDispatcher_(std::move(watermark_factory), time_system_)};
+Event::DispatcherPtr MockApi::allocateDispatcher(const std::string& name,
+                                                 Buffer::WatermarkFactoryPtr&& watermark_factory) {
+  return Event::DispatcherPtr{
+      allocateDispatcher_(name, std::move(watermark_factory), time_system_)};
 }
 
 MockOsSysCalls::MockOsSysCalls() {

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -29,13 +29,15 @@ public:
   ~MockApi() override;
 
   // Api::Api
-  Event::DispatcherPtr allocateDispatcher() override;
-  Event::DispatcherPtr allocateDispatcher(Buffer::WatermarkFactoryPtr&& watermark_factory) override;
+  Event::DispatcherPtr allocateDispatcher(const std::string& name) override;
+  Event::DispatcherPtr allocateDispatcher(const std::string& name,
+                                          Buffer::WatermarkFactoryPtr&& watermark_factory) override;
   TimeSource& timeSource() override { return time_system_; }
 
-  MOCK_METHOD(Event::Dispatcher*, allocateDispatcher_, (Event::TimeSystem&));
+  MOCK_METHOD(Event::Dispatcher*, allocateDispatcher_, (const std::string&, Event::TimeSystem&));
   MOCK_METHOD(Event::Dispatcher*, allocateDispatcher_,
-              (Buffer::WatermarkFactoryPtr && watermark_factory, Event::TimeSystem&));
+              (const std::string&, Buffer::WatermarkFactoryPtr&& watermark_factory,
+               Event::TimeSystem&));
   MOCK_METHOD(Filesystem::Instance&, fileSystem, ());
   MOCK_METHOD(Thread::ThreadFactory&, threadFactory, ());
   MOCK_METHOD(const Stats::Scope&, rootScope, ());

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -18,7 +18,7 @@ namespace Event {
 MockDispatcher::MockDispatcher() : MockDispatcher("test_thread") {}
 
 MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
-  ON_CALL(*this, initializeStats(_)).WillByDefault(Return());
+  ON_CALL(*this, initializeStats(_, _)).WillByDefault(Return());
   ON_CALL(*this, clearDeferredDeleteList()).WillByDefault(Invoke([this]() -> void {
     to_delete_.clear();
   }));

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -15,8 +15,10 @@ using testing::SaveArg;
 namespace Envoy {
 namespace Event {
 
-MockDispatcher::MockDispatcher() {
-  ON_CALL(*this, initializeStats(_, _)).WillByDefault(Return());
+MockDispatcher::MockDispatcher() : MockDispatcher("test_thread") {}
+
+MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
+  ON_CALL(*this, initializeStats(_)).WillByDefault(Return());
   ON_CALL(*this, clearDeferredDeleteList()).WillByDefault(Invoke([this]() -> void {
     to_delete_.clear();
   }));

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -30,9 +30,11 @@ namespace Event {
 class MockDispatcher : public Dispatcher {
 public:
   MockDispatcher();
+  MockDispatcher(const std::string& name);
   ~MockDispatcher() override;
 
   // Dispatcher
+  const std::string& name() override { return name_; }
   TimeSource& timeSource() override { return time_system_; }
   Network::ConnectionPtr createServerConnection(Network::ConnectionSocketPtr&& socket,
                                                 Network::TransportSocketPtr&& transport_socket,
@@ -87,7 +89,7 @@ public:
   }
 
   // Event::Dispatcher
-  MOCK_METHOD(void, initializeStats, (Stats::Scope&, const std::string&));
+  MOCK_METHOD(void, initializeStats, (Stats::Scope&));
   MOCK_METHOD(void, clearDeferredDeleteList, ());
   MOCK_METHOD(Network::Connection*, createServerConnection_, ());
   MOCK_METHOD(Network::ClientConnection*, createClientConnection_,
@@ -122,6 +124,9 @@ public:
   GlobalTimeSystem time_system_;
   std::list<DeferredDeletablePtr> to_delete_;
   MockBufferFactory buffer_factory_;
+
+private:
+  const std::string name_;
 };
 
 class MockTimer : public Timer {

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -89,7 +89,7 @@ public:
   }
 
   // Event::Dispatcher
-  MOCK_METHOD(void, initializeStats, (Stats::Scope&));
+  MOCK_METHOD(void, initializeStats, (Stats::Scope&, const absl::optional<std::string>&));
   MOCK_METHOD(void, clearDeferredDeleteList, ());
   MOCK_METHOD(Network::Connection*, createServerConnection_, ());
   MOCK_METHOD(Network::ClientConnection*, createClientConnection_,

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -343,7 +343,7 @@ public:
   MOCK_METHOD(void, removeListener,
               (Network::ListenerConfig & listener, std::function<void()> completion));
   MOCK_METHOD(void, start, (GuardDog & guard_dog));
-  MOCK_METHOD(void, initializeStats, (Stats::Scope & scope, const std::string& prefix));
+  MOCK_METHOD(void, initializeStats, (Stats::Scope & scope));
   MOCK_METHOD(void, stop, ());
   MOCK_METHOD(void, stopListener,
               (Network::ListenerConfig & listener, std::function<void()> completion));

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -25,7 +25,7 @@ public:
     validation_ = std::make_unique<Api::ValidationImpl>(Thread::threadFactoryForTest(),
                                                         stats_store_, test_time_.timeSystem(),
                                                         Filesystem::fileSystemForTest());
-    dispatcher_ = validation_->allocateDispatcher();
+    dispatcher_ = validation_->allocateDispatcher("test_thread");
   }
 
   DangerousDeprecatedTestTime test_time_;

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -38,7 +38,7 @@ class ConnectionHandlerTest : public testing::Test, protected Logger::Loggable<L
 public:
   ConnectionHandlerTest()
       : socket_factory_(std::make_shared<Network::MockListenSocketFactory>()),
-        handler_(new ConnectionHandlerImpl(dispatcher_, "test")),
+        handler_(new ConnectionHandlerImpl(dispatcher_)),
         filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()),
         listener_filter_matcher_(std::make_shared<NiceMock<Network::MockListenerFilterMatcher>>()) {
     ON_CALL(*listener_filter_matcher_, matches(_)).WillByDefault(Return(false));

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -157,7 +157,7 @@ public:
   std::shared_ptr<Network::MockListenSocketFactory> socket_factory_;
   Network::Address::InstanceConstSharedPtr local_address_{
       new Network::Address::Ipv4Instance("127.0.0.1", 10001)};
-  NiceMock<Event::MockDispatcher> dispatcher_;
+  NiceMock<Event::MockDispatcher> dispatcher_{"test"};
   std::list<TestListenerPtr> listeners_;
   Network::ConnectionHandlerPtr handler_;
   NiceMock<Network::MockFilterChainManager> manager_;

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -3842,7 +3842,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, VerifyIgnoreExpirationWithCA) {
 // Validate that dispatcher stats prefix is set correctly when enabled.
 TEST_F(ListenerManagerImplWithDispatcherStatsTest, DispatherStatsWithCorrectPrefix) {
   EXPECT_CALL(*worker_, start(_));
-  EXPECT_CALL(*worker_, initializeStats(_, "worker_0."));
+  EXPECT_CALL(*worker_, initializeStats(_));
   manager_->startWorkers(guard_dog_);
 }
 

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -25,10 +25,10 @@ namespace {
 class WorkerImplTest : public testing::Test {
 public:
   WorkerImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher()),
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("worker_test")),
         no_exit_timer_(dispatcher_->createTimer([]() -> void {})),
         worker_(tls_, hooks_, std::move(dispatcher_), Network::ConnectionHandlerPtr{handler_},
-                overload_manager_, *api_, "worker_test") {
+                overload_manager_, *api_) {
     // In the real worker the watchdog has timers that prevent exit. Here we need to prevent event
     // loop exit since we use mock timers.
     no_exit_timer_->enableTimer(std::chrono::hours(1));
@@ -73,7 +73,7 @@ TEST_F(WorkerImplTest, BasicFlow) {
 
   NiceMock<Stats::MockStore> store;
   worker_.start(guard_dog_);
-  worker_.initializeStats(store, "test");
+  worker_.initializeStats(store);
   ci.waitReady();
 
   // After a worker is started adding/stopping/removing a listener happens on the worker thread.

--- a/test/test_common/contention.cc
+++ b/test/test_common/contention.cc
@@ -19,7 +19,7 @@ Envoy::Thread::ThreadPtr ContentionGenerator::launchThread(MutexTracerImpl& trac
 }
 
 void ContentionGenerator::holdUntilContention(MutexTracerImpl& tracer) {
-  Event::DispatcherPtr dispatcher = api_.allocateDispatcher();
+  Event::DispatcherPtr dispatcher = api_.allocateDispatcher("test_thread");
   Event::TimerPtr timer = dispatcher->createTimer([&dispatcher]() { dispatcher->exit(); });
   auto sleep_ms = [&timer, &dispatcher](int num_ms) {
     timer->enableTimer(std::chrono::milliseconds(num_ms));


### PR DESCRIPTION
Description: introduce `Event::Dispatcher::name()` to unify per-handler/worker statistics, such as `server.worker_2.watchdog_miss`
Risk Level: Medium
Testing: integration test, manual
Docs Changes: N/A
Release Notes: N/A
Fixes: #10544
