### PR TITLE
[thrift] fix bug.large amount of list or map values ,when socket can not read all and frame.remain still be decreased

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -116,7 +116,7 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::listValue(Buffer::Instan
     return {popReturnState(), FilterStatus::Continue};
   }
   DecoderStatus status = handleValue(buffer, frame.elem_type_, ProtocolState::ListValue);
-  if(status.next_state_ != ProtocolState::WaitForData) {
+  if (status.next_state_ != ProtocolState::WaitForData) {
     frame.remaining_--;
   }
 
@@ -165,7 +165,7 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::mapValue(Buffer::Instanc
   Frame& frame = stack_.back();
   ASSERT(frame.remaining_ != 0);
   DecoderStatus status = handleValue(buffer, frame.value_type_, ProtocolState::MapKey);
-  if(status.next_state_ != ProtocolState::WaitForData) {
+  if (status.next_state_ != ProtocolState::WaitForData) {
     frame.remaining_--;
   }
 

--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -115,9 +115,12 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::listValue(Buffer::Instan
   if (frame.remaining_ == 0) {
     return {popReturnState(), FilterStatus::Continue};
   }
-  frame.remaining_--;
+  DecoderStatus status = handleValue(buffer, frame.elem_type_, ProtocolState::ListValue);
+  if(status.next_state_ != ProtocolState::WaitForData) {
+    frame.remaining_--;
+  }
 
-  return handleValue(buffer, frame.elem_type_, ProtocolState::ListValue);
+  return status;
 }
 
 // ListEnd -> stack's return state
@@ -161,9 +164,12 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::mapValue(Buffer::Instanc
   ASSERT(!stack_.empty());
   Frame& frame = stack_.back();
   ASSERT(frame.remaining_ != 0);
-  frame.remaining_--;
+  DecoderStatus status = handleValue(buffer, frame.value_type_, ProtocolState::MapKey);
+  if(status.next_state_ != ProtocolState::WaitForData) {
+    frame.remaining_--;
+  }
 
-  return handleValue(buffer, frame.value_type_, ProtocolState::MapKey);
+  return status;
 }
 
 // MapEnd -> stack's return state


### PR DESCRIPTION
Description:
When client build large amount list or map values ,and socket can not read them all at once, and the state machine just decode half of list values ,if frame.remaining be decreased ,it will make list could not get all values(just got length - 1),and it will make state machine fall into disorder.

Risk Level:Medium
Testing:linux-gcc
Docs Changes:N/A
Release Notes:N/A
Signed-off-by:Guang Yang pyrl247@gmail.com