### PR TITLE
status: Fix ASAN error in Status payload handling

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -43,10 +43,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://commondatastorage.googleapis.com/chromium-boringssl-docs/fips/boringssl-66005f41fbc3529ffe8d007708756720529da20d.tar.xz"],
     ),
     com_google_absl = dict(
-        sha256 = "2693730730247afb0e7cb2d41664ac2af3ad75c79944efd266be40ba944179b9",
-        strip_prefix = "abseil-cpp-06f0e767d13d4d68071c4fc51e25724e0fc8bc74",
-        # 2020-03-03
-        urls = ["https://github.com/abseil/abseil-cpp/archive/06f0e767d13d4d68071c4fc51e25724e0fc8bc74.tar.gz"],
+        sha256 = "14ee08e2089c2a9b6bf27e1d10abc5629c69c4d0bab4b78ec5b65a29ea1c2af7",
+        strip_prefix = "abseil-cpp-cf3a1998e9d41709d4141e2f13375993cba1130e",
+        # 2020-03-05
+        urls = ["https://github.com/abseil/abseil-cpp/archive/cf3a1998e9d41709d4141e2f13375993cba1130e.tar.gz"],
     ),
     com_github_apache_thrift = dict(
         sha256 = "7d59ac4fdcb2c58037ebd4a9da5f9a49e3e034bf75b3f26d9fe48ba3d8806e6b",


### PR DESCRIPTION
Commit Message:
The absl::Status::GetPayload was returning a copy of the payload and was generating ASAN errors due to lifetime of the copy. Modify payload accessor to use absl::Status::ForEachPayload which allows getting a reference to the payload owned by the Status object. This solves lifetime issues and avoids needless copying.

Also update absl to pull in Cord::TryFlat() method.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
