### PR TITLE
Windows compilation: Ensure thrift_proxy tests/mocks do not fail to compile with missing Validate method on google::protobuf::Struct

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -93,7 +93,7 @@ MockDecoderFilterCallbacks::MockDecoderFilterCallbacks() {
 MockDecoderFilterCallbacks::~MockDecoderFilterCallbacks() = default;
 
 MockFilterConfigFactory::MockFilterConfigFactory()
-    : FactoryBase("envoy.filters.thrift.mock_filter") {
+    : MockFactoryBase("envoy.filters.thrift.mock_filter") {
   mock_filter_ = std::make_shared<NiceMock<MockDecoderFilter>>();
 }
 

--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -92,22 +92,21 @@ MockDecoderFilterCallbacks::MockDecoderFilterCallbacks() {
 }
 MockDecoderFilterCallbacks::~MockDecoderFilterCallbacks() = default;
 
-MockFilterConfigFactory::MockFilterConfigFactory()
-    : MockFactoryBase("envoy.filters.thrift.mock_filter") {
+MockFilterConfigFactory::MockFilterConfigFactory() : name_("envoy.filters.thrift.mock_filter") {
   mock_filter_ = std::make_shared<NiceMock<MockDecoderFilter>>();
 }
 
 MockFilterConfigFactory::~MockFilterConfigFactory() = default;
 
-FilterFactoryCb MockFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const ProtobufWkt::Struct& proto_config, const std::string& stat_prefix,
+FilterFactoryCb MockFilterConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message& proto_config, const std::string& stats_prefix,
     Server::Configuration::FactoryContext& context) {
   UNREFERENCED_PARAMETER(context);
 
-  config_struct_ = proto_config;
-  config_stat_prefix_ = stat_prefix;
+  config_struct_ = dynamic_cast<const ProtobufWkt::Struct&>(proto_config);
+  config_stat_prefix_ = stats_prefix;
 
-  return [this](ThriftFilters::FilterChainFactoryCallbacks& callbacks) -> void {
+  return [this](FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addDecoderFilter(mock_filter_);
   };
 }

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -274,11 +274,11 @@ public:
 
   std::string name() const override { return name_; }
 
-  std::shared_ptr<MockDecoderFilter> mock_filter_;
   ProtobufWkt::Struct config_struct_;
   std::string config_stat_prefix_;
 
 private:
+  std::shared_ptr<MockDecoderFilter> mock_filter_;
   const std::string name_;
 };
 

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -258,47 +258,28 @@ public:
   std::shared_ptr<Router::MockRoute> route_;
 };
 
-template <class ConfigProto> class MockFactoryBase : public NamedThriftFilterConfigFactory {
-public:
-  FilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                               const std::string& stats_prefix,
-                               Server::Configuration::FactoryContext& context) override {
-    const auto& typed_config = dynamic_cast<const ConfigProto&>(proto_config);
-    return createFilterFactoryFromProtoTyped(typed_config, stats_prefix, context);
-  }
-
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<ConfigProto>();
-  }
-
-  std::string name() const override { return name_; }
-
-protected:
-  MockFactoryBase(const std::string& name) : name_(name) {}
-
-private:
-  virtual FilterFactoryCb
-  createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                    const std::string& stats_prefix,
-                                    Server::Configuration::FactoryContext& context) PURE;
-
-  const std::string name_;
-};
-
-class MockFilterConfigFactory : public MockFactoryBase<ProtobufWkt::Struct> {
+class MockFilterConfigFactory : public NamedThriftFilterConfigFactory {
 public:
   MockFilterConfigFactory();
   ~MockFilterConfigFactory() override;
 
-  ThriftFilters::FilterFactoryCb
-  createFilterFactoryFromProtoTyped(const ProtobufWkt::Struct& proto_config,
-                                    const std::string& stat_prefix,
-                                    Server::Configuration::FactoryContext& context) override;
+  FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ProtobufWkt::Struct>();
+  }
+
+  std::string name() const override { return name_; }
 
   std::shared_ptr<MockDecoderFilter> mock_filter_;
   ProtobufWkt::Struct config_struct_;
   std::string config_stat_prefix_;
+
+private:
+  const std::string name_;
 };
 
 } // namespace ThriftFilters


### PR DESCRIPTION
Description:
- ThriftFilters::FactoryBase.createFilterFactoryFromProto() calls protobuf
  utility validation (Validate() method) on the template parameter class
  ConfigProto
- The mocks set the template parameter to be google::protobuf::Struct
  and MSVC cannot find a Validate() method for that type
- Instead, we match the structure of the dubbo_proxy test mocks that
  mock a helper template class similar to FactoryBase that does call any
  protobuf validation code, bypassing the need for Validate() on
  google::protobuf::Struct

Risk Level: Low
Testing: Modifies existing test mocks
Docs Changes: N/A
Release Notes: N/A
