### PR TITLE
Catch exception and return false in cases where std::regex_match throws.

### DIFF
--- a/source/common/common/regex.cc
+++ b/source/common/common/regex.cc
@@ -19,7 +19,11 @@ public:
 
   // CompiledMatcher
   bool match(absl::string_view value) const override {
-    return std::regex_match(value.begin(), value.end(), regex_);
+    try {
+      return std::regex_match(value.begin(), value.end(), regex_);
+    } catch (const std::regex_error& e) {
+      return false;
+    }
   }
 
   // CompiledMatcher


### PR DESCRIPTION
Description: Catch exception and return false in cases where std::regex_match throws.  std::regex can throw during match.  Catch the exception to avoid a potential for crashes in the data plane.  The impact of this change is low since std::regex in config are deprecated in favor of RE2.
Risk Level: low, std::regex in config are deprecated.
Testing: unit
Docs Changes: n/a
Release Notes: n/a
