### PR TITLE
Fix hiding of virtual function in FilterChainBenchmarkFixture

### DIFF
--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -166,7 +166,7 @@ const char YamlSingleDstPortBottom[] = R"EOF(
 
 class FilterChainBenchmarkFixture : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& state) override {
+  void SetUp(::benchmark::State& state) override {
     int64_t input_size = state.range(0);
     std::vector<std::string> port_chains;
     port_chains.reserve(input_size);


### PR DESCRIPTION
Currently `Setup` function in `FilterChainBenchmarkFixture` is hiding virtual function in parent class `benchmark::Fixture` :
```bazel-out/k8-fastbuild/bin/external/com_github_google_benchmark/_virtual_includes/benchmark/benchmark/benchmark.h:1071:16: error: 'virtual void benchmark::Fixture::SetUp(benchmark::State&)' was hidden [-Werror=overloaded-virtual]
   virtual void SetUp(State& st) { SetUp(const_cast<const State&>(st)); }
                ^~~~~
test/server/filter_chain_benchmark_test.cc:169:8: error:   by 'virtual void Envoy::Server::FilterChainBenchmarkFixture::SetUp(const benchmark::State&)' [-Werror=overloaded-virtual]
   void SetUp(const ::benchmark::State& state) override {
        ^~~~~
```
Risk Level: Low
Testing: Covered by existing tests

