### PR TITLE
tools: Exclude third_party directory from pedantic spell checker

### DIFF
--- a/tools/spelling/check_spelling_pedantic.py
+++ b/tools/spelling/check_spelling_pedantic.py
@@ -805,7 +805,10 @@ if __name__ == "__main__":
 
   # Exclude ./third_party/ directory from spell checking, even when requested through arguments.
   # Otherwise git pre-push hook checks it for merged commits.
-  paths = [path for path in paths if not path.startswith('./third_party/') and not path.startswith('./third_party/')]
+  paths = [
+      path for path in paths
+      if not path.startswith('./third_party/') and not path.startswith('./third_party/')
+  ]
 
   exts = ['.cc', '.h', '.proto']
   if args.test_ignore_exts:

--- a/tools/spelling/check_spelling_pedantic.py
+++ b/tools/spelling/check_spelling_pedantic.py
@@ -803,6 +803,10 @@ if __name__ == "__main__":
   if not paths:
     paths = ['./api', './include', './source', './test', './tools']
 
+  # Exclude ./third_party/ directory from spell checking, even when requested through arguments.
+  # Otherwise git pre-push hook checks it for merged commits.
+  paths = [path for path in paths if not path.startswith('./third_party/') and not path.startswith('./third_party/')]
+
   exts = ['.cc', '.h', '.proto']
   if args.test_ignore_exts:
     exts = None

--- a/tools/spelling/check_spelling_pedantic_test.py
+++ b/tools/spelling/check_spelling_pedantic_test.py
@@ -57,12 +57,16 @@ def checkFileExpectingErrors(filename, expected_substrings):
   return expectError(filename, status, stdout, expected_substrings)
 
 
-def checkFileExpectingOK(filename):
-  command, status, stdout = runCheckFormat("check", getInputFile(filename))
+def checkFilePathExpectingOK(filename):
+  command, status, stdout = runCheckFormat("check", filename)
   if status != 0:
     logging.error("Expected %s to have no errors; status=%d, output:\n" % (filename, status))
     emitStdoutAsError(stdout)
   return status
+
+
+def checkFileExpectingOK(filename):
+  return checkFilePathExpectingOK(getInputFile(filename))
 
 
 def runChecks():
@@ -71,6 +75,9 @@ def runChecks():
   errors += checkFileExpectingOK("valid")
   errors += checkFileExpectingOK("skip_file")
   errors += checkFileExpectingOK("exclusions")
+
+  errors += checkFileExpectingOK("third_party/something/file.cc")
+  errors += checkFileExpectingOK("./third_party/something/file.cc")
 
   errors += checkFileExpectingErrors("typos",
                                      ["spacific", "reelistic", "Awwful", "combeenations", "woork"])


### PR DESCRIPTION
git pre-push hook may check the `third_party` directory content when pushing merged commits that have changes there. Exclude it explicitly

Risk Level: Low
Testing: Unit Test + git pre-push hook
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
