### PR TITLE
runtime: moving code around

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -376,7 +376,7 @@ envoy_cc_library(
         "//source/common/common:regex_lib",
         "//source/common/common:utility_lib",
         "//source/common/protobuf:utility_lib",
-        "//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_features_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -15,6 +15,7 @@
 #include "common/http/path_utility.h"
 #include "common/http/utility.h"
 #include "common/network/utility.h"
+#include "common/runtime/runtime_features.h"
 #include "common/tracing/http_tracer_impl.h"
 
 #include "absl/strings/str_cat.h"

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -6,7 +6,7 @@
 #include "common/common/utility.h"
 #include "common/http/header_map_impl.h"
 #include "common/protobuf/utility.h"
-#include "common/runtime/runtime_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "absl/strings/match.h"
 #include "nghttp2/nghttp2.h"

--- a/source/common/http/http1/BUILD
+++ b/source/common/http/http1/BUILD
@@ -38,7 +38,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
         "//source/common/http/http1:header_formatter_lib",
-        "//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_features_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
@@ -66,7 +66,7 @@ envoy_cc_library(
         "//source/common/http:conn_pool_base_legacy_lib",
         "//source/common/http:headers_lib",
         "//source/common/network:utility_lib",
-        "//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/stats:timespan_lib",
         "//source/common/upstream:upstream_lib",
     ],
@@ -90,7 +90,7 @@ envoy_cc_library(
         "//source/common/http:codes_lib",
         "//source/common/http:conn_pool_base_lib",
         "//source/common/http:headers_lib",
-        "//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/upstream:upstream_lib",
     ],
 )

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -16,7 +16,7 @@
 #include "common/http/headers.h"
 #include "common/http/http1/header_formatter.h"
 #include "common/http/utility.h"
-#include "common/runtime/runtime_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "absl/container/fixed_array.h"
 #include "absl/strings/ascii.h"

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -14,7 +14,7 @@
 #include "common/http/codes.h"
 #include "common/http/headers.h"
 #include "common/http/http1/conn_pool_legacy.h"
-#include "common/runtime/runtime_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "absl/strings/match.h"
 

--- a/source/common/http/http1/conn_pool_legacy.cc
+++ b/source/common/http/http1/conn_pool_legacy.cc
@@ -15,7 +15,6 @@
 #include "common/http/codes.h"
 #include "common/http/headers.h"
 #include "common/network/utility.h"
-#include "common/runtime/runtime_impl.h"
 #include "common/stats/timespan_impl.h"
 #include "common/upstream/upstream_impl.h"
 

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -43,7 +43,7 @@ envoy_cc_library(
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
-        "//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_features_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -20,7 +20,6 @@
 #include "common/http/header_utility.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
-#include "common/runtime/runtime_impl.h"
 
 #include "absl/container/fixed_array.h"
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -22,7 +22,6 @@
 #include "common/http/http2/metadata_decoder.h"
 #include "common/http/http2/metadata_encoder.h"
 #include "common/http/utility.h"
-#include "common/runtime/runtime_impl.h"
 
 #include "absl/types/optional.h"
 #include "nghttp2/nghttp2.h"

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -7,6 +7,7 @@
 
 #include "common/http/http2/codec_impl.h"
 #include "common/http/http2/conn_pool_legacy.h"
+#include "common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -32,7 +32,6 @@
 #include "common/router/config_impl.h"
 #include "common/router/debug_config.h"
 #include "common/router/router.h"
-#include "common/runtime/runtime_impl.h"
 #include "common/stream_info/uint32_accessor_impl.h"
 #include "common/tracing/http_tracer_impl.h"
 

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -17,10 +17,26 @@ envoy_cc_library(
         "runtime_features.h",
     ],
     deps = [
+        # AVOID ADDING TO THESE DEPENDENCIES IF POSSIBLE
+        # Any code using runtime guards depends on this library, and the more dependencies there are,
+        # the harder it is to runtime-guard without dependency loops.
+        "//include/envoy/runtime:runtime_interface",
         "//source/common/common:hash_lib",
         "//source/common/singleton:const_singleton",
+        "//source/common/singleton:threadsafe_singleton",
     ],
 )
+
+envoy_cc_library(
+    name = "runtime_protos_lib",
+    hdrs = [
+        "runtime_protos.h",
+    ],
+    deps = [
+        "//include/envoy/runtime:runtime_interface",
+        "@envoy_api//envoy/service/runtime/v3:pkg_cc_proto",
+    ]
+    )
 
 envoy_cc_library(
     name = "runtime_lib",
@@ -29,11 +45,11 @@ envoy_cc_library(
     ],
     hdrs = [
         "runtime_impl.h",
-        "runtime_protos.h",
     ],
     external_deps = ["ssl"],
     deps = [
         ":runtime_features_lib",
+        ":runtime_protos_lib",
         "//include/envoy/config:subscription_interface",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/init:manager_interface",

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -34,9 +34,10 @@ envoy_cc_library(
     ],
     deps = [
         "//include/envoy/runtime:runtime_interface",
-        "@envoy_api//envoy/service/runtime/v3:pkg_cc_proto",
-    ]
-    )
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/type/v3:pkg_cc_proto",
+    ],
+)
 
 envoy_cc_library(
     name = "runtime_lib",

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -32,7 +32,6 @@ uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
   return default_value;
 }
 
-
 // Add additional features here to enable the new code paths by default.
 //
 // Per documentation in CONTRIBUTING.md is expected that new high risk code paths be guarded

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -2,12 +2,19 @@
 
 #include <string>
 
+#include "envoy/runtime/runtime.h"
+
 #include "common/singleton/const_singleton.h"
+#include "common/singleton/threadsafe_singleton.h"
 
 #include "absl/container/flat_hash_set.h"
 
 namespace Envoy {
 namespace Runtime {
+
+bool isRuntimeFeature(absl::string_view feature);
+bool runtimeFeatureEnabled(absl::string_view feature);
+uint64_t getInteger(absl::string_view feature, uint64_t default_value);
 
 class RuntimeFeatures {
 public:

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -32,36 +32,6 @@
 
 namespace Envoy {
 namespace Runtime {
-namespace {
-
-bool isRuntimeFeature(absl::string_view feature) {
-  return RuntimeFeaturesDefaults::get().enabledByDefault(feature) ||
-         RuntimeFeaturesDefaults::get().existsButDisabled(feature);
-}
-
-} // namespace
-
-bool runtimeFeatureEnabled(absl::string_view feature) {
-  ASSERT(isRuntimeFeature(feature));
-  if (Runtime::LoaderSingleton::getExisting()) {
-    return Runtime::LoaderSingleton::getExisting()->threadsafeSnapshot()->runtimeFeatureEnabled(
-        feature);
-  }
-  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::runtime), warn,
-                      "Unable to use runtime singleton for feature {}", feature);
-  return RuntimeFeaturesDefaults::get().enabledByDefault(feature);
-}
-
-uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
-  ASSERT(absl::StartsWith(feature, "envoy."));
-  if (Runtime::LoaderSingleton::getExisting()) {
-    return Runtime::LoaderSingleton::getExisting()->threadsafeSnapshot()->getInteger(
-        std::string(feature), default_value);
-  }
-  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::runtime), warn,
-                      "Unable to use runtime singleton for feature {}", feature);
-  return default_value;
-}
 
 const size_t RandomGeneratorImpl::UUID_LENGTH = 36;
 

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -32,9 +32,6 @@
 namespace Envoy {
 namespace Runtime {
 
-bool runtimeFeatureEnabled(absl::string_view feature);
-uint64_t getInteger(absl::string_view feature, uint64_t default_value);
-
 using RuntimeSingleton = ThreadSafeSingleton<Loader>;
 
 /**

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -10,7 +10,7 @@
 #include "common/common/matchers.h"
 #include "common/http/async_client_impl.h"
 #include "common/http/codes.h"
-#include "common/runtime/runtime_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "absl/strings/str_cat.h"
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -10,7 +10,6 @@
 #include "common/common/logger.h"
 #include "common/common/matchers.h"
 #include "common/router/header_parser.h"
-#include "common/runtime/runtime_protos.h"
 
 #include "extensions/filters/common/ext_authz/ext_authz.h"
 

--- a/test/common/runtime/runtime_flag_override_test.cc
+++ b/test/common/runtime/runtime_flag_override_test.cc
@@ -1,4 +1,4 @@
-#include "common/runtime/runtime_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "gmock/gmock.h"
 

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -9,6 +9,7 @@
 
 #include "common/config/runtime_utility.h"
 #include "common/runtime/runtime_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "test/common/stats/stat_test_utility.h"
 #include "test/mocks/event/mocks.h"

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -8,8 +8,8 @@
 #include "envoy/type/v3/percent.pb.h"
 
 #include "common/config/runtime_utility.h"
-#include "common/runtime/runtime_impl.h"
 #include "common/runtime/runtime_features.h"
+#include "common/runtime/runtime_impl.h"
 
 #include "test/common/stats/stat_test_utility.h"
 #include "test/mocks/event/mocks.h"


### PR DESCRIPTION
In a WIP PR I tried using one utility from another utility and ended up in a dependency loop because runtime features pull all of runtime pull all of gRPC (for RTDS) pull a ton of other code.
Fixing it forward by splitting runtime guards into their own library with very minimal dependencies.

Risk Level: low (just moving code)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
