### PR TITLE
[thrift]try to fix bug.large amount of list or map values ,when socket can not read all and frame.remain still be decreased

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -111,13 +111,16 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::listBegin(Buffer::Instan
 // ListValue -> ListEnd
 DecoderStateMachine::DecoderStatus DecoderStateMachine::listValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  Frame& frame = stack_.back();
-  if (frame.remaining_ == 0) {
+  uint32_t index = stack_.size() - 1;
+  if (stack_[index].remaining_ == 0) {
     return {popReturnState(), FilterStatus::Continue};
   }
-  frame.remaining_--;
+  DecoderStatus status = handleValue(buffer, stack_[index].elem_type_, ProtocolState::ListValue);
+  if (status.next_state_ != ProtocolState::WaitForData) {
+    stack_[index].remaining_--;
+  }
 
-  return handleValue(buffer, frame.elem_type_, ProtocolState::ListValue);
+  return status;
 }
 
 // ListEnd -> stack's return state
@@ -159,11 +162,14 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::mapKey(Buffer::Instance&
 // MapValue -> MapKey
 DecoderStateMachine::DecoderStatus DecoderStateMachine::mapValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  Frame& frame = stack_.back();
-  ASSERT(frame.remaining_ != 0);
-  frame.remaining_--;
+  uint32_t index = stack_.size() - 1;
+  ASSERT(stack_[index].remaining_ != 0);
+  DecoderStatus status = handleValue(buffer, stack_[index].value_type_, ProtocolState::MapKey);
+  if (status.next_state_ != ProtocolState::WaitForData) {
+    stack_[index].remaining_--;
+  }
 
-  return handleValue(buffer, frame.value_type_, ProtocolState::MapKey);
+  return status;
 }
 
 // MapEnd -> stack's return state
@@ -193,13 +199,16 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::setBegin(Buffer::Instanc
 // SetValue -> SetEnd
 DecoderStateMachine::DecoderStatus DecoderStateMachine::setValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  Frame& frame = stack_.back();
-  if (frame.remaining_ == 0) {
+  uint32_t index = stack_.size() - 1;
+  if (stack_[index].remaining_ == 0) {
     return {popReturnState(), FilterStatus::Continue};
   }
-  frame.remaining_--;
+  DecoderStatus status = handleValue(buffer, stack_[index].elem_type_, ProtocolState::SetValue);
+  if (status.next_state_ != ProtocolState::WaitForData) {
+    stack_[index].remaining_--;
+  }
 
-  return handleValue(buffer, frame.elem_type_, ProtocolState::SetValue);
+  return status;
 }
 
 // SetEnd -> stack's return state

--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -111,7 +111,7 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::listBegin(Buffer::Instan
 // ListValue -> ListEnd
 DecoderStateMachine::DecoderStatus DecoderStateMachine::listValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  uint32_t index = stack_.size() - 1;
+  const uint32_t index = stack_.size() - 1;
   if (stack_[index].remaining_ == 0) {
     return {popReturnState(), FilterStatus::Continue};
   }
@@ -162,7 +162,7 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::mapKey(Buffer::Instance&
 // MapValue -> MapKey
 DecoderStateMachine::DecoderStatus DecoderStateMachine::mapValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  uint32_t index = stack_.size() - 1;
+  const uint32_t index = stack_.size() - 1;
   ASSERT(stack_[index].remaining_ != 0);
   DecoderStatus status = handleValue(buffer, stack_[index].value_type_, ProtocolState::MapKey);
   if (status.next_state_ != ProtocolState::WaitForData) {
@@ -199,7 +199,7 @@ DecoderStateMachine::DecoderStatus DecoderStateMachine::setBegin(Buffer::Instanc
 // SetValue -> SetEnd
 DecoderStateMachine::DecoderStatus DecoderStateMachine::setValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  uint32_t index = stack_.size() - 1;
+  const uint32_t index = stack_.size() - 1;
   if (stack_[index].remaining_ == 0) {
     return {popReturnState(), FilterStatus::Continue};
   }


### PR DESCRIPTION
Description:
When client build large amount list or map values ,and socket can not read them all at once, and the state machine just decode half of list values ,if frame.remaining be decreased ,it will make list could not get all values(just got length - 1),and it will make state machine fall into disorder.

I use index rather then reference because the stack_ vector may expand and make the reference(got from stack_.back()) become invalid.
Risk Level:Medium
Testing:N/A
Docs Changes:N/A
Release Notes:N/A
Signed-off-by:Guang Yang pyrl247@gmail.com