### PR TITLE
[fuzz] fix filter decode data state

### DIFF
--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -91,7 +91,7 @@ public:
       }
       Buffer::OwnedImpl buffer(data.data().Get(i));
       ENVOY_LOG_MISC(debug, "Decoding data: {} ", buffer.toString());
-      if (filter->decodeData(buffer, end_stream) != Http::FilterDataStatus::Continue) {
+      if (filter->decodeData(buffer, end_stream) == Http::FilterDataStatus::StopIterationNoBuffer) {
         return;
       }
     }


### PR DESCRIPTION
HCM will continue to call `decodeData` on Filters that return `StopIterationAndBuffer`, `StopIterationAndWatermark` and `Continue`. Just return early when the data status is `StopIterationNoBuffer`.

Signed-off-by: Asra Ali <asraa@google.com>
