### PR TITLE
lua: additional assertion around state creation

### DIFF
--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -51,6 +51,7 @@ ThreadLocalState::ThreadLocalState(const std::string& code, ThreadLocal::SlotAll
 
   // First verify that the supplied code can be parsed.
   CSmartPtr<lua_State, lua_close> state(lua_open());
+  ASSERT(state.get() != nullptr, "unable to create new lua state object");
   luaL_openlibs(state.get());
 
   if (0 != luaL_dostring(state.get(), code.c_str())) {
@@ -91,6 +92,7 @@ CoroutinePtr ThreadLocalState::createCoroutine() {
 }
 
 ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : state_(lua_open()) {
+  ASSERT(state_.get() != nullptr, "unable to create new lua state object");
   luaL_openlibs(state_.get());
   int rc = luaL_dostring(state_.get(), code.c_str());
   ASSERT(rc == 0);


### PR DESCRIPTION
__Description__: In the event that lua is unable to create a new state (such as when mmap
returns an error), a NULL value is returned for the state. The actual segfault
that arises from this may occur in a separate call-stack and can add confusion
to where the error is originating from. This change adds an assertion on state
creation to add additional clarity for this particular, non-recoverable error.

__Risk__: low
__Testing__: manual
__Documentation__: n/a
__Release Notes__: n/a

Signed-off-by: John Murray <murray@stripe.com>