### PR TITLE
xds: reset ApiState during stream termination

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -216,7 +216,16 @@ void GrpcMuxImpl::onStreamEstablished() {
 }
 
 void GrpcMuxImpl::onEstablishmentFailure() {
-  for (const auto& api_state : api_state_) {
+  for (auto& api_state : api_state_) {
+    if (api_state.second.pending_) {
+      ENVOY_LOG(trace, "API {} pending during onEstablishmentFailure(), unsetting pending.", api_state.first);
+      api_state.second.pending_ = false;
+    }
+    if (api_state.second.paused_) {
+      ENVOY_LOG(trace, "API {} paused during onEstablishmentFailure(), unpausing.", api_state.first);
+      api_state.second.paused_ = false;
+    }
+
     for (auto watch : api_state.second.watches_) {
       watch->callbacks_.onConfigUpdateFailed(
           Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, nullptr);

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -222,8 +222,7 @@ void GrpcMuxImpl::onEstablishmentFailure() {
           Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, nullptr);
     }
     if (api_state.second.paused_) {
-      ENVOY_LOG(trace, "API {} paused during onEstablishmentFailure(), resuming.",
-                api_state.first);
+      ENVOY_LOG(trace, "API {} paused during onEstablishmentFailure(), resuming.", api_state.first);
       resume(api_state.first);
     }
   }

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -218,11 +218,13 @@ void GrpcMuxImpl::onStreamEstablished() {
 void GrpcMuxImpl::onEstablishmentFailure() {
   for (auto& api_state : api_state_) {
     if (api_state.second.pending_) {
-      ENVOY_LOG(trace, "API {} pending during onEstablishmentFailure(), unsetting pending.", api_state.first);
+      ENVOY_LOG(trace, "API {} pending during onEstablishmentFailure(), unsetting pending.",
+                api_state.first);
       api_state.second.pending_ = false;
     }
     if (api_state.second.paused_) {
-      ENVOY_LOG(trace, "API {} paused during onEstablishmentFailure(), unpausing.", api_state.first);
+      ENVOY_LOG(trace, "API {} paused during onEstablishmentFailure(), unpausing.",
+                api_state.first);
       api_state.second.paused_ = false;
     }
 


### PR DESCRIPTION
Description:
Currently, when a stream is terminated, an `ApiState` that's in the paused state can remain there indefinitely. This is because `resume` is never called for that `type_url`. If the stream is reestablished, `sendDiscoveryRequest` will set that `ApiState` as pending and no `DiscoveryRequest`s are ever sent out for that type.

The fix here is to explicitly reset the `ApiState` for such types during `onEstablishmentFailure` so that `sendDiscoveryRequest` can correctly start sending requests for that type again once the stream is reestablished.

Risk Level: High
Testing: Added test
Docs Changes: N/A
Release Notes: N/A