### PR TITLE
redis: Fix stack-use-after-scope in test

### DIFF
--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -150,7 +150,8 @@ protected:
                               Network::DnsResolver::ResolutionStatus status =
                                   Network::DnsResolver::ResolutionStatus::Success) {
     EXPECT_CALL(*dns_resolver_, resolve(expected_address, dns_lookup_family, _))
-        .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
+        .WillOnce(Invoke([status, resolved_addresses](
+                             const std::string&, Network::DnsLookupFamily,
                              Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
           cb(status, TestUtility::makeDnsResponse(resolved_addresses));
           return nullptr;

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -686,7 +686,7 @@ TEST_F(RedisClusterTest, FailedDnsResponse) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(1U, cluster_->info()->stats().update_empty_.value());
+  EXPECT_EQ(0U, cluster_->info()->stats().update_empty_.value());
 
   // Does not recreate the timer on subsequent DNS resolve calls.
   EXPECT_CALL(*dns_timer, enableTimer(_, _));
@@ -695,7 +695,7 @@ TEST_F(RedisClusterTest, FailedDnsResponse) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(2U, cluster_->info()->stats().update_empty_.value());
+  EXPECT_EQ(1U, cluster_->info()->stats().update_empty_.value());
 }
 
 TEST_F(RedisClusterTest, Basic) {


### PR DESCRIPTION
Description: Capture `status` by copy instead of referencing stack used for function arguments.
Risk Level: n/a (test only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
