### PR TITLE
cluster: warm up strict dns cluster with 0 hosts

### DIFF
--- a/source/common/upstream/strict_dns_cluster.cc
+++ b/source/common/upstream/strict_dns_cluster.cc
@@ -55,6 +55,11 @@ void StrictDnsClusterImpl::startPreInit() {
   for (const ResolveTargetPtr& target : resolve_targets_) {
     target->startResolve();
   }
+  // If the config provides no endpoints, the cluster is initialized immediately as if all hosts are
+  // resolved in failure.
+  if (resolve_targets_.empty()) {
+    onPreInitComplete();
+  }
 }
 
 void StrictDnsClusterImpl::updateAllHosts(const HostVector& hosts_added,


### PR DESCRIPTION
Description:

Sometime control plane send strict dns cluster with no endpoint. No hosts to resolve so the cluster is never warmed up.
Choose to warmed up the cluster immediately, as if the resolver returns 0 available addresses.

Alternative solution: reject the cluster config.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Risk Level: LOW. Cluster is never guaranteed to have available hosts.
Testing:
Docs Changes:
Release Notes:
Fixes  #3566
[Optional Deprecated:]
