### PR TITLE
Changing initialized 'static const' to definition 'static constexpr'

### DIFF
--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -61,9 +61,9 @@ protected:
 
   void drainBuffer(Buffer::OwnedImpl& buffer) { buffer.drain(buffer.length()); }
 
-  static const int64_t gzip_window_bits{31};
-  static const int64_t memory_level{8};
-  static const uint64_t default_input_size{796};
+  static constexpr int64_t gzip_window_bits{31};
+  static constexpr int64_t memory_level{8};
+  static constexpr uint64_t default_input_size{796};
 };
 
 class ZlibCompressorImplTester : public ZlibCompressorImpl {

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -53,9 +53,9 @@ protected:
     ASSERT_EQ(0, decompressor.decompression_error_);
   }
 
-  static const int64_t gzip_window_bits{31};
-  static const int64_t memory_level{8};
-  static const uint64_t default_input_size{796};
+  static constexpr int64_t gzip_window_bits{31};
+  static constexpr int64_t memory_level{8};
+  static constexpr uint64_t default_input_size{796};
 };
 
 class ZlibDecompressorImplFailureTest : public ZlibDecompressorImplTest {


### PR DESCRIPTION
nit: this enables passing the constants into functions and function templates that accept arguments by reference

Risk Level: Low
Testing: Only modified inside tests

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
