### PR TITLE
rate limit filter: clarify docs

### DIFF
--- a/docs/root/configuration/http/http_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_filter.rst
@@ -101,7 +101,7 @@ ratelimit.http_filter_enabled
   % of requests that will call the rate limit service. Defaults to 100.
 
 ratelimit.http_filter_enforcing
-  % of requests that will call the rate limit service and enforce the decision. Defaults to 100.
+  % of requests that that will have the rate limit service decision enforced. Defaults to 100.
   This can be used to test what would happen before fully enforcing the outcome.
 
 ratelimit.<route_key>.http_filter_enabled


### PR DESCRIPTION
The `ratelimit.http_filter_enforcing` runtime key only gates enforcing
decisions -- not calls. So clarify the wording to say this, otherwise
it reads like this runtime key also dictates if calls to the rate
limit service will happen or not (which is exclusively controlled
by the `ratelimit.http_filter_enabled` key).

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
