### PR TITLE
ci: Enable remote cache in Windows CI

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -143,3 +143,6 @@ jobs:
           TMPDIR: $(Agent.TempDirectory)
           BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC"
           BAZEL_SH: "C:\\Program Files\\Git\\bin\\bash.exe"
+          BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+          BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+          GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)


### PR DESCRIPTION
Description: Enable remote cache in Windows CI, hopefully in order to enable faster builds
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A