### PR TITLE
test: Fix clang-tidy in source/common/http/conn_manager_config.h

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -155,6 +155,7 @@ envoy_cc_library(
         "//include/envoy/http:request_id_extension_interface",
         "//include/envoy/router:rds_interface",
         "//source/common/network:utility_lib",
+        "//source/common/stats:symbol_table_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
Fix clang-tidy in source/common/http/conn_manager_config.h
To avoid [this error](https://dev.azure.com/cncf/envoy/_build/results?buildId=37655&view=logs&j=3bf5ec37-bb6f-5fb6-2cf1-5134dc6106d6&t=41d571fe-3811-578d-07de-68468f467dae&l=1620)

Risk Level: Low
Testing: clang-tidy
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
