### PR TITLE
build: fix build errors for clang 10

### DIFF
--- a/source/extensions/filters/http/common/compressor/compressor.cc
+++ b/source/extensions/filters/http/common/compressor/compressor.cc
@@ -242,7 +242,7 @@ CompressorFilter::chooseEncoding(const Http::ResponseHeaderMap& headers) const {
   // Find intersection of encodings accepted by the user agent and provided
   // by the allowed compressors and choose the one with the highest q-value.
   EncPair choice{Http::Headers::get().AcceptEncodingValues.Identity, static_cast<float>(0)};
-  for (const auto pair : pairs) {
+  for (const auto& pair : pairs) {
     if ((pair.second > choice.second) &&
         (allowed_compressors.count(std::string(pair.first)) ||
          pair.first == Http::Headers::get().AcceptEncodingValues.Identity ||

--- a/source/extensions/filters/network/dubbo_proxy/hessian_utils.cc
+++ b/source/extensions/filters/network/dubbo_proxy/hessian_utils.cc
@@ -29,7 +29,7 @@ typename std::enable_if<std::is_signed<T>::value, T>::type leftShift(T left, uin
 inline void addByte(Buffer::Instance& buffer, const uint8_t value) { buffer.add(&value, 1); }
 
 void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t>& values) {
-  for (const int8_t& value : values) {
+  for (const uint8_t& value : values) {
     buffer.add(&value, 1);
   }
 }

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -50,7 +50,7 @@ void HystrixSink::addHistogramToStream(const QuantileLatencyMap& latency_map, ab
   // TODO: Consider if we better use join here
   ss << ", \"" << key << "\": {";
   bool is_first = true;
-  for (const std::pair<double, double>& element : latency_map) {
+  for (const auto& element : latency_map) {
     const std::string quantile = fmt::sprintf("%g", element.first * 100);
     HystrixSink::addDoubleToStream(quantile, element.second, ss, is_first);
     is_first = false;


### PR DESCRIPTION
Clang 10 warns about implicit conversions for loop variables, so update
cases of these to fix the main envoy build

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
