### PR TITLE
http: do not add content-length: 0 to 101 responses on upgrade

### DIFF
--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -374,7 +374,12 @@ void ConnectionManagerUtility::mutateResponseHeaders(
     // upgrade response it has already passed the protocol checks.
     const bool no_body =
         (!response_headers.TransferEncoding() && !response_headers.ContentLength());
-    if (no_body) {
+
+    const bool is_1xx = CodeUtility::is1xx(Utility::getResponseStatus(response_headers));
+
+    // We are explicitly forbidden from setting content-length for 1xx responses
+    // (RFC7230, Section 3.3.2). We ignore 204 because this is an upgrade.
+    if (no_body && !is_1xx) {
       response_headers.setContentLength(uint64_t(0));
     }
   } else {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -765,16 +765,35 @@ TEST_F(ConnectionManagerUtilityTest, MutateResponseHeaders) {
 // Make sure we don't remove connection headers on all Upgrade responses.
 TEST_F(ConnectionManagerUtilityTest, DoNotRemoveConnectionUpgradeForWebSocketResponses) {
   TestRequestHeaderMapImpl request_headers{{"connection", "UpGrAdE"}, {"upgrade", "foo"}};
-  TestResponseHeaderMapImpl response_headers{
-      {"connection", "upgrade"}, {"transfer-encoding", "foo"}, {"upgrade", "bar"}};
+  TestResponseHeaderMapImpl response_headers{{":status", "101"},
+                                             {"connection", "upgrade"},
+                                             {"transfer-encoding", "foo"},
+                                             {"upgrade", "bar"}};
   EXPECT_TRUE(Utility::isUpgrade(request_headers));
   EXPECT_TRUE(Utility::isUpgrade(response_headers));
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, &request_headers,
                                                   config_.requestIDExtension(), "");
 
-  EXPECT_EQ(2UL, response_headers.size()) << response_headers;
+  EXPECT_EQ(3UL, response_headers.size()) << response_headers;
   EXPECT_EQ("upgrade", response_headers.get_("connection"));
   EXPECT_EQ("bar", response_headers.get_("upgrade"));
+  EXPECT_EQ("101", response_headers.get_(":status"));
+}
+
+// Make sure we don't add a content-length header on Upgrade responses.
+TEST_F(ConnectionManagerUtilityTest, DoNotAddConnectionLengthForWebSocket101Responses) {
+  TestRequestHeaderMapImpl request_headers{{"connection", "UpGrAdE"}, {"upgrade", "foo"}};
+  TestResponseHeaderMapImpl response_headers{
+      {":status", "101"}, {"connection", "upgrade"}, {"upgrade", "bar"}};
+  EXPECT_TRUE(Utility::isUpgrade(request_headers));
+  EXPECT_TRUE(Utility::isUpgrade(response_headers));
+  ConnectionManagerUtility::mutateResponseHeaders(response_headers, &request_headers,
+                                                  config_.requestIDExtension(), "");
+
+  EXPECT_EQ(3UL, response_headers.size()) << response_headers;
+  EXPECT_EQ("upgrade", response_headers.get_("connection"));
+  EXPECT_EQ("bar", response_headers.get_("upgrade"));
+  EXPECT_EQ("101", response_headers.get_(":status"));
 }
 
 TEST_F(ConnectionManagerUtilityTest, ClearUpgradeHeadersForNonUpgradeRequests) {


### PR DESCRIPTION
Per RFC 7230 Section 3.3.2, 101 responses should not contain
either a content-length or transfer-encoding. This change
removes the forced addition of a Content-Length: 0 header in
this case. Upstreams that return 101 or 204 responses with
Content-Length or Transfer-Encoding continue to be forwarded
downstream.

Risk Level: low
Testing: updated tests
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
