### PR TITLE
Windows compilation: ensure statusCodeToString has no control paths that do not return

### DIFF
--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -21,9 +21,8 @@ absl::string_view statusCodeToString(StatusCode code) {
     return "PrematureResponseError";
   case StatusCode::CodecClientError:
     return "CodecClientError";
-  default:
-    NOT_REACHED_GCOVR_EXCL_LINE;
   }
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 struct EnvoyStatusPayload {

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -21,6 +21,8 @@ absl::string_view statusCodeToString(StatusCode code) {
     return "PrematureResponseError";
   case StatusCode::CodecClientError:
     return "CodecClientError";
+  default:
+    RELEASE_ASSERT(false, "Invalid StatusCode value");
   }
 }
 

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -22,7 +22,7 @@ absl::string_view statusCodeToString(StatusCode code) {
   case StatusCode::CodecClientError:
     return "CodecClientError";
   default:
-    RELEASE_ASSERT(false, "Invalid StatusCode value");
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -91,7 +91,7 @@ Status codecClientError(absl::string_view message);
 
 /**
  * Returns Envoy::StatusCode of the given status object.
- * If the status object does not contain valid Envoy::Status value the function will RELEASE_ASSERT.
+ * If the status object does not contain valid Envoy::Status value the function will ASSERT.
  */
 StatusCode getStatusCode(const Status& status);
 
@@ -105,7 +105,7 @@ ABSL_MUST_USE_RESULT bool isCodecClientError(const Status& status);
 
 /**
  * Returns Http::Code value of the PrematureResponseError status.
- * IsPrematureResponseError(status) must be true which is checked by RELEASE_ASSERT.
+ * IsPrematureResponseError(status) must be true which is checked by ASSERT.
  */
 Http::Code getPrematureResponseHttpCode(const Status& status);
 


### PR DESCRIPTION
Description: Fix Windows compilation to ensure all control paths return, any unmatched status code that is unexpected is taken care of by adding NOT_REACHED_GCOVR_EXCL_LINE to induce a PANIC, related to https://github.com/envoyproxy/envoy/pull/10550
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
