### PR TITLE
fix: upstream grpc stats on trailers only

### DIFF
--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -208,15 +208,7 @@ public:
       config_->context_.chargeStat(*cluster_, Grpc::Context::Protocol::Grpc, request_names_,
                                    headers.GrpcStatus());
       if (end_stream) {
-        if (config_->enable_upstream_stats_ &&
-            decoder_callbacks_->streamInfo().lastUpstreamTxByteSent().has_value() &&
-            decoder_callbacks_->streamInfo().lastUpstreamRxByteReceived().has_value()) {
-          std::chrono::milliseconds chrono_duration =
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                  decoder_callbacks_->streamInfo().lastUpstreamRxByteReceived().value() -
-                  decoder_callbacks_->streamInfo().lastUpstreamTxByteSent().value());
-          config_->context_.chargeUpstreamStat(*cluster_, request_names_, chrono_duration);
-        }
+        maybeChargeUpstreamStat();
       }
     }
     return Http::FilterHeadersStatus::Continue;
@@ -239,16 +231,7 @@ public:
     if (doStatTracking()) {
       config_->context_.chargeStat(*cluster_, Grpc::Context::Protocol::Grpc, request_names_,
                                    trailers.GrpcStatus());
-
-      if (config_->enable_upstream_stats_ &&
-          decoder_callbacks_->streamInfo().lastUpstreamTxByteSent().has_value() &&
-          decoder_callbacks_->streamInfo().lastUpstreamRxByteReceived().has_value()) {
-        std::chrono::milliseconds chrono_duration =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                decoder_callbacks_->streamInfo().lastUpstreamRxByteReceived().value() -
-                decoder_callbacks_->streamInfo().lastUpstreamTxByteSent().value());
-        config_->context_.chargeUpstreamStat(*cluster_, request_names_, chrono_duration);
-      }
+      maybeChargeUpstreamStat();
     }
     return Http::FilterTrailersStatus::Continue;
   }
@@ -269,6 +252,18 @@ public:
     }
     filter_object_->request_message_count = request_counter_.frameCount();
     filter_object_->response_message_count = response_counter_.frameCount();
+  }
+
+  void maybeChargeUpstreamStat() {
+    if (config_->enable_upstream_stats_ &&
+        decoder_callbacks_->streamInfo().lastUpstreamTxByteSent().has_value() &&
+        decoder_callbacks_->streamInfo().lastUpstreamRxByteReceived().has_value()) {
+      std::chrono::milliseconds chrono_duration =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              decoder_callbacks_->streamInfo().lastUpstreamRxByteReceived().value() -
+              decoder_callbacks_->streamInfo().lastUpstreamTxByteSent().value());
+      config_->context_.chargeUpstreamStat(*cluster_, request_names_, chrono_duration);
+    }
   }
 
 private:


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>
Fixes https://github.com/envoyproxy/envoy/pull/10748#discussion_r410754033

Description: Record upstream grpc stats on trailers only response
Risk Level: Low
Testing: Unit
Docs Changes: none
Release Notes: none

cc @mattklein123 @ggreenway 
