### PR TITLE
Windows compilation: Remove inclusion of pthread.h

### DIFF
--- a/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
@@ -1,5 +1,3 @@
-#include <pthread.h>
-
 #include "test/integration/fake_upstream.h"
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"


### PR DESCRIPTION
Description: Remove extra inclusion of pthread.h, not needed for compilation and causes Windows compilation to fail
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
